### PR TITLE
fix require statements to an internal package file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix require statements to an internal package file to not include extensions if they're [.js, .ts, .tsx, .jsx]
 - [#1762](https://github.com/teambit/bit/issues/1762) allow compilers to add properties to `package.json` file
 - change dependency links generated when dependencies are saved as components to be module paths and not relative paths
 - add a custom entry point file for Angular components

--- a/e2e/fixtures/fixtures.js
+++ b/e2e/fixtures/fixtures.js
@@ -10,6 +10,7 @@ describe('isType', () => {
   });
 });`;
 export const isTypeES6 = "export default function isType() { return 'got is-type'; };";
+export const isTypeTS = "export default function isType() { return 'got is-type'; };";
 export const isString =
   "const isType = require('./is-type.js'); module.exports = function isString() { return isType() +  ' and got is-string'; };";
 export const isStringV2 =
@@ -24,12 +25,16 @@ describe('isString', () => {
 });`;
 export const isStringES6 =
   "import isType from './is-type.js'; export default function isString() { return isType() +  ' and got is-string'; };";
+export const isStringTS =
+  "import isType from './is-type'; export default function isString() { return isType() +  ' and got is-string'; };";
 export const barFooFixture =
   "const isString = require('../utils/is-string.js'); module.exports = function foo() { return isString() + ' and got foo'; };";
 export const barFooFixtureV2 =
   "const isString = require('../utils/is-string.js'); module.exports = function foo() { return isString() + ' and got foo v2'; };";
 export const barFooES6 =
   "import isString from '../utils/is-string.js'; export default function foo() { return isString() + ' and got foo'; };";
+export const barFooTS =
+  "import isString from '../utils/is-string'; export default function foo() { return isString() + ' and got foo'; };";
 export const barFooSpecES6 = testShouldPass => `const expect = require('chai').expect;
 const foo = require('./foo.js');
 

--- a/e2e/typescript/typescript.e2e.3.js
+++ b/e2e/typescript/typescript.e2e.3.js
@@ -6,6 +6,7 @@ import chai, { expect } from 'chai';
 import Helper from '../e2e-helper';
 import BitsrcTester, { username, supportTestingOnBitsrc } from '../bitsrc-tester';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+import * as fixtures from '../fixtures/fixtures';
 
 chai.use(require('chai-fs'));
 
@@ -402,16 +403,11 @@ export class List extends React.Component {
       helper.getClonedLocalScope(scopeWithTypescriptCompiler);
       npmCiRegistry.setCiScopeInBitJson();
       helper.addRemoteScope();
-      const isTypeFixture = "export default function isType() { return 'got is-type'; };";
-      helper.createFile('utils', 'is-type.ts', isTypeFixture);
+      helper.createFile('utils', 'is-type.ts', fixtures.isTypeTS);
       helper.addComponent('utils/is-type.ts', { i: 'utils/is-type' });
-      const isStringFixture =
-        "import isType from './is-type'; export default function isString() { return isType() +  ' and got is-string'; };";
-      helper.createFile('utils', 'is-string.ts', isStringFixture);
+      helper.createFile('utils', 'is-string.ts', fixtures.isStringTS);
       helper.addComponent('utils/is-string.ts', { i: 'utils/is-string' });
-      const fooBarFixture =
-        "import isString from '../utils/is-string'; export default function foo() { return isString() + ' and got foo'; };";
-      helper.createFile('bar', 'foo.ts', fooBarFixture);
+      helper.createFile('bar', 'foo.ts', fixtures.barFooTS);
       helper.addComponent('bar/foo.ts', { i: 'bar/foo' });
       helper.tagAllComponents();
       helper.exportAllComponents();
@@ -485,6 +481,44 @@ export class List extends React.Component {
           });
         });
       });
+    });
+  });
+  describe('requiring an internal file', () => {
+    before(() => {
+      helper.setNewLocalAndRemoteScopes();
+      helper.getClonedLocalScope(scopeWithTypescriptCompiler);
+      helper.addRemoteScope();
+      helper.createFile('src/utils', 'is-type.ts', '');
+      helper.createFile('src/utils', 'is-type-internal.ts', fixtures.isTypeTS);
+      helper.addComponent('src/utils/is-type.ts src/utils/is-type-internal.ts', {
+        i: 'utils/is-type',
+        m: 'src/utils/is-type.ts'
+      });
+
+      const isStringFixture =
+        "import isType from './is-type-internal'; export default function isString() { return isType() +  ' and got is-string'; };";
+      helper.createFile('src/utils', 'is-string.ts', '');
+      helper.createFile('src/utils', 'is-string-internal.ts', isStringFixture);
+      helper.addComponent('src/utils/is-string.ts src/utils/is-string-internal.ts', {
+        i: 'utils/is-string',
+        m: 'src/utils/is-string.ts'
+      });
+
+      const barFooFixture =
+        "import isString from '../utils/is-string-internal'; export default function foo() { return isString() + ' and got foo'; };";
+      helper.createFile('src/bar', 'foo.ts', barFooFixture);
+      helper.addComponent('src/bar/foo.ts', { i: 'bar/foo', m: 'src/bar/foo.ts' });
+      helper.tagAllComponents();
+
+      helper.exportAllComponents();
+      helper.reInitLocalScope();
+      helper.addRemoteScope();
+      helper.importComponent('bar/foo');
+    });
+    it('should be able to require the main and the internal files and print the results', () => {
+      fs.outputFileSync(path.join(helper.localScopePath, 'app.js'), fixtures.appPrintBarFooES6);
+      const result = helper.runCmd('node app.js');
+      expect(result.trim()).to.equal('got is-type and got is-string and got foo');
     });
   });
 });

--- a/src/links/dependency-file-link-generator.js
+++ b/src/links/dependency-file-link-generator.js
@@ -9,7 +9,7 @@ import logger from '../logger/logger';
 import type Component from '../consumer/component/consumer-component';
 import type { RelativePath } from '../consumer/component/dependencies/dependency';
 import type ComponentMap from '../consumer/bit-map/component-map';
-import { getLinkToPackageContent } from './link-content';
+import { getLinkToPackageContent, EXTENSIONS_TO_STRIP_FROM_PACKAGES } from './link-content';
 import componentIdToPackageName from '../utils/bit/component-id-to-package-name';
 import { pathNormalizeToLinux } from '../utils/path';
 import BitMap from '../consumer/bit-map';
@@ -212,6 +212,16 @@ export default class DependencyFileLinkGenerator {
   }
 
   _getPackagePathToInternalFile() {
+    const packageName = this._getPackageName();
+    const internalFileInsidePackage = this._getInternalFileInsidePackage();
+    const ext = getExt(internalFileInsidePackage);
+    const internalFileWithoutExt = EXTENSIONS_TO_STRIP_FROM_PACKAGES.includes(ext)
+      ? getWithoutExt(internalFileInsidePackage)
+      : internalFileInsidePackage;
+    return `${packageName}/${internalFileWithoutExt}`;
+  }
+
+  _getInternalFileInsidePackage() {
     const dependencySavedLocallyAndDistIsOutside = this.dependencyComponentMap && !this.shouldDistsBeInsideTheComponent;
     const distPrefix =
       this.dependencyComponent.dists.isEmpty() ||
@@ -219,8 +229,7 @@ export default class DependencyFileLinkGenerator {
       dependencySavedLocallyAndDistIsOutside
         ? ''
         : `${DEFAULT_DIST_DIRNAME}/`;
-    const packageName = this._getPackageName();
-    return `${packageName}/${distPrefix}${this.relativePath.destinationRelativePath}`;
+    return distPrefix + this.relativePath.destinationRelativePath;
   }
 
   _getCustomResolveMapping() {

--- a/src/links/link-content.js
+++ b/src/links/link-content.js
@@ -8,7 +8,6 @@ import type { ImportSpecifier } from '../consumer/component/dependencies/depende
 
 const LINKS_CONTENT_TEMPLATES = {
   js: "module.exports = require('{filePath}');",
-  // ts: "import myVar from '{filePath}'; export default myVar;",
   ts: "export * from '{filePath}';",
   jsx: "export * from '{filePath}';",
   tsx: "export * from '{filePath}';",
@@ -29,6 +28,8 @@ const PACKAGES_LINKS_CONTENT_TEMPLATES = {
 };
 
 const fileExtensionsForNpmLinkGenerator = ['js', 'ts', 'jsx', 'tsx'];
+
+export const EXTENSIONS_TO_STRIP_FROM_PACKAGES = ['js', 'ts', 'jsx', 'tsx'];
 
 export function isSupportedExtension(filePath: string) {
   const ext = getExt(filePath);


### PR DESCRIPTION
When a component requires an internal file (not main file) of another component, the generated link had the `require`/`import` statement with the extension. For example:
```
/* THIS IS A BIT-AUTO-GENERATED FILE. DO NOT EDIT THIS FILE DIRECTLY. */

import isString from '@bit/yxlgnwmi-remote.utils.is-string/dist/is-string-internal.ts';
export default isString;%
```
This fix makes sure to strip the extension in this case when the extension is one of the following:
[.js, .ts, .tsx, .jsx]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1773)
<!-- Reviewable:end -->
