### PR TITLE
Harmony/extensions status diff

### DIFF
--- a/e2e/harmony/component-config.e2e.ts
+++ b/e2e/harmony/component-config.e2e.ts
@@ -119,7 +119,7 @@ describe('component config', function () {
         componentJson = helper.componentJson.read('bar');
       });
       it('should have extensions from models in component.json', () => {
-        expect(componentJson.extensions).to.deep.equal({ 'dummy-extension@0.0.1': config });
+        expect(componentJson.extensions).to.deep.equal({ 'my-scope/dummy-extension@0.0.1': config });
       });
     });
   });

--- a/e2e/harmony/extensions-config-diff.e2e.ts
+++ b/e2e/harmony/extensions-config-diff.e2e.ts
@@ -1,8 +1,6 @@
 import chai, { expect } from 'chai';
-import GeneralHelper from '../../src/e2e-helper/e2e-general-helper';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
-import { ComponentConfigFileAlreadyExistsError } from '../../src/extensions/workspace';
 
 chai.use(require('chai-fs'));
 

--- a/e2e/harmony/extensions-config-diff.e2e.ts
+++ b/e2e/harmony/extensions-config-diff.e2e.ts
@@ -1,0 +1,116 @@
+import chai, { expect } from 'chai';
+import GeneralHelper from '../../src/e2e-helper/e2e-general-helper';
+import Helper from '../../src/e2e-helper/e2e-helper';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { ComponentConfigFileAlreadyExistsError } from '../../src/extensions/workspace';
+
+chai.use(require('chai-fs'));
+
+const assertArrays = require('chai-arrays');
+
+chai.use(assertArrays);
+
+describe('extensions config diff', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+    helper.scopeHelper.reInitLocalScope();
+    helper.fixtures.populateExtensions(4);
+    helper.fixtures.createComponentBarFoo();
+    helper.fixtures.addComponentBarFooAsDir();
+    helper.extensions.addExtensionToVariant('bar/foo', 'my-scope/ext1', { key: 'val-variant' });
+    helper.extensions.addExtensionToVariant('bar/foo', 'my-scope/ext2', { key: 'val-variant' });
+    helper.extensions.addExtensionToVariant('bar/foo', 'my-scope/ext3', { key: 'val-variant' });
+    helper.command.tagAllComponents();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('component status and diff', () => {
+    let output;
+    describe('add new extension', () => {
+      before(() => {
+        reEjectAndCheckStatusBefore(helper);
+        helper.componentJson.setExtension('my-scope/ext4', { key: 'val-component-json' });
+      });
+      it('should make the component modified', () => {
+        output = helper.command.statusComponentIsModified('bar/foo@0.0.1');
+        expect(output).to.be.true;
+      });
+      it('should show it in bit diff', () => {
+        output = helper.command.diff();
+        expect(output).to.have.string('--- Extensions (undefined original)');
+        expect(output).to.have.string('+++ Extensions (undefined modified)');
+        expect(output).to.have.string('- [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1 ]');
+        expect(output).to.have.string('+ [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1, ext4@0.0.1 ]');
+        expect(output).to.have.string('--- Ext4@0.0.1 configuration (0.0.1 original)');
+        expect(output).to.have.string('+++ Ext4@0.0.1 configuration (0.0.1 modified)');
+        expect(output).to.have.string('+ "key": "val-component-json"');
+      });
+    });
+    describe('remove extension', () => {
+      before(() => {
+        reEjectAndCheckStatusBefore(helper);
+        helper.componentJson.removeExtension('my-scope/ext3@0.0.1');
+      });
+      it('should make the component modified', () => {
+        output = helper.command.statusComponentIsModified('bar/foo@0.0.1');
+        expect(output).to.be.true;
+      });
+      it('should show it in bit diff', () => {
+        output = helper.command.diff();
+        expect(output).to.have.string('--- Extensions (undefined original)');
+        expect(output).to.have.string('+++ Extensions (undefined modified)');
+        expect(output).to.have.string('- [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1 ]');
+        expect(output).to.have.string('+ [ ext1@0.0.1, ext2@0.0.1 ]');
+        expect(output).to.have.string('--- Ext3@0.0.1 configuration (0.0.1 original)');
+        expect(output).to.have.string('+++ Ext3@0.0.1 configuration (0.0.1 modified)');
+        expect(output).to.have.string('- "key": "val-variant"');
+      });
+    });
+    describe('change extension config', () => {
+      before(() => {
+        reEjectAndCheckStatusBefore(helper);
+        helper.componentJson.setExtension('my-scope/ext2@0.0.1', { newKey: 'newVal' });
+      });
+      it('should make the component modified', () => {
+        output = helper.command.statusComponentIsModified('bar/foo@0.0.1');
+        expect(output).to.be.true;
+      });
+      it('should show it in bit diff', () => {
+        output = helper.command.diff();
+        expect(output).to.have.string('--- Ext2@0.0.1 configuration (0.0.1 original)');
+        expect(output).to.have.string('+++ Ext2@0.0.1 configuration (0.0.1 modified)');
+        expect(output).to.have.string('- "key": "val-variant"');
+        expect(output).to.have.string('+ "newKey": "newVal"');
+      });
+    });
+    // Skipped for now, because of a bug will be unskipped after bug fix
+    // TODO: make sure it works
+    describe.skip('change extension version', () => {
+      before(() => {
+        reEjectAndCheckStatusBefore(helper);
+        helper.command.tagComponent('ext1', 'sss', '-f');
+        helper.componentJson.removeExtension('my-scope/ext1@0.0.21');
+        helper.componentJson.setExtension('my-scope/ext1@0.0.2', { key: 'val' });
+      });
+      it('should make the component modified', () => {
+        output = helper.command.statusComponentIsModified('bar/foo@0.0.1');
+        expect(output).to.be.true;
+      });
+      it('should show it in bit diff', () => {
+        output = helper.command.diff();
+        // TODO: add proper string here
+        expect(output).to.have.string('aaaaaa');
+      });
+    });
+  });
+});
+
+function reEjectAndCheckStatusBefore(helper) {
+  helper.command.ejectConf('bar/foo', { override: '' });
+  const output = helper.command.statusComponentIsModified('bar/foo');
+  expect(output).to.be.false;
+}

--- a/e2e/harmony/extensions-config-diff.e2e.ts
+++ b/e2e/harmony/extensions-config-diff.e2e.ts
@@ -39,8 +39,8 @@ describe('extensions config diff', function () {
       });
       it('should show it in bit diff', () => {
         output = helper.command.diff();
-        expect(output).to.have.string('--- Extensions (undefined original)');
-        expect(output).to.have.string('+++ Extensions (undefined modified)');
+        expect(output).to.have.string('--- Extensions (0.0.1 original)');
+        expect(output).to.have.string('+++ Extensions (0.0.1 modified)');
         expect(output).to.have.string('- [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1 ]');
         expect(output).to.have.string('+ [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1, ext4@0.0.1 ]');
         expect(output).to.have.string('--- Ext4@0.0.1 configuration (0.0.1 original)');
@@ -59,8 +59,8 @@ describe('extensions config diff', function () {
       });
       it('should show it in bit diff', () => {
         output = helper.command.diff();
-        expect(output).to.have.string('--- Extensions (undefined original)');
-        expect(output).to.have.string('+++ Extensions (undefined modified)');
+        expect(output).to.have.string('--- Extensions (0.0.1 original)');
+        expect(output).to.have.string('+++ Extensions (0.0.1 modified)');
         expect(output).to.have.string('- [ ext1@0.0.1, ext2@0.0.1, ext3@0.0.1 ]');
         expect(output).to.have.string('+ [ ext1@0.0.1, ext2@0.0.1 ]');
         expect(output).to.have.string('--- Ext3@0.0.1 configuration (0.0.1 original)');

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -1,5 +1,5 @@
 import R from 'ramda';
-import * as RA from 'ramda-adjunct';
+import { compact } from 'ramda-adjunct';
 import chalk from 'chalk';
 import diff from 'object-diff';
 import normalize from 'normalize-path';
@@ -7,8 +7,11 @@ import arrayDifference from 'array-difference';
 import Component from '../component/consumer-component';
 import { FieldsDiff } from './components-diff';
 import { Consumer } from '..';
-import EnvExtension from '../../legacy-extensions/env-extension';
 
+type ConfigDiff = {
+  fieldName: string;
+  diffOutput: string;
+};
 export function componentToPrintableForDiff(component: Component): Record<string, any> {
   const obj = {};
   const parsePackages = (packages) => {
@@ -16,15 +19,7 @@ export function componentToPrintableForDiff(component: Component): Record<string
       ? Object.keys(packages).map((key) => `${key}@${packages[key]}`)
       : null;
   };
-  const parseEnvFiles = (envExtension: EnvExtension | null | undefined): string[] | null | undefined => {
-    // $FlowFixMe sadly, Flow doesn't know what isNilOrEmpty does
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    if (RA.isNilOrEmpty(envExtension) || RA.isNilOrEmpty(envExtension.files)) return null;
-    // $FlowFixMe sadly, Flow doesn't know what isNilOrEmpty does
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return envExtension.files.map((file) => `${file.name} => ${file.relative}`).sort();
-  };
+
   const {
     lang,
     bindingPrefix,
@@ -71,15 +66,11 @@ export function componentToPrintableForDiff(component: Component): Record<string
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.compiler = compiler ? compiler.name : null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  obj.compilerFiles = parseEnvFiles(compiler);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.language = lang || null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.bindingPrefix = bindingPrefix || null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.tester = tester ? tester.name : null;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  obj.testerFiles = parseEnvFiles(tester);
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.mainFile = mainFile ? normalize(mainFile) : null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -161,11 +152,7 @@ export function diffBetweenComponentsObjects(
   if (!componentLeft.version || !componentRight.version) {
     throw new Error('diffBetweenComponentsObjects component does not have a version');
   }
-  const areVersionsTheSame = componentLeft.version === componentRight.version;
-  const labelLeft = areVersionsTheSame ? `${componentLeft.version} original` : componentLeft.version;
-  const labelRight = areVersionsTheSame ? `${componentRight.version} modified` : componentRight.version;
-  const titleLeft = (field: string): string => `--- ${prettifyFieldName(field)} (${labelLeft})\n`;
-  const titleRight = (field: string): string => `+++ ${prettifyFieldName(field)} (${labelRight})\n`;
+
   const printFieldValue = (fieldValue: string | Array<string>): string => {
     if (typeof fieldValue === 'string') return fieldValue;
     if (Array.isArray(fieldValue)) return `[ ${fieldValue.join(', ')} ]`;
@@ -217,30 +204,89 @@ export function diffBetweenComponentsObjects(
     }, []);
   };
 
-  const envs = ['compiler', 'tester'];
-  const fieldsEnvsConfigOutput = envs
-    .map((env: string) => {
-      const leftConfig = componentLeft[env] && componentLeft[env].dynamicConfig ? componentLeft[env].dynamicConfig : {};
-      const rightConfig = // $FlowFixMe
-        componentRight[env] && componentRight[env].dynamicConfig ? componentRight[env].dynamicConfig : {};
-      // $FlowFixMe we remove the null later
-      if (JSON.stringify(leftConfig) === JSON.stringify(rightConfig)) return null;
-      const fieldName = `${env} configuration`;
-      const title = titleLeft(fieldName) + chalk.bold(titleRight(fieldName));
-      const getValue = (fieldValue: Record<string, any>, left: boolean) => {
-        if (R.isEmpty(fieldValue)) return '';
-        const sign = left ? '-' : '+';
-        const jsonOutput = JSON.stringify(fieldValue, null, `${sign} `);
-        return `${jsonOutput}\n`;
-      };
-      const value = chalk.red(getValue(leftConfig, true)) + chalk.green(getValue(rightConfig, false));
+  const fieldsEnvsConfigOutput = getEnvsConfigOutput(componentLeft, componentRight);
+  const extensionsConfigOutput = getExtensionsConfigOutput(componentLeft, componentRight);
 
-      const diffOutput = title + value;
-      return { fieldName, diffOutput };
-    })
-    .filter((x) => x);
-
-  const allDiffs = [...fieldsDiffOutput, ...fieldsEnvsConfigOutput, ...dependenciesOutput()];
+  const allDiffs = [...fieldsDiffOutput, ...fieldsEnvsConfigOutput, ...extensionsConfigOutput, ...dependenciesOutput()];
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return R.isEmpty(allDiffs) ? undefined : allDiffs;
+}
+
+function getEnvsConfigOutput(componentLeft: Component, componentRight: Component): Array<ConfigDiff> {
+  const envs = ['compiler', 'tester'];
+  const fieldsEnvsConfigOutput = envs.map((env: string) => {
+    const leftConfig = componentLeft[env] && componentLeft[env].dynamicConfig ? componentLeft[env].dynamicConfig : {};
+    const rightConfig =
+      componentRight[env] && componentRight[env].dynamicConfig ? componentRight[env].dynamicConfig : {};
+    if (JSON.stringify(leftConfig) === JSON.stringify(rightConfig)) return undefined;
+    const fieldName = `${env} configuration`;
+    return configsOutput(fieldName, leftConfig, rightConfig, componentLeft.version, componentRight.version);
+  });
+  return compact(fieldsEnvsConfigOutput);
+}
+
+function getExtensionsConfigOutput(componentLeft: Component, componentRight: Component): Array<ConfigDiff> {
+  const leftExtensionsConfigs = componentLeft.extensions.sortById().toConfigObject();
+  const rightExtensionsConfigs = componentRight.extensions.sortById().toConfigObject();
+  const leftExtensionsIds = Object.keys(leftExtensionsConfigs);
+  const rightExtensionsIds = Object.keys(rightExtensionsConfigs);
+
+  // const mutualIds = R.intersection(rightExtensionsIds, rightExtensionsIds);
+  // const onlyOnOneIds = R.symmetricDifference(leftExtensionsIds, rightExtensionsIds);
+  const allIds = R.union(leftExtensionsIds, rightExtensionsIds);
+
+  const allIdsOutput = allIds.map((extId) => {
+    const leftConfig = leftExtensionsConfigs[extId];
+    const rightConfig = rightExtensionsConfigs[extId];
+    const fieldName = `${extId} configuration`;
+    return configsOutput(fieldName, leftConfig, rightConfig, componentLeft.version, componentRight.version);
+  });
+
+  return compact(allIdsOutput);
+}
+
+function labelLeft(leftVersion?: string, rightVersion?: string) {
+  const sameVersions = areVersionsTheSame(leftVersion, rightVersion);
+  return sameVersions ? `${leftVersion} original` : rightVersion;
+}
+
+function labelRight(leftVersion?: string, rightVersion?: string) {
+  const sameVersions = areVersionsTheSame(leftVersion, rightVersion);
+  return sameVersions ? `${rightVersion} modified` : leftVersion;
+}
+
+function areVersionsTheSame(leftVersion?: string, rightVersion?: string) {
+  return leftVersion === rightVersion;
+}
+
+function titleLeft(field: string, leftVersion?: string, rightVersion?: string): string {
+  const leftLabel = labelLeft(leftVersion, rightVersion);
+  return `--- ${prettifyFieldName(field)} (${leftLabel})\n`;
+}
+function titleRight(field: string, leftVersion?: string, rightVersion?: string): string {
+  const rightLabel = labelRight(leftVersion, rightVersion);
+  return `+++ ${prettifyFieldName(field)} (${rightLabel})\n`;
+}
+
+function configsOutput(
+  fieldName: string,
+  leftConfig?: object,
+  rightConfig?: Object,
+  leftVersion?: string,
+  rightVersion?: string
+): ConfigDiff | undefined {
+  if (!leftConfig && !rightConfig) return undefined;
+  if (leftConfig && rightConfig && JSON.stringify(leftConfig) === JSON.stringify(rightConfig)) return undefined;
+  const title =
+    titleLeft(fieldName, leftVersion, rightVersion) + chalk.bold(titleRight(fieldName, leftVersion, rightVersion));
+  const getValue = (left: boolean, fieldValue?: Record<string, any>) => {
+    if (fieldValue === undefined || R.isEmpty(fieldValue)) return '';
+    const sign = left ? '-' : '+';
+    const jsonOutput = JSON.stringify(fieldValue, null, `${sign} `);
+    return `${jsonOutput}\n`;
+  };
+  const value = chalk.red(getValue(true, leftConfig)) + chalk.green(getValue(false, rightConfig));
+
+  const diffOutput = title + value;
+  return { fieldName, diffOutput };
 }

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -7,6 +7,7 @@ import arrayDifference from 'array-difference';
 import Component from '../component/consumer-component';
 import { FieldsDiff } from './components-diff';
 import { Consumer } from '..';
+import { ExtensionDataList } from '../config';
 
 type ConfigDiff = {
   fieldName: string;
@@ -18,6 +19,11 @@ export function componentToPrintableForDiff(component: Component): Record<string
     return !R.isEmpty(packages) && !R.isNil(packages)
       ? Object.keys(packages).map((key) => `${key}@${packages[key]}`)
       : null;
+  };
+
+  const parseExtensions = (extensions?: ExtensionDataList) => {
+    if (!extensions || R.isEmpty(extensions)) return null;
+    return extensions.map((extension) => extension.stringId);
   };
 
   const {
@@ -32,6 +38,7 @@ export function componentToPrintableForDiff(component: Component): Record<string
     compilerPackageDependencies,
     testerPackageDependencies,
     files,
+    extensions,
     mainFile,
     deprecated,
   } = component;
@@ -103,6 +110,8 @@ export function componentToPrintableForDiff(component: Component): Record<string
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         files.filter((file) => file.test).map((file) => normalize(file.relative))
       : null;
+  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  obj.extensions = parseExtensions(extensions);
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   obj.deprecated = deprecated ? 'True' : null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -260,12 +260,12 @@ function getExtensionsConfigOutput(componentLeft: Component, componentRight: Com
 
 function labelLeft(leftVersion?: string, rightVersion?: string) {
   const sameVersions = areVersionsTheSame(leftVersion, rightVersion);
-  return sameVersions ? `${leftVersion} original` : rightVersion;
+  return sameVersions ? `${leftVersion} original` : leftVersion;
 }
 
 function labelRight(leftVersion?: string, rightVersion?: string) {
   const sameVersions = areVersionsTheSame(leftVersion, rightVersion);
-  return sameVersions ? `${rightVersion} modified` : leftVersion;
+  return sameVersions ? `${rightVersion} modified` : rightVersion;
 }
 
 function areVersionsTheSame(leftVersion?: string, rightVersion?: string) {

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -157,6 +157,8 @@ export function diffBetweenComponentsObjects(
 ): FieldsDiff[] | null | undefined {
   const printableLeft = componentToPrintableForDiff(componentLeft);
   const printableRight = componentToPrintableForDiff(componentRight);
+  const leftVersion = componentLeft.version;
+  const rightVersion = componentRight.version;
   const fieldsDiff = getDiffBetweenObjects(printableLeft, printableRight);
   if (!componentLeft.version || !componentRight.version) {
     throw new Error('diffBetweenComponentsObjects component does not have a version');
@@ -178,7 +180,8 @@ export function diffBetweenComponentsObjects(
     return `+ ${printFieldValue(fieldValue)}\n`;
   };
   const fieldsDiffOutput = Object.keys(fieldsDiff).map((field: string) => {
-    const title = titleLeft(field) + chalk.bold(titleRight(field));
+    const title =
+      titleLeft(field, leftVersion, rightVersion) + chalk.bold(titleRight(field, leftVersion, rightVersion));
     const value = chalk.red(printFieldLeft(field)) + chalk.green(printFieldRight(field));
     const diffOutput = title + value;
     return { fieldName: field, diffOutput };
@@ -195,7 +198,8 @@ export function diffBetweenComponentsObjects(
       if (!dependencyRight) return acc;
       if (JSON.stringify(dependencyLeft.relativePaths) === JSON.stringify(dependencyRight.relativePaths)) return acc;
       const fieldName = `Dependency ${idStr} relative-paths`;
-      const title = titleLeft(fieldName) + chalk.bold(titleRight(fieldName));
+      const title =
+        titleLeft(fieldName, leftVersion, rightVersion) + chalk.bold(titleRight(fieldName, leftVersion, rightVersion));
       const getValue = (fieldValue: Record<string, any>, left: boolean) => {
         if (R.isEmpty(fieldValue)) return '';
         const sign = left ? '-' : '+';

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -279,8 +279,8 @@ function titleRight(field: string, leftVersion?: string, rightVersion?: string):
 
 function configsOutput(
   fieldName: string,
-  leftConfig?: object,
-  rightConfig?: Object,
+  leftConfig?: Record<string, any>,
+  rightConfig?: Record<string, any>,
   leftVersion?: string,
   rightVersion?: string
 ): ConfigDiff | undefined {

--- a/src/consumer/config/component-config.ts
+++ b/src/consumer/config/component-config.ts
@@ -144,31 +144,6 @@ export default class ComponentConfig extends AbstractConfig {
   mergeWithComponentData(component: Component) {
     this.bindingPrefix = this.bindingPrefix || component.bindingPrefix;
     this.lang = this.lang || component.lang;
-    // @todo: make sure with Gilad that this logic aligns with him
-    // some extensions are saved in the model but are not loaded by loadFromFileSystem.
-    // e.g. the compiler extension is not configured in workspace.jsonc, but it saved in the model
-    // with the artifacts.
-    // this function makes sure to add all missing extensions and artifacts from the model
-    const populateExtensions = () => {
-      if (!component.extensions.length) return;
-      if (!this.extensions.length) {
-        this.extensions = component.extensions;
-        return;
-      }
-      // both, model and consumer have extensions
-      component.extensions.forEach((extension) => {
-        const extensionFromConsumer = this.extensions.findExtension(extension.stringId);
-        if (!extensionFromConsumer) {
-          this.extensions.push(extension);
-          return;
-        }
-        // same extension exists in both, consumer and model. make sure the artifacts are populated
-        if (extension.artifacts.length && !extensionFromConsumer.artifacts.length) {
-          extensionFromConsumer.artifacts = extension.artifacts;
-        }
-      });
-    };
-    populateExtensions();
   }
 
   /**

--- a/src/consumer/config/extension-data.spec.ts
+++ b/src/consumer/config/extension-data.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
-import { ExtensionDataList } from './extension-data';
+import { ExtensionDataList, ExtensionDataEntry } from './extension-data';
+import { BitId } from '../../bit-id';
 
 describe('ExtensionDataList', () => {
   describe('merge lists', () => {
@@ -52,6 +53,66 @@ describe('ExtensionDataList', () => {
       expect(mergedAsObject['my-scope/ext4']).to.deep.equal({
         conf1: 'val1',
       });
+    });
+  });
+  describe('sort lists', () => {
+    let sorted;
+    before(() => {
+      const list = ExtensionDataList.fromConfigObject({
+        'my-scope/ext3': {
+          conf1: 'val1',
+        },
+        'my-scope/ext1': {
+          conf1: 'val2',
+          conf4: 'val4',
+        },
+        'my-scope/ext4': {
+          conf1: 'val1',
+        },
+      });
+
+      sorted = list.sortById();
+    });
+    it('should sort the list by ids', () => {
+      expect(sorted[0].stringId).to.equal('my-scope/ext1');
+      expect(sorted[1].stringId).to.equal('my-scope/ext3');
+      expect(sorted[2].stringId).to.equal('my-scope/ext4');
+    });
+  });
+  describe('to config array', () => {
+    let configArr;
+    before(() => {
+      const configEntry = new ExtensionDataEntry(undefined, BitId.parse('my-scope/ext1', true), undefined, {
+        conf1: 'val1',
+      });
+      const dataEntry = new ExtensionDataEntry(
+        undefined,
+        BitId.parse('my-scope/ext2', true),
+        undefined,
+        {},
+        { data1: 'val1' }
+      );
+      const dataConfigEntry = new ExtensionDataEntry(
+        undefined,
+        BitId.parse('my-scope/ext3', true),
+        undefined,
+        { conf3: 'val3' },
+        { data3: 'val3' }
+      );
+      const list = ExtensionDataList.fromArray([configEntry, dataEntry, dataConfigEntry]);
+      configArr = list.toConfigArray();
+    });
+    it('should not have entries with data only', () => {
+      expect(configArr.length).to.equal(2);
+    });
+    it('should have entries with config only', () => {
+      expect(configArr[0].id.toString()).to.equal('my-scope/ext1');
+      expect(configArr[0].config).to.deep.equal({ conf1: 'val1' });
+    });
+    it('should have entries with data and config but without the data', () => {
+      expect(configArr[1].id.toString()).to.equal('my-scope/ext3');
+      expect(configArr[1].config).to.deep.equal({ conf3: 'val3' });
+      expect(configArr[1].data).to.be.undefined;
     });
   });
 });

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -10,7 +10,7 @@ import { sortObject } from '../../utils';
 const mergeReducer = (accumulator, currentValue) => R.unionWith(ignoreVersionPredicate, accumulator, currentValue);
 type ConfigOnlyEntry = {
   id: string;
-  config: Object;
+  config: Record<string, any>;
 };
 
 export class ExtensionDataEntry {

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -1,11 +1,17 @@
 /* eslint-disable max-classes-per-file */
 import R, { forEachObjIndexed } from 'ramda';
+import { compact } from 'ramda-adjunct';
 import { BitId, BitIds } from '../../bit-id';
 import { AbstractVinyl } from '../component/sources';
 import { Artifact } from '../component/sources/artifact';
 import Source from '../../scope/models/source';
+import { sortObject } from '../../utils';
 
 const mergeReducer = (accumulator, currentValue) => R.unionWith(ignoreVersionPredicate, accumulator, currentValue);
+type ConfigOnlyEntry = {
+  id: string;
+  config: Object;
+};
 
 export class ExtensionDataEntry {
   constructor(
@@ -108,8 +114,23 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
 
   toConfigObject() {
     const res = {};
-    this.forEach((entry) => (res[entry.stringId] = entry.config));
+    this.forEach((entry) => {
+      if (entry.config && !R.isEmpty(entry.config)) {
+        res[entry.stringId] = entry.config;
+      }
+    });
     return res;
+  }
+
+  toConfigArray(): ConfigOnlyEntry[] {
+    const arr = this.map((entry) => {
+      // Remove extensions without config
+      if (entry.config && !R.isEmpty(entry.config)) {
+        return { id: entry.stringId, config: entry.config };
+      }
+      return undefined;
+    });
+    return compact(arr);
   }
 
   clone(): ExtensionDataList {
@@ -119,6 +140,15 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
 
   _filterLegacy(): ExtensionDataList {
     return ExtensionDataList.fromArray(this.filter((ext) => !ext.isLegacy));
+  }
+
+  sortById(): ExtensionDataList {
+    const arr = R.sortBy(R.prop('stringId'), this);
+    // Also sort the config
+    arr.forEach((entry) => {
+      entry.config = sortObject(entry.config);
+    });
+    return ExtensionDataList.fromArray(arr);
   }
 
   static fromConfigObject(obj: { [extensionId: string]: any }): ExtensionDataList {

--- a/src/e2e-helper/e2e-component-json-helper.ts
+++ b/src/e2e-helper/e2e-component-json-helper.ts
@@ -46,6 +46,13 @@ export default class ComponentJsonHelper {
     this.addKeyVal('extensions', extensions, componentRelativeDir);
   }
 
+  removeExtension(extensionId: string, componentRelativeDir = 'bar') {
+    const componentJson = this.read(componentRelativeDir);
+    const extensions = componentJson.extensions || {};
+    delete extensions[extensionId];
+    this.addKeyVal('extensions', extensions, componentRelativeDir);
+  }
+
   setPropagate(propagateVal: boolean, componentRelativeDir = 'bar') {
     this.addKeyVal('propagate', propagateVal, componentRelativeDir);
   }

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -180,12 +180,18 @@ export default class Version extends BitObject {
       });
     };
 
+    const getExtensions = (extensions: ExtensionDataList) => {
+      const sortedConfigOnly = extensions.sortById().toConfigArray();
+      return sortedConfigOnly;
+    };
+
     const filterFunction = (val, key) => {
       if (
         key === 'devDependencies' ||
         key === 'devPackageDependencies' ||
         key === 'peerPackageDependencies' ||
-        key === 'overrides'
+        key === 'overrides' ||
+        key === 'extensions'
       ) {
         return !R.isEmpty(val);
       }
@@ -217,6 +223,7 @@ export default class Version extends BitObject {
           bindingPrefix: obj.bindingPrefix,
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           overrides: obj.overrides,
+          extensions: getExtensions(this.extensions),
         },
         filterFunction
       )


### PR DESCRIPTION
## Proposed Changes

- add diff for extensions in bit diff command
- fix eject config to add the default scope	
- add toConfigArray and sortById APIs to ExtensionDataList 
- add unit tests for ExtensionDataList	
- remove legacy diff results which are not required any more (env files) 
- refactor diff output generation	
- add removeExtension API to component json test helper	
- write tests for extensions diffs and status	
- remove old merge extensions from models	

