### PR TITLE
fix legacy compilers that use component.extensions to be build upon tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2796](https://github.com/teambit/bit/issues/2796) - fix legacy compilers that use component.extensions to be build upon tag
+
 ## [[14.8.4] - 2020-07-02](https://github.com/teambit/bit/releases/tag/v14.8.4)
 
 - add an option to not use cache when loading scope

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -218,9 +218,10 @@ export default (async function tagModelComponent({
   const legacyComps: Component[] = [];
   const nonLegacyComps: Component[] = [];
 
-  componentsToBuildAndTest.forEach(c =>
-    c.extensions && c.extensions.length ? nonLegacyComps.push(c) : legacyComps.push(c)
-  );
+  componentsToBuildAndTest.forEach(c => {
+    // @todo: change this condition to `c.isLegacy` once harmony-beta is merged.
+    c.extensions && c.extensions.length && !consumer.isLegacy ? nonLegacyComps.push(c) : legacyComps.push(c);
+  });
   if (legacyComps.length) {
     await scope.buildMultiple(componentsToBuildAndTest, consumer, false, verbose);
   }


### PR DESCRIPTION
Fixes #2796 