### PR TITLE
Symlink dependencies to capsules 

### DIFF
--- a/e2e/api/add-many.e2e.1.ts
+++ b/e2e/api/add-many.e2e.1.ts
@@ -25,6 +25,7 @@ function sortComponentsArrayByComponentId(componentsArray) {
 }
 
 describe('bit add many programmatically', function() {
+  this.timeout(0);
   let helper: Helper;
   before(() => {
     helper = new Helper();

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -167,6 +167,9 @@ export default class ComponentWriter {
         // this only needs to be done in an isolated
         // or consumerless (dependency in an isolated) environment
         packageJson.addOrUpdateProperty('version', this._getNextPatchVersion());
+        // bit-bin should not be installed in the capsule. it'll be symlinked later on.
+        // see package-manager.linkBitBinInCapsule();
+        packageJson.removeDependency('bit-bin');
       }
 
       componentConfig.compiler = this.component.compiler ? this.component.compiler.toBitJsonObject() : {};

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -83,7 +83,7 @@ export default class ManyComponentsWriter {
   bitMap: BitMap;
   basePath?: string;
   capsulePaths?: CapsulePaths;
-  pacackgeManager?: string;
+  packageManager?: string;
   // Apply config added by extensions
   applyExtensionsAddedConfig?: boolean;
 
@@ -109,7 +109,7 @@ export default class ManyComponentsWriter {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.bitMap = this.consumer ? this.consumer.bitMap : new BitMap();
     this.capsulePaths = params.capsulePaths;
-    this.pacackgeManager = params.packageManager;
+    this.packageManager = params.packageManager;
     this.applyExtensionsAddedConfig = params.applyExtensionsAddedConfig;
     if (this.consumer && !this.isolated) this.basePath = this.consumer.getPath();
   }
@@ -169,12 +169,12 @@ export default class ManyComponentsWriter {
     const componentWriterInstances = writeComponentsParams.map(writeParams => ComponentWriter.getInstance(writeParams));
     // add componentMap entries into .bitmap before starting the process because steps like writing package-json
     // rely on .bitmap to determine whether a dependency exists and what's its origin
-    componentWriterInstances.forEach(componentWriter => {
+    componentWriterInstances.forEach((componentWriter: ComponentWriter) => {
       componentWriter.existingComponentMap =
         componentWriter.existingComponentMap || componentWriter.addComponentToBitMap(componentWriter.writeToPath);
     });
-    this.writtenComponents = await pMapSeries(componentWriterInstances, componentWriter =>
-      componentWriter.populateComponentsFilesToWrite(this.pacackgeManager)
+    this.writtenComponents = await pMapSeries(componentWriterInstances, (componentWriter: ComponentWriter) =>
+      componentWriter.populateComponentsFilesToWrite(this.packageManager)
     );
   }
   _getWriteComponentsParams(): ComponentWriterProps[] {

--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -128,6 +128,7 @@ export default class PackageJsonFile {
       },
       license: `SEE LICENSE IN ${!R.isEmpty(component.license) ? 'LICENSE' : 'UNLICENSED'}`
     };
+    if (!packageJsonObject.homepage) delete packageJsonObject.homepage;
     return new PackageJsonFile({ filePath, packageJsonObject, fileExist: false });
   }
 
@@ -151,6 +152,10 @@ export default class PackageJsonFile {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.packageJsonObject.devDependencies = Object.assign({}, this.packageJsonObject.devDependencies, dependencies);
+  }
+
+  removeDependency(dependency: string) {
+    delete this.packageJsonObject.dependencies[dependency];
   }
 
   replaceDependencies(dependencies: Record<string, any>) {

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -117,6 +117,8 @@ export function preparePackageJsonToWrite(
     return dependencies.reduce((acc, depId: BitId) => {
       let packageDependency;
       const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(depId);
+      // consider removing the next if block, when coming from a capsule, it shouldn't reach here
+      // because writeBitDependencies is false
       if (capsulePaths && devCapsulePath) {
         const relative = path.relative(
           capsulePaths.getValueIgnoreScopeAndVersion(component.id) as string,

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -1,6 +1,5 @@
 import R from 'ramda';
 import fs from 'fs-extra';
-import path from 'path';
 import { BitId, BitIds } from '../../bit-id';
 import Component from '../component/consumer-component';
 import { COMPONENT_ORIGINS, SUB_DIRECTORIES_GLOB_PATTERN } from '../../constants';
@@ -104,9 +103,8 @@ export function preparePackageJsonToWrite(
   bitMap: BitMap,
   component: Component,
   bitDir: string,
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  override? = true,
-  writeBitDependencies? = false,
+  override = true,
+  writeBitDependencies = false, // e.g. when it's a capsule
   excludeRegistryPrefix?: boolean,
   capsulePaths?: CapsulePaths,
   packageManager?: string
@@ -115,19 +113,13 @@ export function preparePackageJsonToWrite(
   const getBitDependencies = (dependencies: BitIds) => {
     if (!writeBitDependencies) return {};
     return dependencies.reduce((acc, depId: BitId) => {
-      let packageDependency;
-      const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(depId);
-      // consider removing the next if block, when coming from a capsule, it shouldn't reach here
-      // because writeBitDependencies is false
-      if (capsulePaths && devCapsulePath) {
-        const relative = path.relative(
-          capsulePaths.getValueIgnoreScopeAndVersion(component.id) as string,
-          devCapsulePath
+      if (capsulePaths) {
+        // when coming from a capsule, it shouldn't reach here because writeBitDependencies is false
+        throw new Error(
+          `preparePackageJsonToWrite doesn't expect capsules to add bit dependencies to the package.json`
         );
-        packageDependency = `file:${relative}`;
-      } else {
-        packageDependency = getPackageDependency(bitMap, depId, component.id);
       }
+      const packageDependency = getPackageDependency(bitMap, depId, component.id);
       const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
       acc[packageName] = packageDependency;
       return acc;

--- a/src/extensions/isolator/isolator.ts
+++ b/src/extensions/isolator/isolator.ts
@@ -2,7 +2,7 @@ import path from 'path';
 import hash from 'object-hash';
 import fs from 'fs-extra';
 import { flatten, filter, uniq, concat, map, equals } from 'ramda';
-import { CACHE_ROOT } from '../../constants';
+import { CACHE_ROOT, PACKAGE_JSON } from '../../constants';
 import { Component } from '../component';
 import ConsumerComponent from '../../consumer/component';
 import { PackageManager } from '../package-manager';
@@ -12,8 +12,11 @@ import Consumer from '../../consumer/consumer';
 import { loadScope } from '../../scope';
 import CapsuleList from './capsule-list';
 import Graph from '../../scope/graph/graph'; // TODO: use graph extension?
-import { BitId } from '../../bit-id';
+import { BitId, BitIds } from '../../bit-id';
 import { buildOneGraphForComponents } from '../../scope/graph/components-graph';
+import PackageJsonFile from '../../consumer/component/package-json-file';
+import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
+import { symlinkDependenciesToCapsules } from './symlink-dependencies-to-capsules';
 
 const CAPSULES_BASE_DIR = path.join(CACHE_ROOT, 'capsules'); // TODO: move elsewhere
 
@@ -81,29 +84,31 @@ export default class Isolator {
         return { id, value: c };
       })
     );
-    const packageManager = this.packageManager;
-    const before = await getPackageJSONInCapsules(capsules, packageManager);
+    const capsulesWithPackagesData = await getCapsulesPackageJsonData(capsules);
 
     await writeComponentsToCapsules(components, graph, capsules, capsuleList, this.packageManager.name);
-    const after = await getPackageJSONInCapsules(capsules, packageManager);
-    const toInstall = capsules.filter((item, i) => {
-      return (
-        !equals(before[i], after[i]) ||
-        after[i].packageManager === '' ||
-        !isOldPackageManager(after[i].packageManager, config, packageManager)
+    if (config.installPackages) {
+      const capsulesToInstall: Capsule[] = capsulesWithPackagesData
+        .filter(capsuleWithPackageData => {
+          const packageJsonHasChanged = !equals(
+            capsuleWithPackageData.previousPackageJson,
+            capsuleWithPackageData.currentPackageJson
+          );
+          return packageJsonHasChanged;
+        })
+        .map(capsuleWithPackageData => capsuleWithPackageData.capsule);
+      await this.packageManager.runInstall(capsulesToInstall, { packageManager: config.packageManager });
+      await symlinkDependenciesToCapsules(capsulesToInstall, capsuleList);
+    }
+    // rewrite the package-json with the component dependencies in it. the original package.json
+    // that was written before, didn't have these dependencies in order for the package-manager to
+    // be able to install them without crushing when the versions don't exist yet
+    capsulesWithPackagesData.forEach(capsuleWithPackageData => {
+      capsuleWithPackageData.capsule.fs.writeFileSync(
+        PACKAGE_JSON,
+        JSON.stringify(capsuleWithPackageData.currentPackageJson, null, 2)
       );
     });
-    //   await Promise.all(
-    //   capsules
-    //     .filter((_, i) => !isOldPackageManager(config, after, i, packageManager))
-    //     .map(capsule => packageManager.removeLockFilesInCapsule(capsule))
-    // );
-    //  const toInstall = capsules;
-    if (config.installPackages && config.packageManager) {
-      await this.packageManager.runInstall(toInstall, { packageManager: config.packageManager });
-    } else if (config.installPackages) {
-      await this.packageManager.runInstall(toInstall);
-    }
 
     return {
       capsules: capsuleList,
@@ -129,31 +134,59 @@ export default class Isolator {
   }
 }
 
-function isOldPackageManager(
-  name: string,
-  config: { installPackages: boolean; packageManager: undefined },
-  packageManager: PackageManager
-) {
-  const res = config.packageManager ? name === config.packageManager : name === packageManager.packageManagerName;
-  return res;
-}
+type CapsulePackageJsonData = {
+  capsule: Capsule;
+  currentPackageJson: Record<string, any>;
+  previousPackageJson: Record<string, any> | null;
+};
 
-async function getPackageJSONInCapsules(capsules: Capsule[], pm: PackageManager) {
-  const resolvedJsons = await Promise.all(
+async function getCapsulesPackageJsonData(capsules: Capsule[]): Promise<CapsulePackageJsonData[]> {
+  return Promise.all(
     capsules.map(async capsule => {
       const packageJsonPath = path.join(capsule.wrkDir, 'package.json');
-      let capsuleJson: any = null;
-      let packageManager = '';
-
+      let previousPackageJson: any = null;
+      // @ts-ignore this capsule.component thing MUST BE FIXED, once done, if it doesn't have the ConsumerComponent, use the "component" var above
+      const currentPackageJson = getCurrentPackageJson(capsule.component as ConsumerComponent);
+      const result: CapsulePackageJsonData = {
+        capsule,
+        currentPackageJson: currentPackageJson.packageJsonObject,
+        previousPackageJson: null
+      };
       try {
-        capsuleJson = await capsule.fs.promises.readFile(packageJsonPath, { encoding: 'utf8' });
-        packageManager = await pm.checkPackageManagerInCapsule(capsule);
-        // console.log('packageMannagr in ', capsule.wrkDir, ':', packageManager || 'ERRROR!!!')
-        return { capsuleJson: JSON.parse(capsuleJson), packageManager };
-        // eslint-disable-next-line no-empty
-      } catch (e) {}
-      return { capsuleJson, packageManager };
+        previousPackageJson = await capsule.fs.promises.readFile(packageJsonPath, { encoding: 'utf8' });
+        result.previousPackageJson = JSON.parse(previousPackageJson);
+      } catch (e) {
+        // package-json doesn't exist in the capsule, that's fine, it'll be considered as a cache miss
+      }
+      return result;
     })
   );
-  return resolvedJsons;
+}
+
+function getCurrentPackageJson(component: ConsumerComponent): PackageJsonFile {
+  const newVersion = '0.0.1-new';
+  const getBitDependencies = (dependencies: BitIds) => {
+    return dependencies.reduce((acc, depId: BitId) => {
+      // const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(depId);
+      const packageDependency = depId.hasVersion() ? depId.version : newVersion;
+      const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
+      acc[packageName] = packageDependency;
+      return acc;
+    }, {});
+  };
+  const bitDependencies = getBitDependencies(component.dependencies.getAllIds());
+  const bitDevDependencies = getBitDependencies(component.devDependencies.getAllIds());
+  const bitExtensionDependencies = getBitDependencies(component.extensions.extensionsBitIds);
+  const packageJson = PackageJsonFile.createFromComponent('.', component, false);
+  const addDependencies = (packageJsonFile: PackageJsonFile) => {
+    packageJsonFile.addDependencies(bitDependencies);
+    packageJsonFile.addDevDependencies({
+      ...bitDevDependencies,
+      ...bitExtensionDependencies
+    });
+  };
+  addDependencies(packageJson);
+  packageJson.addOrUpdateProperty('version', component.id.hasVersion() ? component.id.version : newVersion);
+  packageJson.removeDependency('bit-bin');
+  return packageJson;
 }

--- a/src/extensions/isolator/symlink-dependencies-to-capsules.ts
+++ b/src/extensions/isolator/symlink-dependencies-to-capsules.ts
@@ -1,0 +1,32 @@
+import path from 'path';
+import { Capsule } from './capsule';
+import CapsuleList from './capsule-list';
+import ConsumerComponent from '../../consumer/component';
+import { BitId } from '../../bit-id';
+import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
+import Symlink from '../../links/symlink';
+
+export async function symlinkDependenciesToCapsules(capsules: Capsule[], capsuleList: CapsuleList) {
+  await Promise.all(
+    capsules.map(capsule => {
+      // @ts-ignore
+      return symlinkComponent(capsule.component, capsuleList);
+    })
+  );
+}
+
+async function symlinkComponent(component: ConsumerComponent, capsuleList: CapsuleList) {
+  const componentCapsule = capsuleList.getValueIgnoreScopeAndVersion(component.id);
+  if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
+  const allDeps = component.getAllDependenciesIds();
+  const symlinks = allDeps.map((depId: BitId) => {
+    const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
+    const devCapsule = capsuleList.getValueIgnoreScopeAndVersion(depId);
+    if (!devCapsule) throw new Error(`unable to find the capsule for ${depId.toStringWithoutVersion()}`);
+    const devCapsulePath = devCapsule.wrkDir;
+    // @todo: this is a hack, the capsule should be the one responsible to symlink, this works only for FS capsules.
+    const dest = path.join(componentCapsule.wrkDir, 'node_modules', packageName);
+    return new Symlink(devCapsulePath, dest, component.id);
+  });
+  await Promise.all(symlinks.map(symlink => symlink.write()));
+}

--- a/src/extensions/isolator/write-components-to-capsules.ts
+++ b/src/extensions/isolator/write-components-to-capsules.ts
@@ -41,7 +41,7 @@ export default async function writeComponentsToCapsules(
     override: false,
     writePackageJson: true,
     writeConfig: false,
-    writeBitDependencies: true,
+    writeBitDependencies: false,
     createNpmLinkFiles: false,
     saveDependenciesAsComponents: false,
     writeDists: false,

--- a/src/extensions/package-manager/package-manager.ts
+++ b/src/extensions/package-manager/package-manager.ts
@@ -66,7 +66,6 @@ export default class PackageManager {
     if (packageManager === 'npm' || packageManager === 'yarn') {
       // Don't run them in parallel (Promise.all), the package-manager doesn't handle it well.
       await pMapSeries(capsules, async capsule => {
-        // manipulatePackageJsonBeforeInstall(capsule);
         // TODO: remove this hack once harmony supports ownExtensionName
         const componentId = capsule.component.id.toString();
         const installProc =

--- a/src/extensions/package-manager/package-manager.ts
+++ b/src/extensions/package-manager/package-manager.ts
@@ -15,21 +15,6 @@ export type installOpts = {
   packageManager?: string;
 };
 
-function deleteBitBinFromPkgJson(capsule: Capsule) {
-  const packageJsonPath = 'package.json';
-  const pjsonString = capsule.fs.readFileSync(packageJsonPath).toString();
-  if (pjsonString) {
-    let packageJson;
-    try {
-      packageJson = JSON.parse(pjsonString);
-    } catch (err) {
-      throw new Error(`failed parsing the package.json file at ${capsule.wrkDir}`);
-    }
-    delete packageJson.dependencies['bit-bin'];
-    capsule.fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
-  }
-}
-
 function linkBitBinInCapsule(capsule) {
   const bitBinPath = path.join(capsule.wrkDir, './node_modules/bit-bin');
   const localBitBinPath = path.join(__dirname, '../..');
@@ -61,16 +46,7 @@ export default class PackageManager {
     } catch (e) {}
     return false;
   }
-  async checkPackageManagerInCapsule(capsule: Capsule): Promise<string> {
-    const isYarn = await this.checkIfFileExistsInCapsule(capsule, 'yarn.lock');
-    if (isYarn) return 'yarn';
-    const isLib = await this.checkIfFileExistsInCapsule(capsule, 'librarian-manifests.json');
-    if (isLib) return 'librarian';
-    const isNPM = await this.checkIfFileExistsInCapsule(capsule, 'node_modules');
-    if (isNPM) return 'npm';
 
-    return '';
-  }
   async removeLockFilesInCapsule(capsule: Capsule) {
     async function safeUnlink(toRemove: string) {
       try {
@@ -87,32 +63,17 @@ export default class PackageManager {
     if (packageManager === 'librarian') {
       return librarian.runMultipleInstalls(capsules.map(cap => cap.wrkDir));
     }
-    if (packageManager === 'yarn') {
+    if (packageManager === 'npm' || packageManager === 'yarn') {
       // Don't run them in parallel (Promise.all), the package-manager doesn't handle it well.
       await pMapSeries(capsules, async capsule => {
-        deleteBitBinFromPkgJson(capsule);
+        // manipulatePackageJsonBeforeInstall(capsule);
         // TODO: remove this hack once harmony supports ownExtensionName
         const componentId = capsule.component.id.toString();
-        const installProc = execa('yarn', [], { cwd: capsule.wrkDir, stdio: 'pipe' });
-        logPublisher.info(componentId, '$ yarn'); // TODO: better
-        logPublisher.info(componentId, '');
-        installProc.stdout!.on('data', d => logPublisher.info(componentId, d.toString()));
-        installProc.stderr!.on('data', d => logPublisher.warn(componentId, d.toString()));
-        installProc.on('error', e => {
-          logPublisher.error(componentId, e);
-          console.error('error', e); // eslint-disable-line no-console
-        });
-        await installProc;
-        linkBitBinInCapsule(capsule);
-      });
-    } else if (packageManager === 'npm') {
-      // Don't run them in parallel (Promise.all), the package-manager doesn't handle it well.
-      await pMapSeries(capsules, async capsule => {
-        deleteBitBinFromPkgJson(capsule);
-        // TODO: remove this hack once harmony supports ownExtensionName
-        const componentId = capsule.component.id.toString();
-        const installProc = execa('npm', ['install', '--no-package-lock'], { cwd: capsule.wrkDir, stdio: 'pipe' });
-        logPublisher.info(componentId, '$ npm install --no-package-lock'); // TODO: better
+        const installProc =
+          packageManager === 'npm'
+            ? execa('npm', ['install', '--no-package-lock'], { cwd: capsule.wrkDir, stdio: 'pipe' })
+            : execa('yarn', [], { cwd: capsule.wrkDir, stdio: 'pipe' });
+        logPublisher.info(componentId, packageManager === 'npm' ? '$ npm install --no-package-lock' : '$ yarn'); // TODO: better
         logPublisher.info(componentId, '');
         installProc.stdout!.on('data', d => logPublisher.info(componentId, d.toString()));
         installProc.stderr!.on('data', d => logPublisher.warn(componentId, d.toString()));


### PR DESCRIPTION
Currently, the package-manager installs them via the relative path but it fails on circular dependencies.
With this PR, the component dependencies are removed from the package-json before "npm install" and then they're back after the installation with versions (rather than relative-paths).

Also, the caching mechanism has improved in terms of readability, performance, and stability.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2612)
<!-- Reviewable:end -->
