### PR TITLE
avoid applying the owner-as-prefix strategy when the user is "bit"

### DIFF
--- a/src/utils/bit/component-id-to-package-name.ts
+++ b/src/utils/bit/component-id-to-package-name.ts
@@ -22,7 +22,7 @@ export default function componentIdToPackageName(
   // Make sure we don't have the prefix also as part of the scope name
   // since prefixes are now taken from the owner name, and the scope name has the owner name as well.
   const registryPrefixWithDotWithoutAt = `${registryPrefix}.`.replace('@', '');
-  if (nameWithoutPrefix.startsWith(registryPrefixWithDotWithoutAt)) {
+  if (nameWithoutPrefix.startsWith(registryPrefixWithDotWithoutAt) && registryPrefix !== '@bit') {
     nameWithoutPrefix = nameWithoutPrefix.replace(registryPrefixWithDotWithoutAt, '');
   }
   return `${registryPrefix}/${nameWithoutPrefix}`;


### PR DESCRIPTION
@GiladShoham , I'm not sure this is how you expected it to be. 
Please let me know if It's needed to be changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/teambit/bit/2664)
<!-- Reviewable:end -->
