### PR TITLE
fix bit export to not export non-staged dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2211](https://github.com/teambit/bit/issues/2211) fix bit export to not export non-staged dependencies
+- [#2308](https://github.com/teambit/bit/issues/2308) fix "Cannot read property 'scope' of undefined" error on bit export
+
 ## [[14.7.4] - 2020-02-06](https://github.com/teambit/bit/releases/tag/v14.7.4)
 
 - [#2300](https://github.com/teambit/bit/issues/2300) improve `bit export` performance by pushing new tags only


### PR DESCRIPTION
Happens when exporting to multiple scopes (by running `bit export` with no id).
The bug was related to the graph built to make sure the export is done in topological order. This graph contains all dependencies of the pending-export components. 
After the sort, Bit was trying to export these dependencies as well although they were not export-pending.

Fixes #2211 and #2308 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2309)
<!-- Reviewable:end -->
