### PR TITLE
Refactoring. Mostly related to BitIdAndValueArray class

### DIFF
--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -19,7 +19,6 @@ import EnvExtension from '../../legacy-extensions/env-extension';
 import ComponentConfig from '../config/component-config';
 import PackageJsonFile from '../component/package-json-file';
 import ShowDoctorError from '../../error/show-doctor-error';
-import CapsulePaths from '../../extensions/isolator/capsule-paths';
 
 export type ComponentWriterProps = {
   component: Component;
@@ -35,7 +34,6 @@ export type ComponentWriterProps = {
   deleteBitDirContent?: boolean;
   existingComponentMap?: ComponentMap;
   excludeRegistryPrefix?: boolean;
-  capsulePaths?: CapsulePaths;
   applyExtensionsAddedConfig?: boolean;
 };
 
@@ -53,7 +51,6 @@ export default class ComponentWriter {
   deleteBitDirContent: boolean | undefined;
   existingComponentMap: ComponentMap | undefined;
   excludeRegistryPrefix: boolean;
-  capsulePaths?: CapsulePaths;
   applyExtensionsAddedConfig?: boolean;
   constructor({
     component,
@@ -68,7 +65,6 @@ export default class ComponentWriter {
     writeBitDependencies = false,
     deleteBitDirContent,
     existingComponentMap,
-    capsulePaths,
     excludeRegistryPrefix = false,
     applyExtensionsAddedConfig = false
   }: ComponentWriterProps) {
@@ -85,7 +81,6 @@ export default class ComponentWriter {
     this.deleteBitDirContent = deleteBitDirContent;
     this.existingComponentMap = existingComponentMap;
     this.excludeRegistryPrefix = excludeRegistryPrefix;
-    this.capsulePaths = capsulePaths;
     this.applyExtensionsAddedConfig = applyExtensionsAddedConfig;
   }
 
@@ -155,7 +150,6 @@ export default class ComponentWriter {
         this.override,
         this.writeBitDependencies,
         this.excludeRegistryPrefix,
-        this.capsulePaths,
         packageManager
       );
 

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -21,7 +21,6 @@ import DataToPersist from '../component/sources/data-to-persist';
 import BitMap from '../bit-map';
 import { composeComponentPath, composeDependencyPathForIsolated } from '../../utils/bit/compose-component-path';
 import { BitId } from '../../bit-id';
-import CapsulePaths from '../../extensions/isolator/capsule-paths';
 
 export interface ManyComponentsWriterParams {
   packageManager?: string;
@@ -43,7 +42,6 @@ export interface ManyComponentsWriterParams {
   verbose?: boolean;
   installProdPackagesOnly?: boolean;
   excludeRegistryPrefix?: boolean;
-  capsulePaths?: CapsulePaths;
   applyExtensionsAddedConfig?: boolean;
 }
 
@@ -82,7 +80,6 @@ export default class ManyComponentsWriter {
   isolated: boolean; // a preparation for the capsule feature
   bitMap: BitMap;
   basePath?: string;
-  capsulePaths?: CapsulePaths;
   packageManager?: string;
   // Apply config added by extensions
   applyExtensionsAddedConfig?: boolean;
@@ -108,7 +105,6 @@ export default class ManyComponentsWriter {
     this.dependenciesIdsCache = {};
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.bitMap = this.consumer ? this.consumer.bitMap : new BitMap();
-    this.capsulePaths = params.capsulePaths;
     this.packageManager = params.packageManager;
     this.applyExtensionsAddedConfig = params.applyExtensionsAddedConfig;
     if (this.consumer && !this.isolated) this.basePath = this.consumer.getPath();
@@ -213,7 +209,6 @@ export default class ManyComponentsWriter {
     };
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return {
-      capsulePaths: this.capsulePaths,
       ...this._getDefaultWriteParams(),
       component: componentWithDeps.component,
       writeToPath: componentRootDir,
@@ -294,8 +289,7 @@ export default class ManyComponentsWriter {
           writeToPath: depRootPath,
           origin: COMPONENT_ORIGINS.NESTED,
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          existingComponentMap: componentMap,
-          capsulePaths: this.capsulePaths
+          existingComponentMap: componentMap
         });
         return componentWriter.populateComponentsFilesToWrite();
       });
@@ -359,8 +353,7 @@ to move all component files to a different directory, run bit remove and then bi
       bitMap: this.bitMap,
       createNpmLinkFiles: this.createNpmLinkFiles,
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      writePackageJson: this.writePackageJson,
-      capsuleMap: this.capsulePaths
+      writePackageJson: this.writePackageJson
     });
   }
   _getComponentRootDir(bitId: BitId): PathOsBasedRelative {

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -18,7 +18,6 @@ import searchFilesIgnoreExt from '../../utils/fs/search-files-ignore-ext';
 import ComponentVersion from '../../scope/component-version';
 import BitMap from '../bit-map/bit-map';
 import ShowDoctorError from '../../error/show-doctor-error';
-import CapsulePaths from '../../extensions/isolator/capsule-paths';
 
 /**
  * Add components as dependencies to root package.json
@@ -106,19 +105,12 @@ export function preparePackageJsonToWrite(
   override = true,
   writeBitDependencies = false, // e.g. when it's a capsule
   excludeRegistryPrefix?: boolean,
-  capsulePaths?: CapsulePaths,
   packageManager?: string
 ): { packageJson: PackageJsonFile; distPackageJson: PackageJsonFile | null | undefined } {
   logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}. override ${override.toString()}`);
   const getBitDependencies = (dependencies: BitIds) => {
     if (!writeBitDependencies) return {};
     return dependencies.reduce((acc, depId: BitId) => {
-      if (capsulePaths) {
-        // when coming from a capsule, it shouldn't reach here because writeBitDependencies is false
-        throw new Error(
-          `preparePackageJsonToWrite doesn't expect capsules to add bit dependencies to the package.json`
-        );
-      }
       const packageDependency = getPackageDependency(bitMap, depId, component.id);
       const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
       acc[packageName] = packageDependency;

--- a/src/extensions/create/create.ts
+++ b/src/extensions/create/create.ts
@@ -1,5 +1,6 @@
 /* eslint max-classes-per-file: 0 */
 import path from 'path';
+import Vinyl from 'vinyl';
 import { ExtensionManifest, Harmony } from '@teambit/harmony';
 import { Workspace } from '../workspace';
 import { BitId } from '../../bit-id';
@@ -12,9 +13,6 @@ import { AddActionResults } from '../../consumer/component-ops/add-components/ad
 type TemplateFile = { path: string; content: string };
 type TemplateFuncResult = { files: TemplateFile[]; main?: string };
 type TemplateFunc = (...args: string[]) => TemplateFuncResult;
-
-export class TemplateFileVinyl extends AbstractVinyl {}
-
 export class Create {
   constructor(private workspace: Workspace, private registry: Registry) {}
 
@@ -68,12 +66,12 @@ export class Create {
   ): Promise<PathOsBasedRelative[]> {
     const dataToPersist = new DataToPersist();
     const vinylFiles = templateFiles.map(templateFile => {
-      const templateFileVinyl = new TemplateFileVinyl({
+      const templateFileVinyl = new Vinyl({
         base: componentPath,
         path: path.join(componentPath, templateFile.path),
         contents: Buffer.from(templateFile.content)
       });
-      return templateFileVinyl;
+      return AbstractVinyl.fromVinyl(templateFileVinyl);
     });
     const results = vinylFiles.map(v => v.path);
     dataToPersist.addManyFiles(vinylFiles);

--- a/src/extensions/flows/flows.ts
+++ b/src/extensions/flows/flows.ts
@@ -6,7 +6,6 @@ import { Workspace } from '../workspace';
 import { Network, GetFlow } from './network';
 import { ComponentID } from '../component';
 import { Flow } from './flow/flow';
-import BitIdAndValueArray from '../../bit-id/bit-id-and-value-array';
 import { ExecutionOptions } from './network/options';
 import { BitId } from '../../bit-id';
 import { Capsule } from '../isolator/capsule';
@@ -85,7 +84,7 @@ export class Flows {
     const getFlow = (capsule: Capsule) => {
       const id = capsule.component.id;
       // @ts-ignore for some reason the capsule.component here is ConsumerComponent
-      const value = flowsWithIds.getValue(id);
+      const value = flowsWithIds.getFlows(id);
       return Promise.resolve(new Flow(value || []));
     };
     const postFlow = (_capsule: Capsule) => Promise.resolve();
@@ -100,4 +99,17 @@ export class Flows {
   }
 }
 
-export class IdsAndFlows extends BitIdAndValueArray<string[]> {}
+export class IdsAndFlows extends Array<{ id: BitId; value: string[] }> {
+  getFlows(id: BitId): string[] | null {
+    const found = this.find(item => item.id.isEqual(id));
+    return found ? found.value : null;
+  }
+  getFlowsIgnoreVersion(id: BitId): string[] | null {
+    const found = this.find(item => item.id.isEqualWithoutVersion(id));
+    return found ? found.value : null;
+  }
+  getFlowsIgnoreScopeAndVersion(id: BitId): string[] | null {
+    const found = this.find(item => item.id.isEqualWithoutScopeAndVersion(id));
+    return found ? found.value : null;
+  }
+}

--- a/src/extensions/isolator/capsule-list.ts
+++ b/src/extensions/isolator/capsule-list.ts
@@ -1,4 +1,17 @@
-import BitIdAndValueArray from '../../bit-id/bit-id-and-value-array';
 import { Capsule } from './capsule';
+import { BitId } from '../../bit-id';
 
-export default class CapsuleList extends BitIdAndValueArray<Capsule> {}
+export default class CapsuleList extends Array<{ id: BitId; value: Capsule }> {
+  getCapsule(id: BitId): Capsule | null {
+    const found = this.find(item => item.id.isEqual(id));
+    return found ? found.value : null;
+  }
+  getCapsuleIgnoreVersion(id: BitId): Capsule | null {
+    const found = this.find(item => item.id.isEqualWithoutVersion(id));
+    return found ? found.value : null;
+  }
+  getCapsuleIgnoreScopeAndVersion(id: BitId): Capsule | null {
+    const found = this.find(item => item.id.isEqualWithoutScopeAndVersion(id));
+    return found ? found.value : null;
+  }
+}

--- a/src/extensions/isolator/capsule-paths.ts
+++ b/src/extensions/isolator/capsule-paths.ts
@@ -1,4 +1,0 @@
-import { PathOsBasedAbsolute } from '../../utils/path';
-import BitIdAndValueArray from '../../bit-id/bit-id-and-value-array';
-
-export default class CapsulePaths extends BitIdAndValueArray<PathOsBasedAbsolute> {}

--- a/src/extensions/isolator/isolator.ts
+++ b/src/extensions/isolator/isolator.ts
@@ -167,7 +167,6 @@ function getCurrentPackageJson(component: ConsumerComponent): PackageJsonFile {
   const newVersion = '0.0.1-new';
   const getBitDependencies = (dependencies: BitIds) => {
     return dependencies.reduce((acc, depId: BitId) => {
-      // const devCapsulePath = capsulePaths && capsulePaths.getValueIgnoreScopeAndVersion(depId);
       const packageDependency = depId.hasVersion() ? depId.version : newVersion;
       const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
       acc[packageName] = packageDependency;

--- a/src/extensions/isolator/symlink-dependencies-to-capsules.ts
+++ b/src/extensions/isolator/symlink-dependencies-to-capsules.ts
@@ -16,12 +16,12 @@ export async function symlinkDependenciesToCapsules(capsules: Capsule[], capsule
 }
 
 async function symlinkComponent(component: ConsumerComponent, capsuleList: CapsuleList) {
-  const componentCapsule = capsuleList.getValueIgnoreScopeAndVersion(component.id);
+  const componentCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(component.id);
   if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
   const allDeps = component.getAllDependenciesIds();
   const symlinks = allDeps.map((depId: BitId) => {
     const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
-    const devCapsule = capsuleList.getValueIgnoreScopeAndVersion(depId);
+    const devCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(depId);
     if (!devCapsule) throw new Error(`unable to find the capsule for ${depId.toStringWithoutVersion()}`);
     const devCapsulePath = devCapsule.wrkDir;
     // @todo: this is a hack, the capsule should be the one responsible to symlink, this works only for FS capsules.


### PR DESCRIPTION
- change classes that inherit BitIdAndValueArray to be self-contained. It makes these classes more readable.
- delete the CapsulePaths class. (previously inherited BitIdAndValueArray and was needed when the package.json written in the capsule had the relative paths for other capsules. currently, the package.json doesn't have the relative paths but actual versions).
- delete TemplateFileVinyl class. Not needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2617)
<!-- Reviewable:end -->
