### PR TITLE
prevent exporting components when import/require doesn't have scope-name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- prevent exporting components when import/require uses a module path with no scope-name
 - fix components dependencies detection to resolve from package.json if not exist on the fs
 
 ## [[14.7.6] - 2020-02-23](https://github.com/teambit/bit/releases/tag/v14.7.6)

--- a/e2e/flows/no-scope.e2e.2.ts
+++ b/e2e/flows/no-scope.e2e.2.ts
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
+import * as fixtures from '../../src/fixtures/fixtures';
 
 chai.use(require('chai-fs'));
 
@@ -38,17 +39,41 @@ describe('import/require using module paths when no scope is set', function() {
         expect(status.modifiedComponent).have.lengthOf(0);
         expect(status.invalidComponents).have.lengthOf(0);
       });
-      // this should work once codemod is implemented
-      describe.skip('exporting the components', () => {
-        before(() => {
-          helper.command.exportAllComponents();
+      describe('exporting the components', () => {
+        describe('without --rewire flag', () => {
+          it('should throw an error preventing the user to export no-scope components', () => {
+            const output = helper.general.runWithTryCatch(`bit export ${helper.scopes.remote}`);
+            expect(output).to.have.string('please use "--rewire" flag to fix the import/require statements');
+          });
         });
-        it('should be able to export them all successfully', () => {
-          const status = helper.command.statusJson();
-          expect(status.stagedComponents).have.lengthOf(0);
-          expect(status.newComponents).have.lengthOf(0);
-          expect(status.modifiedComponent).have.lengthOf(0);
-          expect(status.invalidComponents).have.lengthOf(0);
+        describe('with --rewire flag', () => {
+          before(() => {
+            helper.command.export(`${helper.scopes.remote} --rewire`);
+          });
+          it('should be able to export them all successfully', () => {
+            const status = helper.command.statusJson();
+            expect(status.stagedComponents).have.lengthOf(0);
+            expect(status.newComponents).have.lengthOf(0);
+            expect(status.modifiedComponent).have.lengthOf(0);
+            expect(status.invalidComponents).have.lengthOf(0);
+          });
+          it('should change the source code to include the scope-name in the require statement', () => {
+            const barFoo = helper.fs.readFile('bar/foo.js');
+            expect(barFoo).to.have.string(`require('@bit/${helper.scopes.remote}.utils.is-string')`);
+            expect(barFoo).to.not.have.string("require('@bit/utils.is-string')");
+          });
+          describe('importing the components', () => {
+            before(() => {
+              helper.scopeHelper.reInitLocalScope();
+              helper.scopeHelper.addRemoteScope();
+              helper.command.importComponent('bar/foo');
+            });
+            it('the project should be running while the components are able to require each other', () => {
+              helper.fs.outputFile('app.js', fixtures.appPrintBarFoo);
+              const result = helper.command.runCmd('node app.js');
+              expect(result.trim()).to.equal('got is-type and got is-string and got foo');
+            });
+          });
         });
       });
     });

--- a/src/cli/commands/public-cmds/export-cmd.ts
+++ b/src/cli/commands/public-cmds/export-cmd.ts
@@ -34,7 +34,7 @@ export default class Export extends Command {
     [
       'r',
       'rewire',
-      'EXPERIMENTAL. when exporting to a different scope, replace import/require statements in the source code to the new scope'
+      'EXPERIMENTAL. when exporting to a different or new scope, replace import/require statements in the source code to match the new scope'
     ],
     ['', 'all-versions', 'export not only staged versions but all of them'],
     ['f', 'force', 'force changing a component remote without asking for a confirmation']
@@ -62,11 +62,6 @@ export default class Export extends Command {
     if (includeDependencies && !remote) {
       throw new GeneralError(
         'to use --includeDependencies, please specify a remote (the default remote gets already the dependencies)'
-      );
-    }
-    if (rewire && !includeDependencies) {
-      throw new GeneralError(
-        'to use --rewire, please enter --include-dependencies as well (there is no point of changing the require/import of dependencies without changing themselves)'
       );
     }
     return exportAction({

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -118,11 +118,6 @@ export async function exportMany({
         bitIds,
         codemod
       );
-      // const didChangeDists = await changePartialNamesToFullNamesInDists(
-      //   scope,
-      //   componentAndObject.component,
-      //   componentAndObject.objects
-      // );
       const remoteObj = { url: remote.host, name: remote.name, date: Date.now().toString() };
       componentAndObject.component.addScopeListItem(remoteObj);
 
@@ -319,10 +314,22 @@ async function mergeObjects(scope: Scope, manyObjects: ComponentTree[]): Promise
 }
 
 /**
+ * Component and dependencies id changes:
  * When exporting components with dependencies to a bare-scope, some of the dependencies may be created locally and as
  * a result their scope-name is null. Once the bare-scope gets the components, it needs to convert these scope names
  * to the bare-scope name.
  * Since the changes it does affect the Version objects, the version REF of a component, needs to be changed as well.
+ *
+ * Dist code changes:
+ * see https://github.com/teambit/bit/issues/1770 for complete info
+ * some compilers require the links to be part of the bundle, change the component name in these
+ * files from the id without scope to the id with the scope
+ * e.g. `@bit/utils.is-string` becomes `@bit/scope-name.utils.is-string`.
+ * these files changes need to be done regardless the "--rewire" flag.
+ *
+ * Source code changes (codemod):
+ * when "--rewire" flag is used, import/require statement should be changed from the old scope-name
+ * to the new scope-name. Or from no-scope to the new scope.
  */
 async function convertToCorrectScope(
   scope: Scope,
@@ -402,7 +409,6 @@ async function convertToCorrectScope(
   }
   async function _replaceSrcOfVersionIfNeeded(version: Version): Promise<boolean> {
     let hasVersionChanged = false;
-    // const files = [...version.files, ...(version.dists || [])];
     const processFile = async (file, isDist: boolean) => {
       const newFileObject = await _createNewFileIfNeeded(version, file, isDist);
       if (newFileObject && (codemod || isDist)) {
@@ -437,10 +443,11 @@ async function convertToCorrectScope(
       const idWithNewScope = id.changeScope(remoteScope);
       const pkgNameWithNewScope = componentIdToPackageName(idWithNewScope, componentsObjects.component.bindingPrefix);
       const pkgNameWithOldScope = componentIdToPackageName(id, componentsObjects.component.bindingPrefix);
-      // replace an exact match. (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
-      // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
+      // replace old scope to a new scope (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
+      // or no-scope to a new scope. (e.g. '@bit/is-string' => '@bit/new-scope.is-string')
       newFileString = replacePackageName(newFileString, pkgNameWithOldScope, pkgNameWithNewScope);
       if (!id.scope && !codemod && newFileString !== fileString && !isDist) {
+        // if this is a dist file, no need for the --rewire flag, it should replace them regardless
         throw new GeneralError(`please use "--rewire" flag to fix the import/require statements between "${componentId.toString()}" and "${id.toString()}"
 the current import/require module has no scope-name, which result in an invalid module path upon import`);
       }
@@ -451,69 +458,3 @@ the current import/require module has no scope-name, which result in an invalid 
     return null;
   }
 }
-
-/**
- * see https://github.com/teambit/bit/issues/1770 for complete info
- * some compilers require the links to be part of the bundle, change the component name in these
- * files from the id without scope to the id with the scope
- * e.g. `@bit/utils.is-string` becomes `@bit/scope-name.utils.is-string`
- */
-// async function changePartialNamesToFullNamesInDists(
-//   scope: Scope,
-//   component: ModelComponent,
-//   objects: BitObject[]
-// ): Promise<boolean> {
-//   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-//   const versions: Version[] = objects.filter(object => object instanceof Version);
-//   const haveVersionsChanged = await Promise.all(versions.map(version => _replaceDistsOfVersionIfNeeded(version)));
-
-//   return haveVersionsChanged.some(x => x);
-
-//   async function _replaceDistsOfVersionIfNeeded(version: Version): Promise<boolean> {
-//     const dists = version.dists;
-//     if (!dists) return false;
-//     const hasDistsChanged = await Promise.all(
-//       dists.map(async dist => {
-//         const newDistObject = await _createNewDistIfNeeded(version, dist);
-//         if (newDistObject) {
-//           dist.file = newDistObject.hash();
-//           objects.push(newDistObject);
-//           return true;
-//         }
-//         return false;
-//       })
-//     );
-//     // return true if one of the dists has changed
-//     return hasDistsChanged.some(x => x);
-//   }
-
-//   async function _createNewDistIfNeeded(
-//     version: Version,
-//     dist: Record<string, any>
-//   ): Promise<Source | null | undefined> {
-//     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-//     const currentHash = dist.file;
-//     // if a dist file has changed as a result of codemod, it's not on the fs yet, so we fallback
-//     // to load from the objects it was pushed before. it'd be better to have more efficient mechanism.
-//     // currently, we require calculating the hash for each one of the source every time.
-//     const distObject: Source =
-//       (await currentHash.load(scope.objects)) ||
-//       objects.filter(obj => obj instanceof Source).find(obj => obj.hash().toString() === currentHash.toString());
-//     const distString = distObject.contents.toString();
-//     const dependenciesIds = version.getAllDependencies().map(d => d.id);
-//     const allIds = [...dependenciesIds, component.toBitId()];
-//     let newDistString = distString;
-//     allIds.forEach(id => {
-//       const idWithoutScope = id.changeScope(null);
-//       const pkgNameWithoutScope = componentIdToPackageName(idWithoutScope, component.bindingPrefix);
-//       const pkgNameWithScope = componentIdToPackageName(id, component.bindingPrefix);
-//       // replace an exact match. (e.g. '@bit/is-string' => '@bit/david.utils/is-string')
-//       // the require/import statement might be to an internal path (e.g. '@bit/david.utils/is-string/internal-file')
-//       newDistString = replacePackageName(newDistString, pkgNameWithoutScope, pkgNameWithScope);
-//     });
-//     if (newDistString !== distString) {
-//       return Source.from(Buffer.from(newDistString));
-//     }
-//     return null;
-//   }
-// }


### PR DESCRIPTION
e.g. having the following statement in the code `require('@bit/is-string')` can be only valid for the author, but won't work once the component is imported.
This PR makes sure to throw an error on export suggesting to use the `--rewire` flag to automatically change all import/require statements to include the scope-name.
As a result, the previous `require('@bit/is-string')` becomes `require('@bit/your-scope.is-string')`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2417)
<!-- Reviewable:end -->
