### PR TITLE
Delete index.json file in case its content does not match the scope content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2482](https://github.com/teambit/bit/issues/2482) - delete component's cache upon mismatch
 - stabilize capsule by writing the same paths as the workspace relative to the component rootDir
 - stabilize Bit by eliminating the removal of shared directory upon import and having rootDir for authored components
 - fix `bit link --rewire` for css/sass/less files

--- a/e2e/functionalities/components-index.e2e.2.ts
+++ b/e2e/functionalities/components-index.e2e.2.ts
@@ -148,17 +148,14 @@ describe('scope components index mechanism', function() {
         helper.general.writeIndexJson(indexJsonWithBarFoo);
         // now, index.json has barFoo, however the scope doesn't have it
       });
-      it('bit status should throw an error', () => {
+      it('bit status should throw an error for the first time and then should work on the second run', () => {
         // used to show "Cannot read property 'scope' of null"
         const error = new OutdatedIndexJson('bar/foo', helper.general.indexJsonPath());
         const statusCmd = () => helper.command.status();
         helper.general.expectToThrow(statusCmd, error);
-      });
-      it('bit ls should throw an error', () => {
-        // used to show "Cannot read property 'toBitIdWithLatestVersion' of null"
-        const error = new OutdatedIndexJson('bar/foo', helper.general.indexJsonPath());
-        const statusCmd = () => helper.command.status();
-        helper.general.expectToThrow(statusCmd, error);
+
+        const secondRun = () => helper.command.status();
+        expect(secondRun).not.to.throw();
       });
     });
   });

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -249,9 +249,8 @@ once your changes are merged with the new remote version, please tag and export 
     OutdatedIndexJson,
     err => `error: component ${chalk.bold(
       err.componentId
-    )} found in the index.json file, however, is missing from the scope.
-to get the file rebuild, please delete it at "${err.indexJsonPath}".\n${reportIssueToGithubMsg}
-`
+    )} found in the cache (index.json file), however, is missing from the scope.
+the cache is deleted and will be rebuilt on the next command. please re-run the command.`
   ],
   [CyclicDependencies, err => `${err.msg.toString().toLocaleLowerCase()}`],
   [

--- a/src/scope/objects/components-index.ts
+++ b/src/scope/objects/components-index.ts
@@ -88,6 +88,10 @@ export default class ComponentsIndex {
     this.index = R.without([found], this.index);
     return true;
   }
+  async deleteFile() {
+    logger.debug(`ComponentsIndex, deleting the index file at ${this.indexPath}`);
+    await fs.remove(this.indexPath);
+  }
   getPath() {
     return this.indexPath;
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -164,6 +164,7 @@ export default class Repository {
             );
             return null;
           }
+          await this.componentsIndex.deleteFile();
           // $FlowFixMe componentId must be set as it was retrieved from indexPath before
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           throw new OutdatedIndexJson(componentId, indexJsonPath);


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/2482.

Until now, Bit was throwing an error suggesting the user to delete the file manually.
The idea was to catch these occurrences and understand why they happen.
According to the issue above, it could happen when exporting a component and canceling the operation by ^c, which makes sense. Bit does try to be atomic here so then the update of the scope and index.json occur within the same function.
However, if the cancellation happened exactly after deleting the component file in the scope and before writing the index.json file, they both won't be synced. 

It is possible to keep track of the deleted files one by one and map them to the components and then do some rollback to have it atomic for real, however, it's out of the scope of this PR.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2485)
<!-- Reviewable:end -->
