### PR TITLE
clear error message when Bit can't find private ssh key

### DIFF
--- a/src/scope/network/ssh/ssh.js
+++ b/src/scope/network/ssh/ssh.js
@@ -247,7 +247,7 @@ export default class SSH implements Network {
     return new Promise((resolve, reject) => {
       if (!sshConfig.privateKey) {
         reject(
-          'Could not authenticate\nPlease make sure you have configured ssh access and permissions to the remote scope'
+          'could not locate private SSH key file.\nuse the \"bit config set ssh_key_file\" command to configure its location.'
         );
       }
       try {


### PR DESCRIPTION
the current error message is not clear enough and does not help with fixing the issue.