### PR TITLE
Fix compile to work with the full-name "bit.core/compile"

### DIFF
--- a/src/extensions/compile/compile.ts
+++ b/src/extensions/compile/compile.ts
@@ -57,7 +57,11 @@ export class Compile {
     const idsAndFlows = new IdsAndFlows();
     const componentsWithLegacyCompilers: ComponentAndCapsule[] = [];
     componentsAndCapsules.forEach(c => {
-      const compileConfig = c.component.config.extensions.findCoreExtension('compile')?.config;
+      const compileCore = c.component.config.extensions.findCoreExtension('compile');
+      const compileComponent = c.component.config.extensions.findExtension('compile');
+      const compileComponentExported = c.component.config.extensions.findExtension('bit.core/compile');
+      const compileExtension = compileCore || compileComponent || compileComponentExported;
+      const compileConfig = compileExtension?.config;
       const compiler = compileConfig ? [compileConfig.compiler] : [];
       if (compileConfig) {
         idsAndFlows.push({ id: c.consumerComponent.id, value: compiler });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -213,7 +213,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     });
     // @todo: is this the best way to find out whether a compiler is set?
     const isCompileSet = Boolean(
-      consumerComponent.compiler || clonedComponent.extensions.some(e => e.name === 'compile')
+      consumerComponent.compiler ||
+        clonedComponent.extensions.some(e => e.name === 'compile' || e.name === 'bit.core/compile')
     );
     const { dists, mainDistFile } = clonedComponent.dists.toDistFilesModel(
       consumer,


### PR DESCRIPTION
This is needed for the dogfooding branch when the core-extensions are components and the name of the compile extension is changed to have the full name including the scope name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2662)
<!-- Reviewable:end -->
