### PR TITLE
prevent manually removing component dependency when the require state…

### DIFF
--- a/e2e/functionalities/workspace-config.e2e.2.js
+++ b/e2e/functionalities/workspace-config.e2e.2.js
@@ -181,6 +181,7 @@ describe('workspace config', function () {
     });
     describe('ignoring files and components dependencies', () => {
       let scopeAfterAdding;
+      let remoteScopeEmpty;
       before(() => {
         helper.setNewLocalAndRemoteScopes();
         helper.createFile('foo-dir', 'foo1.js');
@@ -190,6 +191,7 @@ describe('workspace config', function () {
         helper.addComponent('foo-dir/foo2.js', { i: 'utils/foo/foo2' });
         helper.addComponent('bar-dir/bar.js', { i: 'bar' });
         scopeAfterAdding = helper.cloneLocalScope();
+        remoteScopeEmpty = helper.cloneRemoteScope();
       });
       describe('ignoring the component file altogether', () => {
         let showBar;
@@ -415,6 +417,7 @@ describe('workspace config', function () {
         let showBar;
         before(() => {
           helper.getClonedLocalScope(scopeAfterAdding);
+          helper.getClonedRemoteScope(remoteScopeEmpty);
           helper.tagAllComponents();
           helper.exportAllComponents();
           helper.createFile(

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.js
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.js
@@ -433,7 +433,12 @@ Try to run "bit import ${this.component.id.toString()} --objects" to get the com
       }
       return;
     }
-    if (this.overridesDependencies.shouldIgnoreComponent(componentId, fileType)) return;
+    if (this.overridesDependencies.shouldIgnoreComponent(componentId, fileType)) {
+      // we can't support it because on the imported side, we don't know to convert the relative path
+      // to the component name, as it won't have the component installed
+      throw new GeneralError(`unable to ignore "${componentId.toString()}" dependency of "${this.componentId.toString()}" by using ignore components syntax because the component is required with relative path.
+either, use the ignore file syntax or change the require statement to have a module path`);
+    }
     // happens when in the same component one file requires another one. In this case, there is
     // noting to do regarding the dependencies
     if (componentId.isEqual(this.componentId)) {
@@ -544,6 +549,10 @@ Try to run "bit import ${this.component.id.toString()} --objects" to get the com
     }
   }
 
+  /**
+   * process require/import of Bit components where the require statement is not a relative path
+   * but a module path, such as `require('@bit/bit.envs/compiler/babel');`
+   */
   processBits(originFile: PathLinuxRelative, fileType: FileType) {
     const bits = this.tree[originFile].bits;
     if (!bits || R.isEmpty(bits)) return;


### PR DESCRIPTION
…ment uses a relative path (it prevents a bug where an imported component gets the component with an error of missing file)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1568)
<!-- Reviewable:end -->
