### PR TITLE
fix export --all --include-dependencies flags to not duplicate components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [14.8.7-dev.3] - 2020-07-08
+
+- fix export --all --include-dependencies flags to not duplicate components
+
 ## [14.8.7-dev.2] - 2020-07-08
 
 - fix post receive objects duplications

--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -151,6 +151,16 @@ export default class BitIds extends Array<BitId> {
     return BitIds.fromArray(uniq);
   }
 
+  throwForDuplicationIgnoreVersion() {
+    this.forEach(bitId => {
+      const found = this.filterWithoutVersion(bitId);
+      if (found.length > 1) {
+        throw new Error(`bitIds has "${bitId.toStringWithoutVersion()}" duplicated as following:
+${found.map(id => id.toString()).join('\n')}`);
+      }
+    });
+  }
+
   clone(): BitIds {
     const cloneIds = this.map(id => id.clone());
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -211,7 +211,7 @@ export default class ComponentsList {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const newComponents: BitIds = await this.listNewComponents();
     const nonNewComponents = authoredAndImported.filter(component => !newComponents.has(component.id));
-    return BitIds.fromArray(nonNewComponents.map(c => c.id));
+    return BitIds.fromArray(nonNewComponents.map(c => c.id.changeVersion(undefined)));
   }
 
   async updateIdsFromModelIfTheyOutOfSync(ids: BitIds): Promise<BitIds> {

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -100,6 +100,7 @@ export async function exportMany({
     remoteNameStr: string,
     bitIds: BitIds
   ): Promise<{ exported: BitIds; updatedLocally: BitIds }> {
+    bitIds.throwForDuplicationIgnoreVersion();
     const remote: Remote = await remotes.resolve(remoteNameStr, scope);
     const componentObjects = await pMapSeries(bitIds, id => scope.sources.getObjects(id));
     const idsToChangeLocally = BitIds.fromArray(


### PR DESCRIPTION
The `--all` flag caused the ids to get into the export process with versions.
The `--include-dependencies` adds to the ids all dependencies ids.
As a result, even though the duplications were removed before pushing the ids to the remote, these duplications were Versions aware, so for example "scope/component@0.0.1" and "scope/component" were not considered duplications.

The fix in this PR is to make sure the `--all` flag gets the ids without version.
Also, a preventive measurement was taken to avoid sending duplications to the remote.