### PR TITLE
reintroduce -c alias for no cache flag in build command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - avoid installing "undefined" npm package when importing authored components
 - add authentication fallback to ssh-key in case the ssh-agent is enabled but failed to authenticate
 - improve authentication error message to clearly indicate the various strategies failures
+- fix `build` command with no cache flag 
 
 ## [14.0.5] - 2019-04-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - avoid installing "undefined" npm package when importing authored components
 - add authentication fallback to ssh-key in case the ssh-agent is enabled but failed to authenticate
 - improve authentication error message to clearly indicate the various strategies failures
-- fix `build` command with no cache flag 
+- reintroduce `-c` alias for `--no-cache` flag in `bit build` command 
 
 ## [14.0.5] - 2019-04-07
 

--- a/e2e/commands/build.e2e.1.js
+++ b/e2e/commands/build.e2e.1.js
@@ -82,6 +82,15 @@ describe('bit build', function () {
             expect(distFileFullPath).to.be.a.file();
             expect(compilerFolderFullPath).to.be.a.directory().and.not.empty;
           });
+          it('should not take dist files from cache with -c', () => {
+            helper.deleteFile(compilerFolder);
+            const output = helper.buildComponentWithOptions('bar/foo', { c: '' });
+            expect(output).to.have.string(
+              `successfully installed the ${helper.envScope}/compilers/babel@0.0.1 compiler`
+            );
+            expect(distFileFullPath).to.be.a.file();
+            expect(compilerFolderFullPath).to.be.a.directory().and.not.empty;
+          });
         });
         describe('build all components', () => {
           it('should take dist files from cache (models)', () => {
@@ -91,6 +100,14 @@ describe('bit build', function () {
           });
           it('should not take dist files from cache with --no-cache', () => {
             const output = helper.buildComponentWithOptions('', { '-no-cache': '' });
+            expect(output).to.have.string(
+              `successfully installed the ${helper.envScope}/compilers/babel@0.0.1 compiler`
+            );
+            expect(distFileFullPath).to.be.a.file();
+            expect(compilerFolderFullPath).to.be.a.directory().and.not.empty;
+          });
+          it('should not take dist files from cache with -c', () => {
+            const output = helper.buildComponentWithOptions('', { c: '' });
             expect(output).to.have.string(
               `successfully installed the ${helper.envScope}/compilers/babel@0.0.1 compiler`
             );

--- a/src/cli/commands/public-cmds/build-cmd.js
+++ b/src/cli/commands/public-cmds/build-cmd.js
@@ -11,7 +11,7 @@ export default class Build extends Command {
   alias = '';
   opts = [
     ['v', 'verbose [boolean]', 'showing npm verbose output for inspection'],
-    ['', 'no-cache', 'ignore component cache when creating dist file']
+    ['c', 'no-cache', 'ignore component cache when creating dist file']
   ];
   loader = true;
   migration = true;


### PR DESCRIPTION
## Proposed Changes

fix build command with no cache flag.
and now is posible to run the short flag: `bit build -c`

I opened an issue about this https://github.com/teambit/bit/issues/1533

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1535)
<!-- Reviewable:end -->
