### PR TITLE
fix export of component with dependency of another scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2780](https://github.com/teambit/bit/issues/2780) - fix dists codemod of changing one scope to another to not be triggered without --rewire flag
+
 ## [[14.8.3-dev.3] - 2020-06-30]
 
 - add timeout option for load core extension via api

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1147,6 +1147,20 @@ describe('bit export command', function() {
             const result = helper.command.runCmd('node app.js');
             expect(result.trim()).to.equal('got is-type and got is-string and got foo');
           });
+          describe('without --rewire flag', () => {
+            before(() => {
+              helper.scopeHelper.getClonedLocalScope(localBeforeFork);
+              helper.scopeHelper.reInitRemoteScope(forkScopePath);
+              helper.command.export(`${forkScope} --set-current-scope`);
+            });
+            it('should not change the dists objects locally because --rewire was not used', () => {
+              const barFoo = helper.command.catComponent(`${forkScope}/bar/foo@latest`);
+              const fileHash = barFoo.dists[0].file;
+              const fileContent = helper.command.catObject(fileHash);
+              expect(fileContent).to.have.string(helper.scopes.remote);
+              expect(fileContent).to.not.have.string(forkScope);
+            });
+          });
           describe('as imported', () => {
             let output;
             before(() => {

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -477,7 +477,12 @@ async function convertToCorrectScope(
       const idWithNewScope = id.changeScope(remoteScope);
       const pkgNameWithOldScope = componentIdToPackageName(id, componentsObjects.component.bindingPrefix);
       if (!codemod) {
-        if (id.hasScope()) return;
+        // use did not enter --rewire flag
+        if (id.hasScope()) {
+          return; // because only --rewire is permitted to change from scope-a to scope-b.
+        }
+        // dists can change no-scope to scope without --rewire flag. if this is not a dist file
+        // and the file needs to change from no-scope to scope, it needs to --rewire flag
         if (!isDist && fileString.includes(pkgNameWithOldScope)) {
           throw new GeneralError(`please use "--rewire" flag to fix the import/require statements "${pkgNameWithOldScope}" in "${
             file.relativePath

--- a/src/utils/string/replace-package-name.spec.ts
+++ b/src/utils/string/replace-package-name.spec.ts
@@ -3,33 +3,33 @@ import replacePackageName from './replace-package-name';
 
 describe('replacePackageName', () => {
   it('should replace package surrounded with single quotes', () => {
-    const str = "require('@bit/old-scope/is-string');";
-    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
-    expect(result).to.equal("require('@bit/new-scope/is-string');");
+    const str = "require('@bit/old-scope.is-string');";
+    const result = replacePackageName(str, '@bit/old-scope.is-string', '@bit/new-scope.is-string');
+    expect(result).to.equal("require('@bit/new-scope.is-string');");
   });
   it('should replace package surrounded with double quotes', () => {
-    const str = 'require("@bit/old-scope/is-string");';
-    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
-    expect(result).to.equal('require("@bit/new-scope/is-string");');
+    const str = 'require("@bit/old-scope.is-string");';
+    const result = replacePackageName(str, '@bit/old-scope.is-string', '@bit/new-scope.is-string');
+    expect(result).to.equal('require("@bit/new-scope.is-string");');
   });
   it('should replace package path consist of an internal path', () => {
-    const str = "require('@bit/old-scope/is-string/some-internal-path');";
-    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
-    expect(result).to.equal("require('@bit/new-scope/is-string/some-internal-path');");
+    const str = "require('@bit/old-scope.is-string/some-internal-path');";
+    const result = replacePackageName(str, '@bit/old-scope.is-string', '@bit/new-scope.is-string');
+    expect(result).to.equal("require('@bit/new-scope.is-string/some-internal-path');");
   });
   it('should not replace package when it matches only part of the package-name', () => {
-    const str = "require('@bit/old-scope/is-string-util');";
-    const result = replacePackageName(str, '@bit/old-scope/is-string', '@bit/new-scope/is-string');
-    expect(result).to.equal("require('@bit/old-scope/is-string-util');");
+    const str = "require('@bit/old-scope.is-string-util');";
+    const result = replacePackageName(str, '@bit/old-scope.is-string', '@bit/new-scope.is-string');
+    expect(result).to.equal("require('@bit/old-scope.is-string-util');");
   });
   it('should replace package that its require statement has tilda (~)', () => {
-    const str = "@import '~@bit/old-scope/ui.style/my-style.scss';";
-    const result = replacePackageName(str, '@bit/old-scope/ui.style', '@bit/new-scope/ui.style');
-    expect(result).to.equal("@import '~@bit/new-scope/ui.style/my-style.scss';");
+    const str = "@import '~@bit/old-scope.ui.style/my-style.scss';";
+    const result = replacePackageName(str, '@bit/old-scope.ui.style', '@bit/new-scope.ui.style');
+    expect(result).to.equal("@import '~@bit/new-scope.ui.style/my-style.scss';");
   });
-  it('should ignore package that its require statement has other prefixes (~)', () => {
-    const str = "@import '$@bit/old-scope/ui.style';";
-    const result = replacePackageName(str, '@bit/old-scope/ui.style', '@bit/new-scope/ui.style');
-    expect(result).to.equal("@import '$@bit/old-scope/ui.style';");
+  it('should ignore package that its require statement has other prefixes', () => {
+    const str = "@import '$@bit/old-scope.ui.style';";
+    const result = replacePackageName(str, '@bit/old-scope.ui.style', '@bit/new-scope.ui.style');
+    expect(result).to.equal("@import '$@bit/old-scope.ui.style';");
   });
 });


### PR DESCRIPTION
Currently, in some cases, when comp-a requires comp-b and comp-b was exported to scope-b and the user is now exporting comp-a to scope-a, the following happens:
1. if it's the first export for comp-a, it shows an error suggesting to use `--rewire` incorrectly.
2. if it's not the first export, it replaces the dists require/import statement incorrectly to the scope-a. Although the `--rewire` flag was not used.