### PR TITLE
Fix workspace-overrides to not leak rules to unrelated components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2176](https://github.com/teambit/bit/issues/2176) fix workspace overrides to not leak rules to unrelated components
 - [#2171](https://github.com/teambit/bit/issues/2171) fix component-not-found when exporting to multiple scopes and there are dependencies between them
 
 ## [14.6.1-dev.2] - 2019-12-04

--- a/e2e/functionalities/workspace-config.e2e.3.ts
+++ b/e2e/functionalities/workspace-config.e2e.3.ts
@@ -1466,7 +1466,8 @@ describe('workspace config', function() {
         helper.scopeHelper.setNewLocalAndRemoteScopes();
         helper.fixtures.createComponentBarFoo();
         helper.fixtures.addComponentBarFoo();
-        helper.fixtures.addComponentBarFoo();
+        helper.fs.outputFile('baz.js');
+        helper.command.addComponent('baz.js');
         overrides = {
           '*': {
             scripts: {
@@ -1530,6 +1531,18 @@ describe('workspace config', function() {
           expect(output.overrides.scripts).to.have.property('test');
           expect(output.overrides.scripts).to.have.property('watch');
           expect(output.overrides.scripts).to.not.have.property('lint');
+        });
+      });
+      describe('tagging the components and then changing the propagate of one component', () => {
+        before(() => {
+          helper.command.tagAllComponents();
+          const bitJson = helper.bitJson.read();
+          bitJson.overrides['bar/foo'].propagate = false;
+          helper.bitJson.write(bitJson);
+        });
+        it('should not affect other components that do not match any overrides criteria', () => {
+          const status = helper.command.statusJson();
+          expect(status.modifiedComponent).to.not.include('baz@0.0.1');
         });
       });
     });

--- a/src/consumer/config/consumer-overrides.ts
+++ b/src/consumer/config/consumer-overrides.ts
@@ -38,7 +38,7 @@ export default class ConsumerOverrides {
     if (!matches.length) {
       return null;
     }
-    const overrideValues = matches.map(match => this.overrides[match]);
+    const overrideValues = matches.map(match => R.clone(this.overrides[match]));
     let stopPropagation = false;
     return overrideValues.reduce((acc, current) => {
       if (stopPropagation) return acc;
@@ -73,7 +73,7 @@ export default class ConsumerOverrides {
           break;
         default:
           if (isObjectAndNotArray(specificOverrides[field]) && isObjectAndNotArray(generalOverrides[field])) {
-            specificOverrides[field] = Object.assign(generalOverrides[field], specificOverrides[field]);
+            specificOverrides[field] = Object.assign({}, generalOverrides[field], specificOverrides[field]);
           } else if (!specificOverrides[field]) {
             specificOverrides[field] = generalOverrides[field];
           }


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/2176.

This happened due to `object.assign` mutating the workspace overrides, which should be immutable.
It has been fixed by cloning the workspace-overrides before doing any calculation for specific components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2179)
<!-- Reviewable:end -->
