### PR TITLE
make Bit version command faster

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,10 +3,12 @@ import loudRejection from 'loud-rejection';
 import buildRegistrar from './cli/command-registrar-builder';
 import loadExtensions from './extensions/extensions-loader';
 import HooksManager from './hooks';
+import loadVersionHandler from './cli/version-command';
 
 // un-comment the next line to get more than 10 lines in the error stacktrace
 // Error.stackTraceLimit = Infinity;
 
+loadVersionHandler();
 loudRejection();
 HooksManager.init();
 

--- a/src/cli/version-command.js
+++ b/src/cli/version-command.js
@@ -1,0 +1,10 @@
+import { BIT_VERSION } from '../constants';
+
+export default function formatUnhandled() {
+  if (process.argv[2]) {
+    if (process.argv[2] === '-V' || process.argv[2] === '-v' || process.argv[2] === '--version') {
+      console.log(BIT_VERSION);
+      process.exit();
+    }
+  }
+}


### PR DESCRIPTION
## Proposed Changes
  - bit version command took over 2 sec, after it take only 0.05s.
  -
  -

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1372)
<!-- Reviewable:end -->
