### PR TITLE
use workspace defaultScope to generate node-modules links 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- use workspace defaultScope to generate node-modules links for pre-export components
 - [#2258](https://github.com/teambit/bit/issues/2258) don't install devDependencies packages upon extensions import
 - [#2255](https://github.com/teambit/bit/issues/2255) avoid adding unneeded overrides upon import
 - [#2247](https://github.com/teambit/bit/issues/2247) improve auto-tag output

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -107,7 +107,12 @@ export default class NodeModuleLinker {
     const componentId = component.id;
     // @todo: this should probably be `const bindingPrefix = component.bindingPrefix;`
     const bindingPrefix = this.consumer ? this.consumer.config.bindingPrefix : DEFAULT_BINDINGS_PREFIX;
-    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(bindingPrefix, componentId, true);
+    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(
+      bindingPrefix,
+      componentId,
+      true,
+      this._getWorkspaceDefaultScope()
+    );
     // when a user moves the component directory, use component.writtenPath to find the correct target
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -136,6 +141,10 @@ export default class NodeModuleLinker {
     await this._populateDependenciesAndMissingLinks(component);
   }
 
+  _getWorkspaceDefaultScope(): string | undefined | null {
+    return this.consumer ? this.consumer.config.defaultScope : null;
+  }
+
   _populateAuthoredComponentsLinks(component: Component): void {
     const componentId = component.id;
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -147,7 +156,10 @@ export default class NodeModuleLinker {
       const isMain = file === component.componentMap.mainFile;
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const possiblyDist = component.dists.calculateDistFileForAuthored(path.normalize(file), this.consumer, isMain);
-      const dest = path.join(getNodeModulesPathOfComponent(component.bindingPrefix, componentId, true), file);
+      const dest = path.join(
+        getNodeModulesPathOfComponent(component.bindingPrefix, componentId, true, this._getWorkspaceDefaultScope()),
+        file
+      );
       const destRelative = getPathRelativeRegardlessCWD(path.dirname(dest), possiblyDist);
       const fileContent = getLinkToFileContent(destRelative);
       if (fileContent) {
@@ -176,7 +188,12 @@ export default class NodeModuleLinker {
    */
   _deleteOldLinksOfIdWithoutScope(component: Component) {
     if (component.id.scope) {
-      const previousDest = getNodeModulesPathOfComponent(component.bindingPrefix, component.id.changeScope(null), true);
+      const previousDest = getNodeModulesPathOfComponent(
+        component.bindingPrefix,
+        component.id.changeScope(null),
+        true,
+        this._getWorkspaceDefaultScope()
+      );
       this.dataToPersist.removePath(new RemovePath(previousDest));
     }
   }
@@ -273,7 +290,12 @@ export default class NodeModuleLinker {
     rootDir: PathOsBasedRelative,
     bindingPrefix: string
   ): Symlink {
-    const relativeDestPath = getNodeModulesPathOfComponent(bindingPrefix, bitId, true);
+    const relativeDestPath = getNodeModulesPathOfComponent(
+      bindingPrefix,
+      bitId,
+      true,
+      this._getWorkspaceDefaultScope()
+    );
     const destPathInsideParent = path.join(parentRootDir, relativeDestPath);
     return Symlink.makeInstance(rootDir, destPathInsideParent, bitId);
   }
@@ -289,7 +311,9 @@ export default class NodeModuleLinker {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const hasPackageJsonAsComponentFile = component.files.some(file => file.relative === PACKAGE_JSON);
     if (hasPackageJsonAsComponentFile) return; // don't generate package.json on top of the user package.json
-    const dest = path.join(getNodeModulesPathOfComponent(component.bindingPrefix, component.id, true));
+    const dest = path.join(
+      getNodeModulesPathOfComponent(component.bindingPrefix, component.id, true, this._getWorkspaceDefaultScope())
+    );
     const packageJson = PackageJsonFile.createFromComponent(dest, component);
     this.dataToPersist.addFile(packageJson.toVinylFile());
   }

--- a/src/utils/bit/component-node-modules-path.ts
+++ b/src/utils/bit/component-node-modules-path.ts
@@ -7,7 +7,8 @@ import BitId from '../../bit-id/bit-id';
 export default function getNodeModulesPathOfComponent(
   bindingPrefix: string | null | undefined,
   id: BitId,
-  allowNonScope = false
+  allowNonScope = false,
+  defaultScope?: string | null // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
 ): PathOsBasedRelative {
   if (!id.scope && !allowNonScope) {
     throw new GeneralError(
@@ -19,6 +20,7 @@ export default function getNodeModulesPathOfComponent(
   bindingPrefix = bindingPrefix === 'bit' ? '@bit' : bindingPrefix;
   const allSlashes = new RegExp('/', 'g');
   const name = id.name.replace(allSlashes, NODE_PATH_COMPONENT_SEPARATOR);
-  const partsToJoin = id.scope ? [id.scope, name] : [name];
+  const scope = id.scope || defaultScope;
+  const partsToJoin = scope ? [scope, name] : [name];
   return path.join('node_modules', bindingPrefix, partsToJoin.join(NODE_PATH_COMPONENT_SEPARATOR));
 }


### PR DESCRIPTION
when a component id doesn't have a scope-name. (before export for an author).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2262)
<!-- Reviewable:end -->
