### PR TITLE
Fix "Converting circular structure to JSON" error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix "Converting circular structure to JSON" error when logging a circular metadata object
 - [#1999](https://github.com/teambit/bit/issues/1999) show a descriptive error when a component is missing from the scope
 - block tagging components with prerelease versions
 - [#1981](https://github.com/teambit/bit/issues/1981) allow compilers to add all dependencies types and not only devDependencies

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -26,12 +26,7 @@ export const baseFileTransportOpts = {
       winston.format.splat(), // does nothing?
       winston.format.errors({ stack: true }),
       winston.format.prettyPrint({ depth: 3, colorize: true }), // does nothing?
-      winston.format.printf(
-        info =>
-          `${info.timestamp} ${info.level}: ${info.message} ${
-            Object.keys(info.metadata).length ? JSON.stringify(info.metadata, null, 2) : ''
-          }`
-      )
+      winston.format.printf(info => customPrint(info))
     ),
   level: 'debug',
   maxsize: 10 * 1024 * 1024, // 10MB
@@ -40,6 +35,18 @@ export const baseFileTransportOpts = {
   // The filename will always have the most recent log lines. The larger the appended number, the older the log file
   tailable: true
 };
+
+function customPrint(info) {
+  const getMetadata = () => {
+    if (!Object.keys(info.metadata).length) return '';
+    try {
+      return JSON.stringify(info.metadata, null, 2);
+    } catch (err) {
+      return `logger error: logging failed to stringify the metadata Json. (error: ${err.message})`;
+    }
+  };
+  return `${info.timestamp} ${info.level}: ${info.message} ${getMetadata()}`;
+}
 
 const exceptionsFileTransportOpts = Object.assign({}, baseFileTransportOpts, {
   filename: path.join(GLOBAL_LOGS, 'exceptions.log')

--- a/src/logger/logger.js
+++ b/src/logger/logger.js
@@ -1,4 +1,5 @@
 /** @flow */
+import chalk from 'chalk';
 import yn from 'yn';
 import serializeError from 'serialize-error';
 import format from 'string-format';
@@ -7,7 +8,6 @@ import path from 'path';
 import { GLOBAL_LOGS, DEBUG_LOG, CFG_LOG_JSON_FORMAT, CFG_NO_WARNINGS } from '../constants';
 import { Analytics } from '../analytics/analytics';
 import { getSync } from '../api/consumer/lib/global-config';
-import chalk from 'chalk';
 
 // Store the extensionsLoggers to prevent create more than one logger for the same extension
 // in case the extension developer use api.logger more than once
@@ -17,17 +17,7 @@ const jsonFormat = yn(getSync(CFG_LOG_JSON_FORMAT), { default: false });
 
 export const baseFileTransportOpts = {
   filename: DEBUG_LOG,
-  format: jsonFormat
-    ? winston.format.combine(winston.format.timestamp(), winston.format.json())
-    : winston.format.combine(
-      winston.format.metadata(),
-      winston.format.colorize(),
-      winston.format.timestamp(),
-      winston.format.splat(), // does nothing?
-      winston.format.errors({ stack: true }),
-      winston.format.prettyPrint({ depth: 3, colorize: true }), // does nothing?
-      winston.format.printf(info => customPrint(info))
-    ),
+  format: jsonFormat ? winston.format.combine(winston.format.timestamp(), winston.format.json()) : getFormat(),
   level: 'debug',
   maxsize: 10 * 1024 * 1024, // 10MB
   maxFiles: 10,
@@ -36,16 +26,28 @@ export const baseFileTransportOpts = {
   tailable: true
 };
 
-function customPrint(info) {
-  const getMetadata = () => {
-    if (!Object.keys(info.metadata).length) return '';
-    try {
-      return JSON.stringify(info.metadata, null, 2);
-    } catch (err) {
-      return `logger error: logging failed to stringify the metadata Json. (error: ${err.message})`;
-    }
-  };
-  return `${info.timestamp} ${info.level}: ${info.message} ${getMetadata()}`;
+export function getFormat() {
+  return winston.format.combine(
+    winston.format.metadata(),
+    winston.format.colorize(),
+    winston.format.timestamp(),
+    winston.format.splat(), // does nothing?
+    winston.format.errors({ stack: true }),
+    winston.format.prettyPrint({ depth: 3, colorize: true }), // does nothing?
+    winston.format.printf(info => customPrint(info))
+  );
+
+  function customPrint(info) {
+    const getMetadata = () => {
+      if (!Object.keys(info.metadata).length) return '';
+      try {
+        return JSON.stringify(info.metadata, null, 2);
+      } catch (err) {
+        return `logger error: logging failed to stringify the metadata Json. (error: ${err.message})`;
+      }
+    };
+    return `${info.timestamp} ${info.level}: ${info.message} ${getMetadata()}`;
+  }
 }
 
 const exceptionsFileTransportOpts = Object.assign({}, baseFileTransportOpts, {

--- a/src/logger/logger.spec.js
+++ b/src/logger/logger.spec.js
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { getFormat } from './logger';
+
+describe('logger', () => {
+  describe('baseFileTransportOpts', () => {
+    it('should print metadata', () => {
+      const myFormat = getFormat();
+      const result = myFormat.transform({
+        [Symbol.for('level')]: 'error',
+        level: 'error',
+        message: 'my message',
+        metadata: { foo: 'bar' }
+      });
+      expect(result[Symbol.for('message')]).to.have.string('"foo": "bar"');
+    });
+    it('should not throw when the metadata object has a circular structure', () => {
+      const foo = {};
+      const bar = { foo };
+      foo.bar = bar;
+      const metadata = { foo };
+      const myFormat = getFormat();
+      const result = myFormat.transform({
+        [Symbol.for('level')]: 'error',
+        level: 'error',
+        message: 'my message',
+        metadata
+      });
+      expect(result[Symbol.for('message')]).to.have.string('logging failed to stringify the metadata Json');
+      expect(result[Symbol.for('message')]).to.have.string('error: Converting circular structure to JSON');
+    });
+  });
+});


### PR DESCRIPTION
Happens when logging a circular metadata object.
Implemented by catching the error and printing a message saying the metadata has a circular structure and can't be printed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2009)
<!-- Reviewable:end -->
