### PR TITLE
chore(packages): upgrade librarian to 3.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9798,9 +9798,9 @@
       }
     },
     "librarian": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/librarian/-/librarian-3.6.1.tgz",
-      "integrity": "sha512-AY54Y9/bvQl6vH72q4UMZ+uNRmJxjZ4ROhY+EF36l/ELsgTRzvigJ79QdkeShT/ABwdvMu1lmBlxy1oFB7wz1A==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/librarian/-/librarian-3.6.2.tgz",
+      "integrity": "sha512-iCqhEpXLcHuiJz9H/RoS3Dldd3c7bdTPUNLcC00ShMvNJDkKaRLHkwWBsiVT/ctsucyeaBqD/7k/vM2RvKVm1A==",
       "requires": {
         "fs-extra": "^7.0.1",
         "fs-monkey": "^0.3.3",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "jfs": "^0.3.0",
     "level-mem": "^5.0.1",
     "level-party": "^4.0.0",
-    "librarian": "3.6.1",
+    "librarian": "3.6.2",
     "lodash": "^4.17.15",
     "lodash.assignwith": "^4.2.0",
     "lodash.groupby": "^4.6.0",


### PR DESCRIPTION
This is to fix an issue where we would get errors for very large files in a capsule's node_modules.

The fix in librarian has to do with a race condition when extracting tarballs to memory synchronously.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2389)
<!-- Reviewable:end -->
