### PR TITLE
write to legacy logger when calling Harmony logger

### DIFF
--- a/src/cli/command-runner.ts
+++ b/src/cli/command-runner.ts
@@ -58,7 +58,6 @@ export class CommandRunner {
     if (!this.command.render) throw new Error('runRenderHandler expects command.render to be implemented');
     const result = await this.command.render(this.args, this.flags);
     loader.off();
-    render(result);
     const { waitUntilExit } = render(result);
     await waitUntilExit();
     return logger.exitAfterFlush(result.props.code, this.command.name);

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
 // TODO: change to module path once types become a component
 import { LogPublisher } from '../types';
+import legacyLogger from '../../logger/logger';
 
 export enum LogLevel {
   INFO = 'info',
@@ -22,18 +23,22 @@ export default class Logger {
       this.subscribers.push(extensionName);
     }
     const emitter = this.eventEmitter;
+    const emitAndLogToFile = (componentId, messages, logLevel) => {
+      emitter.emit(extensionName, { componentId, messages, logLevel });
+      legacyLogger[logLevel](`${componentId}, ${messages}`);
+    };
     return {
       info(componentId, messages) {
-        emitter.emit(extensionName, { componentId, messages, logLevel: 'info' });
+        emitAndLogToFile(componentId, messages, 'info');
       },
       warn(componentId, messages) {
-        emitter.emit(extensionName, { componentId, messages, logLevel: 'warn' });
+        emitAndLogToFile(componentId, messages, 'warn');
       },
       error(componentId, messages) {
-        emitter.emit(extensionName, { componentId, messages, logLevel: 'error' });
+        emitAndLogToFile(componentId, messages, 'error');
       },
       debug(componentId, messages) {
-        emitter.emit(extensionName, { componentId, messages, logLevel: 'debug' });
+        emitAndLogToFile(componentId, messages, 'debug');
       }
     };
   }

--- a/src/extensions/reporter/reporter.ts
+++ b/src/extensions/reporter/reporter.ts
@@ -4,7 +4,6 @@ import chalk from 'chalk';
 import { Logger, LogEntry, LogLevel } from '../logger';
 import StatusLine from './status-line';
 import getColumnCount from './get-column-count';
-import legacyLogger from '../../logger/logger';
 
 export default class Reporter {
   private outputShouldBeSuppressed = false;
@@ -39,7 +38,6 @@ export default class Reporter {
     this.statusLine.startSpinner();
   }
   info(componentId, messages) {
-    legacyLogger.info(`${componentId}, ${messages}`);
     const lines = messages.split(/\n/);
     this.statusLine.stopSpinner();
     lines
@@ -54,7 +52,6 @@ export default class Reporter {
     this.statusLine.startSpinner();
   }
   warn(componentId, messages) {
-    legacyLogger.warn(`${componentId}, ${messages}`);
     const lines = messages.split(/\n/);
     this.statusLine.stopSpinner();
     lines
@@ -70,7 +67,6 @@ export default class Reporter {
     this.statusLine.startSpinner();
   }
   error(componentId, messages) {
-    legacyLogger.error(`${componentId}, ${messages}`);
     const lines = messages.split(/\n/);
     this.statusLine.stopSpinner();
     lines
@@ -85,7 +81,6 @@ export default class Reporter {
     this.statusLine.startSpinner();
   }
   debug(componentId, messages) {
-    legacyLogger.debug(`${componentId}, ${messages}`);
     const lines = messages.split(/\n/);
     this.statusLine.stopSpinner();
     lines


### PR DESCRIPTION
Also, remove the duplicated render() call.