### PR TITLE
fix bit move --component when running from an inner dir

### DIFF
--- a/src/cli/commands/public-cmds/move-cmd.ts
+++ b/src/cli/commands/public-cmds/move-cmd.ts
@@ -9,7 +9,11 @@ export default class Move implements LegacyCommand {
   description = `move files or directories of component(s)\n  https://${BASE_DOCS_DOMAIN}/docs/add-and-isolate-components#moving-and-renaming-files`;
   alias = 'mv';
   opts = [
-    ['c', 'component', 'move component files that are spread over multiple directories to one directory'],
+    [
+      'c',
+      'component',
+      'move component files that are spread over multiple directories to one directory. synopsis: "move <component-id> <directory>"',
+    ],
   ] as CommandOptions;
   loader = true;
 

--- a/src/consumer/component-ops/move-components.ts
+++ b/src/consumer/component-ops/move-components.ts
@@ -121,7 +121,7 @@ to change that directory, use bit move without --component flag`);
     moveSync(fromAbsolute, path.join(toAbsolute, file.name));
     return { from: file.relativePath, to: pathJoinLinux(toRelative, file.name) };
   });
-  componentMap.addRootDirToDistributedFiles(to);
+  componentMap.addRootDirToDistributedFiles(toRelative);
   consumer.bitMap.markAsChanged();
   return [{ id, changes }];
 }


### PR DESCRIPTION
Previously, it was moving the files correctly but the records in .bitmap were off.