### PR TITLE
support custom package name

### DIFF
--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -149,7 +149,7 @@ describe('dependency-resolver extension', function() {
       expect(depResolverExt.data.dependencies).to.have.lengthOf(1);
       expect(depResolverExt.data.dependencies[0].componentId.name).to.equal('comp3');
       expect(depResolverExt.data.dependencies[0].componentId.version).to.equal('0.0.1');
-      expect(depResolverExt.data.dependencies[0].packageName).to.equal(`@bit/${helper.scopes.remote}.comp3`);
+      expect(depResolverExt.data.dependencies[0].packageName).to.equal('ui.comp3');
     });
     describe('exporting the component', () => {
       before(() => {
@@ -161,7 +161,7 @@ describe('dependency-resolver extension', function() {
         expect(depResolverExt.data.dependencies[0].componentId.scope).to.equal(helper.scopes.remote);
         expect(depResolverExt.data.dependencies[0].componentId.version).to.equal('0.0.1');
         expect(depResolverExt.data.dependencies[0].componentId.name).to.equal('comp3');
-        expect(depResolverExt.data.dependencies[0].packageName).to.equal(`@bit/${helper.scopes.remote}.comp3`);
+        expect(depResolverExt.data.dependencies[0].packageName).to.equal('ui.comp3');
       });
     });
   });

--- a/src/consumer/component-ops/codemod-components.ts
+++ b/src/consumer/component-ops/codemod-components.ts
@@ -63,7 +63,7 @@ function codemodComponent(component: Component): { files: SourceFile[]; warnings
         );
         return;
       }
-      const packageName = componentIdToPackageName(id, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName({ ...component, id });
       const cssFamily = ['.css', '.scss', '.less', '.sass'];
       const isCss = cssFamily.includes(file.extname);
       const packageNameSupportCss = isCss ? `~${packageName}` : packageName;

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -214,12 +214,7 @@ export default class ComponentWriter {
     // if not, remove the "this.consumer.isLegacy" part in the condition below
     if (!this.consumer || this.consumer.isLegacy || this.component.isLegacy) return this.component.writtenPath;
     if (this.origin === COMPONENT_ORIGINS.NESTED) return this.component.writtenPath;
-    return getNodeModulesPathOfComponent(
-      this.consumer.config._bindingPrefix,
-      this.component.id,
-      true,
-      this.component.defaultScope
-    );
+    return getNodeModulesPathOfComponent({ ...this.component, id: this.component.id, allowNonScope: true });
   }
 
   addComponentToBitMap(rootDir: string | undefined): ComponentMap {
@@ -444,9 +439,7 @@ export default class ComponentWriter {
     await Promise.all(
       directDependentIds.map(dependentId => {
         const dependentComponentMap = this.consumer ? this.consumer.bitMap.getComponent(dependentId) : null;
-        const relativeLinkPath = this.consumer
-          ? getNodeModulesPathOfComponent(this.consumer.config._bindingPrefix, this.component.id)
-          : null;
+        const relativeLinkPath = this.consumer ? getNodeModulesPathOfComponent(this.component) : null;
         const nodeModulesLinkAbs =
           this.consumer && dependentComponentMap && relativeLinkPath
             ? this.consumer.toAbsolutePath(path.join(dependentComponentMap.getRootDir(), relativeLinkPath))

--- a/src/consumer/component-ops/eject-components.ts
+++ b/src/consumer/component-ops/eject-components.ts
@@ -166,18 +166,19 @@ export default class EjectComponents {
     const action = 'adding the components as packages into package.json';
     try {
       logger.debugAndAddBreadCrumb('eject', action);
-      const componentsVersions = await Promise.all(
-        this.componentsToEject.map(async bitId => {
-          const modelComponent = await this.consumer.scope.getModelComponent(bitId);
-          // $FlowFixMe componentsToEject has scope and version, see @_validateIdsHaveScopesAndVersions
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          return new ComponentVersion(modelComponent, bitId.version);
-        })
-      );
-      await packageJsonUtils.addComponentsWithVersionToRoot(this.consumer, componentsVersions);
+      const { components } = await this.consumer.loadComponents(this.componentsToEject);
+      // const componentsVersions = await Promise.all(
+      //   this.componentsToEject.map(async bitId => {
+      //     const modelComponent = await this.consumer.scope.getModelComponent(bitId);
+      //     // $FlowFixMe componentsToEject has scope and version, see @_validateIdsHaveScopesAndVersions
+      //     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      //     return new ComponentVersion(modelComponent, bitId.version);
+      //   })
+      // );
+      await packageJsonUtils.addComponentsWithVersionToRoot(this.consumer, components);
       this.notEjectedDependents.forEach(({ dependent, ejectedDependencies }) => {
         const dependenciesToReplace = ejectedDependencies.reduce((acc, dependency) => {
-          const packageName = componentIdToPackageName(dependency.id, dependency.bindingPrefix);
+          const packageName = componentIdToPackageName(dependency);
           acc[packageName] = dependency.version;
           return acc;
         }, {});

--- a/src/consumer/component-ops/eject-components.ts
+++ b/src/consumer/component-ops/eject-components.ts
@@ -17,7 +17,6 @@ import logger from '../../logger/logger';
 import defaultErrorHandler from '../../cli/default-error-handler';
 import { getScopeRemotes } from '../../scope/scope-remotes';
 import PackageJsonFile from '../component/package-json-file';
-import ComponentVersion from '../../scope/component-version';
 import deleteComponentsFiles from './delete-component-files';
 import DependencyGraph from '../../scope/graph/scope-graph';
 import Component from '../component/consumer-component';

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -1030,8 +1030,7 @@ export default class Component {
     });
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  static async fromString(str: string): Component {
+  static async fromString(str: string): Promise<Component> {
     const object = JSON.parse(str);
     object.files = SourceFile.loadFromParsedStringArray(object.files);
 

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -1,5 +1,6 @@
 import * as path from 'path';
 import R from 'ramda';
+import semver from 'semver';
 import * as RA from 'ramda-adjunct';
 import { COMPONENT_ORIGINS, DEPENDENCIES_FIELDS } from '../../../../constants';
 import ComponentMap from '../../../bit-map/component-map';
@@ -706,7 +707,8 @@ either, use the ignore file syntax or change the require statement to have a mod
     if (!bits || R.isEmpty(bits)) return;
     let componentId;
     bits.forEach(bitDep => {
-      const version = bitDep.concreteVersion || bitDep.versionUsedByDependent;
+      const version =
+        this.getValidVersion(bitDep.concreteVersion) || this.getValidVersion(bitDep.versionUsedByDependent);
       if (bitDep.componentId) {
         componentId = bitDep.componentId;
       } else if (bitDep.fullPath) {
@@ -743,6 +745,11 @@ either, use the ignore file syntax or change the require statement to have a mod
         this._pushToMissingBitsIssues(originFile, componentId);
       }
     });
+  }
+  getValidVersion(version: string | undefined) {
+    if (!version) return null;
+    if (!semver.valid(version) && !semver.validRange(version)) return null; // it's probably a relative path to the component
+    return version.replace(/[^0-9.]/g, '');
   }
 
   processPackages(originFile: PathLinuxRelative, fileType: FileType) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -712,6 +712,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       } else if (bitDep.fullPath) {
         componentId = this.consumer.getComponentIdFromNodeModulesPath(bitDep.fullPath, this.component.bindingPrefix);
       } else {
+        // legacy components don't have componentId prop in the package.json
         componentId = packageNameToComponentId(this.consumer, bitDep.name, this.component.bindingPrefix);
       }
       if (componentId && version) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
@@ -133,7 +133,10 @@ export default function updateDependenciesVersions(consumer: Consumer, component
     const rootDir: PathLinux | null | undefined = component.componentMap.rootDir;
     const consumerPath = consumer.getPath();
     const basePath = rootDir ? path.join(consumerPath, rootDir) : consumerPath;
-    const packagePath = getNodeModulesPathOfComponent({ id: componentId, bindingPrefix: component.bindingPrefix });
+    const packagePath = getNodeModulesPathOfComponent({
+      ...component,
+      id: componentId
+    });
     const packageName = packagePath.replace(`node_modules${path.sep}`, '');
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const modulePath = resolvePackagePath(packageName, basePath, consumerPath);
@@ -155,9 +158,9 @@ export default function updateDependenciesVersions(consumer: Consumer, component
       return null;
     }
     const dependencyIdAsPackage = componentIdToPackageName({
+      ...component,
       id: componentId, // this componentId is actually the dependencyId
-      bindingPrefix: component.bindingPrefix,
-      defaultScope: component.defaultScope
+      isDependency: true
     });
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const version = component.packageJsonFile.packageJsonObject.dependencies[dependencyIdAsPackage];

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
@@ -145,7 +145,7 @@ export default function updateDependenciesVersions(consumer: Consumer, component
       return null;
     }
     const dependencyIdAsPackage = componentIdToPackageName(
-      componentId,
+      componentId, // this componentId is actually the dependencyId
       component.bindingPrefix,
       component.defaultScope
     );

--- a/src/consumer/component/dependencies/files-dependency-builder/missing-handler.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/missing-handler.ts
@@ -15,7 +15,7 @@ export type FoundPackages = {
   bits: ResolvedPackageData[];
 };
 
-export class GroupMissing {
+export class MissingHandler {
   constructor(
     private missing: Missing,
     private componentDir: string,
@@ -27,7 +27,7 @@ export class GroupMissing {
    * Run over each entry in the missing array and transform the missing from list of paths
    * to object with missing types
    */
-  doGroup(): { missingGroups: MissingGroupItem[]; foundPackages: FoundPackages } {
+  groupAndFindMissing(): { missingGroups: MissingGroupItem[]; foundPackages: FoundPackages } {
     const missingGroups: MissingGroupItem[] = this.groupMissingByType();
     missingGroups.forEach((group: MissingGroupItem) => {
       if (group.packages) group.packages = group.packages.map(resolvePackageNameByPath);

--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -117,12 +117,7 @@ export default class PackageJsonFile {
     excludeRegistryPrefix? = false
   ): PackageJsonFile {
     const filePath = composePath(componentDir);
-    const name = componentIdToPackageName(
-      component.id,
-      component.bindingPrefix,
-      component.defaultScope,
-      !excludeRegistryPrefix
-    );
+    const name = componentIdToPackageName({ withPrefix: !excludeRegistryPrefix, ...component, id: component.id });
     const packageJsonObject = {
       name,
       version: component.version,

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -246,12 +246,8 @@ export function convertToValidPathForPackageManager(pathStr: PathLinux): string 
 function getPackageDependencyValue(
   dependencyId: BitId,
   parentComponentMap: ComponentMap,
-  dependencyComponentMap?: ComponentMap | null | undefined,
-  capsuleMap?: any
+  dependencyComponentMap?: ComponentMap | null | undefined
 ): string | null | undefined {
-  if (capsuleMap && capsuleMap[dependencyId.toString()]) {
-    return capsuleMap[dependencyId.toString()].wrkdir;
-  }
   if (!dependencyComponentMap || dependencyComponentMap.origin === COMPONENT_ORIGINS.NESTED) {
     return dependencyId.version;
   }

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -43,11 +43,20 @@ export async function addComponentsToRoot(consumer: Consumer, components: Compon
 /**
  * Add given components with their versions to root package.json
  */
-export async function addComponentsWithVersionToRoot(consumer: Consumer, componentsVersions: ComponentVersion[]) {
+// export async function addComponentsWithVersionToRoot(consumer: Consumer, componentsVersions: ComponentVersion[]) {
+//   const componentsToAdd = R.fromPairs(
+//     componentsVersions.map(({ component, version }) => {
+//       const packageName = componentIdToPackageName(component.toBitId(), component.bindingPrefix);
+//       return [packageName, version];
+//     })
+//   );
+//   await _addDependenciesPackagesIntoPackageJson(consumer.getPath(), componentsToAdd);
+// }
+export async function addComponentsWithVersionToRoot(consumer: Consumer, components: Component[]) {
   const componentsToAdd = R.fromPairs(
-    componentsVersions.map(({ component, version }) => {
-      const packageName = componentIdToPackageName(component.toBitId(), component.bindingPrefix);
-      return [packageName, version];
+    components.map(component => {
+      const packageName = componentIdToPackageName(component);
+      return [packageName, component.version];
     })
   );
   await _addDependenciesPackagesIntoPackageJson(consumer.getPath(), componentsToAdd);

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -32,7 +32,7 @@ export async function addComponentsToRoot(consumer: Consumer, components: Compon
       throw new ShowDoctorError(`rootDir is missing from an imported component ${component.id.toString()}`);
     }
     const locationAsUnixFormat = convertToValidPathForPackageManager(componentMap.rootDir);
-    const packageName = componentIdToPackageName(component.id, component.bindingPrefix, component.defaultScope);
+    const packageName = componentIdToPackageName(component);
     acc[packageName] = locationAsUnixFormat;
     return acc;
   }, {});
@@ -87,11 +87,7 @@ export async function changeDependenciesToRelativeSyntax(
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         const dependencyPackageValue = getPackageDependencyValue(dependencyIdStr, componentMap, dependencyComponentMap);
         if (dependencyPackageValue) {
-          const packageName = componentIdToPackageName(
-            dependencyId,
-            dependencyComponent.bindingPrefix,
-            dependencyComponent.defaultScope
-          );
+          const packageName = componentIdToPackageName({ ...dependencyComponent, id: dependencyId });
           acc[packageName] = dependencyPackageValue;
         }
       }

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -15,7 +15,6 @@ import JSONFile from './sources/json-file';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
 import PackageJsonFile from './package-json-file';
 import searchFilesIgnoreExt from '../../utils/fs/search-files-ignore-ext';
-import ComponentVersion from '../../scope/component-version';
 import BitMap from '../bit-map/bit-map';
 import ShowDoctorError from '../../error/show-doctor-error';
 import PackageJson from './package-json';
@@ -107,7 +106,11 @@ export function preparePackageJsonToWrite(
     return dependencies.reduce((acc, depId: BitId) => {
       if (Array.isArray(ignoreBitDependencies) && ignoreBitDependencies.searchWithoutVersion(depId)) return acc;
       const packageDependency = getPackageDependency(bitMap, depId, component.id);
-      const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName({
+        ...component,
+        id: depId,
+        isDependency: true
+      });
       acc[packageName] = packageDependency;
       return acc;
     }, {});

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -207,7 +207,7 @@ async function removeComponentsFromNodeModules(consumer: Consumer, components: C
   // paths without scope name, don't have a symlink in node-modules
   const pathsToRemove = components
     .map(c => {
-      return c.id.scope ? getNodeModulesPathOfComponent(c.bindingPrefix, c.id) : null;
+      return c.id.scope ? getNodeModulesPathOfComponent(c) : null;
     })
     .filter(a => a); // remove null
 

--- a/src/consumer/component/package-json.ts
+++ b/src/consumer/component/package-json.ts
@@ -186,7 +186,7 @@ export default class PackageJson {
     const pkg = await PackageJson.getPackageJson(rootDir);
     if (pkg && pkg.dependencies) {
       components.forEach(c => {
-        delete pkg.dependencies[componentIdToPackageName(c.id, c.bindingPrefix, c.defaultScope)];
+        delete pkg.dependencies[componentIdToPackageName(c)];
       });
       await PackageJson.saveRawObject(rootDir, pkg);
     }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -679,7 +679,7 @@ export default class Consumer {
     const getPackageJsonDir = (componentMap: ComponentMap, component: Component): PathRelative | null | undefined => {
       if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED) {
         if (componentMap.hasRootDir()) return null; // no package.json in this case
-        return getNodeModulesPathOfComponent(component);
+        return getNodeModulesPathOfComponent({ ...component, id: component.id, allowNonScope: true });
       }
       return componentMap.rootDir;
     };

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -693,9 +693,10 @@ export default class Consumer {
         unknownComponent instanceof ModelComponent
           ? unknownComponent.toBitIdWithLatestVersionAllowNull()
           : unknownComponent.id;
+      this.bitMap.updateComponentId(id);
       const component =
         unknownComponent instanceof Component ? unknownComponent : await this.loadComponent(unknownComponent.toBitId());
-      this.bitMap.updateComponentId(id);
+
       const componentMap = this.bitMap.getComponent(id);
       const packageJsonDir = getPackageJsonDir(componentMap, component, id);
       return packageJsonDir // if it has package.json, it's imported, which must have a version

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -676,21 +676,28 @@ export default class Consumer {
   }
 
   updateComponentsVersions(components: Array<ModelComponent | Component>): Promise<any> {
-    const getPackageJsonDir = (componentMap: ComponentMap, component: Component): PathRelative | null | undefined => {
+    const getPackageJsonDir = (
+      componentMap: ComponentMap,
+      component: Component,
+      id: BitId
+    ): PathRelative | null | undefined => {
       if (componentMap.origin === COMPONENT_ORIGINS.AUTHORED) {
         if (componentMap.hasRootDir()) return null; // no package.json in this case
-        return getNodeModulesPathOfComponent({ ...component, id: component.id, allowNonScope: true });
+        return getNodeModulesPathOfComponent({ ...component, id, allowNonScope: true });
       }
       return componentMap.rootDir;
     };
 
     const updateVersionsP = components.map(async unknownComponent => {
+      const id: BitId =
+        unknownComponent instanceof ModelComponent
+          ? unknownComponent.toBitIdWithLatestVersionAllowNull()
+          : unknownComponent.id;
       const component =
         unknownComponent instanceof Component ? unknownComponent : await this.loadComponent(unknownComponent.toBitId());
-      const id = component.id;
       this.bitMap.updateComponentId(id);
       const componentMap = this.bitMap.getComponent(id);
-      const packageJsonDir = getPackageJsonDir(componentMap, component);
+      const packageJsonDir = getPackageJsonDir(componentMap, component, id);
       return packageJsonDir // if it has package.json, it's imported, which must have a version
         ? packageJsonUtils.updateAttribute(this, packageJsonDir, 'version', id.version as string)
         : Promise.resolve();

--- a/src/environment/isolator.ts
+++ b/src/environment/isolator.ts
@@ -221,7 +221,7 @@ export default class Isolator {
       const componentPathInCapsule = path.join(capsulePath, component.writtenPath);
       const relativeDepLocation = path.relative(rootPathInCapsule, componentPathInCapsule);
       const locationAsUnixFormat = convertToValidPathForPackageManager(relativeDepLocation);
-      const packageName = componentIdToPackageName(component.id, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName(component);
       acc[packageName] = locationAsUnixFormat;
       return acc;
     }, {});

--- a/src/extensions/compiler/compile.ts
+++ b/src/extensions/compiler/compile.ts
@@ -75,7 +75,7 @@ export class Compile {
       if (!compilerInstance.compileFile) {
         throw new Error(`compiler ${compilerId.toString()} doesn't implement "compileFile" interface`);
       }
-      const packageName = componentIdToPackageName(component.id, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName(component);
       const packageDir = path.join('node_modules', packageName);
       const distDirName = DEFAULT_DIST_DIRNAME;
       const distDir = path.join(packageDir, distDirName);

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -213,7 +213,11 @@ function getCurrentPackageJson(component: ConsumerComponent, capsule: Capsule): 
   const getBitDependencies = (dependencies: BitIds) => {
     return dependencies.reduce((acc, depId: BitId) => {
       const packageDependency = depId.hasVersion() ? depId.version : newVersion;
-      const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
+      const packageName = componentIdToPackageName({
+        ...component,
+        id: depId,
+        isDependency: true
+      });
       acc[packageName] = packageDependency;
       return acc;
     }, {});

--- a/src/extensions/isolator/symlink-dependencies-to-capsules.ts
+++ b/src/extensions/isolator/symlink-dependencies-to-capsules.ts
@@ -30,7 +30,8 @@ async function symlinkComponent(component: ConsumerComponent, capsuleList: Capsu
       );
       return null;
     }
-    const packageName = componentIdToPackageName(devCapsule.component.state._consumer);
+    // @ts-ignore fix once the capsule has the correct component. change to devCapsule.component.state._consumer
+    const packageName = componentIdToPackageName(devCapsule.component as ConsumerComponent);
     const devCapsulePath = devCapsule.wrkDir;
     // @todo: this is a hack, the capsule should be the one responsible to symlink, this works only for FS capsules.
     const dest = path.join(componentCapsule.wrkDir, 'node_modules', packageName);

--- a/src/extensions/isolator/symlink-dependencies-to-capsules.ts
+++ b/src/extensions/isolator/symlink-dependencies-to-capsules.ts
@@ -21,9 +21,9 @@ async function symlinkComponent(component: ConsumerComponent, capsuleList: Capsu
   if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
   const allDeps = component.getAllDependenciesIds();
   const symlinks = allDeps.map((depId: BitId) => {
-    const packageName = componentIdToPackageName(depId, component.bindingPrefix, component.defaultScope);
     const devCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(new ComponentID(depId));
     if (!devCapsule) throw new Error(`unable to find the capsule for ${depId.toStringWithoutVersion()}`);
+    const packageName = componentIdToPackageName(devCapsule.component.state._consumer);
     const devCapsulePath = devCapsule.wrkDir;
     // @todo: this is a hack, the capsule should be the one responsible to symlink, this works only for FS capsules.
     const dest = path.join(componentCapsule.wrkDir, 'node_modules', packageName);

--- a/src/extensions/workspace/utils.ts
+++ b/src/extensions/workspace/utils.ts
@@ -1,15 +1,12 @@
 import fs from 'fs-extra';
 import path from 'path';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
-import { DEFAULT_REGISTRY_DOMAIN_PREFIX } from '../../constants';
+import { ResolvedComponent } from '../utils/resolved-component';
 
-export async function symlinkCapsulesInNodeModules(isolatedEnvs) {
+export async function symlinkCapsulesInNodeModules(isolatedEnvs: ResolvedComponent[]) {
   await Promise.all(
     isolatedEnvs.map(async e => {
-      const componentPackageName = componentIdToPackageName(
-        e.component.id.legacyComponentId,
-        DEFAULT_REGISTRY_DOMAIN_PREFIX
-      );
+      const componentPackageName = componentIdToPackageName(e.component.state._consumer);
       const linkPath = path.join(process.cwd(), 'node_modules', componentPackageName);
       await fs.mkdirp(path.dirname(linkPath));
       await fs.symlink(e.capsule.wrkDir, linkPath);
@@ -17,13 +14,10 @@ export async function symlinkCapsulesInNodeModules(isolatedEnvs) {
   );
 }
 
-export async function removeExistingLinksInNodeModules(isolatedEnvs) {
+export async function removeExistingLinksInNodeModules(isolatedEnvs: ResolvedComponent[]) {
   await Promise.all(
     isolatedEnvs.map(async e => {
-      const componentPackageName = componentIdToPackageName(
-        e.component.id.legacyComponentId,
-        DEFAULT_REGISTRY_DOMAIN_PREFIX
-      );
+      const componentPackageName = componentIdToPackageName(e.component.state._consumer);
       try {
         await fs.unlink(path.join(process.cwd(), 'node_modules', componentPackageName));
       } catch (err) {

--- a/src/links/dependency-file-link-generator.spec.ts
+++ b/src/links/dependency-file-link-generator.spec.ts
@@ -20,6 +20,7 @@ import barFooSass from '../../fixtures/consumer-components/sass/bar-foo.json';
 // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import utilsIsStringSass from '../../fixtures/consumer-components/sass/utils-is-string.json';
 import * as globalConfig from '../api/consumer/lib/global-config';
+import { ExtensionDataList } from '../consumer/config/extension-data';
 
 const mockBitMap = () => {
   return {
@@ -53,6 +54,12 @@ const mockConsumer = (distIsInsideTheComponent = true) => {
   return consumer;
 };
 
+const mockComponent = async (componentJson): Promise<Component> => {
+  const component = await Component.fromString(JSON.stringify(componentJson));
+  component.extensions = new ExtensionDataList();
+  return component;
+};
+
 const mockGetSync = () => {
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   globalConfig.getSync = () => '@bit';
@@ -76,10 +83,10 @@ describe('DependencyFileLinkGenerator', () => {
       let dependencyFileLinkGenerator;
       let linkResult;
       before(async () => {
-        const component = await Component.fromString(JSON.stringify(barFoo));
+        const component = await mockComponent(barFoo);
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         component.componentMap = getComponentMap();
-        const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsString));
+        const dependencyComponent = await mockComponent(utilsIsString);
         dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           consumer: mockConsumer(),
@@ -109,10 +116,10 @@ describe('DependencyFileLinkGenerator', () => {
         let dependencyFileLinkGenerator;
         let linkResults;
         before(async () => {
-          const component = await Component.fromString(JSON.stringify(barFooEs6));
+          const component = await mockComponent(barFooEs6);
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           component.componentMap = getComponentMap();
-          const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringEs6));
+          const dependencyComponent = await mockComponent(utilsIsStringEs6);
           dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
             // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             consumer: mockConsumer(),
@@ -164,10 +171,10 @@ describe('DependencyFileLinkGenerator', () => {
         let dependencyFileLinkGenerator;
         let linkResults;
         before(async () => {
-          const component = await Component.fromString(JSON.stringify(barFooEs6));
+          const component = await mockComponent(barFooEs6);
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           component.componentMap = getComponentMap();
-          const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringEs6));
+          const dependencyComponent = await mockComponent(utilsIsStringEs6);
           dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
             // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             consumer: mockConsumer(false),
@@ -222,10 +229,10 @@ describe('DependencyFileLinkGenerator', () => {
         let linkResults;
         let linkResult;
         before(async () => {
-          const component = await Component.fromString(JSON.stringify(barFooCustomResolved));
+          const component = await mockComponent(barFooCustomResolved);
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           component.componentMap = getComponentMap();
-          const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringCustomResolved));
+          const dependencyComponent = await mockComponent(utilsIsStringCustomResolved);
           dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
             // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             consumer: mockConsumer(),
@@ -275,10 +282,10 @@ describe('DependencyFileLinkGenerator', () => {
         let dependencyFileLinkGenerator;
         let linkResults;
         before(async () => {
-          const component = await Component.fromString(JSON.stringify(barFooCustomResolved));
+          const component = await mockComponent(barFooCustomResolved);
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           component.componentMap = getComponentMap();
-          const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringCustomResolved));
+          const dependencyComponent = await mockComponent(utilsIsStringCustomResolved);
           dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
             // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
             consumer: mockConsumer(false),
@@ -332,10 +339,10 @@ describe('DependencyFileLinkGenerator', () => {
       let dependencyFileLinkGenerator;
       let linkResult;
       before(async () => {
-        const component = await Component.fromString(JSON.stringify(barFooSass));
+        const component = await mockComponent(barFooSass);
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         component.componentMap = getComponentMap();
-        const dependencyComponent = await Component.fromString(JSON.stringify(utilsIsStringSass));
+        const dependencyComponent = await mockComponent(utilsIsStringSass);
         dependencyFileLinkGenerator = new DependencyFileLinkGenerator({
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           consumer: mockConsumer(),

--- a/src/links/dependency-file-link-generator.ts
+++ b/src/links/dependency-file-link-generator.ts
@@ -259,11 +259,7 @@ export default class DependencyFileLinkGenerator {
   }
 
   _getPackageName() {
-    return componentIdToPackageName(
-      this.dependencyId,
-      this.dependencyComponent.bindingPrefix,
-      this.dependencyComponent.defaultScope
-    );
+    return componentIdToPackageName(this.dependencyComponent);
   }
 
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/links/link-generator.ts
+++ b/src/links/link-generator.ts
@@ -343,7 +343,7 @@ function getInternalCustomResolvedLinks(
     const linkContent = getLinkToFileContent(destRelative);
 
     const postInstallSymlink = createNpmLinkFiles && !linkContent;
-    const packageName = componentIdToPackageName(component.id, component.bindingPrefix, component.defaultScope);
+    const packageName = componentIdToPackageName(component);
     const customResolveMapping = { [customPath.importSource]: `${packageName}/${customPath.destinationPath}` };
     const getSymlink = () => {
       if (linkContent) return undefined;

--- a/src/links/linker.ts
+++ b/src/links/linker.ts
@@ -100,7 +100,7 @@ export async function reLinkDependents(consumer: Consumer, components: Component
 
 /**
  * needed for the following cases:
- * 1) user is importing a component directly which was a dependency before. (before: IMPORTED, now: NESTED).
+ * 1) user is importing a component directly which was a dependency before. (before: NESTED, now: IMPORTED).
  * 2) user used bit-move to move a dependency to another directory.
  * as a result of the cases above, the link from the dependent to the dependency is broken.
  * find the dependents components and re-link them

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -372,10 +372,9 @@ export default class NodeModuleLinker {
     if (hasPackageJsonAsComponentFile) return; // don't generate package.json on top of the user package.json
     const dest = path.join(
       getNodeModulesPathOfComponent({
-        bindingPrefix: component.bindingPrefix,
+        ...component,
         id: component.id,
-        allowNonScope: true,
-        defaultScope: this._getDefaultScope(component)
+        allowNonScope: true
       })
     );
     const packageJson = PackageJsonFile.createFromComponent(dest, component);

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -362,7 +362,12 @@ export default class NodeModuleLinker {
     const hasPackageJsonAsComponentFile = component.files.some(file => file.relative === PACKAGE_JSON);
     if (hasPackageJsonAsComponentFile) return; // don't generate package.json on top of the user package.json
     const dest = path.join(
-      getNodeModulesPathOfComponent(component.bindingPrefix, component.id, true, this._getDefaultScope(component))
+      getNodeModulesPathOfComponent({
+        bindingPrefix: component.bindingPrefix,
+        id: component.id,
+        allowNonScope: true,
+        defaultScope: this._getDefaultScope(component)
+      })
     );
     const packageJson = PackageJsonFile.createFromComponent(dest, component);
     this.dataToPersist.addFile(packageJson.toVinylFile());

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -188,7 +188,8 @@ export default class NodeModuleLinker {
       component.bindingPrefix,
       componentId,
       true,
-      this._getDefaultScope(component)
+      this._getDefaultScope(component),
+      component.extensions
     );
     const componentMap = component.componentMap as ComponentMap;
     const filesToBind = componentMap.getAllFilesPaths();

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -111,12 +111,13 @@ export default class NodeModuleLinker {
     const componentId = component.id;
     // @todo: this should probably be `const bindingPrefix = component.bindingPrefix;`
     const bindingPrefix = component.bindingPrefix || DEFAULT_BINDINGS_PREFIX;
-    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(
+    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent({
       bindingPrefix,
-      componentId,
-      true,
-      this._getDefaultScope(component)
-    );
+      id: componentId,
+      allowNonScope: true,
+      defaultScope: this._getDefaultScope(component),
+      extensions: component.extensions
+    });
     // when a user moves the component directory, use component.writtenPath to find the correct target
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -159,12 +160,13 @@ export default class NodeModuleLinker {
    */
   async _populateImportedNonLegacyComponentsLinks(component: Component) {
     const componentId = component.id;
-    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(
-      component.bindingPrefix,
-      componentId,
-      true,
-      this._getDefaultScope(component)
-    );
+    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent({
+      bindingPrefix: component.bindingPrefix,
+      id: componentId,
+      allowNonScope: true,
+      defaultScope: this._getDefaultScope(component),
+      extensions: component.extensions
+    });
     const componentMap = component.componentMap as ComponentMap;
     const filesToBind = componentMap.getAllFilesPaths();
     filesToBind.forEach(file => {
@@ -184,13 +186,13 @@ export default class NodeModuleLinker {
    */
   _populateAuthoredComponentsLinks(component: Component): void {
     const componentId = component.id;
-    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent(
-      component.bindingPrefix,
-      componentId,
-      true,
-      this._getDefaultScope(component),
-      component.extensions
-    );
+    const linkPath: PathOsBasedRelative = getNodeModulesPathOfComponent({
+      bindingPrefix: component.bindingPrefix,
+      id: componentId,
+      allowNonScope: true,
+      defaultScope: this._getDefaultScope(component),
+      extensions: component.extensions
+    });
     const componentMap = component.componentMap as ComponentMap;
     const filesToBind = componentMap.getAllFilesPaths();
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -239,12 +241,13 @@ export default class NodeModuleLinker {
    */
   _deleteOldLinksOfIdWithoutScope(component: Component) {
     if (component.id.scope) {
-      const previousDest = getNodeModulesPathOfComponent(
-        component.bindingPrefix,
-        component.id.changeScope(null),
-        true,
-        this._getDefaultScope(component)
-      );
+      const previousDest = getNodeModulesPathOfComponent({
+        bindingPrefix: component.bindingPrefix,
+        id: component.id.changeScope(null),
+        allowNonScope: true,
+        defaultScope: this._getDefaultScope(component),
+        extensions: component.extensions
+      });
       this.dataToPersist.removePath(new RemovePath(previousDest));
     }
   }

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -478,7 +478,11 @@ async function convertToCorrectScope(
         return; // nothing to do, the remote has not changed
       }
       const idWithNewScope = id.changeScope(remoteScope);
-      const pkgNameWithOldScope = componentIdToPackageName(id, componentsObjects.component.bindingPrefix);
+      const pkgNameWithOldScope = componentIdToPackageName({
+        id,
+        bindingPrefix: componentsObjects.component.bindingPrefix,
+        extensions: version.extensions
+      });
       if (!codemod) {
         // use did not enter --rewire flag
         if (id.hasScope()) {
@@ -495,7 +499,11 @@ the current import/require module has no scope-name, which result in an invalid 
       }
       // at this stage, we know that either 1) --rewire was used. 2) it's dist and id doesn't have scope-name
       // in both cases, if the file has the old package-name, it should be replaced to the new one.
-      const pkgNameWithNewScope = componentIdToPackageName(idWithNewScope, componentsObjects.component.bindingPrefix);
+      const pkgNameWithNewScope = componentIdToPackageName({
+        id: idWithNewScope,
+        bindingPrefix: componentsObjects.component.bindingPrefix,
+        extensions: version.extensions
+      });
       // replace old scope to a new scope (e.g. '@bit/old-scope.is-string' => '@bit/new-scope.is-string')
       // or no-scope to a new scope. (e.g. '@bit/is-string' => '@bit/new-scope.is-string')
       newFileString = replacePackageName(newFileString, pkgNameWithOldScope, pkgNameWithNewScope);

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -500,8 +500,9 @@ async function convertToCorrectScope(
           return; // because only --rewire is permitted to change from scope-a to scope-b.
         }
         // dists can change no-scope to scope without --rewire flag. if this is not a dist file
-        // and the file needs to change from no-scope to scope, it needs to --rewire flag
-        if (!isDist && fileString.includes(pkgNameWithOldScope)) {
+        // and the file needs to change from no-scope to scope, it needs to --rewire flag.
+        // for non-legacy the no-scope is not possible, so no need to check for it.
+        if (!isDist && fileString.includes(pkgNameWithOldScope) && version.isLegacy) {
           throw new GeneralError(`please use "--rewire" flag to fix the import/require statements "${pkgNameWithOldScope}" in "${
             file.relativePath
           }" file of ${componentId.toString()},

--- a/src/utils/bit/component-id-to-package-name.ts
+++ b/src/utils/bit/component-id-to-package-name.ts
@@ -1,17 +1,28 @@
 import npmRegistryName from './npm-registry-name';
 import { NODE_PATH_COMPONENT_SEPARATOR } from '../../constants';
 import BitId from '../../bit-id/bit-id';
+import { ExtensionDataList } from '../../consumer/config/extension-data';
+import { replacePlaceHolderForPackageName } from './component-placeholders';
 
 /**
  * convert a component name to a valid npm package name
  * e.g. BitId { scope: util, name: is-string } => @bit/util.is-string
  */
-export default function componentIdToPackageName(
-  id: BitId,
-  bindingPrefix: string | null | undefined,
-  defaultScope?: string | null, // if an id doesn't have a scope, use defaultScope if exists
-  withPrefix = true
-): string {
+export default function componentIdToPackageName({
+  id,
+  bindingPrefix,
+  defaultScope,
+  withPrefix = true,
+  extensions
+}: {
+  id: BitId;
+  bindingPrefix: string | null | undefined;
+  defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists
+  withPrefix?: boolean;
+  extensions: ExtensionDataList;
+}): string {
+  const fromExtensions = getNameFromExtensions(id, extensions);
+  if (fromExtensions) return fromExtensions;
   const allSlashes = new RegExp('/', 'g');
   const name = id.name.replace(allSlashes, NODE_PATH_COMPONENT_SEPARATOR);
   const scope = id.scope || defaultScope;
@@ -26,4 +37,12 @@ export default function componentIdToPackageName(
     nameWithoutPrefix = nameWithoutPrefix.replace(registryPrefixWithDotWithoutAt, '');
   }
   return `${registryPrefix}/${nameWithoutPrefix}`;
+}
+
+function getNameFromExtensions(id: BitId, extensions: ExtensionDataList): null | string {
+  const pkgExt = extensions.findExtension('@teambit/pkg');
+  if (!pkgExt) return null;
+  const name = pkgExt.config?.packageJson?.name;
+  if (!name) return null;
+  return replacePlaceHolderForPackageName({ name: id.name, scope: id.scope }, name);
 }

--- a/src/utils/bit/component-id-to-package-name.ts
+++ b/src/utils/bit/component-id-to-package-name.ts
@@ -20,7 +20,7 @@ export default function componentIdToPackageName({
   bindingPrefix: string | null | undefined;
   defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists
   withPrefix?: boolean;
-  extensions?: ExtensionDataList;
+  extensions: ExtensionDataList;
   isDependency?: boolean;
 }): string {
   const fromExtensions = getNameFromExtensions(id, extensions, isDependency);

--- a/src/utils/bit/component-id-to-package-name.ts
+++ b/src/utils/bit/component-id-to-package-name.ts
@@ -19,7 +19,7 @@ export default function componentIdToPackageName({
   bindingPrefix: string | null | undefined;
   defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists
   withPrefix?: boolean;
-  extensions: ExtensionDataList;
+  extensions?: ExtensionDataList;
 }): string {
   const fromExtensions = getNameFromExtensions(id, extensions);
   if (fromExtensions) return fromExtensions;
@@ -39,7 +39,8 @@ export default function componentIdToPackageName({
   return `${registryPrefix}/${nameWithoutPrefix}`;
 }
 
-function getNameFromExtensions(id: BitId, extensions: ExtensionDataList): null | string {
+function getNameFromExtensions(id: BitId, extensions?: ExtensionDataList): null | string {
+  if (!extensions) return null;
   const pkgExt = extensions.findExtension('@teambit/pkg');
   if (!pkgExt) return null;
   const name = pkgExt.config?.packageJson?.name;

--- a/src/utils/bit/component-node-modules-path.ts
+++ b/src/utils/bit/component-node-modules-path.ts
@@ -10,19 +10,28 @@ export default function getNodeModulesPathOfComponent({
   id,
   allowNonScope = false,
   defaultScope, // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
-  extensions
+  extensions,
+  isDependency = false
 }: {
   bindingPrefix?: string;
   id: BitId;
   allowNonScope?: boolean;
   defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
   extensions?: ExtensionDataList;
+  isDependency?: boolean;
 }): PathOsBasedRelative {
   if (!id.scope && !allowNonScope) {
     throw new GeneralError(
       `Failed creating a path in node_modules for ${id.toString()}, as it does not have a scope yet`
     );
   }
-  const packageName = componentIdToPackageName({ id, bindingPrefix, defaultScope, withPrefix: undefined, extensions });
+  const packageName = componentIdToPackageName({
+    id,
+    bindingPrefix,
+    defaultScope,
+    withPrefix: undefined,
+    extensions,
+    isDependency
+  });
   return path.join('node_modules', packageName);
 }

--- a/src/utils/bit/component-node-modules-path.ts
+++ b/src/utils/bit/component-node-modules-path.ts
@@ -17,7 +17,7 @@ export default function getNodeModulesPathOfComponent({
   id: BitId;
   allowNonScope?: boolean;
   defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
-  extensions?: ExtensionDataList;
+  extensions: ExtensionDataList;
   isDependency?: boolean;
 }): PathOsBasedRelative {
   if (!id.scope && !allowNonScope) {

--- a/src/utils/bit/component-node-modules-path.ts
+++ b/src/utils/bit/component-node-modules-path.ts
@@ -3,18 +3,26 @@ import GeneralError from '../../error/general-error';
 import { PathOsBasedRelative } from '../path';
 import BitId from '../../bit-id/bit-id';
 import componentIdToPackageName from './component-id-to-package-name';
+import { ExtensionDataList } from '../../consumer/config/extension-data';
 
-export default function getNodeModulesPathOfComponent(
-  bindingPrefix: string | undefined,
-  id: BitId,
+export default function getNodeModulesPathOfComponent({
+  bindingPrefix,
+  id,
   allowNonScope = false,
-  defaultScope?: string | null // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
-): PathOsBasedRelative {
+  defaultScope, // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
+  extensions
+}: {
+  bindingPrefix?: string;
+  id: BitId;
+  allowNonScope?: boolean;
+  defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
+  extensions: ExtensionDataList;
+}): PathOsBasedRelative {
   if (!id.scope && !allowNonScope) {
     throw new GeneralError(
       `Failed creating a path in node_modules for ${id.toString()}, as it does not have a scope yet`
     );
   }
-  const packageName = componentIdToPackageName(id, bindingPrefix, defaultScope);
+  const packageName = componentIdToPackageName({ id, bindingPrefix, defaultScope, withPrefix: undefined, extensions });
   return path.join('node_modules', packageName);
 }

--- a/src/utils/bit/component-node-modules-path.ts
+++ b/src/utils/bit/component-node-modules-path.ts
@@ -16,7 +16,7 @@ export default function getNodeModulesPathOfComponent({
   id: BitId;
   allowNonScope?: boolean;
   defaultScope?: string | null; // if an id doesn't have a scope, use defaultScope if exists. applies only when allowNonScope is true
-  extensions: ExtensionDataList;
+  extensions?: ExtensionDataList;
 }): PathOsBasedRelative {
   if (!id.scope && !allowNonScope) {
     throw new GeneralError(

--- a/src/utils/bit/component-placeholders.ts
+++ b/src/utils/bit/component-placeholders.ts
@@ -16,6 +16,17 @@ export function replacePlaceHolderWithComponentValue<T>(component: ConsumerCompo
   return format(template, values);
 }
 
+export function replacePlaceHolderForPackageName(
+  { name, scope }: { name: string; scope?: string | null },
+  template: string
+): string {
+  const values = {
+    name: () => replaceSlashesWithDots(name),
+    scope: () => scope
+  };
+  return format(template, values);
+}
+
 function getMainFileWithoutExtension(mainFile: string) {
   return mainFile.replace(new RegExp(`${path.extname(mainFile)}$`), ''); // makes sure it's the last occurrence
 }

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -5,7 +5,7 @@ import { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
 import { BitId } from '../../bit-id';
 
 export interface ResolvedPackageData {
-  fullPath?: PathLinuxAbsolute;
+  fullPath: PathLinuxAbsolute;
   name: string;
   concreteVersion?: string; // Version from the package.json of the package itself
   versionUsedByDependent?: string; // Version from the dependent package.json
@@ -13,26 +13,39 @@ export interface ResolvedPackageData {
 }
 
 /**
- * Get a path to node package and return the name and version
- *
- * @param {any} packageFullPath full path to the package
- * @returns {Object} name and version of the package
+ * find data such as name/version/component-id from the package.json of a component and its dependent.
+ * the version from the dependent may have range (such as ~ or ^).
+ * the version from the dependency is an exact version.
+ * for a package that is not bit-component, we're interested in the range because that's how it was
+ * set in the first place and changing it to an exact version result in the component modified.
+ * for a bit-component, we're interested in the exact version because this is the version that gets
+ * entered into "dependency" field, which not supports range. (when a component is installed via
+ * npm, it can be saved into the package.json with range: ^, ~).
  */
-export function resolvePackageData(cwd: string, packageFullPath: PathLinuxAbsolute): ResolvedPackageData | undefined {
-  const NODE_MODULES = 'node_modules';
-  const result: ResolvedPackageData = {
+export function resolvePackageData(
+  dependentDir: string,
+  packageFullPath: PathLinuxAbsolute
+): ResolvedPackageData | undefined {
+  const packageData: ResolvedPackageData = {
     fullPath: packageFullPath,
     name: '',
     componentId: undefined
   };
-  // Start by searching in the component dir and up from there
-  // If not found search in package dir itself.
-  // We are doing this, because the package.json inside the package dir contain exact version
-  // And the component/consumer package.json might contain semver like ^ or ~
-  // We want to have this semver as dependency and not the exact version, otherwise it will be considered as modified all the time
+  enrichDataFromDependent(packageData, dependentDir);
+  enrichDataFromDependency(packageData);
+  if (!packageData.name) {
+    // data was not found in dependent nor in dependency
+    return undefined;
+  }
+  return packageData;
+}
+
+function enrichDataFromDependent(packageData: ResolvedPackageData, dependentDir: string): ResolvedPackageData {
+  const NODE_MODULES = 'node_modules';
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  const packageJsonInfo = PackageJson.findPackage(cwd);
+  const packageJsonInfo = PackageJson.findPackage(dependentDir);
   if (packageJsonInfo) {
+    const packageFullPath = packageData.fullPath;
     // The +1 is for the / after the node_modules, we didn't enter it into the NODE_MODULES const because it makes problems on windows
     const packageRelativePath = packageFullPath.substring(
       packageFullPath.lastIndexOf(NODE_MODULES) + NODE_MODULES.length + 1,
@@ -46,13 +59,16 @@ export function resolvePackageData(cwd: string, packageFullPath: PathLinuxAbsolu
       R.path(['devDependencies', packageNameNormalized], packageJsonInfo) ||
       R.path(['peerDependencies', packageNameNormalized], packageJsonInfo);
     if (packageVersion) {
-      result.name = packageNameNormalized;
-      result.versionUsedByDependent = packageVersion;
+      packageData.name = packageNameNormalized;
+      packageData.versionUsedByDependent = packageVersion;
     }
   }
+  return packageData;
+}
 
+function enrichDataFromDependency(packageData: ResolvedPackageData) {
   // Get the package relative path to the node_modules dir
-  const packageDir = resolvePackageDirFromFilePath(packageFullPath);
+  const packageDir = resolvePackageDirFromFilePath(packageData.fullPath);
 
   // don't propagate here since loading a package.json of another folder and taking the version from it will result wrong version
   // This for example happen in the following case:
@@ -65,17 +81,13 @@ export function resolvePackageData(cwd: string, packageFullPath: PathLinuxAbsolu
   // when running 'bitjs get-dependencies' command, packageInfo is sometimes empty
   // or when using custom-module-resolution it may be empty or the name/version are empty
   if (!packageInfo || !packageInfo.name || !packageInfo.version) {
-    if (!result.name) {
-      return undefined;
-    }
-    return result;
+    return;
   }
-  result.name = packageInfo.name;
-  result.concreteVersion = packageInfo.version;
+  packageData.name = packageInfo.name;
+  packageData.concreteVersion = packageInfo.version;
   if (packageInfo.componentId) {
-    result.componentId = new BitId(packageInfo.componentId);
+    packageData.componentId = new BitId(packageInfo.componentId);
   }
-  return result;
 }
 
 /**


### PR DESCRIPTION
Currently, the package name is calculated based on the id with no options to change/add anything.
This PR provides full support of having the package-name different than the component-id. 
The implementation of this feature itself was done previously, this is more about fixing all occurrences that convert bit-id to package name so it could actually work.