### PR TITLE
support node 10 (drop support of node 8)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 default_image: &default_image
   docker:
-    - image: circleci/node:12.7.0
+    - image: circleci/node:10.6.0
 
 default_resource_class: &default_resource_class
   resource_class: small


### PR DESCRIPTION
The long term support of node 8 was terminated by the end of last year (2019).
Continue supporting node 8 prevent us from installing Prettier 2, which in turn, prevents some babel packages to be installed, which in turn, prevents using `import type` syntax of TS, and future features of TS.