### PR TITLE
fix graph built for capsules from the workspace to include indirect non-prod deps

### DIFF
--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -61,7 +61,7 @@ export default (async function loadFlattenedDependenciesForCapsule(
 
   async function loadFlattenedFromFsRecursively(components: Component[]) {
     const currentIds = BitIds.fromArray(components.map(c => c.id));
-    const ids = R.flatten(components.filter(c => c.loadedFromFileSystem).map(c => c.dependencies.getAllIds()));
+    const ids = R.flatten(components.filter(c => c.loadedFromFileSystem).map(c => c.getAllDependenciesIds()));
     const idsUniq = BitIds.uniqFromArray(ids);
     const newIds = idsUniq.filter(id => !currentIds.has(id));
     if (R.isEmpty(newIds)) return;

--- a/src/extensions/isolator/write-components-to-capsules.ts
+++ b/src/extensions/isolator/write-components-to-capsules.ts
@@ -21,7 +21,15 @@ export default async function writeComponentsToCapsules(
   components = components.map(c => c.clone());
   const writeToPath = '.';
   const componentsWithDependencies = components.map(component => {
-    const getClonedFromGraph = (id: BitId): ConsumerComponent => graph.node(id.toString()).clone();
+    const getClonedFromGraph = (id: BitId): ConsumerComponent => {
+      const consumerComponent = graph.node(id.toString());
+      if (!consumerComponent) {
+        throw new Error(
+          `unable to find the dependency "${id.toString()}" of "${component.id.toString()}" in the graph`
+        );
+      }
+      return consumerComponent.clone();
+    };
     const getDeps = (dependencies: Dependencies) => dependencies.get().map(dep => getClonedFromGraph(dep.id));
     const dependencies = getDeps(component.dependencies);
     const devDependencies = getDeps(component.devDependencies);

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -117,7 +117,12 @@ function buildGraphFromComponentsObjects(components: Component[], direction: 'no
   };
   components.forEach((component: Component) => {
     Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
-      depIds.forEach(depId => setEdge(component.id, depId, depType));
+      depIds.forEach(depId => {
+        if (!graph.hasNode(depId.toString())) {
+          throw new Error(`buildGraphFromComponentsObjects: missing node of ${depId.toString()}`);
+        }
+        setEdge(component.id, depId, depType);
+      });
     });
   });
 


### PR DESCRIPTION
Currently, when a graph is built using `buildOneGraphForComponents` method, it has only the flattened of dependencies but not the flattened of devDependencies and extensionDependencies.

In this PR, the missing dependencies are part of the graph and in case some deps are missing, it fails early with a descriptive error message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2635)
<!-- Reviewable:end -->
