### PR TITLE
fix parsing error when a Vue file has a dependency prefix with a Tild…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix parsing error when a Vue file has a dependency prefix with a Tilda inside a style section
 - rename `--ignore-missing-dependencies` flag of `bit tag` to `--ignore-unresolved-dependencies`
 - fix detection of .scss files when required with no extension
 - prevent dependency-resolver from parsing json files as they do not contain any dependency


### PR DESCRIPTION
…a inside a style section (fixed on bit-javascript)