### PR TITLE
Improve bit export performance by pushing new tags only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2300](https://github.com/teambit/bit/issues/2300) improve `bit export` performance by pushing new tags only
+
 ## [[14.7.3] - 2020-02-02](https://github.com/teambit/bit/releases/tag/v14.7.3)
 
 ### New

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -829,7 +829,7 @@ describe('bit export command', function() {
             helper.scopeHelper.reInitRemoteScope(forkScopePath);
             helper.fs.createFile('utils', 'is-string.js', ''); // remove the is-type dependency
             helper.command.tagAllComponents();
-            helper.command.exportAllComponents();
+            helper.command.export('--all-versions');
 
             helper.command.export(`${forkScope} utils/is-string --include-dependencies`);
             const forkScopeList = helper.command.listScopeParsed(forkScope);
@@ -854,7 +854,7 @@ describe('bit export command', function() {
             helper.fs.createFile('utils', 'is-string.js', ''); // remove the is-type dependency
             helper.fs.createFile('utils', 'is-type.js', ''); // add another version for is-type
             helper.command.tagAllComponents();
-            helper.command.exportAllComponents();
+            helper.command.export('--all-versions');
 
             helper.scopeHelper.reInitLocalScope();
             helper.scopeHelper.addRemoteScope();

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -600,6 +600,7 @@ describe('bit export command', function() {
     describe('some components were exported to one scope and other to another scope', () => {
       let localScopeBefore;
       let remoteScopeBefore;
+      let anotherRemoteScopeBefore;
       let anotherRemote;
       let anotherRemotePath;
       before(() => {
@@ -618,6 +619,7 @@ describe('bit export command', function() {
         helper.command.tagScope('2.0.0');
         localScopeBefore = helper.scopeHelper.cloneLocalScope();
         remoteScopeBefore = helper.scopeHelper.cloneRemoteScope();
+        anotherRemoteScopeBefore = helper.scopeHelper.cloneScope(anotherRemotePath);
       });
       describe('export with no ids, no remote and no flags', () => {
         let output;
@@ -644,7 +646,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           output = helper.command.exportToCurrentScope('foo1 foo2');
         });
         it('should export successfully all ids, each to its own remote', () => {
@@ -667,7 +669,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           helper.fs.outputFile('foo1.js', "require('./foo2');");
           helper.command.tagScope('3.0.0');
           helper.scopeHelper.addRemoteScope(anotherRemotePath, helper.scopes.remotePath);
@@ -686,7 +688,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           helper.fs.outputFile('foo1.js', "require('./foo2');");
           helper.fs.outputFile('foo2.js', "require('./foo1');");
           helper.command.tagScope('3.0.0');
@@ -704,7 +706,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           helper.fs.outputFile('foo1.js', "require('./foo2');");
 
           helper.command.tagScope('3.0.0');
@@ -727,7 +729,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           helper.fs.outputFile('foo3.js', '');
           helper.command.addComponent('foo3.js');
           helper.command.tagAllComponents();
@@ -748,7 +750,7 @@ describe('bit export command', function() {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScopeBefore);
           helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-          helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+          helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
           helper.fs.outputFile('foo3.js');
           helper.command.addComponent('foo3.js');
           helper.command.tagAllComponents();
@@ -769,7 +771,7 @@ describe('bit export command', function() {
           before(() => {
             helper.scopeHelper.getClonedLocalScope(beforeExportScope);
             helper.scopeHelper.getClonedRemoteScope(remoteScopeBefore);
-            helper.scopeHelper.reInitRemoteScope(anotherRemotePath);
+            helper.scopeHelper.getClonedScope(anotherRemoteScopeBefore, anotherRemotePath);
             helper.bitJson.addKeyVal(undefined, 'defaultScope', helper.scopes.remote);
             output = helper.command.export();
           });

--- a/src/api/consumer/lib/export.ts
+++ b/src/api/consumer/lib/export.ts
@@ -32,6 +32,7 @@ export default (async function exportAction(params: {
   eject: boolean;
   includeDependencies: boolean;
   setCurrentScope: boolean;
+  allVersions: boolean;
   includeNonStaged: boolean;
   codemod: boolean;
   force: boolean;
@@ -52,6 +53,7 @@ async function exportComponents({
   setCurrentScope,
   includeNonStaged,
   codemod,
+  allVersions,
   force
 }: {
   ids: string[];
@@ -60,6 +62,7 @@ async function exportComponents({
   setCurrentScope: boolean;
   includeNonStaged: boolean;
   codemod: boolean;
+  allVersions: boolean;
   force: boolean;
 }): Promise<{ updatedIds: BitId[]; nonExistOnBitMap: BitId[]; missingScope: BitId[]; exported: BitId[] }> {
   const consumer: Consumer = await loadConsumer();
@@ -79,6 +82,7 @@ async function exportComponents({
     includeDependencies,
     changeLocallyAlthoughRemoteIsDifferent: setCurrentScope,
     codemod,
+    allVersions,
     idsWithFutureScope
   });
   const { updatedIds, nonExistOnBitMap } = _updateIdsOnBitMap(consumer.bitMap, updatedLocally);

--- a/src/cli/commands/public-cmds/export-cmd.ts
+++ b/src/cli/commands/public-cmds/export-cmd.ts
@@ -36,6 +36,7 @@ export default class Export extends Command {
       'rewire',
       'EXPERIMENTAL. when exporting to a different scope, replace import/require statements in the source code to the new scope'
     ],
+    ['', 'all-versions', 'export not only staged versions but all of them'],
     ['f', 'force', 'force changing a component remote without asking for a confirmation']
   ];
   loader = true;
@@ -49,6 +50,7 @@ export default class Export extends Command {
       includeDependencies = false,
       setCurrentScope = false,
       all = false,
+      allVersions = false,
       force = false,
       rewire = false
     }: any
@@ -74,6 +76,7 @@ export default class Export extends Command {
       includeDependencies,
       setCurrentScope,
       includeNonStaged: all,
+      allVersions,
       codemod: rewire,
       force
     }).then(results => ({

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -181,21 +181,25 @@ export default class ScopeHelper {
   }
 
   cloneRemoteScope() {
+    return this.cloneScope(this.scopes.remotePath);
+  }
+
+  cloneScope(scopePath: string) {
     const clonedScope = generateRandomStr();
     const clonedScopePath = path.join(this.scopes.e2eDir, clonedScope);
-    if (this.debugMode) console.log(`cloning a scope from ${this.scopes.remotePath} to ${clonedScopePath}`);
-    fs.copySync(this.scopes.remotePath, clonedScopePath);
+    if (this.debugMode) console.log(`cloning a scope from ${scopePath} to ${clonedScopePath}`);
+    fs.copySync(scopePath, clonedScopePath);
     this.clonedScopes.push(clonedScopePath);
     return clonedScopePath;
   }
 
-  getClonedRemoteScope(clonedScopePath: string, deleteCurrentScope = true) {
-    if (deleteCurrentScope) {
-      fs.removeSync(this.scopes.remotePath);
-    } else {
-      this.getNewBareScope();
-    }
-    if (this.debugMode) console.log(`cloning a scope from ${clonedScopePath} to ${this.scopes.remotePath}`);
-    fs.copySync(clonedScopePath, this.scopes.remotePath);
+  getClonedScope(clonedScopePath: string, scopePath: string) {
+    fs.removeSync(scopePath);
+    if (this.debugMode) console.log(`cloning a scope from ${clonedScopePath} to ${scopePath}`);
+    fs.copySync(clonedScopePath, scopePath);
+  }
+
+  getClonedRemoteScope(clonedScopePath: string) {
+    return this.getClonedScope(clonedScopePath, this.scopes.remotePath);
   }
 }

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -59,6 +59,7 @@ export async function exportMany({
   includeDependencies = false, // kind of fork. by default dependencies only cached, with this, their scope-name is changed
   changeLocallyAlthoughRemoteIsDifferent = false, // by default only if remote stays the same the component is changed from staged to exported
   codemod = false,
+  allVersions,
   idsWithFutureScope
 }: {
   scope: Scope;
@@ -68,6 +69,7 @@ export async function exportMany({
   includeDependencies: boolean;
   changeLocallyAlthoughRemoteIsDifferent: boolean;
   codemod: boolean;
+  allVersions: boolean;
   idsWithFutureScope: BitIds;
 }): Promise<{ exported: BitIds; updatedLocally: BitIds }> {
   logger.debugAndAddBreadCrumb('scope.exportMany', 'ids: {ids}', { ids: ids.toString() });
@@ -131,7 +133,7 @@ export async function exportMany({
 
       const componentBuffer = await componentAndObject.component.compress();
       const getObjectsBuffer = () => {
-        if (didConvertScope || didChangeDists) {
+        if (allVersions || didConvertScope || didChangeDists) {
           return Promise.all(componentAndObject.objects.map(obj => obj.compress()));
         }
         return componentAndObject.component.collectVersionsObjects(scope.objects, localVersions);

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -134,8 +134,11 @@ export async function exportMany({
       const componentBuffer = await componentAndObject.component.compress();
       const getObjectsBuffer = () => {
         if (allVersions || includeDependencies || didConvertScope || didChangeDists) {
+          // only when really needed (e.g. fork or version changes), collect all versions objects
           return Promise.all(componentAndObject.objects.map(obj => obj.compress()));
         }
+        // when possible prefer collecting only new/local versions. the server has already
+        // the rest, so no point of sending them.
         return componentAndObject.component.collectVersionsObjects(scope.objects, localVersions);
       };
       const objectsBuffer = await getObjectsBuffer();

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -133,7 +133,7 @@ export async function exportMany({
 
       const componentBuffer = await componentAndObject.component.compress();
       const getObjectsBuffer = () => {
-        if (allVersions || didConvertScope || didChangeDists) {
+        if (allVersions || includeDependencies || didConvertScope || didChangeDists) {
           return Promise.all(componentAndObject.objects.map(obj => obj.compress()));
         }
         return componentAndObject.component.collectVersionsObjects(scope.objects, localVersions);

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -292,9 +292,7 @@ export default class Component extends BitObject {
     return versionRef.loadSync(repository, throws);
   }
 
-  async collectRaw(repo: Repository, versions?: string[]): Promise<Buffer[]> {
-    if (!versions) return super.collectRaw(repo);
-
+  async collectVersionsObjects(repo: Repository, versions: string[]): Promise<Buffer[]> {
     const collectRefs = async (): Promise<Ref[]> => {
       const refsCollection: Ref[] = [];
 
@@ -315,8 +313,8 @@ export default class Component extends BitObject {
     return Promise.all(refs.map(ref => ref.loadRaw(repo)));
   }
 
-  collectObjects(repo: Repository, versions?: string[]): Promise<ComponentObjects> {
-    return Promise.all([this.asRaw(repo), this.collectRaw(repo, versions)])
+  collectObjects(repo: Repository): Promise<ComponentObjects> {
+    return Promise.all([this.asRaw(repo), this.collectRaw(repo)])
       .then(([rawComponent, objects]) => new ComponentObjects(rawComponent, objects))
       .catch(err => {
         if (err.code === 'ENOENT') {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -292,8 +292,31 @@ export default class Component extends BitObject {
     return versionRef.loadSync(repository, throws);
   }
 
-  collectObjects(repo: Repository): Promise<ComponentObjects> {
-    return Promise.all([this.asRaw(repo), this.collectRaw(repo)])
+  async collectRaw(repo: Repository, versions?: string[]): Promise<Buffer[]> {
+    if (!versions) return super.collectRaw(repo);
+
+    const collectRefs = async (): Promise<Ref[]> => {
+      const refsCollection: Ref[] = [];
+
+      async function addRefs(object: BitObject) {
+        const refs = object.refs();
+        const objs = await Promise.all(refs.map(ref => ref.load(repo, true)));
+        refsCollection.push(...refs);
+        await Promise.all(objs.map(obj => addRefs(obj)));
+      }
+
+      const versionsRefs = versions.map(version => this.versions[version]);
+      refsCollection.push(...versionsRefs);
+      const versionsObjects = await Promise.all(versions.map(version => this.versions[version].load(repo)));
+      await Promise.all(versionsObjects.map(versionObject => addRefs(versionObject)));
+      return refsCollection;
+    };
+    const refs = await collectRefs();
+    return Promise.all(refs.map(ref => ref.loadRaw(repo)));
+  }
+
+  collectObjects(repo: Repository, versions?: string[]): Promise<ComponentObjects> {
+    return Promise.all([this.asRaw(repo), this.collectRaw(repo, versions)])
       .then(([rawComponent, objects]) => new ComponentObjects(rawComponent, objects))
       .catch(err => {
         if (err.code === 'ENOENT') {


### PR DESCRIPTION
Fixes part of #2300 .

Currently, `bit export` pushes all versions (tags) of a component, regardless of whether it has changed or not.
With this fix, it sends only the staged versions.
In case of a fork, or codemod, where all versions are changed, it sends them all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2304)
<!-- Reviewable:end -->
