### PR TITLE
change `bit export` to resolve dependencies first, then persisting th…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- avoid corrupted data in a scope when dependencies somehow are not being resolved.
 - bug fix: don't show the version-compatibility warning more than once
 - remove duplications from dependencies list of `bit import` output.
 - suppress dependencies list upon `bit import`, unless a flag `--display_dependencies` is being used.

--- a/src/scope/scope.js
+++ b/src/scope/scope.js
@@ -172,9 +172,10 @@ export default class Scope {
     const objects = componentObjects.toObjects(this.objects);
     const { component } = objects;
     await this.sources.merge(objects, true);
-    await this.objects.persist();
     const compVersion = await component.toComponentVersion(LATEST, this.name);
-    const objs = await this.getObjects([compVersion.id], true);
+    const versions = await this.importMany([compVersion.id], true); // resolve dependencies
+    await this.objects.persist();
+    const objs = await Promise.all(versions.map(version => version.toObjects(this.objects)));
     const consumerComponent = await compVersion.toConsumer(this.objects);
     await index(consumerComponent, this.getPath());
     await postExportHook({ id: consumerComponent.id.toString() });


### PR DESCRIPTION
…e component. It helps to avoid corrupted data in the scope when dependencies somehow are not being resolved.