### PR TITLE
feature/tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- removed `--include-imported` flags as `--all` can be used for the same functionality
+- `--scope` flag can be used without `--all`
+- message in tag command is now optional
+- tag command now accepts version
+- `--all` and `--scope` accepts version (optional for `--all` and mandatory for `--scope`)
+
 ## [0.11.1-dev.8] - 2017-11-26
 
 - `bit import` - prevent overriding local changes unless --force flag was used 

--- a/e2e/commands/commit.e2e.js
+++ b/e2e/commands/commit.e2e.js
@@ -10,7 +10,7 @@ const assertArrays = require('chai-arrays');
 
 chai.use(assertArrays);
 
-describe.only('bit tag command', function () {
+describe('bit tag command', function () {
   this.timeout(0);
   const helper = new Helper();
   after(() => {

--- a/e2e/commands/commit.e2e.js
+++ b/e2e/commands/commit.e2e.js
@@ -717,11 +717,11 @@ describe.only('bit tag command', function () {
       helper.addComponentBarFoo();
       helper.commitComponentBarFoo();
     });
-    describe.only('without --all flag', () => {
+    describe('without --all flag', () => {
       describe('when current components have lower versions', () => {
         let output;
         before(() => {
-          output = helper.commitAllComponents('msg', '--scope 0.0.5');
+          output = helper.tagScope('0.0.5', 'msg');
         });
         it('should tag authored components with the specified version', () => {
           expect(output).to.have.string('1 components tagged');
@@ -752,10 +752,10 @@ describe.only('bit tag command', function () {
         let output;
         before(() => {
           helper.commitComponent('bar/foo 0.1.5', 'msg', '--force');
-          output = helper.commitAllComponents('msg', '--scope 0.1.4');
+          output = helper.tagScope('0.1.4', 'msg');
         });
         it('should display a warning', () => {
-          expect(output).to.have.string('warning: a component bar/foo@0.1.5 has a version greater than 0.1.4');
+          expect(output).to.have.string('warning: bar/foo@0.1.5 has a version greater than 0.1.4');
         });
         it('should continue tagging the authored components', () => {
           expect(output).to.have.string('1 components tagged');

--- a/e2e/commands/commit.e2e.js
+++ b/e2e/commands/commit.e2e.js
@@ -10,7 +10,7 @@ const assertArrays = require('chai-arrays');
 
 chai.use(assertArrays);
 
-describe('bit tag command', function () {
+describe.only('bit tag command', function () {
   this.timeout(0);
   const helper = new Helper();
   after(() => {
@@ -71,11 +71,11 @@ describe('bit tag command', function () {
       it('Should set the exact version when specified on new component', () => {
         helper.createFile('components', 'exact-new.js');
         helper.addComponent('components/exact-new.js');
-        output = helper.commitComponent('components/exact-new', 'message', '-f --exact_version 5.12.10');
+        output = helper.commitComponent('components/exact-new 5.12.10', 'message', '-f');
         expect(output).to.have.string('components/exact-new@5.12.10');
       });
       it('Should set the exact version when specified on existing component', () => {
-        output = helper.commitComponent('components/exact', 'message', '-f --exact_version 3.3.3');
+        output = helper.commitComponent('components/exact 3.3.3', 'message', '-f');
         expect(output).to.have.string('components/exact@3.3.3');
       });
       it('Should increment patch version of dependent when using other flag on tag dependency', () => {
@@ -90,8 +90,8 @@ describe('bit tag command', function () {
         expect(listOutput).to.deep.include({ id: 'components/dependent', localVersion: '0.0.2' });
       });
       it('Should throw error when the version already exists', () => {
-        helper.commitComponent('components/exact', 'message', '-f --exact_version 5.5.5');
-        const tagWithExisting = () => helper.commitComponent('components/exact', 'message', '-f --exact_version 5.5.5');
+        helper.commitComponent('components/exact 5.5.5', 'message', '-f');
+        const tagWithExisting = () => helper.commitComponent('components/exact 5.5.5', 'message', '-f');
         expect(tagWithExisting).to.throw('the version 5.5.5 already exists for components/exact');
       });
       it('Should print same output for flaged tag and non flaged tag', () => {
@@ -152,23 +152,23 @@ describe('bit tag command', function () {
         helper.createFile('components', 'c.js');
         helper.createFile('components', 'd.js');
         helper.addComponent('components/c.js components/d.js');
-        output = helper.commitAllComponents('message', '-f --exact_version 5.12.10');
+        output = helper.commitAllComponents('message', '-f', '5.12.10');
         expect(output).to.have.string('components/c@5.12.10');
         expect(output).to.have.string('components/d@5.12.10');
       });
       it('Should set the exact version when specified on existing component', () => {
         helper.createFile('components', 'a.js', 'v3.3.3');
         helper.createFile('components', 'b.js', 'v3.3.3');
-        output = helper.commitAllComponents('message', '-f --exact_version 3.3.3');
+        output = helper.commitAllComponents('message', '-f', '3.3.3');
         expect(output).to.have.string('components/a@3.3.3');
         expect(output).to.have.string('components/b@3.3.3');
       });
       it('Should throw error when the version already exists in one of the components', () => {
         helper.createFile('components', 'a.js', 'v4.3.4');
         helper.createFile('components', 'b.js', 'v4.3.4');
-        helper.commitComponent('components/a', 'message', '--exact_version 4.3.4');
+        helper.commitComponent('components/a 4.3.4', 'message');
         helper.createFile('components', 'a.js', 'v4.3.4 sss');
-        const tagWithExisting = () => helper.commitAllComponents('message', '--exact_version 4.3.4');
+        const tagWithExisting = () => helper.commitAllComponents('message', '', '4.3.4');
         expect(tagWithExisting).to.throw('the version 4.3.4 already exists for components/a');
       });
     });
@@ -520,7 +520,7 @@ describe('bit tag command', function () {
         expect(output).to.have.string('src/untracked2.js');
       });
     });
-    describe('commit component with missing dependencies with --ignore_missing_dependencies', () => {
+    describe('commit component with missing dependencies with --ignore-missing-dependencies', () => {
       let output;
       before(() => {
         helper.reInitLocalScope();
@@ -539,7 +539,7 @@ describe('bit tag command', function () {
         helper.addComponentWithOptions('src/a.js src/a2.js', { m: 'src/a.js', i: 'comp/a' });
         helper.addComponent('src/b.js');
 
-        const commitOne = () => helper.commitComponent('comp/a', 'commit-msg', '--ignore_missing_dependencies');
+        const commitOne = () => helper.commitComponent('comp/a', 'commit-msg', '--ignore-missing-dependencies');
         try {
           output = commitOne();
         } catch (err) {
@@ -551,7 +551,7 @@ describe('bit tag command', function () {
         expect(output).to.have.string('1 components tagged');
       });
     });
-    describe('commit all components with missing dependencies with --ignore_missing_dependencies', () => {
+    describe('commit all components with missing dependencies with --ignore-missing-dependencies', () => {
       let output;
       before(() => {
         helper.reInitLocalScope();
@@ -570,7 +570,7 @@ describe('bit tag command', function () {
         helper.addComponentWithOptions('src/a.js src/a2.js', { m: 'src/a.js', i: 'comp/a' });
         helper.addComponent('src/b.js');
 
-        const commitAll = () => helper.commitAllComponents('commit-msg', '--ignore_missing_dependencies');
+        const commitAll = () => helper.commitAllComponents('commit-msg', '--ignore-missing-dependencies');
         try {
           output = commitAll();
         } catch (err) {
@@ -717,11 +717,11 @@ describe('bit tag command', function () {
       helper.addComponentBarFoo();
       helper.commitComponentBarFoo();
     });
-    describe('without --include_imported flag', () => {
+    describe.only('without --all flag', () => {
       describe('when current components have lower versions', () => {
         let output;
         before(() => {
-          output = helper.commitAllComponents('msg', '--scope --exact_version 0.0.5');
+          output = helper.commitAllComponents('msg', '--scope 0.0.5');
         });
         it('should tag authored components with the specified version', () => {
           expect(output).to.have.string('1 components tagged');
@@ -737,9 +737,9 @@ describe('bit tag command', function () {
       describe('when one of the components has the same version', () => {
         let output;
         before(() => {
-          helper.commitComponent('bar/foo', 'msg', '--force --exact_version 0.0.8');
+          helper.commitComponent('bar/foo 0.0.8', 'msg', '--force');
           try {
-            helper.commitAllComponents('msg', '--scope --exact_version 0.0.8');
+            helper.commitAllComponents('msg', '--scope 0.0.8');
           } catch (err) {
             output = err.toString();
           }
@@ -751,8 +751,8 @@ describe('bit tag command', function () {
       describe('when one of the components has a greater version', () => {
         let output;
         before(() => {
-          helper.commitComponent('bar/foo', 'msg', '--force --exact_version 0.1.5');
-          output = helper.commitAllComponents('msg', '--scope --exact_version 0.1.4');
+          helper.commitComponent('bar/foo 0.1.5', 'msg', '--force');
+          output = helper.commitAllComponents('msg', '--scope 0.1.4');
         });
         it('should display a warning', () => {
           expect(output).to.have.string('warning: a component bar/foo@0.1.5 has a version greater than 0.1.4');
@@ -762,11 +762,11 @@ describe('bit tag command', function () {
         });
       });
     });
-    describe('with --include_imported flag', () => {
+    describe('with --all flag', () => {
       describe('when current components have lower versions', () => {
         let output;
         before(() => {
-          output = helper.commitAllComponents('msg', '--scope --include_imported --exact_version 0.2.0');
+          output = helper.commitAllComponents('msg', '--scope 0.2.0 --all');
         });
         it('should tag all components with the specified version including the imported components', () => {
           // this also verifies that the auto-tag feature, doesn't automatically update is-string to its next version

--- a/e2e/commands/move.e2e.js
+++ b/e2e/commands/move.e2e.js
@@ -102,7 +102,9 @@ describe('bit move command', function () {
       }
     });
     it('should throw an error', () => {
-      expect(output).to.have.string('Error');
+      expect(output).to.have.string(
+        'Command failed: bit-dev move bar/non-exist-source.js utils/non-exist-dest.js\nboth paths from (bar/non-exist-source.js) and to (utils/non-exist-dest.js) do not exist\n'
+      );
     });
   });
   describe('when both source and destination files exist', () => {
@@ -125,7 +127,9 @@ describe('bit move command', function () {
       filesAfterMove = helper.getConsumerFiles();
     });
     it('should throw an error', () => {
-      expect(output).to.have.string('Error');
+      expect(output).to.have.string(
+        'Command failed: bit-dev move bar/foo.js utils/foo.js\nunable to move because both paths from (bar/foo.js) and to (utils/foo.js) already exist\n'
+      );
     });
     it('should not physically move any file', () => {
       expect(filesBeforeMove).to.deep.equal(filesAfterMove);

--- a/e2e/commands/move.e2e.js
+++ b/e2e/commands/move.e2e.js
@@ -103,7 +103,7 @@ describe('bit move command', function () {
     });
     it('should throw an error', () => {
       expect(output).to.have.string(
-        'Command failed: bit-dev move bar/non-exist-source.js utils/non-exist-dest.js\nboth paths from (bar/non-exist-source.js) and to (utils/non-exist-dest.js) do not exist\n'
+        `Command failed: ${helper.bitBin} move bar/non-exist-source.js utils/non-exist-dest.js\nboth paths from (bar/non-exist-source.js) and to (utils/non-exist-dest.js) do not exist\n`
       );
     });
   });
@@ -128,7 +128,7 @@ describe('bit move command', function () {
     });
     it('should throw an error', () => {
       expect(output).to.have.string(
-        'Command failed: bit-dev move bar/foo.js utils/foo.js\nunable to move because both paths from (bar/foo.js) and to (utils/foo.js) already exist\n'
+        `Command failed: ${helper.bitBin} move bar/foo.js utils/foo.js\nunable to move because both paths from (bar/foo.js) and to (utils/foo.js) already exist\n`
       );
     });
     it('should not physically move any file', () => {

--- a/e2e/e2e-helper.js
+++ b/e2e/e2e-helper.js
@@ -183,8 +183,8 @@ export default class Helper {
   deprecateComponent(id: string, flags: string = '') {
     return this.runCmd(`bit deprecate ${id} ${flags}`);
   }
-  commitAllComponents(commitMsg: string = 'commit-message', options: string = '') {
-    return this.runCmd(`bit tag ${options} -am ${commitMsg} `);
+  commitAllComponents(commitMsg: string = 'commit-message', options: string = '', version: string = '') {
+    return this.runCmd(`bit tag ${options} -a ${version} -m ${commitMsg} `);
   }
 
   exportComponent(id: string, scope: string = this.remoteScope) {

--- a/e2e/e2e-helper.js
+++ b/e2e/e2e-helper.js
@@ -183,8 +183,13 @@ export default class Helper {
   deprecateComponent(id: string, flags: string = '') {
     return this.runCmd(`bit deprecate ${id} ${flags}`);
   }
+
   commitAllComponents(commitMsg: string = 'commit-message', options: string = '', version: string = '') {
     return this.runCmd(`bit tag ${options} -a ${version} -m ${commitMsg} `);
+  }
+
+  tagScope(version: string, message: string = 'commit-message', options: string = '') {
+    return this.runCmd(`bit tag -s ${version} -m ${message} ${options}`);
   }
 
   exportComponent(id: string, scope: string = this.remoteScope) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-bin",
-  "version": "0.11.1-dev.5",
+  "version": "0.11.1-dev.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1171,9 +1171,9 @@
       "integrity": "sha1-muuabF6IY4qtFx4Wf1kAq+JINdA="
     },
     "bit-javascript": {
-      "version": "0.10.7-dev.5",
-      "resolved": "https://registry.npmjs.org/bit-javascript/-/bit-javascript-0.10.7-dev.5.tgz",
-      "integrity": "sha1-+7UarhXCcKAf6OCkSGJGfk866pg=",
+      "version": "0.10.7-dev.6",
+      "resolved": "https://registry.npmjs.org/bit-javascript/-/bit-javascript-0.10.7-dev.6.tgz",
+      "integrity": "sha512-/sPNK+eo7TFs1CAfPljHWOUaSI8hJRpM6Lo8dScx4WsjYqDXr6yLIxAS0DFvob6Mh3CN9XaaxChkj/PkP3h8Ig==",
       "requires": {
         "camelcase": "4.1.0",
         "caporal": "0.5.0",
@@ -1188,14 +1188,6 @@
         "regenerator-runtime": "0.10.5"
       },
       "dependencies": {
-        "babylon": {
-          "version": "6.8.4",
-          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
-          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
-          "requires": {
-            "babel-runtime": "6.26.0"
-          }
-        },
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1208,92 +1200,6 @@
             "supports-color": "2.0.0"
           }
         },
-        "dependency-tree": {
-          "version": "github:teambit/node-dependency-tree#7aef1bb39c7b06eb1f030ee8d7b3fb0978c2145d",
-          "requires": {
-            "commander": "2.11.0",
-            "debug": "2.6.9",
-            "filing-cabinet": "github:teambit/node-filing-cabinet#dade8d2a7c06e49779a0d62634affda08a2fd6ab",
-            "precinct": "github:teambit/node-precinct#07b053904b7f29c75d7a17145d0ce75816d119dc"
-          }
-        },
-        "detective-es6": {
-          "version": "github:teambit/node-detective-es6#3b60150d7704eff70b4f3a32796043a186651ae0",
-          "requires": {
-            "node-source-walk": "3.3.0"
-          }
-        },
-        "detective-stylable": {
-          "version": "github:teambit/detective-stylable#5afbdba6660ff32e3658a4667657d08e9d3ad110",
-          "requires": {
-            "stylable": "4.0.26"
-          }
-        },
-        "detective-typescript": {
-          "version": "github:teambit/detective-typescript#70ee911e694bb502700d18c649f4a13f618ff04e",
-          "requires": {
-            "node-source-walk": "3.2.0",
-            "typescript": "2.6.1",
-            "typescript-eslint-parser": "9.0.0"
-          },
-          "dependencies": {
-            "node-source-walk": {
-              "version": "3.2.0",
-              "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
-              "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
-              "requires": {
-                "babylon": "6.8.4"
-              }
-            }
-          }
-        },
-        "filing-cabinet": {
-          "version": "github:teambit/node-filing-cabinet#dade8d2a7c06e49779a0d62634affda08a2fd6ab",
-          "requires": {
-            "app-module-path": "1.1.0",
-            "commander": "2.11.0",
-            "debug": "2.6.9",
-            "enhanced-resolve": "3.0.3",
-            "is-relative-path": "1.0.2",
-            "module-definition": "2.2.4",
-            "module-lookup-amd": "4.0.5",
-            "object-assign": "4.1.1",
-            "resolve": "1.5.0",
-            "resolve-dependency-path": "1.0.2",
-            "sass-lookup": "1.1.0",
-            "stylus-lookup": "1.0.2",
-            "typescript": "2.6.1"
-          }
-        },
-        "precinct": {
-          "version": "github:teambit/node-precinct#07b053904b7f29c75d7a17145d0ce75816d119dc",
-          "requires": {
-            "commander": "2.11.0",
-            "debug": "3.1.0",
-            "detective-amd": "2.4.0",
-            "detective-cjs": "2.0.0",
-            "detective-es6": "github:teambit/node-detective-es6#3b60150d7704eff70b4f3a32796043a186651ae0",
-            "detective-less": "1.0.0",
-            "detective-sass": "2.0.1",
-            "detective-scss": "1.0.1",
-            "detective-stylable": "github:teambit/detective-stylable#5afbdba6660ff32e3658a4667657d08e9d3ad110",
-            "detective-stylus": "1.0.0",
-            "detective-typescript": "github:teambit/detective-typescript#70ee911e694bb502700d18c649f4a13f618ff04e",
-            "module-definition": "2.2.4",
-            "node-source-walk": "3.3.0"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-              "integrity":
-                "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-              "requires": {
-                "ms": "2.0.0"
-              }
-            }
-          }
-        },
         "ramda": {
           "version": "0.22.1",
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.22.1.tgz",
@@ -1303,16 +1209,6 @@
           "version": "0.10.5",
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
           "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        },
-        "typescript-eslint-parser": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.0.tgz",
-          "integrity":
-            "sha512-A81zCm5N8DVwkIOycAGTZTMrd3sthpyxCVpaA4+XiK1gG/G8xKLPKwDnlxciurNUOc7Z85ji9VvIi8g+ihRjEw==",
-          "requires": {
-            "lodash.unescape": "4.0.1",
-            "semver": "5.4.1"
-          }
         }
       }
     },
@@ -2011,6 +1907,15 @@
       "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM=",
       "dev": true
     },
+    "dependency-tree": {
+      "version": "github:teambit/node-dependency-tree#7aef1bb39c7b06eb1f030ee8d7b3fb0978c2145d",
+      "requires": {
+        "commander": "2.11.0",
+        "debug": "2.6.9",
+        "filing-cabinet": "github:teambit/node-filing-cabinet#dade8d2a7c06e49779a0d62634affda08a2fd6ab",
+        "precinct": "github:teambit/node-precinct#07b053904b7f29c75d7a17145d0ce75816d119dc"
+      }
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -2037,6 +1942,12 @@
       "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
       "requires": {
         "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
+      }
+    },
+    "detective-es6": {
+      "version": "github:teambit/node-detective-es6#3b60150d7704eff70b4f3a32796043a186651ae0",
+      "requires": {
         "node-source-walk": "3.3.0"
       }
     },
@@ -2107,10 +2018,52 @@
         }
       }
     },
+    "detective-stylable": {
+      "version": "github:teambit/detective-stylable#5afbdba6660ff32e3658a4667657d08e9d3ad110",
+      "requires": {
+        "stylable": "4.0.26"
+      }
+    },
     "detective-stylus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
       "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0="
+    },
+    "detective-typescript": {
+      "version": "github:teambit/detective-typescript#70ee911e694bb502700d18c649f4a13f618ff04e",
+      "requires": {
+        "node-source-walk": "3.2.0",
+        "typescript": "2.6.1",
+        "typescript-eslint-parser": "9.0.0"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "requires": {
+            "babel-runtime": "6.26.0"
+          }
+        },
+        "node-source-walk": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
+          "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
+          "requires": {
+            "babylon": "6.8.4"
+          }
+        },
+        "typescript-eslint-parser": {
+          "version": "9.0.0",
+          "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-9.0.0.tgz",
+          "integrity":
+            "sha512-A81zCm5N8DVwkIOycAGTZTMrd3sthpyxCVpaA4+XiK1gG/G8xKLPKwDnlxciurNUOc7Z85ji9VvIi8g+ihRjEw==",
+          "requires": {
+            "lodash.unescape": "4.0.1",
+            "semver": "5.4.1"
+          }
+        }
+      }
     },
     "diff": {
       "version": "3.2.0",
@@ -2814,6 +2767,24 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
       "integrity": "sha1-wcS5vuPglyXdsQa3XB4wH+LxiyY="
+    },
+    "filing-cabinet": {
+      "version": "github:teambit/node-filing-cabinet#dade8d2a7c06e49779a0d62634affda08a2fd6ab",
+      "requires": {
+        "app-module-path": "1.1.0",
+        "commander": "2.11.0",
+        "debug": "2.6.9",
+        "enhanced-resolve": "3.0.3",
+        "is-relative-path": "1.0.2",
+        "module-definition": "2.2.4",
+        "module-lookup-amd": "4.0.5",
+        "object-assign": "4.1.1",
+        "resolve": "1.5.0",
+        "resolve-dependency-path": "1.0.2",
+        "sass-lookup": "1.1.0",
+        "stylus-lookup": "1.0.2",
+        "typescript": "2.6.1"
+      }
     },
     "fill-range": {
       "version": "2.2.3",
@@ -5386,6 +5357,11 @@
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
       "dev": true
     },
+    "lodash.assignwith": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assignwith/-/lodash.assignwith-4.2.0.tgz",
+      "integrity": "sha1-EnqX8CrcQXUalU0ksN4X4QDgOOs="
+    },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6886,6 +6862,35 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz",
       "integrity": "sha1-h/OPnxj3dKSrTIojL1xc6IcqnRU="
+    },
+    "precinct": {
+      "version": "github:teambit/node-precinct#07b053904b7f29c75d7a17145d0ce75816d119dc",
+      "requires": {
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "detective-amd": "2.4.0",
+        "detective-cjs": "2.0.0",
+        "detective-es6": "github:teambit/node-detective-es6#3b60150d7704eff70b4f3a32796043a186651ae0",
+        "detective-less": "1.0.0",
+        "detective-sass": "2.0.1",
+        "detective-scss": "1.0.1",
+        "detective-stylable": "github:teambit/detective-stylable#5afbdba6660ff32e3658a4667657d08e9d3ad110",
+        "detective-stylus": "1.0.0",
+        "detective-typescript": "github:teambit/detective-typescript#70ee911e694bb502700d18c649f4a13f618ff04e",
+        "module-definition": "2.2.4",
+        "node-source-walk": "3.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity":
+            "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",

--- a/src/cli/command-registrar.js
+++ b/src/cli/command-registrar.js
@@ -5,7 +5,7 @@ import chalk from 'chalk';
 import type Command from './command';
 import { migrate } from '../api/consumer';
 import defaultHandleError from './default-error-handler';
-import { empty, first, isNumeric, buildCommandMessage, packCommand } from '../utils';
+import { empty, camelCase, first, isNumeric, buildCommandMessage, packCommand } from '../utils';
 import loader from './loader';
 import logger from '../logger/logger';
 
@@ -24,7 +24,7 @@ function parseSubcommandFromArgs(args: [any]) {
   return null;
 }
 
-function parseCommandName(commandName: string) {
+function parseCommandName(commandName: string): string {
   if (!commandName) return '';
   return first(commandName.split(' '));
 }
@@ -33,7 +33,7 @@ function getOpts(c, opts: [[string, string, string]]): { [string]: boolean | str
   const options = {};
 
   opts.forEach(([, name]) => {
-    name = parseCommandName(name);
+    name = camelCase(parseCommandName(name));
     options[name] = c[name];
   });
 

--- a/src/cli/commands/public-cmds/commit-cmd.js
+++ b/src/cli/commands/public-cmds/commit-cmd.js
@@ -28,14 +28,13 @@ export default class Export extends Command {
   migration = true;
 
   action(
-    [id]: string[],
+    [id, version]: string[],
     {
       message,
       all,
       patch,
       minor,
       major,
-      version,
       force,
       verbose,
       ignoreMissingDependencies = false,
@@ -47,7 +46,6 @@ export default class Export extends Command {
       minor: ?boolean,
       major: ?boolean,
       force: ?boolean,
-      version: ?string,
       verbose: ?boolean,
       ignoreMissingDependencies: ?boolean,
       scope: ?boolean

--- a/src/cli/commands/public-cmds/commit-cmd.js
+++ b/src/cli/commands/public-cmds/commit-cmd.js
@@ -38,7 +38,7 @@ export default class Export extends Command {
       force,
       verbose,
       ignoreMissingDependencies = false,
-      scope = false
+      scope = null
     }: {
       message: string,
       all: ?boolean,
@@ -48,16 +48,16 @@ export default class Export extends Command {
       force: ?boolean,
       verbose: ?boolean,
       ignoreMissingDependencies: ?boolean,
-      scope: ?boolean
+      scope: ?string
     }
   ): Promise<any> {
     function getVersion() {
-      if (all && isString(all)) return all;
       if (scope) return scope;
+      if (all && isString(all)) return all;
       return version;
     }
 
-    if (!id && !all) {
+    if (!id && !all && !scope) {
       return Promise.reject('missing [id]. to tag all components, please use --all flag');
     }
     if (id && all) {
@@ -79,7 +79,7 @@ export default class Export extends Command {
     else if (minor) releaseType = 'minor';
     else if (patch) releaseType = 'patch';
 
-    if (all) {
+    if (all || scope) {
       return commitAllAction({
         message: message || '',
         exactVersion: getVersion(),
@@ -132,7 +132,6 @@ export default class Export extends Command {
       if (comps.length !== 0) {
         let str = '';
         if (breakBefore) str = '\n';
-        console.log('');
         str += `${chalk.cyan(label)} ${joinComponents(comps)}`;
         return str;
       }
@@ -155,9 +154,9 @@ export default class Export extends Command {
       warningsOutput +
       chalk.green(`${components.length + autoUpdatedCount} components tagged`) +
       chalk.gray(
-        ` | ${addedComponents.length} added, ${changedComponents.length} changed, ${autoUpdatedCount} auto-tagged\n`
+        ` | ${addedComponents.length} added, ${changedComponents.length} changed, ${autoUpdatedCount} auto-tagged`
       ) +
-      outputIfExists(addedComponents, 'added components: ') +
+      outputIfExists(addedComponents, 'added components: ', true) +
       outputIfExists(changedComponents, 'changed components: ', true) +
       outputIfExists(
         autoUpdatedComponents,

--- a/src/cli/commands/public-cmds/commit-cmd.js
+++ b/src/cli/commands/public-cmds/commit-cmd.js
@@ -3,27 +3,26 @@ import semver from 'semver';
 import Command from '../../command';
 import { commitAction, commitAllAction } from '../../../api/consumer';
 import Component from '../../../consumer/component';
+import { isString } from '../../../utils';
 import ModelComponent from '../../../scope/models/component';
 import { DEFAULT_BIT_VERSION, DEFAULT_BIT_RELEASE_TYPE } from '../../../constants';
 
 const chalk = require('chalk');
 
 export default class Export extends Command {
-  name = 'tag [id]';
+  name = 'tag [id] [version]';
   description = 'record component changes and lock versions.';
   alias = 't';
   opts = [
-    ['m', 'message <message>', 'message'],
-    ['a', 'all', 'tag all new and modified components'],
-    ['', 'exact_version <exact_version>', 'exact version to tag'],
-    ['', 'patch', 'increment the patch version number'],
-    ['', 'minor', 'increment the minor version number'],
-    ['', 'major', 'increment the major version number'],
+    ['m', 'message <message>', 'log message describing the user changes'],
+    ['a', 'all [version]', 'tag all new and modified components'],
+    ['s', 'scope <version>', 'tag all components of the current scope'],
+    ['p', 'patch', 'increment the patch version number'],
+    ['mi', 'minor', 'increment the minor version number'],
+    ['ma', 'major', 'increment the major version number'],
     ['f', 'force', 'forcely tag even if tests are failing and even when component has not changed'],
     ['v', 'verbose', 'show specs output on tag'],
-    ['', 'ignore_missing_dependencies', 'ignore missing dependencies (default = false)'],
-    ['s', 'scope', 'tag all components of the current scope'],
-    ['', 'include_imported', 'when "scope" flag is used, tag also imported components']
+    ['i', 'ignore-missing-dependencies', 'ignore missing dependencies (default = false)']
   ];
   loader = true;
   migration = true;
@@ -33,29 +32,33 @@ export default class Export extends Command {
     {
       message,
       all,
-      exact_version,
       patch,
       minor,
       major,
+      version,
       force,
       verbose,
-      ignore_missing_dependencies = false,
-      scope = false,
-      include_imported = false
+      ignoreMissingDependencies = false,
+      scope = false
     }: {
       message: string,
       all: ?boolean,
-      exact_version: ?string,
       patch: ?boolean,
       minor: ?boolean,
       major: ?boolean,
       force: ?boolean,
+      version: ?string,
       verbose: ?boolean,
-      ignore_missing_dependencies: ?boolean,
-      scope: ?boolean,
-      include_imported: ?boolean
+      ignoreMissingDependencies: ?boolean,
+      scope: ?boolean
     }
   ): Promise<any> {
+    function getVersion() {
+      if (all && isString(all)) return all;
+      if (scope) return scope;
+      return version;
+    }
+
     if (!id && !all) {
       return Promise.reject('missing [id]. to tag all components, please use --all flag');
     }
@@ -63,14 +66,6 @@ export default class Export extends Command {
       return Promise.reject(
         'you can use either a specific component [id] to tag a particular component or --all flag to tag them all'
       );
-    }
-    if (scope && !exact_version) {
-      return Promise.reject(
-        'tagging the entire scope (--scope), requires specifying an exact-version (--exact-version)'
-      );
-    }
-    if (include_imported && !scope) {
-      return Promise.reject("--include_imported flag can't be in use without --scope flag");
     }
 
     const releaseFlags = [patch, minor, major].filter(x => x);
@@ -80,34 +75,32 @@ export default class Export extends Command {
 
     // const releaseType = major ? 'major' : (minor ? 'minor' : (patch ? 'patch' : DEFAULT_BIT_RELEASE_TYPE));
     let releaseType = DEFAULT_BIT_RELEASE_TYPE;
+    const includeImported = scope && all;
+
     if (major) releaseType = 'major';
     else if (minor) releaseType = 'minor';
     else if (patch) releaseType = 'patch';
 
-    if (!message) {
-      // todo: get rid of this. Make it required by commander
-      return Promise.reject('missing [message], please use -m to write the log message');
-    }
     if (all) {
       return commitAllAction({
-        message,
-        exactVersion: exact_version,
+        message: message || '',
+        exactVersion: getVersion(),
         releaseType,
         force,
         verbose,
-        ignoreMissingDependencies: ignore_missing_dependencies,
+        ignoreMissingDependencies,
         scope,
-        includeImported: include_imported
+        includeImported
       });
     }
     return commitAction({
       id,
       message,
-      exactVersion: exact_version,
+      exactVersion: getVersion(),
       releaseType,
       force,
       verbose,
-      ignoreMissingDependencies: ignore_missing_dependencies
+      ignoreMissingDependencies
     });
   }
 

--- a/src/cli/default-error-handler.js
+++ b/src/cli/default-error-handler.js
@@ -155,7 +155,7 @@ Run \`bit status\` command to list all components available for tag.`
 ];
 
 function formatUnhandled(err: Error): string {
-  return chalk.red(err.message);
+  return chalk.red(err.message || err);
 }
 
 export default (err: Error): ?string => {

--- a/src/cli/default-error-handler.js
+++ b/src/cli/default-error-handler.js
@@ -154,12 +154,16 @@ Run \`bit status\` command to list all components available for tag.`
   [AuthenticationFailed, err => 'authentication failed']
 ];
 
+function formatUnhandled(err: Error): string {
+  return chalk.red(err.message);
+}
+
 export default (err: Error): ?string => {
   const error = errorsMap.find(([ErrorType]) => {
     return err instanceof ErrorType;
   });
 
-  if (!error) return null;
+  if (!error) return formatUnhandled(err);
   const [, func] = error;
   logger.error(`User gets the following error: ${func(err)}`);
   return chalk.red(func(err));

--- a/src/consumer/component/components-list.js
+++ b/src/consumer/component/components-list.js
@@ -190,7 +190,7 @@ export default class ComponentsList {
     const warnings = [];
     commitPendingComponentsLatest.forEach((componentId) => {
       if (semver.gt(componentId.version, version)) {
-        warnings.push(`warning: a component ${componentId.toString()} has a version greater than ${version}`);
+        warnings.push(`warning: ${componentId.toString()} has a version greater than ${version}`);
       }
     });
     return { commitPendingComponents, warnings };

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -70,6 +70,7 @@ import searchFilesIgnoreExt from './fs/search-files-ignore-ext';
 import { pathNormalizeToLinux, pathJoinLinux, pathRelative, pathResolve, pathJoinOs } from './path';
 import getMissingTestFiles from './getMissingTestFiles';
 import identityFile from './ssh/identity-file';
+import camelCase from './string/camel-case';
 
 export {
   identityFile,
@@ -134,6 +135,7 @@ export {
   buildCommandMessage,
   removeFromRequireCache,
   outputFile,
+  camelCase,
   bufferFrom,
   getLatestVersionNumber,
   calculateFileInfo,

--- a/src/utils/string/camel-case.js
+++ b/src/utils/string/camel-case.js
@@ -1,0 +1,4 @@
+// @flow
+export default function camelCase(str: string): string {
+  return str.replace(/-([a-z])/g, g => g[1].toUpperCase());
+}


### PR DESCRIPTION
- removed redundant line break in tag output
- fixed issue with dashes in cli flags (now it's supported well)
- removed --include-imported flags as --all can be used for the same functionality 
- --scope flag can be used without --all
- message in `tag` command is now optional
- `tag` command now accepts version
- --all and --scope accepts version (optional for --all and mandatory for --scope)
