### PR TITLE
fix a capsule-compiler bug when building all components in a certain order

### DIFF
--- a/src/environment/isolator.js
+++ b/src/environment/isolator.js
@@ -53,6 +53,10 @@ export default class Isolator {
         if (!dep.dists || dep.dists.isEmpty()) {
           await dep.build({ scope: this.scope, consumer: this.consumer });
           dep.dists.stripOriginallySharedDir(dep.originallySharedDir);
+        } else {
+          // needed for cases when a component is isolated as an individual first, then as a dependency.
+          // because when it is isolated in the first time, the 'writeDistsFiles' is manually set to false
+          dep.dists.writeDistsFiles = true;
         }
       });
     }


### PR DESCRIPTION
It happens when a component was isolated as a dependency, then, as an individual, then again as a dependency. 
The issue was that the dists files were not written in the last capsule.
See more details and how to reproduce in https://github.com/teambit/bit/issues/1947.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1957)
<!-- Reviewable:end -->
