### PR TITLE
simplify stripping shared-dir feature to apply for any non-authored component

### DIFF
--- a/e2e/commands/import.e2e.1.js
+++ b/e2e/commands/import.e2e.1.js
@@ -703,8 +703,6 @@ describe('bit import', function () {
       it('should mark indirect dependencies as "NESTED" in bit.map file', () => {
         expect(bitMap[`${helper.remoteScope}/global/simple${VERSION_DELIMITER}0.0.1`].origin).to.equal('NESTED');
       });
-      it.skip('should not add existing components to bit.map file', () => {});
-      it.skip('should create bit.json file with all the dependencies in the folder', () => {});
       it('should print a successful message about installed npm packages', () => {
         expect(output).to.have.string('successfully ran npm install');
       });
@@ -717,7 +715,6 @@ describe('bit import', function () {
           'simple',
           helper.remoteScope,
           '0.0.1',
-          'global',
           'simple.js'
         );
         expect(fs.existsSync(depDir)).to.be.true;
@@ -738,7 +735,6 @@ describe('bit import', function () {
           helper.localScopePath,
           'components',
           '.dependencies',
-          'global',
           'simple',
           helper.remoteScope,
           '0.0.1',
@@ -958,7 +954,7 @@ describe('bit import', function () {
         const expectedLocation = path.join(
           'dist/components/.dependencies/utils/is-string',
           helper.remoteScope,
-          '0.0.1/utils/is-string.js'
+          '0.0.1/is-string.js'
         );
         expect(localConsumerFiles).to.include(expectedLocation);
       });

--- a/e2e/commands/import.e2e.1.js
+++ b/e2e/commands/import.e2e.1.js
@@ -735,6 +735,7 @@ describe('bit import', function () {
           helper.localScopePath,
           'components',
           '.dependencies',
+          'global',
           'simple',
           helper.remoteScope,
           '0.0.1',
@@ -745,7 +746,7 @@ describe('bit import', function () {
         expect(packageJsonContent).to.deep.include({
           name: `@bit/${helper.remoteScope}.global.simple`,
           version: '0.0.1',
-          main: 'global/simple.js'
+          main: 'simple.js'
         });
         expect(packageJsonContent.dependencies['lodash.isboolean']).to.have.string('3.0.0');
       });

--- a/e2e/commands/install.e2e.1.js
+++ b/e2e/commands/install.e2e.1.js
@@ -33,7 +33,7 @@ describe('run bit install', function () {
         helper.exportAllComponents();
 
         const requirePath = helper.getRequireBitPath('utils', 'is-string');
-        const fooBarFixture = `const isString = require('${requirePath}/utils/is-string');
+        const fooBarFixture = `const isString = require('${requirePath}');
   module.exports = function foo() { return isString() + ' and got foo'; };`;
         helper.createComponentBarFoo(fooBarFixture);
         helper.createFile('bar', 'foo.js', fooBarFixture);

--- a/e2e/flows/binary-files.e2e.2.js
+++ b/e2e/flows/binary-files.e2e.2.js
@@ -125,9 +125,8 @@ describe('binary files', function () {
       expect(expectedDest).to.be.a.file();
 
       const symlinkValue = fs.readlinkSync(expectedDest);
-      expect(symlinkValue).to.have.string(
-        path.join('components/.dependencies/bar/png', helper.remoteScope, '/0.0.1/bar/png_fixture.png')
-      );
+      expect(symlinkValue).to.have.string(path.normalize('components/.dependencies/bar/png'));
+      expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
       const status = helper.status();
@@ -164,9 +163,8 @@ describe('binary files', function () {
       expect(expectedDest).to.be.a.file();
 
       const symlinkValue = fs.readlinkSync(expectedDest);
-      expect(symlinkValue).to.have.string(
-        path.join('components/.dependencies/bar/png', helper.remoteScope, '/0.0.1/src/bar/png_fixture.png')
-      );
+      expect(symlinkValue).to.have.string(path.normalize('components/.dependencies/bar/png'));
+      expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
       const status = helper.status();
@@ -231,9 +229,8 @@ describe('binary files', function () {
       expect(expectedDest).to.be.a.file();
 
       const symlinkValue = fs.readlinkSync(expectedDest);
-      expect(symlinkValue).to.have.string(
-        path.join('components/.dependencies/bar/png', helper.remoteScope, '/0.0.1/src/bar/png_fixture.png')
-      );
+      expect(symlinkValue).to.have.string(path.normalize('components/.dependencies/bar/png'));
+      expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
       const status = helper.status();
@@ -319,9 +316,8 @@ describe('binary files', function () {
       expect(expectedDest).to.be.a.file();
 
       const symlinkValue = fs.readlinkSync(expectedDest);
-      expect(symlinkValue).to.have.string(
-        path.join('components/.dependencies/bar/png', helper.remoteScope, '/0.0.1/src/bar/png_fixture.png')
-      );
+      expect(symlinkValue).to.have.string(path.normalize('components/.dependencies/bar/png'));
+      expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
       const status = helper.status();
@@ -419,9 +415,8 @@ describe('binary files', function () {
       expect(expectedDest).to.be.a.file();
 
       const symlinkValue = fs.readlinkSync(expectedDest);
-      expect(symlinkValue).to.have.string(
-        path.join('components/.dependencies/bar/png', helper.remoteScope, '/0.0.1/src/bar/png_fixture.png')
-      );
+      expect(symlinkValue).to.have.string(path.normalize('components/.dependencies/bar/png'));
+      expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
       const status = helper.status();

--- a/e2e/flows/import-from-bit-hub.e2e.3.js
+++ b/e2e/flows/import-from-bit-hub.e2e.3.js
@@ -119,11 +119,9 @@ chai.use(require('chai-fs'));
       expect(bitMap).to.have.property(`${scopeId}/utils/is-string@0.0.1`);
       expect(bitMap).to.have.property(`${scopeId}/utils/is-type@0.0.1`);
     });
-    it('should not install the dependencies as npm packages', () => {
-      expect(
-        path.join(barFooDir, 'node_modules', '@bit', `${scopeId}.utils.is-string`, 'is-string.js')
-      ).to.not.be.a.path();
-      expect(path.join(barFooDir, 'node_modules', '@bit', `${scopeId}.utils.is-type`, 'is-type.js')).to.not.be.a.path();
+    it('package.json should not contain the dependency', () => {
+      const packageJson = helper.readPackageJson(barFooDir);
+      expect(packageJson.dependencies).to.deep.equal({});
     });
     it('should generate all the links correctly and print results from all dependencies', () => {
       const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";

--- a/e2e/flows/pad-left-and-is-string.e2e.3.js
+++ b/e2e/flows/pad-left-and-is-string.e2e.3.js
@@ -527,12 +527,7 @@ describe('a flow with two components: is-string and pad-left, where is-string is
           const distDir = path.join(helper.localScopePath, 'dist');
           expect(distDir).to.be.a.path();
           expect(
-            path.join(
-              distDir,
-              'components/.dependencies/string/is-string',
-              helper.remoteScope,
-              '0.0.1/src/is-string/is-string.js'
-            )
+            path.join(distDir, 'components/.dependencies/string/is-string', helper.remoteScope, '0.0.1/is-string.js')
           ).to.be.a.file();
           expect(path.join(distDir, 'pad-left/pad-left/pad-left.js')).to.be.a.file();
         });

--- a/e2e/typescript/typescript.e2e.3.js
+++ b/e2e/typescript/typescript.e2e.3.js
@@ -9,7 +9,6 @@ import BitsrcTester, { username, supportTestingOnBitsrc } from '../bitsrc-tester
 
 const helper = new Helper();
 
-// todo: once the bind is implemented, make it work
 describe('typescript', function () {
   this.timeout(0);
   after(() => {
@@ -100,7 +99,7 @@ describe('typescript', function () {
         const indexPath = path.join(helper.localScopePath, expectedLocation);
         const indexFileContent = fs.readFileSync(indexPath).toString();
         expect(indexFileContent).to.have.string(
-          "module.exports = require('./dist/utils/is-string');",
+          "module.exports = require('./dist/is-string');",
           'dependency index file point to the wrong place'
         );
       });
@@ -110,7 +109,7 @@ describe('typescript', function () {
         expect(packageJsonContent).to.deep.include({
           name: `@bit/${helper.remoteScope}.utils.is-string`,
           version: '0.0.1',
-          main: 'dist/utils/is-string.js'
+          main: 'dist/is-string.js'
         });
       });
       it('should create an index.js file on the is-type dependency root dir pointing to the main file', () => {
@@ -119,7 +118,7 @@ describe('typescript', function () {
         const indexPath = path.join(helper.localScopePath, expectedLocation);
         const indexFileContent = fs.readFileSync(indexPath).toString();
         expect(indexFileContent).to.have.string(
-          "module.exports = require('./dist/utils/is-type');",
+          "module.exports = require('./dist/is-type');",
           'dependency index file point to the wrong place'
         );
       });
@@ -129,20 +128,20 @@ describe('typescript', function () {
         expect(packageJsonContent).to.deep.include({
           name: `@bit/${helper.remoteScope}.utils.is-type`,
           version: '0.0.1',
-          main: 'dist/utils/is-type.js'
+          main: 'dist/is-type.js'
         });
       });
       it('should save the direct dependency nested to the main component', () => {
-        const expectedLocation = path.join(isStringPath, 'utils', 'is-string.ts');
+        const expectedLocation = path.join(isStringPath, 'is-string.ts');
         expect(localConsumerFiles).to.include(expectedLocation);
       });
       it('should save the indirect dependency nested to the main component (as opposed to nested of nested)', () => {
-        const expectedLocation = path.join(isTypePath, 'utils', 'is-type.ts');
+        const expectedLocation = path.join(isTypePath, 'is-type.ts');
         expect(localConsumerFiles).to.include(expectedLocation);
       });
       it('should add dependencies dists files to file system', () => {
-        const expectedIsTypeDistLocation = path.join(isTypePath, 'dist', 'utils', 'is-type.js');
-        const expectedIsStringDistLocation = path.join(isStringPath, 'dist', 'utils', 'is-string.js');
+        const expectedIsTypeDistLocation = path.join(isTypePath, 'dist', 'is-type.js');
+        const expectedIsStringDistLocation = path.join(isStringPath, 'dist', 'is-string.js');
         expect(localConsumerFiles).to.include(expectedIsTypeDistLocation);
         expect(localConsumerFiles).to.include(expectedIsStringDistLocation);
       });
@@ -151,7 +150,7 @@ describe('typescript', function () {
         const linkPath = path.join(helper.localScopePath, expectedLocation);
         const linkPathContent = fs.readFileSync(linkPath).toString();
         const expectedPathSuffix = normalize(
-          path.join('.dependencies', 'utils', 'is-string', helper.remoteScope, '0.0.1', 'utils', 'is-string')
+          path.join('.dependencies', 'utils', 'is-string', helper.remoteScope, '0.0.1', 'is-string')
         );
         expect(localConsumerFiles).to.include(expectedLocation);
         expect(linkPathContent).to.have.string(
@@ -173,24 +172,24 @@ describe('typescript', function () {
         );
       });
       it('should link the indirect dependency from dependent component source folder to its source file in the dependency directory', () => {
-        const expectedLocation = path.join(isStringPath, 'utils', 'is-type.ts');
+        const expectedLocation = path.join(isStringPath, 'is-type.ts');
         const linkPath = path.join(helper.localScopePath, expectedLocation);
         const linkPathContent = fs.readFileSync(linkPath).toString();
-        const expectedPathSuffix = normalize(path.join('is-type', helper.remoteScope, '0.0.1', 'utils', 'is-type'));
+        const expectedPathSuffix = normalize(path.join('is-type', helper.remoteScope, '0.0.1', 'is-type'));
         expect(localConsumerFiles).to.include(expectedLocation);
         expect(linkPathContent).to.have.string(
-          `../../../../${expectedPathSuffix}`,
+          `../../../${expectedPathSuffix}`,
           'in direct dependency link file point to the wrong place'
         );
       });
       it('should link the indirect dependency from dependent component dist folder to its index file in the dependency directory', () => {
-        const expectedLocation = path.join(isStringPath, 'dist', 'utils', 'is-type.js');
+        const expectedLocation = path.join(isStringPath, 'dist', 'is-type.js');
         const linkPath = path.join(helper.localScopePath, expectedLocation);
         const linkPathContent = fs.readFileSync(linkPath).toString();
         const expectedPathSuffix = normalize(path.join('is-type', helper.remoteScope, '0.0.1'));
         expect(localConsumerFiles).to.include(expectedLocation);
         expect(linkPathContent).to.have.string(
-          `../../../../../${expectedPathSuffix}`,
+          `../../../../${expectedPathSuffix}`,
           'in direct dependency link file point to the wrong place'
         );
       });

--- a/src/consumer/bit-map/component-map.js
+++ b/src/consumer/bit-map/component-map.js
@@ -376,9 +376,9 @@ export default class ComponentMap {
     if (this.trackDir && this.origin !== COMPONENT_ORIGINS.AUTHORED) {
       throw new ValidationError(`${errorMessage} trackDir attribute should be set for AUTHORED component only`);
     }
-    if (this.originallySharedDir && this.origin !== COMPONENT_ORIGINS.IMPORTED) {
+    if (this.originallySharedDir && this.origin === COMPONENT_ORIGINS.AUTHORED) {
       throw new ValidationError(
-        `${errorMessage} originallySharedDir attribute should be set for IMPORTED components only`
+        `${errorMessage} originallySharedDir attribute should be set for non AUTHORED components only`
       );
     }
 

--- a/src/consumer/component-ops/manipulate-dir.js
+++ b/src/consumer/component-ops/manipulate-dir.js
@@ -43,7 +43,7 @@ function calculateOriginallySharedDir(version: Version): ?PathLinux {
 }
 
 function getOriginallySharedDirIfNeeded(origin: ComponentOrigin, version: Version): ?PathLinux {
-  if (origin !== COMPONENT_ORIGINS.IMPORTED) return null;
+  if (origin === COMPONENT_ORIGINS.AUTHORED) return null;
   return calculateOriginallySharedDir(version);
 }
 

--- a/src/scope/repositories/sources.js
+++ b/src/scope/repositories/sources.js
@@ -231,8 +231,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
         if (!relativePath.isCustomResolveUsed) {
           // for isCustomResolveUsed it was never stripped
           relativePath.sourceRelativePath = manipulateDirs(relativePath.sourceRelativePath);
-          if (depFromBitMap && depFromBitMap.origin === COMPONENT_ORIGINS.IMPORTED) {
-            // when a dependency is imported directly, we need to also change the
+          if (depFromBitMap && depFromBitMap.origin !== COMPONENT_ORIGINS.AUTHORED) {
+            // when a dependency is not authored, we need to also change the
             // destinationRelativePath, which is the path written in the link file, however, the
             // dir manipulation should be according to this dependency component, not the
             // consumerComponent passed to this function

--- a/src/scope/repositories/sources.js
+++ b/src/scope/repositories/sources.js
@@ -231,17 +231,17 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
         if (!relativePath.isCustomResolveUsed) {
           // for isCustomResolveUsed it was never stripped
           relativePath.sourceRelativePath = manipulateDirs(relativePath.sourceRelativePath);
-          if (depFromBitMap && depFromBitMap.origin !== COMPONENT_ORIGINS.AUTHORED) {
-            // when a dependency is not authored, we need to also change the
-            // destinationRelativePath, which is the path written in the link file, however, the
-            // dir manipulation should be according to this dependency component, not the
-            // consumerComponent passed to this function
-            relativePath.destinationRelativePath = revertDirManipulationForPath(
-              relativePath.destinationRelativePath,
-              depFromBitMap.originallySharedDir,
-              depFromBitMap.wrapDir
-            );
-          }
+        }
+        if (depFromBitMap && depFromBitMap.origin !== COMPONENT_ORIGINS.AUTHORED) {
+          // when a dependency is not authored, we need to also change the
+          // destinationRelativePath, which is the path written in the link file, however, the
+          // dir manipulation should be according to this dependency component, not the
+          // consumerComponent passed to this function
+          relativePath.destinationRelativePath = revertDirManipulationForPath(
+            relativePath.destinationRelativePath,
+            depFromBitMap.originallySharedDir,
+            depFromBitMap.wrapDir
+          );
         }
       });
     });


### PR DESCRIPTION
Currently, we have a mix of behaviors. 
Authored - not stripped.
Imported - stripped.
Nested - if installed via npm - stripped, otherwise - not stripped.
It causes some weird issues with components that were nested before and now imported with different versions. 

This PR simplify the feature to strip the shared directory for any non-author component, including local nested dependencies that are imported into `components/.dependencies` directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1651)
<!-- Reviewable:end -->
