### PR TITLE
prioritize .js files when searching for a parallel file in the dists

### DIFF
--- a/src/links/node-modules-linker.js
+++ b/src/links/node-modules-linker.js
@@ -3,7 +3,7 @@ import path from 'path';
 import R from 'ramda';
 import glob from 'glob';
 import { BitId } from '../bit-id';
-import type Component from '../consumer/component/consumer-component';
+import Component from '../consumer/component/consumer-component';
 import { COMPONENT_ORIGINS, PACKAGE_JSON, DEFAULT_BINDINGS_PREFIX } from '../constants';
 import type ComponentMap from '../consumer/bit-map/component-map';
 import logger from '../logger/logger';

--- a/src/utils/fs/search-files-ignore-ext.js
+++ b/src/utils/fs/search-files-ignore-ext.js
@@ -3,8 +3,10 @@ import R from 'ramda';
 import Vinyl from 'vinyl';
 import getWithoutExt from './fs-no-ext';
 import type { PathOsBased } from '../path';
+import logger from '../../logger/logger';
 
 const LOWER_PRIORITY_EXTENSIONS = ['d.ts'];
+const HIGHER_PRIORITY_EXTENSIONS = ['js'];
 
 export default function searchFilesIgnoreExt(
   files: Vinyl[],
@@ -14,23 +16,39 @@ export default function searchFilesIgnoreExt(
   const _byFileNoExt = file => getWithoutExt(file.relative) === getWithoutExt(fileName);
   const _byFileWithExt = file => file.relative === fileName;
 
-  const getFile = () => {
-    const foundFileWithExt = R.find(_byFileWithExt, files);
-    if (foundFileWithExt) return foundFileWithExt;
-    const foundFilesWithExt = R.filter(_byFileNoExt, files);
-    if (!foundFilesWithExt.length) return null;
-    if (foundFilesWithExt.length === 1) return foundFilesWithExt[0];
-    // prefer files with extensions that are not listed in LOWER_PRIORITY_EXTENSIONS.
-    const withoutLowerPriorities = foundFilesWithExt.filter(
-      file => !LOWER_PRIORITY_EXTENSIONS.some(extension => file.relative.endsWith(extension))
-    );
-    if (withoutLowerPriorities.length) return withoutLowerPriorities[0];
-    return null;
-  };
-
   if (files && !R.isEmpty(files)) {
     const foundFile = getFile();
     return foundFile && returnProp && foundFile[returnProp] ? foundFile[returnProp] : foundFile;
   }
   return null;
+
+  function getFile(): ?Vinyl {
+    const foundFileWithExt = R.find(_byFileWithExt, files);
+    if (foundFileWithExt) return foundFileWithExt;
+    const foundFilesWithExt = R.filter(_byFileNoExt, files);
+    if (!foundFilesWithExt.length) return null;
+    if (foundFilesWithExt.length === 1) return foundFilesWithExt[0];
+    logger.debug(
+      `search-file-ignore-ext, found multiple files matching the criteria for ${fileName}: ${foundFilesWithExt
+        .map(f => f.relative)
+        .join(', ')}`
+    );
+    const prioritizedFile = getMatchingFileByPriority(foundFilesWithExt);
+    logger.debug(`search-file-ignore-ext, ended up using ${prioritizedFile.relative} for ${fileName}`);
+    return prioritizedFile;
+  }
+
+  function getMatchingFileByPriority(foundFilesWithExt): Vinyl {
+    // prefer files with extensions that are listed in HIGHER_PRIORITY_EXTENSIONS.
+    const withHigherPriorities = foundFilesWithExt.filter(file =>
+      HIGHER_PRIORITY_EXTENSIONS.some(extension => file.relative.endsWith(extension))
+    );
+    if (withHigherPriorities.length) return withHigherPriorities[0];
+    // prefer files with extensions that are not listed in LOWER_PRIORITY_EXTENSIONS.
+    const withoutLowerPriorities = foundFilesWithExt.filter(
+      file => !LOWER_PRIORITY_EXTENSIONS.some(extension => file.relative.endsWith(extension))
+    );
+    if (withoutLowerPriorities.length) return withoutLowerPriorities[0];
+    return foundFilesWithExt[0];
+  }
 }

--- a/src/utils/fs/search-files-ignore-ext.spec.js
+++ b/src/utils/fs/search-files-ignore-ext.spec.js
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import searchFilesIgnoreExt from './search-files-ignore-ext';
+
+describe('searchFilesIgnoreExt', () => {
+  it('should find the same file with a different extension', () => {
+    const files = [{ relative: 'foo/baz.js' }, { relative: 'foo/bar.js' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.equal('foo/bar.js');
+  });
+  it('should not return map.js files', () => {
+    const files = [{ relative: 'foo/bar.map.js' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.be.null;
+  });
+  it('should accept .d.ts files', () => {
+    const files = [{ relative: 'foo/bar.d.ts' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.equal('foo/bar.d.ts');
+  });
+  it('should prioritize .js over .d.ts files', () => {
+    const files = [{ relative: 'foo/bar.d.ts' }, { relative: 'foo/bar.js' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.equal('foo/bar.js');
+  });
+  it('should prioritize .js over any other extension', () => {
+    const files = [{ relative: 'foo/bar.gif' }, { relative: 'foo/bar.js' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.equal('foo/bar.js');
+  });
+  it('should prioritize any other extension over .d.ts files', () => {
+    const files = [{ relative: 'foo/bar.d.ts' }, { relative: 'foo/bar.css' }];
+    const result = searchFilesIgnoreExt(files, 'foo/bar.ts', 'relative');
+    expect(result).to.equal('foo/bar.css');
+  });
+});


### PR DESCRIPTION
This is an attempt to fix the hard-to-reproduce bug of "fatal: trying to write a link file into a symlink file".
There is a good chance that it happens when Bit finds the wrong parallel file in the `dists` and generates a symlink instead of a link.
When the error happens to a user, the first thing to check is the log messages start with `search-file-ignore-ext`, it shows what were the options and what ended up used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2010)
<!-- Reviewable:end -->
