### PR TITLE
[WIP] wrap react router links with local links

### DIFF
--- a/package.json
+++ b/package.json
@@ -318,6 +318,7 @@
     "@types/fs-extra": "^8.1.0",
     "@types/get-port": "^4.2.0",
     "@types/graphlib": "^2.1.5",
+    "@types/history": "^4.7.6",
     "@types/lodash.head": "^4.0.6",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.27",

--- a/src/extensions/changelog/changelog.section.tsx
+++ b/src/extensions/changelog/changelog.section.tsx
@@ -10,7 +10,7 @@ export class ChangelogSection implements Section {
     children: <ChangeLogPage className={styles.changeLog} versions={versionsArray} />,
   };
   navigationLink = {
-    to: '~changelog',
+    href: '~changelog',
     children: 'Changelog',
   };
 }

--- a/src/extensions/component/component.ui.tsx
+++ b/src/extensions/component/component.ui.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import { RouteProps, NavLinkProps } from 'react-router-dom';
+import { RouteProps } from 'react-router-dom';
 import { Slot } from '@teambit/harmony';
+
+import { NavLinkProps } from '../react-router/nav-link';
 import { Component } from './ui/component';
 import { RouteSlot, NavigationSlot } from '../react-router/slot-router';
 

--- a/src/extensions/component/section/section.tsx
+++ b/src/extensions/component/section/section.tsx
@@ -1,4 +1,5 @@
-import { RouteProps, NavLinkProps } from 'react-router-dom';
+import { RouteProps } from 'react-router-dom';
+import { NavLinkProps } from '../../react-router/nav-link';
 
 export interface Section {
   route: RouteProps;

--- a/src/extensions/component/ui/top-bar-nav/top-bar-nav.tsx
+++ b/src/extensions/component/ui/top-bar-nav/top-bar-nav.tsx
@@ -1,21 +1,22 @@
 import React from 'react';
 import classnames from 'classnames';
-import { NavLink, NavLinkProps, useRouteMatch } from 'react-router-dom';
+import { useRouteMatch } from 'react-router-dom';
 
 import styles from './top-bar-nav.module.scss';
-import { extendPath } from '../../../react-router/extend-path/extend-path';
+import { extendPath } from '../../../react-router/extend-path';
+import { NavLink, NavLinkProps } from '../../../react-router/nav-link';
 
 export function TopBarNav(props: NavLinkProps) {
   const { url } = useRouteMatch();
-  const { to } = props;
-  const target = typeof to === 'string' ? extendPath(url, to) : to;
+  const { href } = props;
+  const target = extendPath(url, href);
 
   return (
     <NavLink
       {...props}
       className={classnames(props.className, styles.topBarLink)}
       activeClassName={classnames(props.className, styles.active)}
-      to={target}
+      href={target}
     />
   );
 }

--- a/src/extensions/component/ui/top-bar-widget-link/top-bar-widget-link.tsx
+++ b/src/extensions/component/ui/top-bar-widget-link/top-bar-widget-link.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import classnames from 'classnames';
-import { NavLink, NavLinkProps, useRouteMatch } from 'react-router-dom';
 
+import { useRouteMatch } from 'react-router-dom';
+import { NavLink, NavLinkProps } from '../../../react-router/nav-link';
+import { extendPath } from '../../../react-router/extend-path';
 import styles from './top-bar-widget-link.module.scss';
 
 export function TopBarWidgetLink(props: NavLinkProps) {
@@ -12,7 +14,7 @@ export function TopBarWidgetLink(props: NavLinkProps) {
       {...props}
       className={classnames(props.className, styles.widgetLink)}
       activeClassName={classnames(props.className, styles.active)}
-      to={`${url}/${props.to}`}
+      href={extendPath(url, props.href)}
     >
       {props.children}
     </NavLink>

--- a/src/extensions/component/ui/top-bar/top-bar.tsx
+++ b/src/extensions/component/ui/top-bar/top-bar.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 import classnames from 'classnames';
-// import { NavLink, NavLinkProps, useRouteMatch } from 'react-router-dom';
-// import { Button } from '@bit/bit.evangelist.elements.button';
 import { Icon } from '@bit/bit.evangelist.elements.icon';
-// import { themedText } from '@bit/bit.base-ui.text.themed-text';
 
 // placeholder until we publish the component from react new project
 import { VersionTag } from '../../../stage-components/workspace-components/version-tag';
@@ -41,7 +38,7 @@ export function TopBar({ navigationSlot, widgetSlot, className, version }: TopBa
           <Icon className={classnames(styles.icon)} of="dependency" />
         </span> */}
         {widgetLinks.map((widget, index) => (
-          <TopBarWidgetLink key={index} to={widget.to} className={styles.widget}>
+          <TopBarWidgetLink key={index} href={widget.href} className={styles.widget}>
             <Icon className={classnames(styles.icon)} of="changelog" />
           </TopBarWidgetLink>
         ))}

--- a/src/extensions/compositions/composition.section.tsx
+++ b/src/extensions/compositions/composition.section.tsx
@@ -12,7 +12,7 @@ export class CompositionsSection implements Section {
   ) {}
 
   navigationLink = {
-    to: '~compositions',
+    href: '~compositions',
     children: 'Compositions',
   };
 

--- a/src/extensions/docs/overview.section.tsx
+++ b/src/extensions/docs/overview.section.tsx
@@ -12,7 +12,7 @@ export class OverviewSection implements Section {
   ) {}
 
   navigationLink = {
-    to: '',
+    href: '',
     exact: true,
     children: 'Overview',
   };

--- a/src/extensions/react-router/extend-path/index.ts
+++ b/src/extensions/react-router/extend-path/index.ts
@@ -1,0 +1,1 @@
+export * from './extend-path';

--- a/src/extensions/react-router/link/index.ts
+++ b/src/extensions/react-router/link/index.ts
@@ -1,0 +1,1 @@
+export * from './link';

--- a/src/extensions/react-router/link/link.tsx
+++ b/src/extensions/react-router/link/link.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { Link as BaseLink } from 'react-router-dom';
+
+const EXTERNAL_PROPS = { rel: 'noopener', target: '_blank' };
+
+type LinkProps = {
+  /** When true, clicking the link will replace the current entry in the history stack instead of adding a new one */
+  replace?: boolean;
+  /** Open link in a new tab */
+  external?: boolean;
+} & React.AnchorHTMLAttributes<HTMLAnchorElement>;
+
+export function Link({ href = '', external, ...rest }: LinkProps) {
+  if (external) {
+    const externalProps = external ? EXTERNAL_PROPS : {};
+    return <a {...rest} {...externalProps} />;
+  }
+
+  return <BaseLink {...rest} to={href} />;
+}

--- a/src/extensions/react-router/nav-link/index.ts
+++ b/src/extensions/react-router/nav-link/index.ts
@@ -1,0 +1,1 @@
+export * from './nav-link';

--- a/src/extensions/react-router/nav-link/nav-link.tsx
+++ b/src/extensions/react-router/nav-link/nav-link.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { NavLink as BaseNavLink, LinkProps as BaseLinkProps, NavLinkProps as BaseNavLinkProps } from 'react-router-dom';
+import { LocationState } from 'history';
+
+/* props of NavLink except props of Link - activeClassName, exact, strict, etc */
+type MatchProps<S = LocationState> = Pick<
+  BaseNavLinkProps<S>,
+  Exclude<keyof BaseNavLinkProps<S>, keyof BaseLinkProps<S>>
+>;
+
+export type NavLinkProps<S = LocationState> = {
+  href: string;
+  /** When true, clicking the link will replace the current entry in the history stack instead of adding a new one */
+  replace?: boolean;
+} & React.AnchorHTMLAttributes<HTMLAnchorElement> &
+  MatchProps<S>;
+
+export function NavLink({ href = '', ...rest }: NavLinkProps) {
+  return <BaseNavLink {...rest} to={href} />;
+}

--- a/src/extensions/react-router/slot-router.tsx
+++ b/src/extensions/react-router/slot-router.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { Switch, Route, useRouteMatch, RouteProps, NavLinkProps } from 'react-router-dom';
+import { Switch, Route, useRouteMatch, RouteProps } from 'react-router-dom';
 
-import { extendPath } from './extend-path/extend-path';
+import { extendPath } from './extend-path';
 import { SlotRegistry } from '../../api';
+import { NavLinkProps } from './nav-link';
 
 export type RouteSlot = SlotRegistry<RouteProps>;
 export type NavigationSlot = SlotRegistry<NavLinkProps>;

--- a/src/extensions/stage-components/side-bar/component-tree/component-view/component-view.tsx
+++ b/src/extensions/stage-components/side-bar/component-tree/component-view/component-view.tsx
@@ -1,6 +1,7 @@
 import React, { useContext, useCallback } from 'react';
 import classNames from 'classnames';
-import { NavLink } from 'react-router-dom';
+
+import { NavLink } from '../../../../react-router/nav-link';
 import { TreeNodeProps } from '../recursive-tree';
 import { ComponentTreeContext } from '../component-tree-context';
 import { indentClass } from '../indent';
@@ -22,7 +23,7 @@ export function ComponentView(props: TreeNodeProps) {
 
   return (
     <NavLink
-      to={`/${node.id}`}
+      href={`/${node.id}`}
       className={classNames(indentClass, clickable, hoverable, styles.component)}
       activeClassName={styles.active}
       onClick={handleClick}


### PR DESCRIPTION
## Proposed Changes

- Wrap react router's Link and NavLink
- Specifically, use `href` instead of `to`, to align with browser standard `<a/>` tag and reduce coupling with react-router-dom
- Add `external` flag from bit.dev
