### PR TITLE
fix #1665 on bit-javascript. fix resolve-modules prefix with tilda on css files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1665](https://github.com/teambit/bit/issues/1665) fix resolve-modules prefix with tilda
 - [#1627](https://github.com/teambit/bit/issues/1627) improve `bit tag` output
 - introduce a new flag `--machine-name` for `bit login` to help CI servers keep their token not revoked
 - support `bit import` with wildcards to import an entire scope or particular namespace(s)

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "^2.0.7",
+    "bit-javascript": "^2.0.9",
     "bluebird": "^3.5.3",
     "chalk": "^2.4.1",
     "chokidar": "^2.0.3",


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1689)
<!-- Reviewable:end -->
