### PR TITLE
fix #1606, fix dependency resolution to identify link (proxy) files correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix dependency resolution to identify link (proxy) files correctly
 - fix "npm ERR! enoent ENOENT" errors when importing/installing multiple components
 - fix dependency value in the dependent package.json to include the path when importing them both in the same command
 - fix "EEXIST: file already exists" error when running `bit link` or `bit install` and the dist is outside the component directory

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "^2.0.5",
+    "bit-javascript": "2.0.6-dev.1",
     "bluebird": "^3.5.3",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.js
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.js
@@ -97,6 +97,7 @@ export default class DependencyResolver {
 
   setTree(tree: Tree) {
     this.tree = tree;
+    // console.log(JSON.stringify(tree, null, 4)); // uncomment to easily watch the tree received from bit-javascript
   }
 
   /**
@@ -473,6 +474,10 @@ either, use the ignore file syntax or change the require statement to have a mod
       destinationRelativePath
     };
     if (importSpecifiers) {
+      importSpecifiers.map((importSpecifier) => {
+        if (importSpecifier.linkFile) delete importSpecifier.linkFile.exported;
+        if (importSpecifier.mainFile) delete importSpecifier.mainFile.exported;
+      });
       depsPaths.importSpecifiers = importSpecifiers;
     }
     if (depFileObject.isCustomResolveUsed) {


### PR DESCRIPTION
The fix is done on bit-javascript.

A case example for this fix:
compA requires compB with `import { Utils } from compB.js;` , compB requires `Utils` from some_file.js, however, it doesn't export it, only uses it internally.
In this case, bit-javascript identified compB.js as a link file incorrectly. 
With this fix, a link file is identified only when it import and export `Utils`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1621)
<!-- Reviewable:end -->
