### PR TITLE
Fix bugs when exporting with the newly introduced "bit export" enhancements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix exporting to a different scope than workspace configuration of `defaultScope`
+- fix exporting components with and without scope at the same time
 - [#1999](https://github.com/teambit/bit/issues/1999) show a descriptive error when a component is missing from the scope
 - block tagging components with prerelease versions
 - [#1981](https://github.com/teambit/bit/issues/1981) allow compilers to add all dependencies types and not only devDependencies

--- a/e2e/commands/export.e2e.1.js
+++ b/e2e/commands/export.e2e.1.js
@@ -674,6 +674,45 @@ describe('bit export command', function () {
           expect(output).to.have.string('was not found');
         });
       });
+      describe('having another staged component without scope-name', () => {
+        let output;
+        let beforeExportScope;
+        before(() => {
+          helper.scopeHelper.getClonedLocalScope(localScopeBefore);
+          helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
+          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.fs.outputFile('foo3.js');
+          helper.command.addComponent('foo3.js');
+          helper.command.tagAllComponents();
+          beforeExportScope = helper.scopeHelper.cloneLocalScope();
+        });
+        describe('without defaultScope', () => {
+          before(() => {
+            output = helper.command.export();
+          });
+          it('should not throw an error "toGroupByScopeName() expect ids to have a scope name"', () => {
+            expect(output).to.have.string('exported the following 2 component(s)');
+          });
+          it('should indicate that the component without scope-name was not exported', () => {
+            expect(output).to.have.string('the following component(s) were not exported: foo3');
+          });
+        });
+        describe('with defaultScope', () => {
+          before(() => {
+            helper.scopeHelper.getClonedLocalScope(beforeExportScope);
+            helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
+            helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+            helper.bitJson.addKeyVal(undefined, 'defaultScope', helper.scopes.remote);
+            output = helper.command.export();
+          });
+          it('should export them all successfully', () => {
+            expect(output).to.have.string('exported the following 3 component');
+          });
+          it('should export the non-scope into the defaultScope', () => {
+            expect(output).to.have.string(`${helper.scopes.remote}/foo3`);
+          });
+        });
+      });
     });
     describe('export to a different scope', () => {
       let forkScope;
@@ -845,6 +884,25 @@ describe('bit export command', function () {
           });
         });
       });
+    });
+  });
+  describe('export with a remote that is not the same as defaultScope', () => {
+    let anotherRemote;
+    let anotherRemotePath;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateWorkspaceWithComponents();
+      helper.bitJson.addKeyVal(undefined, 'defaultScope', helper.scopes.remote);
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      anotherRemotePath = scopePath;
+      helper.scopeHelper.addRemoteScope(anotherRemotePath);
+      helper.command.tagAllComponents();
+      helper.command.runCmd(`bit export ${anotherRemote} utils/is-type`);
+    });
+    it('should export to the specified remote', () => {
+      const list = helper.command.listScopeParsed(anotherRemote);
+      expect(list).to.have.lengthOf(1);
     });
   });
 });

--- a/src/api/consumer/lib/export.js
+++ b/src/api/consumer/lib/export.js
@@ -47,10 +47,15 @@ async function exportComponents({
   force: boolean
 }): Promise<{ updatedIds: BitId[], nonExistOnBitMap: BitId[], missingScope: BitId[], exported: BitId[] }> {
   const consumer: Consumer = await loadConsumer();
-  if (consumer.config.defaultScope) {
-    remote = consumer.config.defaultScope;
-  }
-  const { idsToExport, missingScope } = await getComponentsToExport(ids, consumer, remote, includeNonStaged, force);
+  const defaultScope = consumer.config.defaultScope;
+  const { idsToExport, missingScope } = await getComponentsToExport(
+    ids,
+    consumer,
+    remote,
+    includeNonStaged,
+    defaultScope,
+    force
+  );
   if (R.isEmpty(idsToExport)) return { updatedIds: [], nonExistOnBitMap: [], missingScope, exported: [] };
 
   // todo: what happens when some failed? we might consider avoid Promise.all
@@ -61,7 +66,8 @@ async function exportComponents({
     remote,
     undefined,
     includeDependencies,
-    setCurrentScope
+    setCurrentScope,
+    defaultScope
   );
   const { updatedIds, nonExistOnBitMap } = _updateIdsOnBitMap(consumer.bitMap, updatedLocally);
   await linkComponents(updatedIds, consumer);
@@ -90,14 +96,15 @@ async function getComponentsToExport(
   consumer: Consumer,
   remote: ?string,
   includeNonStaged: boolean,
+  defaultScope: ?string,
   force: boolean
 ): Promise<{ idsToExport: BitIds, missingScope: BitId[] }> {
   const componentsList = new ComponentsList(consumer);
   const idsHaveWildcard = hasWildcard(ids);
   const filterNonScopeIfNeeded = (bitIds: BitIds): { idsToExport: BitIds, missingScope: BitId[] } => {
     if (remote) return { idsToExport: bitIds, missingScope: [] };
-    const [missingScope, idsToExport] = R.splitWhen(id => id.hasScope(), bitIds);
-    return { idsToExport, missingScope };
+    const [idsToExport, missingScope] = R.partition(id => id.hasScope() || defaultScope, bitIds);
+    return { idsToExport: BitIds.fromArray(idsToExport), missingScope };
   };
   if (!ids || !ids.length || idsHaveWildcard) {
     loader.start(BEFORE_LOADING_COMPONENTS);

--- a/src/bit-id/bit-ids.js
+++ b/src/bit-id/bit-ids.js
@@ -90,14 +90,14 @@ export default class BitIds extends Array<BitId> {
     return this.map(id => id.toString()).join(', ');
   }
 
-  toGroupByScopeName(): { [scopeName: string]: BitIds } {
+  toGroupByScopeName(defaultScope?: ?string): { [scopeName: string]: BitIds } {
     return this.reduce((acc, current) => {
-      const scopeName = current.scope;
+      const scopeName = current.scope || defaultScope;
       if (!scopeName) {
         throw new Error(`toGroupByScopeName() expect ids to have a scope name, got ${current.toString()}`);
       }
       // $FlowFixMe
-      if (acc[scopeName]) acc[current.scope].push(current);
+      if (acc[scopeName]) acc[scopeName].push(current);
       // $FlowFixMe
       else acc[scopeName] = new BitIds(current);
       return acc;

--- a/src/scope/component-ops/export-scope-components.js
+++ b/src/scope/component-ops/export-scope-components.js
@@ -54,7 +54,8 @@ export async function exportMany(
   remoteName: ?string,
   context: Object = {},
   includeDependencies: boolean = false, // kind of fork. by default dependencies only cached, with this, their scope-name is changed
-  changeLocallyAlthoughRemoteIsDifferent: boolean = false // by default only if remote stays the same the component is changed from staged to exported
+  changeLocallyAlthoughRemoteIsDifferent: boolean = false, // by default only if remote stays the same the component is changed from staged to exported
+  defaultScope: ?string
 ): Promise<{ exported: BitIds, updatedLocally: BitIds }> {
   logger.debugAndAddBreadCrumb('scope.exportMany', 'ids: {ids}', { ids: ids.toString() });
   enrichContextFromGlobal(context);
@@ -68,7 +69,7 @@ export async function exportMany(
   if (remoteName) {
     return exportIntoRemote(remoteName, ids);
   }
-  const groupedByScope = ids.toGroupByScopeName();
+  const groupedByScope = ids.toGroupByScopeName(defaultScope);
   const results = await pMapSeries(Object.keys(groupedByScope), scopeName =>
     exportIntoRemote(scopeName, groupedByScope[scopeName])
   );


### PR DESCRIPTION
* fix exporting to a different scope than workspace configuration of `defaultScope` to not export it to the default-scope.

* fix `toGroupByScopeName() expect ids to have a scope name` error when exporting multiple components when some of them were exported before and some were not.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2007)
<!-- Reviewable:end -->
