### PR TITLE
fix duplicate dependencies 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2260](https://github.com/teambit/bit/issues/2260) fix duplicate dependencies
 - [#2264](https://github.com/teambit/bit/issues/2264) fix generated dependencies links on capsule
 - [#2267](https://github.com/teambit/bit/issues/2267) fix duplicate devDependencies
 - support overrides of the workspace defaultScope per components

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -1038,7 +1038,7 @@ either, use the ignore file syntax or change the require statement to have a mod
   }
 
   getExistingDependency(dependencies: Dependency[], id: BitId): Dependency | null | undefined {
-    return dependencies.find(d => d.id.isEqual(id));
+    return dependencies.find(d => d.id.isEqualWithoutVersion(id));
   }
 
   getExistingDepRelativePaths(dependency: Dependency, relativePath: RelativePath) {


### PR DESCRIPTION
Happens when a dependency has a different version in the main package.json and in the dist/package.json (relevant for typescript components).

This PR makes sure to disregard the dependencies versions and not add them twice.

Fixes #2260.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2271)
<!-- Reviewable:end -->
