### PR TITLE
Not show fail or success icon when building component without compiler

### DIFF
--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -283,7 +283,11 @@ export default class Scope {
       loader.start(`building component - ${component.id}`);
       await component.build({ scope: this, consumer, noCache, verbose, dontPrintEnvMsg });
       const buildResults = await component.dists.writeDists(component, consumer, false);
-      loader.succeed();
+      if (buildResults) {
+        loader.succeed();
+      } else {
+        loader.fail();
+      }
       return { component: component.id.toString(), buildResults };
     };
     const writeLinks = async (component: Component) => component.dists.writeDistsLinks(component, consumer);

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -280,14 +280,10 @@ export default class Scope {
       if (components.length > 1) loader.stopAndPersist({ text: `${BEFORE_RUNNING_BUILD}...` });
     }
     const build = async (component: Component) => {
-      loader.start(`building component - ${component.id}`);
+      if (component.compiler) loader.start(`building component - ${component.id}`);
       await component.build({ scope: this, consumer, noCache, verbose, dontPrintEnvMsg });
       const buildResults = await component.dists.writeDists(component, consumer, false);
-      if (buildResults) {
-        loader.succeed();
-      } else {
-        loader.fail();
-      }
+      if (component.compiler) loader.succeed();
       return { component: component.id.toString(), buildResults };
     };
     const writeLinks = async (component: Component) => component.dists.writeDistsLinks(component, consumer);


### PR DESCRIPTION
## Proposed Changes

When we build/tag a component without a compiler, the loader shows a success status, so I update the code to check if the component has a compiler attached to it before running the loader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2156)
<!-- Reviewable:end -->
