### PR TITLE
fix #1656, remove dist dir upon eject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix `bit remove` and `bit eject` to delete the dist directory when located outside the components dir
+- fix `bit eject` to support component custom npm registry scope
 - fix generated `package.json` when dist is outside the components dir to point the `main` to the dist file (#1648)
 - avoid generating links of devDependencies when installing component as packages (#1614)
 

--- a/e2e/commands/remove.e2e.2.js
+++ b/e2e/commands/remove.e2e.2.js
@@ -416,8 +416,8 @@ describe('bit remove command', function () {
       const output = helper.removeComponent('utils/is-string2 -s');
       expect(output).to.contain.string('successfully removed components');
       expect(output).to.contain.string(`${helper.remoteScope}/utils/is-string2`);
-      assert.isEmptyDirectory(importedComponentDir, 'directory not empty');
-      assert.isEmptyDirectory(importedDependeceDir, 'directory not empty');
+      expect(importedComponentDir).to.not.be.a.path();
+      expect(importedDependeceDir).to.not.be.a.path();
     });
     it('bitmap should not contain component and dependences', () => {
       const bitMap = helper.readBitMap();

--- a/e2e/flows/dist-outside-components.e2e.2.js
+++ b/e2e/flows/dist-outside-components.e2e.2.js
@@ -142,6 +142,7 @@ export default function foo() { return isString() + ' and got foo v2'; };`;
       });
     });
     describe('as imported', () => {
+      let scopeAfterImport;
       before(() => {
         helper.getClonedLocalScope(clonedScope);
         helper.tagAllComponents();
@@ -152,6 +153,7 @@ export default function foo() { return isString() + ' and got foo v2'; };`;
         helper.addRemoteScope();
         helper.modifyFieldInBitJson('dist', { target: 'dist' });
         helper.importComponent('bar/foo');
+        scopeAfterImport = helper.cloneLocalScope();
       });
       it('should be able to require its direct dependency and print results from all dependencies', () => {
         fs.outputFileSync(path.join(helper.localScopePath, 'app.js'), appJsFixture);
@@ -198,6 +200,15 @@ export default function foo() { return isString() + ' and got foo v2'; };`;
             const result = helper.runCmd('node app.js');
             expect(result.trim()).to.equal('got is-type and got is-string and got foo v2');
           });
+        });
+      });
+      describe('removing the component', () => {
+        before(() => {
+          helper.getClonedLocalScope(scopeAfterImport);
+          helper.removeComponent('bar/foo', '-s');
+        });
+        it('should remove the dist directory as well', () => {
+          expect(path.join(helper.localScopePath, 'dist/components/bar')).to.not.be.a.path();
         });
       });
     });

--- a/e2e/typescript/typescript.e2e.3.js
+++ b/e2e/typescript/typescript.e2e.3.js
@@ -2,11 +2,13 @@
 
 import path from 'path';
 import fs from 'fs-extra';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import normalize from 'normalize-path';
 import Helper from '../e2e-helper';
 import BitsrcTester, { username, supportTestingOnBitsrc } from '../bitsrc-tester';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+
+chai.use(require('chai-fs'));
 
 const helper = new Helper();
 
@@ -501,6 +503,14 @@ export default function foo() { return isArray() +  ' and ' + isString() +  ' an
         });
         it('should be able to require its direct dependency and print results from all dependencies', () => {
           runAppJs();
+        });
+        describe('ejecting the component', () => {
+          before(() => {
+            helper.ejectComponents('bar/foo');
+          });
+          it('should delete also the dist directory', () => {
+            expect(path.join(helper.localScopePath, 'dist/components/bar')).to.not.be.a.path();
+          });
         });
       });
     });

--- a/src/consumer/component-ops/delete-component-files.js
+++ b/src/consumer/component-ops/delete-component-files.js
@@ -1,0 +1,43 @@
+// @flow
+import logger from '../../logger/logger';
+import BitIds from '../../bit-id/bit-ids';
+import { COMPONENT_ORIGINS } from '../../constants';
+import Consumer from '../consumer';
+import DataToPersist from '../component/sources/data-to-persist';
+import RemovePath from '../component/sources/remove-path';
+import Dists from '../component/sources/dists';
+
+export default async function deleteComponentsFiles(consumer: Consumer, bitIds: BitIds, deleteFilesForAuthor: boolean) {
+  logger.debug(`deleteComponentsFiles, ids: ${bitIds.toString()}`);
+  const filesToDelete = getFilesToDelete();
+  filesToDelete.addBasePath(consumer.getPath());
+  return filesToDelete.persistAllToFS();
+
+  function getFilesToDelete(): DataToPersist {
+    const dataToPersist = new DataToPersist();
+    bitIds.forEach((id) => {
+      const ignoreVersion = id.isLocal() || !id.hasVersion();
+      const componentMap = consumer.bitMap.getComponentIfExist(id, { ignoreVersion });
+      if (!componentMap) {
+        logger.warn(
+          `deleteComponentsFiles was unable to delete ${id.toString()} because the id is missing from bitmap`
+        );
+        return null;
+      }
+      if (componentMap.origin === COMPONENT_ORIGINS.IMPORTED || componentMap.origin === COMPONENT_ORIGINS.NESTED) {
+        // $FlowFixMe rootDir is set for non authored
+        const rootDir: string = componentMap.rootDir;
+        dataToPersist.removePath(new RemovePath(rootDir, true));
+        if (!consumer.shouldDistsBeInsideTheComponent()) {
+          const distDir = Dists.getDistDirWhenDistIsOutsideCompDir(consumer.config, rootDir);
+          dataToPersist.removePath(new RemovePath(distDir, true));
+        }
+      } else if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED && deleteFilesForAuthor) {
+        const filesToRemove = componentMap.getAllFilesPaths().map(f => new RemovePath(f));
+        dataToPersist.removeManyPaths(filesToRemove);
+      }
+      return null;
+    });
+    return dataToPersist;
+  }
+}

--- a/src/consumer/component/package-json-utils.js
+++ b/src/consumer/component/package-json-utils.js
@@ -18,6 +18,7 @@ import npmRegistryName from '../../utils/bit/npm-registry-name';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
 import PackageJsonFile from './package-json-file';
 import searchFilesIgnoreExt from '../../utils/fs/search-files-ignore-ext';
+import ComponentVersion from '../../scope/component-version';
 
 /**
  * Add components as dependencies to root package.json
@@ -41,16 +42,14 @@ export async function addComponentsToRoot(consumer: Consumer, components: Compon
 /**
  * Add given components with their versions to root package.json
  */
-export async function addComponentsWithVersionToRoot(consumer: Consumer, componentsIds: BitIds) {
-  const driver = consumer.driver.getDriver(false);
-  const PackageJson = driver.PackageJson;
-
+export async function addComponentsWithVersionToRoot(consumer: Consumer, componentsVersions: ComponentVersion[]) {
   const componentsToAdd = R.fromPairs(
-    componentsIds.map((id) => {
-      return [id.toStringWithoutVersion(), id.version];
+    componentsVersions.map(({ component, version }) => {
+      const packageName = componentIdToPackageName(component.toBitId(), component.bindingPrefix);
+      return [packageName, version];
     })
   );
-  await PackageJson.addComponentsIntoExistingPackageJson(consumer.getPath(), componentsToAdd, npmRegistryName());
+  await _addDependenciesPackagesIntoPackageJson(consumer.getPath(), componentsToAdd);
 }
 
 export async function changeDependenciesToRelativeSyntax(

--- a/src/consumer/component/sources/dists.js
+++ b/src/consumer/component/sources/dists.js
@@ -15,6 +15,7 @@ import Source from '../../../scope/models/source';
 import type CompilerExtension from '../../../extensions/compiler-extension';
 import type { DistFileModel } from '../../../scope/models/version';
 import DataToPersist from './data-to-persist';
+import WorkspaceConfig from '../../config/workspace-config';
 
 /**
  * Dist paths are by default saved into the component's root-dir/dist. However, when dist is set in bit.json, the paths
@@ -78,18 +79,22 @@ export default class Dists {
    * relative to consumer root.
    */
   getDistDirForConsumer(consumer: Consumer, componentRootDir: PathLinux): PathOsBasedRelative {
-    const workspaceConfig = consumer.config;
     if (consumer.shouldDistsBeInsideTheComponent()) {
-      // should be relative to component
       this.distsRootDir = path.join(componentRootDir, DEFAULT_DIST_DIRNAME);
     } else {
-      // should be relative to consumer root
-      if (workspaceConfig.distEntry) componentRootDir = componentRootDir.replace(workspaceConfig.distEntry, '');
-      const distTarget = workspaceConfig.distTarget || DEFAULT_DIST_DIRNAME;
       this.areDistsInsideComponentDir = false;
-      this.distsRootDir = path.join(distTarget, componentRootDir);
+      this.distsRootDir = Dists.getDistDirWhenDistIsOutsideCompDir(consumer.config, componentRootDir);
     }
     return this.distsRootDir;
+  }
+
+  static getDistDirWhenDistIsOutsideCompDir(
+    workspaceConfig: WorkspaceConfig,
+    componentRootDir: PathLinux
+  ): PathOsBasedRelative {
+    if (workspaceConfig.distEntry) componentRootDir = componentRootDir.replace(workspaceConfig.distEntry, '');
+    const distTarget = workspaceConfig.distTarget || DEFAULT_DIST_DIRNAME;
+    return path.join(distTarget, componentRootDir);
   }
 
   getDistDir(consumer: ?Consumer, componentRootDir: PathLinux): PathOsBasedRelative {


### PR DESCRIPTION
* fix bit-remove and bit-eject to delete the dist directory when located outside the components dir. 

* fix bit-eject to support component custom npm registry scope

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1664)
<!-- Reviewable:end -->
