### PR TITLE
fix error "Cannot read property 'clone' of undefined"

### DIFF
--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -16,6 +16,7 @@ export default (async function loadFlattenedDependenciesForCapsule(
 
   await loadFlattened(dependencies);
   await loadFlattened(devDependencies);
+  await loadFlattened(extensionDependencies);
 
   return new ComponentWithDependencies({
     component,


### PR DESCRIPTION
Happens when loading one component that has extensions (as opposed to loading all components from the workspace).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2618)
<!-- Reviewable:end -->
