### PR TITLE
Fix #1883 - Properly exclude files excluded by the add command

### DIFF
--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -34,6 +34,7 @@ import ComponentConfig from '../config';
 import ConfigDir from './config-dir';
 import WorkspaceConfig from '../config/workspace-config';
 import ShowDoctorError from '../../error/show-doctor-error';
+import { PathOrDSL } from '../../consumer/component-ops/add-components/add-components';
 
 export type BitMapComponents = { [componentId: string]: ComponentMap };
 
@@ -599,7 +600,7 @@ export default class BitMap {
     trackDir?: PathOsBased | null | undefined;
     originallySharedDir?: PathLinux | null | undefined;
     wrapDir?: PathLinux | null | undefined;
-    exclude?: string[] | null | undefined;
+    exclude?: PathOrDSL[] | null | undefined;
   }): ComponentMap {
     const componentIdStr = componentId.toString();
     logger.debug(`adding to bit.map ${componentIdStr}`);

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -587,7 +587,8 @@ export default class BitMap {
     configDir,
     trackDir,
     originallySharedDir,
-    wrapDir
+    wrapDir,
+    exclude
   }: {
     componentId: BitId;
     files: ComponentMapFile[];
@@ -598,6 +599,7 @@ export default class BitMap {
     trackDir?: PathOsBased | null | undefined;
     originallySharedDir?: PathLinux | null | undefined;
     wrapDir?: PathLinux | null | undefined;
+    exclude?: string[] | null | undefined;
   }): ComponentMap {
     const componentIdStr = componentId.toString();
     logger.debug(`adding to bit.map ${componentIdStr}`);
@@ -627,6 +629,9 @@ export default class BitMap {
     }
     if (wrapDir) {
       this.components[componentIdStr].wrapDir = wrapDir;
+    }
+    if (exclude) {
+      this.components[componentIdStr].exclude = exclude;
     }
     this.components[componentIdStr].removeTrackDirIfNeeded();
     if (originallySharedDir) {

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -8,7 +8,7 @@ import { PathOsBasedRelative, PathLinux, PathOsBased, PathLinuxRelative } from '
 import Consumer from '../consumer';
 import { BitId } from '../../bit-id';
 import AddComponents from '../component-ops/add-components';
-import { AddContext } from '../component-ops/add-components/add-components';
+import { AddContext, PathOrDSL } from '../component-ops/add-components/add-components';
 import { NoFiles, EmptyDirectory } from '../component-ops/add-components/exceptions';
 import ValidationError from '../../error/validation-error';
 import ComponentNotFoundInPath from '../component/exceptions/component-not-found-in-path';
@@ -36,7 +36,7 @@ export type ComponentMapData = {
   originallySharedDir?: PathLinux;
   wrapDir?: PathLinux;
   exported?: boolean;
-  exclude?: string[];
+  exclude?: PathOrDSL[];
 };
 
 export type PathChange = { from: PathLinux; to: PathLinux };
@@ -59,7 +59,7 @@ export default class ComponentMap {
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   markBitMapChangedCb: Function;
   exported: boolean | null | undefined; // relevant for authored components only, it helps finding out whether a component has a scope
-  exclude?: string[];
+  exclude?: PathOrDSL[];
   constructor({
     id,
     files,

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -36,6 +36,7 @@ export type ComponentMapData = {
   originallySharedDir?: PathLinux;
   wrapDir?: PathLinux;
   exported?: boolean;
+  exclude?: string[];
 };
 
 export type PathChange = { from: PathLinux; to: PathLinux };
@@ -58,6 +59,7 @@ export default class ComponentMap {
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   markBitMapChangedCb: Function;
   exported: boolean | null | undefined; // relevant for authored components only, it helps finding out whether a component has a scope
+  exclude?: string[];
   constructor({
     id,
     files,
@@ -67,7 +69,8 @@ export default class ComponentMap {
     configDir,
     origin,
     originallySharedDir,
-    wrapDir
+    wrapDir,
+    exclude
   }: ComponentMapData) {
     let confDir;
     if (configDir && typeof configDir === 'string') {
@@ -84,6 +87,7 @@ export default class ComponentMap {
     this.origin = origin;
     this.originallySharedDir = originallySharedDir;
     this.wrapDir = wrapDir;
+    this.exclude = exclude;
   }
 
   static fromJson(componentMapObj: ComponentMapData): ComponentMap {
@@ -101,7 +105,8 @@ export default class ComponentMap {
       origin: this.origin,
       originallySharedDir: this.originallySharedDir,
       wrapDir: this.wrapDir,
-      exported: this.exported
+      exported: this.exported,
+      exclude: this.exclude
     };
     const notNil = val => {
       return !R.isNil(val);
@@ -324,7 +329,8 @@ export default class ComponentMap {
         id: id.toString(),
         override: false, // this makes sure to not override existing files of componentMap
         trackDirFeature: true,
-        origin: this.origin
+        origin: this.origin,
+        exclude: this.exclude
       };
       const numOfFilesBefore = this.files.length;
       const addContext: AddContext = { consumer };

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -394,14 +394,17 @@ export default class AddComponents {
 
   // remove excluded files from file list
   async removeExcludedFiles(componentsWithFiles: AddedComponent[]) {
+    const excludeAndResolvedExcludedFiles = [...this.exclude, ...this.resolvedExcludedFiles];
     componentsWithFiles.forEach((componentWithFiles: AddedComponent) => {
       const mainFile = componentWithFiles.mainFile ? pathNormalizeToLinux(componentWithFiles.mainFile) : undefined;
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      if (this.resolvedExcludedFiles.includes(mainFile)) {
+      if (excludeAndResolvedExcludedFiles.includes(mainFile)) {
         componentWithFiles.files = [];
       } else {
         // if mainFile is excluded, exclude all files
-        componentWithFiles.files = componentWithFiles.files.filter(key => !this.exclude.includes(key.relativePath));
+        componentWithFiles.files = componentWithFiles.files.filter(
+          key => !excludeAndResolvedExcludedFiles.includes(key.relativePath)
+        );
       }
     });
   }

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -133,6 +133,8 @@ export default class AddComponents {
       emptyDirectory: [],
       existInScope: []
     };
+    this.resolvedExcludedFiles = [];
+    this.ignoreList = [];
     this.addedComponents = [];
   }
 
@@ -391,7 +393,6 @@ export default class AddComponents {
 
   // remove excluded files from file list
   async removeExcludedFiles(componentsWithFiles: AddedComponent[]) {
-    const files = R.flatten(componentsWithFiles.map(x => x.files.map(i => i.relativePath)));
     componentsWithFiles.forEach((componentWithFiles: AddedComponent) => {
       const mainFile = componentWithFiles.mainFile ? pathNormalizeToLinux(componentWithFiles.mainFile) : undefined;
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -676,7 +676,10 @@ export default class AddComponents {
     );
 
     // add excluded list to gitignore to remove excluded files from list
-    this.resolvedExcludedFiles = await this.getFilesAccordingToDsl(this.exclude);
+    this.resolvedExcludedFiles = await this.getFilesAccordingToDsl(
+      resolvedComponentPathsWithoutGitIgnore,
+      this.exclude
+    );
     this.ignoreList = [...this.ignoreList, ...this.resolvedExcludedFiles];
     this.gitIgnore = ignore().add(this.ignoreList); // add ignore list
 

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -337,7 +337,8 @@ export default class AddComponents {
         trackDir,
         origin: COMPONENT_ORIGINS.AUTHORED,
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        override: this.override
+        override: this.override,
+        exclude: this.exclude
       });
     };
     const componentMap = getComponentMap();

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -320,6 +320,7 @@ export default class AddComponents {
     } else {
       component.files = componentFiles;
     }
+    if (!R.isEmpty(this.exclude)) await this.removeExcludedFiles([component]);
 
     const { componentId, trackDir } = component;
     const mainFile = determineMainFile(component, foundComponentFromBitMap);
@@ -716,7 +717,6 @@ export default class AddComponents {
         if (addedResult) this.addedComponents.push(addedResult);
       }
     }
-    if (!R.isEmpty(this.exclude)) await this.removeExcludedFiles(this.addedComponents);
     Analytics.setExtraData('num_components', this.addedComponents.length);
     return { addedComponents: this.addedComponents, warnings: this.warnings };
   }

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -216,7 +216,8 @@ export default class ComponentWriter {
       origin: this.origin,
       trackDir: this.existingComponentMap && this.existingComponentMap.trackDir,
       originallySharedDir: this.component.originallySharedDir,
-      wrapDir: this.component.wrapDir
+      wrapDir: this.component.wrapDir,
+      exclude: this.component.exclude
     });
   }
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -72,6 +72,7 @@ import Capsule from '../../../components/core/capsule';
 import { stripSharedDirFromPath } from '../component-ops/manipulate-dir';
 import ComponentsPendingImport from '../component-ops/exceptions/components-pending-import';
 import ExtensionIsolateResult from '../../extensions/extension-isolate-result';
+import { PathOrDSL } from '../component-ops/add-components/add-components';
 
 export type customResolvedPath = { destinationPath: PathLinux; importSource: string };
 
@@ -166,7 +167,7 @@ export default class Component {
   originallySharedDir: PathLinux | null | undefined; // needed to reduce a potentially long path that was used by the author
   _wasOriginallySharedDirStripped: boolean | null | undefined; // whether stripOriginallySharedDir() method had been called, we don't want to strip it twice
   wrapDir: PathLinux | null | undefined; // needed when a user adds a package.json file to the component root
-  exclude: string[] | null | undefined;
+  exclude: PathOrDSL[] | null | undefined;
   loadedFromFileSystem = false; // whether a component was loaded from the filesystem or converted from the model
   componentMap: ComponentMap | null | undefined; // always populated when the loadedFromFileSystem is true
   componentFromModel: Component | null | undefined; // populated when loadedFromFileSystem is true and it exists in the model

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -166,6 +166,7 @@ export default class Component {
   originallySharedDir: PathLinux | null | undefined; // needed to reduce a potentially long path that was used by the author
   _wasOriginallySharedDirStripped: boolean | null | undefined; // whether stripOriginallySharedDir() method had been called, we don't want to strip it twice
   wrapDir: PathLinux | null | undefined; // needed when a user adds a package.json file to the component root
+  exclude: string[] | null | undefined;
   loadedFromFileSystem = false; // whether a component was loaded from the filesystem or converted from the model
   componentMap: ComponentMap | null | undefined; // always populated when the loadedFromFileSystem is true
   componentFromModel: Component | null | undefined; // populated when loadedFromFileSystem is true and it exists in the model


### PR DESCRIPTION
## Proposed Changes

This pull request really fixes two issues. The first issue being that after `resolvedExcludedFiles` is first calculated, it's values are added to the `ignoreList`. Because it relies on `getFilesAccordingToDsl` which skips files in `ignoreList` any subsequent attempts to calculate `resolvedExcludedFiles` won't return anything since all the files are now on the `ignoreList`. Not confidently knowing how this `ignoreList` is globally used I opted for moving `resolvedExcludedFiles` to be attached to the class and only calculated once.

The second fix (the one I really intended to do) is to make the `--exclude` argument of the `add` command actually work. The issue was that `resolvedExcludedFiles` tracks the `fullPath` to the file, but `removeExcludedFiles` checks against the `relativePath`. Since the `fullPath` isn't saved on the `componentWithFiles` but the `relativePath` is available in `this.exclude` I just used that. I see no harm with excluding a file that may not have been actually resolved, but please let me know if there are any cases I didn't consider.

*Possible change before being merged* I did not change `resolvedExcludedFiles` to use `this.exclude` when checking for the `mainFile` as I'm under the assumption that works as intended and didn't want to break that. Please let me know if this was an incorrect assumption.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2210)
<!-- Reviewable:end -->
