### PR TITLE
added correct print after removing excluded files

### DIFF
--- a/src/api/consumer/lib/add.js
+++ b/src/api/consumer/lib/add.js
@@ -274,5 +274,5 @@ export default (async function addAction(
     added.push(addedOne);
   }
   await bitMap.write();
-  return added;
+  return added.filter(id => !R.isEmpty(id.files));
 });


### PR DESCRIPTION
this is related to the  bug : https://app.asana.com/0/137456040763555/422670930696674
after excluding file bit didnt print the correct number of components 