### PR TITLE
More fixes of misuse BitId as strings

### DIFF
--- a/src/api/consumer/lib/capsule-isolate.ts
+++ b/src/api/consumer/lib/capsule-isolate.ts
@@ -1,13 +1,13 @@
 import { loadConsumerIfExist } from '../../../consumer';
 import CapsuleBuilder, { Options } from '../../../environment/capsule-builder';
 import { CapsuleOptions } from '../../../extensions/capsule/orchestrator/types';
-import { ComponentCapsule } from '../../../extensions/capsule-ext';
+import CapsuleList from '../../../environment/capsule-list';
 
 export default (async function capsuleIsolate(
   bitIds: string[],
   capsuleOptions: CapsuleOptions,
   options: Options
-): Promise<{ [bitId: string]: ComponentCapsule }> {
+): Promise<CapsuleList> {
   const consumer = await loadConsumerIfExist();
   if (!consumer) throw new Error('no consumer found');
   const capsuleBuilder = new CapsuleBuilder(consumer.getPath());

--- a/src/bit-id/bit-id-and-value-array.ts
+++ b/src/bit-id/bit-id-and-value-array.ts
@@ -1,0 +1,16 @@
+import { BitId } from '../bit-id';
+
+export default class BitIdAndValueArray<T> extends Array<{ id: BitId; value: T }> {
+  getValue(id: BitId): T | null {
+    const found = this.find(item => item.id.isEqual(id));
+    return found ? found.value : null;
+  }
+  getValueIgnoreVersion(id: BitId): T | null {
+    const found = this.find(item => item.id.isEqualWithoutVersion(id));
+    return found ? found.value : null;
+  }
+  getValueIgnoreScopeAndVersion(id: BitId): T | null {
+    const found = this.find(item => item.id.isEqualWithoutScopeAndVersion(id));
+    return found ? found.value : null;
+  }
+}

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -116,10 +116,10 @@ export function preparePackageJsonToWrite(
     if (!writeBitDependencies) return {};
     return dependencies.get().reduce((acc, dep) => {
       let packageDependency;
-      const devCapsulePath = capsulePaths && capsulePaths.getPathIgnoreScopeAndVersion(dep.id);
+      const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(dep.id);
       if (capsulePaths && devCapsulePath) {
         const relative = path.relative(
-          capsulePaths.getPathIgnoreScopeAndVersion(component.id) as string,
+          capsulePaths.getValueIgnoreScopeAndVersion(component.id) as string,
           devCapsulePath
         );
         packageDependency = `file:${relative}`;

--- a/src/environment/capsule-list.ts
+++ b/src/environment/capsule-list.ts
@@ -1,0 +1,4 @@
+import BitIdAndValueArray from '../bit-id/bit-id-and-value-array';
+import { ComponentCapsule } from '../extensions/capsule-ext';
+
+export default class CapsuleList extends BitIdAndValueArray<ComponentCapsule> {}

--- a/src/environment/capsule-paths.ts
+++ b/src/environment/capsule-paths.ts
@@ -1,17 +1,4 @@
 import { PathOsBasedAbsolute } from '../utils/path';
-import { BitId } from '../bit-id';
+import BitIdAndValueArray from '../bit-id/bit-id-and-value-array';
 
-export default class CapsulePaths extends Array<{ id: BitId; path: PathOsBasedAbsolute }> {
-  getPath(id: BitId): PathOsBasedAbsolute | null {
-    const found = this.find(item => item.id.isEqual(id));
-    return found ? found.path : null;
-  }
-  getPathIgnoreVersion(id: BitId): PathOsBasedAbsolute | null {
-    const found = this.find(item => item.id.isEqualWithoutVersion(id));
-    return found ? found.path : null;
-  }
-  getPathIgnoreScopeAndVersion(id: BitId): PathOsBasedAbsolute | null {
-    const found = this.find(item => item.id.isEqualWithoutScopeAndVersion(id));
-    return found ? found.path : null;
-  }
-}
+export default class CapsulePaths extends BitIdAndValueArray<PathOsBasedAbsolute> {}

--- a/src/extensions/bit/bit.ts
+++ b/src/extensions/bit/bit.ts
@@ -73,10 +73,10 @@ export default class Bit {
       const allRegisteredExtensionIds = this.harmony.extensionsIds;
       const nonRegisteredExtensions = difference(extensionsIds, allRegisteredExtensionIds);
       const extensionsComponents = await this.workspace.getMany(nonRegisteredExtensions);
-      const capsulesMap = await this.capsule.create(extensionsComponents);
+      const capsuleList = await this.capsule.create(extensionsComponents);
 
-      return Object.values(capsulesMap).map(capsule => {
-        const extPath = capsule.wrkDir;
+      return capsuleList.map(({ value }) => {
+        const extPath = value.wrkDir;
         // eslint-disable-next-line global-require, import/no-dynamic-require
         const mod = require(extPath);
         return mod;

--- a/src/extensions/capsule/capsule.ts
+++ b/src/extensions/capsule/capsule.ts
@@ -4,6 +4,7 @@ import { Component } from '../component';
 import { CapsuleOrchestrator } from './orchestrator/orchestrator';
 import { ComponentCapsule } from '../capsule-ext';
 import CapsuleBuilder from '../../environment/capsule-builder';
+import CapsuleList from '../../environment/capsule-list';
 
 export default class CapsuleFactory {
   constructor(
@@ -19,7 +20,7 @@ export default class CapsuleFactory {
    * create a new capsule from a component.
    */
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  create(components: Component[], config?: CreateConfig) {
+  create(components: Component[], config?: CreateConfig): Promise<CapsuleList> {
     return this.builder.isolateComponents(components.map(component => component.id.toString()));
   }
 

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -3,7 +3,7 @@ import { Scope } from '../scope';
 import { Component, ComponentFactory } from '../component';
 import ComponentsList from '../../consumer/component/components-list';
 import { ComponentHost } from '../../shared-types';
-import { BitIds } from '../../bit-id';
+import { BitIds, BitId } from '../../bit-id';
 import ConsumerComponent from '../../consumer/component';
 import { Capsule } from '../capsule';
 import { ResolvedComponent } from './resolved-component';
@@ -87,9 +87,10 @@ export default class Workspace implements ComponentHost {
   }
 
   /**
+   * @todo: remove the string option, use only BitId
    * fully load components, inclduing dependency resuoltion and prepare them for runtime.
    */
-  async load(ids: string[]) {
+  async load(ids: Array<BitId | string>) {
     const components = await this.getMany(ids);
     const capsules = await this.capsule.create(components);
 
@@ -97,17 +98,21 @@ export default class Workspace implements ComponentHost {
   }
 
   /**
+   * @todo: remove the string option, use only BitId
    * get a component from workspace
    * @param id component ID
    */
-  async get(id: string): Promise<Component | undefined> {
-    const componentId = this.consumer.getParsedId(id);
+  async get(id: string | BitId): Promise<Component | undefined> {
+    const componentId = typeof id === 'string' ? this.consumer.getParsedId(id) : id;
     const legacyComponent = await this.consumer.loadComponent(componentId);
     return this.componentFactory.fromLegacyComponent(legacyComponent);
   }
 
-  async getMany(ids: string[]) {
-    const componentIds = ids.map(id => this.consumer.getParsedId(id));
+  /**
+   * @todo: remove the string option, use only BitId
+   */
+  async getMany(ids: Array<BitId | string>) {
+    const componentIds = ids.map(id => (typeof id === 'string' ? this.consumer.getParsedId(id) : id));
     const legacyComponents = await this.consumer.loadComponents(BitIds.fromArray(componentIds));
     // @ts-ignore
     return this.transformLegacyComponents(legacyComponents.components);


### PR DESCRIPTION
- fix Workspace to get BitIds as a parameter (still, support bitId as a string)
- add a new class "capsule-list" for an array of BitId and Capsule to eliminate the use of BitId as strings.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2318)
<!-- Reviewable:end -->
