### PR TITLE
Automatically mark added files as tests when their path indicate so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1715](https://github.com/teambit/bit/issues/1715) support test/spec file conventions
 - [#1710](https://github.com/teambit/bit/issues/1710) improve performance of importing an entire collection
 
 ## [14.2.2] - 2019-07-24

--- a/e2e/commands/add.e2e.1.js
+++ b/e2e/commands/add.e2e.1.js
@@ -1288,4 +1288,20 @@ describe('bit add command', function () {
       expect(files[3].relativePath).to.equal('ddd.js');
     });
   });
+  describe('adding specs/tests files without using the --test flag', () => {
+    before(() => {
+      helper.reInitLocalScope();
+      helper.createFile('utils', 'is-string.js');
+      helper.createFile('utils', 'is-string.spec.js');
+      helper.addComponent('utils', { m: 'is-string.js' });
+    });
+    it('should recognize the tests file by their names', () => {
+      const bitMap = helper.readBitMap();
+      const files = bitMap.utils.files;
+      const specFile = files.find(f => f.relativePath === 'utils/is-string.spec.js');
+      expect(specFile.test).to.be.true;
+      const nonSpecFile = files.find(f => f.relativePath === 'utils/is-string.js');
+      expect(nonSpecFile.test).to.be.false;
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-bin",
-  "version": "14.2.1",
+  "version": "14.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9316,11 +9316,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.1.tgz",
       "integrity": "sha1-vyJJiGzlFM2hEvrpIYzcBlIR/Jw="
-    },
-    "lodash.unionby": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/lodash.unionby/-/lodash.unionby-4.8.0.tgz",
-      "integrity": "sha1-iD8Jj/ePVkpye3UI4JzdU5c0u4M="
     },
     "lodash.uniqby": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "lodash.partition": "^4.6.0",
     "lodash.set": "^4.3.2",
     "lodash.toarray": "^4.4.0",
-    "lodash.unionby": "^4.8.0",
     "lodash.uniqby": "^4.7.0",
     "loud-rejection": "^1.6.0",
     "make-fetch-happen": "^4.0.1",

--- a/src/utils/file/is-test-file.js
+++ b/src/utils/file/is-test-file.js
@@ -1,0 +1,6 @@
+// @flow
+
+export default function isTestFile(fileName: string) {
+  // see unit tests for examples
+  return new RegExp('^.*.(test|spec|specs|tests).(js|ts|tsx|jsx)$').test(fileName);
+}

--- a/src/utils/file/is-test-file.spec.js
+++ b/src/utils/file/is-test-file.spec.js
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import isTestFile from './is-test-file';
+
+describe('isTestFile', () => {
+  it('should return true for files ending with [spec|test|specs|tests].[js|jsx|ts|tsx])', () => {
+    expect(isTestFile('foo.spec.js')).to.be.true;
+    expect(isTestFile('foo.spec.ts')).to.be.true;
+    expect(isTestFile('foo.spec.tsx')).to.be.true;
+    expect(isTestFile('foo.spec.jsx')).to.be.true;
+    expect(isTestFile('foo.test.js')).to.be.true;
+    expect(isTestFile('foo.test.ts')).to.be.true;
+    expect(isTestFile('foo.test.tsx')).to.be.true;
+    expect(isTestFile('foo.test.jsx')).to.be.true;
+    expect(isTestFile('foo.specs.js')).to.be.true;
+    expect(isTestFile('foo.tests.js')).to.be.true;
+  });
+  it('should return false for anything else', () => {
+    expect(isTestFile('foo.testjs')).to.be.false;
+    expect(isTestFile('foo.test.jsv')).to.be.false;
+    expect(isTestFile('test.js')).to.be.false;
+    expect(isTestFile('spec.js')).to.be.false;
+    expect(isTestFile('foo.spec.bar.js')).to.be.false;
+  });
+});


### PR DESCRIPTION
specifically when their suffix is `(test|spec|tests|specs).(js|ts|tsx|jsx)`.
Implements https://github.com/teambit/bit/issues/1715

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1854)
<!-- Reviewable:end -->
