### PR TITLE
improve bit link --rewire to preserve internal paths

### DIFF
--- a/src/consumer/component-ops/codemod-components.ts
+++ b/src/consumer/component-ops/codemod-components.ts
@@ -1,3 +1,4 @@
+import path from 'path';
 import Component from '../component/consumer-component';
 import { SourceFile } from '../component/sources';
 import { RelativeComponentsAuthoredEntry } from '../component/dependencies/dependency-resolver/dependencies-resolver';
@@ -5,7 +6,7 @@ import componentIdToPackageName from '../../utils/bit/component-id-to-package-na
 import replacePackageName from '../../utils/string/replace-package-name';
 import DataToPersist from '../component/sources/data-to-persist';
 import { BitId, BitIds } from '../../bit-id';
-import { pathNormalizeToLinux } from '../../utils';
+import { pathNormalizeToLinux, pathJoinLinux, pathRelativeLinux } from '../../utils';
 import { Consumer } from '..';
 import IncorrectRootDir from '../component/exceptions/incorrect-root-dir';
 import { ImportSpecifier } from '../component/dependencies/files-dependency-builder/types/dependency-tree-type';
@@ -24,7 +25,7 @@ export async function changeCodeFromRelativeToModulePaths(
   const componentsWithRelativeIssues = components.filter(c => c.issues && c.issues.relativeComponentsAuthored);
   const dataToPersist = new DataToPersist();
   const codemodResults = componentsWithRelativeIssues.map(component => {
-    const { files, warnings } = codemodComponent(component);
+    const { files, warnings } = codemodComponent(consumer, component);
     dataToPersist.addManyFiles(files);
     return { id: component.id, changedFiles: files.map(f => f.relative), warnings };
   });
@@ -42,7 +43,7 @@ async function loadComponents(consumer: Consumer, bitIds: BitId[]): Promise<Comp
   return components;
 }
 
-function codemodComponent(component: Component): { files: SourceFile[]; warnings?: string[] } {
+function codemodComponent(consumer: Consumer, component: Component): { files: SourceFile[]; warnings?: string[] } {
   const issues = component.issues;
   const files: SourceFile[] = [];
   if (!issues || !issues.relativeComponentsAuthored) return { files };
@@ -55,7 +56,7 @@ function codemodComponent(component: Component): { files: SourceFile[]; warnings
     let newFileString = fileBefore;
     relativeInstances.forEach((relativeEntry: RelativeComponentsAuthoredEntry) => {
       const id = relativeEntry.componentId;
-      if (isLinkFileHasDifferentImportType(relativeEntry.importSpecifiers)) {
+      if (isLinkFileHasDifferentImportType(relativeEntry.relativePath.importSpecifiers)) {
         warnings.push(
           `"${file.relative}" requires "${id.toString()}" through a link-file ("${
             relativeEntry.importSource
@@ -67,7 +68,8 @@ function codemodComponent(component: Component): { files: SourceFile[]; warnings
       const cssFamily = ['.css', '.scss', '.less', '.sass'];
       const isCss = cssFamily.includes(file.extname);
       const packageNameSupportCss = isCss ? `~${packageName}` : packageName;
-      newFileString = replacePackageName(newFileString, relativeEntry.importSource, packageNameSupportCss);
+      const stringToReplace = getNameWithoutInternalPath(consumer, relativeEntry);
+      newFileString = replacePackageName(newFileString, stringToReplace, packageNameSupportCss);
     });
     if (fileBefore !== newFileString) {
       // @ts-ignore
@@ -76,6 +78,42 @@ function codemodComponent(component: Component): { files: SourceFile[]; warnings
     }
   });
   return { files, warnings };
+}
+
+/**
+ * e.g.
+ * importSource: '../workspace/workspace.ui'
+ * sourceRelativePath: 'extensions/workspace/workspace.ui.tsx'
+ * rootDir in .bitmap: 'extensions/workspace'.
+ *
+ * expected to return "../workspace", as this is the path to the package root without the internal path.
+ *
+ * eventually, only this string is replaced by the new package-name and the internal-path part
+ * remains intact. ('../workspace/workspace.ui' => '@bit/workspace/workspace.ui').
+ */
+function getNameWithoutInternalPath(consumer: Consumer, relativeEntry: RelativeComponentsAuthoredEntry): string {
+  const importSource = relativeEntry.importSource;
+  const componentMap = consumer.bitMap.getComponentIfExist(relativeEntry.componentId);
+  if (!componentMap) return importSource;
+  const rootDir = componentMap.trackDir || componentMap.rootDir;
+  if (!rootDir) return importSource;
+  const mainFile = componentMap.trackDir ? componentMap.mainFile : pathJoinLinux(rootDir, componentMap.mainFile);
+  const filePathRelativeToWorkspace = relativeEntry.relativePath.sourceRelativePath;
+  if (filePathRelativeToWorkspace === mainFile) {
+    return importSource;
+  }
+  // the importSource is not the main-file but an internal file, remove the internal part.
+  const internalPath = pathRelativeLinux(rootDir, filePathRelativeToWorkspace);
+  const removeLastOccurrence = (str, toRemove) => str.replace(new RegExp(`/${toRemove}$`), '');
+  if (importSource.endsWith(internalPath)) {
+    return removeLastOccurrence(importSource, internalPath);
+  }
+  const internalPathNoExt = internalPath.replace(path.extname(internalPath), '');
+  if (importSource.endsWith(internalPathNoExt)) {
+    return removeLastOccurrence(importSource, internalPathNoExt);
+  }
+  // unable to find anything useful. just return the importSource.
+  return importSource;
 }
 
 /**

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -53,7 +53,7 @@ export interface UntrackedFileDependencyEntry {
 export type RelativeComponentsAuthoredEntry = {
   importSource: string;
   componentId: BitId;
-  importSpecifiers: ImportSpecifier[] | undefined;
+  relativePath: RelativePath;
 };
 
 type UntrackedDependenciesIssues = Record<string, UntrackedFileDependencyEntry>;
@@ -617,12 +617,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       this._pushToRelativeComponentsIssues(originFile, componentId);
       return false;
     }
-    this._pushToRelativeComponentsAuthoredIssues(
-      originFile,
-      componentId,
-      depFileObject.importSource,
-      depsPaths.importSpecifiers
-    );
+    this._pushToRelativeComponentsAuthoredIssues(originFile, componentId, depFileObject.importSource, depsPaths);
 
     const allDependencies: Dependency[] = [
       ...this.allDependencies.dependencies,
@@ -1149,16 +1144,11 @@ either, use the ignore file syntax or change the require statement to have a mod
       this.issues.relativeComponents[originFile] = [componentId];
     }
   }
-  _pushToRelativeComponentsAuthoredIssues(
-    originFile,
-    componentId,
-    importSource: string,
-    importSpecifiers: ImportSpecifier[] | undefined
-  ) {
+  _pushToRelativeComponentsAuthoredIssues(originFile, componentId, importSource: string, relativePath: RelativePath) {
     if (!this.issues.relativeComponentsAuthored[originFile]) {
       this.issues.relativeComponentsAuthored[originFile] = [];
     }
-    this.issues.relativeComponentsAuthored[originFile].push({ importSource, componentId, importSpecifiers });
+    this.issues.relativeComponentsAuthored[originFile].push({ importSource, componentId, relativePath });
   }
   _pushToMissingBitsIssues(originFile: PathLinuxRelative, componentId: BitId) {
     this.issues.missingBits[originFile]


### PR DESCRIPTION
Currently, when relative-path points to an internal file of another component, the `bit link --rewire` replace it with the link to the package without the internal file part. 
This PR finds the internal file and preserves it.