### PR TITLE
Fix react-docs to preserve spaces/tabs of @example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2512](https://github.com/teambit/bit/issues/2512) - fix react-docs to preserve spaces/tabs of `@example`
+
 ## [[14.7.7-dev.3] - 2020-03-31]
 
 - support react-docs of multiple exports

--- a/fixtures/jsdoc/react/react-docs.js
+++ b/fixtures/jsdoc/react/react-docs.js
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types';
  * @description Styled button component for the rich and famous!
  *
  * @example
- * <Button text="Example button text" buttonColor="red" buttonHoverColor="green" />
+ * <Button
+ *   text="Example button text"
+ *   buttonColor="red"
+ *   buttonHoverColor="green"
+ * />
  */
 
 class Button extends Component {

--- a/src/jsdoc/extract-data-regex.ts
+++ b/src/jsdoc/extract-data-regex.ts
@@ -29,8 +29,8 @@ function formatTag(tag: Record<string, any>): Record<string, any> {
   return tag;
 }
 
-export default function extractDataRegex(doc: string, doclets: Array<Doclet>, filePath?: PathOsBased) {
-  const commentsAst = doctrine.parse(doc.trim(), { unwrap: true, recoverable: true, sloppy: true });
+export default function extractDataRegex(doc: string, doclets: Array<Doclet>, filePath?: PathOsBased, unwrap = true) {
+  const commentsAst = doctrine.parse(doc.trim(), { unwrap, recoverable: true, sloppy: true });
   if (!commentsAst) return;
 
   const args = [];

--- a/src/jsdoc/react/react-parser.spec.ts
+++ b/src/jsdoc/react/react-parser.spec.ts
@@ -45,6 +45,10 @@ describe('React docs Parser', () => {
           .that.is.an('array')
           .with.lengthOf(1);
       });
+      it('should preserve the spaces in the example', () => {
+        const example = doclet.examples[0].raw;
+        expect(example).to.string('  text');
+      });
       it('should parse the properties description correctly', () => {
         expect(doclet)
           .to.have.property('properties')

--- a/src/jsdoc/react/react-parser.ts
+++ b/src/jsdoc/react/react-parser.ts
@@ -106,7 +106,7 @@ export default async function parse(data: string, filePath?: PathOsBased): Promi
         // this is a workaround to get the 'example' tag parsed when using react-docs
         // because as of now Docgen doesn't parse @example tag, instead, it shows it inside
         // the @description tag.
-        extractDataRegex(formatted.description, doclets, filePath);
+        extractDataRegex(formatted.description, doclets, filePath, false);
         formatted.description = doclets[0].description;
         formatted.examples = doclets[0].examples;
         return formatted;


### PR DESCRIPTION
Fixes #2512 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2577)
<!-- Reviewable:end -->
