### PR TITLE
improve create-capsule command and add types for isolate-components-options

### DIFF
--- a/src/extensions/builder/builder.service.ts
+++ b/src/extensions/builder/builder.service.ts
@@ -35,10 +35,7 @@ export class BuilderService implements EnvService {
     );
 
     const buildContext = Object.assign(context, {
-      capsuleGraph: await this.workspace.createNetwork(
-        context.components.map((component) => component.id.toString()),
-        this.workspace.consumer
-      ),
+      capsuleGraph: await this.workspace.createNetwork(context.components.map((component) => component.id.toString())),
     });
 
     const components = await buildPipe.execute(buildContext);

--- a/src/extensions/workspace/capsule-create.cmd.ts
+++ b/src/extensions/workspace/capsule-create.cmd.ts
@@ -1,14 +1,14 @@
 import chalk from 'chalk';
-import _ from 'lodash';
 import { Command, CommandOptions } from '../cli';
 import { Workspace } from '.';
 import CapsuleList from '../isolator/capsule-list';
 
 type CreateOpts = {
   baseDir?: string;
-  alwaysNew: boolean;
+  alwaysNew?: boolean;
   id: string;
-  installPackages: boolean;
+  installPackages?: boolean;
+  packageManager?: string;
 };
 
 export class CapsuleCreateCmd implements Command {
@@ -19,22 +19,23 @@ export class CapsuleCreateCmd implements Command {
   private = true;
   alias = '';
   options = [
-    ['b', 'baseDir <name>', 'set base dir of all capsules'],
-    ['a', 'alwaysNew', 'create new environment for capsule'],
+    ['b', 'base-dir <name>', 'set base dir of all capsules'],
+    ['a', 'always-new', 'create new environment for capsule'],
     ['i', 'id <name>', 'reuse capsule of certain name'],
     ['j', 'json', 'json format'],
-    ['d', 'installPackages', 'install packages in capsule with npm'],
+    ['d', 'install-packages', 'install packages by the package-manager'],
+    ['p', 'package-manager', 'npm, yarn on pnpm, default to npm'],
   ] as CommandOptions;
 
   constructor(private workspace: Workspace) {}
 
   async create(
     [componentIds]: [string[]],
-    { baseDir, alwaysNew = false, id, installPackages = false }: CreateOpts
+    { baseDir, alwaysNew = false, id, installPackages = false, packageManager = 'npm' }: CreateOpts
   ): Promise<CapsuleList> {
     // @todo: why it is not an array?
     if (componentIds && !Array.isArray(componentIds)) componentIds = [componentIds];
-    const capsuleOptions = _.omitBy({ baseDir, installPackages, alwaysNew, name: id }, _.isNil);
+    const capsuleOptions = { baseDir, installPackages, alwaysNew, name: id, packageManager };
     const isolatedEnvironment = await this.workspace.createNetwork(componentIds, capsuleOptions);
     const capsules = isolatedEnvironment.capsules;
     return capsules;


### PR DESCRIPTION
* add an option to specify package-manager in the create-capsule command.
* add types for `createNetwork` and `isolateComponents` methods.
