### PR TITLE
Fix flows to not exit the process unexpectedly

### DIFF
--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -16,6 +16,7 @@ chai.use(require('chai-fs'));
     helper.scopeHelper.destroy();
   });
   describe('workspace with a new compiler extension', () => {
+    let scopeBeforeTag: string;
     before(async () => {
       helper.scopeHelper.initWorkspaceAndRemoteScope();
 
@@ -36,6 +37,7 @@ chai.use(require('chai-fs'));
         }
       };
       helper.bitJsonc.write(bitjsonc);
+      scopeBeforeTag = helper.scopeHelper.cloneLocalScope();
     });
     describe('compile from the cmd', () => {
       before(() => {
@@ -91,6 +93,19 @@ chai.use(require('chai-fs'));
             expect(path.join(capsulePath, 'dist/help.js')).to.be.a.file();
           });
         });
+      });
+    });
+    describe('add another component that does not need any compilation', () => {
+      let output;
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
+        helper.fs.outputFile('bar/foo.js');
+        helper.command.addComponent('bar');
+        output = helper.command.tagAllComponents();
+      });
+      // a guard for Flows tag that exits unexpectedly
+      it('should be able to tag', () => {
+        expect(output).to.have.string('2 component(s) tagged');
       });
     });
   });

--- a/src/extensions/flows/flow/flow.ts
+++ b/src/extensions/flows/flow/flow.ts
@@ -4,6 +4,7 @@
 import { Subject, ReplaySubject } from 'rxjs';
 import { Task } from '../task';
 import { Capsule } from '../../isolator';
+import logger from '../../../logger/logger';
 
 export class Flow {
   private result: any[] = [];
@@ -24,14 +25,18 @@ export class Flow {
       startTime
     });
     if (this.tasks && this.tasks.length) {
+      logger.debug(`flowsExt, flow.execute of ${id}. tasks: ${this.tasks.join(', ')}`);
       this.execSequence(capsule, subject, startTime, 0);
     } else {
+      logger.debug(`flowsExt, flow.execute of ${id}. no tasks. handleDone`);
       setImmediate(() => this.handleDone(subject, capsule, startTime));
     }
     return subject;
   }
 
   private execSequence(capsule: Capsule, subject: Subject<any>, start: Date, index: number) {
+    const id = capsule.component.id.toString();
+    logger.debug(`flowsExt, flow.execSequence of ${id}. index: ${index}`);
     const that = this;
     const task = Task.execute(this.tasks[index], capsule);
     subject.next(task);
@@ -72,6 +77,7 @@ export class Flow {
 
   private handleDone(subject: Subject<any>, capsule: Capsule, startTime: Date, isError = false) {
     const endTime = new Date();
+    logger.debug(`flowsExt, flow.handleDone of ${capsule.component.id.toString()}. isError: ${isError}`);
     subject[isError ? 'error' : 'next']({
       type: 'flow:result',
       id: capsule.component.id,

--- a/src/extensions/flows/task/execution-stream.ts
+++ b/src/extensions/flows/task/execution-stream.ts
@@ -1,7 +1,9 @@
 import { ReplaySubject, Subject } from 'rxjs';
 import { ContainerExec } from '../../isolator';
+import logger from '../../../logger/logger';
 
-export function createExecutionStream(exec: ContainerExec, id: string, time: Date = new Date()): Subject<any> {
+export function createExecutionStream(exec: ContainerExec, id: string, time: Date = new Date()): Subject<unknown> {
+  logger.debug(`flowsExt, createExecutionStream of ${id} started`);
   let message: any = null;
   const subscriber = new ReplaySubject();
   subscriber.next({
@@ -19,6 +21,7 @@ export function createExecutionStream(exec: ContainerExec, id: string, time: Dat
   });
 
   exec.stderr.on('data', function(data) {
+    logger.debug(`flowsExt, createExecutionStream of ${id} got error: ${data.toString()}`);
     subscriber.next({
       type: 'task:stderr',
       id,
@@ -31,6 +34,7 @@ export function createExecutionStream(exec: ContainerExec, id: string, time: Dat
   });
 
   exec.on('close', function() {
+    logger.debug(`flowsExt, createExecutionStream of ${id} completed!`);
     const streamMessage = {
       type: 'task:result',
       id,


### PR DESCRIPTION
Flows exited the process with a success code during processing the flows/tasks. 
This happened when the workspace had two components, one with no tasks and one with a task that ended up with an error.

This PR includes lots of logger statements to easier the debugging process of Flows.
@qballer , please, leave them there until Flows is simplified. As of now, debugging it is time-consuming and the loggers help a lot.

The most important part of this fix is:
```
if (seederAmount === 0) {
  walk();
}
```
Inside `subscribe.error`. 

@qballer , although this fixed my issue. I'm still not sure why RxJS would exit the process.
You can easily debug the issue by uncommenting the lines above and running the test 'add another component that does not need any compilation' inside compile.e2e file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2642)
<!-- Reviewable:end -->
