### PR TITLE
update Homebrew install method availability

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ If you have NPM installed, you can use it to install Bit: (recommended)
 
 Homebrew - Bit can be installed via Homebrew package manager:
 
-`brew install bit` (currently unavailable)
+`brew install bit`
 
 ## Debian/Ubuntu Linux
 


### PR DESCRIPTION
Homebrew once again has a working formula for `bit`, so remove the 'currently unavailable' label from the command to install `bit` via Homebrew.