### PR TITLE
Auto recognize mainFile when one of the added files has the same name as its dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1714](https://github.com/teambit/bit/issues/1714) auto recognize mainFile when a file added with the same name as its dir
 - [#1856](https://github.com/teambit/bit/issues/1856) fix links deletion from `node_modules` after installing packages by a compiler on a capsule
 - [#1710](https://github.com/teambit/bit/issues/1710) improve performance of importing an entire collection
 

--- a/e2e/commands/add.e2e.1.js
+++ b/e2e/commands/add.e2e.1.js
@@ -1246,6 +1246,19 @@ describe('bit add command', function () {
       });
     });
   });
+  describe('no mainFile and one of the files has the same name as the directory', () => {
+    before(() => {
+      helper.reInitLocalScope();
+      helper.createFile('bar', 'bar.js');
+      helper.createFile('bar', 'foo.js');
+      helper.addComponent('bar');
+    });
+    it('should resolve the mainFile as the file with the same name as the directory', () => {
+      const bitMap = helper.readBitMap();
+      const bar = bitMap.bar;
+      expect(bar.mainFile).to.equal('bar/bar.js');
+    });
+  });
   describe('sort .bitmap components', () => {
     before(() => {
       helper.reInitLocalScope();

--- a/src/consumer/component-ops/add-components/determine-main-file.js
+++ b/src/consumer/component-ops/add-components/determine-main-file.js
@@ -1,0 +1,114 @@
+// @flow
+import path from 'path';
+import R from 'ramda';
+import type { PathLinux } from '../../../utils/path';
+import ComponentMap from '../../bit-map/component-map';
+import { MissingMainFile } from '../../bit-map/exceptions';
+import { DEFAULT_INDEX_EXTS, DEFAULT_INDEX_NAME, DEFAULT_SEPARATOR } from '../../../constants';
+import { pathJoinLinux, pathNormalizeToLinux } from '../../../utils/path';
+import type { AddedComponent } from './add-components';
+
+export default function determineMainFile(
+  addedComponent: AddedComponent,
+  existingComponentMap: ?ComponentMap
+): PathLinux {
+  const mainFile = addedComponent.mainFile;
+  const componentIdStr = addedComponent.componentId.toString();
+  const files = addedComponent.files.filter(file => !file.test);
+  const rootDir = existingComponentMap && existingComponentMap.rootDir;
+  const strategies: Function[] = [
+    getExistingIfNotChanged,
+    getUserSpecifiedMainFile,
+    onlyOneFileEnteredUseIt,
+    searchForFileNameIndex,
+    searchForSameFileNameAsImmediateDir
+  ];
+
+  for (const strategy of strategies) {
+    const foundMainFile = strategy();
+    if (foundMainFile) {
+      return foundMainFile;
+    }
+  }
+  const mainFileString = `${DEFAULT_INDEX_NAME}.[${DEFAULT_INDEX_EXTS.join(', ')}]`;
+  throw new MissingMainFile(componentIdStr, mainFileString, files.map(file => path.normalize(file.relativePath)));
+
+  /**
+   * user didn't enter mainFile but the component already exists with mainFile
+   */
+  function getExistingIfNotChanged(): ?PathLinux {
+    if (!mainFile && existingComponentMap) {
+      return existingComponentMap.mainFile;
+    }
+    return null;
+  }
+  /**
+   * user entered mainFile => search the mainFile in the files array, throw error if not found
+   */
+  function getUserSpecifiedMainFile(): ?PathLinux {
+    if (mainFile) {
+      const foundMainFile = _searchMainFile(pathNormalizeToLinux(mainFile));
+      if (foundMainFile) return foundMainFile;
+      throw new MissingMainFile(componentIdStr, mainFile, files.map(file => path.normalize(file.relativePath)));
+    }
+    return null;
+  }
+  /**
+   * user didn't enter mainFile and the component has only one file, use that file as the main file
+   */
+  function onlyOneFileEnteredUseIt(): ?PathLinux {
+    if (files.length === 1) {
+      return files[0].relativePath;
+    }
+    return null;
+  }
+  /**
+   * user didn't enter mainFile and the component has multiple files, search for file name "index",
+   * e.g. `index.js`, `index.css`, etc.
+   */
+  function searchForFileNameIndex(): ?PathLinux {
+    for (const ext of DEFAULT_INDEX_EXTS) {
+      const mainFileNameToSearch = `${DEFAULT_INDEX_NAME}.${ext}`;
+      const searchResult = _searchMainFile(mainFileNameToSearch);
+      if (searchResult) {
+        return searchResult;
+      }
+    }
+    return null;
+  }
+  /**
+   * user didn't enter mainFile and the component has multiple files, search for file with the same
+   * name as the directory (see #1714)
+   */
+  function searchForSameFileNameAsImmediateDir(): ?PathLinux {
+    if (addedComponent.immediateDir) {
+      for (const ext of DEFAULT_INDEX_EXTS) {
+        const mainFileNameToSearch = `${addedComponent.immediateDir}.${ext}`;
+        const searchResult = _searchMainFile(mainFileNameToSearch);
+        if (searchResult) {
+          return searchResult;
+        }
+      }
+    }
+    return null;
+  }
+
+  function _searchMainFile(baseMainFile: PathLinux): ?PathLinux {
+    // search for an exact relative-path
+    let mainFileFromFiles = files.find(file => file.relativePath === baseMainFile);
+    if (mainFileFromFiles) return baseMainFile;
+    if (rootDir) {
+      const mainFileUsingRootDir = files.find(file => pathJoinLinux(rootDir, file.relativePath) === baseMainFile);
+      if (mainFileUsingRootDir) return mainFileUsingRootDir.relativePath;
+    }
+    // search for a file-name
+    const potentialMainFiles = files.filter(file => file.name === baseMainFile);
+    if (!potentialMainFiles.length) return null;
+    // when there are several files that met the criteria, choose the closer to the root
+    const sortByNumOfDirs = (a, b) =>
+      a.relativePath.split(DEFAULT_SEPARATOR).length - b.relativePath.split(DEFAULT_SEPARATOR).length;
+    potentialMainFiles.sort(sortByNumOfDirs);
+    mainFileFromFiles = R.head(potentialMainFiles);
+    return mainFileFromFiles.relativePath;
+  }
+}

--- a/src/consumer/component-ops/component-writer.js
+++ b/src/consumer/component-ops/component-writer.js
@@ -206,7 +206,7 @@ export default class ComponentWriter {
     return this.bitMap.addComponent({
       componentId: this.component.id,
       files: filesForBitMap,
-      mainFile: this.component.mainFile, // $FlowFixMe
+      mainFile: pathNormalizeToLinux(this.component.mainFile), // $FlowFixMe
       rootDir, // $FlowFixMe
       configDir: getConfigDir(),
       origin: this.origin,


### PR DESCRIPTION
Also, extract the logic of finding the mainFile from bitMap class to a new file and reorganize the code to loop through the different strategies
Implements https://github.com/teambit/bit/issues/1714.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1860)
<!-- Reviewable:end -->
