### PR TITLE
Add tomato integration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -239,6 +239,17 @@ jobs:
         run:
           name: 'run ESLint'
           command: 'cd bit && npm run lint-circle'
+      - run:
+          name: install pip
+          when: always
+          command: |
+              python <(curl https://bootstrap.pypa.io/get-pip.py) --user && PATH=~/.local/bin pip install --user tomato-lib
+      - run:
+          name: Send reports to tomato
+          when: always
+          command: |
+              pwd
+              PATH=$PATH:~/.local/bin tomato /home/circleci/bit/bit/junit/eslint-results.xml
       -
         store_test_results:
           path: bit/junit


### PR DESCRIPTION
## Add tomato bot to report lint issues back to GitHub
Hey and Shalom,
My name is Moshe and I wrote [Tomato Bot](https://tomato-bot.com) a friendly bot to report back your test and styling results to GitHub by using the Checks API.

Tomato reads the JUnit reports, parse them and POST the relevant data to GitHub in order to shorten the time between test failure and finding the actual issue.
In order to make it work you need to merge this PR and install the app on this repo [here](https://github.com/apps/tomato-bot)
You can see it in action in my fork [Example](https://github.com/moshe/bit/pull/2/files#diff-e1d62d8c4965edf0e532dfa19da0891f)
![image](https://user-images.githubusercontent.com/7490448/53630616-21c63e80-3c19-11e9-9608-05756eba3429.png)

Let me know if you have any questions/issues you want me to address / concerns (:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1466)
<!-- Reviewable:end -->
