### PR TITLE
Feature/extension flat config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [unreleased]
 
 - fix fork of a component when a dependency exists in an older version only
+- change the extension / envs input config to be flat
 
 ## [14.4.4-dev.3] - 2019-11-13
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "precommit": "lint-staged",
     "ts-coverage": "type-coverage",
     "check-types": "tsc",
+    "check-types:watch": "tsc --watch",
     "lint": "tsc && eslint \"{src,e2e}/**/*.ts\"",
     "lint:table": "eslint \"{src,e2e}/**/*.ts\" --format table",
     "lint:html": "eslint \"{src,e2e}/**/*.ts\" --format html -o eslint-report.html",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -68,12 +68,11 @@ export const DEFAULT_TESTER_ID = NO_PLUGIN_TYPE;
 
 export const DEFAULT_PACKAGE_MANAGER = 'npm';
 
+export const EXTENSION_BIT_CONFIG_PREFIX = '_bit_';
+
 export const DEFAULT_EXTENSIONS = {
   'ext-docs-parser': {
-    rawConfig: {},
-    options: {
-      core: true
-    }
+    [`${EXTENSION_BIT_CONFIG_PREFIX}_core`]: true
   }
 };
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -72,7 +72,7 @@ export const EXTENSION_BIT_CONFIG_PREFIX = '_bit_';
 
 export const DEFAULT_EXTENSIONS = {
   'ext-docs-parser': {
-    [`${EXTENSION_BIT_CONFIG_PREFIX}_core`]: true
+    [`${EXTENSION_BIT_CONFIG_PREFIX}core`]: true
   }
 };
 

--- a/src/consumer/config/abstract-config.spec.ts
+++ b/src/consumer/config/abstract-config.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import AbstractConfig from './abstract-config';
+import { EXTENSION_BIT_CONFIG_PREFIX } from '../../constants';
+
+describe('extensions transformation', () => {
+  describe('from extension to raw extension', () => {
+    let rawExtension;
+    before(() => {
+      const extension = {
+        rawConfig: {
+          myKey: 'myVal'
+        },
+        options: {
+          pathToLoadFrom: '/myExtensionPath',
+          disabled: false
+        }
+      };
+      rawExtension = AbstractConfig.transformExtensionToRawExtension(extension);
+    });
+    it('should have bit options with correct prefix', () => {
+      expect(rawExtension).to.have.property(`${EXTENSION_BIT_CONFIG_PREFIX}pathToLoadFrom`, '/myExtensionPath');
+      expect(rawExtension).to.have.property(`${EXTENSION_BIT_CONFIG_PREFIX}disabled`, false);
+    });
+    it('should have the raw config', () => {
+      expect(rawExtension).to.have.property('myKey', 'myVal');
+    });
+    it('should not have the extension keys (rawConfig / options)', () => {
+      expect(rawExtension).to.not.have.property('rawConfig');
+      expect(rawExtension).to.not.have.property('options');
+    });
+  });
+  describe('from raw extension to extension', () => {
+    let extension;
+    before(() => {
+      const rawExtension = {
+        myKey: 'myVal',
+        _bit_pathToLoadFrom: '/myExtensionPath',
+        _bit_disabled: false
+      };
+      extension = AbstractConfig.transformRawExtensionToExtension(rawExtension);
+    });
+    it('should have bit options with correct values', () => {
+      expect(extension).to.have.property('options');
+      expect(extension.options).to.have.property('pathToLoadFrom', '/myExtensionPath');
+      expect(extension.options).to.have.property('disabled', false);
+    });
+    it('should have the raw config', () => {
+      expect(extension).to.have.property('rawConfig');
+      expect(extension.rawConfig).to.have.property('myKey', 'myVal');
+    });
+    it('should not have the original raw extension keys', () => {
+      expect(extension).to.not.have.property('myKey');
+      expect(extension).to.not.have.property('_bit_pathToLoadFrom');
+      expect(extension).to.not.have.property('_bit_disabled');
+    });
+  });
+});

--- a/src/consumer/config/abstract-config.spec.ts
+++ b/src/consumer/config/abstract-config.spec.ts
@@ -5,13 +5,19 @@ import { EXTENSION_BIT_CONFIG_PREFIX } from '../../constants';
 const rawExtension1 = {
   myKey: 'myVal',
   _bit_pathToLoadFrom: '/myExtensionPath',
-  _bit_disabled: false
+  _bit_disabled: false,
+  _bit_files: {
+    myFile: 'myFilePath'
+  }
 };
 
 const rawExtension2 = {
   myKey2: 'myVal2',
   _bit_pathToLoadFrom: '/myExtensionPath2',
-  _bit_disabled: false
+  _bit_disabled: false,
+  _bit_files: {
+    myFile2: 'myFilePath2'
+  }
 };
 
 describe('extensions transformation', () => {
@@ -25,6 +31,9 @@ describe('extensions transformation', () => {
         options: {
           pathToLoadFrom: '/myExtensionPath',
           disabled: false
+        },
+        files: {
+          myFile: 'myFilePath'
         }
       };
       rawExtension = AbstractConfig.transformExtensionToRawExtension(extension);
@@ -36,9 +45,15 @@ describe('extensions transformation', () => {
     it('should have the raw config', () => {
       expect(rawExtension).to.have.property('myKey', 'myVal');
     });
+    it('should have the files', () => {
+      const filesKeyName = `${EXTENSION_BIT_CONFIG_PREFIX}files`;
+      expect(rawExtension).to.have.property(filesKeyName);
+      expect(rawExtension[filesKeyName]).to.have.property('myFile', 'myFilePath');
+    });
     it('should not have the extension keys (rawConfig / options)', () => {
       expect(rawExtension).to.not.have.property('rawConfig');
       expect(rawExtension).to.not.have.property('options');
+      expect(rawExtension).to.not.have.property('files');
     });
   });
   describe('from raw extension to extension', () => {
@@ -55,10 +70,15 @@ describe('extensions transformation', () => {
       expect(extension).to.have.property('rawConfig');
       expect(extension.rawConfig).to.have.property('myKey', 'myVal');
     });
+    it('should have the config files', () => {
+      expect(extension).to.have.property('files');
+      expect(extension.files).to.have.property('myFile', 'myFilePath');
+    });
     it('should not have the original raw extension keys', () => {
       expect(extension).to.not.have.property('myKey');
       expect(extension).to.not.have.property('_bit_pathToLoadFrom');
       expect(extension).to.not.have.property('_bit_disabled');
+      expect(extension).to.not.have.property('_bit_files');
     });
   });
   describe('transform all raw extensions to extensions', () => {
@@ -88,13 +108,21 @@ describe('extensions transformation', () => {
       expect(extensions.ext2).to.have.property('rawConfig');
       expect(extensions.ext2.rawConfig).to.have.property('myKey2', 'myVal2');
     });
+    it('should have the config files', () => {
+      expect(extensions.ext1).to.have.property('files');
+      expect(extensions.ext2).to.have.property('files');
+      expect(extensions.ext1.files).to.have.property('myFile', 'myFilePath');
+      expect(extensions.ext2.files).to.have.property('myFile2', 'myFilePath2');
+    });
     it('should not have the original raw extension keys', () => {
       expect(extensions.ext1).to.not.have.property('myKey');
       expect(extensions.ext1).to.not.have.property('_bit_pathToLoadFrom');
       expect(extensions.ext1).to.not.have.property('_bit_disabled');
+      expect(extensions.ext1).to.not.have.property('_bit_files');
       expect(extensions.ext2).to.not.have.property('myKey');
       expect(extensions.ext2).to.not.have.property('_bit_pathToLoadFrom');
       expect(extensions.ext2).to.not.have.property('_bit_disabled');
+      expect(extensions.ext2).to.not.have.property('_bit_files');
     });
   });
   describe('transform all extensions to raw extensions', () => {

--- a/src/consumer/config/abstract-config.spec.ts
+++ b/src/consumer/config/abstract-config.spec.ts
@@ -2,6 +2,18 @@ import { expect } from 'chai';
 import AbstractConfig from './abstract-config';
 import { EXTENSION_BIT_CONFIG_PREFIX } from '../../constants';
 
+const rawExtension1 = {
+  myKey: 'myVal',
+  _bit_pathToLoadFrom: '/myExtensionPath',
+  _bit_disabled: false
+};
+
+const rawExtension2 = {
+  myKey2: 'myVal2',
+  _bit_pathToLoadFrom: '/myExtensionPath2',
+  _bit_disabled: false
+};
+
 describe('extensions transformation', () => {
   describe('from extension to raw extension', () => {
     let rawExtension;
@@ -32,12 +44,7 @@ describe('extensions transformation', () => {
   describe('from raw extension to extension', () => {
     let extension;
     before(() => {
-      const rawExtension = {
-        myKey: 'myVal',
-        _bit_pathToLoadFrom: '/myExtensionPath',
-        _bit_disabled: false
-      };
-      extension = AbstractConfig.transformRawExtensionToExtension(rawExtension);
+      extension = AbstractConfig.transformRawExtensionToExtension(rawExtension1);
     });
     it('should have bit options with correct values', () => {
       expect(extension).to.have.property('options');
@@ -52,6 +59,42 @@ describe('extensions transformation', () => {
       expect(extension).to.not.have.property('myKey');
       expect(extension).to.not.have.property('_bit_pathToLoadFrom');
       expect(extension).to.not.have.property('_bit_disabled');
+    });
+  });
+  describe.only('transform all raw extensions to extensions', () => {
+    let rawExtensions = {
+      ext1: rawExtension1,
+      ext2: rawExtension2
+    };
+    let extensions;
+    before(() => {
+      extensions = AbstractConfig.transformAllRawExtensionsToExtensions(rawExtensions);
+    });
+    it('should have all extensions entries', () => {
+      expect(extensions).to.have.property('ext1');
+      expect(extensions).to.have.property('ext2');
+    });
+    it('should have bit options with correct values', () => {
+      expect(extensions.ext1).to.have.property('options');
+      expect(extensions.ext1.options).to.have.property('pathToLoadFrom', '/myExtensionPath');
+      expect(extensions.ext1.options).to.have.property('disabled', false);
+      expect(extensions.ext2).to.have.property('options');
+      expect(extensions.ext2.options).to.have.property('pathToLoadFrom', '/myExtensionPath2');
+      expect(extensions.ext2.options).to.have.property('disabled', false);
+    });
+    it('should have the raw config', () => {
+      expect(extensions.ext1).to.have.property('rawConfig');
+      expect(extensions.ext1.rawConfig).to.have.property('myKey', 'myVal');
+      expect(extensions.ext2).to.have.property('rawConfig');
+      expect(extensions.ext2.rawConfig).to.have.property('myKey2', 'myVal2');
+    });
+    it('should not have the original raw extension keys', () => {
+      expect(extensions.ext1).to.not.have.property('myKey');
+      expect(extensions.ext1).to.not.have.property('_bit_pathToLoadFrom');
+      expect(extensions.ext1).to.not.have.property('_bit_disabled');
+      expect(extensions.ext2).to.not.have.property('myKey');
+      expect(extensions.ext2).to.not.have.property('_bit_pathToLoadFrom');
+      expect(extensions.ext2).to.not.have.property('_bit_disabled');
     });
   });
 });

--- a/src/consumer/config/abstract-config.spec.ts
+++ b/src/consumer/config/abstract-config.spec.ts
@@ -61,7 +61,7 @@ describe('extensions transformation', () => {
       expect(extension).to.not.have.property('_bit_disabled');
     });
   });
-  describe.only('transform all raw extensions to extensions', () => {
+  describe('transform all raw extensions to extensions', () => {
     let rawExtensions = {
       ext1: rawExtension1,
       ext2: rawExtension2
@@ -95,6 +95,21 @@ describe('extensions transformation', () => {
       expect(extensions.ext2).to.not.have.property('myKey');
       expect(extensions.ext2).to.not.have.property('_bit_pathToLoadFrom');
       expect(extensions.ext2).to.not.have.property('_bit_disabled');
+    });
+  });
+  describe('transform all extensions to raw extensions', () => {
+    let rawExtensions = {
+      ext1: rawExtension1,
+      ext2: rawExtension2
+    };
+    let rawExtensionsCalculated;
+    before(() => {
+      let extensions;
+      extensions = AbstractConfig.transformAllRawExtensionsToExtensions(rawExtensions);
+      rawExtensionsCalculated = AbstractConfig.transformAllExtensionsToRawExtensions(extensions);
+    });
+    it('should transform correct', () => {
+      expect(rawExtensionsCalculated).to.deep.equal(rawExtensions);
     });
   });
 });

--- a/src/consumer/config/abstract-config.ts
+++ b/src/consumer/config/abstract-config.ts
@@ -285,13 +285,16 @@ export default class AbstractConfig {
   static transformExtensionToRawExtension(extension: RegularExtensionObject | RawExtensionObject): RawExtensionObject {
     const rawExtension = {};
     // Support case when got a raw extension instead of extension
-    if (!extension.options && !extension.rawConfig) {
+    if (!extension.options && !extension.rawConfig && !extension.files) {
       return extension;
     }
     if (extension.options) {
       R.forEachObjIndexed((value, key) => {
         rawExtension[`${EXTENSION_BIT_CONFIG_PREFIX}${key}`] = value;
       }, extension.options);
+    }
+    if (extension.files) {
+      rawExtension[`${EXTENSION_BIT_CONFIG_PREFIX}files`] = extension.files;
     }
     if (extension.rawConfig) {
       R.forEachObjIndexed((value, key) => {
@@ -320,7 +323,11 @@ export default class AbstractConfig {
     R.forEachObjIndexed((value, key) => {
       if (R.startsWith(EXTENSION_BIT_CONFIG_PREFIX, key)) {
         const optionKey = key.replace(EXTENSION_BIT_CONFIG_PREFIX, '');
-        set(extension, ['options', optionKey], value);
+        if (optionKey === 'files') {
+          extension.files = value;
+        } else {
+          set(extension, ['options', optionKey], value);
+        }
       } else {
         set(extension, ['rawConfig', key], value);
       }

--- a/src/consumer/config/abstract-config.ts
+++ b/src/consumer/config/abstract-config.ts
@@ -28,6 +28,7 @@ export type RawExtensionObject = any;
 export type RegularExtensionObject = {
   rawConfig: Record<string, any>;
   options: ExtensionOptions;
+  files: Record<string, any>;
 };
 
 export type EnvFile = {
@@ -309,6 +310,7 @@ export default class AbstractConfig {
   ): RegularExtensionObject {
     const extension: RegularExtensionObject = {
       options: {},
+      files: {},
       rawConfig: {}
     };
     // Backward compatibility support

--- a/src/consumer/config/abstract-config.ts
+++ b/src/consumer/config/abstract-config.ts
@@ -84,7 +84,6 @@ export default class AbstractConfig {
   testerDependencies: { [key: string]: string };
   lang: string;
   bindingPrefix: string;
-  extensions: Extensions;
   writeToPackageJson = false;
   writeToBitJson = false;
 
@@ -124,10 +123,8 @@ export default class AbstractConfig {
     this._tester = AbstractConfig.transformEnvToObject(tester);
   }
 
-  get extensions(): Extensions {
-    const testerObj = AbstractConfig.transformEnvToObject(this._tester);
-    if (R.isEmpty(testerObj)) return undefined;
-    return testerObj;
+  get extensions(): Extensions | undefined {
+    return AbstractConfig.transformAllRawExtensionsToExtensions(this._rawExtensions);
   }
 
   addDependencies(bitIds: BitId[]): this {
@@ -315,5 +312,16 @@ export default class AbstractConfig {
       }
     }, rawExtension);
     return extension;
+  }
+
+  static transformAllRawExtensionsToExtensions(rawExtensions: RawExtensions): Extensions {
+    let extensions;
+    if (rawExtensions) {
+      extensions = {};
+      R.forEachObjIndexed((value, key) => {
+        extensions[key] = AbstractConfig.transformRawExtensionToExtension(value);
+      }, rawExtensions);
+    }
+    return extensions;
   }
 }

--- a/src/e2e-helper/e2e-bit-json-helper.ts
+++ b/src/e2e-helper/e2e-bit-json-helper.ts
@@ -3,6 +3,7 @@ import * as path from 'path';
 import fs from 'fs-extra';
 import set from 'lodash.set';
 import ScopesData from './e2e-scopes';
+import { EXTENSION_BIT_CONFIG_PREFIX } from '../constants';
 
 export default class BitJsonHelper {
   scopes: ScopesData;
@@ -39,7 +40,7 @@ export default class BitJsonHelper {
     filePath: string,
     envType: 'compiler' | 'tester'
   ) {
-    this._addKeyValToEnvProp(bitJsonPath, 'files', fileName, filePath, envType);
+    this._addKeyValToEnvProp(bitJsonPath, `${EXTENSION_BIT_CONFIG_PREFIX}files`, fileName, filePath, envType);
   }
   addToRawConfigOfEnv(
     bitJsonPath: string = this.scopes.localPath,
@@ -47,7 +48,7 @@ export default class BitJsonHelper {
     val: string,
     envType: 'compiler' | 'tester'
   ) {
-    this._addKeyValToEnvProp(bitJsonPath, 'rawConfig', key, val, envType);
+    this._addKeyValToEnvProp(bitJsonPath, '', key, val, envType);
   }
   manageWorkspaces(withWorkspaces = true) {
     const bitJson = this.read();
@@ -84,7 +85,10 @@ export default class BitJsonHelper {
   ) {
     const bitJson = this.read(bitJsonDir);
     const envName = this._getEnvNameByType(bitJson, envType);
-    const propPath = ['env', envType, envName, propName];
+    const propPath = ['env', envType, envName];
+    if (propName) {
+      propPath.push(propName);
+    }
     const prop = R.pathOr({}, propPath, bitJson);
     prop[key] = val;
     set(bitJson, propPath, prop);

--- a/src/extensions/base-extension.ts
+++ b/src/extensions/base-extension.ts
@@ -22,7 +22,7 @@ const ajv = new Ajv();
 const CORE_EXTENSIONS_PATH = './core-extensions';
 
 export type BaseExtensionOptions = {
-  file?: string | null | undefined;
+  pathToLoadFrom?: string;
 };
 
 type BaseArgs = {
@@ -240,7 +240,6 @@ export default class BaseExtension {
   }
 
   setExtensionPathInScope(scopePath: string): void {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const { resolvedPath, componentPath } = _getExtensionPath(this.name, scopePath, this.options.core);
     this.filePath = resolvedPath;
     this.rootDir = componentPath;
@@ -275,10 +274,10 @@ export default class BaseExtension {
   }: BaseLoadArgsProps): Promise<BaseExtensionProps> {
     logger.debug(`base-extension loading ${name}`);
     const concreteBaseAPI = _getConcreteBaseAPI({ name });
-    if (options.file) {
-      let absPath = options.file;
-      const file = options.file || '';
-      if (!path.isAbsolute(options.file) && consumerPath) {
+    if (options.pathToLoadFrom) {
+      let absPath = options.pathToLoadFrom;
+      const file = options.pathToLoadFrom || '';
+      if (!path.isAbsolute(options.pathToLoadFrom) && consumerPath) {
         absPath = path.resolve(consumerPath, file);
       }
       const staticExtensionProps: StaticProps = await BaseExtension.loadFromFile({
@@ -381,7 +380,7 @@ export default class BaseExtension {
     if (!isFileExist) {
       // Do not throw an error if the file not exist since we will install it later
       // unless you specify the options.file which means you want a specific file which won't be installed automatically later
-      if (throws && options.file) {
+      if (throws && options.pathToLoadFrom) {
         const err = new Error(`the file ${filePath} not found`);
         throw new ExtensionLoadError(err, extensionProps.name);
       }

--- a/src/extensions/extensions-loader.ts
+++ b/src/extensions/extensions-loader.ts
@@ -41,9 +41,7 @@ const _loadExtension = (consumerPath: string | null | undefined, scopePath: stri
 ): Promise<Extension> => {
   const loadArgs: LoadArgsProps = {
     name,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     rawConfig: rawConfig.config,
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     options: rawConfig.options,
     consumerPath,
     scopePath
@@ -67,15 +65,13 @@ export default (async function loadExtensions(): Promise<Extension[]> {
       }
     };
     const consumer: Consumer | null | undefined = await getConsumer();
-    let consumerPath = null;
-    let scopePath = null;
+    let consumerPath;
+    let scopePath;
 
     let rawExtensions = {};
     if (consumer) {
       rawExtensions = consumer.config.extensions || {};
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       consumerPath = consumer.getPath();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       scopePath = consumer.scope.path;
     }
 


### PR DESCRIPTION
## Proposed Changes

- change the extension / envs input config to be flat 
- rename options.file to _bit_pathToLoadFrom

previous extension structure:
```json
{
  "extensions": {
    "extension-id": {
      "rawConfig": {
        "someKey": "someVal"
      },
      "options": {
        "core": true,
        "file": "/myExtensionPath"
      }
    }
  }
}
```
new extension structure:
```json
{
  "extensions": {
    "extension-id": {
      "someKey": "someVal",
      "_bit_core": true,
      "_bit_pathToLoadFrom": "/myExtensionPath"
    }
  }
}
```
previous env structure:
```json
{
  "env": {
    "compiler/tester": {
      "env-id": {
        "rawConfig": {
          "someKey": "someVal"
        },
        "options": {
          "core": true,
          "file": "/myExtensionPath"
        },
        "files": {
          "myConfigFile": "/pathToConfigFile"
        }
      }
    }
  }
}
```
new env structure:
```json
{
  "env": {
    "compiler/tester": {
      "env-id": {
        "someKey": "someVal",
        "_bit_pathToLoadFrom": "/myExtensionPath",
        "_bit_files": {
          "myConfigFile": "/pathToConfigFile"
        }
      }
    }
  }
}
```