### PR TITLE
fail early when exporting nested dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fail early when exporting nested dependency
+- fix an error "Cannot read property log of null" upon bit log
+
 ## [14.2.6-dev.5] - 2019-09-10
 
 - [#1988](https://github.com/teambit/bit/issues/1988) avoid adding a component to root package.json when importing with `--ignore-package-json` flag

--- a/e2e/commands/log.e2e.1.js
+++ b/e2e/commands/log.e2e.1.js
@@ -28,5 +28,12 @@ describe('bit log', function () {
       expect(output).to.have.string('2.0.0');
       expect(output).to.have.string('new-tagging-message');
     });
+    describe('exporting NESTED component which does not have all its versions', () => {
+      it('should not throw an error about object not found, but a descriptive one', () => {
+        const output = helper.general.runWithTryCatch(`bit export ${helper.scopes.remote} utils/is-string`);
+        expect(output).not.to.have.string('ENOENT');
+        expect(output).to.have.string('unable to export');
+      });
+    });
   });
 });

--- a/src/api/consumer/lib/export.js
+++ b/src/api/consumer/lib/export.js
@@ -123,6 +123,11 @@ async function getComponentsToExport(
   const idsToExportP = ids.map(async (id) => {
     const parsedId = await getParsedId(consumer, id);
     const status = await consumer.getComponentStatusById(parsedId);
+    if (status.nested) {
+      throw new GeneralError(
+        `unable to export "${parsedId.toString()}", the component is not fully available. please use "bit import" first`
+      );
+    }
     // don't allow to re-export an exported component unless it's being exported to another scope
     if (remote && !status.staged && parsedId.scope === remote) {
       throw new IdExportedAlready(parsedId.toString(), remote);


### PR DESCRIPTION
currently, it fails only when collecting the objects with an error "ENOENT: no such file or directory"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1992)
<!-- Reviewable:end -->
