### PR TITLE
introduce a new command "publish" to publish components to a registry

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -1,0 +1,66 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+
+chai.use(require('chai-fs'));
+
+describe('publish command', function() {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('workspace with TS components', () => {
+    let appOutput: string;
+    let owner;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      owner = '@ci';
+      helper.bitJsonc.addDefaultScope();
+      helper.bitJsonc.addDefaultOwner(owner);
+      appOutput = helper.fixtures.populateComponentsTS(3, owner);
+      const environments = {
+        env: '@teambit/react',
+        config: {}
+      };
+      helper.extensions.addExtensionToVariant('*', '@teambit/envs', environments);
+    });
+    describe('publishing before tag', () => {
+      // @todo: complete
+      it('should throw an error', () => {});
+    });
+    (supportNpmCiRegistryTesting ? describe : describe.skip)('publishing the components using "bit publish"', () => {
+      let npmCiRegistry: NpmCiRegistry;
+      before(async () => {
+        npmCiRegistry = new NpmCiRegistry(helper);
+        helper.scopeHelper.reInitRemoteScope();
+        npmCiRegistry.setCiScopeInBitJson();
+        npmCiRegistry.configureCiInPackageJsonHarmony();
+        helper.command.tagAllComponents();
+        helper.command.exportAllComponents();
+        await npmCiRegistry.init();
+        npmCiRegistry.publishEntireScopeHarmony();
+      });
+      after(() => {
+        npmCiRegistry.destroy();
+      });
+      // this also makes sure that the main of package.json points to the dist file correctly
+      it('should publish them successfully and be able to consume them by installing the packages', () => {
+        helper.scopeHelper.reInitLocalScope();
+        helper.npm.initNpm();
+        helper.npm.installNpmPackage(`${owner}/${helper.scopes.remote}.comp1`, '0.0.1');
+        helper.fs.outputFile(
+          'app.js',
+          `const comp1 = require('${owner}/${helper.scopes.remote}.comp1').default;\nconsole.log(comp1())`
+        );
+        const output = helper.command.runCmd('node app.js');
+        expect(output.trim()).to.be.equal(appOutput.trim());
+      });
+    });
+  });
+});

--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -8,6 +8,7 @@ chai.use(require('chai-fs'));
 describe('publish command', function() {
   this.timeout(0);
   let helper: Helper;
+  let npmCiRegistry: NpmCiRegistry;
   before(() => {
     helper = new Helper();
     helper.command.setFeatures(HARMONY_FEATURE);
@@ -17,7 +18,8 @@ describe('publish command', function() {
   });
   describe('workspace with TS components', () => {
     let appOutput: string;
-    let owner;
+    let owner: string;
+    let scopeBeforeTag: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       owner = '@ci';
@@ -29,37 +31,76 @@ describe('publish command', function() {
         config: {}
       };
       helper.extensions.addExtensionToVariant('*', '@teambit/envs', environments);
+      npmCiRegistry = new NpmCiRegistry(helper);
+      helper.scopeHelper.reInitRemoteScope();
+      npmCiRegistry.setCiScopeInBitJson();
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      scopeBeforeTag = helper.scopeHelper.cloneLocalScope();
     });
     describe('publishing before tag', () => {
-      // @todo: complete
-      it('should throw an error', () => {});
+      it('should throw an error', () => {
+        const output = helper.general.runWithTryCatch('bit publish comp1');
+        expect(output).to.have.string(
+          'unable to publish the following component(s), please make sure they are exported: comp1'
+        );
+      });
     });
-    (supportNpmCiRegistryTesting ? describe : describe.skip)('publishing the components using "bit publish"', () => {
-      let npmCiRegistry: NpmCiRegistry;
-      before(async () => {
-        npmCiRegistry = new NpmCiRegistry(helper);
-        helper.scopeHelper.reInitRemoteScope();
-        npmCiRegistry.setCiScopeInBitJson();
-        npmCiRegistry.configureCiInPackageJsonHarmony();
+    describe('publishing before export', () => {
+      before(() => {
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+      });
+      it('should throw an error when --allow-staged flag is not used', () => {
+        const output = helper.general.runWithTryCatch('bit publish comp1');
+        expect(output).to.have.string(
+          'unable to publish the following component(s), please make sure they are exported: comp1'
+        );
+      });
+    });
+    (supportNpmCiRegistryTesting ? describe : describe.skip)('publishing the components', () => {
+      before(async () => {
         await npmCiRegistry.init();
-        npmCiRegistry.publishEntireScopeHarmony();
       });
       after(() => {
         npmCiRegistry.destroy();
       });
-      // this also makes sure that the main of package.json points to the dist file correctly
-      it('should publish them successfully and be able to consume them by installing the packages', () => {
-        helper.scopeHelper.reInitLocalScope();
-        helper.npm.initNpm();
-        helper.npm.installNpmPackage(`${owner}/${helper.scopes.remote}.comp1`, '0.0.1');
-        helper.fs.outputFile(
-          'app.js',
-          `const comp1 = require('${owner}/${helper.scopes.remote}.comp1').default;\nconsole.log(comp1())`
-        );
-        const output = helper.command.runCmd('node app.js');
-        expect(output.trim()).to.be.equal(appOutput.trim());
+      describe('automatically by PostExport hook', () => {
+        before(() => {
+          helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
+          helper.command.tagAllComponents();
+          helper.command.exportAllComponents();
+        });
+        it('should publish them successfully and be able to consume them by installing the packages', () => {
+          helper.scopeHelper.reInitLocalScope();
+          helper.npm.initNpm();
+          helper.npm.installNpmPackage(`${owner}/${helper.scopes.remote}.comp1`, '0.0.1');
+          helper.fs.outputFile(
+            'app.js',
+            `const comp1 = require('${owner}/${helper.scopes.remote}.comp1').default;\nconsole.log(comp1())`
+          );
+          const output = helper.command.runCmd('node app.js');
+          expect(output.trim()).to.be.equal(appOutput.trim());
+        });
+      });
+      describe('using "bit publish"', () => {
+        before(async () => {
+          helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
+          helper.command.tagScope('2.0.0');
+          helper.command.publish('comp1', '--allow-staged');
+          helper.command.publish('comp2', '--allow-staged');
+          helper.command.publish('comp3', '--allow-staged');
+        });
+        // this also makes sure that the main of package.json points to the dist file correctly
+        it('should publish them successfully and be able to consume them by installing the packages', () => {
+          helper.scopeHelper.reInitLocalScope();
+          helper.npm.initNpm();
+          helper.npm.installNpmPackage(`${owner}/${helper.scopes.remote}.comp1`, '2.0.0');
+          helper.fs.outputFile(
+            'app.js',
+            `const comp1 = require('${owner}/${helper.scopes.remote}.comp1').default;\nconsole.log(comp1())`
+          );
+          const output = helper.command.runCmd('node app.js');
+          expect(output.trim()).to.be.equal(appOutput.trim());
+        });
       });
     });
   });

--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -141,4 +141,22 @@ describe('publish functionality', function() {
       expect(output.trim()).to.be.equal('hello button');
     });
   });
+  describe('with invalid package name', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      helper.fixtures.populateComponentsTS(1);
+      const environments = {
+        env: '@teambit/react',
+        config: {}
+      };
+      helper.extensions.addExtensionToVariant('*', '@teambit/envs', environments);
+
+      npmCiRegistry.configureCustomNameInPackageJsonHarmony('invalid/name/{name}');
+    });
+    it('builder should show the npm error about invalid name', () => {
+      const output = helper.general.runWithTryCatch('bit run-new');
+      expect(output).to.have.string('npm ERR! Invalid name: "invalid/name/comp1"');
+    });
+  });
 });

--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -45,8 +45,6 @@ describe('publish functionality', function() {
           'unable to publish the following component(s), please make sure they are exported: comp1'
         );
       });
-      // @todo
-      it('should allow when --dry-run is specified', () => {});
     });
     describe('publishing before export', () => {
       before(() => {
@@ -57,6 +55,10 @@ describe('publish functionality', function() {
         expect(output).to.have.string(
           'unable to publish the following component(s), please make sure they are exported: comp1'
         );
+      });
+      it('should allow when --dry-run is specified', () => {
+        const output = helper.command.publish('comp1', '--dry-run');
+        expect(output).to.have.string(`+ @ci/${helper.scopes.remote}.comp1@0.0.1`);
       });
     });
     (supportNpmCiRegistryTesting ? describe : describe.skip)('publishing the components', () => {

--- a/e2e/npm-ci-registry.ts
+++ b/e2e/npm-ci-registry.ts
@@ -155,6 +155,22 @@ EOD`;
     this.helper.bitJsonc.addToVariant(undefined, '*', '@teambit/pkg', pkg);
   }
 
+  configureCustomNameInPackageJsonHarmony(name: string) {
+    const pkg = {
+      packageJson: {
+        name,
+        publishConfig: {
+          registry: this.ciRegistry
+        }
+      }
+    };
+    this.helper.bitJsonc.addToVariant(undefined, '*', '@teambit/pkg', pkg);
+  }
+
+  installPackage(pkgName: string) {
+    this.helper.command.runCmd(`npm install ${pkgName} --registry=${this.ciRegistry}`);
+  }
+
   unpublishComponent(packageName: string) {
     this.helper.command.runCmd(`npm unpublish @ci/${this.helper.scopes.remote}.${packageName} --force`);
   }

--- a/e2e/npm-ci-registry.ts
+++ b/e2e/npm-ci-registry.ts
@@ -155,10 +155,6 @@ EOD`;
     this.helper.bitJsonc.addToVariant(undefined, '*', '@teambit/pkg', pkg);
   }
 
-  publishComponentHarmony(componentName: string) {
-    this.helper.command.publish(componentName);
-  }
-
   unpublishComponent(packageName: string) {
     this.helper.command.runCmd(`npm unpublish @ci/${this.helper.scopes.remote}.${packageName} --force`);
   }
@@ -171,12 +167,6 @@ EOD`;
     const remoteIds = remoteComponents.map(c => c.id);
     this.helper.scopeHelper.removeRemoteScope();
     remoteIds.forEach(id => this.publishComponent(id));
-  }
-
-  publishEntireScopeHarmony() {
-    const remoteComponents = this.helper.command.listRemoteScopeParsed();
-    const remoteIds = remoteComponents.map(c => c.id);
-    remoteIds.forEach(id => this.publishComponentHarmony(id));
   }
 
   /**

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -20,6 +20,7 @@ import ComponentConfig from '../config/component-config';
 import PackageJsonFile from '../component/package-json-file';
 import ShowDoctorError from '../../error/show-doctor-error';
 import { Artifact } from '../component/sources/artifact';
+import { replacePlaceHolderWithComponentValue } from '../../utils/bit/component-placeholders';
 
 export type ComponentWriterProps = {
   component: Component;
@@ -247,7 +248,12 @@ export default class ComponentWriter {
     const specialKeys = ['extensions', 'dependencies', 'devDependencies', 'peerDependencies'];
     if (!this.component.extensionsAddedConfig || R.isEmpty(this.component.extensionsAddedConfig)) return;
     const valuesToMerge = R.omit(specialKeys, this.component.extensionsAddedConfig);
-    packageJson.mergePackageJsonObject(valuesToMerge);
+    const valuesToMergeFormatted = Object.keys(valuesToMerge).reduce((acc, current) => {
+      const value = replacePlaceHolderWithComponentValue(this.component, valuesToMerge[current]);
+      acc[current] = value;
+      return acc;
+    }, {});
+    packageJson.mergePackageJsonObject(valuesToMergeFormatted);
   }
 
   /**

--- a/src/consumer/config/component-config.ts
+++ b/src/consumer/config/component-config.ts
@@ -124,7 +124,31 @@ export default class ComponentConfig extends AbstractConfig {
   mergeWithComponentData(component: Component) {
     this.bindingPrefix = this.bindingPrefix || component.bindingPrefix;
     this.lang = this.lang || component.lang;
-    this.extensions = this.extensions.length ? this.extensions : component.extensions;
+    // @todo: make sure with Gilad that this logic aligns with him
+    // some extensions are saved in the model but are not loaded by loadFromFileSystem.
+    // e.g. the compiler extension is not configured in workspace.jsonc, but it saved in the model
+    // with the artifacts.
+    // this function makes sure to add all missing extensions and artifacts from the model
+    const populateExtensions = () => {
+      if (!component.extensions.length) return;
+      if (!this.extensions.length) {
+        this.extensions = component.extensions;
+        return;
+      }
+      // both, model and consumer have extensions
+      component.extensions.forEach(extension => {
+        const extensionFromConsumer = this.extensions.findExtension(extension.stringId);
+        if (!extensionFromConsumer) {
+          this.extensions.push(extension);
+          return;
+        }
+        // same extension exists in both, consumer and model. make sure the artifacts are populated
+        if (extension.artifacts.length && !extensionFromConsumer.artifacts.length) {
+          extensionFromConsumer.artifacts = extension.artifacts;
+        }
+      });
+    };
+    populateExtensions();
   }
 
   /**

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -1,5 +1,5 @@
 /* eslint-disable max-classes-per-file */
-import R, { find, forEachObjIndexed } from 'ramda';
+import R, { forEachObjIndexed } from 'ramda';
 import { BitId, BitIds } from '../../bit-id';
 import Consumer from '../consumer';
 import { ExtensionConfigList, IExtensionConfigList } from './extension-config-list';
@@ -66,18 +66,16 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> implements IExt
   }
 
   findExtension(extensionId: string, ignoreVersion = false): ExtensionDataEntry | undefined {
-    return find((extEntry: ExtensionDataEntry) => {
+    return this.find(extEntry => {
       if (!ignoreVersion) {
         return extEntry.stringId === extensionId;
       }
       return extEntry.extensionId?.toStringWithoutVersion() === extensionId;
-    }, this);
+    });
   }
 
   findCoreExtension(extensionId: string): ExtensionDataEntry | undefined {
-    return find((extEntry: ExtensionDataEntry) => {
-      return extEntry.name === extensionId;
-    }, this);
+    return this.find(extEntry => extEntry.name === extensionId);
   }
 
   remove(id: BitId) {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -368,8 +368,8 @@ export default class CommandHelper {
     }
     return result;
   }
-  publish(id: string) {
-    return this.runCmd(`bit publish ${id}`);
+  publish(id: string, flags = '') {
+    return this.runCmd(`bit publish ${id} ${flags}`);
   }
   ejectConf(id = 'bar/foo', options?: Record<string, any>) {
     const value = options

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -368,7 +368,9 @@ export default class CommandHelper {
     }
     return result;
   }
-
+  publish(id: string) {
+    return this.runCmd(`bit publish ${id}`);
+  }
   ejectConf(id = 'bar/foo', options?: Record<string, any>) {
     const value = options
       ? Object.keys(options) // $FlowFixMe

--- a/src/e2e-helper/e2e-fixtures-helper.ts
+++ b/src/e2e-helper/e2e-fixtures-helper.ts
@@ -158,11 +158,11 @@ module.exports = () => 'comp${index} and ' + ${nextComp}();`;
       .join(' and ');
   }
 
-  populateComponentsTS(numOfComponents = 3): string {
+  populateComponentsTS(numOfComponents = 3, owner = '@bit'): string {
     const getImp = index => {
       if (index === numOfComponents) return `export default () => 'comp${index}';`;
       const nextComp = `comp${index + 1}`;
-      return `import ${nextComp} from '@bit/${this.scopes.remote}.${nextComp}';
+      return `import ${nextComp} from '${owner}/${this.scopes.remote}.${nextComp}';
 export default () => 'comp${index} and ' + ${nextComp}();`;
     };
     for (let i = 1; i <= numOfComponents; i += 1) {
@@ -172,7 +172,7 @@ export default () => 'comp${index} and ' + ${nextComp}();`;
     this.command.link();
     this.fs.outputFile(
       'app.js',
-      `const comp1 = require('@bit/${this.scopes.remote}.comp1').default;\nconsole.log(comp1())`
+      `const comp1 = require('${owner}/${this.scopes.remote}.comp1').default;\nconsole.log(comp1())`
     );
     return Array(numOfComponents)
       .fill(null)

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import tar from 'tar';
 import fs from 'fs-extra';
 import { expect } from 'chai';
-import { BIT_VERSION } from '../constants';
+import { BIT_VERSION, WORKSPACE_JSONC } from '../constants';
 import defaultErrorHandler from '../cli/default-error-handler';
 import { removeChalkCharacters, generateRandomStr } from '../utils';
 import { ensureAndWriteJson } from './e2e-helper';
@@ -74,6 +74,10 @@ export default class GeneralHelper {
 
     const { message: errorString } = defaultErrorHandler(error);
     expect(GeneralHelper.alignOutput(output)).to.have.string(GeneralHelper.alignOutput(errorString) as string);
+  }
+
+  isProjectNew() {
+    return fs.existsSync(path.join(this.scopes.localPath, WORKSPACE_JSONC));
   }
 
   getRequireBitPath(box: string, name: string) {

--- a/src/extensions/builder/types.ts
+++ b/src/extensions/builder/types.ts
@@ -1,5 +1,5 @@
 import { Component, ComponentID } from '../component';
-import { Network } from '../isolator/isolator.extension';
+import { Network } from '../isolator';
 import { ExecutionContext } from '../environments';
 
 export interface BuildContext extends ExecutionContext {

--- a/src/extensions/isolator/capsule-create.cmd.tsx
+++ b/src/extensions/isolator/capsule-create.cmd.tsx
@@ -35,6 +35,8 @@ export class CapsuleCreateCmd implements Command {
     [componentIds]: [string[]],
     { baseDir, alwaysNew = false, id, installPackages = false }: CreateOpts
   ): Promise<CapsuleList> {
+    // @todo: why it is not an array?
+    if (componentIds && !Array.isArray(componentIds)) componentIds = [componentIds];
     // TODO: remove this consumer loading from here. it shouldn't be here
     const consumer = await loadConsumerIfExist();
     // TODO: throw a proper error instance

--- a/src/extensions/isolator/capsule-list.ts
+++ b/src/extensions/isolator/capsule-list.ts
@@ -23,4 +23,7 @@ export default class CapsuleList extends Array<{ id: ComponentID; capsule: Capsu
     const found = this.find(item => pathInCapsule.startsWith(item.capsule.wrkDir));
     return found ? found.id : null;
   }
+  getAllCapsules(): Capsule[] {
+    return this.map(c => c.capsule);
+  }
 }

--- a/src/extensions/isolator/capsule/capsule.ts
+++ b/src/extensions/isolator/capsule/capsule.ts
@@ -33,7 +33,14 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
     this._wrkDir = container.wrkDir;
   }
 
+  /**
+   * @deprecated please use `this.path`
+   */
   get wrkDir(): string {
+    return this.path;
+  }
+
+  get path(): string {
     return realpathSync(this._wrkDir);
   }
 

--- a/src/extensions/isolator/index.ts
+++ b/src/extensions/isolator/index.ts
@@ -1,2 +1,3 @@
-export { IsolatorExtension, Network } from './isolator.extension';
+export { IsolatorExtension } from './isolator.extension';
+export { Network } from './network';
 export { FsContainer, Capsule, ContainerExec } from './capsule';

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -22,6 +22,7 @@ import { symlinkDependenciesToCapsules } from './symlink-dependencies-to-capsule
 import logger from '../../logger/logger';
 import { CLIExtension } from '../cli';
 import { DEPENDENCIES_FIELDS } from '../../constants';
+import { Network } from './network';
 
 const CAPSULES_BASE_DIR = path.join(CACHE_ROOT, 'capsules'); // TODO: move elsewhere
 
@@ -29,10 +30,6 @@ export type IsolatorDeps = [DependencyResolverExtension, CLIExtension];
 export type ListResults = {
   workspace: string;
   capsules: string[];
-};
-export type Network = {
-  capsules: CapsuleList;
-  components: Graph;
 };
 
 async function createCapsulesFromComponents(components: any[], baseDir, orchOptions): Promise<Capsule[]> {
@@ -141,10 +138,11 @@ export class IsolatorExtension {
       );
     });
 
-    return {
-      capsules: capsuleList,
-      components: graph
-    };
+    return new Network(
+      capsuleList,
+      graph,
+      seederIds.map(s => new ComponentID(s))
+    );
   }
   async list(consumer: Consumer): Promise<ListResults> {
     const workspacePath = consumer.getPath();

--- a/src/extensions/isolator/network.ts
+++ b/src/extensions/isolator/network.ts
@@ -1,0 +1,16 @@
+import CapsuleList from './capsule-list';
+import Graph from '../../scope/graph/graph';
+import { ComponentID } from '../component';
+import { Capsule } from './capsule';
+
+export class Network {
+  constructor(public capsules: CapsuleList, public components: Graph, public seedersIds: ComponentID[]) {}
+
+  get seedersCapsules(): Capsule[] {
+    return this.seedersIds.map(seederId => {
+      const capsule = this.capsules.getCapsule(seederId);
+      if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
+      return capsule;
+    });
+  }
+}

--- a/src/extensions/pkg/pkg.extension.ts
+++ b/src/extensions/pkg/pkg.extension.ts
@@ -2,12 +2,15 @@ import { SlotRegistry, Slot } from '@teambit/harmony';
 // import { BitCli as CLI, BitCliExt as CLIExtension } from '../cli';
 import { ScopeExtension } from '../scope';
 import { PackCmd } from './pack.cmd';
+import { PublishCmd } from './publish.cmd';
 import { Packer, PackResult } from './pack';
 import { ExtensionDataList } from '../../consumer/config/extension-data';
 import ConsumerComponent from '../../consumer/component';
 import { Environments } from '../environments';
 import { CLIExtension } from '../cli';
 import { IsolatorExtension } from '../isolator';
+import { Publisher } from './publisher';
+import { LoggerExt, Logger } from '../logger';
 
 export interface PackageJsonProps {
   [key: string]: any;
@@ -29,21 +32,24 @@ export type ComponentPkgExtensionConfig = {
 
 export class PkgExtension {
   static id = '@teambit/pkg';
-  static dependencies = [CLIExtension, ScopeExtension, Environments, IsolatorExtension];
+  static dependencies = [CLIExtension, ScopeExtension, Environments, IsolatorExtension, LoggerExt];
   static slots = [Slot.withType<PackageJsonProps>()];
   static defaultConfig = {};
 
   static provider(
-    [cli, scope, envs, isolator]: [CLIExtension, ScopeExtension, Environments, IsolatorExtension],
+    [cli, scope, envs, isolator, logger]: [CLIExtension, ScopeExtension, Environments, IsolatorExtension, Logger],
     config: PkgExtensionConfig,
     [packageJsonPropsRegistry]: [PackageJsonPropsRegistry]
   ) {
+    const logPublisher = logger.createLogPublisher(PkgExtension.id);
     const packer = new Packer(isolator, scope?.legacyScope);
+    const publisher = new Publisher(isolator, logPublisher, scope?.legacyScope);
     const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs);
     // TODO: maybe we don't really need the id here any more
     ConsumerComponent.registerAddConfigAction(PkgExtension.id, pkg.mergePackageJsonProps.bind(pkg));
     // TODO: consider passing the pkg instead of packer
     cli.register(new PackCmd(packer));
+    cli.register(new PublishCmd(publisher));
 
     return pkg;
   }
@@ -117,7 +123,7 @@ export class PkgExtension {
     let newProps = {};
     const env = this.envs.getEnvFromExtensions(configuredExtensions);
     if (env?.getPackageJsonProps && typeof env.getPackageJsonProps === 'function') {
-      const propsFromEnv = await env.getPackageJsonProps();
+      const propsFromEnv = env.getPackageJsonProps();
       newProps = Object.assign(newProps, propsFromEnv);
     }
     const configuredIds = configuredExtensions.ids;

--- a/src/extensions/pkg/pkg.extension.ts
+++ b/src/extensions/pkg/pkg.extension.ts
@@ -45,6 +45,10 @@ export class PkgExtension {
     const packer = new Packer(isolator, scope?.legacyScope);
     const publisher = new Publisher(isolator, logPublisher, scope?.legacyScope);
     const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs);
+
+    const postExportFunc = publisher.postExportListener.bind(publisher);
+    if (scope) scope.onPostExport(postExportFunc);
+
     // TODO: maybe we don't really need the id here any more
     ConsumerComponent.registerAddConfigAction(PkgExtension.id, pkg.mergePackageJsonProps.bind(pkg));
     // TODO: consider passing the pkg instead of packer

--- a/src/extensions/pkg/pkg.extension.ts
+++ b/src/extensions/pkg/pkg.extension.ts
@@ -11,6 +11,7 @@ import { CLIExtension } from '../cli';
 import { IsolatorExtension } from '../isolator';
 import { Publisher } from './publisher';
 import { LoggerExt, Logger } from '../logger';
+import { PublishDryRunTask } from './publish-dry-run.task';
 
 export interface PackageJsonProps {
   [key: string]: any;
@@ -44,7 +45,8 @@ export class PkgExtension {
     const logPublisher = logger.createLogPublisher(PkgExtension.id);
     const packer = new Packer(isolator, scope?.legacyScope);
     const publisher = new Publisher(isolator, logPublisher, scope?.legacyScope);
-    const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs);
+    const dryRunTask = new PublishDryRunTask(PkgExtension.id, publisher);
+    const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs, dryRunTask);
 
     const postExportFunc = publisher.postExportListener.bind(publisher);
     if (scope) scope.onPostExport(postExportFunc);
@@ -84,7 +86,9 @@ export class PkgExtension {
     /**
      * envs extension.
      */
-    private envs: Environments
+    private envs: Environments,
+
+    readonly dryRunTask: PublishDryRunTask
   ) {}
 
   /**

--- a/src/extensions/pkg/publish-dry-run.task.ts
+++ b/src/extensions/pkg/publish-dry-run.task.ts
@@ -1,0 +1,22 @@
+import { BuildContext } from '../builder';
+import { BuildTask, BuildResults } from '../builder';
+import { Publisher } from './publisher';
+
+/**
+ * publish build task is running "publish --dry-run" to avoid later npm errors during export
+ */
+export class PublishDryRunTask implements BuildTask {
+  constructor(readonly extensionId: string, private publisher: Publisher) {}
+
+  async execute(context: BuildContext): Promise<BuildResults> {
+    this.publisher.options.dryRun = true;
+    const capsules = context.capsuleGraph.capsules.getAllCapsules();
+    // @ts-ignore todo: fix once the component here is not ConsumerComponent, just change to c.component.config.extensions
+    const capsulesToPublish = capsules.filter(c => this.publisher.shouldPublish(c.component.extensions));
+    const results = await this.publisher.publishMultipleCapsules(capsulesToPublish);
+    return {
+      components: results,
+      artifacts: []
+    };
+  }
+}

--- a/src/extensions/pkg/publish.cmd.tsx
+++ b/src/extensions/pkg/publish.cmd.tsx
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 import { CommandOptions, Command } from '../cli';
-import { Publisher } from './publisher';
-import { BuildResults } from '../builder';
+import { Publisher, PublishResult } from './publisher';
 
 type PublishArgs = [string];
 type PublishOptions = { dryRun: boolean };
@@ -22,16 +21,16 @@ export class PublishCmd implements Command {
 
   async report(args: PublishArgs, options: PublishOptions) {
     const result = await this.json(args, options);
-    const data: BuildResults = result.data;
+    const components = result.data;
     const title = chalk.white.inverse.bold(' Publish Results \n');
-    const output = data.components
+    const output = components
       .map(component => {
         const compName = component.id.toString();
         const getData = () => {
           if (component.errors.length) {
             return chalk.red(component.errors.join('\n'));
           }
-          return chalk.green(component.data);
+          return chalk.green(component.data as string);
         };
         return `${chalk.bold(compName)}\n${getData()}\n`;
       })
@@ -39,7 +38,7 @@ export class PublishCmd implements Command {
     return title + output;
   }
 
-  async json([componentId]: PublishArgs, options: PublishOptions) {
+  async json([componentId]: PublishArgs, options: PublishOptions): Promise<{ data: PublishResult[]; code: number }> {
     const compId = typeof componentId === 'string' ? componentId : componentId[0];
     const packResult = await this.publisher.publish([compId], options);
     return {

--- a/src/extensions/pkg/publish.cmd.tsx
+++ b/src/extensions/pkg/publish.cmd.tsx
@@ -1,15 +1,15 @@
 import chalk from 'chalk';
 import { CommandOptions, Command } from '../cli';
-import { Publisher, PublishResult } from './publisher';
+import { Publisher, PublishResult, PublisherOptions } from './publisher';
 
 type PublishArgs = [string];
-type PublishOptions = { dryRun: boolean };
 
 export class PublishCmd implements Command {
   name = 'publish <componentId>';
   description = 'publish components to npm (npm publish)';
   options = [
     ['d', 'dry-run [boolean]', 'npm publish --dry-run'],
+    ['', 'allow-staged', 'allow publish components that were not exported yet (not recommended)'],
     ['j', 'json [boolean]', 'return the output as JSON']
   ] as CommandOptions;
   shortDescription = '';
@@ -19,7 +19,7 @@ export class PublishCmd implements Command {
 
   constructor(private publisher: Publisher) {}
 
-  async report(args: PublishArgs, options: PublishOptions) {
+  async report(args: PublishArgs, options: PublisherOptions) {
     const result = await this.json(args, options);
     const components = result.data;
     const title = chalk.white.inverse.bold(' Publish Results \n');
@@ -38,7 +38,7 @@ export class PublishCmd implements Command {
     return title + output;
   }
 
-  async json([componentId]: PublishArgs, options: PublishOptions): Promise<{ data: PublishResult[]; code: number }> {
+  async json([componentId]: PublishArgs, options: PublisherOptions): Promise<{ data: PublishResult[]; code: number }> {
     const compId = typeof componentId === 'string' ? componentId : componentId[0];
     const packResult = await this.publisher.publish([compId], options);
     return {

--- a/src/extensions/pkg/publish.cmd.tsx
+++ b/src/extensions/pkg/publish.cmd.tsx
@@ -22,7 +22,10 @@ export class PublishCmd implements Command {
   async report(args: PublishArgs, options: PublisherOptions) {
     const result = await this.json(args, options);
     const components = result.data;
-    const title = chalk.white.inverse.bold(' Publish Results \n');
+    if (!components.length) return 'no components were found candidate for publish';
+
+    const publishOrDryRun = options.dryRun ? 'dry-run' : 'published';
+    const title = chalk.white.bold(`successfully ${publishOrDryRun} the following components\n`);
     const output = components
       .map(component => {
         const compName = component.id.toString();

--- a/src/extensions/pkg/publish.cmd.tsx
+++ b/src/extensions/pkg/publish.cmd.tsx
@@ -1,0 +1,50 @@
+import chalk from 'chalk';
+import { CommandOptions, Command } from '../cli';
+import { Publisher } from './publisher';
+import { BuildResults } from '../builder';
+
+type PublishArgs = [string];
+type PublishOptions = { dryRun: boolean };
+
+export class PublishCmd implements Command {
+  name = 'publish <componentId>';
+  description = 'publish components to npm (npm publish)';
+  options = [
+    ['d', 'dry-run [boolean]', 'npm publish --dry-run'],
+    ['j', 'json [boolean]', 'return the output as JSON']
+  ] as CommandOptions;
+  shortDescription = '';
+  alias = '';
+  private = true;
+  group = 'collaborate';
+
+  constructor(private publisher: Publisher) {}
+
+  async report(args: PublishArgs, options: PublishOptions) {
+    const result = await this.json(args, options);
+    const data: BuildResults = result.data;
+    const title = chalk.white.inverse.bold(' Publish Results \n');
+    const output = data.components
+      .map(component => {
+        const compName = component.id.toString();
+        const getData = () => {
+          if (component.errors.length) {
+            return chalk.red(component.errors.join('\n'));
+          }
+          return chalk.green(component.data);
+        };
+        return `${chalk.bold(compName)}\n${getData()}\n`;
+      })
+      .join('\n');
+    return title + output;
+  }
+
+  async json([componentId]: PublishArgs, options: PublishOptions) {
+    const compId = typeof componentId === 'string' ? componentId : componentId[0];
+    const packResult = await this.publisher.publish([compId], options);
+    return {
+      data: packResult,
+      code: 0
+    };
+  }
+}

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -11,7 +11,7 @@ export type PublisherOptions = {
   dryRun?: boolean;
 };
 
-type PublishResult = { id: ComponentID; data?: string; errors: string[] };
+export type PublishResult = { id: ComponentID; data?: string; errors: string[] };
 
 export class Publisher {
   packageManager = 'npm'; // @todo: decide if this is mandatory or using the workspace settings

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -1,0 +1,53 @@
+import execa from 'execa';
+import { IsolatorExtension } from '../isolator';
+import { Scope } from '../../scope';
+import { LogPublisher } from '../types';
+import { BuildResults } from '../builder';
+import { loadConsumer } from '../../consumer';
+
+export type PublisherOptions = {
+  dryRun: boolean;
+};
+
+export class Publisher {
+  constructor(private isolator: IsolatorExtension, private logger: LogPublisher, private scope: Scope) {}
+
+  async publish(componentIds: string[], options: PublisherOptions): Promise<BuildResults> {
+    const packageManager = 'npm';
+    // @todo hack alert!
+    // currently, when loading a component from the model, it doesn't load the extension
+    // as such, the package json value such as the main-file is not loaded from the env.
+    // change it back to `createNetworkFromScope` once Gilad fixes it.
+    const consumer = await loadConsumer();
+    // const network = await this.isolator.createNetworkFromScope(componentIds, this.scope);
+    const network = await this.isolator.createNetworkFromConsumer(componentIds, consumer);
+    const resultsP = network.seedersCapsules.map(async capsule => {
+      const publishParams = ['publish'];
+      if (options.dryRun) publishParams.push('--dry-run');
+      const publishParamsStr = publishParams.join(' ');
+      const cwd = capsule.path;
+      const componentIdStr = capsule.id.toString();
+      const errors: string[] = [];
+      let data;
+      try {
+        // @todo: once capsule.exec works properly, replace this
+        const { stdout, stderr } = await execa(packageManager, publishParams, { cwd });
+        this.logger.debug(componentIdStr, `successfully ran ${packageManager} ${publishParamsStr} at ${cwd}`);
+        this.logger.debug(componentIdStr, `stdout: ${stdout}`);
+        this.logger.debug(componentIdStr, `stderr: ${stderr}`);
+        data = stdout;
+      } catch (err) {
+        const errorMsg = `failed running ${packageManager} ${publishParamsStr} at ${cwd}`;
+        this.logger.error(errorMsg);
+        this.logger.error(err.stderr);
+        errors.push(`${errorMsg}\n${err.stderr}`);
+      }
+      return { id: capsule.component.id, data, errors };
+    });
+    const components = await Promise.all(resultsP);
+    return {
+      components,
+      artifacts: []
+    };
+  }
+}

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -107,7 +107,7 @@ export class Publisher {
   private async throwForNonStagedOrTaggedComponents(bitIds: BitId[]) {
     const idsWithoutScope = bitIds.filter(id => !id.hasScope());
     if (!idsWithoutScope.length) return;
-    if (!this.options.allowStaged) {
+    if (!this.options.allowStaged && !this.options.dryRun) {
       throw new GeneralError(
         `unable to publish the following component(s), please make sure they are exported: ${idsWithoutScope.join(
           ', '
@@ -125,9 +125,7 @@ export class Publisher {
     );
     if (missingFromScope.length) {
       throw new GeneralError(
-        `unable to publish the following component(s), please make sure they are not new: ${missingFromScope.join(
-          ', '
-        )}`
+        `unable to publish the following component(s), please make sure they are tagged: ${missingFromScope.join(', ')}`
       );
     }
   }

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -1,53 +1,96 @@
 import execa from 'execa';
-import { IsolatorExtension } from '../isolator';
+import { IsolatorExtension, Capsule } from '../isolator';
 import { Scope } from '../../scope';
 import { LogPublisher } from '../types';
-import { BuildResults } from '../builder';
 import { loadConsumer } from '../../consumer';
+import { BitId, BitIds } from '../../bit-id';
+import { ComponentID } from '../component';
+import { PublishPostExportResult } from '../../scope/component-ops/publish-during-export';
 
 export type PublisherOptions = {
-  dryRun: boolean;
+  dryRun?: boolean;
 };
 
+type PublishResult = { id: ComponentID; data?: string; errors: string[] };
+
 export class Publisher {
+  packageManager = 'npm'; // @todo: decide if this is mandatory or using the workspace settings
   constructor(private isolator: IsolatorExtension, private logger: LogPublisher, private scope: Scope) {}
 
-  async publish(componentIds: string[], options: PublisherOptions): Promise<BuildResults> {
-    const packageManager = 'npm';
+  async publish(componentIds: string[], options: PublisherOptions): Promise<PublishResult[]> {
+    const capsules = await this.getComponentCapsules(componentIds);
+    const resultsP = capsules.map(capsule => this.publishOneCapsule(capsule, options));
+    return Promise.all(resultsP);
+  }
+
+  async postExportListener(ids: BitId[]): Promise<PublishPostExportResult[]> {
+    const componentIds = ids.map(id => id.toString());
+    const components = await this.publish(componentIds, {});
+    return components.map(c => ({
+      id: c.id instanceof BitId ? c.id : c.id.legacyComponentId,
+      data: c.data,
+      errors: c.errors as string[]
+    }));
+  }
+
+  private async publishOneCapsule(capsule: Capsule, options: PublisherOptions): Promise<PublishResult> {
+    const publishParams = ['publish'];
+    if (options.dryRun) publishParams.push('--dry-run');
+    const publishParamsStr = publishParams.join(' ');
+    const cwd = capsule.path;
+    const componentIdStr = capsule.id.toString();
+    const errors: string[] = [];
+    let data;
+    try {
+      // @todo: once capsule.exec works properly, replace this
+      const { stdout, stderr } = await execa(this.packageManager, publishParams, { cwd });
+      this.logger.debug(componentIdStr, `successfully ran ${this.packageManager} ${publishParamsStr} at ${cwd}`);
+      this.logger.debug(componentIdStr, `stdout: ${stdout}`);
+      this.logger.debug(componentIdStr, `stderr: ${stderr}`);
+      data = stdout;
+    } catch (err) {
+      const errorMsg = `failed running ${this.packageManager} ${publishParamsStr} at ${cwd}`;
+      this.logger.error(errorMsg);
+      this.logger.error(err.stderr);
+      errors.push(`${errorMsg}\n${err.stderr}`);
+    }
+    return { id: capsule.component.id, data, errors };
+  }
+
+  private async getComponentCapsules(componentIds: string[]): Promise<Capsule[]> {
     // @todo hack alert!
     // currently, when loading a component from the model, it doesn't load the extension
     // as such, the package json value such as the main-file is not loaded from the env.
     // change it back to `createNetworkFromScope` once Gilad fixes it.
     const consumer = await loadConsumer();
+    if (consumer.isLegacy) {
+      // publish is supported on Harmony only
+      return [];
+    }
     // const network = await this.isolator.createNetworkFromScope(componentIds, this.scope);
-    const network = await this.isolator.createNetworkFromConsumer(componentIds, consumer);
-    const resultsP = network.seedersCapsules.map(async capsule => {
-      const publishParams = ['publish'];
-      if (options.dryRun) publishParams.push('--dry-run');
-      const publishParamsStr = publishParams.join(' ');
-      const cwd = capsule.path;
-      const componentIdStr = capsule.id.toString();
-      const errors: string[] = [];
-      let data;
-      try {
-        // @todo: once capsule.exec works properly, replace this
-        const { stdout, stderr } = await execa(packageManager, publishParams, { cwd });
-        this.logger.debug(componentIdStr, `successfully ran ${packageManager} ${publishParamsStr} at ${cwd}`);
-        this.logger.debug(componentIdStr, `stdout: ${stdout}`);
-        this.logger.debug(componentIdStr, `stderr: ${stderr}`);
-        data = stdout;
-      } catch (err) {
-        const errorMsg = `failed running ${packageManager} ${publishParamsStr} at ${cwd}`;
-        this.logger.error(errorMsg);
-        this.logger.error(err.stderr);
-        errors.push(`${errorMsg}\n${err.stderr}`);
-      }
-      return { id: capsule.component.id, data, errors };
-    });
-    const components = await Promise.all(resultsP);
-    return {
-      components,
-      artifacts: []
-    };
+    const idsToPublish = await this.getIdsToPublish(componentIds);
+    const network = await this.isolator.createNetworkFromConsumer(idsToPublish, consumer);
+    return network.seedersCapsules;
+  }
+
+  /**
+   * only components that use pkg extension and configure "publishConfig" with their own registry
+   * should be published. ignore the rest.
+   */
+  private async getIdsToPublish(componentIds: string[]): Promise<string[]> {
+    const ids = BitIds.fromArray(componentIds.map(id => BitId.parse(id, true)));
+    const components = await this.scope.getComponentsAndVersions(ids);
+    return components
+      .filter(c => {
+        const ext = c.version.extensions.findExtension('@teambit/pkg');
+        if (!ext) return false;
+        return ext.config?.packageJson?.publishConfig;
+      })
+      .map(c =>
+        c.component
+          .toBitId()
+          .changeVersion(c.versionStr)
+          .toString()
+      );
   }
 }

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -79,7 +79,7 @@ export class Publisher {
    */
   private async getIdsToPublish(componentIds: string[]): Promise<string[]> {
     const ids = BitIds.fromArray(componentIds.map(id => BitId.parse(id, true)));
-    const components = await this.scope.getComponentsAndVersions(ids);
+    const components = await this.scope.getComponentsAndVersions(ids, true);
     return components
       .filter(c => {
         const ext = c.version.extensions.findExtension('@teambit/pkg');

--- a/src/extensions/pkg/publisher.ts
+++ b/src/extensions/pkg/publisher.ts
@@ -35,7 +35,7 @@ export class Publisher {
     const componentIds = ids.map(id => id.toString());
     const components = await this.publish(componentIds, {});
     return components.map(c => ({
-      id: c.id instanceof BitId ? c.id : c.id.legacyComponentId,
+      id: c.id.legacyComponentId,
       data: c.data,
       errors: c.errors as string[]
     }));
@@ -67,7 +67,9 @@ export class Publisher {
       if (err.stderr) this.logger.error(componentIdStr, err.stderr);
       errors.push(`${errorMsg}\n${err.stderr}`);
     }
-    return { id: capsule.component.id, data, errors };
+    // @ts-ignore fix once capsule has the right Component object
+    const id = new ComponentID(capsule.component.id as BitId);
+    return { id, data, errors };
   }
 
   private async getComponentCapsules(componentIds: string[]): Promise<Capsule[]> {

--- a/src/extensions/pkg/readme.md
+++ b/src/extensions/pkg/readme.md
@@ -1,10 +1,11 @@
-# `extension Pkg name`
+# `extension @teambit/pkg`
 
-An extension that:
 1. allows users to change (add) properties in the component's package.json
-2. allow other extensions to add new properties to the component's package.json
-3. allow an env to add new properties to the component's package.json
-4. expose a pack command to pack a component into a tar suitable for an npm registry
+2. allows other extensions to add new properties to the component's package.json
+3. allows an env to add new properties to the component's package.json
+4. exposes a pack command to pack a component into a tar suitable for an npm registry
+5. exposes a publish command to publish components to a private registry
+6. utilizes PostExport hook to auto publish components during export
 
 ## Usage
 
@@ -21,7 +22,7 @@ This extensions gets properties to add to the package.json in the variants confi
 ```js
 {
   "ui/*": {
-    "Pkg": {
+    "@teambit/pkg": {
       "packageJson": {
         "myPropToAdd": "propValue"
       }
@@ -30,11 +31,30 @@ This extensions gets properties to add to the package.json in the variants confi
 }
 ```
 
+#### Publish
+
+Configure the `publishConfig` prop with your registry data. For example:
+
+```js
+"ui/*": {
+  "@teambit/pkg": {
+    "packageJson": {
+       "publishConfig": {
+         "scope": "@custom",
+         "registry": "http://localhost:4873"
+      }
+    }
+  }
+}
+```
+
+The auto-publishing during export is triggered only when this `publishConfig` is set
+
 #### Placeholders
 
-`{main}` main source file without the extension
-`{scope}` scope name
-`{name}` component name
+* `{main}` main source file without the extension
+* `{scope}` scope name
+* `{name}` component name
 
 e.g.
 ```js

--- a/src/extensions/pkg/readme.md
+++ b/src/extensions/pkg/readme.md
@@ -30,6 +30,20 @@ This extensions gets properties to add to the package.json in the variants confi
 }
 ```
 
+#### Placeholders
+
+`{main}` main source file without the extension
+`{scope}` scope name
+`{name}` component name
+
+e.g.
+```js
+ "packageJson": {
+    "main": "dist/{main}.js"
+  }
+```
+if the main file is "index.ts", it'll be translated to `dist/index.js`.
+
 ### Commands
 This extension register a new `pack` command.
 `pack <componentId> [scopePath]`

--- a/src/extensions/react/react.env.ts
+++ b/src/extensions/react/react.env.ts
@@ -17,6 +17,7 @@ import { JestExtension } from '../jest';
 import { TypescriptExtension } from '../typescript';
 import { BuildTask } from '../builder';
 import { Compiler, Compile } from '../compiler';
+import { PkgExtension } from '../pkg';
 
 export class ReactEnv implements Environment {
   constructor(
@@ -24,7 +25,8 @@ export class ReactEnv implements Environment {
     private jest: JestExtension,
     private ts: TypescriptExtension,
     private compiler: Compile,
-    private tester: TesterExtension
+    private tester: TesterExtension,
+    private pkg: PkgExtension
   ) {}
 
   // this should happen on component load.
@@ -97,7 +99,7 @@ export class ReactEnv implements Environment {
   getPipe(): BuildTask[] {
     // return BuildPipe.from([this.compiler.task, this.tester.task]);
     // return BuildPipe.from([this.tester.task]);
-    return [this.compiler.task];
+    return [this.compiler.task, this.pkg.dryRunTask];
   }
 
   dev(workspace: Workspace, components: Component[]) {

--- a/src/extensions/react/react.env.ts
+++ b/src/extensions/react/react.env.ts
@@ -71,6 +71,10 @@ export class ReactEnv implements Environment {
     return this.ts.createCompiler(tsConfig);
   }
 
+  getPackageJsonProps() {
+    return TypescriptExtension.getPackageJsonProps();
+  }
+
   async dependencies() {
     return {
       dependencies: {

--- a/src/extensions/react/react.extension.ts
+++ b/src/extensions/react/react.extension.ts
@@ -5,6 +5,7 @@ import { JestExtension } from '../jest';
 import { TypescriptExtension } from '../typescript';
 import { Compile, CompileExt } from '../compiler';
 import { TesterExtension } from '../tester';
+import { PkgExtension } from '../pkg';
 
 export type ReactConfig = {
   writeDist: boolean;
@@ -13,23 +14,32 @@ export type ReactConfig = {
 
 export class React {
   static id = '@teambit/react';
-  static dependencies = [Environments, LoggerExt, JestExtension, TypescriptExtension, CompileExt, TesterExtension];
+  static dependencies = [
+    Environments,
+    LoggerExt,
+    JestExtension,
+    TypescriptExtension,
+    CompileExt,
+    TesterExtension,
+    PkgExtension
+  ];
 
   // createTsCompiler(tsconfig: {}) {}
 
   setTsConfig() {}
 
   // @typescript-eslint/no-unused-vars
-  static provider([envs, logger, jest, ts, compile, tester]: [
+  static provider([envs, logger, jest, ts, compile, tester, pkg]: [
     Environments,
     Logger,
     JestExtension,
     TypescriptExtension,
     Compile,
-    TesterExtension
+    TesterExtension,
+    PkgExtension
   ]) {
     // support factories from harmony?
-    envs.registerEnv(new ReactEnv(logger.createLogPublisher(this.id), jest, ts, compile, tester));
+    envs.registerEnv(new ReactEnv(logger.createLogPublisher(this.id), jest, ts, compile, tester, pkg));
     return {};
   }
 }

--- a/src/extensions/typescript/typescript.extension.ts
+++ b/src/extensions/typescript/typescript.extension.ts
@@ -6,6 +6,9 @@ export class TypescriptExtension {
   createCompiler(tsConfig: Record<string, any>) {
     return new TypescriptCompiler(tsConfig);
   }
+  static getPackageJsonProps() {
+    return { main: 'dist/{main}.js' };
+  }
   static provider() {
     return new TypescriptExtension();
   }

--- a/src/scope/component-ops/publish-during-export.ts
+++ b/src/scope/component-ops/publish-during-export.ts
@@ -1,0 +1,50 @@
+import { BitId } from '../../bit-id';
+import logger from '../../logger/logger';
+import { loadConsumer } from '../../consumer';
+
+export type PublishResults = {
+  publishedComponents: {
+    id: BitId;
+    package: string;
+  }[];
+  failedComponents: {
+    id: BitId;
+    errors: string[];
+  }[];
+};
+
+export type PublishPostExportResult = {
+  id: BitId;
+  data: string | undefined;
+  errors: string[];
+};
+
+export async function publishComponentsToRegistry({
+  newIdsOnRemote,
+  updatedIds
+}: {
+  newIdsOnRemote: BitId[];
+  updatedIds: BitId[];
+}): Promise<PublishResults> {
+  const consumer = await loadConsumer();
+  let postExportResults;
+  try {
+    postExportResults = await Promise.all(consumer.scope.onPostExport.map(func => func(newIdsOnRemote)));
+  } catch (err) {
+    const publishErr = `The components ${updatedIds.map(c => c.toString()).join(', ')} were exported successfully.
+    However, the publish operation has failed due to an error: ${err.msg || err}`;
+    logger.error(publishErr, err);
+    throw new Error(publishErr);
+  }
+  const publishPostExport: PublishPostExportResult[] = postExportResults[0]; // as of now, this is the only function running on PostExport
+  const publishResults: PublishResults = { publishedComponents: [], failedComponents: [] };
+  publishPostExport.forEach(component => {
+    if (component.errors.length) {
+      publishResults.failedComponents.push({ id: component.id, errors: component.errors });
+    } else if (component.data) {
+      publishResults.publishedComponents.push({ id: component.id, package: component.data });
+    }
+  });
+
+  return publishResults;
+}

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -620,6 +620,11 @@ export default class Scope {
     return removeNils(componentsAndVersions);
   }
 
+  async isComponentInScope(id: BitId): Promise<boolean> {
+    const comp = await this.sources.get(id);
+    return Boolean(comp);
+  }
+
   async getComponentsAndAllLocalUnexportedVersions(ids: BitIds): Promise<ComponentsAndVersions[]> {
     const componentsObjects = await this.sources.getMany(ids);
     const componentsAndVersionsP = componentsObjects.map(async componentObjects => {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -102,6 +102,7 @@ export default class Scope {
   }
 
   public onTag: Function[] = []; // enable extensions to hook during the tag process
+  public onPostExport: Function[] = []; // enable extensions to hook during the tag process
 
   /**
    * import components to the `Scope.

--- a/src/utils/bit/component-placeholders.spec.ts
+++ b/src/utils/bit/component-placeholders.spec.ts
@@ -1,0 +1,25 @@
+import { expect } from 'chai';
+import { replacePlaceHolderWithComponentValue } from './component-placeholders';
+
+describe('replacePlaceHolderWithComponentValue', () => {
+  it('should be able to replace the main file without an extension', () => {
+    // @ts-ignore
+    const result = replacePlaceHolderWithComponentValue({ mainFile: 'index.ts' }, 'dist/{main}.js');
+    expect(result).to.equal('dist/index.js');
+  });
+  it('should be able to replace the component name', () => {
+    // @ts-ignore
+    const result = replacePlaceHolderWithComponentValue({ name: 'foo' }, 'bar/baz/{name}');
+    expect(result).to.equal('bar/baz/foo');
+  });
+  it('should be able to replace the component scope', () => {
+    // @ts-ignore
+    const result = replacePlaceHolderWithComponentValue({ scope: 'foo' }, 'bar/baz/{scope}');
+    expect(result).to.equal('bar/baz/foo');
+  });
+  it('should return the same value if it is not string', () => {
+    // @ts-ignore
+    const result = replacePlaceHolderWithComponentValue({ name: 'foo' }, false);
+    expect(result).to.equal(false);
+  });
+});

--- a/src/utils/bit/component-placeholders.ts
+++ b/src/utils/bit/component-placeholders.ts
@@ -4,18 +4,23 @@ import ConsumerComponent from '../../consumer/component';
 
 /**
  * search for placeholders, such as {main}, {name} in a template and replace them with the values
- * from the component
+ * from the component with some manipulations
  */
 export function replacePlaceHolderWithComponentValue<T>(component: ConsumerComponent, template: T): T {
   if (typeof template !== 'string') return template;
   const values = {
     main: () => getMainFileWithoutExtension(component.mainFile),
-    name: component.name,
-    scope: component.scope
+    name: () => replaceSlashesWithDots(component.name),
+    scope: () => component.scope
   };
   return format(template, values);
 }
 
 function getMainFileWithoutExtension(mainFile: string) {
   return mainFile.replace(new RegExp(`${path.extname(mainFile)}$`), ''); // makes sure it's the last occurrence
+}
+
+function replaceSlashesWithDots(name: string) {
+  const allSlashes = new RegExp('/', 'g');
+  return name.replace(allSlashes, '.');
 }

--- a/src/utils/bit/component-placeholders.ts
+++ b/src/utils/bit/component-placeholders.ts
@@ -1,0 +1,21 @@
+import format from 'string-format';
+import path from 'path';
+import ConsumerComponent from '../../consumer/component';
+
+/**
+ * search for placeholders, such as {main}, {name} in a template and replace them with the values
+ * from the component
+ */
+export function replacePlaceHolderWithComponentValue<T>(component: ConsumerComponent, template: T): T {
+  if (typeof template !== 'string') return template;
+  const values = {
+    main: () => getMainFileWithoutExtension(component.mainFile),
+    name: component.name,
+    scope: component.scope
+  };
+  return format(template, values);
+}
+
+function getMainFileWithoutExtension(mainFile: string) {
+  return mainFile.replace(new RegExp(`${path.extname(mainFile)}$`), ''); // makes sure it's the last occurrence
+}


### PR DESCRIPTION
Currently, components are published automatically to the Bit registry and require the consumers to configure NPM with `@bit` scope.
This PR allows publishing directly to NPM or to any other custom/private registry.
There will be two ways to publish components.
1. automatically as part of the export process. 
2. manually via `bit publish` command.
To configure the registry, add `publishConfig` settings to the `@teambit/pkg` extension.
For example:
```
"ui/*": {
  "@teambit/pkg": {
    "packageJson": {
       "publishConfig": {
         "scope": "@ci",
         "registry": "http://localhost:4873"
      }
    }
  }
},
```
Subtasks:
- [x] implement `bit publish` command
- [x] replace the template for package.json main to the actual main-dist file.
- [ ] fetch components from Scope instead of Consumer
- [x] implement and register to postExport hook
- [x] enable custom package names
- [x] avoid publishing on PostExport slot when pkg is not configured with `publishConfig`.
- [x] stop `bit publish` when a component is not exported, unless a special flag is used.
- [x] add a task of publish-dry-run to be executing during build process