### PR TITLE
change importMany implementation of splitting the local & external components 

### DIFF
--- a/src/scope/component-ops/scope-components-importer.js
+++ b/src/scope/component-ops/scope-components-importer.js
@@ -46,7 +46,7 @@ export default class ScopeComponentsImporter {
     const idsWithoutNils = removeNils(ids);
     if (R.isEmpty(idsWithoutNils)) return Promise.resolve([]);
 
-    const [externals, locals] = R.splitWhen(id => id.isLocal(this.scope.name), idsWithoutNils);
+    const [locals, externals] = R.partition(id => id.isLocal(this.scope.name), idsWithoutNils);
 
     const localDefs = await this.sources.getMany(locals);
     const versionDeps = await pMapSeries(localDefs, (def) => {


### PR DESCRIPTION
to be done by `R.partition` rather than `R.splitWhen`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2008)
<!-- Reviewable:end -->
