### PR TITLE
change PaperError to not render React component

### DIFF
--- a/src/cli/command-runner.ts
+++ b/src/cli/command-runner.ts
@@ -2,11 +2,10 @@ import { serializeError } from 'serialize-error';
 import { render } from 'ink';
 import { Command, CLIArgs, Flags } from './command';
 import { migrate } from '../api/consumer';
-import defaultHandleError, { sendToAnalyticsAndSentry } from './default-error-handler';
+import defaultHandleError from './default-error-handler';
 import { isNumeric, buildCommandMessage, packCommand } from '../utils';
 import loader from './loader';
 import logger from '../logger/logger';
-import { PaperError } from '../extensions/cli';
 
 export class CommandRunner {
   constructor(private command: Command, private args: CLIArgs, private flags: Flags) {}
@@ -64,9 +63,8 @@ export class CommandRunner {
     const result = await this.command.render(this.args, this.flags);
     loader.off();
     render(result);
-    // @todo: not clear if is needed to call waitUntilExit()
-    // const { waitUntilExit } = render(result);
-    // await waitUntilExit();
+    const { waitUntilExit } = render(result);
+    await waitUntilExit();
     return logger.exitAfterFlush(result.props.code, this.command.name);
   }
 
@@ -106,20 +104,13 @@ export function handleErrorAndExit(err: Error, commandName: string, shouldSerial
     )}`
   );
   loader.off();
-  if (err instanceof PaperError) {
-    sendToAnalyticsAndSentry(err);
-    PaperError.handleError(err);
-    return logger.exitAfterFlush(1, commandName);
-  }
-  const handledError = defaultHandleError(err);
-  if (shouldSerialize) return serializeErrAndExit(err, commandName);
-  return logErrAndExit(handledError || err, commandName);
+  const { message, error } = defaultHandleError(err);
+  if (shouldSerialize) return serializeErrAndExit(error, commandName);
+  return logErrAndExit(message, commandName);
 }
 
 export function logErrAndExit(err: Error | string, commandName: string) {
   if (!err) throw new Error(`logErrAndExit expects to get either an Error or a string, got nothing`);
-  // probably not needed, because commands from the ssh are private and as such serialized
-  // if (err.code) throw err;
   console.error(err); // eslint-disable-line
   logger.exitAfterFlush(1, commandName);
 }

--- a/src/consumer/component-ops/eject-components.ts
+++ b/src/consumer/component-ops/eject-components.ts
@@ -259,9 +259,7 @@ please use bit remove command to remove them.`,
   }
 
   throwEjectError(message: string, originalError: Error) {
-    // $FlowFixMe that's right, we don't know whether originalError has 'msg' property, but most have. what other choices do we have?
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const originalErrorMessage: string = defaultErrorHandler(originalError) || originalError.msg || originalError;
+    const { message: originalErrorMessage } = defaultErrorHandler(originalError);
     logger.error(`eject has stopped due to an error ${originalErrorMessage}`, originalError);
     throw new Error(`${message}
 

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -72,7 +72,7 @@ export default class GeneralHelper {
       output = err.toString();
     }
 
-    const errorString = defaultErrorHandler(error);
+    const { message: errorString } = defaultErrorHandler(error);
     expect(GeneralHelper.alignOutput(output)).to.have.string(GeneralHelper.alignOutput(errorString) as string);
   }
 

--- a/src/extensions/cli/exceptions/already-exists.tsx
+++ b/src/extensions/cli/exceptions/already-exists.tsx
@@ -1,13 +1,10 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
-import { Color } from 'ink';
 import { PaperError } from './paper-error';
 
 export class AlreadyExistsError extends PaperError {
   constructor(type: string, name: string) {
     super(`${type} ${name} already exists.`);
   }
-  render() {
-    return <Color red>{this.message}</Color>;
+  report() {
+    return this.message;
   }
 }

--- a/src/extensions/cli/exceptions/command-not-found.tsx
+++ b/src/extensions/cli/exceptions/command-not-found.tsx
@@ -1,5 +1,4 @@
-import React from 'react';
-import { Color, Text, Box } from 'ink';
+import chalk from 'chalk';
 import { PaperError } from './paper-error';
 
 export class CommandNotFound extends PaperError {
@@ -10,32 +9,14 @@ export class CommandNotFound extends PaperError {
     this.commandName = commandName;
     this.suggestion = suggestion;
   }
-  render() {
-    return (
-      <Box flexDirection="column">
-        <Box>
-          <Color yellow>
-            warning: <Text bold>{this.commandName}</Text> is not a valid command
-          </Color>
-        </Box>
-        <Box>
-          <Color yellow>see &apos;bit --help&apos; for additional information</Color>
-        </Box>
-        {this.renderSuggestion()}
-      </Box>
+  report() {
+    let output = chalk.yellow(
+      `warning: '${chalk.bold(this.commandName)}' is not a valid command.
+see 'bit --help' for additional information`
     );
-  }
-
-  renderSuggestion() {
-    if (!this.suggestion) return <Box></Box>;
-    return (
-      <Box flexDirection="column">
-        <Box>
-          <Color red>
-            Did you mean: <Text bold>{this.suggestion}</Text>?
-          </Color>
-        </Box>
-      </Box>
-    );
+    if (this.suggestion) {
+      output += `\nDid you mean ${chalk.bold(this.suggestion)}?`;
+    }
+    return output;
   }
 }

--- a/src/extensions/cli/exceptions/paper-error.tsx
+++ b/src/extensions/cli/exceptions/paper-error.tsx
@@ -1,12 +1,8 @@
-import { render } from 'ink';
-
-import React from 'react';
-
 export abstract class PaperError extends Error {
   isUserError: boolean; // user errors are not reported to Sentry
-  abstract render(): React.ReactElement;
+  abstract report(): string;
 
-  static handleError(err: PaperError): void {
-    render(err.render());
+  static handleError(err: PaperError): string {
+    return err.report();
   }
 }

--- a/src/extensions/config/exceptions/invalid-config-file.tsx
+++ b/src/extensions/config/exceptions/invalid-config-file.tsx
@@ -1,20 +1,15 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import React from 'react';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Color } from 'ink';
 import chalk from 'chalk';
 import { PaperError } from '../../cli';
 
 export default class InvalidConfigFile extends PaperError {
   showDoctorMessage: boolean;
-
-  render() {
-    return <Color red>{this.message}</Color>;
-  }
-
   constructor(readonly path: string) {
     super(generateMessage(path));
     this.showDoctorMessage = true;
+  }
+
+  report() {
+    return this.message;
   }
 }
 

--- a/src/extensions/insights/exceptions/insight-already-exists.tsx
+++ b/src/extensions/insights/exceptions/insight-already-exists.tsx
@@ -1,14 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
-import { Color } from 'ink';
 import { PaperError } from '../../cli';
 
 export default class InsightAlreadyExists extends PaperError {
   constructor(readonly insightName: string) {
     super(generateMessage(insightName));
   }
-  render() {
-    return <Color red>{this.message}</Color>;
+  report() {
+    return this.message;
   }
 }
 function generateMessage(insightName: string) {

--- a/src/extensions/insights/exceptions/insight-not-found.tsx
+++ b/src/extensions/insights/exceptions/insight-not-found.tsx
@@ -1,14 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
-import { Color } from 'ink';
 import { PaperError } from '../../cli';
 
 export default class InsightNotFound extends PaperError {
   constructor(readonly insightName: string) {
     super(generateMessage(insightName));
   }
-  render() {
-    return <Color red>{this.message}</Color>;
+  report() {
+    return this.message;
   }
 }
 function generateMessage(insightName: string) {

--- a/src/extensions/insights/exceptions/no-data-for-insight.tsx
+++ b/src/extensions/insights/exceptions/no-data-for-insight.tsx
@@ -1,14 +1,11 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react';
-import { Color } from 'ink';
 import { PaperError } from '../../cli';
 
 export default class NoDataForInsight extends PaperError {
   constructor(readonly insightName: string) {
     super(generateMessage(insightName));
   }
-  render() {
-    return <Color red>{this.message}</Color>;
+  report() {
+    return this.message;
   }
 }
 function generateMessage(insightName: string) {

--- a/src/extensions/pkg/exceptions/scope-not-found.tsx
+++ b/src/extensions/pkg/exceptions/scope-not-found.tsx
@@ -1,7 +1,3 @@
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import React from 'react';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { Color } from 'ink';
 import { PaperError } from '../../cli';
 
 export class ScopeNotFound extends PaperError {
@@ -9,12 +5,8 @@ export class ScopeNotFound extends PaperError {
     super(generateMessage(scopePath));
   }
 
-  render() {
-    if (this.scopePath) {
-      return <Color red>{this.message}</Color>;
-    }
-    return <Color red>{this.message}</Color>;
-    // return this.message
+  report() {
+    return this.message;
   }
 }
 

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -102,7 +102,8 @@ class BitLogger {
   console(msg: string | Error, level = 'info', color?: string) {
     let actualMessage = msg;
     if (msg instanceof Error) {
-      actualMessage = defaultHandleError(msg) || msg;
+      const { message } = defaultHandleError(msg);
+      actualMessage = message;
     }
     if (!this.shouldWriteToConsole) {
       this[level](actualMessage);


### PR DESCRIPTION
No need to render React component when throwing an error. It's easier to work with strings.