### PR TITLE
fix(extensions): installation and build bugs

### DIFF
--- a/e2e/flows/dependencies-as-packages.e2e.2.ts
+++ b/e2e/flows/dependencies-as-packages.e2e.2.ts
@@ -110,7 +110,8 @@ chai.use(require('chai-fs'));
         });
         it('bit status should not show any error', () => {
           const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          const outputWithoutLinebreaks = output.replace(/\n/, '');
+          expect(outputWithoutLinebreaks).to.have.string(statusWorkspaceIsCleanMsg);
         });
         it('should be able to require its direct dependency and print results from all dependencies', () => {
           const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
@@ -132,7 +133,8 @@ chai.use(require('chai-fs'));
           });
           it('bit status should not show any error', () => {
             const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string('pending updates');
+            const outputWithoutLinebreaks = output.replace(/\n/, '');
+            expect(outputWithoutLinebreaks).to.have.string('pending updates');
           });
           it('should be able to require its direct dependency and print results from all dependencies', () => {
             const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
@@ -156,7 +158,8 @@ chai.use(require('chai-fs'));
           });
           it('bit status should not show any error', () => {
             const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            const outputWithoutLinebreaks = output.replace(/\n/, '');
+            expect(outputWithoutLinebreaks).to.have.string(statusWorkspaceIsCleanMsg);
           });
           describe('bit checkout all components to an older version', () => {
             let checkoutOutput;
@@ -218,7 +221,8 @@ chai.use(require('chai-fs'));
               });
               it('bit status should not show the component as modified', () => {
                 const status = helper.command.status();
-                expect(status).to.not.have.string('modified');
+                const statusWithoutLinebreaks = status.replace(/\n/, '');
+                expect(statusWithoutLinebreaks).to.not.have.string('modified');
               });
             });
           });
@@ -366,7 +370,8 @@ chai.use(require('chai-fs'));
         });
         it('bit status should not show any error', () => {
           const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          const outputWithoutLinebreaks = output.replace(/\n/, '');
+          expect(outputWithoutLinebreaks).to.have.string(statusWorkspaceIsCleanMsg);
         });
         it('should be able to require its direct dependency and print results from all dependencies', () => {
           const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
@@ -380,8 +385,9 @@ chai.use(require('chai-fs'));
           });
           it('bit status should show missing components and not untracked components', () => {
             const status = helper.command.status();
-            expect(status).to.have.string(componentIssuesLabels.missingComponents);
-            expect(status).not.to.have.string(componentIssuesLabels.untrackedDependencies);
+            const statusWithoutLinebreaks = status.replace(/\n/g, '');
+            expect(statusWithoutLinebreaks).to.have.string(componentIssuesLabels.missingComponents);
+            expect(statusWithoutLinebreaks).not.to.have.string(componentIssuesLabels.untrackedDependencies);
           });
         });
         describe('import with dist outside the component directory', () => {
@@ -393,7 +399,8 @@ chai.use(require('chai-fs'));
           });
           it('bit status should not show any error', () => {
             const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            const outputWithoutLinebreaks = output.replace(/\n/, '');
+            expect(outputWithoutLinebreaks).to.have.string(statusWorkspaceIsCleanMsg);
           });
           describe('running bit link after deleting the symlink from dist directory', () => {
             let symlinkPath;

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -93,7 +93,7 @@ export default class Workspace implements ComponentHost {
    */
   async load(ids: Array<BitId | string>) {
     const components = await this.getMany(ids);
-    const capsules = await this.capsule.create(components, { workspace: this.path, packageManager: 'npm' });
+    const capsules = await this.capsule.create(components, { workspace: this.path });
     const capsulesMap = capsules.reduce((accum, curr) => {
       accum[curr.id.toString()] = curr.value;
       return accum;


### PR DESCRIPTION
This includes a few fixes:
1. when installing with npm, use the `--no-package-lock` option. This is because there are platform bugs with package locks and optional dependencies (eg. fsevents on linux/windows).
2. use execa to delete/link bit-bin inside capsules instead of capsule-fs. This is much safer and does what we want (as explained in the comment).
3. Use the default package manager in the project for installing non-extensions components rather than hard-coded npm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2395)
<!-- Reviewable:end -->
