### PR TITLE
remove flattened extension dependencies that are also flattened dependencies

### DIFF
--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -79,6 +79,9 @@ export default class BitIds extends Array<BitId> {
   removeIfExistWithoutVersion(bitId: BitId): BitIds {
     return BitIds.fromArray(this.filter(id => !id.isEqualWithoutVersion(bitId)));
   }
+  removeMultipleIfExistWithoutVersion(bitIds: BitIds): BitIds {
+    return BitIds.fromArray(this.filter(id => !bitIds.hasWithoutVersion(id)));
+  }
 
   /**
    * make sure to pass only bit ids you know they have scope, otherwise, you'll get invalid bit ids.

--- a/src/scope/component-ops/get-flattened-dependencies.ts
+++ b/src/scope/component-ops/get-flattened-dependencies.ts
@@ -43,9 +43,14 @@ export async function getAllFlattenedDependencies(
     prodGraph: graphDeps
   });
 
+  const getFlattenedDevDeps = () => {
+    const flattenedDevAndExt = BitIds.uniqFromArray([...flattenedDevDependencies, ...flattenedExtensionDependencies]);
+    return flattenedDevAndExt.removeMultipleIfExistWithoutVersion(flattenedDependencies);
+  };
+
   return {
     flattenedDependencies,
-    flattenedDevDependencies: BitIds.uniqFromArray([...flattenedDevDependencies, ...flattenedExtensionDependencies])
+    flattenedDevDependencies: getFlattenedDevDeps()
   };
 }
 

--- a/src/scope/component-ops/get-flattened-dependencies.ts
+++ b/src/scope/component-ops/get-flattened-dependencies.ts
@@ -44,8 +44,10 @@ export async function getAllFlattenedDependencies(
   });
 
   const getFlattenedDevDeps = () => {
-    const flattenedDevAndExt = BitIds.uniqFromArray([...flattenedDevDependencies, ...flattenedExtensionDependencies]);
-    return flattenedDevAndExt.removeMultipleIfExistWithoutVersion(flattenedDependencies);
+    // remove extensions dependencies that are also regular dependencies
+    // (no need to do the same for devDependencies, because their duplicated are removed previously)
+    const flattenedExt = flattenedExtensionDependencies.removeMultipleIfExistWithoutVersion(flattenedDependencies);
+    return BitIds.uniqFromArray([...flattenedDevDependencies, ...flattenedExt]);
   };
 
   return {


### PR DESCRIPTION
Currently, they might be duplicate. e.g. `test` component has `compile` as a dependency and also as an extension dependency, it shows twice, once in flattenedDependencies and also in flattenedDevDependencies.

This PR removes the duplicated ids.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2649)
<!-- Reviewable:end -->
