### PR TITLE
change capsule-workspace-map object to a class CapsulePaths

### DIFF
--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -27,6 +27,7 @@ import EnvExtension from '../../legacy-extensions/env-extension';
 import ComponentConfig from '../config/component-config';
 import PackageJsonFile from '../component/package-json-file';
 import ShowDoctorError from '../../error/show-doctor-error';
+import CapsulePaths from '../../environment/capsule-paths';
 
 export type ComponentWriterProps = {
   component: Component;
@@ -43,7 +44,7 @@ export type ComponentWriterProps = {
   deleteBitDirContent?: boolean;
   existingComponentMap?: ComponentMap;
   excludeRegistryPrefix?: boolean;
-  capsuleWrkspaceMap?: { [key: string]: string };
+  capsulePaths?: CapsulePaths;
 };
 
 export default class ComponentWriter {
@@ -61,7 +62,7 @@ export default class ComponentWriter {
   deleteBitDirContent: boolean | null | undefined;
   existingComponentMap: ComponentMap | null | undefined;
   excludeRegistryPrefix: boolean;
-  capsuleWrkspaceMap?: { [key: string]: string };
+  capsulePaths?: CapsulePaths;
   constructor({
     component,
     writeToPath,
@@ -76,7 +77,7 @@ export default class ComponentWriter {
     writeBitDependencies = false,
     deleteBitDirContent,
     existingComponentMap,
-    capsuleWrkspaceMap,
+    capsulePaths,
     excludeRegistryPrefix = false
   }: ComponentWriterProps) {
     this.component = component;
@@ -93,7 +94,7 @@ export default class ComponentWriter {
     this.deleteBitDirContent = deleteBitDirContent;
     this.existingComponentMap = existingComponentMap;
     this.excludeRegistryPrefix = excludeRegistryPrefix;
-    this.capsuleWrkspaceMap = capsuleWrkspaceMap;
+    this.capsulePaths = capsulePaths;
   }
 
   static getInstance(componentWriterProps: ComponentWriterProps): ComponentWriter {
@@ -182,7 +183,7 @@ export default class ComponentWriter {
         this.override,
         this.writeBitDependencies,
         this.excludeRegistryPrefix,
-        this.capsuleWrkspaceMap
+        this.capsulePaths
       );
 
       const componentConfig = ComponentConfig.fromComponent(this.component);

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -21,6 +21,7 @@ import DataToPersist from '../component/sources/data-to-persist';
 import BitMap from '../bit-map';
 import { composeComponentPath, composeDependencyPathForIsolated } from '../../utils/bit/compose-component-path';
 import { BitId } from '../../bit-id';
+import CapsulePaths from '../../environment/capsule-paths';
 
 export interface ManyComponentsWriterParams {
   consumer?: Consumer;
@@ -42,7 +43,7 @@ export interface ManyComponentsWriterParams {
   verbose?: boolean;
   installProdPackagesOnly?: boolean;
   excludeRegistryPrefix?: boolean;
-  capsuleWrkspaceMap?: { [key: string]: string };
+  capsulePaths?: CapsulePaths;
 }
 
 /**
@@ -81,7 +82,7 @@ export default class ManyComponentsWriter {
   isolated: boolean; // a preparation for the capsule feature
   bitMap: BitMap;
   basePath?: string;
-  capsuleWrkspaceMap?: { [key: string]: string };
+  capsulePaths?: CapsulePaths;
 
   constructor(params: ManyComponentsWriterParams) {
     this.consumer = params.consumer;
@@ -105,7 +106,7 @@ export default class ManyComponentsWriter {
     this.dependenciesIdsCache = {};
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.bitMap = this.consumer ? this.consumer.bitMap : new BitMap();
-    this.capsuleWrkspaceMap = params.capsuleWrkspaceMap;
+    this.capsulePaths = params.capsulePaths;
     if (this.consumer && !this.isolated) this.basePath = this.consumer.getPath();
   }
   _setBooleanDefault(field: boolean | null | undefined, defaultValue: boolean): boolean {
@@ -222,7 +223,7 @@ export default class ManyComponentsWriter {
     };
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return {
-      capsuleWrkspaceMap: this.capsuleWrkspaceMap,
+      capsulePaths: this.capsulePaths,
       ...this._getDefaultWriteParams(),
       component: componentWithDeps.component,
       writeToPath: componentRootDir,
@@ -303,7 +304,7 @@ export default class ManyComponentsWriter {
           origin: COMPONENT_ORIGINS.NESTED,
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           existingComponentMap: componentMap,
-          capsuleWrkspaceMap: this.capsuleWrkspaceMap
+          capsulePaths: this.capsulePaths
         });
         return componentWriter.populateComponentsFilesToWrite();
       });
@@ -368,7 +369,7 @@ to move all component files to a different directory, run bit remove and then bi
       createNpmLinkFiles: this.createNpmLinkFiles,
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       writePackageJson: this.writePackageJson,
-      capsuleMap: this.capsuleWrkspaceMap
+      capsuleMap: this.capsulePaths
     });
   }
   _getComponentRootDir(bitId: BitId): PathOsBasedRelative {

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -20,6 +20,7 @@ import searchFilesIgnoreExt from '../../utils/fs/search-files-ignore-ext';
 import ComponentVersion from '../../scope/component-version';
 import BitMap from '../bit-map/bit-map';
 import ShowDoctorError from '../../error/show-doctor-error';
+import CapsulePaths from '../../environment/capsule-paths';
 
 /**
  * Add components as dependencies to root package.json
@@ -108,17 +109,18 @@ export function preparePackageJsonToWrite(
   override? = true,
   writeBitDependencies? = false,
   excludeRegistryPrefix?: boolean,
-  capsuleWrkspaceMap?: { [key: string]: string }
+  capsulePaths?: CapsulePaths
 ): { packageJson: PackageJsonFile; distPackageJson: PackageJsonFile | null | undefined } {
   logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}. override ${override.toString()}`);
   const getBitDependencies = (dependencies: Dependencies) => {
     if (!writeBitDependencies) return {};
     return dependencies.get().reduce((acc, dep) => {
       let packageDependency;
-      if (capsuleWrkspaceMap && capsuleWrkspaceMap[dep.id.toString()]) {
+      const devCapsulePath = capsulePaths && capsulePaths.getPathIgnoreScopeAndVersion(dep.id);
+      if (capsulePaths && devCapsulePath) {
         const relative = path.relative(
-          capsuleWrkspaceMap[component.id.toString()],
-          capsuleWrkspaceMap[dep.id.toString()]
+          capsulePaths.getPathIgnoreScopeAndVersion(component.id) as string,
+          devCapsulePath
         );
         packageDependency = `file:${relative}`;
       } else {

--- a/src/environment/capsule-paths.ts
+++ b/src/environment/capsule-paths.ts
@@ -1,0 +1,17 @@
+import { PathOsBasedAbsolute } from '../utils/path';
+import { BitId } from '../bit-id';
+
+export default class CapsulePaths extends Array<{ id: BitId; path: PathOsBasedAbsolute }> {
+  getPath(id: BitId): PathOsBasedAbsolute | null {
+    const found = this.find(item => item.id.isEqual(id));
+    return found ? found.path : null;
+  }
+  getPathIgnoreVersion(id: BitId): PathOsBasedAbsolute | null {
+    const found = this.find(item => item.id.isEqualWithoutVersion(id));
+    return found ? found.path : null;
+  }
+  getPathIgnoreScopeAndVersion(id: BitId): PathOsBasedAbsolute | null {
+    const found = this.find(item => item.id.isEqualWithoutScopeAndVersion(id));
+    return found ? found.path : null;
+  }
+}


### PR DESCRIPTION
 in order to retrieve a capsule-path by BitId rather than by a string

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2296)
<!-- Reviewable:end -->
