### PR TITLE
Fix parsing bit-id from scope to get the correct scope name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2159](https://github.com/teambit/bit/issues/2159) - fix `bit export` to not show the "fork" message when specifying an id without scope-name
 - [#2512](https://github.com/teambit/bit/issues/2512) - fix react-docs to preserve spaces/tabs of `@example`
 
 ## [[14.7.7-dev.3] - 2020-03-31]

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1261,4 +1261,22 @@ describe('bit export command', function() {
       });
     });
   });
+  describe('re-export using the component name without the scope name', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.tagAllComponents();
+      helper.command.exportAllComponents();
+      helper.command.tagComponent('bar/foo -f');
+      helper.command.exportAllComponents();
+      helper.command.tagComponent('bar/foo -f');
+      output = helper.command.exportComponent('bar/foo');
+    });
+    // this was a bug where on the third export, it parses the id "bar/foo" as: { scope: bar, name: foo }
+    it('should not show the "fork" prompt', () => {
+      expect(output).to.have.string('exported 1 components');
+    });
+  });
 });

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -376,7 +376,7 @@ describe('bit export command', function() {
       remote2 = scopeName;
       remote2Path = scopePath;
       helper.scopeHelper.addRemoteScope(scopePath);
-      helper.command.exportComponent('utils/is-string2', remote2);
+      helper.command.exportComponent('utils/is-string2', remote2, true, '--force');
     });
     it('should have is-type@0.0.2 on that remote', () => {
       const isType = helper.command.catComponent(`${helper.scopes.remote}/utils/is-type@0.0.2`, remote2Path);

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -394,7 +394,7 @@ describe('bit export command', function() {
     describe('export a component is-string1 with a dependency is-type of version 0.0.1', () => {
       before(() => {
         helper.command.importComponent('utils/is-string1');
-        output = helper.command.exportComponent('utils/is-string1', remote2);
+        output = helper.command.exportComponent('utils/is-string1', remote2, true, '--force');
       });
       it('should not throw an error saying it does not have the version 0.0.1 of the dependency', () => {
         expect(output).to.not.have.string('failed loading version 0.0.1');

--- a/e2e/commands/import.e2e.1.ts
+++ b/e2e/commands/import.e2e.1.ts
@@ -1665,7 +1665,7 @@ console.log(barFoo.default());`;
       const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
       scopeB = scopeName;
       helper.scopeHelper.addRemoteScope(scopePath);
-      helper.command.exportComponent(`${helper.scopes.remote}/utils/is-string@0.0.2`, scopeB);
+      helper.command.exportComponent(`${helper.scopes.remote}/utils/is-string@0.0.2`, scopeB, true, '--force');
       // import to a new local scope
       helper.scopeHelper.initNewLocalScope();
       helper.scopeHelper.addRemoteScope(scopePath);

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -114,7 +114,7 @@ export default class CommandHelper {
     return this.runCmd(`bit untag ${id}`);
   }
   exportComponent(id: string, scope: string = this.scopes.remote, assert = true) {
-    const result = this.runCmd(`bit export ${scope} ${id} --force`);
+    const result = this.runCmd(`bit export ${scope} ${id}`);
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -113,8 +113,8 @@ export default class CommandHelper {
   untag(id: string) {
     return this.runCmd(`bit untag ${id}`);
   }
-  exportComponent(id: string, scope: string = this.scopes.remote, assert = true) {
-    const result = this.runCmd(`bit export ${scope} ${id}`);
+  exportComponent(id: string, scope: string = this.scopes.remote, assert = true, flags = '') {
+    const result = this.runCmd(`bit export ${scope} ${id} ${flags}`);
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -15,7 +15,8 @@ import {
   SCOPE_JSON,
   COMPONENT_ORIGINS,
   NODE_PATH_SEPARATOR,
-  CURRENT_UPSTREAM
+  CURRENT_UPSTREAM,
+  LATEST
 } from '../constants';
 import { ScopeJson, getPath as getScopeJsonPath } from './scope-json';
 import { ScopeNotFound, ComponentNotFound } from './exceptions';
@@ -309,7 +310,7 @@ export default class Scope {
             component.devDependencies.isCustomResolvedUsed() ||
             component.compilerDependencies.isCustomResolvedUsed() ||
             component.testerDependencies.isCustomResolvedUsed()) &&
-          (component.componentMap && component.componentMap.origin === COMPONENT_ORIGINS.AUTHORED) &&
+          component.componentMap && component.componentMap.origin === COMPONENT_ORIGINS.AUTHORED &&
           !component.dists.isEmpty()
       );
     if (isNodePathNeeded) {
@@ -704,7 +705,7 @@ export default class Scope {
     });
   }
 
-  async loadModelComponentByIdStr(id: string): Promise<Component> {
+  async loadModelComponentByIdStr(id: string): Promise<ModelComponent> {
     // Remove the version before hashing since hashing with the version number will result a wrong hash
     const idWithoutVersion = BitId.getStringWithoutVersion(id);
     const ref = Ref.from(BitObject.makeHash(idWithoutVersion));
@@ -712,17 +713,16 @@ export default class Scope {
     return this.objects.load(ref);
   }
 
-  /**
-   * if it's not in the scope, it's probably new, we assume it doesn't have scope.
-   */
-  async isIdHasScope(id: BitIdStr): Promise<boolean> {
-    const component = await this.loadModelComponentByIdStr(id);
-    return Boolean(component && component.scope);
-  }
-
   async getParsedId(id: BitIdStr): Promise<BitId> {
-    const idHasScope = await this.isIdHasScope(id);
-    return BitId.parse(id, idHasScope);
+    const component = await this.loadModelComponentByIdStr(id);
+    const idHasScope = Boolean(component && component.scope);
+    if (!idHasScope) {
+      // if it's not in the scope, it's probably new, we assume it doesn't have scope.
+      return BitId.parse(id, false);
+    }
+    const bitId: BitId = component.toBitId();
+    const version = BitId.getVersionOnlyFromString(id);
+    return bitId.changeVersion(version || LATEST);
   }
 
   static ensure(


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/pull/2591.

See my last comment in the issue above for more info.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2591)
<!-- Reviewable:end -->
