### PR TITLE
avoid running multiple instances of npm & yarn in parallel

### DIFF
--- a/e2e/platforms/vue.e2e.3.ts
+++ b/e2e/platforms/vue.e2e.3.ts
@@ -102,16 +102,15 @@ describe('support vue files', function() {
         helper.command.runCmd('npm i fuzzysearch');
       });
 
-      // tests are flaky for some reason.
-      it.skip('should find missing vue dependencies', () => {
+      it('should find missing vue dependencies', () => {
         const output = helper.command.tagAllComponents();
         expect(output).to.have.string('9 component(s) tagged');
       });
-      it.skip('should export tagged components', () => {
+      it('should export tagged components', () => {
         const output = helper.command.exportAllComponents();
         expect(output).to.have.string(`exported 9 components to scope ${helper.scopes.remote}`);
       });
-      it.skip('should import component', () => {
+      it('should import component', () => {
         helper.scopeHelper.reInitLocalScope();
         helper.scopeHelper.addRemoteScope(helper.scopes.remotePath);
         const output = helper.command.importComponent('vue/ui-autocomplete');


### PR DESCRIPTION
This has been fixed in the past for the workspace. Now it's been an issue on the capsules.
When running `Promise.all` of `npm install` on multiple capsules, it fails randomly.
The reason is that capsules are connected to each other by the file paths in their `dependencies` prop of the package.json. As a result, npm ends up running on the same directory with multiple instances and depends on the exact point when it happens it can fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2569)
<!-- Reviewable:end -->
