### PR TITLE
fix extensions to not use internal paths of other extensions

### DIFF
--- a/src/extensions/bit/bit.manifest.ts
+++ b/src/extensions/bit/bit.manifest.ts
@@ -5,8 +5,8 @@ import provideBit from './bit.provider';
 import { ComposerExt } from '../composer';
 import { InstallExt } from '../install';
 
-import CompileExt from '../compile/compile.manifest';
-import TestExt from '../test/test.manifest';
+import { CompileExt } from '../compile';
+import { TestExt } from '../test';
 import { ComponentGraphExt } from '../graph';
 import { CreateExt } from '../create';
 import { FlowsExt } from '../flows';

--- a/src/extensions/compile/compile.cmd.tsx
+++ b/src/extensions/compile/compile.cmd.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 import { Command, CLIArgs } from '../cli';
-import { Flags, PaperOptions } from '../paper/command';
+import { Flags, PaperOptions } from '../paper';
 import { Compile } from './compile';
 
 export class CompileCmd implements Command {

--- a/src/extensions/compile/compile.ts
+++ b/src/extensions/compile/compile.ts
@@ -5,11 +5,10 @@ import { BitId } from '../../bit-id';
 import { ResolvedComponent } from '../workspace/resolved-component';
 import buildComponent from '../../consumer/component-ops/build-component';
 import { Component } from '../component';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 import DataToPersist from '../../consumer/component/sources/data-to-persist';
 import { Scope } from '../scope';
-import { Flows } from '../flows';
-import { IdsAndFlows } from '../flows/flows';
+import { Flows, IdsAndFlows } from '../flows';
 
 export type ComponentAndCapsule = {
   consumerComponent: ConsumerComponent;

--- a/src/extensions/component/component-factory.ts
+++ b/src/extensions/component/component-factory.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import Isolator from '../isolator/isolator';
+import { Isolator } from '../isolator';
 import ConsumerComponent from '../../consumer/component';
 import Component from './component';
 import State from './state';

--- a/src/extensions/component/component.provider.ts
+++ b/src/extensions/component/component.provider.ts
@@ -1,5 +1,5 @@
 import { ComponentFactory } from '../component';
-import Isolator from '../isolator/isolator';
+import { Isolator } from '../isolator';
 
 type ComponentDeps = [Isolator];
 type ComponentConfig = {};

--- a/src/extensions/component/component.ts
+++ b/src/extensions/component/component.ts
@@ -7,7 +7,7 @@ import TagMap from './tag-map';
 import ComponentID from './id';
 import State from './state';
 import Snap, { Author } from './snap';
-import Isolator from '../isolator/isolator';
+import { Isolator } from '../isolator';
 import { loadConsumerIfExist } from '../../consumer';
 
 /**

--- a/src/extensions/flows/cache.ts
+++ b/src/extensions/flows/cache.ts
@@ -7,7 +7,7 @@ import { promises as fs } from 'fs';
 import { lock, unlock } from 'proper-lockfile';
 import { join } from 'path';
 import { CACHE_ROOT } from '../../constants';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 import ConsumerComponent from '../../consumer/component';
 import { AbstractVinyl } from '../../consumer/component/sources';
 

--- a/src/extensions/flows/flow/flow.ts
+++ b/src/extensions/flows/flow/flow.ts
@@ -3,7 +3,7 @@
 /* eslint-disable max-len */
 import { Subject, ReplaySubject } from 'rxjs';
 import { Task } from '../task';
-import { Capsule } from '../../isolator/capsule';
+import { Capsule } from '../../isolator';
 
 export class Flow {
   private result: any[] = [];

--- a/src/extensions/flows/flows.ts
+++ b/src/extensions/flows/flows.ts
@@ -7,7 +7,7 @@ import { ComponentID } from '../component';
 import { Flow } from './flow/flow';
 import { ExecutionOptions } from './network/options';
 import { BitId } from '../../bit-id';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 import { PostFlow, getWorkspaceGraph } from './network/network';
 import { getExecutionCache } from './cache';
 

--- a/src/extensions/flows/index.ts
+++ b/src/extensions/flows/index.ts
@@ -1,5 +1,5 @@
 export { default as FlowsExt } from './flows.manifest';
-export { Flows } from './flows';
+export { Flows, IdsAndFlows } from './flows';
 export { flattenNestedMap, flattenReplaySubject } from './util/flatten-nested-map';
 export { createFakeCapsule } from './util/create-capsule';
 export { createGetGraphFn, createTestNetworkStream } from './util/create-fake-network';

--- a/src/extensions/flows/network/network.ts
+++ b/src/extensions/flows/network/network.ts
@@ -13,7 +13,7 @@ import { ExecutionOptions } from './options';
 import { createSubGraph, getNeighborsByDirection } from './sub-graph';
 import { Flow } from '../flow';
 import { ComponentID } from '../../component';
-import { Capsule } from '../../isolator/capsule';
+import { Capsule } from '../../isolator';
 
 export type GetFlow = (capsule: Capsule) => Promise<Flow>;
 export type PostFlow = (capsule: Capsule) => Promise<void>; // runs when finishes flow successfully

--- a/src/extensions/flows/run/run.cmd.tsx
+++ b/src/extensions/flows/run/run.cmd.tsx
@@ -4,7 +4,7 @@
 import React from 'react';
 import { ReplaySubject } from 'rxjs';
 import { Command, CLIArgs } from '../../cli';
-import { Flags, PaperOptions } from '../../paper/command';
+import { Flags, PaperOptions } from '../../paper';
 import { Flows } from '../flows';
 import { reportRunStream } from './handle-run-stream';
 import { flowEvents } from './handle-run-stream';

--- a/src/extensions/flows/task/execution-stream.ts
+++ b/src/extensions/flows/task/execution-stream.ts
@@ -1,5 +1,5 @@
 import { ReplaySubject, Subject } from 'rxjs';
-import ContainerExec from '../../isolator/capsule/container-exec';
+import { ContainerExec } from '../../isolator';
 
 export function createExecutionStream(exec: ContainerExec, id: string, time: Date = new Date()): Subject<any> {
   let message: any = null;

--- a/src/extensions/flows/task/task.ts
+++ b/src/extensions/flows/task/task.ts
@@ -3,8 +3,7 @@
 import { Subject } from 'rxjs';
 import { join } from 'path';
 import { createExecutionStream } from './execution-stream';
-import ContainerExec from '../../isolator/capsule/container-exec';
-import { Capsule } from '../../isolator/capsule';
+import { Capsule, ContainerExec } from '../../isolator';
 
 export const PackageMarker = '#';
 

--- a/src/extensions/flows/util/create-capsule.ts
+++ b/src/extensions/flows/util/create-capsule.ts
@@ -3,7 +3,7 @@ import { State, Console } from '@teambit/capsule';
 import { tmpdir } from 'os';
 import { mkdirp, writeFile } from 'fs-extra';
 import { Component } from '../../component';
-import { FsContainer, Capsule } from '../../isolator/capsule';
+import { FsContainer, Capsule } from '../../isolator';
 
 type CapsuleContent = { [k: string]: string };
 

--- a/src/extensions/flows/util/create-fake-network.ts
+++ b/src/extensions/flows/util/create-fake-network.ts
@@ -6,10 +6,10 @@ import { ComponentID, Component } from '../../component';
 import { Network } from '../network';
 import { BitId } from '../../../bit-id';
 import { Consumer } from '../../../consumer';
-import { Workspace } from '../../..';
+import { Workspace } from '../../workspace';
 import { getFakeCapsuleLocation, createFakeCapsule } from './create-capsule';
 import { Flow } from '../flow';
-import { Capsule } from '../../isolator/capsule';
+import { Capsule } from '../../isolator';
 
 export type GraphTestCase = {
   graph: { [id: string]: string[] };

--- a/src/extensions/graph/component-graph/component-graph.ts
+++ b/src/extensions/graph/component-graph/component-graph.ts
@@ -1,10 +1,10 @@
 import { Graph } from 'cleargraph';
 import { Graph as LegacyGraph } from 'graphlib';
-import Component from '../../component/component';
+import { Component } from '../../component';
 import { Dependency } from '../dependency';
 import { Workspace } from '../../workspace';
 import { buildOneGraphForComponents } from '../../../scope/graph/components-graph';
-import ComponentFactory from '../../component/component-factory';
+import { ComponentFactory } from '../../component';
 import { DuplicateDependency, VersionSubgraph } from '../duplicate-dependency';
 
 export const DEPENDENCIES_TYPES = ['dependencies', 'devDependencies'];

--- a/src/extensions/graph/index.ts
+++ b/src/extensions/graph/index.ts
@@ -2,4 +2,4 @@ export { ComponentGraph } from './component-graph';
 export { GraphBuilder } from './graph-builder';
 export { default as ComponentGraphExt } from './graph.manifest';
 export { Dependency } from './dependency';
-export { DuplicateDependency } from './duplicate-dependency';
+export { DuplicateDependency, VersionSubgraph } from './duplicate-dependency';

--- a/src/extensions/insights/all-insights/duplicate-dependencies.tsx
+++ b/src/extensions/insights/all-insights/duplicate-dependencies.tsx
@@ -2,8 +2,7 @@
 import React from 'react';
 import { Color, Box, Text, render } from 'ink';
 import { Insight, InsightResult, RawResult } from '../insight';
-import { GraphBuilder } from '../../graph';
-import { VersionSubgraph } from '../../graph/duplicate-dependency';
+import { GraphBuilder, VersionSubgraph } from '../../graph';
 import NoDataForInsight from '../exceptions/no-data-for-insight';
 
 export const INSIGHT_NAME = 'duplicate dependencies';

--- a/src/extensions/insights/insights.cmd.tsx
+++ b/src/extensions/insights/insights.cmd.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Color, Box, Text } from 'ink';
 import { Command, CLIArgs } from '../cli';
-import { Flags } from '../paper/command';
+import { Flags } from '../paper';
 import { InsightManager } from './insight-manager';
 import { InsightResult } from './insight';
 

--- a/src/extensions/isolator/capsule/index.ts
+++ b/src/extensions/isolator/capsule/index.ts
@@ -1,2 +1,3 @@
 export { default as Capsule } from './capsule';
 export { default as FsContainer } from './container';
+export { default as ContainerExec } from './container-exec';

--- a/src/extensions/isolator/index.ts
+++ b/src/extensions/isolator/index.ts
@@ -1,2 +1,3 @@
 export { default as IsolatorExt } from './isolator.manifest';
 export { default as Isolator } from './isolator';
+export { FsContainer, Capsule, ContainerExec } from './capsule';

--- a/src/extensions/pack/pack.cmd.tsx
+++ b/src/extensions/pack/pack.cmd.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Color } from 'ink';
 import { Command, CLIArgs } from '../cli';
 import { Packer } from './pack';
-import { Flags, PaperOptions } from '../paper/command';
+import { Flags, PaperOptions } from '../paper';
 
 export class PackCmd implements Command {
   name = 'pack <componentId> [scopePath]';

--- a/src/extensions/package-manager/package-manager.ts
+++ b/src/extensions/package-manager/package-manager.ts
@@ -8,7 +8,7 @@ import pMapSeries from 'p-map-series';
 import execa from 'execa';
 import librarian from 'librarian';
 import { Logger, LogPublisher } from '../logger';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 import { pipeOutput } from '../../utils/child_process';
 import createSymlinkOrCopy from '../../utils/fs/create-symlink-or-copy';
 

--- a/src/extensions/paper/index.ts
+++ b/src/extensions/paper/index.ts
@@ -1,4 +1,4 @@
 export { Paper } from './paper';
 export { default as PaperExt } from './paper.extension';
-export { Command, CLIArgs, PaperOptions } from './command';
+export { Command, CLIArgs, PaperOptions, Flags } from './command';
 export * from './exceptions';

--- a/src/extensions/test/index.ts
+++ b/src/extensions/test/index.ts
@@ -1,1 +1,1 @@
-export { default as TextExt } from './test.manifest';
+export { default as TestExt } from './test.manifest';

--- a/src/extensions/test/test.cmd.tsx
+++ b/src/extensions/test/test.cmd.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { Color, AppContext } from 'ink';
 import { Command, CLIArgs } from '../cli';
-import { Flags, PaperOptions } from '../paper/command';
+import { Flags, PaperOptions } from '../paper';
 import { Test } from './test';
 import { paintAllSpecsResults, paintSummarySpecsResults } from '../../cli/chalk-box';
 

--- a/src/extensions/test/test.ts
+++ b/src/extensions/test/test.ts
@@ -2,7 +2,7 @@ import { Workspace } from '../workspace';
 import ConsumerComponent from '../../consumer/component';
 import { BitId } from '../../bit-id';
 import { Component } from '../component';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 import { Compile } from '../compile/compile';
 import ComponentsList from '../../consumer/component/components-list';
 

--- a/src/extensions/workspace/resolved-component.ts
+++ b/src/extensions/workspace/resolved-component.ts
@@ -1,5 +1,5 @@
 import { Component } from '../component';
-import { Capsule } from '../isolator/capsule';
+import { Capsule } from '../isolator';
 
 export class ResolvedComponent {
   constructor(readonly component: Component, readonly capsule: Capsule) {}


### PR DESCRIPTION
Makes sure that extensions expose all their APIs from the main `index.ts` file, so then no need to import their internals. (this is needed for the "bit link --rewire" that will be running later).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2636)
<!-- Reviewable:end -->
