### PR TITLE
Fix generated links for .scss and .sass packages to point to the main file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#1965](https://github.com/teambit/bit/issues/1965) fix generated links for `.scss` and `.sass` packages to point to the main file
 - [#1956](https://github.com/teambit/bit/issues/1956) support `defaultScope` settings in workspace config for `bit export` to use when no scope was entered
 - [#1956](https://github.com/teambit/bit/issues/1956) introduce a new flag `--include-dependencies` for `bit export` to be able to fork (kind of) a component to another scope
 - [#1959](https://github.com/teambit/bit/issues/1959) improve message when running `bit build` when compiler not configured

--- a/fixtures/consumer-components/sass/bar-foo.json
+++ b/fixtures/consumer-components/sass/bar-foo.json
@@ -1,0 +1,55 @@
+{
+  "name": "bar/foo",
+  "version": "0.0.1",
+  "mainFile": "bar/foo.scss",
+  "scope": "remote-scope",
+  "lang": "javascript",
+  "bindingPrefix": "@bit",
+  "compiler": null,
+  "tester": null,
+  "dependencies": [{
+      "id": "remote-scope/utils/is-string@0.0.1",
+      "relativePaths": [{
+          "sourceRelativePath": "utils/is-string.scss",
+          "destinationRelativePath": "utils/is-string.scss"
+      }]
+  }],
+  "devDependencies": [],
+  "compilerDependencies": [],
+  "testerDependencies": [],
+  "packageDependencies": {},
+  "devPackageDependencies": {},
+  "peerPackageDependencies": {},
+  "compilerPackageDependencies": {},
+  "testerPackageDependencies": {},
+  "files": [{
+      "stat": null,
+      "_contents": {
+          "type": "Buffer",
+          "data": [99, 111, 110, 115, 116, 32, 105, 115, 83, 116, 114, 105, 110, 103, 32, 61, 32, 114, 101, 113, 117, 105, 114, 101, 40, 39, 46, 46, 47, 117, 116, 105, 108, 115, 47, 105, 115, 45, 115, 116, 114, 105, 110, 103, 46, 106, 115, 39, 41, 59, 32, 109, 111, 100, 117, 108, 101, 46, 101, 120, 112, 111, 114, 116, 115, 32, 61, 32, 102, 117, 110, 99, 116, 105, 111, 110, 32, 102, 111, 111, 40, 41, 32, 123, 32, 114, 101, 116, 117, 114, 110, 32, 105, 115, 83, 116, 114, 105, 110, 103, 40, 41, 32, 43, 32, 39, 32, 97, 110, 100, 32, 103, 111, 116, 32, 102, 111, 111, 39, 59, 32, 125, 59]
+      },
+      "history": ["bar/foo.scss"],
+      "_cwd": "/Users/davidfirst",
+      "_base": ".",
+      "_isVinyl": true,
+      "_symlink": null,
+      "test": false
+  }],
+  "docs": [],
+  "dists": {
+      "writeDistsFiles": true,
+      "areDistsInsideComponentDir": true,
+      "distEntryShouldBeStripped": false,
+      "_distsPathsAreUpdated": false,
+      "dists": []
+  },
+  "specsResults": null,
+  "license": null,
+  "log": {
+      "message": "tag-message",
+      "date": "1541588058604",
+      "username": "David First",
+      "email": "david@bit.dev"
+  },
+  "deprecated": false
+}

--- a/fixtures/consumer-components/sass/utils-is-string.json
+++ b/fixtures/consumer-components/sass/utils-is-string.json
@@ -1,0 +1,55 @@
+{
+  "name": "utils/is-string",
+  "version": "0.0.1",
+  "mainFile": "utils/is-string.scss",
+  "scope": "remote-scope",
+  "lang": "javascript",
+  "bindingPrefix": "@bit",
+  "compiler": null,
+  "tester": null,
+  "dependencies": [{
+      "id": "remote-scope/utils/is-type@0.0.1",
+      "relativePaths": [{
+          "sourceRelativePath": "utils/is-type.scss",
+          "destinationRelativePath": "utils/is-type.scss"
+      }]
+  }],
+  "devDependencies": [],
+  "compilerDependencies": [],
+  "testerDependencies": [],
+  "packageDependencies": {},
+  "devPackageDependencies": {},
+  "peerPackageDependencies": {},
+  "compilerPackageDependencies": {},
+  "testerPackageDependencies": {},
+  "files": [{
+      "stat": null,
+      "_contents": {
+          "type": "Buffer",
+          "data": [99, 111, 110, 115, 116, 32, 105, 115, 84, 121, 112, 101, 32, 61, 32, 114, 101, 113, 117, 105, 114, 101, 40, 39, 46, 47, 105, 115, 45, 116, 121, 112, 101, 46, 106, 115, 39, 41, 59, 32, 109, 111, 100, 117, 108, 101, 46, 101, 120, 112, 111, 114, 116, 115, 32, 61, 32, 102, 117, 110, 99, 116, 105, 111, 110, 32, 105, 115, 83, 116, 114, 105, 110, 103, 40, 41, 32, 123, 32, 114, 101, 116, 117, 114, 110, 32, 105, 115, 84, 121, 112, 101, 40, 41, 32, 43, 32, 32, 39, 32, 97, 110, 100, 32, 103, 111, 116, 32, 105, 115, 45, 115, 116, 114, 105, 110, 103, 39, 59, 32, 125, 59]
+      },
+      "history": ["utils/is-string.scss"],
+      "_cwd": "/Users/davidfirst",
+      "_base": ".",
+      "_isVinyl": true,
+      "_symlink": null,
+      "test": false
+  }],
+  "docs": [],
+  "dists": {
+      "writeDistsFiles": true,
+      "areDistsInsideComponentDir": true,
+      "distEntryShouldBeStripped": false,
+      "_distsPathsAreUpdated": false,
+      "dists": []
+  },
+  "specsResults": null,
+  "license": null,
+  "log": {
+      "message": "tag-message",
+      "date": "1541588058580",
+      "username": "David First",
+      "email": "david@bit.dev"
+  },
+  "deprecated": false
+}

--- a/fixtures/consumer-components/sass/utils-is-type.json
+++ b/fixtures/consumer-components/sass/utils-is-type.json
@@ -1,0 +1,49 @@
+{
+  "name": "utils/is-type",
+  "version": "0.0.1",
+  "mainFile": "utils/is-type.scss",
+  "scope": "remote-scope",
+  "lang": "javascript",
+  "bindingPrefix": "@bit",
+  "compiler": null,
+  "tester": null,
+  "dependencies": [],
+  "devDependencies": [],
+  "compilerDependencies": [],
+  "testerDependencies": [],
+  "packageDependencies": {},
+  "devPackageDependencies": {},
+  "peerPackageDependencies": {},
+  "compilerPackageDependencies": {},
+  "testerPackageDependencies": {},
+  "files": [{
+      "stat": null,
+      "_contents": {
+          "type": "Buffer",
+          "data": [109, 111, 100, 117, 108, 101, 46, 101, 120, 112, 111, 114, 116, 115, 32, 61, 32, 102, 117, 110, 99, 116, 105, 111, 110, 32, 105, 115, 84, 121, 112, 101, 40, 41, 32, 123, 32, 114, 101, 116, 117, 114, 110, 32, 39, 103, 111, 116, 32, 105, 115, 45, 116, 121, 112, 101, 39, 59, 32, 125, 59]
+      },
+      "history": ["utils/is-type.scss"],
+      "_cwd": "/Users/davidfirst",
+      "_base": ".",
+      "_isVinyl": true,
+      "_symlink": null,
+      "test": false
+  }],
+  "docs": [],
+  "dists": {
+      "writeDistsFiles": true,
+      "areDistsInsideComponentDir": true,
+      "distEntryShouldBeStripped": false,
+      "_distsPathsAreUpdated": false,
+      "dists": []
+  },
+  "specsResults": null,
+  "license": null,
+  "log": {
+      "message": "tag-message",
+      "date": "1541588058327",
+      "username": "David First",
+      "email": "david@bit.dev"
+  },
+  "deprecated": false
+}

--- a/src/links/dependency-file-link-generator.spec.js
+++ b/src/links/dependency-file-link-generator.spec.js
@@ -8,6 +8,8 @@ import barFooEs6 from '../../fixtures/consumer-components/es6/bar-foo.json';
 import utilsIsStringEs6 from '../../fixtures/consumer-components/es6/utils-is-string.json';
 import barFooCustomResolved from '../../fixtures/consumer-components/custom-resolved-modules/bar-foo.json';
 import utilsIsStringCustomResolved from '../../fixtures/consumer-components/custom-resolved-modules/utils-is-string.json';
+import barFooSass from '../../fixtures/consumer-components/sass/bar-foo.json';
+import utilsIsStringSass from '../../fixtures/consumer-components/sass/utils-is-string.json';
 import * as globalConfig from '../api/consumer/lib/global-config';
 
 const mockBitMap = () => {
@@ -309,6 +311,37 @@ describe('DependencyFileLinkGenerator', () => {
             expect(linkResult.linkContent).to.equal("module.exports = require('@bit/remote-scope.utils.is-string');");
           });
         });
+      });
+    });
+    describe('using sass files', () => {
+      let dependencyFileLinkGenerator;
+      let linkResult;
+      before(async () => {
+        const component = await Component.fromString(JSON.stringify(barFooSass));
+        component.componentMap = {
+          rootDir: 'components/bar/foo',
+          getRootDir() {
+            return this.rootDir;
+          }
+        };
+        const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringSass));
+        dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
+          consumer: mockConsumer(),
+          bitMap: mockBitMap(),
+          component,
+          relativePath: component.dependencies.get()[0].relativePaths[0],
+          dependencyComponent,
+          createNpmLinkFiles: false,
+          targetDir: ''
+        });
+        const linkResults = dependencyFileLinkGenerator.generate();
+        linkResult = linkResults[0];
+      });
+      it('should generate linkPath that consist of component rootDir + sourceRelativePath', () => {
+        expect(linkResult.linkPath).to.equal(path.normalize('components/bar/foo/utils/is-string.scss'));
+      });
+      it('should generate linkContent that points to the main file inside the package', () => {
+        expect(linkResult.linkContent).to.equal("@import '~@bit/remote-scope.utils.is-string/utils/is-string.scss';");
       });
     });
   });

--- a/src/links/link-content.js
+++ b/src/links/link-content.js
@@ -33,6 +33,8 @@ const fileExtensionsForNpmLinkGenerator = ['js', 'ts', 'jsx', 'tsx'];
 export const JAVASCRIPT_FLAVORS_EXTENSIONS = ['js', 'ts', 'jsx', 'tsx'];
 export const EXTENSIONS_TO_STRIP_FROM_PACKAGES = ['js', 'ts', 'jsx', 'tsx', 'd.ts'];
 export const EXTENSIONS_TO_REPLACE_TO_JS_IN_PACKAGES = ['ts', 'jsx', 'tsx'];
+// node-sass doesn't resolve directories to 'index.scss', @see https://github.com/sass/sass/issues/690
+export const EXTENSIONS_NOT_SUPPORT_DIRS = ['scss', 'sass'];
 
 export function isSupportedExtension(filePath: string) {
   const ext = getExt(filePath);

--- a/src/links/link-generator.js
+++ b/src/links/link-generator.js
@@ -20,7 +20,7 @@ import type Consumer from '../consumer/consumer';
 import ComponentMap from '../consumer/bit-map/component-map';
 import type { PathOsBased, PathOsBasedAbsolute } from '../utils/path';
 import postInstallTemplate from '../consumer/component/templates/postinstall.default-template';
-import { getLinkToFileContent, JAVASCRIPT_FLAVORS_EXTENSIONS } from './link-content';
+import { getLinkToFileContent, JAVASCRIPT_FLAVORS_EXTENSIONS, EXTENSIONS_NOT_SUPPORT_DIRS } from './link-content';
 import DependencyFileLinkGenerator from './dependency-file-link-generator';
 import type { LinkFileType } from './dependency-file-link-generator';
 import LinkFile from './link-file';
@@ -371,9 +371,12 @@ function getEntryPointsForComponent(component: Component, consumer: ?Consumer, b
   const mainFile = component.dists.calculateMainDistFile(component.mainFile);
   const mainFileExt = getExt(mainFile);
   if (JAVASCRIPT_FLAVORS_EXTENSIONS.includes(mainFileExt) && component.packageJsonFile) {
-    // throw new Error('hi')
     // if the main file is a javascript kind of file and the component has package.json file, no
     // need for an entry-point file because the "main" attribute of package.json takes care of that
+    return [];
+  }
+  if (EXTENSIONS_NOT_SUPPORT_DIRS.includes(mainFileExt)) {
+    // some extensions (such as .scss according to node-sass) don't know to resolve by an entry-point
     return [];
   }
   const files = [];


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/1965.

Sadly, node-sass doesn't resolve directories to the default 'index.scss', so the generated link needs to manually point to the main file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1968)
<!-- Reviewable:end -->
