### PR TITLE
add the default binding prefix to the version model id 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - add `--outdated` flag to `bit list` command to show the remote versions of components
+- fix bug which make imported components considered as modified
 
 ## [0.10.9] - 2017-10-18
 

--- a/src/scope/models/version.js
+++ b/src/scope/models/version.js
@@ -122,8 +122,7 @@ export default class Version extends BitObject {
           tester: obj.tester,
           log: obj.log,
           dependencies,
-          packageDependencies: obj.packageDependencies,
-          bindingPrefix: obj.bindingPrefix
+          packageDependencies: obj.packageDependencies
         },
         val => !!val
       )

--- a/src/scope/models/version.js
+++ b/src/scope/models/version.js
@@ -8,7 +8,7 @@ import ConsumerComponent from '../../consumer/component';
 import { BitIds, BitId } from '../../bit-id';
 import ComponentVersion from '../component-version';
 import type { Doclet } from '../../jsdoc/parser';
-import { DEFAULT_BUNDLE_FILENAME } from '../../constants';
+import { DEFAULT_BUNDLE_FILENAME, DEFAULT_BINDINGS_PREFIX } from '../../constants';
 import type { Results } from '../../specs-runner/specs-runner';
 
 type CiProps = {
@@ -174,7 +174,7 @@ export default class Version extends BitObject {
           })
           : null,
         compiler: this.compiler ? this.compiler.toString() : null,
-        bindingPrefix: this.bindingPrefix || null,
+        bindingPrefix: this.bindingPrefix || DEFAULT_BINDINGS_PREFIX,
         tester: this.tester ? this.tester.toString() : null,
         log: {
           message: this.log.message,


### PR DESCRIPTION
add the default binding prefix to the version model id when not specified (fix a bug which makes imported components considered as modified)