### PR TITLE
Fix legacy capsule exec to not hang on error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [unreleased]
 
+- [#2809](https://github.com/teambit/bit/issues/2809) - fix legacy capsule exec to not hang on error
+
 ## [[14.8.6] - 2020-07-05](https://github.com/teambit/bit/releases/tag/v14.8.6)
 
 - add an option to not use load scope from cache for pkg extension

--- a/src/environment/isolator.ts
+++ b/src/environment/isolator.ts
@@ -24,6 +24,7 @@ import GeneralError from '../error/general-error';
 import { PathOsBased } from '../utils/path';
 import loader from '../cli/loader';
 import { PackageManagerResults } from '../npm-client/npm-client';
+import execa from 'execa';
 
 export interface IsolateOptions {
   writeToPath?: PathOsBased; // Path to write the component to
@@ -235,7 +236,7 @@ export default class Isolator {
   }
 
   async _getNpmVersion() {
-    const { stdout: versionString } = await this.capsuleExec('npm --version');
+    const { stdout: versionString } = await this.capsuleExecUsingExeca('npm', ['--version']);
     const validVersion = semver.coerce(versionString);
     return validVersion ? validVersion.raw : null;
   }
@@ -243,7 +244,7 @@ export default class Isolator {
   async installPackagesOnRoot(modules: string[] = []) {
     await this._throwForOldNpmVersion();
     const args = ['install', ...modules, '--no-save'];
-    return this.capsuleExec(`npm ${args.join(' ')}`, { cwd: this.componentRootDir });
+    return this.capsuleExecUsingExeca('npm', args, this.componentRootDir);
   }
 
   async _throwForOldNpmVersion() {
@@ -261,6 +262,11 @@ export default class Isolator {
       );
     }
     this._npmVersionHasValidated = true;
+  }
+
+  async capsuleExecUsingExeca(pkgManager: string, args: string[], dir = ''): Promise<PackageManagerResults> {
+    const cwd = path.join(this.capsule.wrkDir, dir);
+    return execa(pkgManager, args, { cwd });
   }
 
   async capsuleExec(cmd: string, options?: Record<string, any> | null | undefined): Promise<PackageManagerResults> {
@@ -326,14 +332,18 @@ export default class Isolator {
   }
 
   async _getNpmListOutput(packageManager: string): Promise<string> {
-    const args = [packageManager, 'list', '-j'];
+    const args = ['list', '-j'];
     try {
-      const { stdout, stderr } = await this.capsuleExec(args.join(' '), { cwd: this.componentRootDir });
+      const { stdout, stderr } = await this.capsuleExecUsingExeca(packageManager, args, this.componentRootDir);
       if (stderr && stderr.startsWith('{')) return stderr;
       return stdout;
     } catch (err) {
-      if (err && err.startsWith('{')) return err; // it's probably a valid json with errors, that's fine, parse it.
-      throw err;
+      if (err.stdout && err.stdout.startsWith('{')) {
+        // it's probably a valid json with errors, that's fine, parse it.
+        return err.stdout;
+      }
+      logger.error('npm-client got an error', err);
+      throw new Error(`failed running ${err.cmd} to find the peer dependencies due to an error: ${err.message}`);
     }
   }
 }

--- a/src/environment/isolator.ts
+++ b/src/environment/isolator.ts
@@ -1,4 +1,5 @@
 import R from 'ramda';
+import execa from 'execa';
 import * as path from 'path';
 import semver from 'semver';
 import pMapSeries from 'p-map-series';
@@ -24,7 +25,6 @@ import GeneralError from '../error/general-error';
 import { PathOsBased } from '../utils/path';
 import loader from '../cli/loader';
 import { PackageManagerResults } from '../npm-client/npm-client';
-import execa from 'execa';
 
 export interface IsolateOptions {
   writeToPath?: PathOsBased; // Path to write the component to


### PR DESCRIPTION
Fixes #2809 .

This is happening due to some changes in the `capsule.exec` method. Specifically, the command `npm list -j` was hanging when NPM throws the peer-dependencies errors.

Fixed by changing to `execa`.