### PR TITLE
in case of a merge-conflict (discrepancies of hashes of same versions…

### DIFF
--- a/src/scope/repositories/sources.js
+++ b/src/scope/repositories/sources.js
@@ -302,14 +302,15 @@ export default class SourceRepository {
    *
    * When this function get called originally from import command, the 'force' parameter is true. Otherwise, if it was
    * originated from export command, it'll be false.
-   * If the 'force' is true, it doesn't check for discrepancies, but simply override the existing component.
+   * If the 'force' is true and the existing component wasn't changed locally (existingComponent.local if false), it
+   * doesn't check for discrepancies, but simply override the existing component.
    * When using import command, it makes sense to override a component in case of discrepancies because the source of
-   * true should be the remote scope from where the import fetch the component.
+   * true should be the remote scope from where the import fetches the component.
    */
   merge({ component, objects }: ComponentTree, inScope: boolean = false, force: boolean = true): Promise<Component> {
     if (inScope) component.scope = this.scope.name;
-    return this.findComponent(component).then((existingComponent) => {
-      if (!existingComponent || force || component.compatibleWith(existingComponent)) {
+    return this.findComponent(component).then((existingComponent: ?Component) => {
+      if (!existingComponent || (force && !existingComponent.local) || component.compatibleWith(existingComponent)) {
         return this.put({ component, objects });
       }
 

--- a/src/scope/repositories/sources.js
+++ b/src/scope/repositories/sources.js
@@ -299,11 +299,17 @@ export default class SourceRepository {
 
   /**
    * Adds the objects into scope.object array, in-memory. It doesn't save anything to the file-system.
+   *
+   * When this function get called originally from import command, the 'force' parameter is true. Otherwise, if it was
+   * originated from export command, it'll be false.
+   * If the 'force' is true, it doesn't check for discrepancies, but simply override the existing component.
+   * When using import command, it makes sense to override a component in case of discrepancies because the source of
+   * true should be the remote scope from where the import fetch the component.
    */
-  merge({ component, objects }: ComponentTree, inScope: boolean = false): Promise<Component> {
+  merge({ component, objects }: ComponentTree, inScope: boolean = false, force: boolean = true): Promise<Component> {
     if (inScope) component.scope = this.scope.name;
     return this.findComponent(component).then((existingComponent) => {
-      if (!existingComponent || component.compatibleWith(existingComponent)) {
+      if (!existingComponent || force || component.compatibleWith(existingComponent)) {
         return this.put({ component, objects });
       }
 

--- a/src/scope/scope.js
+++ b/src/scope/scope.js
@@ -491,7 +491,7 @@ export default class Scope {
   async exportManyBareScope(componentsObjects: ComponentObjects[]): Promise<string[]> {
     logger.debug(`exportManyBareScope: Going to save ${componentsObjects.length} components`);
     const manyObjects = componentsObjects.map(componentObjects => componentObjects.toObjects(this.objects));
-    await Promise.all(manyObjects.map(objects => this.sources.merge(objects, true)));
+    await Promise.all(manyObjects.map(objects => this.sources.merge(objects, true, false)));
     const manyCompVersions = await Promise.all(
       manyObjects.map(objects => objects.component.toComponentVersion(LATEST))
     );


### PR DESCRIPTION
…) during import, override the current component by the imported one