### PR TITLE
remove dependency mentioned twice in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "mocha-junit-reporter": "^1.13.0",
     "prettier-eslint": "^8.8.1",
     "prettier-eslint-cli": "^4.7.1",
-    "requestify": "^0.2.5",
     "sinon": "^5.0.7"
   },
   "optionalDependencies": {


### PR DESCRIPTION
## Proposed Changes

 as you can see `requestify` appears twice in package.json. It is used outside the context of tests so I removed it from devDependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1125)
<!-- Reviewable:end -->
