### PR TITLE
Docs - fix bitsrc links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - increased max listeners to 100 (prevent warning message)
 - colored commit success message
 - support for merge conflict error reporting via ssh
+- docs - fix bitsrc links to work
 
 ## [0.6.2] - 2017-05-21
 

--- a/docs/CLI-reference.md
+++ b/docs/CLI-reference.md
@@ -373,7 +373,7 @@ If you search in the current scope, use `bit search search_query -s @this`.
 
 To search in another scope, use `bit search search_query -s @scope_name`
 
-To search public components on [bitsrc.io](https://www.bitsrc.io), use `bit search search_query`
+To search public components on [bitsrc.io](https://bitsrc.io), use `bit search search_query`
 
 ### Examples
 
@@ -385,7 +385,7 @@ Search for a component in a remote scope.
 
 `bit search concat array -s @my_remote_scope`
 
-Search for a public component on [bitsrc.io](https://www.bitsrc.io).
+Search for a public component on [bitsrc.io](https://bitsrc.io).
 
 `bit search concat array`
 

--- a/docs/CLI-reference.md
+++ b/docs/CLI-reference.md
@@ -373,7 +373,7 @@ If you search in the current scope, use `bit search search_query -s @this`.
 
 To search in another scope, use `bit search search_query -s @scope_name`
 
-To search public components on [bitsrc.io] (www.bitsrc.io), use `bit search search_query`
+To search public components on [bitsrc.io](https://www.bitsrc.io), use `bit search search_query`
 
 ### Examples
 
@@ -385,7 +385,7 @@ Search for a component in a remote scope.
 
 `bit search concat array -s @my_remote_scope`
 
-Search for a public component on [bitsrc.io] (www.bitsrc.io).
+Search for a public component on [bitsrc.io](https://www.bitsrc.io).
 
 `bit search concat array`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,7 +451,7 @@ You can find components using the ‘search’ command.
 
     > global/is-string
 
-3. A third option is to search for public components. All public components are hosted in [www.bitsrc.io](https://www.bitsrc.io).
+3. A third option is to search for public components. All public components are hosted in [bitsrc.io](https://www.bitsrc.io).
 
   To search public components type:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,7 +451,7 @@ You can find components using the ‘search’ command.
 
     > global/is-string
 
-3. A third option is to search for public components. All public components are hosted in [bitsrc.io](https://www.bitsrc.io).
+3. A third option is to search for public components. All public components are hosted in [bitsrc.io](https://bitsrc.io).
 
   To search public components type:
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -451,7 +451,7 @@ You can find components using the ‘search’ command.
 
     > global/is-string
 
-3. A third option is to search for public components. All public components are hosted in [www.bitsrc.io](www.bitsrc.io).
+3. A third option is to search for public components. All public components are hosted in [www.bitsrc.io](https://www.bitsrc.io).
 
   To search public components type:
 


### PR DESCRIPTION
The links in "Getting Started" and "CLI Reference" to bitsrc.io did not work.