### PR TITLE
fix symlinks between bit-bin and capsules 

### DIFF
--- a/src/extensions/package-manager/package-manager.ts
+++ b/src/extensions/package-manager/package-manager.ts
@@ -18,7 +18,18 @@ export type installOpts = {
 
 function linkBitBinInCapsule(capsule) {
   const bitBinPath = path.join(capsule.wrkDir, './node_modules/bit-bin');
-  const localBitBinPath = path.join(__dirname, '../..');
+  const getLocalBitBinPath = () => {
+    const pathOutsideNodeModules = path.join(__dirname, '../..');
+    if (pathOutsideNodeModules.endsWith(`${path.sep}dist`)) {
+      return pathOutsideNodeModules;
+    }
+    if (__dirname.includes('node_modules')) {
+      // for bit-bin development, the cli extension is installed as a package in node_modules
+      return path.join(__dirname.split('node_modules')[0], 'dist');
+    }
+    throw new Error('unable to link bit-bin to the capsule, the location of bit-bin is unknown');
+  };
+  const localBitBinPath = getLocalBitBinPath();
   // if there are no deps, sometimes the node_modules folder is not created
   // and we need it in order to perform the linking
   try {


### PR DESCRIPTION
to work when the extensions are loaded from node_modules

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2663)
<!-- Reviewable:end -->
