### PR TITLE
remove typescript from the dependencies. it was there for a workaroun…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- bit-javascript: replace the deprecated typescript-eslint-parser with @typescript-eslint/typescript-estree
+
 ## [13.0.6-dev.37] - 2019-01-27
 
 - fix link files generated to a package when it should point to an internal file of the package

--- a/package.json
+++ b/package.json
@@ -101,7 +101,6 @@
     "symlink-or-copy": "^1.1.8",
     "table": "^4.0.3",
     "tty-table": "^2.6.9",
-    "typescript": "2.9.1",
     "uniqid": "^5.0.3",
     "user-home": "^2.0.0",
     "uuid": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "^1.0.6-dev.14",
+    "bit-javascript": "^1.0.6-dev.15",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",
     "cli-spinners": "^1.0.0",


### PR DESCRIPTION
…d (see #1002). however, replacing typescript-eslint-parser with @typescript-eslint/typescript-estree in bit-javascript, fixes the root issue

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1402)
<!-- Reviewable:end -->
