### PR TITLE
Avoid writing dependencies dists to a capsule when their compiler was removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2182](https://github.com/teambit/bit/issues/2182) don't write dependencies dists to a capsule when their compiler was removed
+
 ## [14.7.1-dev.1] - 2019-12-08
 
 - improve isolate function for testers API

--- a/e2e/fixtures/compilers/capsule/compiler.js
+++ b/e2e/fixtures/compilers/capsule/compiler.js
@@ -42,7 +42,7 @@ function getCapsuleDirByComponentName(compilerOutput, componentName) {
       'the output of capsule compiler is expected to include the build component name (see the console.log inside the compile function)'
     );
   }
-  return componentOutput.replace(`generated a capsule for ${componentName} at `, '');
+  return componentOutput.replace(new RegExp(`generated a capsule for ${componentName}(.*) at `), '');
 }
 
 const newCompilerApi = {

--- a/e2e/functionalities/capsule.e2e.2.ts
+++ b/e2e/functionalities/capsule.e2e.2.ts
@@ -285,7 +285,7 @@ describe('capsule', function() {
           expect(buildResult).to.have.string('generated a capsule for utils/is-string');
         });
         describe('remove the compiler from the dependency', () => {
-          let capsuleDir;
+          let isStringCapsuleDir;
           before(() => {
             const overrides = {
               'utils/is-type': {
@@ -297,14 +297,14 @@ describe('capsule', function() {
             helper.bitJson.addOverrides(overrides);
             const buildResult = helper.command.tagComponent('utils/is-type');
             expect(buildResult).to.have.string('generated a capsule for utils/is-string');
-            capsuleDir = capsuleCompiler.getCapsuleDirByComponentName(buildResult, 'utils/is-string');
+            isStringCapsuleDir = capsuleCompiler.getCapsuleDirByComponentName(buildResult, 'utils/is-string');
           });
           // tests https://github.com/teambit/bit/issues/2182
           it('should not save the dists of the dependency in the capsule of the dependent', () => {
-            const distPath = path.join(capsuleDir, '.dependencies/utils/is-type/dist');
+            const distPath = path.join(isStringCapsuleDir, '.dependencies/utils/is-type/dist');
             expect(distPath).to.not.be.a.path();
             // just to make sure the original path of the component is there
-            expect(path.join(capsuleDir, '.dependencies/utils/is-type')).to.be.a.path();
+            expect(path.join(isStringCapsuleDir, '.dependencies/utils/is-type')).to.be.a.path();
           });
         });
       });

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -1215,11 +1215,6 @@ export default class Component {
     // for authored componentConfig is normally undefined
     const bitJson = componentConfig || workspaceConfig;
 
-    // Remove dists if compiler has been deleted
-    if (dists && !bitJson.hasCompiler()) {
-      dists = undefined;
-    }
-
     const envsContext = {
       componentDir: bitDir,
       workspaceDir: consumerPath
@@ -1278,6 +1273,11 @@ export default class Component {
     const docsP = _getDocsForFiles(files);
     const docs = await Promise.all(docsP);
     const flattenedDocs = docs ? R.flatten(docs) : [];
+
+    // remove dists if compiler has been deleted
+    if (dists && !compiler) {
+      dists = undefined;
+    }
 
     return new Component({
       name: id.name,


### PR DESCRIPTION
Fixes one out of two issues found in https://github.com/teambit/bit/issues/2182.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2188)
<!-- Reviewable:end -->
