### PR TITLE
fix #1698, avoid genereting dependencies symlinks when they do not ha…

### DIFF
--- a/src/links/node-modules-linker.js
+++ b/src/links/node-modules-linker.js
@@ -214,6 +214,7 @@ export default class NodeModuleLinker {
       const dependenciesLinks: Symlink[] = [];
       if (!dependencyComponentMap) return dependenciesLinks;
       const parentRootDir = componentMap.getRootDir();
+      if (!dependencyComponentMap.rootDir) return dependenciesLinks;
       const dependencyRootDir = dependencyComponentMap.getRootDir();
       dependenciesLinks.push(
         this._getDependencyLink(parentRootDir, dependency.id, dependencyRootDir, component.bindingPrefix)


### PR DESCRIPTION
…ve rootDir, otherwise, the symlinks are generated from workspace root and as a result, the version resolution uses the root package.json version, which is wrong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1703)
<!-- Reviewable:end -->
