### PR TITLE
fix error "dependency.id.serialize is not a function" when migration …

### DIFF
--- a/src/scope/models/version.js
+++ b/src/scope/models/version.js
@@ -449,10 +449,7 @@ export default class Version extends BitObject {
    * used by raw-object.toRealObject()
    */
   static from(versionProps: VersionProps): Version {
-    const compiler = versionProps.compiler ? parseEnv(versionProps.compiler) : null;
-    const tester = versionProps.tester ? parseEnv(versionProps.tester) : null;
-    const actualVersionProps = { ...versionProps, compiler, tester };
-    return new Version(actualVersionProps);
+    return Version.parse(JSON.stringify(versionProps));
   }
 
   /**


### PR DESCRIPTION
…is running by changing the way how it creates a new Version object to be the same as other parts of the system

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1434)
<!-- Reviewable:end -->
