### PR TITLE
Fix bit import when one module resolution alias is a directory of another alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2013](https://github.com/teambit/bit/issues/2013) fix bit import when one module resolution alias is a directory of another alias
 - [#2004](https://github.com/teambit/bit/issues/2004) ask for approval before exporting a component to another scope (fork)
 - [#1956](https://github.com/teambit/bit/issues/1956) introduce a new flag `--codemod` for `bit export` to replace the import/require statements in the source to the newly exported scope
 - fix "Converting circular structure to JSON" error when logging a circular metadata object

--- a/package-lock.json
+++ b/package-lock.json
@@ -2603,9 +2603,9 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
     "bit-javascript": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/bit-javascript/-/bit-javascript-2.1.1.tgz",
-      "integrity": "sha512-XGvxZdgblPUagS1X7m2RvsobcCQBbchedfaR5RVf/rdHi2ydGj2KNdmAJmUvVEHSBoIb9swtuSNE9Zir8urJAA==",
+      "version": "2.1.2-dev.1",
+      "resolved": "https://registry.npmjs.org/bit-javascript/-/bit-javascript-2.1.2-dev.1.tgz",
+      "integrity": "sha512-vTPybxMBrI7iItf1FO3KfDSpD0HNjNS9OFGOrwLirB2qe0cZa+mKu4Hmjb4XZ2voBIDB5hwJx4tZQhU6Xx7ekA==",
       "requires": {
         "@babel/runtime": "^7.0.0",
         "@typescript-eslint/typescript-estree": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "array-difference": "^0.0.1",
     "async-exit-hook": "^2.0.1",
     "babel-runtime": "^6.23.0",
-    "bit-javascript": "^2.1.1",
+    "bit-javascript": "2.1.2-dev.1",
     "bluebird": "^3.5.3",
     "chalk": "^2.4.1",
     "chokidar": "^3.0.2",


### PR DESCRIPTION
By adding a suffix of `index.js` when needed.

Fixes https://github.com/teambit/bit/issues/2013

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2016)
<!-- Reviewable:end -->
