### PR TITLE
fix tagging Harmony components that have legacy dependencies

### DIFF
--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -21,6 +21,7 @@ import PackageJsonFile from '../component/package-json-file';
 import ShowDoctorError from '../../error/show-doctor-error';
 import { Artifact } from '../component/sources/artifact';
 import { replacePlaceHolderWithComponentValue } from '../../utils/bit/component-placeholders';
+import { BitIds } from '../../bit-id';
 
 export type ComponentWriterProps = {
   component: Component;
@@ -32,7 +33,7 @@ export type ComponentWriterProps = {
   origin: ComponentOrigin;
   consumer: Consumer | undefined;
   bitMap: BitMap;
-  writeBitDependencies?: boolean;
+  ignoreBitDependencies?: boolean | BitIds;
   deleteBitDirContent?: boolean;
   existingComponentMap?: ComponentMap;
   excludeRegistryPrefix?: boolean;
@@ -49,7 +50,7 @@ export default class ComponentWriter {
   origin: ComponentOrigin;
   consumer: Consumer | undefined; // when using capsule, the consumer is not defined
   bitMap: BitMap;
-  writeBitDependencies: boolean;
+  ignoreBitDependencies: boolean | BitIds;
   deleteBitDirContent: boolean | undefined;
   existingComponentMap: ComponentMap | undefined;
   excludeRegistryPrefix: boolean;
@@ -64,7 +65,7 @@ export default class ComponentWriter {
     origin,
     consumer,
     bitMap,
-    writeBitDependencies = false,
+    ignoreBitDependencies = true,
     deleteBitDirContent,
     existingComponentMap,
     excludeRegistryPrefix = false,
@@ -79,7 +80,7 @@ export default class ComponentWriter {
     this.origin = origin;
     this.consumer = consumer;
     this.bitMap = bitMap;
-    this.writeBitDependencies = writeBitDependencies;
+    this.ignoreBitDependencies = ignoreBitDependencies;
     this.deleteBitDirContent = deleteBitDirContent;
     this.existingComponentMap = existingComponentMap;
     this.excludeRegistryPrefix = excludeRegistryPrefix;
@@ -152,7 +153,7 @@ export default class ComponentWriter {
         this.component,
         artifactsDir || this.writeToPath,
         this.override,
-        this.writeBitDependencies,
+        this.ignoreBitDependencies,
         this.excludeRegistryPrefix,
         packageManager
       );

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -33,7 +33,7 @@ export interface ManyComponentsWriterParams {
   writePackageJson?: boolean;
   saveDependenciesAsComponents?: boolean;
   writeConfig?: boolean;
-  writeBitDependencies?: boolean;
+  ignoreBitDependencies?: boolean;
   createNpmLinkFiles?: boolean;
   writeDists?: boolean;
   installNpmPackages?: boolean;
@@ -63,7 +63,7 @@ export default class ManyComponentsWriter {
   override: boolean;
   writePackageJson: boolean;
   writeConfig: boolean;
-  writeBitDependencies: boolean;
+  ignoreBitDependencies: boolean;
   createNpmLinkFiles: boolean;
   writeDists: boolean;
   installNpmPackages: boolean;
@@ -93,7 +93,7 @@ export default class ManyComponentsWriter {
     this.isolated = this._setBooleanDefault(params.isolated, false);
     this.writePackageJson = this._setBooleanDefault(params.writePackageJson, true);
     this.writeConfig = this._setBooleanDefault(params.writeConfig, false);
-    this.writeBitDependencies = this._setBooleanDefault(params.writeBitDependencies, false);
+    this.ignoreBitDependencies = this._setBooleanDefault(params.ignoreBitDependencies, true);
     this.createNpmLinkFiles = this._setBooleanDefault(params.createNpmLinkFiles, false);
     this.writeDists = this._setBooleanDefault(params.writeDists, true);
     this.installPeerDependencies = this._setBooleanDefault(params.installPeerDependencies, false);
@@ -213,7 +213,7 @@ export default class ManyComponentsWriter {
       component: componentWithDeps.component,
       writeToPath: componentRootDir,
       writeConfig: this.writeConfig,
-      writeBitDependencies: this.writeBitDependencies || !componentWithDeps.component.dependenciesSavedAsComponents, // when dependencies are written as npm packages, they must be written in package.json
+      ignoreBitDependencies: this.ignoreBitDependencies || componentWithDeps.component.dependenciesSavedAsComponents, // when dependencies are written as npm packages, they must be written in package.json
       ...getParams()
     };
   }

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -63,7 +63,7 @@ export default class ManyComponentsWriter {
   override: boolean;
   writePackageJson: boolean;
   writeConfig: boolean;
-  ignoreBitDependencies: boolean;
+  ignoreBitDependencies: boolean | undefined;
   createNpmLinkFiles: boolean;
   writeDists: boolean;
   installNpmPackages: boolean;
@@ -93,7 +93,7 @@ export default class ManyComponentsWriter {
     this.isolated = this._setBooleanDefault(params.isolated, false);
     this.writePackageJson = this._setBooleanDefault(params.writePackageJson, true);
     this.writeConfig = this._setBooleanDefault(params.writeConfig, false);
-    this.ignoreBitDependencies = this._setBooleanDefault(params.ignoreBitDependencies, true);
+    this.ignoreBitDependencies = params.ignoreBitDependencies;
     this.createNpmLinkFiles = this._setBooleanDefault(params.createNpmLinkFiles, false);
     this.writeDists = this._setBooleanDefault(params.writeDists, true);
     this.installPeerDependencies = this._setBooleanDefault(params.installPeerDependencies, false);
@@ -213,7 +213,10 @@ export default class ManyComponentsWriter {
       component: componentWithDeps.component,
       writeToPath: componentRootDir,
       writeConfig: this.writeConfig,
-      ignoreBitDependencies: this.ignoreBitDependencies || componentWithDeps.component.dependenciesSavedAsComponents, // when dependencies are written as npm packages, they must be written in package.json
+      ignoreBitDependencies:
+        typeof this.ignoreBitDependencies === 'boolean'
+          ? this.ignoreBitDependencies
+          : componentWithDeps.component.dependenciesSavedAsComponents, // when dependencies are written as npm packages, they must be written in package.json
       ...getParams()
     };
   }

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -105,14 +105,15 @@ export function preparePackageJsonToWrite(
   component: Component,
   bitDir: string,
   override = true,
-  writeBitDependencies = false, // e.g. when it's a capsule
+  ignoreBitDependencies: BitIds | boolean = true,
   excludeRegistryPrefix?: boolean,
   packageManager?: string
 ): { packageJson: PackageJsonFile; distPackageJson: PackageJsonFile | null | undefined } {
   logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}. override ${override.toString()}`);
   const getBitDependencies = (dependencies: BitIds) => {
-    if (!writeBitDependencies) return {};
+    if (ignoreBitDependencies === true) return {};
     return dependencies.reduce((acc, depId: BitId) => {
+      if (Array.isArray(ignoreBitDependencies) && ignoreBitDependencies.searchWithoutVersion(depId)) return acc;
       const packageDependency = getPackageDependency(bitMap, depId, component.id);
       const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
       acc[packageName] = packageDependency;

--- a/src/environment/environment.ts
+++ b/src/environment/environment.ts
@@ -61,7 +61,7 @@ export default class Environment {
       override: opts.override,
       writePackageJson: opts.writePackageJson,
       writeConfig: opts.writeConfig,
-      writeBitDependencies: opts.writeBitDependencies,
+      ignoreBitDependencies: !opts.writeBitDependencies,
       createNpmLinkFiles: opts.createNpmLinkFiles,
       writeDists: opts.writeDists,
       saveDependenciesAsComponents: opts.saveDependenciesAsComponents !== false,

--- a/src/environment/isolator.ts
+++ b/src/environment/isolator.ts
@@ -104,7 +104,7 @@ export default class Isolator {
       override: opts.override,
       writePackageJson: opts.writePackageJson,
       writeConfig: opts.writeConfig,
-      writeBitDependencies: opts.writeBitDependencies,
+      ignoreBitDependencies: !opts.writeBitDependencies,
       createNpmLinkFiles: opts.createNpmLinkFiles,
       saveDependenciesAsComponents: opts.saveDependenciesAsComponents !== false,
       writeDists: opts.writeDists,

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -69,6 +69,7 @@ export class IsolatorExtension {
     const seedersIds = seeders.map(seeder => consumer.getParsedId(seeder));
     const graph = await buildOneGraphForComponents(seedersIds, consumer);
     const baseDir = path.join(CAPSULES_BASE_DIR, hash(consumer.projectPath)); // TODO: move this logic elsewhere
+    opts = Object.assign(opts || {}, { consumer });
     return this.createNetwork(seedersIds, graph, baseDir, opts);
   }
   async createNetworkFromScope(seeders: string[], scope: Scope, opts?: {}): Promise<Network> {
@@ -97,7 +98,14 @@ export class IsolatorExtension {
       },
       opts
     );
-    const components = findSuccessorsInGraph(graph, seeders);
+    const compsAndDeps = findSuccessorsInGraph(graph, seeders);
+    const filterNonWorkspaceComponents = () => {
+      // @ts-ignore @todo: fix this opts to have types
+      const consumer: Consumer = opts?.consumer;
+      if (!consumer) return compsAndDeps;
+      return compsAndDeps.filter(c => consumer.bitMap.getComponentIfExist(c.id, { ignoreVersion: true }));
+    };
+    const components = filterNonWorkspaceComponents();
     const capsules = await createCapsulesFromComponents(components, baseDir, config);
 
     const capsuleList = new CapsuleList(

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -116,13 +116,7 @@ export class IsolatorExtension {
     );
     const capsulesWithPackagesData = await getCapsulesPreviousPackageJson(capsules);
 
-    await writeComponentsToCapsules(
-      components,
-      graph,
-      capsules,
-      capsuleList,
-      this.dependencyResolver.packageManagerName
-    );
+    await writeComponentsToCapsules(components, graph, capsules, capsuleList);
     updateWithCurrentPackageJsonData(capsulesWithPackagesData, capsules);
     if (config.installPackages) {
       const capsulesToInstall: Capsule[] = capsulesWithPackagesData

--- a/src/extensions/isolator/write-components-to-capsules.ts
+++ b/src/extensions/isolator/write-components-to-capsules.ts
@@ -11,8 +11,7 @@ export default async function writeComponentsToCapsules(
   components: ConsumerComponent[],
   graph: Graph,
   capsules: Capsule[],
-  capsuleList: CapsuleList,
-  packageManager: string
+  capsuleList: CapsuleList
 ) {
   components = components.map(c => c.clone());
   const allIds = BitIds.fromArray(components.map(c => c.id));

--- a/src/extensions/isolator/write-components-to-capsules.ts
+++ b/src/extensions/isolator/write-components-to-capsules.ts
@@ -1,14 +1,11 @@
 import ConsumerComponent from '../../consumer/component';
 import { Capsule } from './capsule';
-
-import { ComponentWithDependencies } from '../../scope';
-import ManyComponentsWriter, { ManyComponentsWriterParams } from '../../consumer/component-ops/many-components-writer';
-
 import CapsuleList from './capsule-list';
 import Graph from '../../scope/graph/graph'; // TODO: use graph extension?
-import { BitId } from '../../bit-id';
-import { Dependencies } from '../../consumer/component/dependencies';
+import { BitIds } from '../../bit-id';
 import { ComponentID } from '../component';
+import ComponentWriter, { ComponentWriterProps } from '../../consumer/component-ops/component-writer';
+import BitMap from '../../consumer/bit-map';
 
 export default async function writeComponentsToCapsules(
   components: ConsumerComponent[],
@@ -18,57 +15,34 @@ export default async function writeComponentsToCapsules(
   packageManager: string
 ) {
   components = components.map(c => c.clone());
-  const writeToPath = '.';
-  const componentsWithDependencies = components.map(component => {
-    const getClonedFromGraph = (id: BitId): ConsumerComponent => {
-      const consumerComponent = graph.node(id.toString());
-      if (!consumerComponent) {
-        throw new Error(
-          `unable to find the dependency "${id.toString()}" of "${component.id.toString()}" in the graph`
-        );
-      }
-      return consumerComponent.clone();
-    };
-    const getDeps = (dependencies: Dependencies) => dependencies.get().map(dep => getClonedFromGraph(dep.id));
-    const dependencies = getDeps(component.dependencies);
-    const devDependencies = getDeps(component.devDependencies);
-    const extensionDependencies = component.extensions.extensionsBitIds.map(getClonedFromGraph);
-    return new ComponentWithDependencies({
-      component,
-      dependencies,
-      devDependencies,
-      extensionDependencies
-    });
-  });
-  const concreteOpts: ManyComponentsWriterParams = {
-    componentsWithDependencies,
-    writeToPath,
+  const allIds = BitIds.fromArray(components.map(c => c.id));
+  await Promise.all(
+    components.map(async component => {
+      const capsule = capsuleList.getCapsule(new ComponentID(component.id));
+      if (!capsule) return;
+      const params = getComponentWriteParams(component, allIds);
+      const componentWriter = new ComponentWriter(params);
+      await componentWriter.populateComponentsFilesToWrite();
+      await component.dataToPersist.persistAllToCapsule(capsule, { keepExistingCapsule: true });
+    })
+  );
+  // return manyComponentsWriter.writtenComponents;
+}
+
+function getComponentWriteParams(component: ConsumerComponent, ids: BitIds): ComponentWriterProps {
+  return {
+    component,
+    // @ts-ignore
+    bitMap: new BitMap(),
+    writeToPath: '.',
+    origin: 'IMPORTED',
+    consumer: undefined,
     override: false,
     writePackageJson: true,
     writeConfig: false,
-    writeBitDependencies: false,
-    createNpmLinkFiles: true,
-    saveDependenciesAsComponents: false,
-    writeDists: true,
-    installNpmPackages: false,
-    installPeerDependencies: false,
-    addToRootPackageJson: false,
-    verbose: false,
+    ignoreBitDependencies: ids,
     excludeRegistryPrefix: false,
-    silentPackageManagerResult: false,
     isolated: true,
-    packageManager,
     applyExtensionsAddedConfig: true
   };
-  const manyComponentsWriter = new ManyComponentsWriter(concreteOpts);
-  await manyComponentsWriter._populateComponentsFilesToWrite();
-  // write data to capsule
-  await Promise.all(
-    manyComponentsWriter.writtenComponents.map(async componentToWrite => {
-      const capsule = capsuleList.getCapsule(new ComponentID(componentToWrite.id));
-      if (!capsule) return;
-      await componentToWrite.dataToPersist.persistAllToCapsule(capsule, { keepExistingCapsule: true });
-    })
-  );
-  return manyComponentsWriter.writtenComponents;
 }


### PR DESCRIPTION
create capsules only for workspace dependencies and npm-install the rest.