### PR TITLE
Fix package-name replacement of dists when a package has a tilda prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2182](https://github.com/teambit/bit/issues/2182) fix package-name replacement of dists when a package has a tilda prefix
+
 ## [14.7.1-dev.1] - 2019-12-08
 
 - improve isolate function for testers API

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -18,6 +18,7 @@ import componentIdToPackageName from '../../utils/bit/component-id-to-package-na
 import Source from '../models/source';
 import { buildOneGraphForComponentsAndMultipleVersions } from '../graph/components-graph';
 import GeneralError from '../../error/general-error';
+import replacePackageName from '../../utils/string/replace-package-name';
 
 /**
  * @TODO there is no real difference between bare scope and a working directory scope - let's adjust terminology to avoid confusions in the future
@@ -370,20 +371,9 @@ async function convertToCorrectScope(
       const idWithNewScope = id.changeScope(remoteScope);
       const pkgNameWithNewScope = componentIdToPackageName(idWithNewScope, componentsObjects.component.bindingPrefix);
       const pkgNameWithOldScope = componentIdToPackageName(id, componentsObjects.component.bindingPrefix);
-      const singleQuote = "'";
-      const doubleQuotes = '"';
-      [singleQuote, doubleQuotes].forEach(quoteType => {
-        // replace an exact match. (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
-        newFileString = newFileString.replace(
-          new RegExp(quoteType + pkgNameWithOldScope + quoteType, 'g'),
-          quoteType + pkgNameWithNewScope + quoteType
-        );
-        // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
-        newFileString = newFileString.replace(
-          new RegExp(`${quoteType}${pkgNameWithOldScope}/`, 'g'),
-          `${quoteType}${pkgNameWithNewScope}/`
-        );
-      });
+      // replace an exact match. (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
+      // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
+      newFileString = replacePackageName(newFileString, pkgNameWithOldScope, pkgNameWithNewScope);
     });
     if (newFileString !== fileString) {
       return Source.from(Buffer.from(newFileString));
@@ -442,20 +432,9 @@ async function changePartialNamesToFullNamesInDists(
       const idWithoutScope = id.changeScope(null);
       const pkgNameWithoutScope = componentIdToPackageName(idWithoutScope, component.bindingPrefix);
       const pkgNameWithScope = componentIdToPackageName(id, component.bindingPrefix);
-      const singleQuote = "'";
-      const doubleQuotes = '"';
-      [singleQuote, doubleQuotes].forEach(quoteType => {
-        // replace an exact match. (e.g. '@bit/is-string' => '@bit/david.utils/is-string')
-        newDistString = newDistString.replace(
-          new RegExp(quoteType + pkgNameWithoutScope + quoteType, 'g'),
-          quoteType + pkgNameWithScope + quoteType
-        );
-        // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
-        newDistString = newDistString.replace(
-          new RegExp(`${quoteType}${pkgNameWithoutScope}/`, 'g'),
-          `${quoteType}${pkgNameWithScope}/`
-        );
-      });
+      // replace an exact match. (e.g. '@bit/is-string' => '@bit/david.utils/is-string')
+      // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
+      newDistString = replacePackageName(newDistString, pkgNameWithoutScope, pkgNameWithScope);
     });
     if (newDistString !== distString) {
       return Source.from(Buffer.from(newDistString));

--- a/src/utils/string/replace-package-name.spec.ts
+++ b/src/utils/string/replace-package-name.spec.ts
@@ -1,0 +1,35 @@
+import { expect } from 'chai';
+import replacePackageName from './replace-package-name';
+
+describe('replacePackageName', () => {
+  it('should replace package surrounded with single quotes', () => {
+    const str = "require('@bit/old-scope/is-string');";
+    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
+    expect(result).to.equal("require('@bit/new-scope/is-string');");
+  });
+  it('should replace package surrounded with double quotes', () => {
+    const str = 'require("@bit/old-scope/is-string");';
+    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
+    expect(result).to.equal('require("@bit/new-scope/is-string");');
+  });
+  it('should replace package path consist of an internal path', () => {
+    const str = "require('@bit/old-scope/is-string/some-internal-path');";
+    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
+    expect(result).to.equal("require('@bit/new-scope/is-string/some-internal-path');");
+  });
+  it('should not replace package when it matches only part of the package-name', () => {
+    const str = "require('@bit/old-scope/is-string-util');";
+    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
+    expect(result).to.equal("require('@bit/old-scope/is-string-util');");
+  });
+  it('should replace package that its require statement has tilda (~)', () => {
+    const str = "@import '~@bit/old-scope/ui.style/my-style.scss';";
+    const result = replacePackageName(str, '@bit/old-scope/ui.style', '@bit/new-scope/ui.style');
+    expect(result).to.equal("@import '~@bit/new-scope/ui.style/my-style.scss';");
+  });
+  it('should ignore package that its require statement has other prefixes (~)', () => {
+    const str = "@import '$@bit/old-scope/ui.style';";
+    const result = replacePackageName(str, '@bit/old-scope/ui.style', '@bit/new-scope/ui.style');
+    expect(result).to.equal("@import '$@bit/old-scope/ui.style';");
+  });
+});

--- a/src/utils/string/replace-package-name.ts
+++ b/src/utils/string/replace-package-name.ts
@@ -1,0 +1,19 @@
+const singleQuote = "'";
+const doubleQuotes = '"';
+
+/**
+ * 1) replace an exact match. (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
+ * 2) the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
+ * 3) the import can start with `~` when working with scss files
+ *
+ * Read this regex `(${quoteType}~?)${oldName}(/|${quoteType})` as follows:
+ * (${quoteType}~?) => string starts with a quote, and then zero or one tilda (~). this whole part got replaced by $1
+ * ${oldName} => this is the only part in the string that really got changed, all other are preserved
+ * (/|${quoteType}) => string that is either a slash or a quote. (must be one of the two). this whole part got replace by $2
+ */
+export default function replacePackageName(str: string, oldName: string, newName: string): string {
+  [singleQuote, doubleQuotes].forEach(quoteType => {
+    str = str.replace(new RegExp(`(${quoteType}~?)${oldName}(/|${quoteType})`, 'g'), `$1${newName}$2`);
+  });
+  return str;
+}


### PR DESCRIPTION
Fixes one out of two issues found in #2182.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2189)
<!-- Reviewable:end -->
