### PR TITLE
refactoring, separate the watch of legacy components from the onComponentChange hook

### DIFF
--- a/src/extensions/compiler/workspace-compiler.ts
+++ b/src/extensions/compiler/workspace-compiler.ts
@@ -13,7 +13,7 @@ import componentIdToPackageName from '../../utils/bit/component-id-to-package-na
 import { Environments } from '../environments';
 import { Compiler } from './types';
 import { Component } from '../component';
-import { OnComponentChangeOptions, OnComponentChangeResult } from '../workspace/on-component-change';
+import { OnComponentChangeResult } from '../workspace/on-component-change';
 
 type BuildResult = { component: string; buildResults: string[] | null | undefined };
 
@@ -111,8 +111,8 @@ export class WorkspaceCompiler {
     if (this.workspace) this.workspace.registerOnComponentChange(this.onComponentChange.bind(this));
   }
 
-  async onComponentChange(component: Component, options: OnComponentChangeOptions): Promise<OnComponentChangeResult> {
-    const buildResults = await this.compileComponents([component.id.toString()], options);
+  async onComponentChange(component: Component): Promise<OnComponentChangeResult> {
+    const buildResults = await this.compileComponents([component.id.toString()], {});
     return {
       results: buildResults,
       toString() {

--- a/src/extensions/workspace/on-component-change.ts
+++ b/src/extensions/workspace/on-component-change.ts
@@ -1,10 +1,5 @@
 import { Component } from '../component';
 
-export type OnComponentChangeOptions = { noCache?: boolean; verbose?: boolean };
-
 export type OnComponentChangeResult = { results: any; toString: () => string };
 
-export type OnComponentChange = (
-  component: Component,
-  options: OnComponentChangeOptions
-) => Promise<OnComponentChangeResult>;
+export type OnComponentChange = (component: Component) => Promise<OnComponentChangeResult>;

--- a/src/extensions/workspace/watch/watcher.ts
+++ b/src/extensions/workspace/watch/watcher.ts
@@ -10,6 +10,7 @@ import { pathNormalizeToLinux } from '../../../utils';
 import { Consumer } from '../../../consumer';
 import { ComponentID } from '../../component';
 import logger from '../../../logger/logger';
+import { build } from '../../../api/consumer';
 
 export type WatcherProcessData = { watchProcess: ChildProcess; compilerId: BitId; componentIds: BitId[] };
 
@@ -69,37 +70,49 @@ export class Watcher {
   private async handleChange(filePath: string, isNew = false) {
     const start = new Date().getTime();
     const componentId = await this.getBitIdByPathAndReloadConsumer(filePath, isNew);
-    let resultMsg = '';
-    if (componentId) {
-      if (this.isComponentWatchedExternally(componentId)) {
-        // update capsule, once done, it automatically triggers the external watcher
-        await this.workspace.load([componentId]);
-      } else {
-        const idStr = componentId.toString();
-        logger.console(`running OnComponentChange hook for ${chalk.bold(idStr)}`);
-        const options = {
-          noCache: false,
-          verbose: this.verbose,
-        };
-        const buildResults = await this.workspace.triggerOnComponentChange(new ComponentID(componentId), options);
-        if (buildResults && buildResults.length) {
-          buildResults.forEach((extensionResult) => {
-            logger.console(chalk.cyan(`\tresults from ${extensionResult.extensionId}`));
-            logger.console(`\t${extensionResult.results.toString()}`);
-          });
-        } else {
-          resultMsg = `${idStr} doesn't have a compiler, nothing to build`;
-        }
-      }
-    } else {
-      resultMsg = `file ${filePath} is not part of any component, ignoring it`;
+    if (!componentId) {
+      logger.console(`file ${filePath} is not part of any component, ignoring it`);
+      return this.completeWatch(start);
     }
+    if (this.isComponentWatchedExternally(componentId)) {
+      // update capsule, once done, it automatically triggers the external watcher
+      await this.workspace.load([componentId]);
+      return this.completeWatch(start);
+    }
+    const component = await this.workspace.consumer.loadComponent(componentId);
+    const idStr = componentId.toString();
+    if (component.isLegacy) {
+      await this.buildLegacy(idStr);
+      return this.completeWatch(start);
+    }
+    logger.console(`running OnComponentChange hook for ${chalk.bold(idStr)}`);
+    const buildResults = await this.workspace.triggerOnComponentChange(new ComponentID(componentId));
+    if (buildResults && buildResults.length) {
+      buildResults.forEach((extensionResult) => {
+        logger.console(chalk.cyan(`\tresults from ${extensionResult.extensionId}`));
+        logger.console(`\t${extensionResult.results.toString()}`);
+      });
+      return this.completeWatch(start);
+    }
+    logger.console(`${idStr} doesn't have a compiler, nothing to build`);
+    return this.completeWatch(start);
+  }
 
+  private completeWatch(start: number) {
     const duration = new Date().getTime() - start;
     loader.stop();
-    logger.console(resultMsg);
     logger.console(`took ${duration}ms`);
     logger.console(chalk.yellow(WATCHER_COMPLETED_MSG));
+  }
+
+  private async buildLegacy(idStr: string) {
+    logger.console(`running build for ${chalk.bold(idStr)}`);
+    const buildResults = await build(idStr, false, this.verbose, this.workspace.path);
+    if (buildResults) {
+      logger.console(`\t${chalk.cyan(buildResults.join('\n\t'))}`);
+    } else {
+      logger.console(`${idStr} doesn't have a compiler, nothing to build`);
+    }
   }
 
   private isComponentWatchedExternally(componentId: BitId) {

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -31,7 +31,7 @@ import Config from '../component/config';
 import { buildOneGraphForComponents } from '../../scope/graph/components-graph';
 import { OnComponentLoadSlot, OnComponentChangeSlot } from './workspace.provider';
 import { OnComponentLoad } from './on-component-load';
-import { OnComponentChange, OnComponentChangeOptions, OnComponentChangeResult } from './on-component-change';
+import { OnComponentChange, OnComponentChangeResult } from './on-component-change';
 import { IsolateComponentsOptions } from '../isolator/isolator.extension';
 
 export type EjectConfResult = {
@@ -243,14 +243,13 @@ export default class Workspace implements ComponentFactory {
   }
 
   async triggerOnComponentChange(
-    id: ComponentID,
-    options: OnComponentChangeOptions
+    id: ComponentID
   ): Promise<Array<{ extensionId: string; results: OnComponentChangeResult }>> {
     const component = await this.get(id);
     const onChangeEntries = this.onComponentChangeSlot.toArray(); // e.g. [ [ '@teambit/compiler', [Function: bound onComponentChange] ] ]
     const results: Array<{ extensionId: string; results: OnComponentChangeResult }> = [];
     await BluebirdPromise.mapSeries(onChangeEntries, async ([extension, onChangeFunc]) => {
-      const onChangeResult = await onChangeFunc(component, options);
+      const onChangeResult = await onChangeFunc(component);
       results.push({ extensionId: extension, results: onChangeResult });
     });
 


### PR DESCRIPTION
Currently, both, legacy and new components are passing to the `onComponentChange` hook, which, later are passed to the `workspace.get` potentially causing issues when a legacy component doesn't have dir.