### PR TITLE
add "ids" argument to bit-link to support linking particular components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- support running `bit link` for specific components
 - [#2482](https://github.com/teambit/bit/issues/2482) - delete component's cache upon mismatch
 - stabilize capsule by writing the same paths as the workspace relative to the component rootDir
 - stabilize Bit by eliminating the removal of shared directory upon import and having rootDir for authored components

--- a/e2e/commands/link.e2e.1.ts
+++ b/e2e/commands/link.e2e.1.ts
@@ -357,6 +357,19 @@ console.log(isType());`;
         expect(result.trim()).to.equal('got is-type and got is-string and got foo');
       });
     });
+    describe('with entering specific ids', () => {
+      let output;
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(beforeLink);
+        output = helper.command.linkAndRewire('bar/foo');
+      });
+      it('should link only the specified ids', () => {
+        expect(output).to.have.string('linked 1 components');
+      });
+      it('should rewire only the specified ids', () => {
+        expect(output).to.have.string('rewired 1 components');
+      });
+    });
     describe('with css files in one dir and extension', () => {
       before(() => {
         helper.scopeHelper.reInitLocalScope();

--- a/src/api/consumer/lib/link.ts
+++ b/src/api/consumer/lib/link.ts
@@ -2,14 +2,15 @@ import { loadConsumer, Consumer } from '../../../consumer';
 import { linkAllToNodeModules } from '../../../links';
 import { changeCodeFromRelativeToModulePaths } from '../../../consumer/component-ops/codemod-components';
 
-export default async function linkAction(changeRelativeToModulePaths: boolean) {
+export default async function linkAction(ids: string[], changeRelativeToModulePaths: boolean) {
   const consumer: Consumer = await loadConsumer();
+  const bitIds = ids.map(id => consumer.getParsedId(id));
   let codemodResults;
   if (changeRelativeToModulePaths) {
-    codemodResults = await changeCodeFromRelativeToModulePaths(consumer);
+    codemodResults = await changeCodeFromRelativeToModulePaths(consumer, bitIds);
     consumer.componentLoader.clearComponentsCache();
   }
-  const linksResults = await linkAllToNodeModules(consumer);
+  const linksResults = await linkAllToNodeModules(consumer, bitIds);
   await consumer.onDestroy();
   return { linksResults, codemodResults };
 }

--- a/src/cli/commands/public-cmds/link-cmd.ts
+++ b/src/cli/commands/public-cmds/link-cmd.ts
@@ -7,7 +7,7 @@ import { CodemodResult } from '../../../consumer/component-ops/codemod-component
 import { codemodTemplate } from '../../templates/codemod-template';
 
 export default class Link extends Command {
-  name = 'link';
+  name = 'link [ids...]';
   description = `generate symlinks to resolve module paths for imported components.\n  https://${BASE_DOCS_DOMAIN}/docs/dependencies#missing-links`;
   alias = 'b';
   // @ts-ignore
@@ -17,8 +17,8 @@ export default class Link extends Command {
   private = false;
   loader = true;
 
-  action(args: string[], { rewire = false }: { rewire: boolean }): Promise<any> {
-    return link(rewire);
+  action([ids]: [string[]], { rewire = false }: { rewire: boolean }): Promise<any> {
+    return link(ids, rewire);
   }
 
   report(results: { linksResults: LinksResult[]; codemodResults?: CodemodResult[] }): string {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -348,8 +348,8 @@ export default class CommandHelper {
   link() {
     return this.runCmd('bit link');
   }
-  linkAndRewire() {
-    return this.runCmd('bit link --rewire');
+  linkAndRewire(ids = '') {
+    return this.runCmd(`bit link ${ids} --rewire`);
   }
   ejectConf(id = 'bar/foo', options: Record<string, any> | null | undefined) {
     const value = options

--- a/src/links/linker.ts
+++ b/src/links/linker.ts
@@ -11,13 +11,13 @@ import { LinksResult } from './node-modules-linker';
 import GeneralError from '../error/general-error';
 import ComponentMap from '../consumer/bit-map/component-map';
 import DataToPersist from '../consumer/component/sources/data-to-persist';
-import { BitIds } from '../bit-id';
+import { BitIds, BitId } from '../bit-id';
 import ComponentsList from '../consumer/component/components-list';
 import BitMap from '../consumer/bit-map/bit-map';
 import { COMPONENT_ORIGINS } from '../constants';
 
-export async function linkAllToNodeModules(consumer: Consumer): Promise<LinksResult[]> {
-  const componentsIds = consumer.bitmapIds;
+export async function linkAllToNodeModules(consumer: Consumer, bitIds: BitId[] = []): Promise<LinksResult[]> {
+  const componentsIds = bitIds.length ? BitIds.fromArray(bitIds) : consumer.bitmapIds;
   if (R.isEmpty(componentsIds)) throw new GeneralError('nothing to link');
   const { components } = await consumer.loadComponents(componentsIds);
   const nodeModuleLinker = new NodeModuleLinker(components, consumer, consumer.bitMap);


### PR DESCRIPTION
Currently, `bit link` links all components with no option to specify individual components.
This PR enables link specific components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2490)
<!-- Reviewable:end -->
