### PR TITLE
bug fix - on Linux module path (require('a.js')) is resolved as relat…

### DIFF
--- a/e2e/fixtures/components/dependency-status/dependency-status-test-files/b.js
+++ b/e2e/fixtures/components/dependency-status/dependency-status-test-files/b.js
@@ -1,2 +1,2 @@
-require('a.js');
-require('c.js');
+require('./a.js');
+require('./c.js');


### PR DESCRIPTION
…ive path (require('./a.js')) (fixed on bit-javascript)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1123)
<!-- Reviewable:end -->
