### PR TITLE
disconnect the shouldDependenciesSavedAsComponents logic from manipul…

### DIFF
--- a/src/consumer/component-ops/manipulate-dir.js
+++ b/src/consumer/component-ops/manipulate-dir.js
@@ -34,9 +34,8 @@ export async function getManipulateDirForExistingComponents(
   if (!version) {
     throw new CorruptedComponent(id.toString(), componentVersion.version);
   }
-  const isAuthor = Boolean(componentMap && componentMap.origin === COMPONENT_ORIGINS.AUTHORED);
-  const originallySharedDir = componentMap ? getOriginallySharedDirIfNeeded(isAuthor, version) : null;
-  const wrapDir = componentMap ? getWrapDirIfNeeded(isAuthor, version) : null;
+  const originallySharedDir = componentMap ? getOriginallySharedDirIfNeeded(componentMap.origin, version) : null;
+  const wrapDir = componentMap ? getWrapDirIfNeeded(componentMap.origin, version) : null;
   manipulateDirData.push({ id, originallySharedDir, wrapDir });
   const dependencies = version.getAllDependencies();
   dependencies.forEach((dependency) => {
@@ -68,10 +67,11 @@ export async function getManipulateDirWhenImportingComponents(
     const manipulateDirComponent = await getManipulateDirItemFromComponentVersion(
       versionDependency.component,
       bitMap,
-      repository
+      repository,
+      false
     );
     const manipulateDirDependenciesP = versionDependency.allDependencies.map((dependency: ComponentVersion) => {
-      return getManipulateDirItemFromComponentVersion(dependency, bitMap, repository);
+      return getManipulateDirItemFromComponentVersion(dependency, bitMap, repository, true);
     });
     const manipulateDirDependencies = await Promise.all(manipulateDirDependenciesP);
     // a component might be a dependency and directly imported at the same time, in which case,
@@ -114,8 +114,8 @@ function calculateOriginallySharedDir(version: Version): ?PathLinux {
   return sharedStartDirectories.join(pathSep);
 }
 
-function getOriginallySharedDirIfNeeded(isAuthor: boolean, version: Version): ?PathLinux {
-  if (isAuthor) return null;
+function getOriginallySharedDirIfNeeded(origin: ComponentOrigin, version: Version): ?PathLinux {
+  if (origin === COMPONENT_ORIGINS.AUTHORED) return null;
   return calculateOriginallySharedDir(version);
 }
 
@@ -134,8 +134,8 @@ function isWrapperDirNeeded(version: Version) {
   );
 }
 
-function getWrapDirIfNeeded(isAuthor: boolean, version: Version): ?PathLinux {
-  if (isAuthor) return null;
+function getWrapDirIfNeeded(origin: ComponentOrigin, version: Version): ?PathLinux {
+  if (origin === COMPONENT_ORIGINS.AUTHORED) return null;
   return isWrapperDirNeeded(version) ? WRAPPER_DIR : null;
 }
 
@@ -151,17 +151,39 @@ function getDependencyComponentMap(bitMap, dependencyId): ?ComponentMap {
   return bitMap.getComponentIfExist(dependencyId) || bitMap.getComponentIfExist(dependencyId, { ignoreVersion: true });
 }
 
+/**
+ * an authored component that is now imported, is still authored.
+ * however, nested component that is now imported directly, is actually imported.
+ * if there is no entry for this component in bitmap, it is imported.
+ */
+function getComponentOrigin(bitmapOrigin: ?ComponentOrigin, isDependency: boolean): ComponentOrigin {
+  if (!bitmapOrigin) return isDependency ? COMPONENT_ORIGINS.NESTED : COMPONENT_ORIGINS.IMPORTED;
+  if (bitmapOrigin === COMPONENT_ORIGINS.NESTED && !isDependency) {
+    return COMPONENT_ORIGINS.IMPORTED;
+  }
+  return bitmapOrigin;
+}
+
 async function getManipulateDirItemFromComponentVersion(
   componentVersion: ComponentVersion,
   bitMap: BitMap,
-  repository
+  repository,
+  isDependency: boolean
 ): Promise<ManipulateDirItem> {
   const id: BitId = componentVersion.id;
-  const componentMap: ?ComponentMap = bitMap.getComponentIfExist(id, { ignoreScopeAndVersion: true });
-  const isAuthor = Boolean(componentMap && componentMap.origin === COMPONENT_ORIGINS.AUTHORED);
+  // when a component is now imported, ignore the version because if it was nested before, we just
+  // replace it with the imported one.
+  // however, the opposite is not true, if it is now nested and was imported before, we can have them both.
+  // (see 'when imported component has lower dependencies versions than local' in import.e2e for such a case).
+  // we might change this behavior as it is confusing.
+  const componentMap: ?ComponentMap = isDependency
+    ? bitMap.getComponentIfExist(id)
+    : bitMap.getComponentPreferNonNested(id);
+  const bitmapOrigin = componentMap ? componentMap.origin : null;
+  const origin = getComponentOrigin(bitmapOrigin, isDependency);
   const version: Version = await componentVersion.getVersion(repository);
-  const originallySharedDir = getOriginallySharedDirIfNeeded(isAuthor, version);
-  const wrapDir = getWrapDirIfNeeded(isAuthor, version);
+  const originallySharedDir = getOriginallySharedDirIfNeeded(origin, version);
+  const wrapDir = getWrapDirIfNeeded(origin, version);
   return { id, originallySharedDir, wrapDir };
 }
 

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -331,14 +331,10 @@ export default class Consumer {
     }
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
     const versionDependencies = await scopeComponentsImporter.componentToVersionDependencies(modelComponent, id);
-    const shouldDependenciesSavedAsComponents = await this.shouldDependenciesSavedAsComponents([
-      versionDependencies.component.id
-    ]);
     const manipulateDirData = await getManipulateDirWhenImportingComponents(
       this.bitMap,
       [versionDependencies],
-      this.scope.objects,
-      shouldDependenciesSavedAsComponents
+      this.scope.objects
     );
     return versionDependencies.toConsumer(this.scope.objects, manipulateDirData);
   }
@@ -375,8 +371,7 @@ export default class Consumer {
     const manipulateDirData = await getManipulateDirWhenImportingComponents(
       this.bitMap,
       versionDependenciesArr,
-      this.scope.objects,
-      shouldDependenciesSavedAsComponents
+      this.scope.objects
     );
     const componentWithDependencies = await pMapSeries(versionDependenciesArr, versionDependencies =>
       versionDependencies.toConsumer(this.scope.objects, manipulateDirData)
@@ -1014,14 +1009,10 @@ export default class Consumer {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
 
     const versionDependenciesArr = await scopeComponentsImporter.importMany(dependentsIds, true, false);
-    const shouldDependenciesSavedAsComponents = await this.shouldDependenciesSavedAsComponents(
-      versionDependenciesArr.map(v => v.component.id)
-    );
     const manipulateDirData = await getManipulateDirWhenImportingComponents(
       this.bitMap,
       versionDependenciesArr,
-      this.scope.objects,
-      shouldDependenciesSavedAsComponents
+      this.scope.objects
     );
     const dependentComponentsP = versionDependenciesArr.map(c =>
       c.component.toConsumer(this.scope.objects, manipulateDirData)


### PR DESCRIPTION
…ate-dir because it is not needed anymore. (this became possible after merging the https://github.com/teambit/bit/pull/1651)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1653)
<!-- Reviewable:end -->
