### PR TITLE
Fix component-not-found when exporting to multiple scopes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2171](https://github.com/teambit/bit/issues/2171) fix component-not-found when exporting to multiple scopes and there are dependencies between them
+
 ## [14.6.1-dev.2] - 2019-12-04
 
 - make bit status recursively show untracked files dependencies

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -177,8 +177,10 @@ export async function exportMany({
     const addToGroupedSorted = (id: BitId) => {
       if (groupedArraySorted.length) {
         const lastItem = groupedArraySorted[groupedArraySorted.length - 1];
-        if (lastItem.scopeName === id.scope) lastItem.ids.push(id);
-        return;
+        if (lastItem.scopeName === id.scope) {
+          lastItem.ids.push(id);
+          return;
+        }
       }
       groupedArraySorted.push({ scopeName: id.scope || (defaultScope as string), ids: new BitIds(id) });
     };

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -6,7 +6,6 @@ import ComponentWithDependencies from '../component-dependencies';
 import GeneralError from '../../error/general-error';
 import { ComponentsAndVersions } from '../scope';
 import { BitId } from '../../bit-id';
-import { Dependency } from '../../consumer/component/dependencies';
 
 export type AllDependenciesGraphs = {
   graphDeps: Graph;

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -6,6 +6,7 @@ import ComponentWithDependencies from '../component-dependencies';
 import GeneralError from '../../error/general-error';
 import { ComponentsAndVersions } from '../scope';
 import { BitId } from '../../bit-id';
+import { Dependency } from '../../consumer/component/dependencies';
 
 export type AllDependenciesGraphs = {
   graphDeps: Graph;
@@ -43,6 +44,22 @@ export function buildComponentsGraphForComponentsAndVersion(
     _setGraphEdges(bitId, version.testerDependencies, graphTesterDeps);
   });
   return { graphDeps, graphDevDeps, graphCompilerDeps, graphTesterDeps };
+}
+
+export function buildOneGraphForComponentsAndMultipleVersions(components: ComponentsAndVersions[]): Graph {
+  const graph = new Graph();
+  components.forEach(({ component, version }) => {
+    const bitId = component.toBitId().changeVersion(null);
+    const idStr = bitId.toString();
+    if (!graph.hasNode(idStr)) graph.setNode(idStr, bitId);
+    version.getAllDependencies().forEach(dependency => {
+      const depId = dependency.id.changeVersion(null);
+      const depIdStr = depId.toString();
+      if (!graph.hasNode(depIdStr)) graph.setNode(depIdStr, depId);
+      graph.setEdge(idStr, depIdStr);
+    });
+  });
+  return graph;
 }
 
 function _setGraphEdges(bitId: BitId, dependencies: Dependencies, graph: Graph) {


### PR DESCRIPTION
and there are dependencies between them. Fixes https://github.com/teambit/bit/issues/2171.

This happens when a component in one scope has a dependency in another remote. e.g. a component remoteA/compA depends on remoteB/compB.
in case remoteA/compA was exported first, remoteA throws an error that remoteB/compB was not found.
The solution implemented in this PR, sorts the components topologically, which ensures that we export remoteB/compB first.

It also takes care of the following cases:
1) in case there are cycle dependencies between the scopes, it's impossible to toposort, so Bit throws a descriptive error, suggesting to untag.
2) the cycle dependencies can be between different versions. e.g. remoteA/compA@0.0.1 requires remoteB/compB@0.0.1 and remoteB/compB@0.0.2 requires remoteA/compA@0.0.2.
3) it's possible to have circle dependencies inside the same scope, and non-circle dependencies between the different scopes. in this case, the toposort is done after removing the ids that participated in the circular.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2174)
<!-- Reviewable:end -->
