### PR TITLE
avoid suppressing errors of BitObject.parse()

### DIFF
--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -102,11 +102,11 @@ export default class Repository {
         return parsedObject;
       })
       .catch(err => {
-        if (err.code === 'ENOENT') {
-          logger.silly(`Failed finding a ref file ${this.objectPath(ref)}.`);
-        } else {
+        if (err.code !== 'ENOENT') {
           logger.error(`Failed reading a ref file ${this.objectPath(ref)}. Error: ${err.message}`);
+          throw err;
         }
+        logger.silly(`Failed finding a ref file ${this.objectPath(ref)}.`);
         if (throws) throw err;
         return null;
       });


### PR DESCRIPTION
Currently, it's hard to find errors happening during the parse phase of a BitObject.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2579)
<!-- Reviewable:end -->
