### PR TITLE
Write the package.json of imported components on he node_modules

### DIFF
--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -83,6 +83,25 @@ describe('compile extension', function() {
         it('should not show the component as modified', () => {
           helper.command.expectStatusToBeClean();
         });
+        it('should save the artifacts and package.json on node_modules', () => {
+          const artifactsPath = path.join(
+            helper.scopes.localPath,
+            'node_modules/@bit',
+            `${helper.scopes.remote}.comp1`
+          );
+          expect(path.join(artifactsPath, 'dist/index.js')).to.be.a.file();
+          expect(path.join(artifactsPath, 'package.json')).to.be.a.file();
+        });
+        it('should save the artifacts and package.json for NESTED in the component dir, same as legacy', () => {
+          const nestedPath = path.join(
+            helper.scopes.localPath,
+            'components/.dependencies/comp2',
+            helper.scopes.remote,
+            '0.0.1'
+          );
+          expect(path.join(nestedPath, 'dist/index.js')).to.be.a.file();
+          expect(path.join(nestedPath, 'package.json')).to.be.a.file();
+        });
         describe('running compile on the imported component', () => {
           it('should generate dists also after deleting the dists from the workspace', () => {
             const distPath = path.join(

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -209,7 +209,7 @@ export default class ComponentWriter {
   }
 
   private getArtifactsDir() {
-    if (!this.consumer) return null;
+    if (!this.consumer || this.consumer.isLegacy) return null;
     if (this.origin === COMPONENT_ORIGINS.NESTED) return this.component.writtenPath;
     return getNodeModulesPathOfComponent(
       this.consumer.config._bindingPrefix,

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -145,10 +145,11 @@ export default class ComponentWriter {
       this.writePackageJson &&
       (this.isolated || (this.consumer && this.consumer.isolated) || this.writeToPath !== '.')
     ) {
+      const artifactsDir = this.getArtifactsDir();
       const { packageJson, distPackageJson } = preparePackageJsonToWrite(
         this.bitMap,
         this.component,
-        this.writeToPath,
+        artifactsDir || this.writeToPath,
         this.override,
         this.writeBitDependencies,
         this.excludeRegistryPrefix,
@@ -198,23 +199,24 @@ export default class ComponentWriter {
    * later, this responsibility might move to pkg extension, which could write only artifacts
    * that are set in package.json.files[], to have a similar structure of a package.
    */
-  populateArtifacts() {
+  private populateArtifacts() {
     const artifactsVinyl: Artifact[] = R.flatten(this.component.extensions.map(e => e.artifacts));
-    const getArtifactsDir = () => {
-      if (!this.consumer) return null;
-      if (this.origin === COMPONENT_ORIGINS.NESTED) return this.component.writtenPath;
-      return getNodeModulesPathOfComponent(
-        this.consumer.config._bindingPrefix,
-        this.component.id,
-        true,
-        this.component.defaultScope
-      );
-    };
-    const artifactsDir = getArtifactsDir();
+    const artifactsDir = this.getArtifactsDir();
     if (artifactsDir) {
       artifactsVinyl.forEach(a => a.updatePaths({ newBase: artifactsDir }));
     }
     this.component.dataToPersist.addManyFiles(artifactsVinyl);
+  }
+
+  private getArtifactsDir() {
+    if (!this.consumer) return null;
+    if (this.origin === COMPONENT_ORIGINS.NESTED) return this.component.writtenPath;
+    return getNodeModulesPathOfComponent(
+      this.consumer.config._bindingPrefix,
+      this.component.id,
+      true,
+      this.component.defaultScope
+    );
   }
 
   addComponentToBitMap(rootDir: string | undefined): ComponentMap {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -837,6 +837,19 @@ export default class Consumer {
   }
 
   /**
+   * legacy is a workspace uses the old bit.json or "bit" prop of package.json.
+   * new workspaces use workspace.jsonc file
+   */
+  get isLegacy(): boolean {
+    if (!('isLegacy' in this.config)) {
+      // this happens for example when running `bit import --compiler`. the environment dir has its
+      // own consumer and the config is not ILegacyWorkspaceConfig but WorkspaceConfig
+      return true;
+    }
+    return this.config.isLegacy;
+  }
+
+  /**
    * clean up removed components from bitmap
    * @param {BitIds} componentsToRemoveFromFs - delete component that are used by other components.
    * @param {BitIds} removedDependencies - delete component that are used by other components.

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -103,7 +103,7 @@ export default class NodeModuleLinker {
     return linksResults;
   }
   async _populateImportedComponentsLinks(component: Component): Promise<void> {
-    if (this.consumer && this.consumer.config.isLegacy === false) {
+    if (this.consumer && !this.consumer.isLegacy) {
       await this._populateImportedNonLegacyComponentsLinks(component);
       return;
     }


### PR DESCRIPTION
of the component instead of the component-dir. (for Harmony only).

This way, the files' structure of imported and authored are the same.