### PR TITLE
Generate node_modules links upon build for new components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- generate node_modules links upon build for new components
+
 ## [[14.2.5] - 2019-08-22](https://github.com/teambit/bit/releases/tag/v14.2.5)
 
 ### New

--- a/src/api/consumer/lib/build.js
+++ b/src/api/consumer/lib/build.js
@@ -10,11 +10,9 @@ export async function build(id: string, noCache: boolean, verbose: boolean): Pro
   const consumer = await loadConsumer();
   const bitId = consumer.getParsedId(id);
   const component: Component = await consumer.loadComponent(bitId);
-  const result = await component.build({ scope: consumer.scope, noCache, consumer, verbose });
-  if (result === null) return null;
-  const distFilePaths = await component.dists.writeDists(component, consumer);
+  const results = await consumer.scope.buildMultiple([component], consumer, noCache, verbose);
   await consumer.onDestroy();
-  return distFilePaths;
+  return results[0].buildResults;
 }
 
 export async function buildAll(noCache: boolean, verbose: boolean): Promise<Object> {

--- a/src/consumer/component/sources/dists.js
+++ b/src/consumer/component/sources/dists.js
@@ -180,7 +180,7 @@ export default class Dists {
       ? consumer.bitMap.getComponent(component.id, { ignoreVersion: true })
       : component.componentMap;
     if (!componentMap) throw new Error('writeDistsLinks expect componentMap to be defined');
-    if (componentMap.origin !== COMPONENT_ORIGINS.IMPORTED) return;
+    if (componentMap.origin === COMPONENT_ORIGINS.NESTED) return;
     const dataToPersist = await getLinksInDistToWrite(component, componentMap, consumer, consumer.bitMap);
     dataToPersist.addBasePath(consumer.getPath());
     await dataToPersist.persistAllToFS();


### PR DESCRIPTION
It is important for the dists generated by the capsule-compiler to have these links, otherwise, authors who use Bit generated dists, will get the dists with broken links. (on the capsule the links worked but on the workspace they didn't).