### PR TITLE
refactor the group missing packages/components logic

### DIFF
--- a/e2e/flows/dependencies-versions-resolution.e2e.2.ts
+++ b/e2e/flows/dependencies-versions-resolution.e2e.2.ts
@@ -167,7 +167,7 @@ describe('dependencies versions resolution', function() {
       it('should strip those characters and get the exact version', () => {});
     });
     describe('when the the dependents has package.json file but it does not contain the dependency and the root package.json does', () => {
-      // @todo: this should be fixed in bit-javascript resolveNodePackage() to work this way
+      // @todo: this should be fixed in resolvePackageData() to work this way
       // currently if it finds package.json in the dependents it stops there, doesn't find the
       // dependency and goes directly to the dependency directory.
       it('should find the dependency version from the root package.json', () => {});

--- a/src/consumer/component-ops/dependency-status.ts
+++ b/src/consumer/component-ops/dependency-status.ts
@@ -9,7 +9,7 @@ async function getTopLevelDependencies(consumer: Consumer, dependencyStatusProps
   const paths = dependencyStatusProps.mainFile;
   const consumerPath = consumer.getPath();
   const tree = await getDependencyTree({
-    baseDir: consumerPath,
+    componentDir: consumerPath,
     workspacePath: consumerPath,
     filePaths: paths,
     bindingPrefix: DEFAULT_BINDINGS_PREFIX,

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -163,7 +163,7 @@ export default class DependencyResolver {
     const allFiles = [...nonTestsFiles, ...testsFiles];
     // find the dependencies (internal files and packages) through automatic dependency resolution
     const dependenciesTree = await getDependencyTree({
-      baseDir: bitDir,
+      componentDir: bitDir,
       workspacePath: this.consumerPath,
       filePaths: allFiles,
       bindingPrefix: this.component.bindingPrefix,
@@ -773,9 +773,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       this._pushToMissingDependenciesOnFs(originFile, missingFiles);
     };
     const processMissingPackages = () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       if (RA.isNilOrEmpty(missing.packages)) return;
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const missingPackages = missing.packages.filter(
         pkg => !this.overridesDependencies.shouldIgnorePackage(pkg, fileType)
       );
@@ -796,9 +794,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       }
     };
     const processMissingComponents = () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       if (RA.isNilOrEmpty(missing.bits)) return;
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this._addToMissingComponentsIfNeeded(missing.bits, originFile, fileType);
     };
     processMissingFiles();

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
@@ -11,7 +11,7 @@ import Dependencies from '../dependencies';
 import componentIdToPackageName from '../../../../utils/bit/component-id-to-package-name';
 import Dependency from '../dependency';
 import { ExtensionDataEntry, ExtensionDataList } from '../../../config/extension-data';
-import { resolveModulePath, resolveNodePackage } from '../files-dependency-builder';
+import { resolvePackagePath, resolvePackageData } from '../../../../utils/packages';
 
 /**
  * The dependency version is determined by the following strategies by this order.
@@ -112,8 +112,8 @@ export default function updateDependenciesVersions(consumer: Consumer, component
   }
 
   /**
-   * the logic of finding the dependency version in the package.json is mostly done in the driver
-   * resolveNodePackage method.
+   * the logic of finding the dependency version in the package.json is mostly done in
+   * resolvePackageData function.
    * it first searches in the dependent package.json and propagate up to the consumer root, if not
    * found it goes to the dependency package.json.
    */
@@ -127,10 +127,9 @@ export default function updateDependenciesVersions(consumer: Consumer, component
     const packagePath = getNodeModulesPathOfComponent(component.bindingPrefix, componentId);
     const packageName = packagePath.replace(`node_modules${path.sep}`, '');
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const modulePath = resolveModulePath(packageName, basePath, consumerPath);
+    const modulePath = resolvePackagePath(packageName, basePath, consumerPath);
     if (!modulePath) return null; // e.g. it's author and wasn't exported yet, so there's no node_modules of that component
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const packageObject = resolveNodePackage(basePath, modulePath);
+    const packageObject = resolvePackageData(basePath, modulePath);
     if (!packageObject || R.isEmpty(packageObject)) return null;
     const packageId = Object.keys(packageObject)[0];
     const version = packageObject[packageId];

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
@@ -11,7 +11,7 @@ describe('buildTree', () => {
     const filePaths: string[] = [];
     let visited: any;
     const dependencyTreeParams = {
-      baseDir: '.',
+      componentDir: '.',
       workspacePath: __dirname,
       filePaths,
       bindingPrefix: '@bit',

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
@@ -1,11 +1,7 @@
-// @flow
-// TODO: This should be exported as a bit component
-
-import fs from 'fs';
 import path from 'path';
 import R from 'ramda';
-import { partition, set } from 'lodash';
-import generateTree, { processPath } from './generate-tree-madge';
+import { set } from 'lodash';
+import generateTree from './generate-tree-madge';
 import { DEFAULT_BINDINGS_PREFIX } from '../../../../constants';
 import { getPathMapWithLinkFilesData, convertPathMapToRelativePaths } from './path-map';
 import { PathMapItem } from './path-map';
@@ -14,12 +10,11 @@ import {
   FileObject,
   ImportSpecifier,
   DependencyTreeParams,
-  ResolveModulesConfig,
-  ResolvedNodePackage
+  ResolveModulesConfig
 } from './types/dependency-tree-type';
-import PackageJson from '../../package-json';
-import { PathOsBased, PathLinuxAbsolute } from '../../../../utils/path';
-import { BitId } from '../../../../bit-id';
+import { PathOsBased } from '../../../../utils/path';
+import { MissingGroupItem, GroupMissing, FoundPackages } from './group-missing';
+import { resolvePackageData, ResolvedPackageData } from '../../../../utils/packages';
 
 export type LinkFile = {
   file: string;
@@ -47,95 +42,8 @@ const byType = (list, bindingPrefix): SimpleGroupedDependencies => {
   return grouped(list);
 };
 
-/**
- * Get a path to node package and return the name and version
- *
- * @param {any} packageFullPath full path to the package
- * @returns {Object} name and version of the package
- */
-export function resolveNodePackage(cwd: string, packageFullPath: PathLinuxAbsolute): ResolvedNodePackage | undefined {
-  const NODE_MODULES = 'node_modules';
-  const result: ResolvedNodePackage = {
-    fullPath: packageFullPath,
-    name: '',
-    componentId: undefined
-  };
-  // Start by searching in the component dir and up from there
-  // If not found search in package dir itself.
-  // We are doing this, because the package.json inside the package dir contain exact version
-  // And the component/consumer package.json might contain semver like ^ or ~
-  // We want to have this semver as dependency and not the exact version, otherwise it will be considered as modified all the time
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  const packageJsonInfo = PackageJson.findPackage(cwd);
-  if (packageJsonInfo) {
-    // The +1 is for the / after the node_modules, we didn't enter it into the NODE_MODULES const because it makes problems on windows
-    const packageRelativePath = packageFullPath.substring(
-      packageFullPath.lastIndexOf(NODE_MODULES) + NODE_MODULES.length + 1,
-      packageFullPath.length
-    );
-
-    const packageName = resolvePackageNameByPath(packageRelativePath);
-    const packageNameNormalized = packageName.replace('\\', '/');
-    const packageVersion =
-      R.path(['dependencies', packageNameNormalized], packageJsonInfo) ||
-      R.path(['devDependencies', packageNameNormalized], packageJsonInfo) ||
-      R.path(['peerDependencies', packageNameNormalized], packageJsonInfo);
-    if (packageVersion) {
-      result.name = packageNameNormalized;
-      result.versionUsedByDependent = packageVersion;
-    }
-  }
-
-  // Get the package relative path to the node_modules dir
-  const packageDir = resolvePackageDirFromFilePath(packageFullPath);
-
-  // don't propagate here since loading a package.json of another folder and taking the version from it will result wrong version
-  // This for example happen in the following case:
-  // if you have 2 authored component which one dependent on the other
-  // we will look for the package.json on the dependency but won't find it
-  // if we propagate we will take the version from the root's package json which has nothing with the component version
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  const packageInfo = PackageJson.loadSync(packageDir);
-
-  // when running 'bitjs get-dependencies' command, packageInfo is sometimes empty
-  // or when using custom-module-resolution it may be empty or the name/version are empty
-  if (!packageInfo || !packageInfo.name || !packageInfo.version) {
-    if (!result.name) {
-      return undefined;
-    }
-    return result;
-  }
-  result.name = packageInfo.name;
-  result.concreteVersion = packageInfo.version;
-  if (packageInfo.componentId) {
-    result.componentId = new BitId(packageInfo.componentId);
-  }
-  return result;
-}
-
-/**
- * given the full path of a package file, returns the root dir of the package, so then we could
- * find the package.json in that directory.
- *
- * example of a normal package:
- * absolutePackageFilePath: /user/workspace/node_modules/lodash.isboolean/index.js
- * returns: /user/workspace/node_modules/lodash.isboolean
- *
- * example of a scoped package:
- * absolutePackageFilePath: /user/workspace/node_modules/@babel/core/lib/index.js
- * returns: /user/workspace/node_modules/@babel/core
- */
-function resolvePackageDirFromFilePath(absolutePackageFilePath: string): string {
-  const NODE_MODULES = 'node_modules';
-  const indexOfLastNodeModules = absolutePackageFilePath.lastIndexOf(NODE_MODULES) + NODE_MODULES.length + 1;
-  const pathInsideNodeModules = absolutePackageFilePath.substring(indexOfLastNodeModules);
-  const packageName = resolvePackageNameByPath(pathInsideNodeModules);
-  const pathUntilNodeModules = absolutePackageFilePath.substring(0, indexOfLastNodeModules);
-  return pathUntilNodeModules + packageName;
-}
-
 interface GroupedDependenciesResolved {
-  bits: Array<ResolvedNodePackage>;
+  bits: Array<ResolvedPackageData>;
   packages: PackageDependency;
   files: string[];
   unidentifiedPackages: PathOsBased[];
@@ -162,7 +70,7 @@ function groupDependencyList(list, cwd, bindingPrefix): GroupedDependenciesResol
   if (groups.packages) {
     const packages = {};
     groups.packages.forEach(packagePath => {
-      const resolvedPackage = resolveNodePackage(cwd, path.join(cwd, packagePath));
+      const resolvedPackage = resolvePackageData(cwd, path.join(cwd, packagePath));
       // If the package is actually a component add it to the components (bits) list
       if (resolvedPackage) {
         if (resolvedPackage.componentId) {
@@ -182,7 +90,7 @@ function groupDependencyList(list, cwd, bindingPrefix): GroupedDependenciesResol
   }
   if (groups.bits) {
     groups.bits.forEach(packagePath => {
-      const resolvedPackage = resolveNodePackage(cwd, path.join(cwd, packagePath));
+      const resolvedPackage = resolvePackageData(cwd, path.join(cwd, packagePath));
       // If the package is actually a component add it to the components (bits) list
       if (resolvedPackage) {
         resultGroups.bits.push(resolvedPackage);
@@ -221,185 +129,8 @@ function groupDependencyTree(tree, cwd, bindingPrefix): GroupedDependenciesTree 
   return result;
 }
 
-/**
- * return the package name by the import statement path to node package
- *
- * @param {string} packagePath import statement path
- * @returns {string} name of the package
- */
-function resolvePackageNameByPath(packagePath): string {
-  const packagePathArr = packagePath.split(path.sep); // TODO: make sure this is working on windows
-  // Regular package without path. example - import _ from 'lodash'
-  if (packagePathArr.length === 1) return packagePath;
-  // Scoped package. example - import getSymbolIterator from '@angular/core/src/util.d.ts';
-  if (packagePathArr[0].startsWith('@')) return path.join(packagePathArr[0], packagePathArr[1]);
-  // Regular package with internal path. example import something from 'mypackage/src/util/isString'
-  return packagePathArr[0];
-}
-
-/**
- * Recursively search for node module inside node_modules dir
- * This function propagate up until it gets to the root provided then stops
- *
- * @param {string} nmPath - package name
- * @param {string} workingDir - dir to start searching of
- * @param {string} root - path to dir to stop the search
- * @returns The resolved path for the package directory
- */
-export function resolveModulePath(nmPath: string, workingDir: string, root: string): PathOsBased | undefined {
-  const pathToCheck = path.resolve(workingDir, 'node_modules', nmPath);
-
-  if (fs.existsSync(pathToCheck)) {
-    return pathToCheck;
-  }
-
-  if (workingDir === root) {
-    return undefined;
-  }
-
-  const parentWorkingDir = path.dirname(workingDir);
-  if (parentWorkingDir === workingDir) return undefined;
-
-  return resolveModulePath(nmPath, parentWorkingDir, root);
-}
-
 interface PackageDependency {
   [dependencyId: string]: string;
-}
-
-interface PackageDependenciesTypes {
-  dependencies?: PackageDependency;
-  devDependencies?: PackageDependency;
-  peerDependencies?: PackageDependency;
-}
-interface FindPackagesResult {
-  foundPackages: {
-    [packageName: string]: PackageDependenciesTypes;
-  };
-  missingPackages: string[];
-}
-
-/**
- * Resolve package dependencies from package.json according to package names
- *
- * @param {Object} packageJson
- * @param {string []} packagesNames
- * @returns new object with found and missing
- */
-function findPackagesInPackageJson(packageJson: Record<string, any>, packagesNames: string[]): FindPackagesResult {
-  const { dependencies, devDependencies, peerDependencies } = packageJson;
-  const foundPackages = {};
-  const mergedDependencies = Object.assign({}, dependencies, devDependencies, peerDependencies);
-  if (packagesNames && packagesNames.length && !R.isNil(mergedDependencies)) {
-    const [foundPackagesPartition, missingPackages] = partition(packagesNames, item => item in mergedDependencies);
-    foundPackagesPartition.forEach(pack => (foundPackages[pack] = mergedDependencies[pack]));
-    return { foundPackages, missingPackages };
-  }
-  return { foundPackages: {}, missingPackages: packagesNames };
-}
-
-type Missing = { [absolutePath: string]: string[] }; // e.g. { '/tmp/workspace': ['lodash', 'ramda'] };
-type MissingGroupItem = { originFile: string; packages?: string[]; bits?: string[]; files?: string[] };
-type FoundPackages = { packages: { [packageName: string]: string }; bits: Array<ResolvedNodePackage> };
-/**
- * Run over each entry in the missing array and transform the missing from list of paths
- * to object with missing types
- *
- * @param {Array} missing
- * @param {string} cwd
- * @param {string} workspacePath
- * @param {string} bindingPrefix
- * @returns new object with grouped missing
- */
-function groupMissing(
-  missing: Missing,
-  cwd,
-  workspacePath,
-  bindingPrefix
-): { missingGroups: MissingGroupItem[]; foundPackages: FoundPackages } {
-  // temporarily disable this functionality since it cause few bugs: explanation below (on using the packageJson)
-  // const packageJson = PackageJson.findPackage(cwd);
-
-  /**
-   * Group missing dependencies by types (files, bits, packages)
-   * @param {Array} missing list of missing paths to group
-   * @returns {Function} function which group the dependencies
-   */
-  const byPathType = R.groupBy(item => {
-    if (item.startsWith(`${bindingPrefix}/`) || item.startsWith(`${DEFAULT_BINDINGS_PREFIX}/`)) return 'bits';
-    return item.startsWith('.') ? 'files' : 'packages';
-  });
-  const groups: MissingGroupItem[] = Object.keys(missing).map(key =>
-    Object.assign({ originFile: processPath(key, {}, cwd) }, byPathType(missing[key], bindingPrefix))
-  );
-  groups.forEach((group: MissingGroupItem) => {
-    if (group.packages) group.packages = group.packages.map(resolvePackageNameByPath);
-    if (group.bits) group.bits = group.bits.map(resolvePackageNameByPath);
-  });
-  // This is a hack to solve problems that madge has with packages for type script files
-  // It see them as missing even if they are exists
-  const foundPackages: FoundPackages = {
-    packages: {},
-    bits: []
-  };
-  const packageJson = PackageJson.findPackage(cwd);
-  groups.forEach((group: MissingGroupItem) => {
-    const missingPackages: string[] = [];
-    if (group.packages) {
-      group.packages.forEach(packageName => {
-        // Don't try to resolve the same package twice
-        if (R.contains(packageName, missingPackages)) return;
-        const resolvedPath = resolveModulePath(packageName, cwd, workspacePath);
-        if (!resolvedPath) {
-          missingPackages.push(packageName);
-          return;
-        }
-        const resolvedPackage = resolveNodePackage(cwd, resolvedPath);
-
-        // If the package is actually a component add it to the components (bits) list
-        if (resolvedPackage) {
-          if (resolvedPackage.componentId) {
-            foundPackages.bits.push(resolvedPackage);
-          } else {
-            const version = resolvedPackage.versionUsedByDependent || resolvedPackage.concreteVersion;
-            if (version) {
-              const packageWithVersion = {
-                [resolvedPackage.name]: version
-              };
-              Object.assign(foundPackages.packages, packageWithVersion);
-            }
-          }
-        } else {
-          missingPackages.push(packageName);
-        }
-      });
-    }
-    // this was disabled since it cause these bugs:
-    // (as part of 9ddeb61aa29c170cd58df0c2cc1cc30db1ebded8 of bit-javascript)
-    // https://github.com/teambit/bit/issues/635
-    // https://github.com/teambit/bit/issues/690
-    // later it re-enabled by this commit (d192a295632255dba9f0d62232fb237feeb8f33a of bit-javascript)
-    // we should think if we really want it
-    if (packageJson) {
-      const result = findPackagesInPackageJson(packageJson, missingPackages);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      groups.packages = result.missingPackages;
-      Object.assign(foundPackages.packages, result.foundPackages);
-
-      if (group.bits) {
-        const foundBits = findPackagesInPackageJson(packageJson, group.bits);
-        R.forEachObjIndexed((version, name) => {
-          const resolvedFoundBit: ResolvedNodePackage = {
-            name,
-            versionUsedByDependent: version
-          };
-          foundPackages.bits.push(resolvedFoundBit);
-        }, foundBits.foundPackages);
-      }
-    }
-  });
-
-  return { missingGroups: groups, foundPackages };
 }
 
 /**
@@ -532,10 +263,9 @@ function mergeErrorsToTree(baseDir, errors, tree: Tree) {
  * @param workspacePath
  * @param filePaths path of the file to calculate the dependencies
  * @param bindingPrefix
- * @return {Promise<{missing, tree}>}
  */
 export async function getDependencyTree({
-  baseDir,
+  componentDir, // component rootDir, for legacy-authored it's the same as workspacePath
   workspacePath,
   filePaths,
   bindingPrefix,
@@ -545,7 +275,7 @@ export async function getDependencyTree({
 }: DependencyTreeParams): Promise<{ tree: Tree }> {
   const resolveConfigAbsolute = getResolveConfigAbsolute(workspacePath, resolveModulesConfig);
   const config = {
-    baseDir,
+    baseDir: componentDir,
     includeNpm: true,
     requireConfig: null,
     webpackConfig: null,
@@ -557,21 +287,26 @@ export async function getDependencyTree({
   // This is important because without this, madge won't know to resolve files if we run the
   // CMD not from the root dir
   const fullPaths = filePaths.map(filePath => {
-    if (filePath.startsWith(baseDir)) {
+    if (filePath.startsWith(componentDir)) {
       return filePath;
     }
-    return path.resolve(baseDir, filePath);
+    return path.resolve(componentDir, filePath);
   });
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const { madgeTree, skipped, pathMap, errors } = generateTree(fullPaths, config);
   // @ts-ignore
-  const tree: Tree = groupDependencyTree(madgeTree, baseDir, bindingPrefix);
-  const { missingGroups, foundPackages } = groupMissing(skipped, baseDir, workspacePath, bindingPrefix);
+  const tree: Tree = groupDependencyTree(madgeTree, componentDir, bindingPrefix);
+  const { missingGroups, foundPackages } = new GroupMissing(
+    skipped,
+    componentDir,
+    workspacePath,
+    bindingPrefix
+  ).doGroup();
 
   if (foundPackages) mergeManuallyFoundPackagesToTree(foundPackages, missingGroups, tree);
-  if (errors) mergeErrorsToTree(baseDir, errors, tree);
+  if (errors) mergeErrorsToTree(componentDir, errors, tree);
   if (missingGroups) mergeMissingToTree(missingGroups, tree);
-  if (pathMap) updateTreeWithPathMap(tree, pathMap, baseDir);
+  if (pathMap) updateTreeWithPathMap(tree, pathMap, componentDir);
 
   return { tree };
 }

--- a/src/consumer/component/dependencies/files-dependency-builder/group-missing.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/group-missing.ts
@@ -1,0 +1,165 @@
+import R from 'ramda';
+import { partition } from 'lodash';
+import { processPath } from './generate-tree-madge';
+import { DEFAULT_BINDINGS_PREFIX } from '../../../../constants';
+import PackageJson from '../../package-json';
+import {
+  resolvePackagePath,
+  resolvePackageData,
+  resolvePackageNameByPath,
+  ResolvedPackageData
+} from '../../../../utils/packages';
+
+type Missing = { [absolutePath: string]: string[] }; // e.g. { '/tmp/workspace': ['lodash', 'ramda'] };
+export type MissingGroupItem = { originFile: string; packages?: string[]; bits?: string[]; files?: string[] };
+export type FoundPackages = {
+  packages: { [packageName: string]: string };
+  bits: ResolvedPackageData[];
+};
+
+export class GroupMissing {
+  constructor(
+    private missing: Missing,
+    private componentDir: string,
+    private workspacePath: string,
+    private bindingPrefix: string
+  ) {}
+
+  /**
+   * Run over each entry in the missing array and transform the missing from list of paths
+   * to object with missing types
+   */
+  doGroup(): { missingGroups: MissingGroupItem[]; foundPackages: FoundPackages } {
+    const missingGroups: MissingGroupItem[] = this.groupMissingByType();
+    missingGroups.forEach((group: MissingGroupItem) => {
+      if (group.packages) group.packages = group.packages.map(resolvePackageNameByPath);
+      if (group.bits) group.bits = group.bits.map(resolvePackageNameByPath);
+    });
+    // This is a hack to solve problems that madge has with packages for type script files
+    // It see them as missing even if they are exists
+    const foundPackages: FoundPackages = {
+      packages: {},
+      bits: []
+    };
+    const packageJson = PackageJson.findPackage(this.componentDir);
+    missingGroups.forEach(group => this.processMissingGroup(group, packageJson, foundPackages, missingGroups));
+
+    return { missingGroups, foundPackages };
+  }
+
+  private processMissingGroup(
+    group: MissingGroupItem,
+    packageJson: {},
+    foundPackages: FoundPackages,
+    missingGroups: MissingGroupItem[]
+  ) {
+    const missingPackages: string[] = [];
+    if (group.packages) {
+      group.packages.forEach(packageName => {
+        // Don't try to resolve the same package twice
+        if (missingPackages.includes(packageName)) return;
+        const resolvedPath = resolvePackagePath(packageName, this.componentDir, this.workspacePath);
+        if (!resolvedPath) {
+          missingPackages.push(packageName);
+          return;
+        }
+        const resolvedPackageData = resolvePackageData(this.componentDir, resolvedPath);
+        if (!resolvedPackageData) {
+          missingPackages.push(packageName);
+          return;
+        }
+        // if the package is actually a component add it to the components (bits) list
+        if (resolvedPackageData.componentId) {
+          foundPackages.bits.push(resolvedPackageData);
+        } else {
+          const version = resolvedPackageData.versionUsedByDependent || resolvedPackageData.concreteVersion;
+          if (!version) throw new Error(`unable to find the version for a package ${packageName}`);
+          const packageWithVersion = {
+            [resolvedPackageData.name]: version
+          };
+          Object.assign(foundPackages.packages, packageWithVersion);
+        }
+      });
+    }
+    // this was disabled since it cause these bugs:
+    // (as part of 9ddeb61aa29c170cd58df0c2cc1cc30db1ebded8 of bit-javascript)
+    // https://github.com/teambit/bit/issues/635
+    // https://github.com/teambit/bit/issues/690
+    // later it re-enabled by this commit (d192a295632255dba9f0d62232fb237feeb8f33a of bit-javascript)
+    // now with Harmony, it makes sense to disable it because if we can't find the package.json of
+    // that package, we have no way to know whether this is a package or a component. as a reminder,
+    // with Harmony it's possible to have a totally different package-name than the component-id
+    // and the only way to know the component-id is by loading the package.json and reading the
+    // component-id data.
+    if (packageJson) {
+      const result = findPackagesInPackageJson(packageJson, missingPackages);
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      missingGroups.packages = result.missingPackages;
+      Object.assign(foundPackages.packages, result.foundPackages);
+
+      if (group.bits) {
+        const foundBits = findPackagesInPackageJson(packageJson, group.bits);
+        R.forEachObjIndexed((version, name) => {
+          const resolvedFoundBit: ResolvedPackageData = {
+            name,
+            versionUsedByDependent: version
+          };
+          foundPackages.bits.push(resolvedFoundBit);
+        }, foundBits.foundPackages);
+      }
+    }
+  }
+
+  /**
+   * Group missing dependencies by types (files, bits, packages)
+   * @param {Array} missing list of missing paths to group
+   * @returns {Function} function which group the dependencies
+   */
+  private groupMissingByType(): MissingGroupItem[] {
+    const byPathType = R.groupBy(item => {
+      if (item.startsWith(`${this.bindingPrefix}/`) || item.startsWith(`${DEFAULT_BINDINGS_PREFIX}/`)) return 'bits';
+      return item.startsWith('.') ? 'files' : 'packages';
+    });
+    return Object.keys(this.missing).map(key =>
+      Object.assign(
+        { originFile: processPath(key, {}, this.componentDir) },
+        byPathType(this.missing[key], this.bindingPrefix)
+      )
+    );
+  }
+}
+
+interface PackageDependency {
+  [dependencyId: string]: string;
+}
+
+interface PackageDependenciesTypes {
+  dependencies?: PackageDependency;
+  devDependencies?: PackageDependency;
+  peerDependencies?: PackageDependency;
+}
+interface FindPackagesResult {
+  foundPackages: {
+    [packageName: string]: PackageDependenciesTypes;
+  };
+  missingPackages: string[];
+}
+
+/**
+ * Resolve package dependencies from package.json according to package names
+ *
+ * @param {Object} packageJson
+ * @param {string []} packagesNames
+ * @returns new object with found and missing
+ */
+function findPackagesInPackageJson(packageJson: Record<string, any>, packagesNames: string[]): FindPackagesResult {
+  const { dependencies, devDependencies, peerDependencies } = packageJson;
+  const foundPackages = {};
+  const mergedDependencies = Object.assign({}, dependencies, devDependencies, peerDependencies);
+  if (packagesNames && packagesNames.length && !R.isNil(mergedDependencies)) {
+    const [foundPackagesPartition, missingPackages] = partition(packagesNames, item => item in mergedDependencies);
+    foundPackagesPartition.forEach(pack => (foundPackages[pack] = mergedDependencies[pack]));
+    return { foundPackages, missingPackages };
+  }
+  return { foundPackages: {}, missingPackages: packagesNames };
+}

--- a/src/consumer/component/dependencies/files-dependency-builder/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/index.ts
@@ -1,5 +1,5 @@
-import { getDependencyTree, resolveNodePackage, resolveModulePath } from './build-tree';
+import { getDependencyTree } from './build-tree';
 // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import getDependenciesFromSource from './precinct';
 
-export { resolveNodePackage, resolveModulePath, getDependencyTree, getDependenciesFromSource };
+export { getDependencyTree, getDependenciesFromSource };

--- a/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -1,5 +1,4 @@
-import { BitId } from '../../../../../bit-id';
-import { PathLinuxAbsolute } from '../../../../../utils/path';
+import { ResolvedPackageData } from '../../../../../utils/packages';
 
 /**
  * Import Specifier data.
@@ -38,22 +37,11 @@ export type LinkFile = {
 
 type MissingType = 'files' | 'packages' | 'bits';
 
-export interface ResolvedNodePackage {
-  fullPath?: PathLinuxAbsolute;
-  name: string;
-  // Version from the package.json of the package itself
-  concreteVersion?: string;
-  // Version from the dependent package.json
-  versionUsedByDependent?: string;
-  // add the component id in case it's a bit component
-  componentId?: BitId;
-}
-
 export type DependenciesResults = {
   files?: FileObject[];
   packages?: { [packageName: string]: string }; // pkgName: pkgVersion
   unidentifiedPackages?: string[];
-  bits?: Array<ResolvedNodePackage>;
+  bits?: ResolvedPackageData[];
   error?: Error; // error.code is either PARSING_ERROR or RESOLVE_ERROR
   missing?: { [key in MissingType]: string[] };
 };
@@ -69,7 +57,7 @@ export type ResolveModulesConfig = {
 };
 
 export type DependencyTreeParams = {
-  baseDir: string;
+  componentDir: string;
   workspacePath: string;
   filePaths: string[];
   bindingPrefix: string;

--- a/src/consumer/config/component-overrides.ts
+++ b/src/consumer/config/component-overrides.ts
@@ -177,7 +177,7 @@ export default class ComponentOverrides {
   // TODO: This strategy should be stopped using since harmony, because a package name
   // TODO: might be completely different than a component id
   // TODO: instead we should go to the package.json and check the component name there
-  // TODO: Like we do in build-tree.resolveNodePackage
+  // TODO: Like we do in resolvePackageData()
   // TODO: or use some index that store it (doesn't exist at the moment)
   /**
    * it is possible that a user added the component into the overrides as a package.

--- a/src/utils/packages/index.ts
+++ b/src/utils/packages/index.ts
@@ -1,0 +1,3 @@
+export { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
+export { resolvePackagePath } from './resolve-pkg-path';
+export { resolvePackageData, ResolvedPackageData } from './resolve-pkg-data';

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -1,0 +1,100 @@
+import R from 'ramda';
+import { PathLinuxAbsolute } from '../path';
+import PackageJson from '../../consumer/component/package-json';
+import { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
+import { BitId } from '../../bit-id';
+
+export interface ResolvedPackageData {
+  fullPath?: PathLinuxAbsolute;
+  name: string;
+  concreteVersion?: string; // Version from the package.json of the package itself
+  versionUsedByDependent?: string; // Version from the dependent package.json
+  componentId?: BitId; // add the component id in case it's a bit component
+}
+
+/**
+ * Get a path to node package and return the name and version
+ *
+ * @param {any} packageFullPath full path to the package
+ * @returns {Object} name and version of the package
+ */
+export function resolvePackageData(cwd: string, packageFullPath: PathLinuxAbsolute): ResolvedPackageData | undefined {
+  const NODE_MODULES = 'node_modules';
+  const result: ResolvedPackageData = {
+    fullPath: packageFullPath,
+    name: '',
+    componentId: undefined
+  };
+  // Start by searching in the component dir and up from there
+  // If not found search in package dir itself.
+  // We are doing this, because the package.json inside the package dir contain exact version
+  // And the component/consumer package.json might contain semver like ^ or ~
+  // We want to have this semver as dependency and not the exact version, otherwise it will be considered as modified all the time
+  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  const packageJsonInfo = PackageJson.findPackage(cwd);
+  if (packageJsonInfo) {
+    // The +1 is for the / after the node_modules, we didn't enter it into the NODE_MODULES const because it makes problems on windows
+    const packageRelativePath = packageFullPath.substring(
+      packageFullPath.lastIndexOf(NODE_MODULES) + NODE_MODULES.length + 1,
+      packageFullPath.length
+    );
+
+    const packageName = resolvePackageNameByPath(packageRelativePath);
+    const packageNameNormalized = packageName.replace('\\', '/');
+    const packageVersion =
+      R.path(['dependencies', packageNameNormalized], packageJsonInfo) ||
+      R.path(['devDependencies', packageNameNormalized], packageJsonInfo) ||
+      R.path(['peerDependencies', packageNameNormalized], packageJsonInfo);
+    if (packageVersion) {
+      result.name = packageNameNormalized;
+      result.versionUsedByDependent = packageVersion;
+    }
+  }
+
+  // Get the package relative path to the node_modules dir
+  const packageDir = resolvePackageDirFromFilePath(packageFullPath);
+
+  // don't propagate here since loading a package.json of another folder and taking the version from it will result wrong version
+  // This for example happen in the following case:
+  // if you have 2 authored component which one dependent on the other
+  // we will look for the package.json on the dependency but won't find it
+  // if we propagate we will take the version from the root's package json which has nothing with the component version
+  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  const packageInfo = PackageJson.loadSync(packageDir);
+
+  // when running 'bitjs get-dependencies' command, packageInfo is sometimes empty
+  // or when using custom-module-resolution it may be empty or the name/version are empty
+  if (!packageInfo || !packageInfo.name || !packageInfo.version) {
+    if (!result.name) {
+      return undefined;
+    }
+    return result;
+  }
+  result.name = packageInfo.name;
+  result.concreteVersion = packageInfo.version;
+  if (packageInfo.componentId) {
+    result.componentId = new BitId(packageInfo.componentId);
+  }
+  return result;
+}
+
+/**
+ * given the full path of a package file, returns the root dir of the package, so then we could
+ * find the package.json in that directory.
+ *
+ * example of a normal package:
+ * absolutePackageFilePath: /user/workspace/node_modules/lodash.isboolean/index.js
+ * returns: /user/workspace/node_modules/lodash.isboolean
+ *
+ * example of a scoped package:
+ * absolutePackageFilePath: /user/workspace/node_modules/@babel/core/lib/index.js
+ * returns: /user/workspace/node_modules/@babel/core
+ */
+function resolvePackageDirFromFilePath(absolutePackageFilePath: string): string {
+  const NODE_MODULES = 'node_modules';
+  const indexOfLastNodeModules = absolutePackageFilePath.lastIndexOf(NODE_MODULES) + NODE_MODULES.length + 1;
+  const pathInsideNodeModules = absolutePackageFilePath.substring(indexOfLastNodeModules);
+  const packageName = resolvePackageNameByPath(pathInsideNodeModules);
+  const pathUntilNodeModules = absolutePackageFilePath.substring(0, indexOfLastNodeModules);
+  return pathUntilNodeModules + packageName;
+}

--- a/src/utils/packages/resolve-pkg-name-by-path.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.ts
@@ -1,0 +1,17 @@
+import path from 'path';
+
+/**
+ * return the package name by the import statement path to node package
+ *
+ * @param {string} packagePath import statement path
+ * @returns {string} name of the package
+ */
+export function resolvePackageNameByPath(packagePath: string): string {
+  const packagePathArr = packagePath.split(path.sep); // TODO: make sure this is working on windows
+  // Regular package without path. example - import _ from 'lodash'
+  if (packagePathArr.length === 1) return packagePath;
+  // Scoped package. example - import getSymbolIterator from '@angular/core/src/util.d.ts';
+  if (packagePathArr[0].startsWith('@')) return path.join(packagePathArr[0], packagePathArr[1]);
+  // Regular package with internal path. example import something from 'mypackage/src/util/isString'
+  return packagePathArr[0];
+}

--- a/src/utils/packages/resolve-pkg-path.ts
+++ b/src/utils/packages/resolve-pkg-path.ts
@@ -1,0 +1,29 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { PathOsBased } from '../path';
+
+/**
+ * Recursively search for node package inside node_modules dir
+ * This function propagates up until it gets to the root provided then stops
+ *
+ * @param {string} packageName - package name
+ * @param {string} workingDir - dir to start searching of
+ * @param {string} root - path to dir to stop the search
+ * @returns The resolved path for the package directory
+ */
+export function resolvePackagePath(packageName: string, workingDir: string, root: string): PathOsBased | undefined {
+  const pathToCheck = path.resolve(workingDir, 'node_modules', packageName);
+
+  if (fs.existsSync(pathToCheck)) {
+    return pathToCheck;
+  }
+
+  if (workingDir === root) {
+    return undefined;
+  }
+
+  const parentWorkingDir = path.dirname(workingDir);
+  if (parentWorkingDir === workingDir) return undefined;
+
+  return resolvePackagePath(packageName, parentWorkingDir, root);
+}


### PR DESCRIPTION
Extract it to a new file and makes it clearer.
Also, add an e2e-test to make sure we get the component-id from build-tree.
