### PR TITLE
fix errors when exporting a huge number of components. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix errors "JavaScript heap out of memory" and "Error: EMFILE: too many open files" when exporting a huge number of components
+
 ## [13.0.5-dev.14 - 2018-10-11]
 
 - improve `bit export` performance by avoid calling some readSync methods when not needed


### PR DESCRIPTION
1) fix "Error: EMFILE: too many open files" by opening the objects files of a component by one by and not all at the same time. 
2) fix "JavaScript heap out of memory" by running toVersionDependencies() of the components one after another and not all at once

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1270)
<!-- Reviewable:end -->
