### PR TITLE
bug fix - when using bit tag --scope and the components has already a…

### DIFF
--- a/src/scope/scope.js
+++ b/src/scope/scope.js
@@ -298,7 +298,10 @@ export default class Scope {
         if (flattenedDependencies) return Promise.resolve(flattenedDependencies);
 
         // Calculate the flatten dependencies
-        if (sortedConsumerComponentsIds.includes(dependency.id.toStringWithoutVersion())) {
+        if (
+          sortedConsumerComponentsIds.includes(dependency.id.toStringWithoutVersion()) ||
+          sortedConsumerComponentsIds.includes(dependency.id.toString())
+        ) {
           // when a dependency includes in the components list to tag, don't use the existing version, because the
           // existing version will be obsolete once it's tagged. Instead, remove the version, and later on, when
           // importDependencies is called, it'll fetch the newly tagged version.


### PR DESCRIPTION
…n exact version, it does not save the tagged dependencies with the new version