### PR TITLE
fix `bit tag` with `--force` flag to force tagging when exceptions occurred…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix `bit tag` with `--force` flag to force tagging when exceptions occurred during test
+- fix `bit test` error message to display the actual exception if occurred
+- improve error message of `bit tag --verbose` when tests failed to include tests results
+
 ## [0.12.8-dev.3] - 2018-03-08
 
 - merge process.env from the main process to tester process fork
@@ -15,7 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - bug fix - tests files were ignored during bit add when they're weren't part of the files array and .gitignore contained a record with leading exclamation mark
 - improve handling of errors from compilers which return promises
-- symlink tester env in isolated envs 
+- symlink tester env in isolated envs
 
 ## [0.12.8-dev.1] - 2018-03-05
 

--- a/src/api/consumer/lib/test.js
+++ b/src/api/consumer/lib/test.js
@@ -22,5 +22,5 @@ export default (async function test(id?: string, verbose: ?boolean): Promise<Bit
   };
   const components = await getComponents();
 
-  return consumer.scope.testMultiple(components, consumer, verbose);
+  return consumer.scope.testMultiple({ components, consumer, verbose });
 });

--- a/src/api/scope/lib/test-in-scope.js
+++ b/src/api/scope/lib/test-in-scope.js
@@ -8,7 +8,7 @@ import logger from '../../../logger/logger';
 export default function testInScope({
   id,
   save,
-  verbose,
+  verbose, // gets called during CI, verbose is always true
   scopePath,
   directory,
   keep,

--- a/src/cli/chalk-box.js
+++ b/src/cli/chalk-box.js
@@ -93,8 +93,8 @@ const paintStats = (results) => {
   return `${statsHeader}\n${totalDuration}\n`;
 };
 
-export const paintSpecsResults = (results: SpecsResults[]): string => {
-  if (!results) return '';
+export const paintSpecsResults = (results?: SpecsResults[]): string[] => {
+  if (!results) return [];
   return results.map((specResult) => {
     const stats = paintStats(specResult);
     const tests = specResult.tests ? `${specResult.tests.map(paintTest).join('\n')}\n` : '';

--- a/src/cli/commands/private-cmds/ci-update-cmd.js
+++ b/src/cli/commands/private-cmds/ci-update-cmd.js
@@ -9,7 +9,7 @@ export default class CiUpdate extends Command {
   description = 'run an update for build and test of a certain bit-component';
   alias = '';
   opts = [
-    ['v', 'verbose [boolean]', 'showing npm verbose output for inspection'],
+    // ['v', 'verbose [boolean]', 'showing npm verbose output for inspection'],
     ['d', 'directory [file]', 'directory to run ci-update'],
     ['k', 'keep', 'keep test environment after run (default false)'],
     ['o', 'output [file]', 'save ci results to file system']
@@ -19,13 +19,18 @@ export default class CiUpdate extends Command {
   action(
     [id, scopePath]: [string, ?string],
     {
-      verbose = false,
+      // verbose = true,
       directory,
       output,
       keep = false
-    }: { verbose: ?boolean, directory: ?string, output: ?string, keep: boolean }
+    }: {
+      // verbose: ?boolean,
+      directory: ?string,
+      output: ?string,
+      keep: boolean
+    }
   ): Promise<any> {
-    verbose = true; // During ci-update we always want to see verbose outputs
+    const verbose = true; // During ci-update we always want to see verbose outputs
     return ciUpdateAction(id, scopePath || process.cwd(), verbose, directory, keep).then(
       ({ specsResults, dists, mainFile }) => ({ specsResults, dists, mainFile, output, directory })
     );

--- a/src/cli/commands/public-cmds/commit-cmd.js
+++ b/src/cli/commands/public-cmds/commit-cmd.js
@@ -1,11 +1,10 @@
 /** @flow */
-import semver from 'semver';
 import Command from '../../command';
 import { commitAction, commitAllAction } from '../../../api/consumer';
 import Component from '../../../consumer/component';
 import { isString } from '../../../utils';
 import ModelComponent from '../../../scope/models/component';
-import { DEFAULT_BIT_VERSION, DEFAULT_BIT_RELEASE_TYPE } from '../../../constants';
+import { DEFAULT_BIT_RELEASE_TYPE } from '../../../constants';
 
 const chalk = require('chalk');
 
@@ -21,7 +20,7 @@ export default class Export extends Command {
     ['mi', 'minor', 'increment the minor version number'],
     ['ma', 'major', 'increment the major version number'],
     ['f', 'force', 'forcely tag even if tests are failing and even when component has not changed'],
-    ['v', 'verbose', 'show specs output on tag'],
+    ['v', 'verbose', 'show specs output on failure'],
     ['i', 'ignore-missing-dependencies', 'ignore missing dependencies (default = false)']
   ];
   loader = true;

--- a/src/consumer/component/consumer-component.js
+++ b/src/consumer/component/consumer-component.js
@@ -43,6 +43,7 @@ import { Dependency, Dependencies } from './dependencies';
 import Dists from './sources/dists';
 import type { PathLinux, PathOsBased } from '../../utils/path';
 import type { RawTestsResults } from '../specs-results/specs-results';
+import { paintSpecsResults } from '../../cli/chalk-box';
 
 export type ComponentProps = {
   name: string,
@@ -561,7 +562,7 @@ export default class Component {
 
   async runSpecs({
     scope,
-    rejectOnFailure,
+    rejectOnFailure = false, // reject when some (or all) of the tests were failed. relevant when running tests during 'bit tag'
     consumer,
     save,
     verbose,
@@ -594,96 +595,83 @@ export default class Component {
     }
     logger.debug('Environment components are installed.');
 
+    const run = async (mainFile: PathOsBased, distTestFiles: Dist[], actualTesterFilePath: PathOsBased) => {
+      loader.start(BEFORE_RUNNING_SPECS);
+      const specsResultsP = distTestFiles.map(async (testFile) => {
+        return specsRunner.run({
+          scope,
+          testerFilePath: actualTesterFilePath,
+          testerId: this.testerId,
+          mainFile,
+          testFile
+        });
+      });
+      const specsResults: RawTestsResults[] = await Promise.all(specsResultsP);
+      this.specsResults = specsResults.map(specRes => SpecsResults.createFromRaw(specRes));
+
+      if (rejectOnFailure && !this.specsResults.every(element => element.pass)) {
+        // some or all the tests were failed.
+        loader.stop();
+        if (verbose) {
+          // $FlowFixMe this.specsResults is not null at this point
+          const specsResultsPretty = paintSpecsResults(this.specsResults).join('\n');
+          console.log(this.id.toString() + specsResultsPretty); // eslint-disable-line no-console
+        }
+        return Promise.reject(new ComponentSpecsFailed());
+      }
+
+      if (save) {
+        await scope.sources.modifySpecsResults({
+          source: this,
+          specsResults: this.specsResults
+        });
+      }
+
+      return this.specsResults;
+    };
+
+    if (!isolated && consumer) {
+      logger.debug('Building the component before running the tests');
+      await this.build({ scope, verbose, consumer });
+      await this.dists.writeDists(this, consumer);
+      const testDists = !this.dists.isEmpty()
+        ? this.dists.get().filter(dist => dist.test)
+        : this.files.filter(file => file.test);
+      return run(this.mainFile, testDists, testerFilePath);
+    }
+
+    const isolatedEnvironment = new IsolatedEnvironment(scope, directory);
+
     try {
-      const run = async (mainFile: PathOsBased, distTestFiles: Dist[], actualTesterFilePath: PathOsBased) => {
-        loader.start(BEFORE_RUNNING_SPECS);
-        try {
-          const specsResultsP = distTestFiles.map(async (testFile) => {
-            return specsRunner.run({
-              scope,
-              testerFilePath: actualTesterFilePath,
-              testerId: this.testerId,
-              mainFile,
-              testFile
-            });
-          });
-          const specsResults: RawTestsResults[] = await Promise.all(specsResultsP);
-          this.specsResults = specsResults.map(specRes => SpecsResults.createFromRaw(specRes));
-          if (rejectOnFailure && !this.specsResults.every(element => element.pass)) {
-            return Promise.reject(new ComponentSpecsFailed());
-          }
-
-          if (save) {
-            await scope.sources.modifySpecsResults({
-              source: this,
-              specsResults: this.specsResults
-            });
-            return this.specsResults;
-          }
-
-          return this.specsResults;
-        } catch (err) {
-          // Put this condition in comment for now because we want to catch exceptions in the testers
-          // We can just pass the rejectOnFailure=true in the consumer.runComponentSpecs
-          // Because this will also affect the condition few lines above:
-          // if (rejectOnFailure && !this.specsResults.every(element => element.pass)) {
-          // in general there is some coupling with the test running between the params:
-          // rejectOnFailure / verbose and the initiator of the running (scope / consumer)
-          // We should make a better architecture for this
-
-          // if (rejectOnFailure) {
-          if (verbose) throw err;
-          throw new ComponentSpecsFailed();
-          // }
-          // return this.specsResults;
-        }
+      await isolatedEnvironment.create();
+      const isolateOpts = {
+        verbose,
+        dist: true,
+        installPackages: true,
+        noPackageJson: false
       };
+      const localTesterPath = path.join(isolatedEnvironment.getPath(), 'tester');
+      const componentWithDependencies = await isolatedEnvironment.isolateComponent(this.id.toString(), isolateOpts);
 
-      if (!isolated && consumer) {
-        logger.debug('Building the component before running the tests');
-        await this.build({ scope, verbose, consumer });
-        await this.dists.writeDists(this, consumer);
-        const testDists = !this.dists.isEmpty()
-          ? this.dists.get().filter(dist => dist.test)
-          : this.files.filter(file => file.test);
-        return run(this.mainFile, testDists, testerFilePath);
+      createSymlinkOrCopy(testerFilePath, localTesterPath);
+      const component = componentWithDependencies.component;
+      component.isolatedEnvironment = isolatedEnvironment;
+      logger.debug(`the component ${this.id.toString()} has been imported successfully into an isolated environment`);
+
+      await component.build({ scope, verbose });
+      if (!component.dists.isEmpty()) {
+        const specDistWrite = component.dists.get().map(file => file.write());
+        await Promise.all(specDistWrite);
       }
-
-      const isolatedEnvironment = new IsolatedEnvironment(scope, directory);
-
-      try {
-        await isolatedEnvironment.create();
-        const isolateOpts = {
-          verbose,
-          dist: true,
-          installPackages: true,
-          noPackageJson: false
-        };
-        const localTesterPath = path.join(isolatedEnvironment.getPath(), 'tester');
-        const componentWithDependencies = await isolatedEnvironment.isolateComponent(this.id.toString(), isolateOpts);
-
-        createSymlinkOrCopy(testerFilePath, localTesterPath);
-        const component = componentWithDependencies.component;
-        component.isolatedEnvironment = isolatedEnvironment;
-        logger.debug(`the component ${this.id.toString()} has been imported successfully into an isolated environment`);
-
-        await component.build({ scope, verbose });
-        if (!component.dists.isEmpty()) {
-          const specDistWrite = component.dists.get().map(file => file.write());
-          await Promise.all(specDistWrite);
-        }
-        const testFilesList = !component.dists.isEmpty()
-          ? component.dists.get().filter(dist => dist.test)
-          : component.files.filter(file => file.test);
-        const results = await run(component.mainFile, testFilesList, localTesterPath);
-        if (!keep) await isolatedEnvironment.destroy();
-        return isCI ? { specResults: results, mainFile: this.dists.calculateMainDistFile(this.mainFile) } : results;
-      } catch (e) {
-        await isolatedEnvironment.destroy();
-        return Promise.reject(e);
-      }
-    } catch (err) {
-      return Promise.reject(err);
+      const testFilesList = !component.dists.isEmpty()
+        ? component.dists.get().filter(dist => dist.test)
+        : component.files.filter(file => file.test);
+      const results = await run(component.mainFile, testFilesList, localTesterPath);
+      if (!keep) await isolatedEnvironment.destroy();
+      return isCI ? { specResults: results, mainFile: this.dists.calculateMainDistFile(this.mainFile) } : results;
+    } catch (e) {
+      await isolatedEnvironment.destroy();
+      return Promise.reject(e);
     }
   }
 
@@ -700,9 +688,9 @@ export default class Component {
     save?: boolean,
     consumer?: Consumer,
     verbose?: boolean,
-    directory: ?string,
-    keep: ?boolean,
-    isCI: boolean
+    directory?: string,
+    keep?: boolean,
+    isCI?: boolean
   }): Promise<?string> {
     logger.debug(`consumer-component.build ${this.id}`);
     // @TODO - write SourceMap Type

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -351,7 +351,7 @@ export default class Consumer {
     saveDependenciesAsComponents = false,
     installNpmPackages = true,
     addToRootPackageJson = true,
-    verbose = false,
+    verbose = false, // display the npm output
     excludeRegistryPrefix = false
   }: {
     silentPackageManagerResult: boolean,

--- a/src/npm-client/install-packages.js
+++ b/src/npm-client/install-packages.js
@@ -9,9 +9,9 @@ import { Consumer } from '../consumer';
 export async function installPackages(
   consumer: Consumer,
   dirs: string[],
-  verbose: boolean,
+  verbose: boolean, // true shows all messages, false shows only a successful message
   installRootPackageJson: boolean = false,
-  silentPackageManagerResult: boolean = false
+  silentPackageManagerResult: boolean = false // don't shows packageManager results at all
 ) {
   const packageManager = consumer.bitJson.packageManager;
   const packageManagerArgs = consumer.packageManagerArgs.length
@@ -43,7 +43,7 @@ export async function installPackages(
   if (!Array.isArray(results)) {
     results = [results];
   }
-  if (!silentPackageManagerResult) {
+  if (!silentPackageManagerResult || verbose) {
     results.forEach((result) => {
       if (result) npmClient.printResults(result);
     });

--- a/src/npm-client/npm-client.js
+++ b/src/npm-client/npm-client.js
@@ -7,6 +7,8 @@ import path from 'path';
 import logger from '../logger/logger';
 import { DEFAULT_PACKAGE_MANAGER } from '../constants';
 
+type PackageManagerResults = { stdout: string, stderr: string };
+
 const objectToArray = obj => map(join('@'), toPairs(obj));
 const rejectNils = R.reject(isNil);
 
@@ -79,7 +81,7 @@ const _installInOneDirectory = ({
   packageManagerProcessOptions = {},
   dir,
   verbose = false
-}) => {
+}): Promise<PackageManagerResults> => {
   // Handle process options
   const allowedPackageManagerProcessOptions = getAllowdPackageManagerProcessOptions(packageManagerProcessOptions);
   const concretePackageManagerProcessOptions = merge(
@@ -154,7 +156,7 @@ const installAction = async ({
   rootDir,
   installRootPackageJson = false,
   verbose = false
-}: installArgs) => {
+}: installArgs): Promise<PackageManagerResults | PackageManagerResults[]> => {
   if (useWorkspaces && packageManager === 'yarn') {
     return _installInOneDirectory({
       modules,


### PR DESCRIPTION
- fix `bit tag` with `--force` flag to force tagging when exceptions occurred during the test
- fix `bit test` error message to display the actual exception if occurred
- improve error message of `bit tag --verbose` when tests failed to include tests results