### PR TITLE
avoid resolving package data from the main package.json

### DIFF
--- a/e2e/commands/status.e2e.2.ts
+++ b/e2e/commands/status.e2e.2.ts
@@ -601,7 +601,6 @@ describe('bit status command', function() {
     });
   });
   describe('when a component requires a missing bit component that exists on package.json', () => {
-    let output;
     before(() => {
       helper.scopeHelper.reInitLocalScope();
       const fooFixture = "require ('@bit/scope.bar.baz');";
@@ -609,17 +608,10 @@ describe('bit status command', function() {
       helper.fixtures.addComponentBarFoo();
       helper.npm.initNpm();
       helper.packageJson.addKeyValue({ dependencies: { '@bit/scope.bar.baz': '1.0.0' } });
-      output = helper.command.runCmd('bit status');
     });
-    it('should not show the bit package as missing', () => {
-      expect(output).to.not.have.string('missing components');
+    it('should show the bit package as missing', () => {
       const status = helper.command.statusJson();
-      expect(status.componentsWithMissingDeps).to.have.lengthOf(0);
-    });
-    it('should resolve the component version from the package.json file', () => {
-      const show = helper.command.showComponentParsed();
-      expect(show.dependencies).to.have.lengthOf(1);
-      expect(show.dependencies[0].id).to.equal('scope.bar/baz@1.0.0');
+      expect(status.componentsWithMissingDeps).to.have.lengthOf(1);
     });
   });
   /**

--- a/e2e/flows/dependencies-as-packages.e2e.2.ts
+++ b/e2e/flows/dependencies-as-packages.e2e.2.ts
@@ -376,10 +376,10 @@ chai.use(require('chai-fs'));
           before(() => {
             helper.fs.deletePath('components/bar/foo/node_modules/@ci');
           });
-          it('bit status should show not show it as untracked components', () => {
+          it('bit status should show it as missing deps not as untracked', () => {
             const statusJson = helper.command.statusJson();
             expect(statusJson.invalidComponents).to.have.lengthOf(0);
-            expect(statusJson.componentsWithMissingDeps).to.have.lengthOf(0);
+            expect(statusJson.componentsWithMissingDeps).to.have.lengthOf(1);
             const status = helper.command.status();
             const statusWithoutLinebreaks = status.replace(/\n/g, '');
             expect(statusWithoutLinebreaks).not.to.have.string(componentIssuesLabels.untrackedDependencies);

--- a/src/consumer/component/dependencies/files-dependency-builder/group-missing.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/group-missing.ts
@@ -91,23 +91,23 @@ export class GroupMissing {
     // with Harmony it's possible to have a totally different package-name than the component-id
     // and the only way to know the component-id is by loading the package.json and reading the
     // component-id data.
-    if (packageJson) {
-      const result = findPackagesInPackageJson(packageJson, missingPackages);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      missingGroups.packages = result.missingPackages;
-      Object.assign(foundPackages.packages, result.foundPackages);
+    // if (packageJson) {
+    //   const result = findPackagesInPackageJson(packageJson, missingPackages);
+    //   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    //   missingGroups.packages = result.missingPackages;
+    //   Object.assign(foundPackages.packages, result.foundPackages);
 
-      if (group.bits) {
-        const foundBits = findPackagesInPackageJson(packageJson, group.bits);
-        R.forEachObjIndexed((version, name) => {
-          const resolvedFoundBit: ResolvedPackageData = {
-            name,
-            versionUsedByDependent: version
-          };
-          foundPackages.bits.push(resolvedFoundBit);
-        }, foundBits.foundPackages);
-      }
-    }
+    //   if (group.bits) {
+    //     const foundBits = findPackagesInPackageJson(packageJson, group.bits);
+    //     R.forEachObjIndexed((version, name) => {
+    //       const resolvedFoundBit: ResolvedPackageData = {
+    //         name,
+    //         versionUsedByDependent: version
+    //       };
+    //       foundPackages.bits.push(resolvedFoundBit);
+    //     }, foundBits.foundPackages);
+    //   }
+    // }
   }
 
   /**


### PR DESCRIPTION
require the package.json of the package to make sure whether it is a component or a package
