### PR TITLE
fix an e2e-test to not interact with "bit.dev"

### DIFF
--- a/e2e/commands/import.e2e.1.ts
+++ b/e2e/commands/import.e2e.1.ts
@@ -2151,10 +2151,11 @@ console.log(barFoo.default());`;
   });
   describe('import compiler with a non-exist version', () => {
     before(() => {
-      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
     });
     it('should throw an error that a component does not exist', () => {
-      const compiler = 'bit.envs/compilers/babel@1000.0.0';
+      helper.env.importCompiler(); // makes sure the component exists. (only not the same version)
+      const compiler = `${helper.scopes.env}/compilers/babel@1000.0.1`;
       const error = new ComponentNotFound(compiler);
       const importCmd = () => helper.env.importCompiler(compiler);
       helper.general.expectToThrow(importCmd, error);

--- a/e2e/interactive/init.interactive.e2e.3.ts
+++ b/e2e/interactive/init.interactive.e2e.3.ts
@@ -67,7 +67,7 @@ describe('run bit init - interactive', function() {
       });
     }
   });
-  describe('change dir, use yarn, set compiler from bit.envs', () => {
+  describe.skip('change dir, use yarn, set compiler from bit.envs', () => {
     // Skip on windows since the interactive keys are not working on windows
     if (IS_WINDOWS || process.env.APPVEYOR === 'True') {
       // @ts-ignore


### PR DESCRIPTION
This is related to a refactor we have done a while ago to remove all tests related to bit.dev and replace them with local tests. One test seemed to be forgotten and it's fixed here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2607)
<!-- Reviewable:end -->
