### PR TITLE
add back typescript package. turned out that estree has the same warn…

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,20 +79,20 @@ jobs:
       -
         restore_cache:
           keys:
-            - 'npm-deps11-{{ checksum "./bit/package.json" }}'
-            - npm-deps11
+            - 'npm-deps12-{{ checksum "./bit/package.json" }}'
+            - npm-deps12
       -
         run:
           name: 'Insatll npm dependencies'
           command: 'cd bit && npm install'
       -
         save_cache:
-          key: 'npm-deps11-{{ checksum "./bit/package.json" }}'
+          key: 'npm-deps12-{{ checksum "./bit/package.json" }}'
           paths:
             - ./bit/node_modules
       -
         save_cache:
-          key: npm-deps11
+          key: npm-deps12
           paths:
             - ./bit/node_modules
       -

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "^1.0.6-dev.15",
+    "bit-javascript": "^1.0.6-dev.16",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",
     "cli-spinners": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "symlink-or-copy": "^1.1.8",
     "table": "^4.0.3",
     "tty-table": "^2.6.9",
-    "typescript": "^3.2.4",
+    "typescript": "3.2.4",
     "uniqid": "^5.0.3",
     "user-home": "^2.0.0",
     "uuid": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -101,6 +101,7 @@
     "symlink-or-copy": "^1.1.8",
     "table": "^4.0.3",
     "tty-table": "^2.6.9",
+    "typescript": "^3.2.4",
     "uniqid": "^5.0.3",
     "user-home": "^2.0.0",
     "uuid": "^3.0.1",


### PR DESCRIPTION
…ing message as typescript-eslint-parser ("WARNING: You are currently running a version of TypeScript which is not officially supported by typescript-estree") see #1002 and #1402

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1414)
<!-- Reviewable:end -->
