### PR TITLE
on harmony warn about components without rootDir/trackDir in bit-status

### DIFF
--- a/src/api/consumer/lib/status.ts
+++ b/src/api/consumer/lib/status.ts
@@ -21,6 +21,7 @@ export type StatusResult = {
   outdatedComponents: Component[];
   mergePendingComponents: DivergedComponent[];
   componentsDuringMergeState: BitIds;
+  componentsWithIndividualFiles: Component[];
 };
 
 export default (async function status(): Promise<StatusResult> {
@@ -76,5 +77,6 @@ export default (async function status(): Promise<StatusResult> {
     outdatedComponents,
     mergePendingComponents,
     componentsDuringMergeState,
+    componentsWithIndividualFiles: await componentsList.listComponentsWithIndividualFiles(),
   };
 });

--- a/src/cli/commands/public-cmds/status-cmd.ts
+++ b/src/cli/commands/public-cmds/status-cmd.ts
@@ -46,6 +46,7 @@ export default class Status implements LegacyCommand {
     outdatedComponents,
     mergePendingComponents,
     componentsDuringMergeState,
+    componentsWithIndividualFiles,
   }: StatusResult): string {
     if (this.json) {
       return JSON.stringify(
@@ -60,6 +61,7 @@ export default class Status implements LegacyCommand {
           outdatedComponents: outdatedComponents.map((c) => c.id.toString()),
           mergePendingComponents: mergePendingComponents.map((c) => c.id.toString()),
           componentsDuringMergeState: componentsDuringMergeState.map((id) => id.toString()),
+          componentsWithIndividualFiles: componentsWithIndividualFiles.map((c) => c.id.toString()),
         },
         null,
         2
@@ -168,6 +170,15 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       invalidComponents.length ? chalk.underline.white(statusInvalidComponentsMsg) + invalidDesc : ''
     ).join('\n');
 
+    const individualFilesDesc = `\nthese components were added as individual files and not as directories, which are invalid in Harmony
+please make sure each component has its own directory and re-add it. alternatively, use "bit move --component" to help with the move.\n`;
+    const individualFilesOutput = immutableUnshift(
+      componentsWithIndividualFiles.map((c) => format(c.id.toString(), false, 'individual files')).sort(),
+      componentsWithIndividualFiles.length
+        ? chalk.underline.white('components with individual files') + individualFilesDesc
+        : ''
+    ).join('\n');
+
     const stagedDesc = '\n(use "bit export <remote_scope> to push these components to a remote scope")\n';
     const stagedComponentsOutput = immutableUnshift(
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -188,6 +199,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
           stagedComponentsOutput,
           autoTagPendingOutput,
           invalidComponentOutput,
+          individualFilesOutput,
         ]
           .filter((x) => x)
           .join(chalk.underline('\n                         \n') + chalk.white('\n')) +

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -352,6 +352,16 @@ export default class ComponentsList {
     return this._invalidComponents;
   }
 
+  async listComponentsWithIndividualFiles(): Promise<Component[]> {
+    if (this.consumer.isLegacy) return [];
+    const workspaceComponents = await this.getFromFileSystem(COMPONENT_ORIGINS.AUTHORED);
+    return workspaceComponents.filter((component) => {
+      const componentMap = component.componentMap;
+      if (!componentMap) throw new Error('listComponentsWithIndividualFiles componentMap is missing');
+      return Boolean(!componentMap.trackDir && !componentMap.rootDir);
+    });
+  }
+
   getFromBitMap(origin?: ComponentOrigin): BitIds {
     const originParam = origin ? [origin] : undefined;
     return this.bitMap.getAllIdsAvailableOnLane(originParam);


### PR DESCRIPTION
On Harmony, only directories can be added not individual files. This makes sure to show a warning on "bit status" when migrating from legacy to Harmony and components have individual files.