### PR TITLE
disallow adding individual files by bit-add unless --allow-files flag is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- disallow adding individual files by `bit add` unless `--allow-files` flag is used
 - introduce `bit link --rewire` to change relative paths in the source code to module paths
 - prevent tagging components that require each other by relative paths (bypassable by `--allow-relative-paths`)
 - prevent exporting components when import/require uses a module path with no scope-name

--- a/e2e/commands/add.e2e.1.ts
+++ b/e2e/commands/add.e2e.1.ts
@@ -18,6 +18,7 @@ import { InvalidName } from '../../src/bit-id/exceptions';
 import { statusInvalidComponentsMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { MissingMainFile } from '../../src/consumer/bit-map/exceptions';
 import AddTestsWithoutId from '../../src/cli/commands/exceptions/add-tests-without-id';
+import { AddingIndividualFiles } from '../../src/consumer/component-ops/add-components/exceptions/addding-individual-files';
 
 chai.use(require('chai-fs'));
 
@@ -214,7 +215,7 @@ describe('bit add command', function() {
     it('should be able to mark a file as test after adding it as non-test', () => {
       helper.fs.createFile('bar', 'foo.js');
       helper.fs.createFile('bar', 'foo.spec.js');
-      helper.command.addComponent('bar', { m: 'bar/foo.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'bar/foo.js', i: 'bar/foo' });
       helper.command.addComponent(' -t bar/foo.spec.js --id bar/foo');
       const bitMap = helper.bitMap.read();
       const files = bitMap['bar/foo'].files;
@@ -347,8 +348,8 @@ describe('bit add command', function() {
     it('should change a test file to regular file by re-adding the component using --override flag', () => {
       helper.fs.createFile('bar', 'foo.js');
       helper.fs.createFile('bar', 'foo.spec.js');
-      helper.command.addComponent('bar', { t: 'bar/foo.spec.js', m: 'bar/foo.js' });
-      helper.command.addComponent('bar', { o: true, m: 'bar/foo.js' });
+      helper.command.addComponentDir('bar', { t: 'bar/foo.spec.js', m: 'bar/foo.js' });
+      helper.command.addComponentDir('bar', { o: true, m: 'bar/foo.js' });
       const bitMap = helper.bitMap.read();
       const specFile = bitMap.bar.files.find(f => f.relativePath === 'bar/foo.spec.js');
       expect(specFile.test).to.be.false;
@@ -359,7 +360,7 @@ describe('bit add command', function() {
       helper.fs.createFile('bar', file1);
       helper.fs.createFile('bar', file2);
 
-      const addCmd = () => helper.command.addComponent('bar', { n: 'test' });
+      const addCmd = () => helper.command.addComponentDir('bar', { n: 'test' });
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const error = new MissingMainFile('test/bar');
       helper.general.expectToThrow(addCmd, error);
@@ -396,7 +397,7 @@ describe('bit add command', function() {
       const mainFileOs = path.normalize('{PARENT}/{PARENT}.js');
       helper.fs.createFile('bar', 'bar.js');
       helper.fs.createFile('bar', 'foo1.js');
-      helper.command.addComponent('bar', { m: mainFileOs, n: 'test' });
+      helper.command.addComponentDir('bar', { m: mainFileOs, n: 'test' });
       const bitMap = helper.bitMap.read();
       const mainFile = bitMap['test/bar'].mainFile;
       expect(bitMap).to.have.property('test/bar');
@@ -445,7 +446,7 @@ describe('bit add command', function() {
       helper.fs.createFile('bar', 'foo3.js');
       helper.fs.createFile('test', 'foo.spec.js');
       helper.fs.createFile('test', 'foo2.spec.js');
-      helper.command.addComponent('bar', {
+      helper.command.addComponentDir('bar', {
         i: 'bar/foo',
         m: path.normalize('bar/foo.js'),
         t: path.normalize('test/{FILE_NAME}.spec.js')
@@ -457,18 +458,6 @@ describe('bit add command', function() {
       expect(files).to.deep.include({ relativePath: 'test/foo.spec.js', test: true, name: 'foo.spec.js' });
       expect(bitMap).to.have.property('bar/foo');
     });
-    it('Should return error if used the "-i" flag without specifying an ID', () => {
-      helper.fs.createFile('bar', 'foo.js');
-      let errorMessage;
-      try {
-        helper.command.addComponent('bar', {
-          i: ''
-        });
-      } catch (err) {
-        errorMessage = err.message;
-      }
-      expect(errorMessage).to.have.string("error: option `-i, --id <name>' argument missing");
-    });
     it('Should return error if used an invalid ID', () => {
       helper.fs.createFile('bar', 'foo.js');
       const addFunc = () => helper.command.addComponent('bar/foo.js', { i: 'Bar/foo' });
@@ -477,7 +466,7 @@ describe('bit add command', function() {
     });
     it('should add component with id contains only one level', () => {
       helper.fs.createFile('bar', 'foo.js');
-      helper.command.addComponent('bar', {
+      helper.command.addComponentDir('bar', {
         i: 'foo'
       });
       const bitMap = helper.bitMap.read();
@@ -490,7 +479,7 @@ describe('bit add command', function() {
       helper.fs.createFile('test/bar', 'foo.spec.js');
       helper.fs.createFile('test/bar', 'foo2.spec.js');
       helper.fs.createFile('test', 'foo2.spec.js');
-      helper.command.addComponent('bar/', {
+      helper.command.addComponentDir('bar/', {
         i: 'bar/foo',
         m: path.normalize('bar/foo.js'),
         t: 'test/{PARENT}/{FILE_NAME}.spec.js,test/{FILE_NAME}.spec.js'
@@ -531,7 +520,7 @@ describe('bit add command', function() {
       helper.fs.createFile('test/bar', 'foo.spec.js');
       helper.fs.createFile('test/bar', 'foo2.spec.js');
       helper.fs.createFile('test', 'foo2.spec.js');
-      helper.command.addComponent('bar/', {
+      helper.command.addComponentDir('bar/', {
         i: 'bar/foo',
         m: path.normalize('bar/foo.js'),
         t: 'test/{PARENT}/{FILE_NAME}.spec.js,test/*.spec.js'
@@ -564,7 +553,7 @@ describe('bit add command', function() {
       helper.fs.createFile('test/bar', 'foo.spec.js');
       helper.fs.createFile('test/bar', 'foo2.spec.js');
       helper.fs.createFile('test', 'foo2.spec.js');
-      helper.command.addComponent('bar/', {
+      helper.command.addComponentDir('bar/', {
         i: 'bar/foo',
         m: path.normalize('bar/foo.js'),
         t: 'test/{PARENT}/{FILE_NAME}.spec.js,test/*.spec.js',
@@ -600,7 +589,7 @@ describe('bit add command', function() {
       helper.fs.createFile('bar', 'foo2.js');
       helper.fs.createFile('bar', 'index.js');
       helper.fs.createFile('bars', 'foo3.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo' });
       const bitMap1 = helper.bitMap.read();
       const files1 = bitMap1['bar/foo'].files;
       expect(bitMap1).to.have.property('bar/foo');
@@ -692,26 +681,13 @@ describe('bit add command', function() {
       expect(bitMap).to.have.property('test/foo2');
       expect(output).to.have.string('tracking 2 new components');
     });
-    it('Should return error for missing namespace', () => {
-      helper.scopeHelper.reInitLocalScope();
-      const basePath = path.normalize('bar/*');
-      let errorMessage;
-      helper.fs.createFile('bar', 'foo2.js');
-      helper.fs.createFile('bar', 'foo1.js');
-      try {
-        helper.command.addComponent(basePath, { n: '' });
-      } catch (err) {
-        errorMessage = err.message;
-      }
-      expect(errorMessage).to.have.string("error: option `-n, --namespace <namespace>' argument missing");
-    });
     it('should indicate in the error message which components are missing the main file', () => {
       helper.scopeHelper.reInitLocalScope();
       helper.fs.createFile('bar', 'baz1/foo.js');
       helper.fs.createFile('bar', 'baz1/foo2.js');
       helper.fs.createFile('bar', 'baz2/foo.js');
       helper.fs.createFile('bar', 'baz2/foo2.js');
-      const addFunc = () => helper.command.addComponent('bar/*');
+      const addFunc = () => helper.command.addComponentDir('bar/*');
       const error = new MissingMainFileMultipleComponents(['baz1, baz2']);
       helper.general.expectToThrow(addFunc, error);
     });
@@ -721,7 +697,7 @@ describe('bit add command', function() {
         helper.scopeHelper.reInitLocalScope();
         helper.fs.createFile('bar', 'baz1/foo.js');
         helper.fs.createFile('bar', 'baz2/foo3.js');
-        output = helper.command.addComponent('bar/*', { e: 'bar/baz2/foo3.js' });
+        output = helper.command.addComponentDir('bar/*', { e: 'bar/baz2/foo3.js' });
       });
       it('should not break the operation if some of the components have empty directory', () => {
         expect(output).to.have.string('tracking component baz1');
@@ -740,7 +716,7 @@ describe('bit add command', function() {
       });
       describe('adding them as directories so the name are not conflicting', () => {
         before(() => {
-          helper.command.addComponent('bar/*');
+          helper.command.addComponentDir('bar/*');
         });
         it('should generate a short id out of the directory only', () => {
           const bitMap = helper.bitMap.readWithoutVersion();
@@ -776,7 +752,7 @@ describe('bit add command', function() {
     it('should throw an error when main file is excluded', () => {
       helper.fs.createFile('bar', 'foo1.js');
       helper.fs.createFile('bar', 'foo2.js');
-      const addCmd = () => helper.command.addComponent('bar', { i: 'bar/foo', e: 'bar/foo1.js', m: 'bar/foo1.js' });
+      const addCmd = () => helper.command.addComponentDir('bar', { i: 'bar/foo', e: 'bar/foo1.js', m: 'bar/foo1.js' });
       const error = new ExcludedMainFile(path.join('bar', 'foo1.js'));
       helper.general.expectToThrow(addCmd, error);
     });
@@ -879,7 +855,7 @@ describe('bit add command', function() {
       helper.fs.createFile('bar', 'foo.js');
       helper.fs.createFile(path.join('bar', 'exceptions'), 'some-exception.js');
       helper.fs.createFile(path.join('bar', 'exceptions'), 'index.js');
-      helper.command.addComponent('bar', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { i: 'bar/foo' });
     });
     it('should identify the closest index file as the main file', () => {
       const bitMap = helper.bitMap.read();
@@ -992,7 +968,7 @@ describe('bit add command', function() {
       helper.fs.createFile('bar', 'boo.js');
       helper.fs.createFile('bar', 'index.js');
       helper.git.writeGitIgnore(['bar/foo.js', 'bar/foo3.js']);
-      output = helper.command.addComponent(path.normalize('bar/'), { i: 'bar/foo' });
+      output = helper.command.addComponentDir(path.normalize('bar/'), { i: 'bar/foo' });
     });
     it('Should track component ', () => {
       expect(output).to.contain('tracking component bar/foo');
@@ -1083,11 +1059,11 @@ describe('bit add command', function() {
       helper.scopes.remotePath;
       helper.fs.createFile('bar', 'index.js');
       helper.fs.createFile('bar', 'foo2.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo ' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo ' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
       helper.fs.deletePath('bar/foo2.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo ' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo ' });
       helper.command.runCmd('bit s');
       bitMap = helper.bitMap.read();
     });
@@ -1159,7 +1135,7 @@ describe('bit add command', function() {
       helper.scopeHelper.reInitLocalScope();
       helper.fs.createFile('bar', 'foo.js');
       helper.fs.createFile('bar', 'foo-main.js');
-      helper.command.addComponent('bar', { m: 'foo-main.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'foo-main.js', i: 'bar/foo' });
       helper.fs.deletePath('bar/foo-main.js');
       const status = helper.command.status();
       expect(status).to.have.string(statusInvalidComponentsMsg);
@@ -1277,7 +1253,7 @@ describe('bit add command', function() {
       helper.scopeHelper.reInitLocalScope();
       helper.fs.createFile('bar', 'bar.js');
       helper.fs.createFile('bar', 'foo.js');
-      helper.command.addComponent('bar');
+      helper.command.addComponentDir('bar');
     });
     it('should resolve the mainFile as the file with the same name as the directory', () => {
       const bitMap = helper.bitMap.read();
@@ -1325,6 +1301,17 @@ describe('bit add command', function() {
       expect(files[1].relativePath).to.equal('bbb.js');
       expect(files[2].relativePath).to.equal('ccc.js');
       expect(files[3].relativePath).to.equal('ddd.js');
+    });
+  });
+  describe('adding files when not using --allow-files flag', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.createComponentBarFoo();
+    });
+    it('should throw an error AddingIndividualFiles', () => {
+      const addFunc = () => helper.command.addComponentDir('bar/foo.js');
+      const error = new AddingIndividualFiles('bar/foo.js');
+      helper.general.expectToThrow(addFunc, error);
     });
   });
 });

--- a/e2e/commands/add.e2e.1.ts
+++ b/e2e/commands/add.e2e.1.ts
@@ -1310,7 +1310,7 @@ describe('bit add command', function() {
     });
     it('should throw an error AddingIndividualFiles', () => {
       const addFunc = () => helper.command.addComponentDir('bar/foo.js');
-      const error = new AddingIndividualFiles('bar/foo.js');
+      const error = new AddingIndividualFiles(path.normalize('bar/foo.js'));
       helper.general.expectToThrow(addFunc, error);
     });
   });

--- a/e2e/commands/checkout.e2e.1.ts
+++ b/e2e/commands/checkout.e2e.1.ts
@@ -349,7 +349,7 @@ describe('bit checkout command', function() {
       helper.fixtures.addComponentBarFoo();
       helper.command.tagAllComponents();
       helper.fs.createFile('bar', 'foo2.js');
-      helper.command.addComponent('bar', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { i: 'bar/foo' });
       helper.command.tagAllComponents();
 
       helper.command.checkoutVersion('0.0.1', 'bar/foo');

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -82,8 +82,8 @@ describe('bit export command', function() {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       createFile('bar', 'foo1');
       createFile('bar', 'foo2');
-      helper.command.addComponent('bit add bar/foo1.js', { i: 'bar/foo1' });
-      helper.command.addComponent('bit add bar/foo2.js', { i: 'bar/foo2' });
+      helper.command.addComponent('bar/foo1.js', { i: 'bar/foo1' });
+      helper.command.addComponent('bar/foo2.js', { i: 'bar/foo2' });
       helper.command.tagAllComponents();
       // DO NOT change the next line to `helper.command.exportAllComponents()`. the current form catches some wierd bugs
       helper.command.exportComponent('bar/foo1 bar/foo2');

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -64,7 +64,7 @@ describe('bit export command', function() {
       createFile('bar', 'foo2');
       createFile('baz', 'foo1');
       createFile('baz', 'foo2');
-      helper.command.addComponent('bar', { m: 'foo1.js' });
+      helper.command.addComponentDir('bar', { m: 'foo1.js' });
       helper.command.addComponent('baz', { m: 'foo1.js' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
@@ -295,7 +295,7 @@ describe('bit export command', function() {
       fs.copySync(sourcePngFile, destPngFile);
       const stats = fs.statSync(destPngFile);
       pngSize = stats.size;
-      helper.command.addComponent('bar', { m: 'foo.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'foo.js', i: 'bar/foo' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
     });

--- a/e2e/commands/import.e2e.1.ts
+++ b/e2e/commands/import.e2e.1.ts
@@ -71,9 +71,11 @@ describe('bit import', function() {
         helper.fs.createFile('src', 'imprel.js');
         helper.fs.createFile('src', 'imprel.spec.js');
         helper.fs.createFile('src/utils', 'myUtil.js');
-        helper.command.runCmd(
-          'bit add src/imprel.js src/utils/myUtil.js -t src/imprel.spec.js -m src/imprel.js -i imprel/imprel'
-        );
+        helper.command.addComponent('src/imprel.js src/utils/myUtil.js', {
+          t: 'src/imprel.spec.js',
+          m: 'src/imprel.js',
+          i: 'imprel/imprel'
+        });
         helper.command.tagComponent('imprel/imprel');
         helper.command.exportComponent('imprel/imprel');
         helper.scopeHelper.reInitLocalScope();
@@ -392,9 +394,11 @@ describe('bit import', function() {
         helper.fs.createFile('src', 'imprel.js');
         helper.fs.createFile('src', 'imprel.spec.js');
         helper.fs.createFile('src/utils', 'myUtil.js');
-        helper.command.runCmd(
-          'bit add src/imprel.js src/utils/myUtil.js -t src/imprel.spec.js -m src/imprel.js -i imprel/impreldist'
-        );
+        helper.command.addComponent('src/imprel.js src/utils/myUtil.js', {
+          t: 'src/imprel.spec.js',
+          m: 'src/imprel.js',
+          i: 'imprel/impreldist'
+        });
         helper.command.tagComponent('imprel/impreldist');
         helper.command.exportComponent('imprel/impreldist');
       });
@@ -532,9 +536,11 @@ describe('bit import', function() {
       helper.fs.createFile('src', 'imprel.js');
       helper.fs.createFile('src', 'imprel.spec.js');
       helper.fs.createFile('src/utils', 'myUtil.js');
-      helper.command.runCmd(
-        'bit add src/imprel.js src/utils/myUtil.js -t src/imprel.spec.js -m src/imprel.js -i imprel/imprel'
-      );
+      helper.command.addComponent('src/imprel.js src/utils/myUtil.js', {
+        t: 'src/imprel.spec.js',
+        m: 'src/imprel.js',
+        i: 'imprel/imprel'
+      });
       helper.command.tagComponent('imprel/imprel');
       helper.command.deprecateComponent('imprel/imprel');
       helper.command.exportComponent('imprel/imprel');

--- a/e2e/commands/move.e2e.1.ts
+++ b/e2e/commands/move.e2e.1.ts
@@ -69,7 +69,7 @@ describe('bit move command', function() {
       helper.fs.createFile('bar', 'foo1.js');
       helper.fs.createFile('bar', 'foo2.js');
       helper.fs.createFile('bar', 'foo1.spec.js');
-      helper.command.addComponent('bar', {
+      helper.command.addComponentDir('bar', {
         i: 'bar/foo',
         t: path.normalize('bar/foo1.spec.js'),
         m: path.normalize('bar/foo1.js')

--- a/e2e/commands/remove.e2e.1.ts
+++ b/e2e/commands/remove.e2e.1.ts
@@ -410,7 +410,7 @@ describe('bit remove command', function() {
       helper.scopeHelper.reInitLocalScope();
       helper.fs.createFile('bar', 'foo.js');
       helper.fs.createFile('bar', 'foo-main.js');
-      helper.command.addComponent('bar', { m: 'foo-main.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'foo-main.js', i: 'bar/foo' });
       helper.command.tagAllComponents();
       helper.fs.deletePath('bar/foo-main.js');
       const status = helper.command.status();

--- a/e2e/commands/show.e2e.2.ts
+++ b/e2e/commands/show.e2e.2.ts
@@ -370,7 +370,7 @@ describe('bit show command', function() {
       helper.scopeHelper.initNewLocalScope();
       helper.fixtures.createComponentBarFoo();
       helper.fs.createFile('bar', 'index.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo' });
     });
     it('Should show component only with the left files', () => {
       const beforeRemoveBitMap = helper.bitMap.read();
@@ -401,7 +401,7 @@ describe('bit show command', function() {
       helper.scopeHelper.initNewLocalScope();
       helper.fixtures.createComponentBarFoo();
       helper.fs.createFile('bar', 'index.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo' });
     });
     describe('when adding a component without tagging it', () => {
       it('Should throw error nothing to compare no previous versions found', () => {

--- a/e2e/commands/status.e2e.2.ts
+++ b/e2e/commands/status.e2e.2.ts
@@ -480,7 +480,7 @@ describe('bit status command', function() {
         helper.scopeHelper.initNewLocalScope();
         helper.fixtures.createComponentBarFoo();
         helper.fs.createFile('bar', 'index.js');
-        helper.command.addComponent('bar/', { i: 'bar/foo' });
+        helper.command.addComponentDir('bar/', { i: 'bar/foo' });
         helper.fs.deletePath('bar/foo.js');
       });
       it('should remove the files from bit.map', () => {
@@ -496,7 +496,7 @@ describe('bit status command', function() {
       it('Should show "non-existing dependency" when deleting a file that is required by other files', () => {
         helper.fs.createFile('bar', 'foo1.js');
         helper.fs.createFile('bar', 'foo2.js', 'var index = require("./foo1.js")');
-        helper.command.addComponent('bar/', { i: 'bar/foo' });
+        helper.command.addComponentDir('bar/', { i: 'bar/foo' });
         helper.fs.deletePath('bar/foo1.js');
         const output = helper.command.runCmd('bit status');
         expect(output).to.have.string('non-existing dependency files');
@@ -507,7 +507,7 @@ describe('bit status command', function() {
           helper.scopeHelper.reInitLocalScope();
           helper.fs.createFile('bar', 'index.js');
           helper.fs.createFile('bar', 'foo.js');
-          helper.command.addComponent('bar/', { i: 'bar/foo' });
+          helper.command.addComponentDir('bar/', { i: 'bar/foo' });
           helper.fs.deletePath('bar/index.js');
         });
         it('should show an error indicating the mainFile was deleting', () => {
@@ -523,7 +523,7 @@ describe('bit status command', function() {
         helper.scopeHelper.initNewLocalScope();
         helper.fixtures.createComponentBarFoo();
         helper.fs.createFile('bar', 'index.js');
-        helper.command.addComponent('bar/', { i: 'bar/foo' });
+        helper.command.addComponentDir('bar/', { i: 'bar/foo' });
         helper.fs.deletePath('bar/index.js');
         helper.fs.deletePath('bar/foo.js');
         output = helper.command.runCmd('bit status');
@@ -559,7 +559,7 @@ describe('bit status command', function() {
         helper.scopeHelper.initNewLocalScope();
         helper.fixtures.createComponentBarFoo();
         helper.fs.createFile('bar', 'index.js');
-        helper.command.addComponent('bar/', { i: 'bar/foo' });
+        helper.command.addComponentDir('bar/', { i: 'bar/foo' });
         helper.fs.deletePath('bar');
         output = helper.command.runCmd('bit status');
       });

--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -810,7 +810,7 @@ describe('bit tag command', function() {
       helper.scopeHelper.initNewLocalScope();
       helper.fixtures.createComponentBarFoo();
       helper.fs.createFile('bar', 'index.js');
-      helper.command.addComponent('bar/', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo' });
     });
     it('Should tag component only with the left files', () => {
       const beforeRemoveBitMap = helper.bitMap.read();
@@ -827,7 +827,7 @@ describe('bit tag command', function() {
       let errMsg;
       helper.fs.createFile('bar', 'foo.js', '');
       helper.fs.createFile('bar', 'index.js', 'var foo = require("./foo.js")');
-      helper.command.addComponent('bar/', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar/', { i: 'bar/foo' });
       helper.fs.deletePath('bar/foo.js');
       try {
         helper.command.runCmd('bit tag -a');

--- a/e2e/flows/big-file.e2e.2.ts
+++ b/e2e/flows/big-file.e2e.2.ts
@@ -23,7 +23,7 @@ describe('big text file', function() {
       const windowsFormatContent = bigFileContent.replace(/\r\n|\r|\n/g, '\r\n');
       fs.outputFileSync(path.join(helper.scopes.localPath, 'bar', 'big-text-file.txt'), windowsFormatContent);
       helper.fixtures.createComponentBarFoo();
-      helper.command.addComponent('bar', { i: 'bar/text', m: 'bar/foo.js' });
+      helper.command.addComponentDir('bar', { i: 'bar/text', m: 'bar/foo.js' });
       tagOutput = helper.command.tagComponent('bar/text');
     });
     it('tagging the component should not throw any error', () => {

--- a/e2e/flows/import-package-json.e2e.3.ts
+++ b/e2e/flows/import-package-json.e2e.3.ts
@@ -91,7 +91,7 @@ describe('component with package.json as a file of the component', function() {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       helper.fs.createJsonFile('bar/package.json', fixturePackageJson);
       helper.fs.createFile('bar', 'foo.js');
-      const addOutput = helper.command.addComponent('bar', { i: 'bar/foo', m: 'foo.js' });
+      const addOutput = helper.command.addComponentDir('bar', { i: 'bar/foo', m: 'foo.js' });
       expect(addOutput).to.have.string('package.json');
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();

--- a/e2e/flows/permissions-errors.e2e.3.ts
+++ b/e2e/flows/permissions-errors.e2e.3.ts
@@ -18,7 +18,7 @@ describe.skip('permissions', function() {
     before(() => {
       helper.scopeHelper.reInitLocalScope();
       helper.fixtures.createComponentBarFoo();
-      const output = helper.command.runCmd('sudo bit add bar/foo.js');
+      const output = helper.command.runCmd('sudo bit add bar/foo.js --allow-files');
       expect(output).to.have.string('Warning');
       expect(output).to.have.string('root');
     });

--- a/e2e/functionalities/binary-files.e2e.2.ts
+++ b/e2e/functionalities/binary-files.e2e.2.ts
@@ -29,7 +29,7 @@ describe('binary files', function() {
       fs.copySync(sourcePngFile, destPngFile);
       const stats = fs.statSync(destPngFile);
       pngSize = stats.size;
-      helper.command.addComponent('bar', { m: 'foo.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'foo.js', i: 'bar/foo' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
     });
@@ -59,7 +59,7 @@ describe('binary files', function() {
       fs.copySync(sourcePngFile, destPngFile);
       const stats = fs.statSync(destPngFile);
       pngSize = stats.size;
-      helper.command.addComponent('bar', { m: 'png_fixture.png', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'png_fixture.png', i: 'bar/foo' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
     });
@@ -112,7 +112,7 @@ describe('binary files', function() {
       const sourcePngFile = path.join(__dirname, '..', 'fixtures', 'png_fixture.png');
       destPngFile = path.join(helper.scopes.localPath, 'bar', 'png_fixture.png');
       fs.copySync(sourcePngFile, destPngFile);
-      helper.command.addComponent('bar', { m: 'png_fixture.png', i: 'bar/png' });
+      helper.command.addComponentDir('bar', { m: 'png_fixture.png', i: 'bar/png' });
       const fixture = 'require("./png_fixture.png")';
       helper.fs.createFile('bar', 'foo.js', fixture);
       helper.command.addComponent('bar/foo.js', { i: 'bar/foo' });
@@ -494,7 +494,7 @@ describe('binary files', function() {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fs.createFile('bar', 'my-comp.md', 'some md5 content');
       helper.fs.createFile('bar', 'my-comp.js');
-      helper.command.addComponent('bar', { m: 'my-comp.js', i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { m: 'my-comp.js', i: 'bar/foo' });
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
       helper.env.importDummyCompiler();

--- a/e2e/functionalities/dev-dependencies.e2e.2.ts
+++ b/e2e/functionalities/dev-dependencies.e2e.2.ts
@@ -210,7 +210,7 @@ describe('foo', () => {
       helper.fs.createFile('bar', 'foo.spec.js', fixtures.barFooFixture);
       helper.fs.createFile('utils', 'is-string.js', fixtures.isString);
       helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
-      helper.command.addComponent('bar', { i: 'bar/foo', m: 'bar/foo.js', t: 'bar/foo.spec.js' });
+      helper.command.addComponentDir('bar', { i: 'bar/foo', m: 'bar/foo.js', t: 'bar/foo.spec.js' });
       helper.fixtures.addComponentUtilsIsString();
       helper.fixtures.addComponentUtilsIsType();
       helper.command.tagAllComponents();

--- a/e2e/functionalities/link-generation.e2e.2.ts
+++ b/e2e/functionalities/link-generation.e2e.2.ts
@@ -24,7 +24,7 @@ describe('link generation', function() {
       helper.fs.deletePath('bar');
       helper.command.status(); // removes the old directory 'bar' from .bitmap
       helper.fs.createFile('', 'bar');
-      helper.command.addComponent('bar', { i: 'bar/foo' });
+      helper.command.addComponentDir('bar', { i: 'bar/foo' });
       helper.command.tagAllComponents();
       // a previous bug was throwing an error upon export "EISDIR: illegal operation on a directory, read"
       helper.command.exportAllComponents();

--- a/e2e/functionalities/link-generation.e2e.2.ts
+++ b/e2e/functionalities/link-generation.e2e.2.ts
@@ -24,7 +24,7 @@ describe('link generation', function() {
       helper.fs.deletePath('bar');
       helper.command.status(); // removes the old directory 'bar' from .bitmap
       helper.fs.createFile('', 'bar');
-      helper.command.addComponentDir('bar', { i: 'bar/foo' });
+      helper.command.addComponent('bar', { i: 'bar/foo' });
       helper.command.tagAllComponents();
       // a previous bug was throwing an error upon export "EISDIR: illegal operation on a directory, read"
       helper.command.exportAllComponents();

--- a/e2e/platforms/angular.e2e.3.ts
+++ b/e2e/platforms/angular.e2e.3.ts
@@ -47,7 +47,7 @@ export class AppModule {}
       before(() => {
         helper.fs.createFile('bar', 'my-template.html');
         helper.fs.createFile('bar', 'my-style.css');
-        helper.command.addComponent('bar', { i: 'bar/foo ' });
+        helper.command.addComponentDir('bar', { i: 'bar/foo ' });
       });
       it('should not warn about it anymore', () => {
         const output = helper.command.runCmd('bit status');

--- a/src/api/consumer/lib/add.ts
+++ b/src/api/consumer/lib/add.ts
@@ -43,6 +43,7 @@ export async function addMany(components: AddProps[], alternateCwd?: string): Pr
       ? component.tests.map(testFile => path.normalize(testFile.trim()))
       : [];
     component.tests = normalizedTests;
+    component.allowFiles = true;
     component.exclude = component.exclude
       ? component.exclude.map(excludeFile => path.normalize(excludeFile.trim()))
       : [];

--- a/src/cli/commands/public-cmds/add-cmd.ts
+++ b/src/cli/commands/public-cmds/add-cmd.ts
@@ -12,7 +12,7 @@ import GeneralError from '../../../error/general-error';
 export default class Add extends Command {
   name = 'add [path...]';
   description = `add any subset of files to be tracked as a component(s)
-  all flags support glob patterns and {PARENT} {FILE_NAME} annotations 
+  all flags support glob patterns and {PARENT} {FILE_NAME} annotations
   https://${BASE_DOCS_DOMAIN}/docs/add-and-isolate-components`;
   alias = 'a';
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -24,12 +24,13 @@ export default class Add extends Command {
       'tests <file>/"<file>,<file>"',
       'specify test files to track. use quotation marks to list files or use a glob pattern'
     ],
-    ['n', 'namespace <namespace>', 'orginize component in a namespace'],
+    ['n', 'namespace <namespace>', 'organize component in a namespace'],
     [
       'e',
       'exclude <file>/"<file>,<file>"',
       'exclude file from being tracked. use quotation marks to list files or use a glob pattern'
     ],
+    ['', 'allow-files', 'allow adding individual files (not recommended)'],
     ['o', 'override <boolean>', 'override existing component if exists (default = false)']
   ];
   loader = true;
@@ -43,6 +44,7 @@ export default class Add extends Command {
       tests,
       namespace,
       exclude,
+      allowFiles = false,
       override = false
     }: {
       id: string | null | undefined;
@@ -50,6 +52,7 @@ export default class Add extends Command {
       tests: string | null | undefined;
       namespace: string | null | undefined;
       exclude: string | null | undefined;
+      allowFiles: boolean;
       override: boolean;
     }
   ): Promise<any> {
@@ -77,6 +80,7 @@ export default class Add extends Command {
       namespace,
       tests: testsArray,
       exclude: excludedFiles,
+      allowFiles,
       override
     });
   }

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -103,6 +103,7 @@ import RemoteResolverError from '../scope/network/exceptions/remote-resolver-err
 import ExportAnotherOwnerPrivate from '../scope/network/exceptions/export-another-owner-private';
 import ComponentsPendingImport from '../consumer/component-ops/exceptions/components-pending-import';
 import { importPendingMsg } from './commands/public-cmds/status-cmd';
+import { AddingIndividualFiles } from '../consumer/component-ops/add-components/exceptions/addding-individual-files';
 
 const reportIssueToGithubMsg =
   'This error should have never happened. Please report this issue on Github https://github.com/teambit/bit/issues';
@@ -138,6 +139,11 @@ const errorsMap: Array<[Class<Error>, (err: Class<Error>) => string]> = [
   //   err => `error: The compiler "${err.plugin}" is not installed, please use "bit install ${err.plugin}" to install it.`
   // ],
   [FileSourceNotFound, err => `file or directory "${err.path}" was not found`],
+  [
+    AddingIndividualFiles,
+    err => `error: unable to add individual files ("${err.file}"), please add directories only.
+to bypass this error, use --allow-files flag`
+  ],
   [ExtensionFileNotFound, err => `file "${err.path}" was not found`],
   [
     ExtensionNameNotValid,

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -323,6 +323,7 @@ export default class ComponentMap {
         id: id.toString(),
         override: false, // this makes sure to not override existing files of componentMap
         trackDirFeature: true,
+        allowFiles: true,
         origin: this.origin
       };
       const numOfFilesBefore = this.files.length;

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -47,6 +47,7 @@ import PathOutsideConsumer from './exceptions/path-outside-consumer';
 import { ModelComponent } from '../../../scope/models';
 import determineMainFile from './determine-main-file';
 import ShowDoctorError from '../../../error/show-doctor-error';
+import { AddingIndividualFiles } from './exceptions/addding-individual-files';
 
 export type AddResult = { id: string; files: ComponentMapFile[] };
 type Warnings = {
@@ -84,6 +85,7 @@ export type AddProps = {
   exclude?: PathOrDSL[];
   override: boolean;
   trackDirFeature?: boolean;
+  allowFiles: boolean;
   origin?: ComponentOrigin;
 };
 // This is the contxt of the add operation. By default, the add is executed in the same folder in which the consumer is located and it is the process.cwd().
@@ -114,6 +116,7 @@ export default class AddComponents {
   origin: ComponentOrigin;
   alternateCwd: string | null | undefined;
   addedComponents: AddResult[];
+  allowFiles: boolean;
   constructor(context: AddContext, addProps: AddProps) {
     this.alternateCwd = context.alternateCwd;
     this.consumer = context.consumer;
@@ -123,6 +126,7 @@ export default class AddComponents {
     this.main = addProps.main;
     this.namespace = addProps.namespace;
     this.tests = addProps.tests ? this.joinConsumerPathIfNeeded(addProps.tests) : [];
+    this.allowFiles = addProps.allowFiles;
     this.exclude = addProps.exclude ? this.joinConsumerPathIfNeeded(addProps.exclude) : [];
     this.override = addProps.override;
     this.trackDirFeature = addProps.trackDirFeature;
@@ -504,7 +508,10 @@ export default class AddComponents {
 
   async _mergeTestFilesWithFiles(files: ComponentMapFile[]): Promise<ComponentMapFile[]> {
     const testFiles = !R.isEmpty(this.tests)
-      ? await this.getFilesAccordingToDsl(files.map(file => file.relativePath), this.tests)
+      ? await this.getFilesAccordingToDsl(
+          files.map(file => file.relativePath),
+          this.tests
+        )
       : [];
 
     const resolvedTestFiles = testFiles.map(testFile => {
@@ -701,6 +708,13 @@ export default class AddComponents {
       } else {
         throw new NoFiles(diff);
       }
+    }
+    if (!this.allowFiles) {
+      Object.keys(componentPathsStats).forEach(compPath => {
+        if (!componentPathsStats[compPath].isDir) {
+          throw new AddingIndividualFiles(compPath);
+        }
+      });
     }
     // if a user entered multiple paths and entered an id, he wants all these paths to be one component
     // conversely, if a user entered multiple paths without id, he wants each dir as an individual component

--- a/src/consumer/component-ops/add-components/exceptions/addding-individual-files.ts
+++ b/src/consumer/component-ops/add-components/exceptions/addding-individual-files.ts
@@ -1,0 +1,9 @@
+import AbstractError from '../../../../error/abstract-error';
+
+export class AddingIndividualFiles extends AbstractError {
+  file: string;
+  constructor(file: string) {
+    super();
+    this.file = file;
+  }
+}

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -72,6 +72,12 @@ export default class CommandHelper {
     const value = Object.keys(options)
       .map(key => `-${key} ${options[key]}`)
       .join(' ');
+    return this.runCmd(`bit add ${filePaths} ${value} --allow-files`, cwd);
+  }
+  addComponentDir(filePaths: string, options: Record<string, any> = {}, cwd: string = this.scopes.localPath) {
+    const value = Object.keys(options)
+      .map(key => `-${key} ${options[key]}`)
+      .join(' ');
     return this.runCmd(`bit add ${filePaths} ${value}`, cwd);
   }
   getConfig(configName: string) {


### PR DESCRIPTION
This will help stabilize the product by enabling only directories to be added.
Adding individual files means there is no one base-dir for the component and many components can have the same base-dir, as a result, when importing the component, a process of stripping-shared-dir needs to be done. This process is complex and error-prone. This PR is a big step toward eliminating it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2426)
<!-- Reviewable:end -->
