### PR TITLE
(experimental) support exporting components to their last remote

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- (experimental) support exporting components without mentioning a remote by exporting to their last remotes
+
 ## [[14.2.5] - 2019-08-22](https://github.com/teambit/bit/releases/tag/v14.2.5)
 
 ### New

--- a/src/bit-id/bit-ids.js
+++ b/src/bit-id/bit-ids.js
@@ -86,6 +86,10 @@ export default class BitIds extends Array<BitId> {
     return this.map(id => id.toString()).join(', ');
   }
 
+  toGroupByScopeName(): { [scopeName: string]: BitId[] } {
+    return R.groupBy(R.prop('scope'), this);
+  }
+
   static fromObject(dependencies: { [string]: string }) {
     const array = [];
 

--- a/src/cli/commands/public-cmds/export-cmd.js
+++ b/src/cli/commands/public-cmds/export-cmd.js
@@ -9,17 +9,30 @@ import type { EjectResults } from '../../../consumer/component-ops/eject-compone
 import ejectTemplate from '../../templates/eject-template';
 
 export default class Export extends Command {
-  name = 'export <remote> [id...]';
+  name = 'export [remote] [id...]';
   description = `export components to a remote scope.
+  bit export <remote> [id...] => export (optionally given ids) to the specified remote
+  bit export [id...] --last-scope => export given ids to their last exported remote
+  bit export => export all ids to their last exported remote
   https://${BASE_DOCS_DOMAIN}/docs/organizing-components-in-scopes.html
   ${WILDCARD_HELP('export remote-scope')}`;
   alias = 'e';
-  opts = [['e', 'eject', 'replaces the exported components from the local scope with the corresponding packages']];
+  opts = [
+    ['e', 'eject', 'replaces the exported components from the local scope with the corresponding packages'],
+    ['o', 'last-scope', 'EXPERIMENTAL. export to the last exported remote (omit the [remote] when this flag is used)']
+  ];
   loader = true;
   migration = true;
 
-  action([remote, ids]: [string, string[]], { eject }: any): Promise<*> {
-    return exportAction(ids, remote, eject).then(results => ({
+  action([remote, ids]: [string, string[]], { eject, lastScope }: any): Promise<*> {
+    if (lastScope && remote) {
+      ids.push(remote); // when --last-scope is used, the first argument is actually an id
+      remote = '';
+    }
+    if (!remote && !ids.length) {
+      lastScope = true; // when "bit export" was used with no args, export all to the last scope
+    }
+    return exportAction(ids, remote, eject, lastScope).then(results => ({
       ...results,
       remote
     }));
@@ -28,18 +41,23 @@ export default class Export extends Command {
   report({
     componentsIds,
     nonExistOnBitMap,
+    missingScope,
     ejectResults,
     remote
   }: {
     componentsIds: BitId[],
     nonExistOnBitMap: BitId[],
+    missingScope: BitId[],
     ejectResults: ?EjectResults,
     remote: string
   }): string {
-    if (R.isEmpty(componentsIds) && R.isEmpty(nonExistOnBitMap)) return chalk.yellow('nothing to export');
+    if (R.isEmpty(componentsIds) && R.isEmpty(nonExistOnBitMap) && R.isEmpty(missingScope)) { return chalk.yellow('nothing to export'); }
     const exportOutput = () => {
       if (R.isEmpty(componentsIds)) return '';
-      return chalk.green(`exported ${componentsIds.length} components to scope ${chalk.bold(remote)}`);
+      if (remote) return chalk.green(`exported ${componentsIds.length} components to scope ${chalk.bold(remote)}`);
+      return chalk.green(
+        `exported the following ${componentsIds.length} component(s):\n${chalk.bold(componentsIds.join('\n'))}`
+      );
     };
     const nonExistOnBitMapOutput = () => {
       if (R.isEmpty(nonExistOnBitMap)) return '';
@@ -48,12 +66,19 @@ export default class Export extends Command {
         `${ids}\nexported successfully. bit did not update the workspace as the component files are not tracked. this might happen when a component was tracked in a different git branch. to fix it check if they where tracked in a different git branch, checkout to that branch and resync by running 'bit import'. or stay on your branch and track the components again using 'bit add'.`
       );
     };
+    const missingScopeOutput = () => {
+      if (R.isEmpty(missingScope)) return '';
+      const ids = missingScope.map(id => id.toString()).join(', ');
+      return chalk.yellow(
+        `the following component(s) were not exported: ${chalk.bold(ids)}.\nplease specify <remote> to export them\n\n`
+      );
+    };
     const ejectOutput = () => {
       if (!ejectResults) return '';
       const output = ejectTemplate(ejectResults);
       return `\n${output}`;
     };
 
-    return nonExistOnBitMapOutput() + exportOutput() + ejectOutput();
+    return nonExistOnBitMapOutput() + missingScopeOutput() + exportOutput() + ejectOutput();
   }
 }

--- a/src/e2e-helper/e2e-command-helper.js
+++ b/src/e2e-helper/e2e-command-helper.js
@@ -108,13 +108,17 @@ export default class CommandHelper {
   untag(id: string) {
     return this.runCmd(`bit untag ${id}`);
   }
-
   exportComponent(id: string, scope: string = this.scopes.remote, assert: boolean = true) {
     const result = this.runCmd(`bit export ${scope} ${id}`);
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }
-
+  exportAllComponents(scope: string = this.scopes.remote) {
+    return this.runCmd(`bit export ${scope}`);
+  }
+  exportToLastScope(ids?: string) {
+    return this.runCmd(`bit export ${ids || ''} --last-scope`);
+  }
   ejectComponents(ids: string, flags?: string) {
     return this.runCmd(`bit eject ${ids} ${flags || ''}`);
   }
@@ -124,11 +128,6 @@ export default class CommandHelper {
     const jsonResult = result.substring(jsonStart);
     return JSON.parse(jsonResult);
   }
-
-  exportAllComponents(scope: string = this.scopes.remote) {
-    return this.runCmd(`bit export ${scope}`);
-  }
-
   importComponent(id: string) {
     return this.runCmd(`bit import ${this.scopes.remote}/${id}`);
   }

--- a/src/e2e-helper/e2e-scope-helper.js
+++ b/src/e2e-helper/e2e-scope-helper.js
@@ -114,9 +114,9 @@ export default class ScopeHelper {
     return this.removeRemoteScope(this.scopes.env, isGlobal);
   }
 
-  reInitRemoteScope() {
-    fs.emptyDirSync(this.scopes.remotePath);
-    return this.command.runCmd('bit init --bare', this.scopes.remotePath);
+  reInitRemoteScope(scopePath?: string = this.scopes.remotePath) {
+    fs.emptyDirSync(scopePath);
+    return this.command.runCmd('bit init --bare', scopePath);
   }
 
   /**


### PR DESCRIPTION
By omitting the `remote` arg and using `--last-scope` flag (the flag name might be changed later)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1953)
<!-- Reviewable:end -->
