### PR TITLE
fix some more tsc errors thrown during "bit compile" of core extensions

### DIFF
--- a/src/consumer/component/sources/data-to-persist.ts
+++ b/src/consumer/component/sources/data-to-persist.ts
@@ -73,7 +73,7 @@ export default class DataToPersist {
     await this._persistFilesToFS();
     await this._persistSymlinksToFS();
   }
-  async persistAllToCapsule(capsule: Capsule, opts = { keepExistingCapsule: false }) {
+  async persistAllToCapsule(capsule: any, opts = { keepExistingCapsule: false }) {
     this._log();
     this._validateRelative();
     if (!opts.keepExistingCapsule) {

--- a/src/consumer/component/sources/source-file.ts
+++ b/src/consumer/component/sources/source-file.ts
@@ -54,8 +54,7 @@ export default class SourceFile extends AbstractVinyl {
     return new SourceFile({ base: '.', path: file.relativePath, contents: content.contents, test: file.test });
   }
 
-  // @ts-ignore
-  clone(): SourceFile {
+  clone(): this {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new SourceFile(this);
   }

--- a/src/extensions/cli/legacy-command.tsx
+++ b/src/extensions/cli/legacy-command.tsx
@@ -1,7 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color, AppContext } from 'ink';
 import React from 'react';
-import { Command, PaperOptions, GenericObject } from '../paper/command';
+import { Command, PaperOptions, GenericObject } from '../paper';
 import LegacyInterface from '../../cli/command';
 import allHelp from '../../cli/templates/all-help';
 import { getID } from '../paper/registry';

--- a/src/extensions/flows/flows.ts
+++ b/src/extensions/flows/flows.ts
@@ -96,7 +96,13 @@ export class Flows {
    * @param options
    * @param network optional custom network
    */
-  async run(seeders: ComponentID[], name = 'build', options?: Partial<ExecutionOptions>, network?: Network) {
+  // @todo: @qballer please add return type
+  async run(
+    seeders: ComponentID[],
+    name = 'build',
+    options?: Partial<ExecutionOptions>,
+    network?: Network
+  ): Promise<any> {
     const opts: ExecutionOptions = Object.assign(
       {
         caching: true,

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 export enum LogLevel {
   INFO = 'info',

--- a/src/extensions/paper/index.ts
+++ b/src/extensions/paper/index.ts
@@ -1,4 +1,4 @@
 export { Paper } from './paper';
 export { default as PaperExt } from './paper.extension';
-export { Command, CLIArgs, PaperOptions, Flags } from './command';
+export { Command, CLIArgs, PaperOptions, Flags, GenericObject } from './command';
 export * from './exceptions';

--- a/src/extensions/reporter/logger.ts
+++ b/src/extensions/reporter/logger.ts
@@ -1,4 +1,4 @@
-import EventEmitter from 'events';
+import { EventEmitter } from 'events';
 
 // we use this and not EventEmitter directly in order to be able
 // to provide tab completions for intellisense(-like) IDEs

--- a/src/extensions/scope/scope.ts
+++ b/src/extensions/scope/scope.ts
@@ -2,10 +2,8 @@ import LegacyScope from '../../scope/scope';
 import { PersistOptions } from '../../scope/types';
 import { BitIds as ComponentsIds } from '../../bit-id';
 import { Component, ComponentID } from '../component';
-import { ComponentHost } from '../../shared-types';
 
-// eslint-disable-next-line import/prefer-default-export
-export class Scope implements ComponentHost {
+export class Scope {
   public onBuild?: Function[];
   constructor(
     /**

--- a/src/extensions/workspace/core-configurable-extensions.ts
+++ b/src/extensions/workspace/core-configurable-extensions.ts
@@ -1,3 +1,4 @@
+import { ExtensionManifest } from '@teambit/harmony';
 // TODO: make this in a better way
 // This used by the workspace to do:
 // 1. know which extensions to look in the workspace itself (in the bitmap) and which are core
@@ -8,7 +9,7 @@ import workspaceExt from './workspace.manifest';
 import { FlowsExt } from '../flows';
 import { CreateExt } from '../create';
 
-const coreConfigurableExtensions = {
+const coreConfigurableExtensions: { [extName: string]: ExtensionManifest } = {
   // TODO: change the way we get the name when moving to decorators
   [ComposerExt.name]: ComposerExt,
   [FlowsExt.name]: FlowsExt,

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -4,9 +4,8 @@ import { compact } from 'ramda-adjunct';
 import { Consumer } from '../../consumer';
 import { Scope } from '../scope';
 import { WorkspaceConfig } from '../workspace-config';
-import { Component, ComponentFactory } from '../component';
+import { Component, ComponentFactory, ComponentID } from '../component';
 import ComponentsList from '../../consumer/component/components-list';
-import { ComponentHost } from '../../shared-types';
 import { BitIds, BitId } from '../../bit-id';
 import { Isolator } from '../isolator';
 import { LogPublisher } from '../logger';
@@ -25,7 +24,7 @@ import { DependencyResolver } from '../dependency-resolver';
 /**
  * API of the Bit Workspace
  */
-export default class Workspace implements ComponentHost {
+export default class Workspace {
   owner?: string;
   componentsScopeDirsMap: ComponentScopeDirMap;
 
@@ -145,8 +144,13 @@ export default class Workspace implements ComponentHost {
    * get a component from workspace
    * @param id component ID
    */
-  async get(id: string | BitId): Promise<Component | undefined> {
-    const componentId = typeof id === 'string' ? this.consumer.getParsedId(id) : id;
+  async get(id: string | BitId | ComponentID): Promise<Component | undefined> {
+    const getBitId = (): BitId => {
+      if (id instanceof ComponentID) return id._legacy;
+      if (typeof id === 'string') return this.consumer.getParsedId(id);
+      return id;
+    };
+    const componentId = getBitId();
     if (!componentId) return undefined;
     const legacyComponent = await this.consumer.loadComponent(componentId);
     return this.componentFactory.fromLegacyComponent(legacyComponent);

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -349,7 +349,6 @@ export default class Scope {
             contents: Buffer.from(file.content)
           });
         });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         component.setDists(distsFiles);
         return { component: component.id.toString(), buildResults: builtFiles.map(b => b.path) };
       })


### PR DESCRIPTION
As part of the dogfooding process, in `harmony/dogfooding` branch all extensions are components and compiled with "bit compile". Some errors are thrown from `tsc` that are not shown in the linter of bit-bin workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2641)
<!-- Reviewable:end -->
