### PR TITLE
support "export X from Y" syntax of ES6 without importing X first

### DIFF
--- a/e2e/flows/es6-link-files.e2e.js
+++ b/e2e/flows/es6-link-files.e2e.js
@@ -153,6 +153,59 @@ describe('es6 components with link files', function () {
     });
   });
 
+  describe('when a component uses link file to import multiple members with export (without import) syntax', () => {
+    let utilIndexFixture;
+    before(() => {
+      helper.setNewLocalAndRemoteScopes();
+      helper.importCompiler();
+      const isArrayFixture = "export default function isArray() { return 'got is-array'; };";
+      helper.createFile('utils', 'is-array.js', isArrayFixture);
+      helper.addComponent('utils/is-array.js');
+      const isStringFixture = "export default function isString() { return 'got is-string'; };";
+      helper.createFile('utils', 'is-string.js', isStringFixture);
+      helper.addComponent('utils/is-string.js');
+      utilIndexFixture = "export isArray from './is-array'; export isString from './is-string'; ";
+      helper.createFile('utils', 'index.js', utilIndexFixture);
+      const fooBarFixture =
+        "import { isString } from '../utils'; export default function foo() { return isString() + ' and got foo'; };";
+      helper.createComponentBarFoo(fooBarFixture);
+      helper.addComponentBarFoo();
+
+      helper.commitAllComponents();
+      helper.exportAllComponents();
+    });
+    describe('when the project cloned to somewhere else as AUTHORED', () => {
+      before(() => {
+        helper.mimicGitCloneLocalProject(false);
+        helper.addRemoteScope();
+        helper.importAllComponents(true);
+      });
+      it('should not override the original link file', () => {
+        const currentUtilIndex = fs.readFileSync(path.join(helper.localScopePath, 'utils', 'index.js'));
+        expect(currentUtilIndex.toString()).to.equal(utilIndexFixture);
+      });
+    });
+    describe('when importing the component', () => {
+      before(() => {
+        helper.reInitLocalScope();
+        helper.addRemoteScope();
+        helper.importComponent('bar/foo ');
+      });
+      it('should auto-generate a link file', () => {
+        const currentUtilIndex = fs.readFileSync(
+          path.join(helper.localScopePath, 'components', 'bar', 'foo', 'utils', 'index.js')
+        );
+        expect(currentUtilIndex.toString()).to.not.equal(utilIndexFixture);
+      });
+      it('should rewrite the relevant part of the link file', () => {
+        const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo.default());";
+        fs.outputFileSync(path.join(helper.localScopePath, 'app.js'), appJsFixture);
+        const result = helper.runCmd('node app.js');
+        expect(result.trim()).to.equal('got is-string and got foo');
+      });
+    });
+  });
+
   describe('when a component uses link file to import members AND that link file is part of the component', () => {
     let utilIndexFixture;
     before(() => {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "0.10.16",
+    "bit-javascript": "0.10.17-dev.1",
     "buffer-from": "^0.1.1",
     "chalk": "^2.1.0",
     "chokidar": "^1.7.0",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/981)
<!-- Reviewable:end -->
