### PR TITLE
Do not require core-extensions to have a hash prefix

### DIFF
--- a/src/extensions/flows/task/task.ts
+++ b/src/extensions/flows/task/task.ts
@@ -33,10 +33,7 @@ export class Task {
 }
 
 function createHostScript(capsule: Capsule, task: string) {
-  const parts = task
-    .trim()
-    .slice(1)
-    .split(':');
+  const parts = task.trim().split(':');
   const host = '__bit_container.js';
   const containerScript = getContainerScript();
   capsule.fs.writeFileSync(host, containerScript, { encoding: 'utf8' });


### PR DESCRIPTION
Currently, a core extension needs to be prefixed with `#` before the id name in the bit.jsonc file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2542)
<!-- Reviewable:end -->
