### PR TITLE
fix built-types script to not override dists files 

### DIFF
--- a/scripts/build-types.bash
+++ b/scripts/build-types.bash
@@ -2,8 +2,5 @@
 set -e
 rm -rf types
 node_modules/.bin/tsc --project tsconfig.types.json
-rm -rf types/fixtures
-mv types/src/*  types/
-rm -r types/src
-cp -r types/* dist
+cp -r types/src/* dist
 rm -rf types

--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -2,6 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "types",
+    "emitDeclarationOnly": true,
     "declaration": true
   },
   "include": [


### PR DESCRIPTION
This script used to emit also .js files, as a result, after running this script, "bit" wasn't working anymore.
This PR changes the tsconfig.json of this script to emit only "d.ts" files.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2647)
<!-- Reviewable:end -->
