### PR TITLE
Fix fork of a component when a dependency exists in an older version only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- fix fork of a component when a dependency exists in an older version only
+
 ## [14.4.4-dev.3] - 2019-11-13
 
 - update `react-docgen` version from `2.21.0` to `4.1.1`, and update all docs parser structure

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -757,6 +757,25 @@ describe('bit export command', function() {
           expect(show.scopesList[0].name).to.equal(helper.scopes.remote);
           expect(show.scopesList[1].name).to.equal(forkScope);
         });
+        describe('when an older version has dependencies that are not exist in the new version', () => {
+          before(() => {
+            helper.scopeHelper.getClonedLocalScope(localScope);
+            helper.scopeHelper.reInitRemoteScope(forkScopePath);
+            helper.fs.createFile('utils', 'is-string.js', ''); // remove the is-type dependency
+            helper.command.tagAllComponents();
+            helper.command.exportAllComponents();
+
+            helper.command.export(`${forkScope} utils/is-string --include-dependencies`);
+            const forkScopeList = helper.command.listScopeParsed(forkScope);
+            forkScopeIds = forkScopeList.map(c => c.id);
+          });
+          it('should fork the component', () => {
+            expect(forkScopeIds).to.deep.include(`${forkScope}/utils/is-string`);
+          });
+          it('should fork the dependencies of the older version', () => {
+            expect(forkScopeIds).to.deep.include(`${forkScope}/utils/is-type`);
+          });
+        });
       });
       describe('export staged component without --set-current-scope', () => {
         let output;

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -783,6 +783,7 @@ describe('bit export command', function() {
         describe('when an older version has dependencies that are not exist in the new version and those dependencies have more versions', () => {
           before(() => {
             helper.scopeHelper.getClonedLocalScope(localScope);
+            helper.scopeHelper.reInitRemoteScope();
             helper.scopeHelper.reInitRemoteScope(forkScopePath);
             helper.fs.createFile('utils', 'is-string.js', ''); // remove the is-type dependency
             helper.fs.createFile('utils', 'is-type.js', ''); // add another version for is-type

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -776,6 +776,35 @@ describe('bit export command', function() {
             expect(forkScopeIds).to.deep.include(`${forkScope}/utils/is-type`);
           });
         });
+        // in this case, is-string@0.0.1 has a dependency is-type@0.0.1.
+        // the last version, 0.0.2, of is-string, doesn't have the dependency.
+        // also, is-type has an additional version, 0.0.2, which is not required by any version of
+        // is-string, which caused an error ENOENT of the is-type@0.0.2 object.
+        describe('when an older version has dependencies that are not exist in the new version and those dependencies have more versions', () => {
+          before(() => {
+            helper.scopeHelper.getClonedLocalScope(localScope);
+            helper.scopeHelper.reInitRemoteScope(forkScopePath);
+            helper.fs.createFile('utils', 'is-string.js', ''); // remove the is-type dependency
+            helper.fs.createFile('utils', 'is-type.js', ''); // add another version for is-type
+            helper.command.tagAllComponents();
+            helper.command.exportAllComponents();
+
+            helper.scopeHelper.reInitLocalScope();
+            helper.scopeHelper.addRemoteScope();
+            helper.scopeHelper.addRemoteScope(forkScopePath);
+            helper.command.importComponent('utils/is-string');
+
+            helper.command.export(`${forkScope} utils/is-string --include-dependencies`);
+            const forkScopeList = helper.command.listScopeParsed(forkScope);
+            forkScopeIds = forkScopeList.map(c => c.id);
+          });
+          it('should fork the component', () => {
+            expect(forkScopeIds).to.deep.include(`${forkScope}/utils/is-string`);
+          });
+          it('should fork the dependencies of the older version', () => {
+            expect(forkScopeIds).to.deep.include(`${forkScope}/utils/is-type`);
+          });
+        });
       });
       describe('export staged component without --set-current-scope', () => {
         let output;

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -92,9 +92,8 @@ export default class ScopeComponentsImporter {
    */
   async importManyWithAllVersions(
     ids: BitIds,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    cache? = true,
-    allDepsVersions = false
+    cache = true,
+    allDepsVersions = false // by default, only dependencies of the latest version are imported
   ): Promise<VersionDependencies[]> {
     logger.debug(`scope.getManyWithAllVersions, Ids: ${ids.join(', ')}`);
     Analytics.addBreadCrumb('getManyWithAllVersions', `scope.getManyWithAllVersions, Ids: ${Analytics.hashData(ids)}`);
@@ -112,9 +111,12 @@ export default class ScopeComponentsImporter {
       });
       allIdsWithAllVersions.push(...removeNils(idsWithAllVersions));
     });
-    allDepsVersions
-      ? await this.importMany(allIdsWithAllVersions, cache)
-      : await this.importManyWithoutDependencies(allIdsWithAllVersions);
+    if (allDepsVersions) {
+      const versionDependenciesOfOlderVersions = await this.importMany(allIdsWithAllVersions, cache);
+      versionDependenciesArr.push(...versionDependenciesOfOlderVersions);
+    } else {
+      await this.importManyWithoutDependencies(allIdsWithAllVersions);
+    }
 
     return versionDependenciesArr;
   }

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -112,8 +112,12 @@ export default class ScopeComponentsImporter {
       allIdsWithAllVersions.push(...removeNils(idsWithAllVersions));
     });
     if (allDepsVersions) {
-      const versionDependenciesOfOlderVersions = await this.importMany(allIdsWithAllVersions, cache);
-      versionDependenciesArr.push(...versionDependenciesOfOlderVersions);
+      const verDepsOfOlderVersions = await this.importMany(allIdsWithAllVersions, cache);
+      versionDependenciesArr.push(...verDepsOfOlderVersions);
+      const allFlattenDepsIds = versionDependenciesArr.map(v => v.allDependencies.map(d => d.id));
+      const dependenciesOnly = R.flatten(allFlattenDepsIds).filter((id: BitId) => !ids.hasWithoutVersion(id));
+      const verDepsOfAllFlattenDeps = await this.importManyWithAllVersions(BitIds.uniqFromArray(dependenciesOnly));
+      versionDependenciesArr.push(...verDepsOfAllFlattenDeps);
     } else {
       await this.importManyWithoutDependencies(allIdsWithAllVersions);
     }


### PR DESCRIPTION
Before the fix, it used to throw an error ComponentNotFound of the dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2129)
<!-- Reviewable:end -->
