### PR TITLE
Fix ComponentNotFound when using bit-export with no args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2171](https://github.com/teambit/bit/issues/2171) - fix ComponentNotFound when using `bit export` with no args and a flattened dependency was converted from no-scope to a remote-scope
 - add infrastructure for feature-toggle
 - deprecate files overrides (using file:// prefix)
 - disallow adding individual files by `bit add` unless `--allow-files` flag is used

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -600,6 +600,24 @@ describe('bit export command', function() {
         });
       });
     });
+    describe('when a component has flattened dependency change', () => {
+      let output;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.fixtures.populateWorkspaceWithThreeComponents();
+        helper.bitJson.addDefaultScope();
+        helper.command.tagAllComponents();
+        helper.command.exportAllComponents();
+        helper.fs.outputFile('qux.js');
+        helper.command.addComponent('qux.js');
+        helper.fs.outputFile('utils/is-string.js', 'require("../qux");');
+        helper.command.tagAllComponents();
+        output = helper.command.export();
+      });
+      it('should send the component with the flattened dependency changes to the remote', () => {
+        expect(output).to.have.string('exported the following 3 component(s)');
+      });
+    });
     describe('some components were exported to one scope and other to another scope', () => {
       let localScopeBefore;
       let remoteScopeBefore;

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -381,10 +381,20 @@ async function convertToCorrectScope(
         dependency.id = updatedScope;
       }
     });
-    version.flattenedDependencies = getBitIdsWithUpdatedScope(version.flattenedDependencies);
-    version.flattenedDevDependencies = getBitIdsWithUpdatedScope(version.flattenedDevDependencies);
-    version.flattenedCompilerDependencies = getBitIdsWithUpdatedScope(version.flattenedCompilerDependencies);
-    version.flattenedTesterDependencies = getBitIdsWithUpdatedScope(version.flattenedTesterDependencies);
+    const flattenedFields = [
+      'flattenedDependencies',
+      'flattenedDevDependencies',
+      'flattenedCompilerDependencies',
+      'flattenedTesterDependencies'
+    ];
+    flattenedFields.forEach(flattenedField => {
+      const ids: BitIds = version[flattenedField];
+      const needsChange = ids.some(id => id.scope !== remoteScope);
+      if (needsChange) {
+        version[flattenedField] = getBitIdsWithUpdatedScope(ids);
+        hasChanged = true;
+      }
+    });
     return hasChanged;
   }
 


### PR DESCRIPTION
And a flattened dependency was converted from no-scope to a remote-scope.

See this for more details:
https://github.com/teambit/bit/issues/2171#issuecomment-600135982

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2466)
<!-- Reviewable:end -->
