### PR TITLE
re-structure the isolated component files on the capsule as described in #1758

### DIFF
--- a/e2e/fixtures/fixtures.js
+++ b/e2e/fixtures/fixtures.js
@@ -39,8 +39,11 @@ describe('foo', () => {
   });
 });`;
 export const appPrintIsType = "const isType = require('./components/utils/is-type'); console.log(isType());";
+export const appPrintIsTypeCapsule = "const isType = require('.'); console.log(isType());";
 export const appPrintIsString = "const isString = require('./components/utils/is-string'); console.log(isString());";
+export const appPrintIsStringCapsule = "const isString = require('.'); console.log(isString());";
 export const appPrintBarFoo = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
+export const appPrintBarFooCapsule = "const barFoo = require('.'); console.log(barFoo());";
 export const appPrintBarFooES6 = "const barFoo = require('./components/bar/foo'); console.log(barFoo.default());";
 export const appPrintBarFooAuthor = "const barFoo = require('./bar/foo'); console.log(barFoo());";
 export const objectRestSpread = `const g = 5;

--- a/e2e/flows/capsule.e2e.2.js
+++ b/e2e/flows/capsule.e2e.2.js
@@ -16,7 +16,7 @@ describe('capsule', function () {
       helper.setNewLocalAndRemoteScopes();
       helper.populateWorkspaceWithComponents();
       helper.runCmd(`bit isolate bar/foo --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFoo);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFooCapsule);
     });
     it('should have the components and dependencies installed correctly with all the links', () => {
       const result = helper.runCmd('node app.js', capsuleDir);
@@ -30,7 +30,7 @@ describe('capsule', function () {
       helper.populateWorkspaceWithComponents();
       helper.tagAllComponents();
       helper.runCmd(`bit isolate bar/foo --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFoo);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFooCapsule);
     });
     it('should have the components and dependencies installed correctly with all the links', () => {
       const result = helper.runCmd('node app.js', capsuleDir);
@@ -52,7 +52,7 @@ describe('capsule', function () {
       helper.tagAllComponents();
       helper.exportAllComponents();
       helper.runCmd(`bit isolate utils/is-type --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintIsType);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintIsTypeCapsule);
     });
     it('should have the component installed correctly with the peer dependencies', () => {
       const result = helper.runCmd('node app.js', capsuleDir);
@@ -76,7 +76,7 @@ describe('capsule', function () {
       helper.tagAllComponents();
       helper.exportAllComponents();
       helper.runCmd(`bit isolate utils/is-string --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintIsString);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintIsStringCapsule);
     });
     it('should have the component installed correctly with the peer packages of the dependency', () => {
       const result = helper.runCmd('node app.js', capsuleDir);
@@ -91,7 +91,7 @@ describe('capsule', function () {
       helper.tagAllComponents();
       helper.exportAllComponents();
       helper.runCmd(`bit isolate bar/foo --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFoo);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFooCapsule);
     });
     it('should have the components and dependencies installed correctly with all the links', () => {
       const result = helper.runCmd('node app.js', capsuleDir);
@@ -110,7 +110,7 @@ describe('capsule', function () {
       helper.addRemoteScope();
       helper.importComponent('bar/foo');
       helper.runCmd(`bit isolate bar/foo --use-capsule --directory ${capsuleDir}`);
-      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFoo);
+      fs.outputFileSync(path.join(capsuleDir, 'app.js'), fixtures.appPrintBarFooCapsule);
     });
     it('should have the components and dependencies installed correctly with all the links', () => {
       const result = helper.runCmd('node app.js', capsuleDir);

--- a/src/consumer/component-ops/component-writer.js
+++ b/src/consumer/component-ops/component-writer.js
@@ -124,6 +124,7 @@ export default class ComponentWriter {
     await this._updateConsumerConfigIfNeeded();
     this._determineWhetherToWritePackageJson();
     await this.populateFilesToWriteToComponentDir();
+    this.component.dataToPersist.toConsole();
     return this.component;
   }
 
@@ -143,7 +144,10 @@ export default class ComponentWriter {
     // make sure the project's package.json is not overridden by Bit
     // If a consumer is of isolated env it's ok to override the root package.json (used by the env installation
     // of compilers / testers / extensions)
-    if (this.writePackageJson && ((this.consumer && this.consumer.isolated) || this.writeToPath !== '.')) {
+    if (
+      this.writePackageJson &&
+      (this.isolated || (this.consumer && this.consumer.isolated) || this.writeToPath !== '.')
+    ) {
       const { packageJson, distPackageJson } = preparePackageJsonToWrite(
         this.consumer,
         this.component,

--- a/src/consumer/component-ops/many-components-writer.js
+++ b/src/consumer/component-ops/many-components-writer.js
@@ -9,7 +9,7 @@ import { installNpmPackagesForComponents } from '../../npm-client/install-packag
 import * as packageJsonUtils from '../component/package-json-utils';
 import type { ComponentWithDependencies } from '../../scope';
 import type Component from '../component/consumer-component';
-import { COMPONENT_ORIGINS } from '../../constants';
+import { COMPONENT_ORIGINS, DEFAULT_DIR_DEPENDENCIES } from '../../constants';
 import logger from '../../logger/logger';
 import type Consumer from '../consumer';
 import { isDir, isDirEmptySync } from '../../utils';
@@ -175,7 +175,10 @@ export default class ManyComponentsWriter {
     );
   }
   _getWriteParamsOfOneComponent(componentWithDeps: ComponentWithDependencies): ComponentWriterProps {
-    const componentRootDir: PathOsBasedRelative = this._getComponentRootDir(componentWithDeps.component.id);
+    // for isolated components, the component files should be on the root. see #1758
+    const componentRootDir: PathOsBasedRelative = this.isolated
+      ? '.'
+      : this._getComponentRootDir(componentWithDeps.component.id);
     const getParams = () => {
       if (!this.consumer) {
         return {
@@ -324,7 +327,7 @@ export default class ManyComponentsWriter {
   }
   _getDependencyRootDir(bitId: BitId): PathOsBasedRelative {
     if (this.isolated) {
-      return composeDependencyPathForIsolated(bitId);
+      return composeDependencyPathForIsolated(bitId, DEFAULT_DIR_DEPENDENCIES);
     }
     // $FlowFixMe consumer is set here
     return this.consumer.composeRelativeDependencyPath(bitId);


### PR DESCRIPTION
Specifically, change the following:

- component files are on the root directory of the capsule
- dependencies are imported into `.dependencies` of the capsule root and not on `components/.dependencies`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1763)
<!-- Reviewable:end -->
