### PR TITLE
fix "npm ERR! enoent ENOENT" errors when importing/installing multiple components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix "npm ERR! enoent ENOENT" errors when importing/installing multiple components
 - fix dependency value in the dependent package.json to include the path when importing them both in the same command
 - fix "EEXIST: file already exists" error when running `bit link` or `bit install` and the dist is outside the component directory
 - fix `bit add` to ignore directories when their files are added (#1406)


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/1617.

The error is thrown due to a race condition between npm installation of the directories.
The error can be reproduced by running the e2e-test `‘import dependency and dependent with the same command => when the dependent comes before the dependency` multiple times.
In the example of this e2e-test, `bar/foo` has a dependency `utils/is-string`, which has a dependency `utils/is-type`. 
The package.json of `bar/foo` has `utils/is-string` as a relative path (instead of a version), so ‘npm install’ of `bar/foo` causes installation of npm in `utils/is-string` as well. 
When installing npm in parallel for both `bar/foo` and `utils/is-string`, it’s like running in parallel npm installation twice for the same directory `components/utils/is-string`. 
When npm tries to install `utils/is-type` twice at the same time in the same directory, random errors are thrown because one of the processes tries to delete/open/chown a file that the other process already removed.
This behavior has been observed by running directly `npm install` twice at the same time, regardless of Bit.

The fix done in this PR is to change the npm installation to be running in serial and not in parallel. As an unfortunate result, the npm installation part is a bit slower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1618)
<!-- Reviewable:end -->
