### PR TITLE
enable new commands to declare the args and flags types

### DIFF
--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -75,7 +75,7 @@ export interface Command {
    * @param flags - command flags as described in options.
    * @return - JSX element which is rendered with ink
    */
-  render?: (args: CLIArgs, flags: Flags) => Promise<React.ReactElement>;
+  render?(args: CLIArgs, flags: Flags): Promise<React.ReactElement>;
 
   /**
    * Command handler which is called for legacy commands or when process.isTTY is false
@@ -83,7 +83,7 @@ export interface Command {
    * @param flags - command flags as described in options.
    * @return - Report object. The Report.data is printed to the stdout as is.
    */
-  report?: (args: CLIArgs, flags: Flags) => Promise<Report>;
+  report?(args: CLIArgs, flags: Flags): Promise<Report>;
 
   /**
    * Optional handler to provide a raw result of the command.
@@ -92,9 +92,9 @@ export interface Command {
    * @param flags - command flags as described in options.
    * @return a GenericObject to be rendered to string (by json.stringify) in the console.
    */
-  json?: (args: CLIArgs, flags: Flags) => Promise<GenericObject>;
+  json?(args: CLIArgs, flags: Flags): Promise<GenericObject>;
 }
-export type Flags = { [flagName: string]: string | boolean };
+export type Flags = { [flagName: string]: string | boolean | undefined };
 export type CLIArgs = Array<string[] | string>;
 export type GenericObject = { [k: string]: any };
 export type Report = { data: string; code: number };

--- a/src/extensions/builder/run.cmd.tsx
+++ b/src/extensions/builder/run.cmd.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Box, Color } from 'ink';
-import { Command, CLIArgs } from '../cli';
+import { Command } from '../cli';
 import { Workspace } from '../workspace';
 import { BuilderExtension } from './builder.extension';
 
@@ -16,7 +16,7 @@ export class BuilderCmd implements Command {
 
   constructor(private builder: BuilderExtension, private workspace: Workspace) {}
 
-  async render([userPattern]: CLIArgs) {
+  async render([userPattern]: [string]) {
     const pattern = userPattern && userPattern.toString();
     const results = await this.builder.build(
       pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list()

--- a/src/extensions/compiler/compiler.cmd.tsx
+++ b/src/extensions/compiler/compiler.cmd.tsx
@@ -1,7 +1,5 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
-import { Command, CLIArgs } from '../cli';
-import { Flags, CommandOptions } from '../cli';
+import { Command, CommandOptions } from '../cli';
 import { Compile } from './compile';
 
 export class CompileCmd implements Command {
@@ -18,7 +16,7 @@ export class CompileCmd implements Command {
 
   constructor(private compile: Compile) {}
 
-  async render([components]: CLIArgs, { verbose, noCache }: Flags) {
+  async render([components]: [string[]], { verbose, noCache }: { verbose: boolean; noCache: boolean }) {
     // @ts-ignore
     const compileResults = await this.compile.compileOnWorkspace(components, { verbose, noCache });
     // eslint-disable-next-line no-console
@@ -27,7 +25,7 @@ export class CompileCmd implements Command {
     return <div>{output}</div>;
   }
 
-  async json([components]: CLIArgs, { verbose, noCache }: Flags) {
+  async json([components]: [string[]], { verbose, noCache }: { verbose: boolean; noCache: boolean }) {
     // @ts-ignore
     const compileResults = await this.compile.compileOnWorkspace(components, { verbose, noCache });
     return {

--- a/src/extensions/create/create.cmd.tsx
+++ b/src/extensions/create/create.cmd.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color, Text, Box } from 'ink';
-import { Command, CLIArgs } from '../cli';
+import { Command } from '../cli';
 import { Create } from './create';
 
 export class CreateCmd implements Command {
@@ -15,7 +15,7 @@ export class CreateCmd implements Command {
 
   constructor(private create: Create) {}
 
-  async render([name]: CLIArgs) {
+  async render([name]: [string]) {
     // @ts-ignore
     const results = await this.create.create(name);
     const result = results.addedComponents[0];

--- a/src/extensions/insights/insights.cmd.tsx
+++ b/src/extensions/insights/insights.cmd.tsx
@@ -1,8 +1,7 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color, Box, Text } from 'ink';
-import { Command, CLIArgs, CommandOptions } from '../cli';
-import { Flags } from '../cli';
+import { Command, CommandOptions } from '../cli';
 import { InsightManager } from './insight-manager';
 import { InsightResult } from './insight';
 
@@ -16,7 +15,7 @@ export default class InsightsCmd implements Command {
     this.insightManager = insightManager;
   }
 
-  async render([names]: CLIArgs, { list }: Flags) {
+  async render([names]: [string[]], { list }: { list: boolean }) {
     if (list) {
       const results = this.insightManager.listInsights();
       const listItems = results.map(insight => (insight += '\n'));

--- a/src/extensions/isolator/capsule-create.cmd.tsx
+++ b/src/extensions/isolator/capsule-create.cmd.tsx
@@ -3,17 +3,17 @@ import React from 'react';
 import _ from 'lodash';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color } from 'ink';
-import { Command, CommandOptions, CLIArgs, Flags } from '../cli';
+import { Command, CommandOptions } from '../cli';
 import { IsolatorExtension } from './isolator.extension';
 import { loadConsumerIfExist } from '../../consumer';
 import CapsuleList from './capsule-list';
 
-interface CreateOpts {
-  baseDir: string | null | undefined;
+type CreateOpts = {
+  baseDir?: string;
   alwaysNew: boolean;
   id: string;
   installPackages: boolean;
-}
+};
 
 export class CapsuleCreateCmd implements Command {
   name = 'capsule-create [componentIds...]';
@@ -44,14 +44,14 @@ export class CapsuleCreateCmd implements Command {
     return capsules;
   }
 
-  async render([componentIds]: CLIArgs, opts: Flags) {
+  async render([componentIds]: [string[]], opts: CreateOpts) {
     // @ts-ignore
     const capsules = await this.create(componentIds, opts);
     // TODO: improve output
     return <Color green>created capsules {capsules}</Color>;
   }
 
-  async json([componentIds]: CLIArgs, opts: Flags) {
+  async json([componentIds]: [string[]], opts: CreateOpts) {
     // @ts-ignore
     const capsules = await this.create(componentIds, opts);
     return capsules;

--- a/src/extensions/pkg/pack.cmd.tsx
+++ b/src/extensions/pkg/pack.cmd.tsx
@@ -3,7 +3,17 @@ import React from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color } from 'ink';
 import { Packer } from './pack';
-import { Flags, CommandOptions, Command, CLIArgs } from '../cli';
+import { CommandOptions, Command } from '../cli';
+
+type PackArgs = [string, string];
+
+type PackFlags = {
+  outDir: string;
+  prefix?: boolean;
+  override?: boolean;
+  keep?: boolean;
+  json?: boolean;
+};
 
 export class PackCmd implements Command {
   name = 'pack <componentId> [scopePath]';
@@ -21,12 +31,12 @@ export class PackCmd implements Command {
 
   constructor(private packer: Packer) {}
 
-  async render(args: CLIArgs, options: Flags) {
+  async render(args: PackArgs, options: PackFlags) {
     const packResult = await this.json(args, options);
     return <Color green>tar path: {packResult.data.tarPath}</Color>;
   }
 
-  async json([componentId, scopePath]: CLIArgs, options: Flags) {
+  async json([componentId, scopePath]: PackArgs, options: PackFlags) {
     const compId = typeof componentId === 'string' ? componentId : componentId[0];
     let scopePathStr: string | undefined;
     if (scopePath) {
@@ -36,7 +46,6 @@ export class PackCmd implements Command {
     const packResult = await this.packer.packComponent(
       compId,
       scopePathStr,
-      // @ts-ignore
       options.outDir,
       options.prefix,
       options.override,

--- a/src/extensions/tester/test.cmd.tsx
+++ b/src/extensions/tester/test.cmd.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Box, Color } from 'ink';
-import { Command, CLIArgs } from '../cli';
+import { Command } from '../cli';
 import { TesterExtension } from './tester.extension';
 import { Workspace } from '../workspace';
 
@@ -16,7 +16,7 @@ export class TestCmd implements Command {
 
   constructor(private tester: TesterExtension, private workspace: Workspace) {}
 
-  async render([userPattern]: CLIArgs) {
+  async render([userPattern]: [string]) {
     const pattern = userPattern && userPattern.toString();
     const results = await this.tester.test(
       pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list()

--- a/src/extensions/ui/start.cmd.tsx
+++ b/src/extensions/ui/start.cmd.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react';
 import { Box, Color, Text } from 'ink';
 // import { EnvConsole } from './components';
 // make sure to update eslint to read JSX.
-import { Command, CLIArgs } from '../cli';
+import { Command } from '../cli';
 import { Workspace } from '../workspace';
 import { UIExtension } from './ui.extension';
 
@@ -32,8 +32,7 @@ export class StartCmd implements Command {
     process.stdout.write(process.platform === 'win32' ? '\x1B[2J\x1B[0f' : '\x1B[2J\x1B[3J\x1B[H');
   }
 
-  // @ts-ignore TODO: align cli api.
-  async render([userPattern]: CLIArgs): Promise<React.ReactElement> {
+  async render([userPattern]: [string]): Promise<React.ReactElement> {
     // @teambit/variants should be the one to take care of component patterns.
     const pattern = userPattern && userPattern.toString();
     const uiRuntime = await this.ui.createRuntime(pattern ? await this.workspace.byPattern(pattern) : undefined);

--- a/src/extensions/watch/watch.cmd.tsx
+++ b/src/extensions/watch/watch.cmd.tsx
@@ -1,8 +1,6 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { Color } from 'ink';
-import { Command, CLIArgs, CommandOptions } from '../cli';
+import { Command, CommandOptions } from '../cli';
 import { Watch } from '.';
 
 export class WatchCommand implements Command {
@@ -15,7 +13,7 @@ export class WatchCommand implements Command {
 
   constructor(private watch: Watch) {}
 
-  async render(cliArgs: CLIArgs, { verbose = false }: { verbose?: boolean }) {
+  async render(cliArgs: [], { verbose = false }: { verbose?: boolean }): Promise<React.ReactElement> {
     await this.watch.watch({ verbose });
     return <Color>watcher terminated</Color>;
   }


### PR DESCRIPTION
Currently, the only type they accept is the generic `CLIArgs` and `Flags`.

Also, replace the args and flags of new commands with the concrete types.