### PR TITLE
Fix dist replacements upon export to support require statements to an internal path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix dist replacements upon export (for angular compiler) to support require statements to an internal path
+
 ## [14.2.6-dev.1] - 2019-08-26
 
 - [#1947](https://github.com/teambit/bit/issues/1947) workaround an angular-compiler issue when the dists have a prefix

--- a/e2e/commands/export.e2e.1.js
+++ b/e2e/commands/export.e2e.1.js
@@ -519,6 +519,9 @@ describe('bit export command', function () {
     it('should not replace other ids that only has the prefix of other ids/deps', () => {
       expect(distContent).to.not.have.string(`"@bit/${helper.scopes.remote}.bar-non-exist"`);
     });
+    it('should replace the ids without scope name to ids with scope name even when it points to an internal file', () => {
+      expect(distContent).to.have.string(`"@bit/${helper.scopes.remote}.bar-dep/internal-path"`);
+    });
   });
   describe('without specifying a remote', () => {
     describe('some components are new and some are tagged', () => {

--- a/e2e/fixtures/compilers/add-scope-name/compiler.js
+++ b/e2e/fixtures/compilers/add-scope-name/compiler.js
@@ -11,7 +11,7 @@ function compile(files, distPath) {
       const distFile = file.clone();
       distFile.base = distPath;
       distFile.path = path.join(distPath, file.relative);
-      distFile.contents = Buffer.from('require("@bit/bar-dep"); require("@bit/bar-non-exist");');
+      distFile.contents = Buffer.from('require("@bit/bar-dep"); require("@bit/bar-non-exist"); require("@bit/bar-dep/internal-path");');
       return distFile;
     });
 }

--- a/src/scope/component-ops/export-scope-components.js
+++ b/src/scope/component-ops/export-scope-components.js
@@ -238,9 +238,15 @@ async function changePartialNamesToFullNamesInDists(
       const singleQuote = "'";
       const doubleQuotes = '"';
       [singleQuote, doubleQuotes].forEach((quoteType) => {
+        // replace an exact match. (e.g. '@bit/is-string' => '@bit/david.utils/is-string')
         newDistString = newDistString.replace(
           new RegExp(quoteType + pkgNameWithoutScope + quoteType, 'g'),
           quoteType + pkgNameWithScope + quoteType
+        );
+        // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
+        newDistString = newDistString.replace(
+          new RegExp(`${quoteType}${pkgNameWithoutScope}/`, 'g'),
+          `${quoteType}${pkgNameWithScope}/`
         );
       });
     });


### PR DESCRIPTION
Currently, the dist replacements (implemented for angular-compilers when the dists contain the link files) works only for an exact match.
This PR does the replacements also when the require/import statements are for an internal path.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1961)
<!-- Reviewable:end -->
