### PR TITLE
stabilize CIs (CircleCI and AppVeyor) by invalidating cache upon package.json/package-lock.json/ci-config-file changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,20 +79,14 @@ jobs:
       -
         restore_cache:
           keys:
-            - 'npm-deps13-{{ checksum "./bit/package.json" }}'
-            - npm-deps13
+            - 'npm-deps-v14-{{ checksum "./bit/package.json" }}-{{ checksum "./bit/package-lock.json" }}-{{ checksum "./bit/.circleci/config.yml" }}'
       -
         run:
-          name: 'Insatll npm dependencies'
+          name: 'Install npm dependencies'
           command: 'cd bit && npm install'
       -
         save_cache:
-          key: 'npm-deps13-{{ checksum "./bit/package.json" }}'
-          paths:
-            - ./bit/node_modules
-      -
-        save_cache:
-          key: npm-deps13
+          key: 'npm-deps-v14-{{ checksum "./bit/package.json" }}-{{ checksum "./bit/package-lock.json" }}-{{ checksum "./bit/.circleci/config.yml" }}'
           paths:
             - ./bit/node_modules
       -
@@ -111,7 +105,7 @@ jobs:
           at: ./
       -
         run:
-          name: 'Insatll npm dependencies'
+          name: 'Install npm dependencies'
           command: 'cd bit-javascript && npm install'
       -
         persist_to_workspace:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,12 +35,10 @@ for:
       - ps: "npm run e2e-test:appveyor3"
 
 
-
-
 # build cache to preserve files/folders between builds
 cache:
-  - node_modules                    # local npm modules
-  - '%APPDATA%\npm-cache'           # npm cache
+  - node_modules -> package.json, package-lock.json, appveyor.yml           # local npm modules
+  - '%APPDATA%\npm-cache -> package.json, package-lock.json, appveyor.yml'  # npm cache
 
 environment:
   priv_key:


### PR DESCRIPTION
Currently, CIs build fails often due to using old cache.
With this change, the CI won't use the NPM cache and node_modules cache when one of the following files has changed:

- package.json
- package-lock.json
- CI config file (.circleci/config.yml or appveyor.yml)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1748)
<!-- Reviewable:end -->
