### PR TITLE
allow having the same dependency as a prod/dev dependency and as an extension dependency

### DIFF
--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -249,6 +249,10 @@ export default class Version extends BitObject {
     return BitIds.fromArray(allDependencies);
   }
 
+  getDependenciesIdsExcludeExtensions(): BitIds {
+    return BitIds.fromArray([...this.dependencies.getAllIds(), ...this.devDependencies.getAllIds()]);
+  }
+
   updateFlattenedDependency(currentId: BitId, newId: BitId) {
     const getUpdated = (flattenedDependencies: BitIds): BitIds => {
       const updatedIds = flattenedDependencies.map(depId => {

--- a/src/scope/version-validator.ts
+++ b/src/scope/version-validator.ts
@@ -200,7 +200,10 @@ export default function validateVersionInstance(version: Version): void {
   };
   validateFlattenedDependencies(version.flattenedDependencies);
   validateFlattenedDependencies(version.flattenedDevDependencies);
-  const allDependenciesIds = version.getAllDependenciesIds();
+  // extensions can be duplicate with other dependencies type. e.g. "test" can have "compile" as a
+  // dependency and extensionDependency. we can't remove it from extDep, otherwise, the ext won't
+  // be running
+  const allDependenciesIds = version.getDependenciesIdsExcludeExtensions();
   const depsDuplications = allDependenciesIds.findDuplicationsIgnoreVersion();
   if (!R.isEmpty(depsDuplications)) {
     const duplicationStr = Object.keys(depsDuplications)


### PR DESCRIPTION
Normally version-validator makes sure to not tag a Version that has the same dependency in prod-deps and dev-deps. 
This PR excludes extension-dependencies from this duplication check.
It's needed because a component may have another component as a dependency and also as an extension. Removing it from the extensions list will result in not finding the extension for the component.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2640)
<!-- Reviewable:end -->
