### PR TITLE
fix bit-link error messages to not be shown as a stringified JSON

### DIFF
--- a/src/cli/commands/public-cmds/link-cmd.js
+++ b/src/cli/commands/public-cmds/link-cmd.js
@@ -10,7 +10,7 @@ export default class Create extends Command {
   description = `generate symlinks for sourced components absolute path resolution.\n  https://${BASE_DOCS_DOMAIN}/docs/cli-link.html`;
   alias = 'b';
   opts = [];
-  private = true;
+  private = false;
   loader = true;
 
   action(): Promise<*> {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1297)
<!-- Reviewable:end -->
