### PR TITLE
Fix import with "--path" flag for author

### DIFF
--- a/e2e/commands/import.e2e.1.js
+++ b/e2e/commands/import.e2e.1.js
@@ -165,23 +165,42 @@ describe('bit import', function () {
 
     describe('with a specific path, using -p flag', () => {
       describe('as author', () => {
-        describe.only('when there is a track dir', () => {
+        describe('when there is a track dir', () => {
           before(() => {
             helper.reInitLocalScope();
             helper.addRemoteScope();
-            helper.createFile('bar-author', 'foo1.js');
-            helper.createFile('bar-author', 'foo2.js');
+            helper.createFile('bar-author-track', 'foo1.js');
+            helper.createFile('bar-author-track', 'foo2.js');
             helper.outputFile('should-not-be-deleted.js');
-            helper.addComponent('bar-author', { m: 'foo1.js' });
+            helper.addComponent('bar-author-track', { m: 'foo1.js' });
             helper.tagAllComponents();
             helper.exportAllComponents();
-            helper.importComponentWithOptions('bar-author', { p: 'my-new-dir' });
+            helper.importComponentWithOptions('bar-author-track', { p: 'my-new-dir' });
           });
           it('should not delete other files on the workspace', () => {
             expect(path.join(helper.localScopePath, 'should-not-be-deleted.js')).to.be.a.file();
           });
-          it('should move the component to the specified directory', () => {
+          it('should throw an error saying it is not possible to move the component', () => {
             expect(path.join(helper.localScopePath, 'my-new-dir')).to.be.a.directory();
+          });
+        });
+        describe('when there is no track dir', () => {
+          before(() => {
+            helper.reInitLocalScope();
+            helper.addRemoteScope();
+            helper.createFile('bar-author', 'foo.js');
+            helper.outputFile('should-not-be-deleted.js');
+            helper.addComponent('bar-author/foo.js');
+            helper.tagAllComponents();
+            helper.exportAllComponents();
+            const func = () => helper.importComponentWithOptions('foo', { p: 'my-new-dir' });
+            expect(func).to.throw();
+          });
+          it('should not delete other files on the workspace', () => {
+            expect(path.join(helper.localScopePath, 'should-not-be-deleted.js')).to.be.a.file();
+          });
+          it('should not move the component', () => {
+            expect(path.join(helper.localScopePath, 'bar-author')).to.be.a.directory();
           });
         });
       });

--- a/e2e/commands/import.e2e.1.js
+++ b/e2e/commands/import.e2e.1.js
@@ -164,76 +164,99 @@ describe('bit import', function () {
     });
 
     describe('with a specific path, using -p flag', () => {
-      const componentFileLocation = path.join(helper.localScopePath, 'my-custom-location/simple.js');
-      before(() => {
-        helper.reInitLocalScope();
-        helper.addRemoteScope();
-      });
-      describe('when the destination is a non-exist directory', () => {
-        before(() => {
-          helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
-        });
-        it('should write the component to the specified path', () => {
-          expect(componentFileLocation).to.be.a.file();
-        });
-      });
-      describe('when the destination is an existing empty directory', () => {
-        before(() => {
-          helper.reInitLocalScope();
-          helper.addRemoteScope();
-          fs.ensureDirSync(path.join(helper.localScopePath, 'my-custom-location'));
-          helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
-        });
-        it('should write the component to the specified path', () => {
-          expect(componentFileLocation).to.be.a.file();
+      describe('as author', () => {
+        describe.only('when there is a track dir', () => {
+          before(() => {
+            helper.reInitLocalScope();
+            helper.addRemoteScope();
+            helper.createFile('bar-author', 'foo1.js');
+            helper.createFile('bar-author', 'foo2.js');
+            helper.outputFile('should-not-be-deleted.js');
+            helper.addComponent('bar-author', { m: 'foo1.js' });
+            helper.tagAllComponents();
+            helper.exportAllComponents();
+            helper.importComponentWithOptions('bar-author', { p: 'my-new-dir' });
+          });
+          it('should not delete other files on the workspace', () => {
+            expect(path.join(helper.localScopePath, 'should-not-be-deleted.js')).to.be.a.file();
+          });
+          it('should move the component to the specified directory', () => {
+            expect(path.join(helper.localScopePath, 'my-new-dir')).to.be.a.directory();
+          });
         });
       });
-      describe('when the destination directory is not empty', () => {
-        let output;
-        const existingFile = path.join(helper.localScopePath, 'my-custom-location/my-file.js');
+      describe('as imported', () => {
+        const componentFileLocation = path.join(helper.localScopePath, 'my-custom-location/simple.js');
         before(() => {
           helper.reInitLocalScope();
           helper.addRemoteScope();
-          fs.ensureDirSync(path.join(helper.localScopePath, 'my-custom-location'));
-          fs.outputFileSync(existingFile, 'console.log()');
-          output = helper.runWithTryCatch(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
         });
-        it('should not import the component', () => {
-          expect(componentFileLocation).to.not.be.a.path();
+        describe('when the destination is a non-exist directory', () => {
+          before(() => {
+            helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
+          });
+          it('should write the component to the specified path', () => {
+            expect(componentFileLocation).to.be.a.file();
+          });
         });
-        it('should not delete the existing file', () => {
-          expect(existingFile).to.be.a.file();
+        describe('when the destination is an existing empty directory', () => {
+          before(() => {
+            helper.reInitLocalScope();
+            helper.addRemoteScope();
+            fs.ensureDirSync(path.join(helper.localScopePath, 'my-custom-location'));
+            helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
+          });
+          it('should write the component to the specified path', () => {
+            expect(componentFileLocation).to.be.a.file();
+          });
         });
-        it('should throw an error', () => {
-          expect(output).to.have.string('unable to import');
+        describe('when the destination directory is not empty', () => {
+          let output;
+          const existingFile = path.join(helper.localScopePath, 'my-custom-location/my-file.js');
+          before(() => {
+            helper.reInitLocalScope();
+            helper.addRemoteScope();
+            fs.ensureDirSync(path.join(helper.localScopePath, 'my-custom-location'));
+            fs.outputFileSync(existingFile, 'console.log()');
+            output = helper.runWithTryCatch(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
+          });
+          it('should not import the component', () => {
+            expect(componentFileLocation).to.not.be.a.path();
+          });
+          it('should not delete the existing file', () => {
+            expect(existingFile).to.be.a.file();
+          });
+          it('should throw an error', () => {
+            expect(output).to.have.string('unable to import');
+          });
+          it('should import successfully if the --override flag is used', () => {
+            helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location --override`);
+            expect(componentFileLocation).to.be.a.file();
+          });
         });
-        it('should import successfully if the --override flag is used', () => {
-          helper.runCmd(`bit import ${helper.remoteScope}/global/simple -p my-custom-location --override`);
-          expect(componentFileLocation).to.be.a.file();
-        });
-      });
-      describe('when the destination is a file', () => {
-        let output;
-        before(() => {
-          helper.reInitLocalScope();
-          helper.addRemoteScope();
-          fs.outputFileSync(path.join(helper.localScopePath, 'my-custom-location'), 'console.log()');
-          output = helper.runWithTryCatch(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
-        });
-        it('should not import the component', () => {
-          expect(componentFileLocation).to.not.be.a.path();
-        });
-        it('should not delete the existing file', () => {
-          expect(path.join(helper.localScopePath, 'my-custom-location')).to.be.a.file();
-        });
-        it('should throw an error', () => {
-          expect(output).to.have.string('unable to import');
-        });
-        it('should throw an error also when the --override flag is used', () => {
-          output = helper.runWithTryCatch(
-            `bit import ${helper.remoteScope}/global/simple -p my-custom-location --override`
-          );
-          expect(output).to.have.string('unable to import');
+        describe('when the destination is a file', () => {
+          let output;
+          before(() => {
+            helper.reInitLocalScope();
+            helper.addRemoteScope();
+            fs.outputFileSync(path.join(helper.localScopePath, 'my-custom-location'), 'console.log()');
+            output = helper.runWithTryCatch(`bit import ${helper.remoteScope}/global/simple -p my-custom-location`);
+          });
+          it('should not import the component', () => {
+            expect(componentFileLocation).to.not.be.a.path();
+          });
+          it('should not delete the existing file', () => {
+            expect(path.join(helper.localScopePath, 'my-custom-location')).to.be.a.file();
+          });
+          it('should throw an error', () => {
+            expect(output).to.have.string('unable to import');
+          });
+          it('should throw an error also when the --override flag is used', () => {
+            output = helper.runWithTryCatch(
+              `bit import ${helper.remoteScope}/global/simple -p my-custom-location --override`
+            );
+            expect(output).to.have.string('unable to import');
+          });
         });
       });
     });

--- a/src/consumer/component-ops/many-components-writer.js
+++ b/src/consumer/component-ops/many-components-writer.js
@@ -270,7 +270,8 @@ export default class ManyComponentsWriter {
   _moveComponentsIfNeeded() {
     if (this.writeToPath && this.consumer) {
       this.componentsWithDependencies.forEach((componentWithDeps) => {
-        const componentMap = componentWithDeps.component.componentMap;
+        // $FlowFixMe componentWithDeps.component.componentMap is set
+        const componentMap: ComponentMap = componentWithDeps.component.componentMap;
         if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED && !componentMap.trackDir) {
           throw new GeneralError(`unable to use "--path" flag.
 to move individual files, use bit move.

--- a/src/consumer/component-ops/many-components-writer.js
+++ b/src/consumer/component-ops/many-components-writer.js
@@ -270,7 +270,15 @@ export default class ManyComponentsWriter {
   _moveComponentsIfNeeded() {
     if (this.writeToPath && this.consumer) {
       this.componentsWithDependencies.forEach((componentWithDeps) => {
-        const relativeWrittenPath = componentWithDeps.component.writtenPath;
+        const componentMap = componentWithDeps.component.componentMap;
+        if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED && !componentMap.trackDir) {
+          throw new GeneralError(`unable to use "--path" flag.
+to move individual files, use bit move.
+to move all component files to a different directory, run bit remove and then bit import --path`);
+        }
+        const relativeWrittenPath = componentMap.trackDir
+          ? componentMap.trackDir
+          : componentWithDeps.component.writtenPath;
         // $FlowFixMe relativeWrittenPath is set
         const absoluteWrittenPath = this.consumer.toAbsolutePath(relativeWrittenPath);
         // $FlowFixMe this.writeToPath is set

--- a/src/consumer/component-ops/move-components.js
+++ b/src/consumer/component-ops/move-components.js
@@ -11,6 +11,7 @@ import type Component from '../component/consumer-component';
 import moveSync from '../../utils/fs/move-sync';
 import RemovePath from '../component/sources/remove-path';
 import BitIds from '../../bit-id/bit-ids';
+import { COMPONENT_ORIGINS } from '../../constants';
 
 export async function movePaths(
   consumer: Consumer,
@@ -60,10 +61,17 @@ export function moveExistingComponent(
   const newPathRelative = consumer.getPathRelativeToConsumer(newPath);
   componentMap.updateDirLocation(oldPathRelative, newPathRelative);
   consumer.bitMap.markAsChanged();
-  component.dataToPersist.files.forEach((file) => {
-    const newBase = file.base.replace(oldPathRelative, newPathRelative);
-    file.updatePaths({ newBase });
-  });
+  if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED) {
+    component.dataToPersist.files.forEach((file) => {
+      const newRelative = file.relative.replace(oldPathRelative, newPathRelative);
+      file.updatePaths({ newRelative });
+    });
+  } else {
+    component.dataToPersist.files.forEach((file) => {
+      const newBase = file.base.replace(oldPathRelative, newPathRelative);
+      file.updatePaths({ newBase });
+    });
+  }
   component.dataToPersist.removePath(new RemovePath(oldPathRelative));
   component.writtenPath = newPathRelative;
 }


### PR DESCRIPTION
- when a component has trackDir, move the component after import.
- when there is no trackDir, throw an error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1877)
<!-- Reviewable:end -->
