### PR TITLE
Remove extensions from devDependencies

### DIFF
--- a/e2e/harmony/extensions-config.e2e.3.ts
+++ b/e2e/harmony/extensions-config.e2e.3.ts
@@ -59,8 +59,8 @@ describe('harmony extension config', function() {
       describe('extension is new component on the workspace', () => {
         it('should not allow tagging the component without tagging the extensions', () => {
           output = helper.general.runWithTryCatch('bit tag bar/foo');
-          expect(output).to.have.string('has a dependency "dummy-extension"');
-          expect(output).to.have.string('this dependency was not included in the tag command');
+          expect(output).to.have.string('has an extension "dummy-extension"');
+          expect(output).to.have.string('this extension was not included in the tag command');
         });
         describe('tagging extension and component together', () => {
           let componentModel;
@@ -77,10 +77,8 @@ describe('harmony extension config', function() {
           it('should persist extension config during tag', () => {
             expect(componentModel.extensions[0].config).to.deep.equal(config);
           });
-          it('should insert extensions into the component dev deps', () => {
-            expect(componentModel.devDependencies).to.be.of.length(1);
-            expect(componentModel.devDependencies[0].id.name).to.equal('dummy-extension');
-            expect(componentModel.devDependencies[0].id.version).to.equal('0.0.1');
+          it('should not insert extensions into the component dev deps', () => {
+            expect(componentModel.devDependencies).to.be.of.length(0);
           });
           it('should auto tag the component when tagging the extension again', () => {
             output = helper.command.tagComponent('dummy-extension', 'message', '-f');
@@ -101,10 +99,8 @@ describe('harmony extension config', function() {
           it('should have version for extension in the component models when tagging the extension before component', () => {
             expect(componentModel.extensions[0].extensionId.version).to.equal('0.0.1');
           });
-          it('should insert extensions into the component dev deps', () => {
-            expect(componentModel.devDependencies).to.be.of.length(1);
-            expect(componentModel.devDependencies[0].id.name).to.equal('dummy-extension');
-            expect(componentModel.devDependencies[0].id.version).to.equal('0.0.1');
+          it('should not insert extensions into the component dev deps', () => {
+            expect(componentModel.devDependencies).to.be.of.length(0);
           });
         });
         describe('exporting component with extension', () => {

--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -14,6 +14,7 @@ export default (async function loadFlattenedDependenciesForCapsule(
   const devDependencies = await loadManyDependencies(component.devDependencies.getAllIds());
   const compilerDependencies = await loadManyDependencies(component.compilerDependencies.getAllIds());
   const testerDependencies = await loadManyDependencies(component.testerDependencies.getAllIds());
+  const extensionDependencies = await loadManyDependencies(component.extensions.extensionsBitIds);
 
   await loadFlattened(dependencies);
   await loadFlattened(devDependencies);
@@ -25,7 +26,8 @@ export default (async function loadFlattenedDependenciesForCapsule(
     dependencies,
     devDependencies,
     compilerDependencies,
-    testerDependencies
+    testerDependencies,
+    extensionDependencies
   });
 
   async function loadManyDependencies(dependenciesIds: BitId[]): Promise<Component[]> {

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -11,7 +11,6 @@ import { DependencyResolver, updateDependenciesVersions } from './dependencies/d
 import { getScopeRemotes } from '../../scope/scope-remotes';
 import { ModelComponent } from '../../scope/models';
 import ComponentsPendingImport from '../component-ops/exceptions/components-pending-import';
-import { Dependency } from './dependencies';
 
 export default class ComponentLoader {
   _componentsCache: Record<string, any> = {}; // cache loaded components

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -127,24 +127,12 @@ export default class ComponentLoader {
       return component;
     }
     const loadDependencies = async () => {
-      const addExtensionsAsDevDependencies = componentToMutate => {
-        // TODO: in case there are core extensions they should be excluded here
-        componentToMutate.extensions.forEach(ext => {
-          const extId = ext.extensionId;
-          // For core extensions there won't be an extensionId but name
-          // We only want to add external extensions to the dev deps
-          if (extId) {
-            componentToMutate.devDependencies.add(new Dependency(extId, []));
-          }
-        });
-      };
       const dependencyResolver = new DependencyResolver(component, this.consumer, id);
       await dependencyResolver.loadDependenciesForComponent(
         bitDir,
         this.cacheResolvedDependencies,
         this.cacheProjectAst
       );
-      addExtensionsAsDevDependencies(component);
       updateDependenciesVersions(this.consumer, component);
     };
     try {

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -486,7 +486,7 @@ export default class Component {
   get depsIdsGroupedByType(): { dependencies: BitIds; devDependencies: BitIds; extensionDependencies: BitIds } {
     return {
       dependencies: this.dependencies.getAllIds(),
-      devDependencies: this.dependencies.getAllIds(),
+      devDependencies: this.devDependencies.getAllIds(),
       extensionDependencies: this.extensions.extensionsBitIds
     };
   }

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -975,12 +975,14 @@ export default class Component {
     const devDependencies = await getDependenciesComponents(getFlatten('flattenedDevDependencies'));
     const compilerDependencies = await getDependenciesComponents(getFlatten('flattenedCompilerDependencies'));
     const testerDependencies = await getDependenciesComponents(getFlatten('flattenedTesterDependencies'));
+    const extensionDependencies = await getDependenciesComponents(this.extensions.extensionsBitIds);
     return new ComponentWithDependencies({
       component: this,
       dependencies,
       devDependencies,
       compilerDependencies,
-      testerDependencies
+      testerDependencies,
+      extensionDependencies
     });
   }
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -483,6 +483,14 @@ export default class Component {
     return BitIds.fromArray(allDependencies.map(dependency => dependency.id));
   }
 
+  get depsIdsGroupedByType(): { dependencies: BitIds; devDependencies: BitIds; extensionDependencies: BitIds } {
+    return {
+      dependencies: this.dependencies.getAllIds(),
+      devDependencies: this.dependencies.getAllIds(),
+      extensionDependencies: this.extensions.extensionsBitIds
+    };
+  }
+
   hasDependencies(): boolean {
     const allDependencies = this.getAllDependencies();
     return Boolean(allDependencies.length);

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -479,8 +479,8 @@ export default class Component {
   }
 
   getAllDependenciesIds(): BitIds {
-    const allDependencies = this.getAllDependencies();
-    return BitIds.fromArray(allDependencies.map(dependency => dependency.id));
+    const allDependencies = R.flatten(Object.values(this.depsIdsGroupedByType));
+    return BitIds.fromArray(allDependencies);
   }
 
   get depsIdsGroupedByType(): { dependencies: BitIds; devDependencies: BitIds; extensionDependencies: BitIds } {
@@ -492,7 +492,7 @@ export default class Component {
   }
 
   hasDependencies(): boolean {
-    const allDependencies = this.getAllDependencies();
+    const allDependencies = this.getAllDependenciesIds();
     return Boolean(allDependencies.length);
   }
 

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -7,7 +7,6 @@ import { COMPONENT_ORIGINS, SUB_DIRECTORIES_GLOB_PATTERN } from '../../constants
 import ComponentMap from '../bit-map/component-map';
 import { pathRelativeLinux } from '../../utils';
 import Consumer from '../consumer';
-import { Dependencies } from './dependencies';
 import { pathNormalizeToLinux } from '../../utils/path';
 import getNodeModulesPathOfComponent from '../../utils/bit/component-node-modules-path';
 import { PathLinux, PathOsBasedAbsolute, PathRelative } from '../../utils/path';

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -60,37 +60,38 @@ export async function changeDependenciesToRelativeSyntax(
   dependencies: Component[]
 ): Promise<JSONFile[]> {
   const dependenciesIds = BitIds.fromArray(dependencies.map(dependency => dependency.id));
-  const updateComponentPackageJson = async (component): Promise<JSONFile | null | undefined> => {
+  const updateComponentPackageJson = async (component: Component): Promise<JSONFile | null | undefined> => {
     const componentMap = consumer.bitMap.getComponent(component.id);
     const componentRootDir = componentMap.rootDir;
     if (!componentRootDir) return null;
     const packageJsonFile = await PackageJsonFile.load(consumer.getPath(), componentRootDir);
     if (!packageJsonFile.fileExist) return null; // if package.json doesn't exist no need to update anything
-    const devDeps = getPackages(component.devDependencies, componentMap);
-    const compilerDeps = getPackages(component.compilerDependencies, componentMap);
-    const testerDeps = getPackages(component.testerDependencies, componentMap);
-    packageJsonFile.addDependencies(getPackages(component.dependencies, componentMap));
-    packageJsonFile.addDevDependencies({ ...devDeps, ...compilerDeps, ...testerDeps });
+    const devDeps = getPackages(component.devDependencies.getAllIds(), componentMap);
+    const compilerDeps = getPackages(component.compilerDependencies.getAllIds(), componentMap);
+    const testerDeps = getPackages(component.testerDependencies.getAllIds(), componentMap);
+    const extensionDeps = getPackages(component.extensions.extensionsBitIds, componentMap);
+    packageJsonFile.addDependencies(getPackages(component.dependencies.getAllIds(), componentMap));
+    packageJsonFile.addDevDependencies({ ...devDeps, ...compilerDeps, ...testerDeps, ...extensionDeps });
     return packageJsonFile.toVinylFile();
   };
   const packageJsonFiles = await Promise.all(components.map(component => updateComponentPackageJson(component)));
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return packageJsonFiles.filter(file => file);
 
-  function getPackages(deps: Dependencies, componentMap: ComponentMap) {
-    return deps.get().reduce((acc, dependency) => {
-      const dependencyId = dependency.id.toStringWithoutVersion();
-      if (dependenciesIds.searchWithoutVersion(dependency.id)) {
-        const dependencyComponent = dependencies.find(d => d.id.isEqualWithoutVersion(dependency.id));
+  function getPackages(deps: BitIds, componentMap: ComponentMap) {
+    return deps.reduce((acc, dependencyId: BitId) => {
+      const dependencyIdStr = dependencyId.toStringWithoutVersion();
+      if (dependenciesIds.searchWithoutVersion(dependencyId)) {
+        const dependencyComponent = dependencies.find(d => d.id.isEqualWithoutVersion(dependencyId));
         if (!dependencyComponent) {
           throw new Error('getDependenciesAsPackages, dependencyComponent is missing');
         }
         const dependencyComponentMap = consumer.bitMap.getComponentIfExist(dependencyComponent.id);
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        const dependencyPackageValue = getPackageDependencyValue(dependencyId, componentMap, dependencyComponentMap);
+        const dependencyPackageValue = getPackageDependencyValue(dependencyIdStr, componentMap, dependencyComponentMap);
         if (dependencyPackageValue) {
           const packageName = componentIdToPackageName(
-            dependency.id,
+            dependencyId,
             dependencyComponent.bindingPrefix,
             dependencyComponent.defaultScope
           );
@@ -114,11 +115,11 @@ export function preparePackageJsonToWrite(
   packageManager?: string
 ): { packageJson: PackageJsonFile; distPackageJson: PackageJsonFile | null | undefined } {
   logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}. override ${override.toString()}`);
-  const getBitDependencies = (dependencies: Dependencies) => {
+  const getBitDependencies = (dependencies: BitIds) => {
     if (!writeBitDependencies) return {};
-    return dependencies.get().reduce((acc, dep) => {
+    return dependencies.reduce((acc, depId: BitId) => {
       let packageDependency;
-      const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(dep.id);
+      const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(depId);
       if (capsulePaths && devCapsulePath) {
         const relative = path.relative(
           capsulePaths.getValueIgnoreScopeAndVersion(component.id) as string,
@@ -126,23 +127,29 @@ export function preparePackageJsonToWrite(
         );
         packageDependency = `file:${relative}`;
       } else {
-        packageDependency = getPackageDependency(bitMap, dep.id, component.id);
+        packageDependency = getPackageDependency(bitMap, depId, component.id);
       }
-      const packageName = componentIdToPackageName(dep.id, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
       acc[packageName] = packageDependency;
       return acc;
     }, {});
   };
-  const bitDependencies = getBitDependencies(component.dependencies);
-  const bitDevDependencies = getBitDependencies(component.devDependencies);
-  const bitCompilerDependencies = getBitDependencies(component.compilerDependencies);
-  const bitTesterDependencies = getBitDependencies(component.testerDependencies);
+  const bitDependencies = getBitDependencies(component.dependencies.getAllIds());
+  const bitDevDependencies = getBitDependencies(component.devDependencies.getAllIds());
+  const bitCompilerDependencies = getBitDependencies(component.compilerDependencies.getAllIds());
+  const bitTesterDependencies = getBitDependencies(component.testerDependencies.getAllIds());
+  const bitExtensionDependencies = getBitDependencies(component.extensions.extensionsBitIds);
   const packageJson = PackageJsonFile.createFromComponent(bitDir, component, excludeRegistryPrefix);
   const main = pathNormalizeToLinux(component.dists.calculateMainDistFile(component.mainFile));
   packageJson.addOrUpdateProperty('main', main);
   const addDependencies = (packageJsonFile: PackageJsonFile) => {
     packageJsonFile.addDependencies(bitDependencies);
-    packageJsonFile.addDevDependencies({ ...bitDevDependencies, ...bitCompilerDependencies, ...bitTesterDependencies });
+    packageJsonFile.addDevDependencies({
+      ...bitDevDependencies,
+      ...bitCompilerDependencies,
+      ...bitTesterDependencies,
+      ...bitExtensionDependencies
+    });
   };
   packageJson.setPackageManager(packageManager);
   addDependencies(packageJson);

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -66,11 +66,9 @@ export async function changeDependenciesToRelativeSyntax(
     const packageJsonFile = await PackageJsonFile.load(consumer.getPath(), componentRootDir);
     if (!packageJsonFile.fileExist) return null; // if package.json doesn't exist no need to update anything
     const devDeps = getPackages(component.devDependencies.getAllIds(), componentMap);
-    const compilerDeps = getPackages(component.compilerDependencies.getAllIds(), componentMap);
-    const testerDeps = getPackages(component.testerDependencies.getAllIds(), componentMap);
     const extensionDeps = getPackages(component.extensions.extensionsBitIds, componentMap);
     packageJsonFile.addDependencies(getPackages(component.dependencies.getAllIds(), componentMap));
-    packageJsonFile.addDevDependencies({ ...devDeps, ...compilerDeps, ...testerDeps, ...extensionDeps });
+    packageJsonFile.addDevDependencies({ ...devDeps, ...extensionDeps });
     return packageJsonFile.toVinylFile();
   };
   const packageJsonFiles = await Promise.all(components.map(component => updateComponentPackageJson(component)));
@@ -135,8 +133,6 @@ export function preparePackageJsonToWrite(
   };
   const bitDependencies = getBitDependencies(component.dependencies.getAllIds());
   const bitDevDependencies = getBitDependencies(component.devDependencies.getAllIds());
-  const bitCompilerDependencies = getBitDependencies(component.compilerDependencies.getAllIds());
-  const bitTesterDependencies = getBitDependencies(component.testerDependencies.getAllIds());
   const bitExtensionDependencies = getBitDependencies(component.extensions.extensionsBitIds);
   const packageJson = PackageJsonFile.createFromComponent(bitDir, component, excludeRegistryPrefix);
   const main = pathNormalizeToLinux(component.dists.calculateMainDistFile(component.mainFile));
@@ -145,8 +141,6 @@ export function preparePackageJsonToWrite(
     packageJsonFile.addDependencies(bitDependencies);
     packageJsonFile.addDevDependencies({
       ...bitDevDependencies,
-      ...bitCompilerDependencies,
-      ...bitTesterDependencies,
       ...bitExtensionDependencies
     });
   };

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import R, { find, forEachObjIndexed } from 'ramda';
-import { BitId } from '../../bit-id';
+import { BitId, BitIds } from '../../bit-id';
 import Consumer from '../consumer';
 import { ExtensionConfigList } from './extension-config-list';
 
@@ -47,6 +47,14 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
   get ids(): string[] {
     const list = this.map(entry => entry.stringId);
     return list;
+  }
+
+  /**
+   * returns only new 3rd party extension ids, not core, nor legacy.
+   */
+  get extensionsBitIds(): BitIds {
+    const bitIds = this.filter(entry => entry.extensionId).map(entry => entry.extensionId) as BitId[];
+    return BitIds.fromArray(bitIds);
   }
 
   findExtension(extensionId: string, ignoreVersion = false): ExtensionDataEntry | undefined {

--- a/src/extensions/isolator/write-components-to-capsules.ts
+++ b/src/extensions/isolator/write-components-to-capsules.ts
@@ -23,21 +23,20 @@ export default async function writeComponentsToCapsules(
   const capsulePaths = buildCapsulePaths(capsules);
   const writeToPath = '.';
   const componentsWithDependencies = components.map(component => {
-    const getDeps = (dependencies: Dependencies) =>
-      dependencies
-        .get()
-        .map(dep => graph.node(dep.id.toString()))
-        .map(c => c.clone());
+    const getClonedFromGraph = (id: BitId): ConsumerComponent => graph.node(id.toString()).clone();
+    const getDeps = (dependencies: Dependencies) => dependencies.get().map(dep => getClonedFromGraph(dep.id));
     const dependencies = getDeps(component.dependencies);
     const devDependencies = getDeps(component.devDependencies);
     const compilerDependencies = getDeps(component.compilerDependencies);
     const testerDependencies = getDeps(component.testerDependencies);
+    const extensionDependencies = component.extensions.extensionsBitIds.map(getClonedFromGraph);
     return new ComponentWithDependencies({
       component,
       dependencies,
       devDependencies,
       compilerDependencies,
-      testerDependencies
+      testerDependencies,
+      extensionDependencies
     });
   });
   const concreteOpts: ManyComponentsWriterParams = {

--- a/src/scope/component-dependencies.ts
+++ b/src/scope/component-dependencies.ts
@@ -7,6 +7,7 @@ export default class ComponentWithDependencies {
   devDependencies: Component[];
   compilerDependencies: Component[];
   testerDependencies: Component[];
+  extensionDependencies: Component[];
 
   constructor(props: {
     component: Component;
@@ -14,17 +15,25 @@ export default class ComponentWithDependencies {
     devDependencies: Component[];
     compilerDependencies: Component[];
     testerDependencies: Component[];
+    extensionDependencies: Component[];
   }) {
     this.component = props.component;
     this.dependencies = props.dependencies || [];
     this.devDependencies = props.devDependencies || [];
     this.compilerDependencies = props.compilerDependencies || [];
     this.testerDependencies = props.testerDependencies || [];
+    this.extensionDependencies = props.extensionDependencies || [];
   }
 
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   get allDependencies() {
-    return [...this.dependencies, ...this.devDependencies, ...this.compilerDependencies, ...this.testerDependencies];
+    return [
+      ...this.dependencies,
+      ...this.devDependencies,
+      ...this.compilerDependencies,
+      ...this.testerDependencies,
+      ...this.extensionDependencies
+    ];
   }
 
   hasDependency(id: BitId) {

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -169,6 +169,7 @@ export default class ScopeComponentsImporter {
     const devDependencies = await this.importManyWithoutDependencies(version.flattenedDevDependencies);
     const compilerDependencies = await this.importManyWithoutDependencies(version.flattenedCompilerDependencies);
     const testerDependencies = await this.importManyWithoutDependencies(version.flattenedTesterDependencies);
+    const extensionsDependencies = await this.importManyWithoutDependencies(version.extensions.extensionsBitIds);
 
     return new VersionDependencies(
       versionComp,
@@ -176,6 +177,7 @@ export default class ScopeComponentsImporter {
       devDependencies,
       compilerDependencies,
       testerDependencies,
+      extensionsDependencies,
       source
     );
   }
@@ -243,7 +245,12 @@ export default class ScopeComponentsImporter {
 
       logger.debugAndAddBreadCrumb('scope.getExternalMany', `${left.length} left. Fetching them from a remote`);
       return remotes
-        .fetch(left.map(def => def.id), this.scope, undefined, context)
+        .fetch(
+          left.map(def => def.id),
+          this.scope,
+          undefined,
+          context
+        )
         .then(componentObjects => {
           logger.debugAndAddBreadCrumb('scope.getExternalMany', 'writing them to the model');
           return this.scope.writeManyComponentsToModel(componentObjects, persist);
@@ -342,7 +349,12 @@ export default class ScopeComponentsImporter {
         `getExternalOnes: ${left.length} left. Fetching them from a remote`
       );
       return remotes
-        .fetch(left.map(def => def.id), this.scope, true, context)
+        .fetch(
+          left.map(def => def.id),
+          this.scope,
+          true,
+          context
+        )
         .then(componentObjects => {
           return this.scope.writeManyComponentsToModel(componentObjects);
         })

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -113,17 +113,21 @@ function buildGraphFromComponentsObjects(components: Component[], direction: 'no
   });
 
   // set edges
+  const setEdge = (compId: BitId, depId: BitId, depType: string) => {
+    const depIdStr = depId.toString();
+    if (direction === 'normal') {
+      graph.setEdge(compId.toString(), depIdStr, depType);
+    } else {
+      graph.setEdge(depIdStr, compId.toString(), depType);
+    }
+  };
   components.forEach((component: Component) => {
     DEPENDENCIES_TYPES.forEach(depType => {
       component[depType].get().forEach((dependency: Dependency) => {
-        const depIdStr = dependency.id.toString();
-        if (direction === 'normal') {
-          graph.setEdge(component.id.toString(), depIdStr, depType);
-        } else {
-          graph.setEdge(depIdStr, component.id.toString(), depType);
-        }
+        setEdge(component.id, dependency.id, depType);
       });
     });
+    component.extensions.extensionsBitIds.forEach(depId => setEdge(component.id, depId, 'extensionDependencies'));
   });
 
   // uncomment to print the graph content

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -2,14 +2,13 @@ import R from 'ramda';
 import graphLib, { Graph as GraphLib } from 'graphlib';
 import Graph from './graph';
 import Component from '../../consumer/component/consumer-component';
-import Dependencies, { DEPENDENCIES_TYPES } from '../../consumer/component/dependencies/dependencies';
+import Dependencies from '../../consumer/component/dependencies/dependencies';
 import loadFlattenedDependenciesForCapsule from '../../consumer/component-ops/load-flattened-dependencies';
 import ComponentWithDependencies from '../component-dependencies';
 import GeneralError from '../../error/general-error';
 import { ComponentsAndVersions } from '../scope';
 import { BitId, BitIds } from '../../bit-id';
 import { Consumer } from '../../consumer';
-import { Dependency } from '../../consumer/component/dependencies';
 import { Scope } from '..';
 
 export type AllDependenciesGraphs = {
@@ -122,12 +121,9 @@ function buildGraphFromComponentsObjects(components: Component[], direction: 'no
     }
   };
   components.forEach((component: Component) => {
-    DEPENDENCIES_TYPES.forEach(depType => {
-      component[depType].get().forEach((dependency: Dependency) => {
-        setEdge(component.id, dependency.id, depType);
-      });
+    Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
+      depIds.forEach(depId => setEdge(component.id, depId, depType));
     });
-    component.extensions.extensionsBitIds.forEach(depId => setEdge(component.id, depId, 'extensionDependencies'));
   });
 
   // uncomment to print the graph content

--- a/src/scope/graph/graph.ts
+++ b/src/scope/graph/graph.ts
@@ -5,7 +5,6 @@ import ComponentsList from '../../consumer/component/components-list';
 import Component from '../../consumer/component';
 import { ModelComponent, Version } from '../models';
 import { BitId } from '../../bit-id';
-import { DEPENDENCIES_TYPES } from '../../consumer/component/dependencies/dependencies';
 import { loadScope } from '../index';
 import Scope from '../scope';
 
@@ -38,10 +37,10 @@ export default class Graph extends GraphLib {
     const idStr = id.toString();
     // save the full BitId of a string id to be able to retrieve it later with no confusion
     if (!graph.hasNode(idStr)) graph.setNode(idStr, id);
-    DEPENDENCIES_TYPES.forEach(depType => {
-      component[depType].get().forEach(dependency => {
-        const depIdStr = dependency.id.toString();
-        if (!graph.hasNode(depIdStr)) graph.setNode(depIdStr, dependency.id);
+    Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
+      depIds.forEach(dependencyId => {
+        const depIdStr = dependencyId.toString();
+        if (!graph.hasNode(depIdStr)) graph.setNode(depIdStr, dependencyId);
         graph.setEdge(idStr, depIdStr, depType);
       });
     });
@@ -88,9 +87,9 @@ export default class Graph extends GraphLib {
     await this.addScopeComponentsAsNodes(allModelComponents, graph, workspaceComponents, onlyLatest);
     R.forEach((componentId: string) => {
       const component: Component = graph.node(componentId);
-      DEPENDENCIES_TYPES.forEach(depType => {
-        component[depType].get().forEach(dependency => {
-          const depIdStr = dependency.id.toString();
+      Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
+        depIds.forEach(dependencyId => {
+          const depIdStr = dependencyId.toString();
           if (graph.hasNode(depIdStr)) {
             graph.setEdge(componentId, depIdStr, depType);
           }

--- a/src/scope/graph/scope-graph.ts
+++ b/src/scope/graph/scope-graph.ts
@@ -3,7 +3,7 @@ import { BitId, BitIds } from '../../bit-id';
 import { ModelComponent, Version } from '../models';
 import { VERSION_DELIMITER } from '../../constants';
 import Scope from '../scope';
-import { DEPENDENCIES_TYPES, DEPENDENCIES_TYPES_UI_MAP } from '../../consumer/component/dependencies/dependencies';
+import { DEPENDENCIES_TYPES_UI_MAP } from '../../consumer/component/dependencies/dependencies';
 import Component from '../../consumer/component/consumer-component';
 import { getLatestVersionNumber } from '../../utils';
 import Consumer from '../../consumer/consumer';
@@ -159,10 +159,10 @@ export default class DependencyGraph {
     const idStr = id.toString();
     // save the full BitId of a string id to be able to retrieve it later with no confusion
     if (!graph.hasNode(idStr)) graph.setNode(idStr, id);
-    DEPENDENCIES_TYPES.forEach(depType => {
-      component[depType].get().forEach(dependency => {
-        const depIdStr = dependency.id.toString();
-        if (!graph.hasNode(depIdStr)) graph.setNode(depIdStr, dependency.id);
+    Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
+      depIds.forEach(dependencyId => {
+        const depIdStr = dependencyId.toString();
+        if (!graph.hasNode(depIdStr)) graph.setNode(depIdStr, dependencyId);
         if (reverse) {
           graph.setEdge(depIdStr, idStr, depType);
         } else {

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -255,6 +255,14 @@ export default class Version extends BitObject {
     ];
   }
 
+  get depsIdsGroupedByType(): { dependencies: BitIds; devDependencies: BitIds; extensionDependencies: BitIds } {
+    return {
+      dependencies: this.dependencies.getAllIds(),
+      devDependencies: this.dependencies.getAllIds(),
+      extensionDependencies: this.extensions.extensionsBitIds
+    };
+  }
+
   getAllDependenciesCloned(): Dependencies {
     const dependencies = [
       ...this.dependencies.getClone(),
@@ -266,7 +274,7 @@ export default class Version extends BitObject {
   }
 
   getAllDependenciesIds(): BitIds {
-    const allDependencies = this.getAllDependencies();
+    const allDependencies = R.flatten(Object.values(this.depsIdsGroupedByType));
     return BitIds.fromArray(allDependencies.map(dependency => dependency.id));
   }
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -232,6 +232,10 @@ export default class Version extends BitObject {
     );
   }
 
+  get extensionDependencies() {
+    return new Dependencies(this.extensions.extensionsBitIds.map(id => new Dependency(id, [])));
+  }
+
   getAllFlattenedDependencies(): BitIds {
     return BitIds.fromArray([
       ...this.flattenedDependencies,
@@ -246,7 +250,8 @@ export default class Version extends BitObject {
       ...this.dependencies.dependencies,
       ...this.devDependencies.dependencies,
       ...this.compilerDependencies.dependencies,
-      ...this.testerDependencies.dependencies
+      ...this.testerDependencies.dependencies,
+      ...this.extensionDependencies.dependencies
     ];
   }
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -258,7 +258,7 @@ export default class Version extends BitObject {
   get depsIdsGroupedByType(): { dependencies: BitIds; devDependencies: BitIds; extensionDependencies: BitIds } {
     return {
       dependencies: this.dependencies.getAllIds(),
-      devDependencies: this.dependencies.getAllIds(),
+      devDependencies: this.devDependencies.getAllIds(),
       extensionDependencies: this.extensions.extensionsBitIds
     };
   }
@@ -275,7 +275,7 @@ export default class Version extends BitObject {
 
   getAllDependenciesIds(): BitIds {
     const allDependencies = R.flatten(Object.values(this.depsIdsGroupedByType));
-    return BitIds.fromArray(allDependencies.map(dependency => dependency.id));
+    return BitIds.fromArray(allDependencies);
   }
 
   updateFlattenedDependency(currentId: BitId, newId: BitId) {

--- a/src/scope/version-dependencies.ts
+++ b/src/scope/version-dependencies.ts
@@ -10,6 +10,7 @@ export default class VersionDependencies {
   devDependencies: ComponentVersion[];
   compilerDependencies: ComponentVersion[];
   testerDependencies: ComponentVersion[];
+  extensionsDependencies: ComponentVersion[];
   allDependencies: ComponentVersion[];
   sourceScope: string | null | undefined;
 
@@ -19,6 +20,7 @@ export default class VersionDependencies {
     devDependencies: ComponentVersion[],
     compilerDependencies: ComponentVersion[],
     testerDependencies: ComponentVersion[],
+    extensionsDependencies: ComponentVersion[],
     sourceScope: string
   ) {
     this.component = component;
@@ -26,11 +28,13 @@ export default class VersionDependencies {
     this.devDependencies = devDependencies;
     this.compilerDependencies = compilerDependencies;
     this.testerDependencies = testerDependencies;
+    this.extensionsDependencies = extensionsDependencies;
     this.allDependencies = [
       ...this.dependencies,
       ...this.devDependencies,
       ...this.compilerDependencies,
-      ...this.testerDependencies
+      ...this.testerDependencies,
+      ...this.extensionsDependencies
     ];
     this.sourceScope = sourceScope;
   }
@@ -44,20 +48,30 @@ export default class VersionDependencies {
     const devDependenciesP = Promise.all(this.devDependencies.map(depToConsumer));
     const compilerDependenciesP = Promise.all(this.compilerDependencies.map(depToConsumer));
     const testerDependenciesP = Promise.all(this.testerDependencies.map(depToConsumer));
+    const extensionDependenciesP = Promise.all(this.extensionsDependencies.map(depToConsumer));
     const componentP = this.component.toConsumer(repo, manipulateDirData);
-    const [component, dependencies, devDependencies, compilerDependencies, testerDependencies] = await Promise.all([
+    const [
+      component,
+      dependencies,
+      devDependencies,
+      compilerDependencies,
+      testerDependencies,
+      extensionDependencies
+    ] = await Promise.all([
       componentP,
       dependenciesP,
       devDependenciesP,
       compilerDependenciesP,
-      testerDependenciesP
+      testerDependenciesP,
+      extensionDependenciesP
     ]);
     return new ComponentWithDependencies({
       component,
       dependencies,
       devDependencies,
       compilerDependencies,
-      testerDependencies
+      testerDependencies,
+      extensionDependencies
     });
   }
 


### PR DESCRIPTION
- remove extension ids from the model devDependencies. (it was implemented this way as a temporary solution. Now it's implemented the correct way).
- throw a descriptive error when tagging/exporting a component without its extension. 
- write extension dependencies into package.json as devDependencies.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2590)
<!-- Reviewable:end -->
