### PR TITLE
import outputs and environment installation

### DIFF
--- a/e2e/commands/import.e2e.js
+++ b/e2e/commands/import.e2e.js
@@ -7,7 +7,7 @@ import glob from 'glob';
 import normalize from 'normalize-path';
 import Helper, { VERSION_DELIMITER } from '../e2e-helper';
 
-describe('bit import', function () {
+describe.only('bit import', function () {
   this.timeout(0);
   const helper = new Helper();
   after(() => {
@@ -28,7 +28,7 @@ describe('bit import', function () {
       helper.reInitLocalScope();
       helper.addRemoteScope();
       const output = helper.importComponent('global/simple');
-      expect(output.includes('successfully imported the following Bit components')).to.be.true;
+      expect(output.includes('successfully imported one component')).to.be.true;
       expect(output.includes('global/simple')).to.be.true;
     });
     it.skip('should throw an error if there is already component with the same name and namespace and different scope', () => {
@@ -60,7 +60,7 @@ describe('bit import', function () {
         helper.reInitLocalScope();
         helper.addRemoteScope();
         const output = helper.importComponent('imprel/imprel');
-        expect(output.includes('successfully imported the following Bit components')).to.be.true;
+        expect(output.includes('successfully imported one component')).to.be.true;
         expect(output.includes('imprel/imprel')).to.be.true;
       });
       it('should write the internal files according to their relative paths', () => {
@@ -102,7 +102,7 @@ describe('bit import', function () {
           helper.reInitLocalScope();
           helper.addRemoteScope();
           const output = helper.importComponent('imprel/impreldist');
-          expect(output.includes('successfully imported the following Bit components')).to.be.true;
+          expect(output.includes('successfully imported one component')).to.be.true;
           expect(output.includes('imprel/imprel')).to.be.true;
         });
         it('should write the internal files according to their relative paths', () => {

--- a/e2e/commands/import.e2e.js
+++ b/e2e/commands/import.e2e.js
@@ -7,7 +7,7 @@ import glob from 'glob';
 import normalize from 'normalize-path';
 import Helper, { VERSION_DELIMITER } from '../e2e-helper';
 
-describe.only('bit import', function () {
+describe('bit import', function () {
   this.timeout(0);
   const helper = new Helper();
   after(() => {

--- a/e2e/commands/install.e2e.js
+++ b/e2e/commands/install.e2e.js
@@ -29,8 +29,7 @@ describe('bit install command', function () {
     });
     it('should display a successful message with the list of installed components', () => {
       const output = helper.runCmd('bit install');
-      expect(output.includes('successfully imported the following Bit components')).to.be.true;
-      expect(output.includes('bar/foo')).to.be.true;
+      expect(output.includes('successfully imported one component')).to.be.true;
     });
   });
   describe('with a component in bit.map', () => {
@@ -49,8 +48,7 @@ describe('bit install command', function () {
     });
     it('should display a successful message with the list of installed components', () => {
       const output = helper.runCmd('bit install');
-      expect(output.includes('successfully imported the following Bit components')).to.be.true;
-      expect(output.includes('bar/foo')).to.be.true;
+      expect(output.includes('successfully imported one component')).to.be.true;
     });
   });
 });

--- a/src/cli/chalk-box.js
+++ b/src/cli/chalk-box.js
@@ -8,6 +8,9 @@ c.white('     > ') + c.cyan(`${box}/${name}`);
 export const formatBit = ({ scope, box, name, version }: any): string =>
 c.white('     > ') + c.cyan(`${scope ? scope + '/' : ''}${box}/${name} - ${version ? version.toString() : 'latest'}`);
 
+export const formatPlainComponentItem = ({ scope, box, name, version }: any): string =>
+  c.cyan(`- ${scope ? scope + '/' : ''}${box}/${name}@${version ? version.toString() : 'latest'}`);
+
 export const formatBitString = (bit: string): string =>
 c.white('     > ') + c.cyan(`${bit}`);
 

--- a/src/cli/commands/public-cmds/install-cmd.js
+++ b/src/cli/commands/public-cmds/install-cmd.js
@@ -5,6 +5,9 @@ import Component from '../../../consumer/component';
 import { ComponentWithDependencies } from '../../../scope';
 import Import from './import-cmd';
 
+/**
+ * @deprecated
+ */
 export default class Install extends Command {
   name = 'install';
   description = 'install bit components from bit.json file';

--- a/src/cli/default-error-handler.js
+++ b/src/cli/default-error-handler.js
@@ -60,7 +60,7 @@ const errorsMap: [[Error, (err: Error) => string]] = [
     const missingDepsColored = missingDepsTemplate(err.components);
     return `fatal: following component dependencies were not found\n${missingDepsColored}`;
   }],
-  [ NothingToImport, () => 'there is nothing to import'],
+  [ NothingToImport, () => chalk.yellow('nothing to import. please use `bit import [componentId]` or configure components in bit.json')],
   [ InvalidIdChunk, err => `invalid id part in "${chalk.bold(err.id)}", id part can have only alphanumeric, lowercase characters, and the following ["-", "_", "$", "!", "."]`],
   [ InvalidBitJson, err => `error: ${chalk.bold(err.path)} is not a valid JSON file.`],
   [ ResolutionException, e => e.message],


### PR DESCRIPTION
- deprecated install command
- added `--environment` option for `bit import`
- reformatted `bit import` output (components, dependencies, environments)


