### PR TITLE
prevent logger from holding the terminal once a command is completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- support configuring the logger level by running `bit config set log_level <level>`.
+- (internal) introduce a new level of logging "silly"
+- [#2268](https://github.com/teambit/bit/issues/2268) prevent logger from holding the terminal once a command is completed
 - [#2211](https://github.com/teambit/bit/issues/2211) fix bit export to not export non-staged dependencies
 - [#2308](https://github.com/teambit/bit/issues/2308) fix "Cannot read property 'scope' of undefined" error on bit export
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,8 @@ In some cases, you might get very helpful info by prefixing Bit command with `BI
 
 To print the log messages on the console, prefix your command with `BIT_LOG=<debug-level>`, e.g. `BIT_LOG=error`.
 
+The log level written to the log file is by default "debug". To change it, run `bit config set log_level <level>`, e.g. `bit config set log_level silly`.
+
 ### Lint
 
 Run eslint and tsc (for type checking)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-bin",
-  "version": "14.7.2",
+  "version": "14.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2001,6 +2001,12 @@
         "lodash.get": "^4.4.2",
         "objnest": "^3.0.6"
       }
+    },
+    "@types/bluebird": {
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.29.tgz",
+      "integrity": "sha512-kmVtnxTuUuhCET669irqQmPAez4KFnFVKvpleVRyfC3g+SHD1hIkFZcWLim9BVcwUBLO59o8VZE4yGCmTif8Yw==",
+      "dev": true
     },
     "@types/chai": {
       "version": "4.2.5",

--- a/package.json
+++ b/package.json
@@ -180,6 +180,7 @@
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-typescript": "^7.7.7",
     "@babel/register": "^7.4.4",
+    "@types/bluebird": "^3.5.29",
     "@types/chai": "^4.2.5",
     "@types/chai-arrays": "^1.0.3",
     "@types/chai-fs": "^2.0.2",

--- a/src/api/consumer/lib/migrate.ts
+++ b/src/api/consumer/lib/migrate.ts
@@ -15,12 +15,12 @@ export default (async function migrate(
   scopePath: string,
   verbose: boolean
 ): Promise<MigrationResult | null | undefined> {
-  logger.debug('migrate.migrate, starting migration process');
+  logger.silly('migrate.migrate, starting migration process');
   if (verbose) console.log('starting migration process'); // eslint-disable-line no-console
   let scope;
   // If a scope path provided we will run the migrate only for the scope
   if (scopePath) {
-    logger.debug(`migrate.migrate, running migration process for scope in path ${scopePath}`);
+    logger.silly(`migrate.migrate, running migration process for scope in path ${scopePath}`);
     if (verbose) console.log(`running migration process for scope in path ${scopePath}`); // eslint-disable-line no-console
     scope = await loadScope(scopePath);
     return scope.migrate(verbose);
@@ -34,7 +34,7 @@ export default (async function migrate(
   await consumer.migrate(verbose);
   // const consumerMigrationResult = await consumer.migrate(verbose);
   // if (!consumerMigrationResult)
-  logger.debug('migrate.migrate, running migration process for scope in consumer');
+  logger.silly('migrate.migrate, running migration process for scope in consumer');
   if (verbose) console.log('running migration process for scope in consumer'); // eslint-disable-line no-console
   return scope.migrate(verbose);
 });

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-import * as Promise from 'bluebird';
+import Bluebird from 'bluebird';
 import loudRejection from 'loud-rejection';
 import buildRegistrar from './cli/command-registrar-builder';
 import loadExtensions from './extensions/extensions-loader';
@@ -8,8 +8,8 @@ process.env.MEMFS_DONT_WARN = 'true'; // suppress fs experimental warnings from 
 
 // removing this, default to longStackTraces also when env is `development`, which impacts the
 // performance dramatically. (see http://bluebirdjs.com/docs/api/promise.longstacktraces.html)
-Promise.config({
-  longStackTraces: process.env.BLUEBIRD_DEBUG
+Bluebird.config({
+  longStackTraces: Boolean(process.env.BLUEBIRD_DEBUG)
 });
 
 loudRejection();

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -215,6 +215,8 @@ export const CFG_GIT_EXECUTABLE_PATH = 'git_path';
 
 export const CFG_LOG_JSON_FORMAT = 'log_json_format';
 
+export const CFG_LOG_LEVEL = 'log_level';
+
 export const CFG_NO_WARNINGS = 'no_warnings';
 
 export const CFG_INTERACTIVE = 'interactive';
@@ -407,3 +409,5 @@ export const DEPENDENCIES_FIELDS = ['dependencies', 'devDependencies', 'peerDepe
 const MISSING_DEPS_SPACE_COUNT = 10;
 export const MISSING_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT);
 export const MISSING_NESTED_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT + 2);
+
+export const CONCURRENT_IO_LIMIT = 100; // limit number of files to read/write/delete/symlink at the same time

--- a/src/consumer/component/package-json-vinyl.ts
+++ b/src/consumer/component/package-json-vinyl.ts
@@ -30,7 +30,6 @@ export default class PackageJsonVinyl extends AbstractVinyl {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     logger.debug(`package-json-vinyl.write, path ${this.path}`);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     await fs.outputFile(this.path, this.contents);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;

--- a/src/consumer/component/sources/data-to-persist.ts
+++ b/src/consumer/component/sources/data-to-persist.ts
@@ -1,4 +1,5 @@
 import * as path from 'path';
+import Bluebird from 'bluebird';
 import fs from 'fs-extra';
 import Capsule from '../../../../components/core/capsule';
 import AbstractVinyl from './abstract-vinyl';
@@ -6,6 +7,7 @@ import Symlink from '../../../links/symlink';
 import logger from '../../../logger/logger';
 import RemovePath from './remove-path';
 import removeFilesAndEmptyDirsRecursively from '../../../utils/fs/remove-files-and-empty-dirs-recursively';
+import { CONCURRENT_IO_LIMIT as concurrency } from '../../../constants';
 
 export default class DataToPersist {
   files: AbstractVinyl[];
@@ -161,10 +163,10 @@ export default class DataToPersist {
     return dataToPersist;
   }
   async _persistFilesToFS() {
-    return Promise.all(this.files.map(file => file.write()));
+    return Bluebird.map(this.files, file => file.write(), { concurrency });
   }
   async _persistSymlinksToFS() {
-    return Promise.all(this.symlinks.map(symlink => symlink.write()));
+    return Bluebird.map(this.symlinks, symlink => symlink.write(), { concurrency });
   }
   async _deletePathsFromFS() {
     const pathWithRemoveItsDirIfEmptyEnabled = this.remove.filter(p => p.removeItsDirIfEmpty).map(p => p.path);
@@ -172,7 +174,7 @@ export default class DataToPersist {
     if (pathWithRemoveItsDirIfEmptyEnabled.length) {
       await removeFilesAndEmptyDirsRecursively(pathWithRemoveItsDirIfEmptyEnabled);
     }
-    return Promise.all(restPaths.map(removePath => removePath.persistToFS()));
+    return Bluebird.map(restPaths, removePath => removePath.persistToFS(), { concurrency });
   }
   _validateAbsolute() {
     // it's important to make sure that all paths are absolute before writing them to the

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -239,7 +239,7 @@ export default class Consumer {
     const bitmapVersion = this.bitMap.version || '0.10.9';
 
     if (semver.gte(bitmapVersion, BIT_VERSION)) {
-      logger.debug('bit.map version is up to date');
+      logger.silly('bit.map version is up to date');
       return {
         run: false
       };

--- a/src/extensions/env-extension.ts
+++ b/src/extensions/env-extension.ts
@@ -98,8 +98,7 @@ export default class EnvExtension extends BaseExtension {
     opts: { verbose: boolean; dontPrintEnvMsg?: boolean },
     context?: Record<string, any>
   ): Promise<ComponentWithDependencies[] | null | undefined> {
-    Analytics.addBreadCrumb('env-extension', 'install env extension');
-    logger.debug('env-extension - install env extension');
+    logger.debugAndAddBreadCrumb('env-extension', 'install env extension');
 
     // Skip the installation in case of using specific file
     // options.file usually used for develop your extension
@@ -143,7 +142,7 @@ export default class EnvExtension extends BaseExtension {
    */
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   toBitJsonObject(ejectedEnvDirectory: string): { [key: string]: EnvExtensionObject } {
-    logger.debug('env-extension, toBitJsonObject');
+    logger.silly('env-extension, toBitJsonObject');
     const files = {};
     this.files.forEach(file => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -227,7 +226,7 @@ export default class EnvExtension extends BaseExtension {
   }
 
   async reload(scopePath: string, context?: Record<string, any>): Promise<void> {
-    logger.debug('env-extension, reload');
+    logger.silly('env-extension, reload');
     if (context) {
       this.context = context;
     }
@@ -331,7 +330,7 @@ export default class EnvExtension extends BaseExtension {
   static async loadFromSerializedModelObject(
     modelObject: EnvExtensionSerializedModel & { envType: EnvType }
   ): Promise<EnvExtensionProps> {
-    logger.debug('env-extension, loadFromModelObject');
+    logger.silly('env-extension, loadFromModelObject');
     const baseExtensionProps: BaseExtensionProps = super.loadFromModelObject(modelObject);
     let files = [];
     if (modelObject.files && !R.isEmpty(modelObject.files)) {
@@ -373,7 +372,7 @@ export default class EnvExtension extends BaseExtension {
     envType: EnvType;
     context?: Record<string, any>;
   }): Promise<EnvExtension | null | undefined> {
-    logger.debug(`env-extension (${envType}) loadFromCorrectSource`);
+    logger.silly(`env-extension (${envType}) loadFromCorrectSource`);
     const isAuthor = componentOrigin === COMPONENT_ORIGINS.AUTHORED;
     const componentHasWrittenConfig = componentConfig && componentConfig.componentHasWrittenConfig;
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -390,12 +389,12 @@ export default class EnvExtension extends BaseExtension {
       // $FlowFixMe we made sure before that componentConfig is defined
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const configPath = path.dirname(componentConfig.path);
-      logger.debug(`env-extension loading ${envType} from component config`);
+      logger.silly(`env-extension loading ${envType} from component config`);
       return loadFromConfig({ envConfig, envType, consumerPath, scopePath, configPath, context });
     }
     if (!componentHasWrittenConfig && !isAuthor && componentFromModel && componentFromModel[envType]) {
       // config was not written into component dir, load the config from the model
-      logger.debug(`env-extension, loading ${envType} from the model`);
+      logger.silly(`env-extension, loading ${envType} from the model`);
       return componentFromModel[envType];
     }
     if (overridesFromConsumer && overridesFromConsumer.env && overridesFromConsumer.env[envType]) {
@@ -403,12 +402,12 @@ export default class EnvExtension extends BaseExtension {
         logger.debug(`env-extension, ${envType} was manually removed from the consumer config overrides`);
         return null;
       }
-      logger.debug(`env-extension, loading ${envType} from the consumer config overrides`);
+      logger.silly(`env-extension, loading ${envType} from the consumer config overrides`);
       const envConfig = { [envType]: AbstractConfig.transformEnvToObject(overridesFromConsumer.env[envType]) };
       return loadFromConfig({ envConfig, envType, consumerPath, scopePath, configPath: consumerPath, context });
     }
     if (isAuthor && workspaceConfig[envType]) {
-      logger.debug(`env-extension, loading ${envType} from the consumer config`);
+      logger.silly(`env-extension, loading ${envType} from the consumer config`);
       const envConfig = { [envType]: workspaceConfig[envType] };
       return loadFromConfig({ envConfig, envType, consumerPath, scopePath, configPath: consumerPath, context });
     }

--- a/src/extensions/env-factory.ts
+++ b/src/extensions/env-factory.ts
@@ -9,7 +9,7 @@ import { BaseExtensionModel } from './base-extension';
 import Repository from '../scope/objects/repository';
 
 export default (async function makeEnv(envType: EnvType, props: EnvLoadArgsProps): Promise<EnvExtension> {
-  logger.debug(`env-factory, create ${envType}`);
+  logger.silly(`env-factory, create ${envType}`);
   props.envType = envType;
   props.throws = true;
   const envExtensionProps: EnvExtensionProps = await EnvExtension.load(props);
@@ -26,7 +26,7 @@ export async function makeEnvFromModel(
   modelObject: string | BaseExtensionModel,
   repository: Repository
 ): Promise<EnvExtension | null | undefined> {
-  logger.debug(`env-factory, create ${envType} from model`);
+  logger.silly(`env-factory, create ${envType} from model`);
   if (!modelObject) return undefined;
   const actualObject =
     typeof modelObject === 'string'

--- a/src/jsdoc/jsdoc/jsdoc-parser.ts
+++ b/src/jsdoc/jsdoc/jsdoc-parser.ts
@@ -25,7 +25,7 @@ export default async function parse(data: string, filePath?: PathOsBased): Promi
     docs.forEach(doc => extractDataRegex(doc, doclets, filePath));
   } catch (e) {
     // never mind, ignore the doc of this source
-    logger.debug(`failed parsing docs using on path ${filePath} with error`, e);
+    logger.silly(`failed parsing docs using on path ${filePath} with error`, e);
   }
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return doclets.filter(doclet => doclet.access === 'public');

--- a/src/jsdoc/react/react-parser.ts
+++ b/src/jsdoc/react/react-parser.ts
@@ -110,7 +110,7 @@ export default async function parse(data: string, filePath?: PathOsBased): Promi
       return formatted;
     }
   } catch (err) {
-    logger.debug(`failed parsing docs using docgen on path ${filePath} with error`, err);
+    logger.silly(`failed parsing docs using docgen on path ${filePath} with error`, err);
   }
   return undefined;
 }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -5,7 +5,7 @@ import format from 'string-format';
 // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import winston, { Logger } from 'winston';
 import * as path from 'path';
-import { GLOBAL_LOGS, DEBUG_LOG, CFG_LOG_JSON_FORMAT, CFG_NO_WARNINGS } from '../constants';
+import { GLOBAL_LOGS, DEBUG_LOG, CFG_LOG_JSON_FORMAT, CFG_NO_WARNINGS, CFG_LOG_LEVEL } from '../constants';
 import { Analytics } from '../analytics/analytics';
 import { getSync } from '../api/consumer/lib/global-config';
 
@@ -15,10 +15,12 @@ const extensionsLoggers = new Map();
 
 const jsonFormat = yn(getSync(CFG_LOG_JSON_FORMAT), { default: false });
 
+const logLevel = getSync(CFG_LOG_LEVEL) || 'debug';
+
 export const baseFileTransportOpts = {
   filename: DEBUG_LOG,
   format: jsonFormat ? winston.format.combine(winston.format.timestamp(), winston.format.json()) : getFormat(),
-  level: 'debug',
+  level: logLevel,
   maxsize: 10 * 1024 * 1024, // 10MB
   maxFiles: 10,
   // If true, log files will be rolled based on maxsize and maxfiles, but in ascending order.
@@ -60,6 +62,15 @@ class BitLogger {
 
   constructor(logger: Logger) {
     this.logger = logger;
+    logger.on('error', err => {
+      // eslint-disable-next-line no-console
+      console.log('got an error from the logger', err);
+    });
+  }
+
+  silly(...args: any[]) {
+    // @ts-ignore
+    this.logger.silly(...args);
   }
 
   debug(...args: any[]) {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -455,7 +455,7 @@ export default class Component extends BitObject {
   }
 
   validateBeforePersisting(componentStr: string): void {
-    logger.debug(`validating component object: ${this.hash().hash} ${this.id()}`);
+    logger.silly(`validating component object: ${this.hash().hash} ${this.id()}`);
     const component = Component.parse(componentStr);
     component.validate();
   }

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -366,7 +366,7 @@ export default class Version extends BitObject {
   }
 
   validateBeforePersisting(versionStr: string): void {
-    logger.debug(`validating version object, hash: ${this.hash().hash}`);
+    logger.silly(`validating version object, hash: ${this.hash().hash}`);
     const version = Version.parse(versionStr);
     version.validate();
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -103,7 +103,7 @@ export default class Repository {
       })
       .catch(err => {
         if (err.code === 'ENOENT') {
-          logger.debug(`Failed finding a ref file ${this.objectPath(ref)}.`);
+          logger.silly(`Failed finding a ref file ${this.objectPath(ref)}.`);
         } else {
           logger.error(`Failed reading a ref file ${this.objectPath(ref)}. Error: ${err.message}`);
         }
@@ -329,7 +329,7 @@ export default class Repository {
   _deleteOne(ref: Ref): Promise<boolean> {
     this.removeFromCache(ref);
     const pathToDelete = this.objectPath(ref);
-    logger.debug(`repository._deleteOne: deleting ${pathToDelete}`);
+    logger.silly(`repository._deleteOne: deleting ${pathToDelete}`);
     return removeFile(pathToDelete, true);
   }
 
@@ -344,7 +344,7 @@ export default class Repository {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (this.scopeJson.groupName) options.gid = await resolveGroupId(this.scopeJson.groupName);
     const objectPath = this.objectPath(object.hash());
-    logger.debug(`repository._writeOne: ${objectPath}`);
+    logger.silly(`repository._writeOne: ${objectPath}`);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return writeFile(objectPath, contents, options);
   }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -170,14 +170,14 @@ export default class Scope {
    * @memberof Consumer
    */
   async migrate(verbose: boolean): Promise<MigrationResult> {
-    logger.debug('scope.migrate, running migration process for scope');
+    logger.silly('scope.migrate, running migration process for scope');
     if (verbose) console.log('running migration process for scope'); // eslint-disable-line
     // We start to use this process after version 0.10.9, so we assume the scope is in the last production version
     const scopeVersion = this.scopeJson.get('version') || '0.10.9';
     if (semver.gte(scopeVersion, BIT_VERSION)) {
       const upToDateMsg = 'scope version is up to date';
       if (verbose) console.log(upToDateMsg); // eslint-disable-line
-      logger.debug(`scope.migrate, ${upToDateMsg}`);
+      logger.silly(`scope.migrate, ${upToDateMsg}`);
       return {
         run: false
       };


### PR DESCRIPTION
Fixes #2268.

* prevent logger from holding the terminal once a command is completed by adding an error handler.
* introduce a new log level `silly`.
* change some `logger.debug` to `logger.silly`.
* support configuring the logger level by running `bit config set log_level <level>`.
* limit the number of concurrent files written to the fs in the `DataToPersist` class to 100.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2310)
<!-- Reviewable:end -->
