### PR TITLE
allow `bit init` when there is a bit.json file without the `source` o…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- allow `bit init` when there is a bit.json file without the `source` or `env` attributes.
 - bug fix: don't show the version-compatibility warning more than once
 - remove duplications from dependencies list of `bit import` output.
 - suppress dependencies list upon `bit import`, unless a flag `--display_dependencies` is being used.

--- a/src/consumer/bit-json/consumer-bit-json.js
+++ b/src/consumer/bit-json/consumer-bit-json.js
@@ -57,11 +57,11 @@ export default class ConsumerBitJson extends AbstractBitJson {
   static fromPlainObject(object: Object) {
     const { sources, env, dependencies, lang } = object;
     return new ConsumerBitJson({
-      impl: R.prop('impl', sources),
-      spec: R.prop('spec', sources),
-      miscFiles: R.prop('misc', sources),
-      compiler: R.prop('compiler', env),
-      tester: R.prop('tester', env),
+      impl: R.propOr(undefined, 'impl', sources),
+      spec: R.propOr(undefined, 'spec', sources),
+      miscFiles: R.propOr(undefined, 'misc', sources),
+      compiler: R.propOr(undefined, 'compiler', env),
+      tester: R.propOr(undefined, 'tester', env),
       lang,
       dependencies,
     });


### PR DESCRIPTION
…r `env` attributes