### PR TITLE
add componentRootDir to the tester API

### DIFF
--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -784,8 +784,18 @@ export default class Component {
           const oneFileSpecResult = async testFile => {
             const testFilePath = testFile.path;
             try {
+              const componentRootDir = component.componentMap?.getTrackDir();
               const context: Record<string, any> = {
+                /**
+                 * @deprecated
+                 * this is not the component dir, it's the workspace dir
+                 */
                 componentDir: cwd,
+                /**
+                 * absolute path of the component in the workspace.
+                 * available only when is running inside the workspace and the component has either trackDir or rootDir
+                 */
+                componentRootDir: componentRootDir && cwd ? path.join(cwd, componentRootDir) : null, // absolute path of the
                 isolate: isolateFunc
               };
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -795,7 +795,7 @@ export default class Component {
                  * absolute path of the component in the workspace.
                  * available only when is running inside the workspace and the component has either trackDir or rootDir
                  */
-                componentRootDir: componentRootDir && cwd ? path.join(cwd, componentRootDir) : null, // absolute path of the
+                componentRootDir: componentRootDir && cwd ? path.join(cwd, componentRootDir) : null,
                 isolate: isolateFunc
               };
 


### PR DESCRIPTION
Available through the second parameter `context.componentRootDir`.

This is needed for testers to save artifacts into the component's dir. For example, it helps Jest tester to save the screenshots files.