### PR TITLE
Remove "s" from a sentence in Bit monorepo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Update: An extensive extension system is in the works and should become availabe
 
 Any repository or library containing components is already a Bit monorepo.  
 
-Adding Bit to the repository will not change its structure, source code or configurations. You won’t need to refactor or create separate directories and configurations for every components.  
+Adding Bit to the repository will not change its structure, source code or configurations. You won’t need to refactor or create separate directories and configurations for every component.  
 Instead, you can use Bit to track and share the components from your library directly to Bit’s hub. Then, they become availabe to install as individual NPM packages.   
 
 This means that your React UI library + Bit will become a monorepo from which components can be individually discovered and installed, without changing the library. Component dependencies will be automatically defined by Bit, and build/test configurations will be [applied to all the components](https://docs.bit.dev/docs/building-components.html) using [Bit’s environments](https://bit.dev/bit/envs). In addition, you will get discoverability for the components across your team, community or organization.


### PR DESCRIPTION
## Proposed Changes

  - Change word "components" to singular in the sentence: `You won’t need to refactor or create separate directories and configurations for every component.`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1545)
<!-- Reviewable:end -->
