### PR TITLE
Add tests to make sure the new compiler API has the new capsule related functionality

### DIFF
--- a/e2e/e2e-helper.js
+++ b/e2e/e2e-helper.js
@@ -502,6 +502,13 @@ export default class Helper {
     return this.runCmd(`bit import ${id} --compiler`);
   }
 
+  changeDummyCompilerCode(originalCode: string, replaceTo: string) {
+    const compilerPath = path.join('.bit/components/compilers/dummy', this.envScope, '0.0.1/compiler.js');
+    const compilerContent = this.readFile(compilerPath);
+    const changedCompiler = compilerContent.replace(originalCode, replaceTo);
+    this.outputFile(compilerPath, changedCompiler);
+  }
+
   importDummyTester(dummyType?: string = 'dummy') {
     const id = `${this.envScope}/testers/dummy`;
     this.createDummyTester(dummyType);

--- a/e2e/fixtures/compilers/capsule/compiler.js
+++ b/e2e/fixtures/compilers/capsule/compiler.js
@@ -42,8 +42,32 @@ function getCapsuleDirByComponentName(compilerOutput, componentName) {
   return componentOutput.replace(`generated a capsule for ${componentName} at `, '');
 }
 
-module.exports = {
+const newCompilerApi = {
+  init: ({ rawConfig, dynamicConfig, api }) => {
+    logger = api.getLogger();
+    return { write: true };
+  },
+  action: ({
+    files,
+    rawConfig,
+    dynamicConfig,
+    configFiles,
+    api,
+    context
+  }) => {
+    // don't remove the next line, it is important for the tests to make sure the new api is used
+    console.log('using the new compiler API');
+    const distPath = path.join(context.rootDistDir, 'dist');
+    return compile(files, distPath, context);
+  }
+}
+
+const currentCompilerApi = {
   compile,
   stringToRemovedByCompiler,
   getCapsuleDirByComponentName
 };
+
+const isNewAPI = false;
+
+module.exports = isNewAPI ? newCompilerApi : currentCompilerApi;

--- a/e2e/fixtures/compilers/dist-main/compiler.js
+++ b/e2e/fixtures/compilers/dist-main/compiler.js
@@ -19,6 +19,28 @@ function compile(files, distPath) {
     return { dists, mainFile: mainDist.relative };
 }
 
-module.exports = {
-  compile
-};
+const newCompilerApi = {
+  init: ({ rawConfig, dynamicConfig, api }) => {
+    logger = api.getLogger();
+    return { write: true };
+  },
+  action: ({
+    files,
+    rawConfig,
+    dynamicConfig,
+    configFiles,
+    api,
+    context
+  }) => {
+    // don't remove the next line, it is important for the tests to make sure the new api is used
+    console.log('using the new compiler API');
+    const distPath = path.join(context.rootDistDir, 'dist');
+    return compile(files, distPath, context);
+  }
+}
+
+const currentCompilerApi = { compile };
+
+const isNewAPI = false;
+
+module.exports = isNewAPI ? newCompilerApi : currentCompilerApi;

--- a/e2e/fixtures/compilers/pkg-json/compiler.js
+++ b/e2e/fixtures/compilers/pkg-json/compiler.js
@@ -1,5 +1,5 @@
 /**
- * this compiler generates an additional dist main-file which is different than the source main-file
+ * this compiler adds new values into the package.json of the component
  */
 const path = require('path');
 

--- a/e2e/flows/dist-main-is-different.e2e.2.js
+++ b/e2e/flows/dist-main-is-different.e2e.2.js
@@ -19,6 +19,7 @@ describe('mainFile of the dist is different than the source', function () {
   after(() => {
     helper.destroyEnv();
   });
+  let afterImportingCompiler;
   before(() => {
     helper.setNewLocalAndRemoteScopes();
     npmCiRegistry = new NpmCiRegistry(helper);
@@ -42,6 +43,7 @@ describe('mainFile of the dist is different than the source', function () {
     );
     helper.addComponent('src/bar/foo.js', { i: 'bar/foo' });
     helper.importDummyCompiler('dist-main');
+    afterImportingCompiler = helper.cloneLocalScope();
   });
   describe('tagging the component', () => {
     before(() => {
@@ -156,6 +158,21 @@ describe('mainFile of the dist is different than the source', function () {
           });
         });
       });
+    });
+  });
+  describe('using the new compiler API', () => {
+    before(() => {
+      helper.getClonedLocalScope(afterImportingCompiler);
+      helper.changeDummyCompilerCode('isNewAPI = false', 'isNewAPI = true');
+      const output = helper.build();
+      expect(output).to.have.string('using the new compiler API');
+      helper.tagAllComponents();
+    });
+    it('should save the mainDistFile to the scope', () => {
+      const barFoo = helper.catComponent('bar/foo@latest');
+      expect(barFoo).to.have.property('mainDistFile');
+      expect(barFoo.mainDistFile).to.equal('src/bar/foo-main.js');
+      expect(barFoo.mainDistFile).to.not.equal(barFoo.mainFile);
     });
   });
 });


### PR DESCRIPTION
* add an e2e-test to make sure the new functionality added to the compiler API (such as a method to isolate a component) is available also in the new compiler API.

* add another e2e-test to make sure the new values returned by the compiler, such as dist-main-file is also taken care of in the new compiler API

Done for https://github.com/teambit/bit/issues/1888.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1909)
<!-- Reviewable:end -->
