### PR TITLE
fix(performance): integrate librarian with capsule-builder

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8380,9 +8380,9 @@
       }
     },
     "librarian": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/librarian/-/librarian-3.1.0.tgz",
-      "integrity": "sha512-c9BvFm1slNFbnlKRcXzgjEzb21krVQmlKgSmWCMhSDqtaoOgSQWsInx6AgaLDf4Nt3LB7dKRzJB2RuQo1fkkpA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/librarian/-/librarian-3.3.0.tgz",
+      "integrity": "sha512-DVOq0UdhaPprbguJ6oaDDVc0On6vHP1DWkvXidkiDv8DZPk06NZH70aLVggh1OQ2ZYpQierBMLBWKc1J642CTw==",
       "requires": {
         "fs-extra": "^7.0.1",
         "fs-monkey": "^0.3.3",
@@ -10796,20 +10796,27 @@
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
       "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw=="
     },
-    "p-limit": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
-      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
-      "requires": {
-        "p-try": "^1.0.0"
-      }
-    },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "requires": {
         "p-limit": "^1.1.0"
+      },
+      "dependencies": {
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
+        }
       }
     },
     "p-map": {
@@ -10888,11 +10895,6 @@
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         }
       }
-    },
-    "p-try": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-      "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
     },
     "package-json": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "jfs": "^0.2.6",
     "level-mem": "^5.0.1",
     "level-party": "^4.0.0",
-    "librarian": "^3.0.2",
+    "librarian": "^3.3.0",
     "lodash": "^4.17.15",
     "lodash.assignwith": "^4.2.0",
     "lodash.groupby": "^4.6.0",

--- a/src/environment/capsule-builder.ts
+++ b/src/environment/capsule-builder.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import hash from 'object-hash';
 import v4 from 'uuid';
 import filenamify from 'filenamify';
+import librarian from 'librarian';
 import { BitId } from '../bit-id';
 import orchestrator, { CapsuleOrchestrator } from '../capsule/orchestrator/orchestrator';
 import { CapsuleOptions, CreateOptions } from '../capsule/orchestrator/types';
@@ -18,7 +19,6 @@ import { getManipulateDirForComponentWithDependencies } from '../consumer/compon
 import Graph from '../scope/graph/graph';
 import Component from '../consumer/component';
 import { loadConsumerIfExist } from '../consumer';
-import librarian from 'librarian';
 
 export type Options = {
   alwaysNew: boolean;
@@ -96,6 +96,7 @@ export default class CapsuleBuilder {
     try {
       const workDirs = capsules.map(c => c.wrkDir);
       await librarian.runMultipleInstalls(workDirs);
+      return Promise.resolve();
     } catch (e) {
       // TODO: think if we really need to log it here or write it to logger or throw it
       console.log(e); // eslint-disable-line no-console


### PR DESCRIPTION
This branch integrates librarian with the capsule creation process.
It does not yet integrate librarian with the build process, since as I understood from @amitgilad3, that flow is still not connected to harmony.
I removed including the `bit-bin` in the capsules, as @ranm8 said he will make it a dependency of the extensions themselves.

To test this, I used: `bd capsule-create index -d -b /tmp/capsule-test`

This builds the whole `remeda` demo project (~60 components with inter-dependencies) in <5s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2273)
<!-- Reviewable:end -->
