### PR TITLE
refactor e2e-tests to not check for a success message of bit-status

### DIFF
--- a/e2e/commands/eject.e2e.1.ts
+++ b/e2e/commands/eject.e2e.1.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import fs from 'fs-extra';
 import R from 'ramda';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import * as fixtures from '../../src/fixtures/fixtures';
 import { failureEjectMessage, successEjectMessage } from '../../src/cli/templates/eject-template';
 import { MissingBitMapComponent } from '../../src/consumer/bit-map/exceptions';
@@ -111,8 +110,7 @@ describe('bit eject command', function() {
           });
         });
         it('bit status should show a clean state', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('should not delete the objects from the scope', () => {
           const listScope = helper.command.listLocalScopeParsed('--scope');
@@ -155,8 +153,7 @@ describe('bit eject command', function() {
           expect(path.join(helper.scopes.localPath, 'bar', 'foo.js')).not.to.be.a.path();
         });
         it('bit status should show a clean state', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
       });
       describe('eject two components, the additional one has not been exported yet', () => {
@@ -299,8 +296,7 @@ describe('bit eject command', function() {
             });
           });
           it('bit status should show a clean state', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
       });
@@ -312,8 +308,8 @@ describe('bit eject command', function() {
             npmCiRegistry.setCiScopeInBitJson();
             helper.command.importComponent('bar/foo');
             // an intermediate step, make sure the workspace is clean
-            const statusOutput = helper.command.status();
-            expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
+
             helper.fs.createFile('components/bar/foo/bar/', 'foo.js', fixtures.barFooFixtureV2);
             helper.command.tagAllComponents();
             helper.command.exportAllComponents();
@@ -348,8 +344,7 @@ describe('bit eject command', function() {
             });
           });
           it('bit status should show a clean state', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           it('should not delete the objects from the scope', () => {
             const listScope = helper.command.listLocalScopeParsed('--scope');
@@ -366,8 +361,8 @@ describe('bit eject command', function() {
             helper.command.importComponent('bar/foo');
             helper.command.importComponent('utils/is-string');
             // an intermediate step, make sure the workspace is clean
-            const statusOutput = helper.command.status();
-            expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
+
             helper.fs.createFile('components/utils/is-string/', 'is-string.js', fixtures.isStringV2);
 
             npmCiRegistry.setCiScopeInBitJson();
@@ -410,8 +405,7 @@ describe('bit eject command', function() {
               });
             });
             it('bit status should show a clean state', () => {
-              const output = helper.command.runCmd('bit status');
-              expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+              helper.command.expectStatusToBeClean();
             });
             it('should not delete any objects from the scope', () => {
               const listScope = helper.command.listLocalScope('--scope');

--- a/e2e/commands/import.e2e.1.ts
+++ b/e2e/commands/import.e2e.1.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import glob from 'glob';
 import Helper, { VERSION_DELIMITER } from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
-import { statusWorkspaceIsCleanMsg, statusFailureMsg } from '../../src/cli/commands/public-cmds/status-cmd';
+import { statusFailureMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { ComponentNotFound } from '../../src/scope/exceptions';
 import InvalidConfigPropPath from '../../src/consumer/config/exceptions/invalid-config-prop-path';
 import { componentIssuesLabels } from '../../src/cli/templates/component-issues-template';
@@ -1542,7 +1542,7 @@ console.log(barFoo.default());`;
         const output = helper.command.runCmd('bit status');
         expect(output).to.not.have.string('utils/is-string');
         expect(output).to.not.have.string('utils/is-type');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
       it('should not break the is-string component', () => {
         helper.fs.createFile(path.join('components', 'utils', 'is-type'), 'is-type.js', fixtures.isTypeV2);
@@ -1854,8 +1854,7 @@ console.log(barFoo.default());`;
       expect(result.trim()).to.equal('got is-type and got is-string and got foo');
     });
     it('should not show any of the components as new or modified or deleted or staged', () => {
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     describe('when cloning the project to somewhere else', () => {
       before(() => {
@@ -1926,8 +1925,7 @@ console.log(barFoo.default());`;
         expect(output).to.have.string('successfully imported one component');
       });
       it('bit status should show a clean state', () => {
-        const statusOutput = helper.command.runCmd('bit status');
-        expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
     });
   });

--- a/e2e/commands/init.e2e.1.ts
+++ b/e2e/commands/init.e2e.1.ts
@@ -8,7 +8,6 @@ import { BIT_GIT_DIR, BIT_HIDDEN_DIR, BIT_MAP, BIT_JSON, CURRENT_UPSTREAM } from
 import { ScopeJsonNotFound } from '../../src/scope/exceptions';
 import { InvalidBitMap } from '../../src/consumer/bit-map/exceptions';
 import { InvalidBitJson } from '../../src/consumer/config/exceptions';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import InvalidPackageJson from '../../src/consumer/config/exceptions/invalid-package-json';
 
 const assertArrays = require('chai-arrays');
@@ -328,8 +327,7 @@ describe('run bit init', function() {
         expect(path.join(helper.scopes.localPath, 'bar/foo.js')).to.be.a.file();
       });
       it('bit status should show nothing-to-tag', () => {
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
     });
   });

--- a/e2e/commands/status.e2e.2.ts
+++ b/e2e/commands/status.e2e.2.ts
@@ -6,7 +6,6 @@ import MissingFilesFromComponent from '../../src/consumer/component/exceptions/m
 import ComponentNotFoundInPath from '../../src/consumer/component/exceptions/component-not-found-in-path';
 import {
   statusInvalidComponentsMsg,
-  statusWorkspaceIsCleanMsg,
   statusFailureMsg,
   importPendingMsg
 } from '../../src/cli/commands/public-cmds/status-cmd';
@@ -41,8 +40,7 @@ describe('bit status command', function() {
       helper.scopeHelper.initWorkspace();
     });
     it('should indicate that there are no components', () => {
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
   });
 
@@ -53,8 +51,7 @@ describe('bit status command', function() {
       helper.fs.createFile(path.join('components', 'bar'), 'foo.js');
     });
     it('should indicate that there are no components and should not throw an error', () => {
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
   });
   describe('when a component is created and added but not tagged', () => {

--- a/e2e/flows/cyclic-dependencies.e2e.2.ts
+++ b/e2e/flows/cyclic-dependencies.e2e.2.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 
 const fixtureA = `const b = require('./b');
 console.log('got ' + b() + ' and got A')`;
@@ -70,8 +69,7 @@ describe('cyclic dependencies', function() {
           expect(list).to.have.string('comp/b');
         });
         it('should not show a clean workspace', () => {
-          const statusOutput = helper.command.runCmd('bit status');
-          expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
       });
     });
@@ -265,8 +263,7 @@ describe('cyclic dependencies', function() {
           expect(list).to.have.string('comp/a1');
         });
         it('should not show a clean workspace', () => {
-          const statusOutput = helper.command.runCmd('bit status');
-          expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
       });
     });

--- a/e2e/flows/dependencies-as-packages.e2e.2.ts
+++ b/e2e/flows/dependencies-as-packages.e2e.2.ts
@@ -4,7 +4,6 @@ import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { componentIssuesLabels } from '../../src/cli/templates/component-issues-template';
 
 chai.use(require('chai-fs'));
@@ -109,8 +108,7 @@ chai.use(require('chai-fs'));
           expect(path.join(basePath, `${helper.scopes.remote}.utils.is-type`, 'is-type.js')).to.be.a.file();
         });
         it('bit status should not show any error', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('should be able to require its direct dependency and print results from all dependencies', () => {
           const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
@@ -155,8 +153,7 @@ chai.use(require('chai-fs'));
             expect(packages).to.include(`@ci/${helper.scopes.remote}.utils.is-type`);
           });
           it('bit status should not show any error', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           describe('bit checkout all components to an older version', () => {
             let checkoutOutput;
@@ -365,8 +362,7 @@ chai.use(require('chai-fs'));
           helper.command.importComponent('bar/foo');
         });
         it('bit status should not show any error', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('should be able to require its direct dependency and print results from all dependencies', () => {
           const appJsFixture = "const barFoo = require('./components/bar/foo'); console.log(barFoo());";
@@ -394,8 +390,7 @@ chai.use(require('chai-fs'));
             helper.command.importComponent('bar/foo');
           });
           it('bit status should not show any error', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           describe('running bit link after deleting the symlink from dist directory', () => {
             let symlinkPath;

--- a/e2e/flows/import-package-json.e2e.3.ts
+++ b/e2e/flows/import-package-json.e2e.3.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import { WRAPPER_DIR } from '../../src/constants';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 
 const fixturePackageJson = { name: 'nice-package' };
 const fixturePackageJsonV2 = { name: 'nice-package-v2' }; // name must be valid, otherwise, npm skips it and install from nested dirs
@@ -56,16 +55,14 @@ describe('component with package.json as a file of the component', function() {
       expect(componentMap.wrapDir).to.equal(WRAPPER_DIR);
     });
     it('bit status should not show the component as modified', () => {
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     describe('having files in the rootDir outside the wrapDir', () => {
       before(() => {
         helper.fs.createFile('components/foo/pkg', 'bar.js');
       });
       it('should not automatically add them to the component', () => {
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
       it('should prevent users from deliberately adding them', () => {
         const output = helper.command.addComponent('components/foo/pkg/bar.js', { i: 'foo/pkg' });
@@ -111,8 +108,7 @@ describe('component with package.json as a file of the component', function() {
       expect(componentMap).to.not.have.property('originallySharedDir');
     });
     it('bit status should not show the component as modified', () => {
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     describe('importing the component using isolated environment', () => {
       let isolatePath;
@@ -189,8 +185,7 @@ describe('component with package.json as a file of the component', function() {
         helper.command.importComponent('foo/pkg');
 
         // an intermediate step, make sure the components are not modified
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
 
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         helper.fs.createJsonFile(`components/foo/pkg/${WRAPPER_DIR}/package.json`, fixturePackageJsonV2);
@@ -242,8 +237,7 @@ describe('component with package.json as a file of the component', function() {
           expect(packageJson.name).to.equal(fixturePackageJsonV2.name);
         });
         it('should not show the component as modified', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         describe('running bit link', () => {
           before(() => {
@@ -254,8 +248,7 @@ describe('component with package.json as a file of the component', function() {
             expect(packageJson.name).to.equal(fixturePackageJsonV2.name);
           });
           it('should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
       });

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { statusWorkspaceIsCleanMsg, importPendingMsg } from '../../src/cli/commands/public-cmds/status-cmd';
+import { importPendingMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { MissingBitMapComponent } from '../../src/consumer/bit-map/exceptions';
 import ComponentsPendingImport from '../../src/consumer/component-ops/exceptions/components-pending-import';
 
@@ -88,13 +88,12 @@ describe('components that are not synced between the scope and the consumer', fu
       });
     });
     describe('bit status', () => {
-      let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(scopeOutOfSync);
-        output = helper.command.status();
+        helper.command.status();
       });
       it('should sync .bitmap according to the scope', () => {
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
         const bitMap = helper.bitMap.read();
         const newId = `${helper.scopes.remote}/bar/foo@0.0.1`;
         expect(bitMap).to.have.property(newId);
@@ -121,13 +120,12 @@ describe('components that are not synced between the scope and the consumer', fu
       });
     });
     describe('bit status', () => {
-      let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(scopeOutOfSync);
-        output = helper.command.status();
+        helper.command.status();
       });
       it('should sync .bitmap according to the scope', () => {
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
         const bitMap = helper.bitMap.read();
         const newId = `${helper.scopes.remote}/bar/foo@0.0.1`;
         expect(bitMap).to.have.property(newId);
@@ -374,12 +372,11 @@ describe('components that are not synced between the scope and the consumer', fu
         scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
       });
       describe('bit status', () => {
-        let output;
         before(() => {
-          output = helper.command.status();
+          helper.command.status();
         });
         it('should sync .bitmap according to the latest version of the scope', () => {
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
           const bitMap = helper.bitMap.read();
           const newId = `${helper.scopes.remote}/bar/foo@0.0.1`;
           expect(bitMap).to.have.property(newId);

--- a/e2e/flows/pad-left-and-is-string.e2e.3.ts
+++ b/e2e/flows/pad-left-and-is-string.e2e.3.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import * as path from 'path';
 import Helper, { FileStatusWithoutChalk } from '../../src/e2e-helper/e2e-helper';
 import { failureEjectMessage } from '../../src/cli/templates/eject-template';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 
 chai.use(require('chai-fs'));
@@ -466,8 +465,7 @@ describe('a flow with two components: is-string and pad-left, where is-string is
           helper.command.importComponent('string/pad-left');
         });
         it('should not show the component as modified', () => {
-          const status = helper.command.status();
-          expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         describe('re-import for author after changing the overrides of the imported', () => {
           before(() => {

--- a/e2e/functionalities/auto-tagging.e2e.2.ts
+++ b/e2e/functionalities/auto-tagging.e2e.2.ts
@@ -3,7 +3,6 @@ import * as path from 'path';
 import fs from 'fs-extra';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { AUTO_TAGGED_MSG } from '../../src/cli/commands/public-cmds/tag-cmd';
 
 chai.use(require('chai-fs'));
@@ -539,8 +538,7 @@ describe('auto tagging functionality', function() {
       helper.command.importComponent('bar/c');
 
       // as an intermediate step, make sure the re-link done by import C, didn't break anything
-      const output = helper.command.runCmd('bit status');
-      expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
 
       helper.fs.createFile('components/bar/c', 'c.js', 'console.log("I am C v2")');
     });

--- a/e2e/functionalities/binary-files.e2e.2.ts
+++ b/e2e/functionalities/binary-files.e2e.2.ts
@@ -3,7 +3,6 @@ import fs from 'fs-extra';
 import glob from 'glob';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 import { AUTO_GENERATED_STAMP } from '../../src/constants';
 
@@ -132,8 +131,7 @@ describe('binary files', function() {
       expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
-      const status = helper.command.status();
-      expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
   });
   describe('import a PNG file as a dependency with custom-resolve-modules', () => {
@@ -171,8 +169,7 @@ describe('binary files', function() {
       expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
-      const status = helper.command.status();
-      expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     (supportNpmCiRegistryTesting ? describe : describe.skip)('when dependencies are saved as packages', () => {
       let barFooPath;
@@ -237,8 +234,7 @@ describe('binary files', function() {
       expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
-      const status = helper.command.status();
-      expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     (supportNpmCiRegistryTesting ? describe : describe.skip)('when dependencies are saved as packages', () => {
       let barFooPath;
@@ -324,8 +320,7 @@ describe('binary files', function() {
       expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
-      const status = helper.command.status();
-      expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     (supportNpmCiRegistryTesting ? describe : describe.skip)('when dependencies are saved as packages', () => {
       let barFooPath;
@@ -423,8 +418,7 @@ describe('binary files', function() {
       expect(symlinkValue).to.be.a.path();
     });
     it('bit-status should not show the component as modified', () => {
-      const status = helper.command.status();
-      expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
     (supportNpmCiRegistryTesting ? describe : describe.skip)('when dependencies are saved as packages', () => {
       let barFooPath;

--- a/e2e/functionalities/component-config.e2e.2.ts
+++ b/e2e/functionalities/component-config.e2e.2.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 
 chai.use(require('chai-fs'));
 
@@ -175,8 +174,7 @@ describe('component config', function() {
         helper.fs.deletePath('components/bar/foo/package.json');
       });
       it('bit status should not throw an error', () => {
-        const status = helper.command.status();
-        expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
     });
   });

--- a/e2e/functionalities/dev-dependencies.e2e.2.ts
+++ b/e2e/functionalities/dev-dependencies.e2e.2.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import * as fixtures from '../../src/fixtures/fixtures';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 
 chai.use(require('chai-fs'));
@@ -198,8 +197,7 @@ describe('foo', () => {
       expect(output).to.have.string('successfully imported');
     });
     it('bit status should show a clean state', () => {
-      const statusOutput = helper.command.runCmd('bit status');
-      expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
+      helper.command.expectStatusToBeClean();
     });
   });
   describe('dev-dependency that requires prod-dependency', () => {

--- a/e2e/functionalities/env-dependencies.e2e.3.ts
+++ b/e2e/functionalities/env-dependencies.e2e.3.ts
@@ -1,11 +1,7 @@
 import chai, { expect } from 'chai';
 import * as path from 'path';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import {
-  statusFailureMsg,
-  statusInvalidComponentsMsg,
-  statusWorkspaceIsCleanMsg
-} from '../../src/cli/commands/public-cmds/status-cmd';
+import { statusFailureMsg, statusInvalidComponentsMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 
 chai.use(require('chai-fs'));
 
@@ -153,8 +149,7 @@ describe('environments with dependencies', function() {
           expect(output).to.have.string('webpack/base');
         });
         it('should not show the component as modified', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('should generate the links for environment components', () => {
           const linkFile = path.join(helper.scopes.localPath, 'components/bar/foo/base.config.js');
@@ -174,8 +169,7 @@ describe('environments with dependencies', function() {
             helper.command.ejectConf('bar/foo');
           });
           it('still should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
         // @todo: this has been skipped temporarily since the change of overriding envs via package.json, see PR #1576
@@ -186,8 +180,7 @@ describe('environments with dependencies', function() {
             helper.command.ejectConf('bar/foo -p my-conf-dir');
           });
           it('still should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
         // @todo: this has been skipped temporarily since the change of overriding envs via package.json, see PR #1576
@@ -198,8 +191,7 @@ describe('environments with dependencies', function() {
             helper.command.ejectConf('bar/foo -p {COMPONENT_DIR}/my-inner-dir');
           });
           it('still should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
         describe('importing with --conf flag', () => {
@@ -213,8 +205,7 @@ describe('environments with dependencies', function() {
             helper.command.importComponent('bar/foo --conf');
           });
           it('should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           it('should generate the links for environment component', () => {
             expect(linkFile).to.be.a.file();
@@ -237,8 +228,7 @@ describe('environments with dependencies', function() {
             helper.command.importComponent('bar/foo --conf my-config-dir');
           });
           it('should not show the component as modified', () => {
-            const output = helper.command.runCmd('bit status');
-            expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           it('should generate the links for environment component', () => {
             const linkFile = path.join(helper.scopes.localPath, 'my-config-dir/base.config.js');

--- a/e2e/functionalities/envs.e2e.3.ts
+++ b/e2e/functionalities/envs.e2e.3.ts
@@ -10,7 +10,6 @@ import EjectNoDir from '../../src/consumer/component-ops/exceptions/eject-no-dir
 import { MissingBitMapComponent } from '../../src/consumer/bit-map/exceptions';
 import InvalidConfigDir from '../../src/consumer/bit-map/exceptions/invalid-config-dir';
 import { COMPONENT_DIR, BIT_WORKSPACE_TMP_DIRNAME, COMPILER_ENV_TYPE, TESTER_ENV_TYPE } from '../../src/constants';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import InjectNonEjected from '../../src/consumer/component/exceptions/inject-non-ejected';
 import { _verboseMsg as abstractVinylVerboseMsg } from '../../src/consumer/component/sources/abstract-vinyl';
 import ExtensionSchemaError from '../../src/extensions/exceptions/extension-schema-error';
@@ -516,9 +515,7 @@ describe('envs', function() {
         // Restore to clean state of the scope
         helper.scopeHelper.getClonedLocalScope(authorScopeBeforeChanges);
         // Make sure the component is not modified before the changes
-        const statusOutput = helper.command.status();
-        expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
-        expect(statusOutput).to.not.have.string('modified');
+        helper.command.expectStatusToBeClean();
       });
       describe('changing config files', () => {
         it('should show the component as modified after changing compiler config files', () => {
@@ -607,9 +604,7 @@ describe('envs', function() {
       });
       it('should not show the component as modified after import', () => {
         // Make sure the component is not modified before the changes
-        const statusOutput = helper.command.status();
-        expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
-        expect(statusOutput).to.not.have.string('modified');
+        helper.command.expectStatusToBeClean();
       });
       it("should add the envPackageDependencies to devDependencies in component's package.json", () => {
         const packageJson = helper.packageJson.readComponentPackageJson('comp/my-comp');
@@ -1469,9 +1464,7 @@ describe('envs', function() {
           });
           // @todo: this has been skipped temporarily since the change of overriding envs via package.json, see PR #1576
           it.skip('should not show the component as modified', () => {
-            const statusOutput = helper.command.status();
-            expect(statusOutput).to.have.string(statusWorkspaceIsCleanMsg);
-            expect(statusOutput).to.not.have.string('modified');
+            helper.command.expectStatusToBeClean();
           });
         });
         describe('change envs files', () => {
@@ -1599,8 +1592,7 @@ describe('envs with relative paths', function() {
         expect(path.join(helper.scopes.localPath, 'components/bar/foo/dev.config.js')).to.be.a.file();
       });
       it('should not show the component as modified', () => {
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
     });
   });

--- a/e2e/functionalities/peer-dependencies.e2e.3.ts
+++ b/e2e/functionalities/peer-dependencies.e2e.3.ts
@@ -2,7 +2,6 @@ import * as path from 'path';
 import fs from 'fs-extra';
 import { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 
 describe('peer-dependencies functionality', function() {
   this.timeout(0);
@@ -53,8 +52,7 @@ describe('peer-dependencies functionality', function() {
         helper.npm.addNpmPackage('chai', '2.4'); // it's not automatically installed because it's a peer-dependency
       });
       it('should not be shown as modified', () => {
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+        helper.command.expectStatusToBeClean();
       });
       describe('and the package.json of the component was changed to remove the peerDependencies', () => {
         before(() => {
@@ -73,8 +71,7 @@ describe('peer-dependencies functionality', function() {
           fs.removeSync(path.join(helper.scopes.localPath, 'components/bar/foo/package.json'));
         });
         it('should not be shown as modified', () => {
-          const output = helper.command.runCmd('bit status');
-          expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
       });
     });

--- a/e2e/functionalities/workspace-config.e2e.3.ts
+++ b/e2e/functionalities/workspace-config.e2e.3.ts
@@ -706,7 +706,8 @@ describe('workspace config', function() {
               helper.packageJson.write(packageJson, barRoot);
             });
             it('bit status should show the component as modified', () => {
-              helper.command.expectStatusToBeClean();
+              const status = helper.command.status();
+              expect(status).to.have.string('modified components');
             });
             it('should show the previously ignored dependency as a missing component', () => {
               const status = helper.command.status();

--- a/e2e/functionalities/workspace-config.e2e.3.ts
+++ b/e2e/functionalities/workspace-config.e2e.3.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { statusFailureMsg, statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
+import { statusFailureMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { OVERRIDE_COMPONENT_PREFIX, OVERRIDE_FILE_PREFIX } from '../../src/constants';
 import { MISSING_PACKAGES_FROM_OVERRIDES_LABEL } from '../../src/cli/templates/component-issues-template';
 
@@ -693,8 +693,7 @@ describe('workspace config', function() {
             expect(packageJson.bit.overrides.dependencies[`${OVERRIDE_COMPONENT_PREFIX}foo2`]).to.equal('-');
           });
           it('bit status should not show the component as modified', () => {
-            const status = helper.command.status();
-            expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
           it('bit diff should not show any diff', () => {
             const diff = helper.command.diff('bar');
@@ -707,8 +706,7 @@ describe('workspace config', function() {
               helper.packageJson.write(packageJson, barRoot);
             });
             it('bit status should show the component as modified', () => {
-              const status = helper.command.status();
-              expect(status).to.not.have.string(statusWorkspaceIsCleanMsg);
+              helper.command.expectStatusToBeClean();
             });
             it('should show the previously ignored dependency as a missing component', () => {
               const status = helper.command.status();
@@ -779,8 +777,7 @@ describe('workspace config', function() {
           scopeAfterReImport = helper.scopeHelper.cloneLocalScope();
         });
         it('bit status should not show the component as modified', () => {
-          const status = helper.command.status();
-          expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('should save the new overrides to the consumer config', () => {
           const bitJson = helper.bitJson.read();
@@ -1073,8 +1070,7 @@ describe('workspace config', function() {
               });
             });
             it('bit status should show a clean state', () => {
-              const status = helper.command.status();
-              expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+              helper.command.expectStatusToBeClean();
             });
             describe('changing the component name in the overrides to a package syntax', () => {
               before(() => {
@@ -1116,8 +1112,7 @@ describe('workspace config', function() {
                   helper.command.importComponent('bar');
                 });
                 it('bit status should show a clean state', () => {
-                  const status = helper.command.status();
-                  expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+                  helper.command.expectStatusToBeClean();
                 });
                 it('should remove the added dependencies from consumer-config', () => {
                   const bitJson = helper.bitJson.read();
@@ -1199,8 +1194,7 @@ describe('workspace config', function() {
             expect(packageJson.bit.overrides.dependencies).to.deep.equal({ [`${OVERRIDE_COMPONENT_PREFIX}foo`]: '+' });
           });
           it('bit status should show a clean state', () => {
-            const status = helper.command.status();
-            expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+            helper.command.expectStatusToBeClean();
           });
         });
       });
@@ -1383,8 +1377,7 @@ describe('workspace config', function() {
           helper.bitJson.addOverrides(overrides);
         });
         it('bit status should not show the component as modified', () => {
-          const status = helper.command.status();
-          expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         it('bit diff should not show any diff', () => {
           const diff = helper.command.diff('bar/foo');
@@ -1431,8 +1424,7 @@ describe('workspace config', function() {
             .that.equals('my-bin-file.js');
         });
         it('should not show the component as modified', () => {
-          const status = helper.command.status();
-          expect(status).to.have.string(statusWorkspaceIsCleanMsg);
+          helper.command.expectStatusToBeClean();
         });
         describe('changing the value in the package.json directly (not inside overrides)', () => {
           before(() => {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -204,6 +204,13 @@ export default class CommandHelper {
     return JSON.parse(status);
   }
 
+  expectStatusToBeClean() {
+    const statusJson = this.statusJson();
+    Object.keys(statusJson).forEach(key => {
+      expect(statusJson[key], `status.${key} should be empty`).to.have.lengthOf(0);
+    });
+  }
+
   statusComponentIsStaged(id: string): boolean {
     const status = this.statusJson();
     return status.stagedComponents.includes(id);


### PR DESCRIPTION
Instead, use the --json flag to parse the status results.
This is done to prevent CLI styling from affecting the test results. Specifically, this is fixing React/Ink adding '\n' in the status output in the Harmony branch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2550)
<!-- Reviewable:end -->
