### PR TITLE
Improve bit link to regenerate all links in case some links were reported missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2033](https://github.com/teambit/bit/issues/2033) improve bit link to build unrecognized missing links
 - [#2027](https://github.com/teambit/bit/issues/2027) fix ComponentNotFound error when building a typescript component and its Bit dependency is installed as a package
 - [#2011](https://github.com/teambit/bit/issues/2011) update dependents package.json files when ejecting dependencies
 - fix bit graph edge colouring for regular dependencies

--- a/src/cli/commands/public-cmds/link-cmd.js
+++ b/src/cli/commands/public-cmds/link-cmd.js
@@ -1,5 +1,4 @@
 /** @flow */
-import chalk from 'chalk';
 import Command from '../../command';
 import { link } from '../../../api/consumer';
 import linkTemplate from '../../templates/link-template';

--- a/src/consumer/component/consumer-component.js
+++ b/src/consumer/component/consumer-component.js
@@ -899,25 +899,13 @@ export default class Component {
     this.docs = flattenedDocs;
   }
 
-  copyDependenciesFromModel(ids: string[]) {
+  copyAllDependenciesFromModel() {
     const componentFromModel = this.componentFromModel;
     if (!componentFromModel) throw new Error('copyDependenciesFromModel: component is missing from the model');
-    ids.forEach((id: string) => {
-      const addDependency = (modelDependencies: Dependencies, dependencies: Dependencies) => {
-        const dependency = modelDependencies.getByIdStr(id);
-        if (dependency) dependencies.add(dependency);
-        return Boolean(dependency);
-      };
-      const addedDep = addDependency(componentFromModel.dependencies, this.dependencies);
-      if (addedDep) return;
-      const addedDevDep = addDependency(componentFromModel.devDependencies, this.devDependencies);
-      if (addedDevDep) return;
-      const addedCompilerDep = addDependency(componentFromModel.compilerDependencies, this.compilerDependencies);
-      if (addedCompilerDep) return;
-      const addedTesterDep = addDependency(componentFromModel.testerDependencies, this.testerDependencies);
-      if (addedTesterDep) return;
-      throw new Error(`copyDependenciesFromModel unable to find dependency ${id} in the model`);
-    });
+    this.setDependencies(componentFromModel.dependencies.get());
+    this.setDevDependencies(componentFromModel.devDependencies.get());
+    this.setCompilerDependencies(componentFromModel.compilerDependencies.get());
+    this.setTesterDependencies(componentFromModel.testerDependencies.get());
   }
 
   static async fromObject(object: Object): Component {

--- a/src/links/linker.js
+++ b/src/links/linker.js
@@ -5,7 +5,7 @@ import logger from '../logger/logger';
 import { pathNormalizeToLinux } from '../utils';
 import * as linkGenerator from '../links/link-generator';
 import NodeModuleLinker from './node-modules-linker';
-import type Consumer from '../consumer/consumer';
+import Consumer from '../consumer/consumer';
 import ComponentWithDependencies from '../scope/component-dependencies';
 import * as packageJsonUtils from '../consumer/component/package-json-utils';
 import type { LinksResult } from './node-modules-linker';

--- a/src/links/node-modules-linker.js
+++ b/src/links/node-modules-linker.js
@@ -104,7 +104,8 @@ export default class NodeModuleLinker {
   async _populateImportedComponentsLinks(component: Component): Promise<void> {
     const componentMap = component.componentMap;
     const componentId = component.id;
-    const bindingPrefix = component.bindingPrefix || DEFAULT_BINDINGS_PREFIX;
+    // @todo: this should probably be `const bindingPrefix = component.bindingPrefix;`
+    const bindingPrefix = this.consumer ? this.consumer.config.bindingPrefix : DEFAULT_BINDINGS_PREFIX;
     const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(bindingPrefix, componentId, true);
     // when a user moves the component directory, use component.writtenPath to find the correct target
     // $FlowFixMe


### PR DESCRIPTION
Fixes part of https://github.com/teambit/bit/issues/2033.

Currently, when custom-resolved-links or dependency links are missing, Bit regenerate them on 'bit link'. However, turned out that in some cases not all missing links are found and in such cases, bit link won't generate them. 
With this fix, as long as some links are missing, Bit will regenerate them all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2043)
<!-- Reviewable:end -->
