### PR TITLE
Implement compile process for development

### DIFF
--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -87,6 +87,17 @@ export default class PackageJsonFile {
     return new PackageJsonFile({ filePath, packageJsonObject, fileExist: true, workspaceDir, indent, newline });
   }
 
+  static loadFromPathSync(workspaceDir: PathOsBasedAbsolute, pathToLoad: string) {
+    const filePath = composePath(pathToLoad);
+    const filePathAbsolute = path.join(workspaceDir, filePath);
+    const packageJsonStr = PackageJsonFile.getPackageJsonStrIfExistSync(filePathAbsolute);
+    if (!packageJsonStr) {
+      return new PackageJsonFile({ filePath, fileExist: false, workspaceDir });
+    }
+    const packageJsonObject = PackageJsonFile.parsePackageJsonStr(packageJsonStr, pathToLoad);
+    return new PackageJsonFile({ filePath, packageJsonObject, fileExist: true, workspaceDir });
+  }
+
   static createFromComponent(
     componentDir: PathRelative,
     component: Component,

--- a/src/extensions/compile/README.md
+++ b/src/extensions/compile/README.md
@@ -26,6 +26,17 @@ An example:
 To run: `bit compile`
 
 ### Compiler Implementation
+The compiler is responsible for two processes:
+1. compile during development
+This compilation take place on the workspace and the dists are saved inside the component dir.
+The provider should implement `compileFile` function as follows:
+```
+compileFile: (fileContent: string, options: { componentDir: string, filePath: string }) => Array<{ outputText: string, outputPath: string }> | null;
+```
+In case the compiler receive an unsupported file, it should return null.
+
+2. compile for release (during the tag command)
+This compilation take place on the isolated capsule.
 The provider should implement `defineCompiler` function which returns the filename of the task file without the extension.
 An example:
 ```

--- a/src/extensions/compile/compile.ts
+++ b/src/extensions/compile/compile.ts
@@ -1,7 +1,9 @@
+import R from 'ramda';
 import { Harmony } from '@teambit/harmony';
 import path from 'path';
 import pMapSeries from 'p-map-series';
 import { Workspace } from '../workspace';
+import { DEFAULT_DIST_DIRNAME } from './../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { BitId } from '../../bit-id';
 import { ResolvedComponent } from '../workspace/resolved-component';
@@ -17,6 +19,10 @@ import { Dist } from '../../consumer/component/sources';
 import GeneralError from '../../error/general-error';
 import { packageNameToComponentId } from '../../utils/bit/package-name-to-component-id';
 import { ExtensionDataList } from '../../consumer/config/extension-data';
+import CompilerExtension from '../../legacy-extensions/compiler-extension';
+import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
+import { searchFilesIgnoreExt, pathJoinLinux } from '../../utils';
+import PackageJsonFile from '../../consumer/component/package-json-file';
 
 type BuildResult = { component: string; buildResults: string[] | null | undefined };
 
@@ -31,6 +37,10 @@ type buildHookResult = { id: BitId; dists?: Array<{ path: string; content: strin
 type CompilerInstance = {
   defineCompiler: () => { taskFile: string };
   watchMultiple?: (capsulePaths: string[]) => any;
+  compileFile: (
+    fileContent: string,
+    options: { componentDir: string; filePath: string }
+  ) => Array<{ outputText: string; outputPath: string }> | null;
 };
 
 type AggregatedWatcher = {
@@ -38,6 +48,12 @@ type AggregatedWatcher = {
   compilerInstance: CompilerInstance;
   componentIds: BitId[];
   capsulePaths: string[];
+};
+
+type ComponentsAndNewCompilers = {
+  component: ConsumerComponent;
+  compilerInstance: CompilerInstance;
+  compilerId: BitId;
 };
 
 export class Compile {
@@ -51,13 +67,15 @@ export class Compile {
     ids: BitId[],
     noCache?: boolean,
     verbose?: boolean,
-    dontPrintEnvMsg?: boolean
+    dontPrintEnvMsg?: boolean,
+    buildOnCapsules?: boolean
   ): Promise<BuildResult[]> {
     return this.compile(
       ids.map(id => id.toString()),
       noCache,
       verbose,
-      dontPrintEnvMsg
+      dontPrintEnvMsg,
+      buildOnCapsules
     );
   }
 
@@ -65,12 +83,14 @@ export class Compile {
     componentsIds: string[] | BitId[], // when empty, it compiles all
     noCache?: boolean,
     verbose?: boolean,
-    dontPrintEnvMsg?: boolean
+    dontPrintEnvMsg?: boolean,
+    buildOnCapsules = false
   ): Promise<BuildResult[]> {
     const componentsAndCapsules = await getComponentsAndCapsules(componentsIds, this.workspace);
     logger.debug(`compilerExt, completed created of capsules for ${componentsIds.join(', ')}`);
     const idsAndFlows = new IdsAndFlows();
     const componentsWithLegacyCompilers: ComponentAndCapsule[] = [];
+    const componentsAndNewCompilers: ComponentsAndNewCompilers[] = [];
     componentsAndCapsules.forEach(c => {
       const compileCore = c.component.config.extensions.findCoreExtension('compile');
       const compileComponent = c.component.config.extensions.findExtension('compile');
@@ -79,16 +99,30 @@ export class Compile {
       const compileConfig = compileExtension?.config;
       const taskName = this.getTaskNameFromCompiler(compileConfig, c.component.config.extensions);
       const value = taskName ? [taskName] : [];
-      if (compileConfig) {
-        idsAndFlows.push({ id: c.consumerComponent.id, value });
+      if (buildOnCapsules) {
+        if (compileConfig) {
+          idsAndFlows.push({ id: c.consumerComponent.id, value });
+        } else {
+          componentsWithLegacyCompilers.push(c);
+        }
+        // if there is no componentDir (e.g. author that added files, not dir), then we can't write the dists
+        // inside the component dir.
+      } else if (compileConfig && compileConfig.compiler && c.consumerComponent.componentMap?.getComponentDir()) {
+        const compilerInstance = this.getCompilerInstance(compileConfig.compiler, c.component.config.extensions);
+        const compilerId = this.getCompilerBitId(compileConfig.compiler, c.component.config.extensions);
+        componentsAndNewCompilers.push({ component: c.consumerComponent, compilerInstance, compilerId });
       } else {
         componentsWithLegacyCompilers.push(c);
       }
     });
-    let newCompilersResult: BuildResult[] = [];
+    let newCompilersResultOnCapsule: BuildResult[] = [];
+    let newCompilersResultOnWorkspace: BuildResult[] = [];
     let oldCompilersResult: BuildResult[] = [];
+    if (componentsAndNewCompilers.length) {
+      newCompilersResultOnWorkspace = await this.compileWithNewCompilersOnWorkspace(componentsAndNewCompilers);
+    }
     if (idsAndFlows.length) {
-      newCompilersResult = await this.compileWithNewCompilers(
+      newCompilersResultOnCapsule = await this.compileWithNewCompilersOnCapsules(
         idsAndFlows,
         componentsAndCapsules.map(c => c.consumerComponent)
       );
@@ -102,7 +136,79 @@ export class Compile {
       );
     }
 
-    return [...newCompilersResult, ...oldCompilersResult];
+    return [...newCompilersResultOnWorkspace, ...newCompilersResultOnCapsule, ...oldCompilersResult];
+  }
+
+  private async compileWithNewCompilersOnWorkspace(
+    componentsAndNewCompilers: ComponentsAndNewCompilers[]
+  ): Promise<BuildResult[]> {
+    const build = async ({ component, compilerId, compilerInstance }: ComponentsAndNewCompilers) => {
+      if (!compilerInstance.compileFile) {
+        throw new Error(`compiler ${compilerId.toString()} doesn't implement "compileFile" interface`);
+      }
+      const packageName = componentIdToPackageName(component.id, component.bindingPrefix, component.defaultScope);
+      const packageDir = path.join('node_modules', packageName);
+      const distDirName = DEFAULT_DIST_DIRNAME;
+      const distDir = path.join(packageDir, distDirName);
+      const dists: Dist[] = [];
+      const compileErrors: { path: string; error: Error }[] = [];
+      await Promise.all(
+        component.files.map(async file => {
+          const relativeComponentDir = component.componentMap?.getComponentDir();
+          if (!relativeComponentDir)
+            throw new Error(`compileWithNewCompilersOnWorkspace expect to get only components with rootDir`);
+          const componentDir = path.join(this.workspace.path, relativeComponentDir);
+          const options = { componentDir, filePath: file.relative };
+          let compileResults;
+          try {
+            compileResults = compilerInstance.compileFile(file.contents.toString(), options);
+          } catch (error) {
+            compileErrors.push({ path: file.path, error });
+            return;
+          }
+          const base = distDir;
+          if (compileResults) {
+            dists.push(
+              ...compileResults.map(
+                result =>
+                  new Dist({
+                    base,
+                    path: path.join(base, result.outputPath),
+                    contents: Buffer.from(result.outputText)
+                  })
+              )
+            );
+          } else {
+            // compiler doesn't support this file type. copy the file as is to the dist dir.
+            dists.push(new Dist({ base, path: path.join(base, file.relative), contents: file.contents }));
+          }
+        })
+      );
+      if (compileErrors.length) {
+        const formatError = errorItem => `${errorItem.path}\n${errorItem.error}`;
+        throw new Error(`compilation failed. see the following errors from the compiler
+${compileErrors.map(formatError).join('\n')}`);
+      }
+      // writing the dists with `component.setDists(dists); component.dists.writeDists` is tricky
+      // as it uses other base-paths and doesn't respect the new node-modules base path.
+      const dataToPersist = new DataToPersist();
+      dataToPersist.addManyFiles(dists);
+      const found = searchFilesIgnoreExt(dists, component.mainFile, 'relative');
+      if (!found) throw new Error(`unable to find dist main file for ${component.id.toString()}`);
+      const packageJson = PackageJsonFile.loadFromPathSync(this.workspace.path, packageDir);
+      if (!packageJson.fileExist) {
+        throw new Error(`failed finding package.json file in ${packageDir}`);
+      }
+      packageJson.addOrUpdateProperty('main', pathJoinLinux(distDirName, found));
+      dataToPersist.addFile(packageJson.toVinylFile());
+      dataToPersist.addBasePath(this.workspace.path);
+      await dataToPersist.persistAllToFS();
+      const oneBuildResults = dists.map(distFile => distFile.path);
+      if (component.compiler) loader.succeed();
+      return { component: component.id.toString(), buildResults: oneBuildResults };
+    };
+    const allBuildResults = await pMapSeries(componentsAndNewCompilers, build);
+    return allBuildResults;
   }
 
   private getCompilerInstance(compiler: string, extensions: ExtensionDataList): CompilerInstance {
@@ -155,7 +261,10 @@ please make sure the compiler provider returns anything`);
     return compilerExtensionConfig.extensionId;
   }
 
-  async compileWithNewCompilers(idsAndFlows: IdsAndFlows, components: ConsumerComponent[]): Promise<BuildResult[]> {
+  async compileWithNewCompilersOnCapsules(
+    idsAndFlows: IdsAndFlows,
+    components: ConsumerComponent[]
+  ): Promise<BuildResult[]> {
     const reportResults: any = await this.flows.runMultiple(idsAndFlows, { traverse: 'only' });
     // @todo fix once flows.run() get types
     const resultsP: any = Object.values(reportResults.value).map(async (reportResult: any) => {
@@ -191,7 +300,7 @@ please make sure the compiler provider returns anything`);
         if (!resultFromCompiler || !resultFromCompiler.dists) return null;
         const builtFiles = resultFromCompiler.dists;
         builtFiles.forEach(file => {
-          if (!file.path || !file.content || typeof file.content !== 'string') {
+          if (!file.path || !('content' in file) || typeof file.content !== 'string') {
             throw new GeneralError(
               'compile interface expects to get files in a form of { path: string, content: string }'
             );

--- a/src/extensions/typescript/typescript.manifest.js
+++ b/src/extensions/typescript/typescript.manifest.js
@@ -1,8 +1,12 @@
+/* eslint-disable no-console */
+
+const ts = require('typescript');
 const os = require('os');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const childProcess = require('child_process');
+const tsconfig = require('./tsconfig.default.json');
 
 module.exports = {
   name: 'typescript',
@@ -12,7 +16,58 @@ module.exports = {
 
 async function provider() {
   const defineCompiler = () => ({ taskFile: 'transpile' });
-  return { defineCompiler, watchMultiple };
+  return { defineCompiler, watchMultiple, compileFile };
+}
+
+/**
+ *
+ * @param {string} fileContent
+ * @param {
+ *   {
+ *      componentDir: string,
+ *      filePath: string
+ *   }
+ * } options
+ */
+function compileFile(fileContent, options) {
+  const supportedExtensions = ['.ts', '.tsx'];
+  const fileExtension = path.extname(options.filePath);
+  if (!supportedExtensions.includes(fileExtension)) {
+    return null; // file is not supported
+  }
+  const compilerOptionsFromTsconfig = ts.convertCompilerOptionsFromJson(tsconfig.compilerOptions, '.');
+  if (compilerOptionsFromTsconfig.errors.length) {
+    throw new Error(`failed parsing the tsconfig.json.\n${compilerOptionsFromTsconfig.errors.join('\n')}`);
+  }
+  const compilerOptions = compilerOptionsFromTsconfig.options;
+  compilerOptions.sourceRoot = options.componentDir;
+  const result = ts.transpileModule(fileContent, {
+    compilerOptions,
+    fileName: options.filePath,
+    reportDiagnostics: true
+  });
+
+  if (result.diagnostics && result.diagnostics.length) {
+    const formatHost = {
+      getCanonicalFileName: p => p,
+      getCurrentDirectory: ts.sys.getCurrentDirectory,
+      getNewLine: () => ts.sys.newLine
+    };
+    const error = ts.formatDiagnosticsWithColorAndContext(result.diagnostics, formatHost);
+
+    throw new Error(error);
+  }
+
+  const replaceExtToJs = filePath => filePath.replace(new RegExp(`${fileExtension}$`), '.js'); // makes sure it's the last occurrence
+  const outputPath = replaceExtToJs(options.filePath);
+  const outputFiles = [{ outputText: result.outputText, outputPath }];
+  if (result.sourceMapText) {
+    outputFiles.push({
+      outputText: result.sourceMapText,
+      outputPath: `${outputPath}.map`
+    });
+  }
+  return outputFiles;
 }
 
 function watchMultiple(capsulePaths) {

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -179,7 +179,7 @@ export default class NodeModuleLinker {
       const dest = path.join(linkPath, file);
       const destRelative = getPathRelativeRegardlessCWD(path.dirname(dest), possiblyDist);
       const fileContent = getLinkToFileContent(destRelative);
-      if (fileContent) {
+      if (fileContent && !componentMap.hasRootDir()) {
         const linkFile = LinkFile.load({
           filePath: dest,
           content: fileContent,

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -214,7 +214,8 @@ export default (async function tagModelComponent({
 
   logger.debug('scope.putMany: sequentially build all components');
   Analytics.addBreadCrumb('scope.putMany', 'scope.putMany: sequentially build all components');
-  await scope.buildMultiple(componentsToBuildAndTest, consumer, false, verbose);
+  const buildOnCapsules = true;
+  await scope.buildMultiple(componentsToBuildAndTest, consumer, false, verbose, undefined, buildOnCapsules);
 
   logger.debug('scope.putMany: sequentially test all components');
   let testsResults = [];

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -288,7 +288,8 @@ export default class Scope {
     noCache: boolean,
     verbose: boolean,
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    dontPrintEnvMsg? = false
+    dontPrintEnvMsg? = false,
+    buildOnCapsules = false
   ): Promise<{ component: string; buildResults: Record<string, any> }> {
     logger.debugAndAddBreadCrumb('scope.buildMultiple', 'scope.buildMultiple: sequentially build multiple components');
     // Make sure to not start the loader if there are no components to build
@@ -300,7 +301,9 @@ export default class Scope {
     // don't run this hook if the legacy-shared-dir is enabled. otherwise, it'll remove shared-dir
     // for authored and will change the component files.
     if (!isFeatureEnabled(LEGACY_SHARED_DIR_FEATURE)) {
-      return R.flatten(await Promise.all(this.onBuild.map(func => func(ids, noCache, verbose, dontPrintEnvMsg))));
+      return R.flatten(
+        await Promise.all(this.onBuild.map(func => func(ids, noCache, verbose, dontPrintEnvMsg, buildOnCapsules)))
+      );
     }
     logger.debugAndAddBreadCrumb('scope.buildMultiple', 'using the legacy build mechanism');
     const build = async (component: Component) => {


### PR DESCRIPTION
which is different than compile for release.

This compilation takes place on the workspace and the dists are saved inside the component dir.
The provider should implement `compileFile` function as follows:
```
compileFile: (fileContent: string, options: { componentDir: string, filePath: string }) => Array<{ outputText: string, outputPath: string }> | null;
```
In case the compiler receive an unsupported file, it should return null.

Also, implemented the typescript core-ext `compileFile` method.