### PR TITLE
automatic polyfill

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -9,7 +9,9 @@ module.exports = function(api) {
       {
         targets: {
           node: 8
-        }
+        },
+        useBuiltIns: 'usage',
+        corejs: 3
       }
     ]
   ];

--- a/package.json
+++ b/package.json
@@ -151,6 +151,7 @@
     "commander": "^2.20.3",
     "comment-json": "^3.0.2",
     "copy-to-clipboard": "^3.3.1",
+    "core-js": "^3.6.5",
     "cors": "^2.8.5",
     "css-loader": "^3.6.0",
     "css-tree": "^1.0.0-alpha.39",

--- a/src/api.ts
+++ b/src/api.ts
@@ -1,7 +1,3 @@
-// polyfill for flat-map to support node10
-// https://babeljs.io/docs/en/v7-migration#remove-proposal-polyfills-in-babel-polyfill-https-githubcom-babel-babel-issues-8416
-// this is already imported in app.ts file
-import 'core-js/fn/array/flat-map';
 import harmony from '@teambit/harmony';
 import pWaitFor from 'p-wait-for';
 import { getScopeComponent, addMany as addManyInternal, build, buildAll as buildAllApi } from './api/consumer/index';

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,7 +1,3 @@
-// polyfill for flat-map to support node10
-// https://babeljs.io/docs/en/v7-migration#remove-proposal-polyfills-in-babel-polyfill-https-githubcom-babel-babel-issues-8416
-// this is already imported in api.ts file
-import 'core-js/fn/array/flat-map';
 // import Bluebird from 'bluebird';
 import harmony from '@teambit/harmony';
 import HooksManager from './hooks';


### PR DESCRIPTION
Make use of Babel's `preset-env` to automatically inject all required polyfills.

as described in Babel's docs:
> ### useBuiltIns: 'usage'
> Adds specific imports for polyfills when they are used in each file. We take advantage of the fact that a bundler will load the same polyfill only once.

We can also use `useBuiltIns: entry`, which will replace `import 'core-js'` with relevant polyfills.

Tested and working with `harmony/workspace` branch, after `rm -rf node_modules dist`