### PR TITLE
resolve #504, move `save-dependencies-as-components` flag from `bit i…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- move `save-dependencies-as-components` flag from `bit import` command to be configurable in consumer bit.json
+
 ## [0.12.0-ext.10] - 2017-12-27
 
 - add unsafe-perm for installing packages inside components

--- a/e2e/flows/import-from-bit-hub.e2e.js
+++ b/e2e/flows/import-from-bit-hub.e2e.js
@@ -16,7 +16,7 @@ describe('importing bit components from bitsrc.io', function () {
   after(() => {
     helper.destroyEnv();
   });
-  describe('without --save-dependencies-as-components flag', () => {
+  describe('when saveDependenciesAsComponents is the default (FALSE) in consumer bit.json', () => {
     before(() => {
       helper.reInitLocalScope();
       helper.runCmd(`bit import ${componentTestId}`);
@@ -51,10 +51,11 @@ describe('importing bit components from bitsrc.io', function () {
       expect(output.includes('bar/foo')).to.be.false;
     });
   });
-  describe('with --save-dependencies-as-components flag', () => {
+  describe('when saveDependenciesAsComponents is set to TRUE in consumer bit.json', () => {
     before(() => {
       helper.reInitLocalScope();
-      helper.runCmd(`bit import ${componentTestId} --save-dependencies-as-components`);
+      helper.modifyFieldInBitJson('saveDependenciesAsComponents', true);
+      helper.runCmd(`bit import ${componentTestId}`);
     });
     it('should save the dependencies as bit components inside the component directory', () => {
       expect(path.join(helper.localScopePath, 'components', '.dependencies')).to.be.a.path();

--- a/src/api/consumer/lib/import.js
+++ b/src/api/consumer/lib/import.js
@@ -27,7 +27,6 @@ export default (async function importAction({
   conf,
   installNpmPackages,
   withPackageJson,
-  saveDependenciesAsComponents,
   writeBitDependencies = false
 }: {
   ids: string,
@@ -42,19 +41,8 @@ export default (async function importAction({
   conf: boolean,
   installNpmPackages: boolean,
   withPackageJson: ?boolean,
-  saveDependenciesAsComponents: ?boolean,
   writeBitDependencies: ?boolean
 }): Promise<any> {
-  if (!withPackageJson) {
-    // if package.json is not written, it's impossible to install the packages and dependencies as npm packages
-    installNpmPackages = false;
-    saveDependenciesAsComponents = true;
-  }
-  if (!installNpmPackages) {
-    // if npm packages are not installed, don't install dependencies as npm packages
-    saveDependenciesAsComponents = true;
-  }
-
   async function importEnvironment(consumer: Consumer): Promise<any> {
     loader.start(BEFORE_IMPORT_ENVIRONMENT);
 
@@ -112,8 +100,7 @@ export default (async function importAction({
     force,
     dist,
     conf,
-    installNpmPackages,
-    saveDependenciesAsComponents
+    installNpmPackages
   );
   const bitIds = dependencies.map(R.path(['component', 'id']));
   const bitMap = await consumer.getBitMap();

--- a/src/cli/commands/public-cmds/import-cmd.js
+++ b/src/cli/commands/public-cmds/import-cmd.js
@@ -23,7 +23,6 @@ export default class Import extends Command {
     ['v', 'verbose', 'showing verbose output for inspection'],
     ['', 'dist', 'write dist files (when exist) to the configured directory'],
     ['', 'conf', 'write the configuration file (bit.json)'],
-    ['', 'save-dependencies-as-components', 'save hub dependencies as bit components rather than npm packages'],
     [
       '',
       'skip-npm-install',
@@ -52,7 +51,6 @@ export default class Import extends Command {
       dist = false,
       conf = false,
       skipNpmInstall = false,
-      saveDependenciesAsComponents = false,
       ignorePackageJson = false
     }: {
       tester?: boolean,
@@ -66,7 +64,6 @@ export default class Import extends Command {
       dist?: boolean,
       conf?: boolean,
       skipNpmInstall?: boolean,
-      saveDependenciesAsComponents?: boolean,
       ignorePackageJson?: boolean
     }
   ): Promise<any> {
@@ -86,8 +83,7 @@ export default class Import extends Command {
       dist,
       conf,
       installNpmPackages: !skipNpmInstall,
-      withPackageJson: !ignorePackageJson,
-      saveDependenciesAsComponents
+      withPackageJson: !ignorePackageJson
     }).then(importResults => R.assoc('displayDependencies', displayDependencies, importResults));
   }
 

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -411,10 +411,19 @@ export default class Consumer {
     force?: boolean = false,
     dist?: boolean = false,
     conf?: boolean = false,
-    installNpmPackages?: boolean = true,
-    saveDependenciesAsComponents?: boolean = false
+    installNpmPackages?: boolean = true
   ): Promise<{ dependencies: ComponentWithDependencies[], envDependencies?: Component[] }> {
     loader.start(BEFORE_IMPORT_ACTION);
+    let saveDependenciesAsComponents = this.bitJson.saveDependenciesAsComponents;
+    if (!withPackageJson) {
+      // if package.json is not written, it's impossible to install the packages and dependencies as npm packages
+      installNpmPackages = false;
+      saveDependenciesAsComponents = true;
+    }
+    if (!installNpmPackages) {
+      // if npm packages are not installed, don't install dependencies as npm packages
+      saveDependenciesAsComponents = true;
+    }
     if (!rawIds || R.isEmpty(rawIds)) {
       return this.importAccordingToBitJsonAndBitMap(
         verbose,


### PR DESCRIPTION
…mport` command to be configurable in consumer bit.json