### PR TITLE
make extensions work on imported components

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -157,6 +157,7 @@ export const IGNORE_LIST = [
   '**/node_modules/**',
   '**/package-lock.json',
   '**/yarn.lock',
+  '**/librarian-manifests.json',
   '**/LICENSE'
 ];
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -1180,13 +1180,14 @@ export default class Component {
       workspaceConfig
     });
 
-    const extensions: ExtensionDataList = componentConfig.extensions;
-    const extensionsAddedConfig = componentConfig.extensionsAddedConfig;
     // by default, imported components are not written with bit.json file.
     // use the component from the model to get their bit.json values
     if (componentFromModel) {
       componentConfig.mergeWithComponentData(componentFromModel);
     }
+
+    const extensions: ExtensionDataList = componentConfig.extensions;
+    const extensionsAddedConfig = componentConfig.extensionsAddedConfig;
 
     const envsContext = {
       componentDir: bitDir,

--- a/src/consumer/config/component-config.ts
+++ b/src/consumer/config/component-config.ts
@@ -125,6 +125,7 @@ export default class ComponentConfig extends AbstractConfig {
   mergeWithComponentData(component: Component) {
     this.bindingPrefix = this.bindingPrefix || component.bindingPrefix;
     this.lang = this.lang || component.lang;
+    this.extensions = this.extensions.length ? this.extensions : component.extensions;
   }
 
   /**

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import { find, forEachObjIndexed } from 'ramda';
+import R, { find, forEachObjIndexed } from 'ramda';
 import { BitId } from '../../bit-id';
 import Consumer from '../consumer';
 import { ExtensionConfigList } from './extension-config-list';
@@ -30,6 +30,16 @@ export class ExtensionDataEntry {
   get isLegacy(): boolean {
     if (this.config?.__legacy) return true;
     return false;
+  }
+
+  clone(): ExtensionDataEntry {
+    return new ExtensionDataEntry(
+      this.legacyId,
+      this.extensionId?.clone(),
+      this.name,
+      R.clone(this.config),
+      R.clone(this.data)
+    );
   }
 }
 
@@ -76,6 +86,11 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
       };
     });
     return ExtensionConfigList.fromArray(arr);
+  }
+
+  clone(): ExtensionDataList {
+    const extensionDataEntries = this.map(extensionData => extensionData.clone());
+    return new ExtensionDataList(...extensionDataEntries);
   }
 
   _filterLegacy(): ExtensionDataList {

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -42,6 +42,16 @@ export default class BitJsoncHelper {
 
     this.addKeyVal(bitJsoncDir, 'variants', variants);
   }
+
+  addKeyValToWorkspace(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
+    const bitJsonc = this.read(bitJsoncDir);
+    bitJsonc.workspace[key] = val;
+    this.write(bitJsonc, bitJsoncDir);
+  }
+
+  addDefaultScope(scope = this.scopes.remote) {
+    this.addKeyValToWorkspace('defaultScope', scope);
+  }
 }
 
 function composePath(dir: string): string {

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -70,6 +70,12 @@ export default class ScopeHelper {
     return this.command.runCmd(`bit init -p ${this.packageManager}`, workspacePath);
   }
 
+  initWorkspaceAndRemoteScope(workspacePath?: string) {
+    this.initWorkspace(workspacePath);
+    this.reInitRemoteScope();
+    this.addRemoteScope();
+  }
+
   async initInteractive(inputs: InteractiveInputs) {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.command.runInteractiveCmd({ args: ['init', '--interactive'], inputs });

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -436,7 +436,7 @@ export default class Component extends BitObject {
       packageJsonChangedProps: clone(version.packageJsonChangedProps),
       deprecated: this.deprecated,
       scopesList: clone(this.scopesList),
-      extensions: clone(version.extensions)
+      extensions: version.extensions.clone()
     });
     if (manipulateDirData) {
       consumerComponent.stripOriginallySharedDir(manipulateDirData);


### PR DESCRIPTION
- makes sure the extension's objects are imported.
- prevent showing an imported component with extensions as modified.
- load the extensions data from the model if not exists on the file-system.
- add an e2e-test to verify that `bit compile` works on an imported component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2580)
<!-- Reviewable:end -->
