### PR TITLE
Throw proper error when there are circular dependencies between harmony extensions

### DIFF
--- a/src/harmony/exceptions/extension-potential-circular.ts
+++ b/src/harmony/exceptions/extension-potential-circular.ts
@@ -18,9 +18,8 @@ export default class ExtensionPotentialCircular extends HarmonyError {
   }
 
   toString() {
-    return `failed to load extensions' dependencies.
-The dependencies for ${chalk.bold(this.extension.name)} are not loaded.
-This might be a result of wrong import or a circular dependencies
-The following dependencies did loaded correctly: ${chalk.bold(this.validDeps.join(', '))}`;
+    return `Failed to load the dependencies for extension ${chalk.bold(this.extension.name)}. 
+This may result from a wrong import or from circular dependencies in imports. 
+The following dependencies succeeded loading: ${chalk.bold(this.validDeps.join(', '))}`;
   }
 }

--- a/src/harmony/exceptions/extension-potential-circular.ts
+++ b/src/harmony/exceptions/extension-potential-circular.ts
@@ -1,0 +1,26 @@
+import chalk from 'chalk';
+import { Extension } from '../extension';
+import HarmonyError from './harmony-error';
+
+export default class ExtensionPotentialCircular extends HarmonyError {
+  constructor(
+    /**
+     * failed extension
+     */
+    private extension: Extension,
+
+    /**
+     * valid extensions dependencies names
+     */
+    private validDeps: string[]
+  ) {
+    super();
+  }
+
+  toString() {
+    return `failed to load extensions' dependencies.
+The dependencies for ${chalk.bold(this.extension.name)} are not loaded.
+This might be a result of wrong import or a circular dependencies
+The following dependencies did loaded correctly: ${chalk.bold(this.validDeps.join(', '))}`;
+  }
+}

--- a/src/harmony/exceptions/harmony-error.ts
+++ b/src/harmony/exceptions/harmony-error.ts
@@ -1,0 +1,1 @@
+export default class HarmonyError extends Error {}

--- a/src/harmony/exceptions/index.ts
+++ b/src/harmony/exceptions/index.ts
@@ -1,2 +1,3 @@
 export { default as ExtensionLoadError } from './extension-load-error';
+export { default as ExtensionPotentialCircular } from './extension-potential-circular';
 export { HarmonyAlreadyRunning } from './harmony-already-running';

--- a/src/harmony/extension-graph/from-extension.ts
+++ b/src/harmony/extension-graph/from-extension.ts
@@ -2,6 +2,7 @@ import { Vertex, Edge } from 'cleargraph';
 import { AnyExtension } from '../types';
 import { ExtensionManifest } from '../extension-manifest';
 import { extensionFactory } from '../factory';
+import ExtensionPotentialCircular from '../exceptions/extension-potential-circular';
 
 /**
  * build vertices and edges from the given extension
@@ -15,8 +16,11 @@ export function fromExtension(extension: ExtensionManifest) {
     if (vertices[id]) return;
 
     const instance = extensionFactory(root);
+    const validDeps = instance.dependencies.filter(dep => dep).map(dep => dep.name);
+    if (instance.dependencies.length > validDeps.length) {
+      throw new ExtensionPotentialCircular(instance, validDeps);
+    }
     vertices[id] = new Vertex<AnyExtension>(id, instance);
-
     const newEdges = instance.dependencies.map(dep => {
       return Edge.fromObject({
         srcId: id,


### PR DESCRIPTION
## Proposed Changes

- Throw proper error when there are circular dependencies between harmony extensions
- relate to #2280

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2282)
<!-- Reviewable:end -->
