### PR TITLE
bug: skip ssh agent

### DIFF
--- a/src/scope/network/ssh/ssh.js
+++ b/src/scope/network/ssh/ssh.js
@@ -263,17 +263,19 @@ export default class SSH implements Network {
   connect(key: ?string, passphrase: ?string): Promise<SSH> {
     const self = this;
 
-    function prompt() {
-      return promptPassphrase().then((res) => {
-        cachedPassphrase = res.passphrase;
-        return self.connect(key, cachedPassphrase).catch(() => {
-          return prompt();
-        });
-      });
-    }
-
     return this.composeConnectionObject(key, passphrase).then((sshConfig) => {
       return new Promise((resolve, reject) => {
+        function prompt() {
+          return promptPassphrase()
+            .then((res) => {
+              cachedPassphrase = res.passphrase;
+              return self.connect(key, cachedPassphrase).catch(() => {
+                return prompt();
+              });
+            })
+            .catch(err => reject(err));
+        }
+
         const conn = new SSH2();
         try {
           conn

--- a/src/scope/network/ssh/ssh.js
+++ b/src/scope/network/ssh/ssh.js
@@ -264,6 +264,7 @@ export default class SSH implements Network {
     return !!process.env.SSH_AUTH_SOCK;
   }
 
+  // @TODO refactor this method
   connect(key: ?string, passphrase: ?string, skipAgent: boolean = false): Promise<SSH> {
     const self = this;
 


### PR DESCRIPTION
fixed bug for better handling of SSH agent auth failures.
Now falling back to private key auth in case Bit failed to authenticate using ssh-agent.

@GiladShoham would be great if you can check if it works for you before merging