### PR TITLE
add a new prop "internal" to Command and LegacyCommand interfaces 

### DIFF
--- a/e2e/commands/_scope.e2e.1.ts
+++ b/e2e/commands/_scope.e2e.1.ts
@@ -22,5 +22,9 @@ describe('bit _scope command', function() {
     it('should throw ScopeNotFound error', () => {
       expect(output).to.have.string('scope not found');
     });
+    it('should serialize the error and return a json', () => {
+      expect(output).to.string('{"payload":');
+      expect(output).to.string('"name":"ScopeNotFound"');
+    });
   });
 });

--- a/src/cli/command-runner.ts
+++ b/src/cli/command-runner.ts
@@ -27,7 +27,7 @@ export class CommandRunner {
         return await this.runReportHandler();
       }
     } catch (err) {
-      return this.handleError(err);
+      return handleErrorAndExit(err, this.command.name, this.command.internal);
     }
 
     throw new Error(`command "${this.command.name}" doesn't implement "render" nor "report" methods`);
@@ -43,10 +43,6 @@ export class CommandRunner {
       return false;
     }
     return Boolean(this.command.render);
-  }
-
-  private async handleError(err: Error) {
-    return handleErrorAndExit(err, this.command.name, this.command.private);
   }
 
   private async runJsonHandler() {

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -34,9 +34,16 @@ export interface Command {
   group?: string;
 
   /**
-   * Should a command be exposed to the user.
+   * should a command be exposed to the user.
+   * e.g. experimental commands or commands created for the ssh communication should not be exposed
    */
   private?: boolean;
+
+  /**
+   * command that is not running on the terminal, such as "_fetch", "_put".
+   * in case an error is thrown, it is serialized so it's easier to parse it later
+   */
+  internal?: boolean;
 
   /**
    * should turn on Loader
@@ -58,7 +65,7 @@ export interface Command {
   commands?: Command[];
 
   /**
-   * command running on a remote ssh server, such as, _fetch, _put.
+   * interact with a remote, e.g. "export" push to a remote
    * for now, the only difference is that they get a "token" flag to authenticate anonymously.
    */
   remoteOp?: boolean;

--- a/src/cli/commands/private-cmds/_delete-cmd.ts
+++ b/src/cli/commands/private-cmds/_delete-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class Delete implements LegacyCommand {
   name = '_delete <path> <args>';
   private = true;
+  internal = true;
   description = 'remove a component from a scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_deprecate-cmd.ts
+++ b/src/cli/commands/private-cmds/_deprecate-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class Deprecate implements LegacyCommand {
   name = '_deprecate <path> <args>';
   private = true;
+  internal = true;
   description = 'deprecate a component from a scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_fetch-cmd.ts
+++ b/src/cli/commands/private-cmds/_fetch-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class Fetch implements LegacyCommand {
   name = '_fetch <path> <args>';
   private = true;
+  internal = true;
   description = 'fetch components(s) from a scope';
   alias = '';
   opts = [['n', 'no-dependencies', 'do not include component dependencies']] as CommandOptions;

--- a/src/cli/commands/private-cmds/_graph-cmd.ts
+++ b/src/cli/commands/private-cmds/_graph-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class _Graph implements LegacyCommand {
   name = '_graph <path> <args>';
   private = true;
+  internal = true;
   description = 'returns scope graph or sub-graph when component id is given';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_latest-cmd.ts
+++ b/src/cli/commands/private-cmds/_latest-cmd.ts
@@ -10,6 +10,7 @@ let compressResponse;
 export default class Latest implements LegacyCommand {
   name = '_latest <path> <args>';
   private = true;
+  internal = true;
   description = 'latest version numbers of given components';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_list-cmd.ts
+++ b/src/cli/commands/private-cmds/_list-cmd.ts
@@ -12,6 +12,7 @@ let compressResponse;
 export default class List implements LegacyCommand {
   name = '_list <path> <args>';
   private = true;
+  internal = true;
   description = 'list scope components';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_log-cmd.ts
+++ b/src/cli/commands/private-cmds/_log-cmd.ts
@@ -10,6 +10,7 @@ let compressResponse;
 export default class _Log implements LegacyCommand {
   name = '_log <path> <args>';
   private = true;
+  internal = true;
   description = 'show component logs';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_put-cmd.ts
+++ b/src/cli/commands/private-cmds/_put-cmd.ts
@@ -10,6 +10,7 @@ let compressResponse;
 export default class Put implements LegacyCommand {
   name = '_put <path> <args>';
   private = true;
+  internal = true;
   description = 'upload a component to a scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_scope-cmd.ts
+++ b/src/cli/commands/private-cmds/_scope-cmd.ts
@@ -8,6 +8,7 @@ export default class Prepare implements LegacyCommand {
   name = '_scope <path> <args>';
   description = 'describe a scope';
   private = true;
+  internal = true;
   alias = '';
   opts = [];
 

--- a/src/cli/commands/private-cmds/_search-cmd.ts
+++ b/src/cli/commands/private-cmds/_search-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class Search implements LegacyCommand {
   name = '_search <path> <args>';
   private = true;
+  internal = true;
   description = 'search for components on a remote scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_show-cmd.ts
+++ b/src/cli/commands/private-cmds/_show-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class _Show implements LegacyCommand {
   name = '_show <path> <args>';
   private = true;
+  internal = true;
   description = 'show a specific component on scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/_undeprecate-cmd.ts
+++ b/src/cli/commands/private-cmds/_undeprecate-cmd.ts
@@ -11,6 +11,7 @@ let compressResponse;
 export default class Undeprecate implements LegacyCommand {
   name = '_undeprecate <path> <args>';
   private = true;
+  internal = true;
   description = 'undeprecate a component from a scope';
   alias = '';
   opts = [];

--- a/src/cli/commands/private-cmds/ci-update-cmd.ts
+++ b/src/cli/commands/private-cmds/ci-update-cmd.ts
@@ -17,8 +17,7 @@ export default class CiUpdate implements LegacyCommand {
     ['c', 'no-cache', 'ignore component cache when creating dist file'],
     ['o', 'output [file]', 'save ci results to file system']
   ] as CommandOptions;
-  /* changed command to not private so bit will not print {"payload":"","headers":{"version":"0.12.10-dev.1"}} when it fails */
-  private = false;
+  private = true;
 
   action(
     [id, scopePath]: [string, string | null | undefined],

--- a/src/cli/legacy-command.ts
+++ b/src/cli/legacy-command.ts
@@ -11,6 +11,7 @@ export interface LegacyCommand {
   loader?: boolean;
   skipWorkspace?: boolean;
   migration?: boolean;
+  internal?: boolean; // used for serialize the error it returns
   remoteOp?: boolean; // Used for adding the token option globally
 
   action(params: any, opts: { [key: string]: any }, packageManagerArgs?: string[]): Promise<any>;

--- a/src/extensions/cli/commands/help.cmd.tsx
+++ b/src/extensions/cli/commands/help.cmd.tsx
@@ -6,14 +6,7 @@ import { Command } from '../../../cli/command';
 export function Help(Renderer = DefaultHelpRender) {
   return function getHelpProps(commands: { [k: string]: Command }, groups: { [k: string]: string }) {
     const help: HelpProps = Object.entries(commands)
-      // The ci-update condition is a workaround because we don't want to make it private for other reason (see the ci-update-cmd for more info)
-      // TODO: remove this once the ci-update command has been removed soon
-      .filter(
-        ([, command]) =>
-          !command.private &&
-          (command.shortDescription || command.description) &&
-          command.name !== 'ci-update <id> [scopePath]'
-      )
+      .filter(([, command]) => !command.private && (command.shortDescription || command.description))
       .reduce(function(partialHelp, [id, command]) {
         partialHelp[command.group!] = partialHelp[command.group!] || {
           commands: {},

--- a/src/extensions/cli/legacy-command-adapter.ts
+++ b/src/extensions/cli/legacy-command-adapter.ts
@@ -15,6 +15,7 @@ export class LegacyCommandAdapter implements Command {
   commands: Command[];
   private?: boolean;
   migration?: boolean;
+  internal?: boolean;
   _packageManagerArgs?: string[];
   constructor(private cmd: LegacyCommand, cliExtension: CLIExtension) {
     this.name = cmd.name;
@@ -28,6 +29,7 @@ export class LegacyCommandAdapter implements Command {
     this.loader = cmd.loader;
     this.private = cmd.private;
     this.migration = cmd.migration;
+    this.internal = cmd.internal;
     this.commands = (cmd.commands || []).map(sub => new LegacyCommandAdapter(sub, cliExtension));
   }
 


### PR DESCRIPTION
Currently, the "private" prop used for two different things: 
1. indicating that a command should not be shown in help.
2. making sure to serialize the error if it throws.

Now, "private" is responsible for # 1. "internal" is responsible for # 2.