### PR TITLE
introduce "--harmony" flag for "bit migrate" 

### DIFF
--- a/src/api/consumer/lib/feature-toggle.ts
+++ b/src/api/consumer/lib/feature-toggle.ts
@@ -59,6 +59,10 @@ export function isLaneEnabled() {
   return isFeatureEnabled(LANES_FEATURE);
 }
 
+export function isHarmonyEnabled() {
+  return isFeatureEnabled(HARMONY_FEATURE);
+}
+
 export function throwForUsingLaneIfDisabled() {
   if (isLaneEnabled()) return;
   throw new GeneralError(`lanes/snaps features are disabled.

--- a/src/api/consumer/lib/migrate.ts
+++ b/src/api/consumer/lib/migrate.ts
@@ -1,7 +1,8 @@
 import { loadScope } from '../../../scope';
-import { loadConsumerIfExist } from '../../../consumer';
+import { loadConsumerIfExist, loadConsumer } from '../../../consumer';
 import logger from '../../../logger/logger';
 import { MigrationResult } from '../../../migration/migration-helper';
+import { HarmonyMigrator } from '../../../consumer/migrations/harmony-migrator';
 
 /**
  * Running migration process for consumer and / or scope - to update the stores (bitObjects, bit.map.json) to the current version
@@ -11,7 +12,7 @@ import { MigrationResult } from '../../../migration/migration-helper';
  * @param {boolean} verbose - print debug logs
  * @returns {Promise<MigrationResult>} - wether the process run and wether it successeded
  */
-export default (async function migrate(
+export default async function migrate(
   scopePath: string,
   verbose: boolean
 ): Promise<MigrationResult | null | undefined> {
@@ -37,4 +38,12 @@ export default (async function migrate(
   logger.silly('migrate.migrate, running migration process for scope in consumer');
   if (verbose) console.log('running migration process for scope in consumer'); // eslint-disable-line no-console
   return scope.migrate(verbose);
-});
+}
+
+export async function migrateToHarmony() {
+  const consumer = await loadConsumer();
+  const harmonyMigrator = new HarmonyMigrator(consumer);
+  const results = harmonyMigrator.migrate();
+  await consumer.onDestroy();
+  return results;
+}

--- a/src/cli/commands/private-cmds/migrate-cmd.ts
+++ b/src/cli/commands/private-cmds/migrate-cmd.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { LegacyCommand, CommandOptions } from '../../legacy-command';
 import { migrate } from '../../../api/consumer';
+import { migrateToHarmony } from '../../../api/consumer/lib/migrate';
 
 export default class Migrate implements LegacyCommand {
   name = 'migrate [scopePath]';
@@ -9,9 +10,18 @@ export default class Migrate implements LegacyCommand {
   loader = true;
   migration = false;
   alias = '';
-  opts = [['v', 'verbose', 'showing logs for the migration process']] as CommandOptions;
+  opts = [
+    ['v', 'verbose', 'showing logs for the migration process'],
+    ['h', 'harmony', 'migrate workspace from legacy to Harmony'],
+  ] as CommandOptions;
 
-  action([scopePath]: [string], { verbose }: { verbose: boolean | null | undefined }): Promise<any> {
+  action(
+    [scopePath]: [string],
+    { verbose, harmony }: { verbose: boolean | undefined; harmony: boolean }
+  ): Promise<any> {
+    if (harmony) {
+      return migrateToHarmony();
+    }
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return migrate(scopePath, verbose).then((result) => ({ result, verbose }));
   }

--- a/src/cli/commands/public-cmds/init-cmd.ts
+++ b/src/cli/commands/public-cmds/init-cmd.ts
@@ -37,7 +37,11 @@ export default class Init implements LegacyCommand {
     ['d', 'default-directory <default-directory>', 'set up default directory to import components into'],
     ['p', 'package-manager <package-manager>', 'set up package manager (npm or yarn)'],
     ['f', 'force', 'force workspace initialization without clearing local objects'],
-    ['', 'harmony', 'EXPERIMENTAL. create a new workspace using the experimental Harmony version'],
+    [
+      '',
+      'harmony',
+      'EXPERIMENTAL. create a new workspace using the experimental Harmony version. to migrate, run bit migrate --harmony',
+    ],
     ['I', 'interactive', 'EXPERIMENTAL. start an interactive process'],
   ] as CommandOptions;
 

--- a/src/cli/commands/public-cmds/status-cmd.ts
+++ b/src/cli/commands/public-cmds/status-cmd.ts
@@ -18,6 +18,8 @@ export const statusFailureMsg = 'issues found';
 export const statusInvalidComponentsMsg = 'invalid components';
 export const statusWorkspaceIsCleanMsg =
   'nothing to tag or export (use "bit add <file...>" to track files or directories as components)';
+export const individualFilesDesc = `these components were added as individual files and not as directories, which are invalid in Harmony
+  please make sure each component has its own directory and re-add it. alternatively, use "bit move --component" to help with the move.`;
 
 export default class Status implements LegacyCommand {
   name = 'status';
@@ -170,12 +172,10 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       invalidComponents.length ? chalk.underline.white(statusInvalidComponentsMsg) + invalidDesc : ''
     ).join('\n');
 
-    const individualFilesDesc = `\nthese components were added as individual files and not as directories, which are invalid in Harmony
-please make sure each component has its own directory and re-add it. alternatively, use "bit move --component" to help with the move.\n`;
     const individualFilesOutput = immutableUnshift(
       componentsWithIndividualFiles.map((c) => format(c.id.toString(), false, 'individual files')).sort(),
       componentsWithIndividualFiles.length
-        ? chalk.underline.white('components with individual files') + individualFilesDesc
+        ? `${chalk.underline.white('components with individual files')}\n${individualFilesDesc}\n`
         : ''
     ).join('\n');
 

--- a/src/consumer/migrations/harmony-migrator.ts
+++ b/src/consumer/migrations/harmony-migrator.ts
@@ -1,0 +1,51 @@
+import chalk from 'chalk';
+import { Consumer } from '..';
+import { COMPONENT_ORIGINS } from '../../constants';
+import logger from '../../logger/logger';
+import { individualFilesDesc } from '../../cli/commands/public-cmds/status-cmd';
+import GeneralError from '../../error/general-error';
+
+type MigrateResult = { individualFiles: string[]; changedToRootDir: string[] };
+
+export class HarmonyMigrator {
+  constructor(private consumer: Consumer) {}
+
+  migrate(): MigrateResult {
+    this.throwOnLegacy();
+    const status: MigrateResult = { individualFiles: [], changedToRootDir: [] };
+    const authorComponents = this.consumer.bitMap.getAllComponents(COMPONENT_ORIGINS.AUTHORED);
+    authorComponents.forEach((componentMap) => {
+      if (componentMap.rootDir) return;
+      if (!componentMap.trackDir) {
+        status.individualFiles.push(componentMap.id.toStringWithoutVersion());
+        return;
+      }
+      componentMap.changeRootDirAndUpdateFilesAccordingly(componentMap.trackDir);
+      status.changedToRootDir.push(componentMap.id.toStringWithoutVersion());
+      this.consumer.bitMap.markAsChanged();
+    });
+    this.printResults(status);
+    return status;
+  }
+  private throwOnLegacy() {
+    if (this.consumer.isLegacy) {
+      throw new GeneralError(`your workspace is working in legacy mode.
+before starting the migration, please re-init the workspace as harmony by following these steps.
+1. backup and remove your workspace settings (either bit.json or "bit" prop in package.json).
+2. run "BIT_FEATURES=harmony bit init" (on Windows run "set BIT_FEATURES=harmony && bit init")`);
+    }
+  }
+  private printResults(results: MigrateResult) {
+    if (results.individualFiles.length) {
+      logger.console(chalk.red(individualFilesDesc));
+      logger.console(results.individualFiles.join('\n'));
+    }
+    if (results.changedToRootDir.length) {
+      logger.console(chalk.green('the following components were successfully converted from trackDir to rootDir'));
+      logger.console(results.changedToRootDir.join('\n'));
+    }
+    logger.console(
+      chalk.white.bold('please run "bit status" to make sure the workspace is error-free before continue working')
+    );
+  }
+}

--- a/src/extensions/config/workspace-config.ts
+++ b/src/extensions/config/workspace-config.ts
@@ -14,7 +14,7 @@ import { AbstractVinyl } from '../../consumer/component/sources';
 import { Compilers, Testers } from '../../consumer/config/abstract-config';
 
 import { EnvType } from '../../legacy-extensions/env-extension-types';
-import { isFeatureEnabled, HARMONY_FEATURE } from '../../api/consumer/lib/feature-toggle';
+import { isFeatureEnabled, HARMONY_FEATURE, isHarmonyEnabled } from '../../api/consumer/lib/feature-toggle';
 import logger from '../../logger/logger';
 import { InvalidBitJson } from '../../consumer/config/exceptions';
 import { ILegacyWorkspaceConfig, ExtensionDataList } from '../../consumer/config';
@@ -88,12 +88,14 @@ export class WorkspaceConfig implements HostConfig {
   isLegacy: boolean;
 
   constructor(private data?: WorkspaceConfigFileProps, private legacyConfig?: LegacyWorkspaceConfig) {
-    if (data) {
+    const isHarmony = data || (isHarmonyEnabled() && !legacyConfig);
+    this.isLegacy = !isHarmony;
+    logger.debug(`workspace-config, isLegacy: ${this.isLegacy}`);
+    Analytics.setExtraData('is_harmony', isHarmony);
+    if (isHarmony) {
       const withoutInternalConfig = omit(INTERNAL_CONFIG_PROPS, data);
       this._extensions = withoutInternalConfig;
-      this.isLegacy = false;
     } else {
-      this.isLegacy = true;
       // We know we have either data or legacy config
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       this._extensions = transformLegacyPropsToExtensions(legacyConfig!);
@@ -107,7 +109,6 @@ export class WorkspaceConfig implements HostConfig {
         };
       }
     }
-    Analytics.setExtraData('is_harmony', !this.isLegacy);
   }
 
   get path(): PathOsBased {


### PR DESCRIPTION
For now, this flag does the following:
* converts `trackDir` to `rootDir` in .bitmap file and changes the file paths accordingly.
* shows the list of the components that need to be fixed in regards to the individual-files issue.
* suggest how to re-init an existing workspace as Harmony.

Also, fix "bit init" with Harmony feature set and no legacy data to init as Harmony.