### PR TITLE
fixed file content generation on authored components linking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix link content generation for authored components on bit install
+
 ## [13.0.5-dev.25 - 2018-10-23]
 
 - fix context for testers during ci-update

--- a/src/links/node-modules-linker.js
+++ b/src/links/node-modules-linker.js
@@ -202,7 +202,7 @@ function _linkAuthoredComponents(consumer: Consumer, component: Component, compo
   const bound = filesToBind.map((file) => {
     const dest = path.join(Consumer.getNodeModulesPathOfComponent(component.bindingPrefix, componentId), file);
     const destRelative = pathRelativeLinux(path.dirname(dest), file);
-    const fileContent = `module.exports = require('${destRelative}');`;
+    const fileContent = getLinkContent(destRelative);
     fs.outputFileSync(dest, fileContent);
     return { from: dest, to: file };
   });


### PR DESCRIPTION
In vue environment during bit install the process was creating .vue files with module.exports of relative path. The index.vue file is generated fine (the file is generated using getLinkContent) but the internal files contain only module.exports = require... without the script tag.

## Proposed Changes

The change I applied is to use the getLinkContent function in authored components generation too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1299)
<!-- Reviewable:end -->
