### PR TITLE
fix Invalid version latest

### DIFF
--- a/src/api/consumer/lib/add.js
+++ b/src/api/consumer/lib/add.js
@@ -35,7 +35,7 @@ export default (async function addAction(
   function getPathRelativeToProjectRoot(componentPath, projectRoot) {
     if (!componentPath) return componentPath;
     const absPath = path.resolve(componentPath);
-    return absPath.replace(`${projectRoot}${path.sep}`, '');
+    return path.relative(projectRoot, absPath);
   }
 
   // update test files according to dsl

--- a/src/consumer/component/components-list.js
+++ b/src/consumer/component/components-list.js
@@ -224,7 +224,8 @@ export default class ComponentsList {
     const modifiedComponents = await this.listModifiedComponents();
     if (!modifiedComponents || !modifiedComponents.length) return [];
     const modifiedComponentsIds = modifiedComponents.map(modifiedComponent => BitId.parse(modifiedComponent));
-    return this.consumer.listComponentsForAutoTagging(modifiedComponentsIds);
+    const modifiedComponentsLatestVersions = await this.scope.latestVersions(modifiedComponentsIds);
+    return this.consumer.listComponentsForAutoTagging(modifiedComponentsLatestVersions);
   }
 
   async idsFromBitMap(withScopeName: boolean = true, origin?: string): Promise<string[]> {

--- a/src/consumer/component/components-list.js
+++ b/src/consumer/component/components-list.js
@@ -74,7 +74,7 @@ export default class ComponentsList {
    * @param {boolean} [load=false] - Whether to load the component (false will return only the id)
    * @return {Promise<string[]>}
    */
-  async listModifiedComponents(load: boolean = false): Promise<Array<string | Component>> {
+  async listModifiedComponents(load: boolean = false): Promise<Array<BitId | Component>> {
     const getAuthoredAndImportedFromFS = async () => {
       let [authored, imported] = await Promise.all([
         this.getFromFileSystem(COMPONENT_ORIGINS.AUTHORED),
@@ -105,7 +105,7 @@ export default class ComponentsList {
           if (load) {
             modifiedComponents.push(componentFromFS);
           } else {
-            modifiedComponents.push(bitId.toStringWithoutScopeAndVersion());
+            modifiedComponents.push(bitId);
           }
         }
       } else {
@@ -188,7 +188,10 @@ export default class ComponentsList {
       this.listNewComponents(),
       this.listModifiedComponents()
     ]);
-    return [...newComponents, ...modifiedComponents];
+    const modifiedComponentsWithoutScopeAndVersion = modifiedComponents.map(componentId =>
+      componentId.toStringWithoutScopeAndVersion()
+    );
+    return [...newComponents, ...modifiedComponentsWithoutScopeAndVersion];
   }
 
   /**
@@ -223,8 +226,7 @@ export default class ComponentsList {
   async listAutoTagPendingComponents(): Promise<ModelComponent[]> {
     const modifiedComponents = await this.listModifiedComponents();
     if (!modifiedComponents || !modifiedComponents.length) return [];
-    const modifiedComponentsIds = modifiedComponents.map(modifiedComponent => BitId.parse(modifiedComponent));
-    const modifiedComponentsLatestVersions = await this.scope.latestVersions(modifiedComponentsIds);
+    const modifiedComponentsLatestVersions = await this.scope.latestVersions(modifiedComponents);
     return this.consumer.listComponentsForAutoTagging(modifiedComponentsLatestVersions);
   }
 


### PR DESCRIPTION
fix error "TypeError: Invalid Version: latest" when running bit status on local components with auto-tagging candidates