### PR TITLE
enable "--all" flag when "--all-versions" is used and vice versa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2341](https://github.com/teambit/bit/issues/2341) fix `bit export --all` to successfully export when deleted from remote
 - support configuring the logger level by running `bit config set log_level <level>`.
 - [#2268](https://github.com/teambit/bit/issues/2268) prevent logger from holding the terminal once a command is completed
 

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1208,4 +1208,39 @@ describe('bit export command', function() {
       expect(list).to.have.lengthOf(1);
     });
   });
+  describe('export after re-creating the remote', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateWorkspaceWithUtilsIsType();
+      helper.command.tagAllComponents();
+      helper.command.exportAllComponents();
+      helper.scopeHelper.reInitRemoteScope();
+    });
+    describe('export without any flag', () => {
+      it('should show a message that nothing to export', () => {
+        const output = helper.command.exportAllComponents();
+        expect(output).to.have.string('nothing to export');
+      });
+    });
+    describe('export with --all flag', () => {
+      before(() => {
+        helper.scopeHelper.reInitRemoteScope();
+        helper.command.export(`${helper.scopes.remote} ${helper.scopes.remote}/* --all`);
+      });
+      it('should export them successfully', () => {
+        const list = helper.command.listRemoteScopeParsed();
+        expect(list).to.have.lengthOf(1);
+      });
+    });
+    describe('export with --all flag', () => {
+      before(() => {
+        helper.scopeHelper.reInitRemoteScope();
+        helper.command.export(`${helper.scopes.remote} ${helper.scopes.remote}/* --all-versions`);
+      });
+      it('should export them successfully', () => {
+        const list = helper.command.listRemoteScopeParsed();
+        expect(list).to.have.lengthOf(1);
+      });
+    });
+  });
 });

--- a/src/cli/commands/public-cmds/export-cmd.ts
+++ b/src/cli/commands/public-cmds/export-cmd.ts
@@ -75,8 +75,8 @@ export default class Export extends Command {
       eject,
       includeDependencies,
       setCurrentScope,
-      includeNonStaged: all,
-      allVersions,
+      includeNonStaged: all || allVersions,
+      allVersions: allVersions || all,
       codemod: rewire,
       force
     }).then(results => ({


### PR DESCRIPTION
To enable re-exporting a component after deleting it.

Fixes part of #2341 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2345)
<!-- Reviewable:end -->
