### PR TITLE
prevent using dot charachter (.) as part of the bit id because it bei…

### DIFF
--- a/e2e/commands/add.e2e.js
+++ b/e2e/commands/add.e2e.js
@@ -326,9 +326,7 @@ describe('bit add command', function () {
         errorMessage = err.message;
       }
 
-      expect(errorMessage).to.have.string(
-        'invalid id part in "Bar/Foo", id part can have only alphanumeric, lowercase characters, and the following ["-", "_", "$", "!", "."]'
-      );
+      expect(errorMessage).to.have.string('invalid id part in "Bar/Foo"');
     });
     it('Should add component with global namespace if used parcial ID', () => {
       helper.createComponent('bar', 'foo.js');

--- a/src/bit-id/bit-id.js
+++ b/src/bit-id/bit-id.js
@@ -106,7 +106,7 @@ export default class BitId {
 
     if (idSplit.length === 2) {
       const [box, name] = idSplit;
-      if (!isValidIdChunk(name) || !isValidScopeName(box)) {
+      if (!isValidIdChunk(name) || !isValidIdChunk(box)) {
         // $FlowFixMe
         throw new InvalidIdChunk(`${box}/${name}`);
       }
@@ -135,9 +135,14 @@ export default class BitId {
   }
 
   static getValidBitId(box: string, name: string): BitId {
-    if (!isValidIdChunk(name)) name = decamelize(name, '-');
-    if (!isValidIdChunk(box)) box = decamelize(box, '-');
+    const getValidIdChunk = (chunk) => {
+      if (!isValidIdChunk(chunk)) {
+        chunk = chunk.replace(/\./g, '');
+        chunk = decamelize(chunk, '-');
+      }
+      return chunk;
+    };
 
-    return new BitId({ name, box });
+    return new BitId({ name: getValidIdChunk(name), box: getValidIdChunk(box) });
   }
 }

--- a/src/cli/default-error-handler.js
+++ b/src/cli/default-error-handler.js
@@ -119,7 +119,7 @@ const errorsMap: [[Error, (err: Error) => string]] = [
     err =>
       `invalid id part in "${chalk.bold(
         err.id
-      )}", id part can have only alphanumeric, lowercase characters, and the following ["-", "_", "$", "!", "."]`
+      )}", id part can have only alphanumeric, lowercase characters, and the following ["-", "_", "$", "!"]`
   ],
   [InvalidBitJson, err => `error: invalid bit.json: ${chalk.bold(err.path)} is not a valid JSON file.`],
 

--- a/src/scope/scope-json.js
+++ b/src/scope/scope-json.js
@@ -39,7 +39,7 @@ export class ScopeJson {
     const cleanName = suggestedName
       .split('')
       .map((char) => {
-        if (/^[$\-_!.a-z0-9]+$/.test(char)) return char;
+        if (/^[$\-_!a-z0-9]+$/.test(char)) return char;
         return '';
       })
       .join('');

--- a/src/utils/is-valid-id-chunk.js
+++ b/src/utils/is-valid-id-chunk.js
@@ -1,6 +1,6 @@
 import isString from './string/is-string';
 
-const validationRegExp = /^[$\-_!.a-z0-9]+$/;
+const validationRegExp = /^[$\-_!a-z0-9]+$/;
 
 /** @flow */
 export default function isValidIdChunk(val: any): boolean {

--- a/src/utils/is-valid-scope-name.js
+++ b/src/utils/is-valid-scope-name.js
@@ -1,6 +1,7 @@
 import isString from './string/is-string';
 
-const validationRegExp = /^@?[$\-_!.a-z0-9]+$/;
+// the '.' can be in the middle, not at the beginning and not at the end and only once.
+const validationRegExp = /^[$\-_!a-z0-9]+[.]?[$\-_!a-z0-9]+$/;
 
 /** @flow */
 export default function isValidScopeName(val: any): boolean {


### PR DESCRIPTION
…ng used as a separator when generating an npm package name