### PR TITLE
remove bit-javascript jobs from circle 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -351,81 +351,6 @@ jobs:
       -
         store_artifacts:
           path: bit/junit
-  unit_test_bit_javascript:
-    <<: *defaults
-    steps:
-      -
-        run:
-          name: 'save SHA to a file'
-          command: 'echo $CIRCLE_SHA1 > .circle-sha'
-      -
-        attach_workspace:
-          at: ./
-      -
-        run: 'cd bit-javascript && mkdir junit'
-      -
-        run:
-          name: 'Run unit tests'
-          command: 'cd bit-javascript && npm run test-circle'
-          environment:
-            MOCHA_FILE: junit/unit-test-results.xml
-          when: always
-      -
-        store_test_results:
-          path: bit-javascript/junit
-      -
-        store_artifacts:
-          path: bit-javascript/junit
-  lint_bit_javascript:
-    <<: *defaults
-    resource_class: medium
-    steps:
-      -
-        run:
-          name: 'save SHA to a file'
-          command: 'echo $CIRCLE_SHA1 > .circle-sha'
-      -
-        restore_cache:
-          keys:
-            - 'repo-{{ checksum ".circle-sha" }}'
-      -
-        attach_workspace:
-          at: ./
-      -
-        run:
-          name: 'run ESLint'
-          command: 'cd bit-javascript && npm run lint-circle'
-      -
-        store_test_results:
-          path: bit-javascript/junit
-      -
-        store_artifacts:
-          path: bit-javascript/junit
-  check_types_bit_javascript:
-    <<: *defaults
-    resource_class: medium
-    steps:
-      -
-        run:
-          name: 'save SHA to a file'
-          command: 'echo $CIRCLE_SHA1 > .circle-sha'
-      -
-        restore_cache:
-          keys:
-            - 'repo-{{ checksum ".circle-sha" }}'
-      -
-        attach_workspace:
-          at: ./
-      -
-        run:
-          name: 'run TSC'
-          command: 'cd bit-javascript && npm run check-types'
-      -
-        store_test_results:
-          path: bit-javascript/junit
-      -
-        store_artifacts:
-          path: bit-javascript/junit
   lint:
     <<: *defaults
     resource_class: medium
@@ -657,18 +582,6 @@ workflows:
         unit_test:
           requires:
             - build
-      -
-        unit_test_bit_javascript:
-          requires:
-            - build_bit_javascript
-      -
-        lint_bit_javascript:
-          requires:
-            - build_bit_javascript
-      -
-        check_types_bit_javascript:
-          requires:
-            - build_bit_javascript
       -
         lint:
           requires:


### PR DESCRIPTION
## Proposed Changes

- remove bit-javascript jobs from circle (they are part of the bit-javascript repo circle now)
  - unit_test_bit_javascript
  - lint_bit_javascript
  - check_types_bit_javascript

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2080)
<!-- Reviewable:end -->
