### PR TITLE
a workaround for #1764, generate the link correctly when index.ts is replaced by public_api.ts

### DIFF
--- a/src/links/dependency-file-link-generator.js
+++ b/src/links/dependency-file-link-generator.js
@@ -200,7 +200,14 @@ export default class DependencyFileLinkGenerator {
   }
 
   _getPackagePath(): string {
-    if (this.relativePath.destinationRelativePath === pathNormalizeToLinux(this.dependencyComponent.mainFile)) {
+    const dependencyMainFile = pathNormalizeToLinux(this.dependencyComponent.mainFile);
+    if (
+      this.relativePath.destinationRelativePath === dependencyMainFile ||
+      // @todo: this is a temporary workaround for #1764. we need to investigate why the
+      // destinationRelativePath has `index.ts` prefix while the dependency has the main-file with
+      // public_api.ts suffix
+      this.relativePath.destinationRelativePath.replace('index.ts', 'public_api.ts') === dependencyMainFile
+    ) {
       return this._getPackageName();
     }
     // the link is to an internal file, not to the main file


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1766)
<!-- Reviewable:end -->
