### PR TITLE
fix gulp running ES6 tests

### DIFF
--- a/tasks/test-runner.js
+++ b/tasks/test-runner.js
@@ -1,3 +1,4 @@
+require('babel-core/register');
 const gulp = require('gulp');
 const mocha = require('gulp-mocha');
 


### PR DESCRIPTION
'npm run test' is working now.