### PR TITLE
fail early when tagging a component with a prerelease version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- block tagging components with prerelease versions
 - [#1981](https://github.com/teambit/bit/issues/1981) allow compilers to add all dependencies types and not only devDependencies
 
 ## [[14.3.0] - 2019-09-11](https://github.com/teambit/bit/releases/tag/v14.3.0)

--- a/src/api/consumer/lib/tag.js
+++ b/src/api/consumer/lib/tag.js
@@ -10,6 +10,7 @@ import InvalidVersion from './exceptions/invalid-version';
 import { Analytics } from '../../../analytics/analytics';
 import Component from '../../../consumer/component';
 import type { AutoTagResult } from '../../../scope/component-ops/auto-tag';
+import GeneralError from '../../../error/general-error';
 
 const HooksManagerInstance = HooksManager.getInstance();
 
@@ -153,6 +154,7 @@ function _validateVersion(version) {
   if (version) {
     const validVersion = semver.valid(version);
     if (!validVersion) throw new InvalidVersion(version);
+    if (semver.prerelease(version)) throw new GeneralError(`error: a prerelease version "${version}" is not supported`);
     return validVersion;
   }
   return null;

--- a/src/utils/resolveLatestVersion.js
+++ b/src/utils/resolveLatestVersion.js
@@ -24,6 +24,11 @@ export default function getLatestVersionNumber(bitIds: BitIds, bitId: BitId): Bi
   if (R.isEmpty(allVersionsForId)) return bitId;
 
   const maxVersion = semver.maxSatisfying(allVersionsForId, '*');
+  if (!maxVersion) {
+    throw new Error(
+      `semver was not able to find the highest version among the following: ${allVersionsForId.join(', ')}`
+    );
+  }
   const bitIdWithMaxVersion = bitId.changeVersion(maxVersion);
   const result = ignoreScope ? bitIds.searchWithoutScope(bitIdWithMaxVersion) : bitIds.search(bitIdWithMaxVersion);
   if (!result) {

--- a/src/utils/resolveLatestVersion.spec.js
+++ b/src/utils/resolveLatestVersion.spec.js
@@ -23,6 +23,13 @@ describe('getLatestVersionNumber', () => {
     const result = resolveLatestVersion(bitIds, idWithNoVersion);
     expect(result).to.deep.equal(idWithNoVersion);
   });
+  it('should throw when using a pre-release tag', () => {
+    const anotherId = new BitId({ scope: 'foo', name: 'is-type' });
+    const idWithPreRelease = new BitId({ scope: 'foo', name: 'is-type', version: '3.0.0-dev.1' });
+    const bitIds = new BitIds(idWithPreRelease);
+    const func = () => resolveLatestVersion(bitIds, anotherId);
+    expect(func).to.throw('semver was not able to find the highest version among the following: 3.0.0-dev.1');
+  });
   it('should return the id from the bitIds array if it is there with a version', () => {
     const bitIds = new BitIds(idWithVersion1);
     const result = resolveLatestVersion(bitIds, idWithNoVersion);


### PR DESCRIPTION
Otherwise, the user will get an error of "getLatestVersionNumber failed to find ..."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/1994)
<!-- Reviewable:end -->
