### PR TITLE
fix performance regression

### DIFF
--- a/e2e/performance/many-components.performance.ts
+++ b/e2e/performance/many-components.performance.ts
@@ -35,6 +35,20 @@ const maxFlattenedDependencies = 100;
  * status 3,000 with maxFlattenedDependencies of 100 => 46 sec
  * export 3,000 with maxFlattenedDependencies of 100 => 90 sec
  * import 3,000 with maxFlattenedDependencies of 100 => 475 sec
+ *
+ * v14.8.7 (with node v12.7.0)
+ * add 3,000 with maxFlattenedDependencies of 100 => 10 sec
+ * tag 3,000 with maxFlattenedDependencies of 100 => 269 sec
+ * status 3,000 with maxFlattenedDependencies of 100 => 203 sec
+ * export 3,000 with maxFlattenedDependencies of 100 => 125 sec + an error "got an error from the logger Error: write after end"
+ * import 3,000 with maxFlattenedDependencies of 100 => 949 sec
+ *
+ * v14.8.8 (with node v12.7.0)
+ * add 3,000 with maxFlattenedDependencies of 100 => 7 sec
+ * tag 3,000 with maxFlattenedDependencies of 100 => 88 sec
+ * status 3,000 with maxFlattenedDependencies of 100 => 47 sec
+ * export 3,000 with maxFlattenedDependencies of 100 => 94 sec
+ * import 3,000 with maxFlattenedDependencies of 100 => 736 sec
  */
 describe('many components', function() {
   this.timeout(0);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "bit-bin",
-  "version": "14.8.7-dev.3",
+  "version": "14.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/consumer/lib/export.ts
+++ b/src/api/consumer/lib/export.ts
@@ -155,24 +155,22 @@ async function getComponentsToExport(
     loader.start(loaderMsg);
     return filterNonScopeIfNeeded(componentsToExport);
   }
-  const idsToExportP = ids.map(async id => {
-    const parsedId = await getParsedId(consumer, id);
-    const status = await consumer.getComponentStatusById(parsedId);
+  loader.start(BEFORE_EXPORT); // show single export
+  const parsedIds = await Promise.all(ids.map(id => getParsedId(consumer, id)));
+  const statuses = await consumer.getManyComponentsStatuses(parsedIds);
+  statuses.forEach(({ id, status }) => {
     if (status.nested) {
       throw new GeneralError(
-        `unable to export "${parsedId.toString()}", the component is not fully available. please use "bit import" first`
+        `unable to export "${id.toString()}", the component is not fully available. please use "bit import" first`
       );
     }
     // don't allow to re-export an exported component unless it's being exported to another scope
-    if (remote && !status.staged && parsedId.scope === remote) {
-      throw new IdExportedAlready(parsedId.toString(), remote);
+    if (remote && !status.staged && id.scope === remote) {
+      throw new IdExportedAlready(id.toString(), remote);
     }
-    return parsedId;
   });
-  loader.start(BEFORE_EXPORT); // show single export
-  const idsToExport = await Promise.all(idsToExportP);
-  await promptForFork(idsToExport);
-  return filterNonScopeIfNeeded(BitIds.fromArray(idsToExport));
+  await promptForFork(parsedIds);
+  return filterNonScopeIfNeeded(BitIds.fromArray(parsedIds));
 }
 
 function getIdsWithFutureScope(ids: BitIds, consumer: Consumer, remote?: string | null): BitIds {
@@ -281,9 +279,8 @@ async function cleanOldComponents(consumer: Consumer, updatedIds: BitIds, idsToE
 }
 
 async function _throwForModified(consumer: Consumer, ids: BitIds) {
-  await pMapSeries(ids, async id => {
-    const status = consumer.getComponentStatusById(id);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  const statuses = await consumer.getManyComponentsStatuses(ids);
+  statuses.forEach(({ id, status }) => {
     if (status.modified) {
       throw new GeneralError(
         `unable to perform rewire on "${id.toString()}" because it is modified, please tag or discard your changes before re-trying`

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,4 +1,4 @@
-// import Bluebird from 'bluebird';
+import Bluebird from 'bluebird';
 import harmony from '@teambit/harmony';
 import HooksManager from './hooks';
 import { handleErrorAndExit, handleUnhandledRejection } from './cli/command-runner';
@@ -8,14 +8,13 @@ import { CLIExtension } from './extensions/cli';
 
 process.env.MEMFS_DONT_WARN = 'true'; // suppress fs experimental warnings from memfs
 
-// by default Bluebird enable the longStackTraces when env is `development`, or when
+// by default Bluebird enables the longStackTraces when env is `development`, or when
 // BLUEBIRD_DEBUG is set.
 // the drawback of enabling it all the time is a performance hit. (see http://bluebirdjs.com/docs/api/promise.longstacktraces.html)
-// to override the default, uncomment the following, and set to true/false
-
-// Bluebird.config({
-//   longStackTraces: true
-// });
+// some commands are slower by 20% with this enabled.
+Bluebird.config({
+  longStackTraces: Boolean(process.env.BLUEBIRD_DEBUG || process.env.BIT_LOG)
+});
 
 initApp();
 

--- a/src/cli/command-runner.ts
+++ b/src/cli/command-runner.ts
@@ -94,13 +94,9 @@ function serializeErrAndExit(err, commandName: string) {
 }
 
 export function handleErrorAndExit(err: Error, commandName: string, shouldSerialize = false) {
-  logger.error(
-    `got an error from command ${commandName}: ${err}. Error serialized: ${JSON.stringify(
-      err,
-      Object.getOwnPropertyNames(err)
-    )}`
-  );
   loader.off();
+  logger.error(`got an error from command ${commandName}: ${err}`);
+  logger.error(err.stack || '<no error stack was found>');
   const { message, error } = defaultHandleError(err);
   if (shouldSerialize) return serializeErrAndExit(error, commandName);
   return logErrAndExit(message, commandName);

--- a/src/consumer/component-ops/component-status-loader.ts
+++ b/src/consumer/component-ops/component-status-loader.ts
@@ -1,0 +1,113 @@
+import BluebirdPromise from 'bluebird';
+import { Consumer } from '..';
+import { BitId } from '../../bit-id';
+import { COMPONENT_ORIGINS, LATEST } from '../../constants';
+import { MissingBitMapComponent } from '../bit-map/exceptions';
+import { ModelComponent } from '../../scope/models';
+import MissingFilesFromComponent from '../component/exceptions/missing-files-from-component';
+import ComponentNotFoundInPath from '../component/exceptions/component-not-found-in-path';
+import ComponentOutOfSync from '../exceptions/component-out-of-sync';
+import ComponentsPendingImport from '../component-ops/exceptions/components-pending-import';
+import ShowDoctorError from '../../error/show-doctor-error';
+
+export type ComponentStatus = {
+  modified: boolean;
+  newlyCreated: boolean;
+  deleted: boolean;
+  staged: boolean;
+  notExist: boolean;
+  missingFromScope: boolean;
+  nested: boolean; // when a component is nested, it doesn't matter whether it was modified
+};
+
+export type ComponentStatusResult = { id: BitId; status: ComponentStatus };
+
+export class ComponentStatusLoader {
+  private _componentsStatusCache: Record<string, any> = {}; // cache loaded components
+  constructor(private consumer: Consumer) {}
+
+  async getManyComponentsStatuses(ids: BitId[]): Promise<ComponentStatusResult[]> {
+    const results: ComponentStatusResult[] = [];
+    await BluebirdPromise.mapSeries(ids, async id => {
+      const status = await this.getComponentStatusById(id);
+      results.push({ id, status });
+    });
+    return results;
+  }
+
+  /**
+   * Get a component status by ID. Return a ComponentStatus object.
+   * Keep in mind that a result can be a partial object of ComponentStatus, e.g. { notExist: true }.
+   * Each one of the ComponentStatus properties can be undefined, true or false.
+   * As a result, in order to check whether a component is not modified use (status.modified === false).
+   * Don't use (!status.modified) because a component may not exist and the status.modified will be undefined.
+   *
+   * The status may have 'true' for several properties. For example, a component can be staged and modified at the
+   * same time.
+   *
+   * The result is cached per ID and can be called several times with no penalties.
+   */
+  async getComponentStatusById(id: BitId): Promise<ComponentStatus> {
+    if (!this._componentsStatusCache[id.toString()]) {
+      this._componentsStatusCache[id.toString()] = await this.getStatus(id);
+    }
+    return this._componentsStatusCache[id.toString()];
+  }
+
+  private async getStatus(id: BitId) {
+    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    const status: ComponentStatus = {};
+    const componentFromModel: ModelComponent | undefined = await this.consumer.scope.getModelComponentIfExist(id);
+    let componentFromFileSystem;
+    try {
+      // change to 'latest' before loading from FS. don't change to null, otherwise, it'll cause
+      // loadOne to not find model component as it assumes there is no version
+      // also, don't leave the id as is, otherwise, it'll cause issues with import --merge, when
+      // imported version is bigger than .bitmap, it won't find it and will consider as deleted
+      componentFromFileSystem = await this.consumer.loadComponent(id.changeVersion(LATEST));
+    } catch (err) {
+      if (
+        err instanceof MissingFilesFromComponent ||
+        err instanceof ComponentNotFoundInPath ||
+        err instanceof MissingBitMapComponent
+      ) {
+        // the file/s have been deleted or the component doesn't exist in bit.map file
+        if (componentFromModel) status.deleted = true;
+        else status.notExist = true;
+        return status;
+      }
+      if (err instanceof ComponentsPendingImport) {
+        status.missingFromScope;
+        return status;
+      }
+      throw err;
+    }
+    if (componentFromFileSystem.componentMap.origin === COMPONENT_ORIGINS.NESTED) {
+      status.nested = true;
+      return status;
+    }
+    if (!componentFromModel) {
+      status.newlyCreated = true;
+      return status;
+    }
+
+    status.staged = componentFromModel.isLocallyChanged();
+    const versionFromFs = componentFromFileSystem.id.version;
+    const idStr = id.toString();
+    if (!componentFromFileSystem.id.hasVersion()) {
+      throw new ComponentOutOfSync(idStr);
+    }
+    // TODO: instead of doing that like this we should use:
+    // const versionFromModel = await componentFromModel.loadVersion(versionFromFs, this.consumer.scope.objects);
+    // it looks like it's exactly the same code but it's not working from some reason
+    const versionRef = componentFromModel.versions[versionFromFs];
+    if (!versionRef) throw new ShowDoctorError(`version ${versionFromFs} was not found in ${idStr}`);
+    const versionFromModel = await this.consumer.scope.getObject(versionRef.hash);
+    if (!versionFromModel) {
+      throw new ShowDoctorError(`failed loading version ${versionFromFs} of ${idStr} from the scope`);
+    }
+    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    status.modified = await this.consumer.isComponentModified(versionFromModel, componentFromFileSystem);
+    return status;
+  }
+}

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -13,7 +13,7 @@ import { ModelComponent } from '../../scope/models';
 import ComponentsPendingImport from '../component-ops/exceptions/components-pending-import';
 
 export default class ComponentLoader {
-  _componentsCache: Record<string, any> = {}; // cache loaded components
+  _componentsCache: { [idStr: string]: Component } = {}; // cache loaded components
   _componentsCacheForCapsule: Record<string, any> = {}; // cache loaded components for capsule, must not use the cache for the workspace
   consumer: Consumer;
   cacheResolvedDependencies: Record<string, any>;
@@ -48,7 +48,7 @@ export default class ComponentLoader {
     logger.debugAndAddBreadCrumb('ComponentLoader', 'loading consumer-components from the file-system, ids: {ids}', {
       ids: ids.toString()
     });
-    const alreadyLoadedComponents = [];
+    const alreadyLoadedComponents: Component[] = [];
     const idsToProcess: BitId[] = [];
     const invalidComponents: InvalidComponent[] = [];
     ids.forEach((id: BitId) => {
@@ -58,20 +58,19 @@ export default class ComponentLoader {
       const idWithVersion: BitId = getLatestVersionNumber(this.consumer.bitmapIds, id);
       const idStr = idWithVersion.toString();
       if (this._componentsCache[idStr]) {
-        logger.debugAndAddBreadCrumb(
-          'ComponentLoader',
-          'the component {idStr} has been already loaded, use the cached component',
-          { idStr }
-        );
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         alreadyLoadedComponents.push(this._componentsCache[idStr]);
       } else {
         idsToProcess.push(idWithVersion);
       }
     });
+    logger.debugAndAddBreadCrumb(
+      'ComponentLoader',
+      `the following ${alreadyLoadedComponents.length} components have been already loaded, get them from the cache. {idsStr}`,
+      { idsStr: alreadyLoadedComponents.map(c => c.id.toString()).join(', ') }
+    );
     if (!idsToProcess.length) return { components: alreadyLoadedComponents, invalidComponents };
 
-    const allComponents = [];
+    const allComponents: Component[] = [];
     await pMapSeries(idsToProcess, async (id: BitId) => {
       const component = await this.loadOne(id, throwOnFailure, invalidComponents);
       if (component) {
@@ -79,7 +78,6 @@ export default class ComponentLoader {
         logger.debugAndAddBreadCrumb('ComponentLoader', 'Finished loading the component "{id}"', {
           id: component.id.toString()
         });
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         allComponents.push(component);
       }
     });

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -9,7 +9,6 @@ import { InvalidComponent } from '../component/consumer-component';
 import { BitId, BitIds } from '../../bit-id';
 import BitMap from '../bit-map/bit-map';
 import Consumer from '../consumer';
-import { filterAsync } from '../../utils';
 import { COMPONENT_ORIGINS, LATEST } from '../../constants';
 import NoIdMatchWildcard from '../../api/consumer/lib/exceptions/no-id-match-wildcard';
 import { fetchRemoteVersions } from '../../scope/scope-remotes';
@@ -88,8 +87,11 @@ export default class ComponentsList {
   async listModifiedComponents(load = false): Promise<Array<BitId | Component>> {
     if (!this._modifiedComponents) {
       const fileSystemComponents = await this.getAuthoredAndImportedFromFS();
-      this._modifiedComponents = await filterAsync(fileSystemComponents, component => {
-        return this.consumer.getComponentStatusById(component.id).then(status => status.modified);
+      const componentStatuses = await this.consumer.getManyComponentsStatuses(fileSystemComponents.map(f => f.id));
+      this._modifiedComponents = fileSystemComponents.filter(component => {
+        const status = componentStatuses.find(s => s.id.isEqual(component.id));
+        if (!status) throw new Error(`listModifiedComponents unable to find status for ${component.id.toString()}`);
+        return status.status.modified;
       });
     }
     if (load) return this._modifiedComponents;

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -1107,7 +1107,7 @@ export default class Component {
     // Or created using bit create so we don't want all the path but only the relative one
     // Check that bitDir isn't the same as consumer path to make sure we are not loading global stuff into component
     // (like dependencies)
-    logger.debug(`consumer-component.loadFromFileSystem, start loading config ${id.toString()}`);
+    logger.silly(`consumer-component.loadFromFileSystem, start loading config ${id.toString()}`);
     const componentConfig = await ComponentConfig.load({
       consumer,
       componentId: id,
@@ -1115,7 +1115,7 @@ export default class Component {
       workspaceDir: consumerPath,
       workspaceConfig
     });
-    logger.debug(`consumer-component.loadFromFileSystem, finish loading config ${id.toString()}`);
+    logger.silly(`consumer-component.loadFromFileSystem, finish loading config ${id.toString()}`);
     // by default, imported components are not written with bit.json file.
     // use the component from the model to get their bit.json values
     if (componentFromModel) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -166,7 +166,7 @@ export default class DependencyResolver {
       filePaths: allFiles,
       bindingPrefix: this.component.bindingPrefix,
       resolveModulesConfig: this.consumer.config._resolveModules,
-      cacheResolvedDependencies,
+      visited: cacheResolvedDependencies,
       cacheProjectAst
     });
     // we have the files dependencies, these files should be components that are registered in bit.map. Otherwise,

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -26,13 +26,10 @@ import { ConsumerMigrationResult } from './migrations/consumer-migrator';
 import loader from '../cli/loader';
 import { BEFORE_MIGRATION } from '../cli/loader/loader-messages';
 import BitMap from './bit-map/bit-map';
-import { MissingBitMapComponent } from './bit-map/exceptions';
 import logger from '../logger/logger';
 import DirStructure from './dir-structure/dir-structure';
 import { pathNormalizeToLinux, sortObject } from '../utils';
 import { ModelComponent, Version } from '../scope/models';
-import MissingFilesFromComponent from './component/exceptions/missing-files-from-component';
-import ComponentNotFoundInPath from './component/exceptions/component-not-found-in-path';
 import * as packageJsonUtils from './component/package-json-utils';
 import { Dependencies } from './component/dependencies';
 import CompilerExtension from '../legacy-extensions/compiler-extension';
@@ -56,13 +53,11 @@ import ScopeComponentsImporter from '../scope/component-ops/scope-components-imp
 import installExtensions from '../scope/extensions/install-extensions';
 import { Remotes } from '../remotes';
 import { composeComponentPath, composeDependencyPath } from '../utils/bit/compose-component-path';
-import ComponentOutOfSync from './exceptions/component-out-of-sync';
 import getNodeModulesPathOfComponent from '../utils/bit/component-node-modules-path';
 import makeEnv from '../legacy-extensions/env-factory';
 import EnvExtension from '../legacy-extensions/env-extension';
 import ComponentsPendingImport from './component-ops/exceptions/components-pending-import';
 import { AutoTagResult } from '../scope/component-ops/auto-tag';
-import ShowDoctorError from '../error/show-doctor-error';
 import { EnvType } from '../legacy-extensions/env-extension-types';
 import { packageNameToComponentId } from '../utils/bit/package-name-to-component-id';
 import PackageJsonFile from './component/package-json-file';
@@ -70,6 +65,7 @@ import ComponentMap from './bit-map/component-map';
 import { FailedLoadForTag } from './component/exceptions/failed-load-for-tag';
 import WorkspaceConfig, { WorkspaceConfigProps } from './config/workspace-config';
 import { ILegacyWorkspaceConfig } from './config';
+import { ComponentStatusLoader, ComponentStatusResult, ComponentStatus } from './component-ops/component-status-loader';
 
 type ConsumerProps = {
   projectPath: string;
@@ -80,16 +76,6 @@ type ConsumerProps = {
   bitMap: BitMap;
   addedGitHooks?: string[] | undefined;
   existingGitHooks: string[] | undefined;
-};
-
-type ComponentStatus = {
-  modified: boolean;
-  newlyCreated: boolean;
-  deleted: boolean;
-  staged: boolean;
-  notExist: boolean;
-  missingFromScope: boolean;
-  nested: boolean; // when a component is nested, it doesn't matter whether it was modified
 };
 
 /**
@@ -109,6 +95,7 @@ export default class Consumer {
   _componentsStatusCache: Record<string, any> = {}; // cache loaded components
   packageManagerArgs: string[] = []; // args entered by the user in the command line after '--'
   componentLoader: ComponentLoader;
+  componentStatusLoader: ComponentStatusLoader;
   packageJson: any;
 
   constructor({
@@ -130,6 +117,7 @@ export default class Consumer {
     this.addedGitHooks = addedGitHooks;
     this.existingGitHooks = existingGitHooks;
     this.componentLoader = ComponentLoader.getInstance(this);
+    this.componentStatusLoader = new ComponentStatusLoader(this);
     this.packageJson = PackageJsonFile.loadSync(projectPath);
   }
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -496,79 +484,12 @@ export default class Consumer {
     }
   }
 
-  /**
-   * Get a component status by ID. Return a ComponentStatus object.
-   * Keep in mind that a result can be a partial object of ComponentStatus, e.g. { notExist: true }.
-   * Each one of the ComponentStatus properties can be undefined, true or false.
-   * As a result, in order to check whether a component is not modified use (status.modified === false).
-   * Don't use (!status.modified) because a component may not exist and the status.modified will be undefined.
-   *
-   * The status may have 'true' for several properties. For example, a component can be staged and modified at the
-   * same time.
-   *
-   * The result is cached per ID and can be called several times with no penalties.
-   */
-  async getComponentStatusById(id: BitId): Promise<ComponentStatus> {
-    const getStatus = async () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const status: ComponentStatus = {};
-      const componentFromModel: ModelComponent | undefined = await this.scope.getModelComponentIfExist(id);
-      let componentFromFileSystem;
-      try {
-        // change to 'latest' before loading from FS. don't change to null, otherwise, it'll cause
-        // loadOne to not find model component as it assumes there is no version
-        // also, don't leave the id as is, otherwise, it'll cause issues with import --merge, when
-        // imported version is bigger than .bitmap, it won't find it and will consider as deleted
-        componentFromFileSystem = await this.loadComponent(id.changeVersion(LATEST));
-      } catch (err) {
-        if (
-          err instanceof MissingFilesFromComponent ||
-          err instanceof ComponentNotFoundInPath ||
-          err instanceof MissingBitMapComponent
-        ) {
-          // the file/s have been deleted or the component doesn't exist in bit.map file
-          if (componentFromModel) status.deleted = true;
-          else status.notExist = true;
-          return status;
-        }
-        if (err instanceof ComponentsPendingImport) {
-          status.missingFromScope;
-          return status;
-        }
-        throw err;
-      }
-      if (componentFromFileSystem.componentMap.origin === COMPONENT_ORIGINS.NESTED) {
-        status.nested = true;
-        return status;
-      }
-      if (!componentFromModel) {
-        status.newlyCreated = true;
-        return status;
-      }
+  async getManyComponentsStatuses(ids: BitId[]): Promise<ComponentStatusResult[]> {
+    return this.componentStatusLoader.getManyComponentsStatuses(ids);
+  }
 
-      status.staged = componentFromModel.isLocallyChanged();
-      const versionFromFs = componentFromFileSystem.id.version;
-      const idStr = id.toString();
-      if (!componentFromFileSystem.id.hasVersion()) {
-        throw new ComponentOutOfSync(idStr);
-      }
-      // TODO: instead of doing that like this we should use:
-      // const versionFromModel = await componentFromModel.loadVersion(versionFromFs, this.scope.objects);
-      // it looks like it's exactly the same code but it's not working from some reason
-      const versionRef = componentFromModel.versions[versionFromFs];
-      if (!versionRef) throw new ShowDoctorError(`version ${versionFromFs} was not found in ${idStr}`);
-      const versionFromModel = await this.scope.getObject(versionRef.hash);
-      if (!versionFromModel) {
-        throw new ShowDoctorError(`failed loading version ${versionFromFs} of ${idStr} from the scope`);
-      }
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      status.modified = await this.isComponentModified(versionFromModel, componentFromFileSystem);
-      return status;
-    };
-    if (!this._componentsStatusCache[id.toString()]) {
-      this._componentsStatusCache[id.toString()] = await getStatus();
-    }
-    return this._componentsStatusCache[id.toString()];
+  async getComponentStatusById(id: BitId): Promise<ComponentStatus> {
+    return this.componentStatusLoader.getComponentStatusById(id);
   }
 
   async tag(

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -132,7 +132,7 @@ class BitLogger {
       msg = `[*] the command ${commandName} has been terminated with an error code ${code}`;
     }
     this.logger[level](msg);
-    await waitForLogger();
+    await waitForLogger(code);
     process.exit(code);
   }
 
@@ -219,13 +219,13 @@ export const printWarning = (msg: string) => {
  * @credit dpraul from https://github.com/winstonjs/winston/issues/1250
  * it solves an issue when exiting the code explicitly and the log file is not written
  */
-async function waitForLogger() {
+async function waitForLogger(code: number) {
   // don't change it to `logger.on('finish'`, otherwise, it won't finish writing when exporting
   // lots of components (~300)
-  const loggerDone = new Promise(resolve => logger.logger.on('close', resolve));
+  const loggerDone = new Promise(resolve => logger.logger.on(code ? 'finish' : 'close', resolve));
   // unclear when this is needed. in some occasions (exporting 3,000 components via the e2e-tests)
   // this causes an error of "write after end"
-  // logger.logger.end();
+  if (code) logger.logger.end();
   return loggerDone;
 }
 

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -220,8 +220,12 @@ export const printWarning = (msg: string) => {
  * it solves an issue when exiting the code explicitly and the log file is not written
  */
 async function waitForLogger() {
-  const loggerDone = new Promise(resolve => logger.logger.on('finish', resolve));
-  logger.logger.end();
+  // don't change it to `logger.on('finish'`, otherwise, it won't finish writing when exporting
+  // lots of components (~300)
+  const loggerDone = new Promise(resolve => logger.logger.on('close', resolve));
+  // unclear when this is needed. in some occasions (exporting 3,000 components via the e2e-tests)
+  // this causes an error of "write after end"
+  // logger.logger.end();
   return loggerDone;
 }
 


### PR DESCRIPTION
* resolve performance regression by fixing the dependency resolution cache.
* show the entire stack trace formatted on error when setting the "BIT_LOG" environment variable.
* fix the logger to wait until all logs are written on export.
* avoid loading multiple components in parallel to keep the memory usage low.
* disable the `longStackTraces` by default, unless either BLUEBIRD_DEBUG or BIT_LOG is set.
* fix errors to be written to the log formatted with line breaks