### PR TITLE
support tagging the entire local scope and all imported components to…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- support tagging the entire local scope and all imported components to a specific tag using `--scope` and `--include_imported` flags
 - `bit status` - add a new section "deleted components" for components that were deleted from the file-system manually
 - bug fix - components that were not indicated as staged-components by `bit status` were exported by `bit export`
 - bug fix - tests files saved with incorrect path when `bit add` was running from non-consumer root  

--- a/src/consumer/component/components-list.js
+++ b/src/consumer/component/components-list.js
@@ -178,6 +178,24 @@ export default class ComponentsList {
     return { newComponents, importPendingComponents };
   }
 
+  async listCommitPendingOfAllScope(version: string, includeImported: boolean = false) {
+    let commitPendingComponents;
+    commitPendingComponents = await this.idsFromBitMap(true, COMPONENT_ORIGINS.AUTHORED);
+    if (includeImported) {
+      const importedComponents = await this.idsFromBitMap(true, COMPONENT_ORIGINS.IMPORTED);
+      commitPendingComponents = commitPendingComponents.concat(importedComponents);
+    }
+    const commitPendingComponentsIds = commitPendingComponents.map(componentId => BitId.parse(componentId));
+    const commitPendingComponentsLatest = await this.scope.latestVersions(commitPendingComponentsIds);
+    const warnings = [];
+    commitPendingComponentsLatest.forEach((componentId) => {
+      if (semver.gt(componentId.version, version)) {
+        warnings.push(`warning: a component ${componentId.toString()} has a version greater than ${version}`);
+      }
+    });
+    return { commitPendingComponents, warnings };
+  }
+
   /**
    * New and modified components are commit pending
    *


### PR DESCRIPTION
… a specific tag using the newly introduced "—scope" and "—include_imported" flags