### PR TITLE
update component's package.json of authored upon untag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1817](https://github.com/teambit/bit/issues/1817) fix ComponentNotFound error when tagging after export & tag & untag for author using compiler that builds dependencies
+
 ## [14.1.4-dev.10] - 2019-07-11
 
 - [#1810](https://github.com/teambit/bit/issues/1810) avoid generating link files with ts/jsx/tsx extensions inside node_modules

--- a/e2e/commands/untag.e2e.2.js
+++ b/e2e/commands/untag.e2e.2.js
@@ -247,6 +247,32 @@ describe('bit untag command', function () {
         it('should show an error', () => {
           expect(output).to.have.string(`unable to untag ${helper.remoteScope}/utils/is-type`);
         });
+        describe('tagging after the export, then, un-tagging the local tag', () => {
+          let packageJsonUtilsIsStringPath;
+          before(() => {
+            helper.tagScope('2.0.0');
+            helper.tagScope('2.0.1');
+            // an intermediate step, make sure the package.json is updated to that version
+            packageJsonUtilsIsStringPath = path.join(
+              helper.localScopePath,
+              `node_modules/@bit/${helper.remoteScope}.utils.is-string`
+            );
+            const packageJson = helper.readPackageJson(packageJsonUtilsIsStringPath);
+            expect(packageJson.version).to.equal('2.0.1');
+
+            helper.untag('-a 2.0.1');
+          });
+          it('should change the version in the author package.json', () => {
+            const packageJsonUtilsIsString = helper.readPackageJson(packageJsonUtilsIsStringPath);
+            expect(packageJsonUtilsIsString.version).to.equal('2.0.0');
+          });
+          describe('tagging the components after the untag', () => {
+            it('should not throw an error componentNotFound', () => {
+              const tagFunc = () => helper.tagComponent('utils/is-string -f');
+              expect(tagFunc).to.not.throw();
+            });
+          });
+        });
       });
     });
     describe('untag all components', () => {

--- a/e2e/commands/untag.e2e.2.js
+++ b/e2e/commands/untag.e2e.2.js
@@ -266,12 +266,6 @@ describe('bit untag command', function () {
             const packageJsonUtilsIsString = helper.readPackageJson(packageJsonUtilsIsStringPath);
             expect(packageJsonUtilsIsString.version).to.equal('2.0.0');
           });
-          describe('tagging the components after the untag', () => {
-            it('should not throw an error componentNotFound', () => {
-              const tagFunc = () => helper.tagComponent('utils/is-string -f');
-              expect(tagFunc).to.not.throw();
-            });
-          });
         });
       });
     });

--- a/e2e/flows/capsule.e2e.2.js
+++ b/e2e/flows/capsule.e2e.2.js
@@ -205,6 +205,20 @@ describe('capsule', function () {
         const count = result.match(regex);
         expect(count).to.have.lengthOf(1);
       });
+      describe('tag, export, tag, untag then tag', () => {
+        before(() => {
+          helper.tagAllComponents();
+          helper.exportAllComponents();
+          helper.tagScope('2.0.0');
+          helper.tagScope('2.0.1');
+          helper.untag('-a 2.0.1');
+        });
+        // @see https://github.com/teambit/bit/issues/1817
+        it('should not throw an error componentNotFound', () => {
+          const tagFunc = () => helper.tagComponent('utils/is-string -f');
+          expect(tagFunc).to.not.throw();
+        });
+      });
     });
   });
   describe('tag with capsule compiler that saves link files into the dists', () => {

--- a/src/consumer/consumer.js
+++ b/src/consumer/consumer.js
@@ -647,12 +647,12 @@ export default class Consumer {
 
     const autoTaggedComponents = autoTaggedResults.map(r => r.component);
     const allComponents = [...taggedComponents, ...autoTaggedComponents];
-    await this._updateComponentsVersions(allComponents);
+    await this.updateComponentsVersions(allComponents);
 
     return { taggedComponents, autoTaggedResults };
   }
 
-  _updateComponentsVersions(components: Array<ModelComponent | Component>): Promise<any> {
+  updateComponentsVersions(components: Array<ModelComponent | Component>): Promise<any> {
     const getPackageJsonDir = (componentMap: ComponentMap, bitId: BitId, bindingPrefix: string): ?PathRelative => {
       if (componentMap.rootDir) return componentMap.rootDir;
       // it's author
@@ -661,7 +661,8 @@ export default class Consumer {
     };
 
     const updateVersionsP = components.map((component) => {
-      const id: BitId = component instanceof ModelComponent ? component.toBitIdWithLatestVersion() : component.id;
+      const id: BitId =
+        component instanceof ModelComponent ? component.toBitIdWithLatestVersionAllowNull() : component.id;
       this.bitMap.updateComponentId(id);
       const componentMap = this.bitMap.getComponent(id);
       const packageJsonDir = getPackageJsonDir(componentMap, id, component.bindingPrefix);

--- a/src/scope/models/model-component.js
+++ b/src/scope/models/model-component.js
@@ -53,6 +53,8 @@ export type ComponentProps = {
   state?: State // get deleted after export
 };
 
+const VERSION_ZERO = '0.0.0';
+
 /**
  * we can't rename the class as ModelComponent because old components are already saved in the model
  * with 'Component' in their headers. see object-registrar.types()
@@ -133,7 +135,7 @@ export default class Component extends BitObject {
   }
 
   latest(): string {
-    if (empty(this.versions)) return '0.0.0';
+    if (empty(this.versions)) return VERSION_ZERO;
     return semver.maxSatisfying(this.listVersions(), '*');
   }
 
@@ -147,7 +149,7 @@ export default class Component extends BitObject {
    * @memberof Component
    */
   latestExisting(repository: Repository): string {
-    if (empty(this.versions)) return '0.0.0';
+    if (empty(this.versions)) return VERSION_ZERO;
     const versions = this.listVersions('ASC');
     let version = null;
     let versionStr = null;
@@ -155,7 +157,7 @@ export default class Component extends BitObject {
       versionStr = versions.pop();
       version = this.loadVersionSync(versionStr, repository, false);
     }
-    return versionStr || '0.0.0';
+    return versionStr || VERSION_ZERO;
   }
 
   collectLogs(repo: Repository): Promise<{ [number]: { message: string, date: string, hash: string } }> {
@@ -209,6 +211,11 @@ export default class Component extends BitObject {
 
   toBitIdWithLatestVersion(): BitId {
     return new BitId({ scope: this.scope, name: this.name, version: this.latest() });
+  }
+
+  toBitIdWithLatestVersionAllowNull(): BitId {
+    const id = this.toBitIdWithLatestVersion();
+    return id.version === VERSION_ZERO ? id.changeVersion(null) : id;
   }
 
   toObject() {


### PR DESCRIPTION
so then it won't throw ComponentNotFound when tagging after export & tag & untag.

Also, unify the process of updating the versions in `.bitmap` and `package.json` upon tag and untag.
Before, they were unsynced two different processes.

Fix https://github.com/teambit/bit/issues/1817.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1820)
<!-- Reviewable:end -->
