### PR TITLE
show a descriptive error when unit-tests fail to load requirejs package on some node versions

### DIFF
--- a/src/consumer/component/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
@@ -20,7 +20,17 @@ require('resolve-dependency-path');
 require('sass-lookup');
 require('app-module-path');
 require('module-definition');
-require('module-lookup-amd');
+try {
+  require('module-lookup-amd');
+} catch (err) {
+  console.log(`mocha suppresses the error, so console.error is needed to show the error on the screen.
+the problem is with module-lookup-amd that calls requirejs package, which requires a file r.js, which is an invalid js file.
+the error occurs on some specific node versions, such as v12.16.3.
+if you get the error, please change your node version. (e.g. v12.7.0 is fine).
+`);
+  console.error(err);
+  throw err;
+}
 
 describe('filing-cabinet', () => {
   describe('JavaScript', () => {

--- a/src/consumer/component/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/filing-cabinet/index.spec.ts
@@ -20,14 +20,18 @@ require('resolve-dependency-path');
 require('sass-lookup');
 require('app-module-path');
 require('module-definition');
+
 try {
+  // eslint-disable-next-line global-require
   require('module-lookup-amd');
 } catch (err) {
+  // eslint-disable-next-line no-console
   console.log(`mocha suppresses the error, so console.error is needed to show the error on the screen.
-the problem is with module-lookup-amd that calls requirejs package, which requires a file r.js, which is an invalid js file.
-the error occurs on some specific node versions, such as v12.16.3.
-if you get the error, please change your node version. (e.g. v12.7.0 is fine).
+the problem is with module-lookup-amd that calls requirejs package and uses rewire package.
+see https://github.com/jhnns/rewire/issues/178 for more details.
+the error occurs since node v12.16.0. for the time being, to run the tests, use an earlier version.
 `);
+  // eslint-disable-next-line no-console
   console.error(err);
   throw err;
 }


### PR DESCRIPTION
Before, when running the unit-tests on node versions such as v12.17.x or v14, it'd just exit the process without any error.

At some point, we'll need to fix this, probably by removing the mock-fs altogether from the unit tests.