### PR TITLE
Infrastructure for logging long processes

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -181,7 +181,7 @@ describe('publish functionality', function () {
       npmCiRegistry.configureCustomNameInPackageJsonHarmony('invalid/name/{name}');
     });
     it('builder should show the npm error about invalid name', () => {
-      const output = helper.general.runWithTryCatch('bit run-new');
+      const output = helper.general.runWithTryCatch('bit run');
       expect(output).to.have.string('npm ERR! Invalid name: "invalid/name/comp1"');
     });
   });

--- a/src/extensions/builder/build-pipe.ts
+++ b/src/extensions/builder/build-pipe.ts
@@ -26,7 +26,7 @@ export class BuildPipe {
       const components = await taskProcess.saveTaskResults();
       return components;
     });
-    longProcessLogger.done();
+    longProcessLogger.end();
     return results;
   }
 

--- a/src/extensions/builder/build-pipe.ts
+++ b/src/extensions/builder/build-pipe.ts
@@ -18,7 +18,7 @@ export class BuildPipe {
   async execute(buildContext: BuildContext) {
     const longProcessLogger = this.logger.createLongProcessLogger('running tasks', this.tasks.length);
     const results = await pMapSeries(this.tasks, async (task: BuildTask) => {
-      longProcessLogger.processItem(task.extensionId);
+      longProcessLogger.logProgress(task.extensionId);
       const taskResult = await task.execute(buildContext);
       const taskProcess = new TaskProcess(task, taskResult, buildContext);
       taskProcess.throwIfErrorsFound();

--- a/src/extensions/builder/builder.extension.ts
+++ b/src/extensions/builder/builder.extension.ts
@@ -5,7 +5,6 @@ import { Component, ComponentID, ComponentExtension } from '../component';
 import { BuilderService } from './builder.service';
 import { BitId } from '../../bit-id';
 import { ScopeExtension } from '../scope';
-import { IsolatorExtension } from '../isolator';
 import { CLIExtension } from '../cli';
 import { ReporterExt, Reporter } from '../reporter';
 import { LoggerExt, Logger } from '../logger';

--- a/src/extensions/builder/builder.extension.ts
+++ b/src/extensions/builder/builder.extension.ts
@@ -92,7 +92,6 @@ export class BuilderExtension {
     Environments,
     WorkspaceExt,
     ScopeExtension,
-    IsolatorExtension,
     ReporterExt,
     LoggerExt,
     CoreExt,
@@ -100,25 +99,24 @@ export class BuilderExtension {
     ComponentExtension,
   ];
 
-  static async provider([cli, envs, workspace, scope, isolator, reporter, logger, core, graphql]: [
+  static async provider([cli, envs, workspace, scope, reporter, logger, core, graphql]: [
     CLIExtension,
     Environments,
     Workspace,
     ScopeExtension,
-    IsolatorExtension,
     Reporter,
     Logger,
     Core,
     GraphQLExtension
   ]) {
     const logPublisher = logger.createLogPublisher(BuilderExtension.id);
-    const builderService = new BuilderService(isolator, workspace, logPublisher);
+    const builderService = new BuilderService(workspace, logPublisher);
     const builder = new BuilderExtension(envs, workspace, builderService, scope, core);
     graphql.register(builderSchema(builder));
     const func = builder.tagListener.bind(builder);
     if (scope) scope.onTag(func);
 
-    cli.register(new BuilderCmd(builder, workspace, reporter));
+    cli.register(new BuilderCmd(builder, workspace, logPublisher, reporter));
     return builder;
   }
 }

--- a/src/extensions/builder/builder.service.ts
+++ b/src/extensions/builder/builder.service.ts
@@ -1,5 +1,4 @@
 import { EnvService, ExecutionContext } from '../environments';
-import { IsolatorExtension } from '../isolator';
 import { Workspace } from '../workspace';
 import { BuildPipe } from './build-pipe';
 import { LogPublisher } from '../types';
@@ -7,11 +6,6 @@ import { BuildTask } from './types';
 
 export class BuilderService implements EnvService {
   constructor(
-    /**
-     * isolator extension.
-     */
-    private isolator: IsolatorExtension,
-
     /**
      * workspace extension.
      */

--- a/src/extensions/builder/run.cmd.tsx
+++ b/src/extensions/builder/run.cmd.tsx
@@ -2,7 +2,6 @@ import { Command, CommandOptions } from '../cli';
 import { Workspace } from '../workspace';
 import { BuilderExtension } from './builder.extension';
 import { Reporter } from '../reporter';
-import { onCapsuleInstalled, beforeInstallingCapsules } from '../dependency-resolver/package-manager';
 
 export class BuilderCmd implements Command {
   name = 'run-new [pattern]';
@@ -17,18 +16,6 @@ export class BuilderCmd implements Command {
 
   async report([userPattern]: [string], { verbose }: { verbose: boolean }): Promise<string> {
     this.reporter.title('Starting "build"');
-    let capsulesInstalled = 0;
-    let totalCapsules = 0;
-    onCapsuleInstalled((componentName) => {
-      capsulesInstalled += 1;
-      this.reporter.setStatusText(
-        `⏳ Resolving Components from the workspace (${capsulesInstalled}/${totalCapsules}). ${componentName}`
-      );
-    });
-    beforeInstallingCapsules((numCapsules) => {
-      totalCapsules += numCapsules;
-    });
-
     const pattern = userPattern && userPattern.toString();
     this.reporter.title('Loading components');
     const components = pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list();

--- a/src/extensions/builder/run.cmd.tsx
+++ b/src/extensions/builder/run.cmd.tsx
@@ -27,7 +27,7 @@ export class BuilderCmd implements Command {
     const pattern = userPattern && userPattern.toString();
     const components = pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list();
     const results = await this.builder.build(components);
-    longProcessLogger.done();
+    longProcessLogger.end();
     // @todo: decide about the output
     results.forEach((
       result // eslint-disable-next-line no-console

--- a/src/extensions/builder/run.cmd.tsx
+++ b/src/extensions/builder/run.cmd.tsx
@@ -22,15 +22,17 @@ export class BuilderCmd implements Command {
   ) {}
 
   async report([userPattern]: [string]): Promise<string> {
+    this.reporter.start();
     const longProcessLogger = this.logger.createLongProcessLogger('build');
     const pattern = userPattern && userPattern.toString();
     const components = pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list();
     const results = await this.builder.build(components);
+    longProcessLogger.done();
     // @todo: decide about the output
     results.forEach((
       result // eslint-disable-next-line no-console
     ) => console.log('result', `Env: ${result.env}\nResult: success`));
-    longProcessLogger.done();
+
     this.reporter.end();
 
     return chalk.green('the build has been completed');

--- a/src/extensions/dependency-resolver/package-manager.ts
+++ b/src/extensions/dependency-resolver/package-manager.ts
@@ -70,7 +70,7 @@ export default class PackageManager {
         });
         await installProc;
         linkBitBinInCapsule(capsule);
-        longProcessLogger.processItem(componentId);
+        longProcessLogger.logProgress(componentId);
       });
     } else {
       throw new Error(`unsupported package manager ${packageManager}`);

--- a/src/extensions/dependency-resolver/package-manager.ts
+++ b/src/extensions/dependency-resolver/package-manager.ts
@@ -12,28 +12,9 @@ import { pipeOutput } from '../../utils/child_process';
 import createSymlinkOrCopy from '../../utils/fs/create-symlink-or-copy';
 import { installOpts } from './types';
 
-// TODO:
-// this is a hack in order to pass events from here to flows (and later install)
-// we need to solve this hack by changing the dependency chain of the relevant extensions
-// essentially flattening the structure so that we have less extensions to pass this event through
-//
-// at the time of writing, it's Flows => Workspace => Isolator => PackageManager
-let emitter = null;
-export function onCapsuleInstalled(cb) {
-  // @ts-ignore - this is a hack
-  emitter.on('capsuleInstalled', (componentName) => cb(componentName));
-}
-export function beforeInstallingCapsules(cb) {
-  // @ts-ignore - this is a hack
-  emitter.on('beforeInstallingCapsules', (numCapsules) => cb(numCapsules));
-}
-
 export default class PackageManager {
   private emitter = new EventEmitter();
-  constructor(readonly packageManagerName: string, readonly logger: Logger) {
-    // @ts-ignore - this is a hack
-    emitter = this.emitter;
-  }
+  constructor(readonly packageManagerName: string, readonly logger: Logger) {}
 
   get name() {
     return this.packageManagerName;
@@ -59,7 +40,7 @@ export default class PackageManager {
   async capsulesInstall(capsules: Capsule[], opts: installOpts = {}) {
     const packageManager = opts.packageManager || this.packageManagerName;
     const logPublisher = this.logger.createLogPublisher('packageManager');
-    this.emitter.emit('beforeInstallingCapsules', capsules.length);
+    const longProcessLogger = logPublisher.createLongProcessLogger('installing capsules', capsules.length);
     if (packageManager === 'npm' || packageManager === 'yarn' || packageManager === 'pnpm') {
       // Don't run them in parallel (Promise.all), the package-manager doesn't handle it well.
       await pMapSeries(capsules, async (capsule) => {
@@ -89,11 +70,12 @@ export default class PackageManager {
         });
         await installProc;
         linkBitBinInCapsule(capsule);
-        this.emitter.emit('capsuleInstalled', componentId);
+        longProcessLogger.processItem(componentId);
       });
     } else {
       throw new Error(`unsupported package manager ${packageManager}`);
     }
+    longProcessLogger.done();
     return null;
   }
 

--- a/src/extensions/dependency-resolver/package-manager.ts
+++ b/src/extensions/dependency-resolver/package-manager.ts
@@ -75,7 +75,7 @@ export default class PackageManager {
     } else {
       throw new Error(`unsupported package manager ${packageManager}`);
     }
-    longProcessLogger.done();
+    longProcessLogger.end();
     return null;
   }
 

--- a/src/extensions/logger/README.md
+++ b/src/extensions/logger/README.md
@@ -36,6 +36,25 @@ Ends the current phase (this is optional as the same effect can be achieved by s
 otherwise the app will hang.
 
 ### Logger
+
+#### createLongProcessLogger: (processDescription: string, totalItems?: number) => LongProcessLogger;
+Returns an instance of LongProcessLogger and start logging the process description.
+
+If the process involves iteration over a list of items, such as running tag on a list of components, then pass the `totalItems` as the total number of the components in the list.
+
+Later, during the iteration, call `logProgress(componentName)` on the `LongProcessLogger` instance.
+once done, call `end()`, which logs the duration of the process in ms.
+
+if the reporter is used, the status-line will show all messages in the terminal. Something like the following:
+```
+@teambit/workspace, loading components (total: 20)
+@teambit/workspace, loading components (1/20). ui/button
+@teambit/workspace, loading components (2/20). ui/form
+...
+@teambit/workspace, loading components (20/20). ui/page
+@teambit/workspace, loading components (completed in 200ms)
+```
+
 #### info(...messages)
 Emits messages as-is to the log. They will receive a unique color according to the id with which the logger was instantiated.
 

--- a/src/extensions/logger/README.md
+++ b/src/extensions/logger/README.md
@@ -45,13 +45,21 @@ If the process involves iteration over a list of items, such as running tag on a
 Later, during the iteration, call `logProgress(componentName)` on the `LongProcessLogger` instance.
 once done, call `end()`, which logs the duration of the process in ms.
 
-if the reporter is used, the status-line will show all messages in the terminal. Something like the following:
+The reporter can be used to show the progress in the status-line. To enable this, call `this.reporter.start()`. Once done, call `this.reporter.end()`.
+
+Here is an example of the messages produced by this longProcessLogger. If the reporter is used, the status-line always shows the last message.
 ```
 @teambit/workspace, loading components (total: 20)
 @teambit/workspace, loading components (1/20). ui/button
 @teambit/workspace, loading components (2/20). ui/form
 ...
 @teambit/workspace, loading components (20/20). ui/page
+@teambit/workspace, loading components (completed in 200ms)
+```
+
+An example when there is no `totalItems`.
+```
+@teambit/workspace, loading components
 @teambit/workspace, loading components (completed in 200ms)
 ```
 

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -45,8 +45,8 @@ export default class Logger {
       error(componentId, messages) {
         emitAndLogToFile(componentId, messages, 'error');
       },
-      createLongProcessLogger(message: string, totalItems: number): LogLongProcess {
-        return new LogLongProcess(this, extensionName, emitter, message, totalItems);
+      createLongProcessLogger(processDescription: string, totalItems: number): LogLongProcess {
+        return new LogLongProcess(this, extensionName, emitter, processDescription, totalItems);
       },
     };
   }

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -45,7 +45,7 @@ export default class Logger {
       error(componentId, messages) {
         emitAndLogToFile(componentId, messages, 'error');
       },
-      createLongProcessLogger(processDescription: string, totalItems: number): LogLongProcess {
+      createLongProcessLogger(processDescription: string, totalItems?: number): LogLongProcess {
         return new LogLongProcess(this, extensionName, emitter, processDescription, totalItems);
       },
     };

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -2,12 +2,14 @@ import { EventEmitter } from 'events';
 // TODO: change to module path once types become a component
 import { LogPublisher } from '../types';
 import legacyLogger from '../../logger/logger';
+import { LogLongProcess } from './long-process-logger';
 
 export enum LogLevel {
+  SILLY = 'silly',
+  DEBUG = 'debug',
   INFO = 'info',
   WARN = 'warn',
   ERROR = 'error',
-  DEBUG = 'debug',
 }
 export type LogEntry = {
   componentId: string; // TODO: actual ComponentID
@@ -28,6 +30,12 @@ export default class Logger {
       legacyLogger[logLevel](`${componentId}, ${messages}`);
     };
     return {
+      silly(componentId, messages) {
+        emitAndLogToFile(componentId, messages, 'debug');
+      },
+      debug(componentId, messages) {
+        emitAndLogToFile(componentId, messages, 'debug');
+      },
       info(componentId, messages) {
         emitAndLogToFile(componentId, messages, 'info');
       },
@@ -37,8 +45,8 @@ export default class Logger {
       error(componentId, messages) {
         emitAndLogToFile(componentId, messages, 'error');
       },
-      debug(componentId, messages) {
-        emitAndLogToFile(componentId, messages, 'debug');
+      createLongProcessLogger(message: string, totalItems: number): LogLongProcess {
+        return new LogLongProcess(this, extensionName, emitter, message, totalItems);
       },
     };
   }

--- a/src/extensions/logger/logger.ts
+++ b/src/extensions/logger/logger.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from 'events';
 // TODO: change to module path once types become a component
 import { LogPublisher } from '../types';
 import legacyLogger from '../../logger/logger';
-import { LogLongProcess } from './long-process-logger';
+import { LongProcessLogger } from './long-process-logger';
 
 export enum LogLevel {
   SILLY = 'silly',
@@ -45,8 +45,8 @@ export default class Logger {
       error(componentId, messages) {
         emitAndLogToFile(componentId, messages, 'error');
       },
-      createLongProcessLogger(processDescription: string, totalItems?: number): LogLongProcess {
-        return new LogLongProcess(this, extensionName, emitter, processDescription, totalItems);
+      createLongProcessLogger(processDescription: string, totalItems?: number): LongProcessLogger {
+        return new LongProcessLogger(this, extensionName, emitter, processDescription, totalItems);
       },
     };
   }

--- a/src/extensions/logger/long-process-logger.ts
+++ b/src/extensions/logger/long-process-logger.ts
@@ -8,24 +8,26 @@ export class LogLongProcess {
     private logPublisher: LogPublisher,
     private extensionName: string,
     private emitter: EventEmitter,
-    private message: string,
+    private processDescription: string,
     private totalItems: number,
-    private currentItem = 0
+    private currentItem = 0,
+    private start = new Date().getTime()
   ) {
-    const output = `${this.extensionName}, ${this.message} (total: ${this.totalItems})`;
+    const output = `${this.extensionName}, ${this.processDescription} (total: ${this.totalItems})`;
     logPublisher.info(undefined, output);
     emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   processItem(itemName = '') {
     this.currentItem += 1;
-    const output = `${this.extensionName}, ${this.message} (${this.totalItems}/${this.currentItem}). ${itemName}`;
+    const output = `${this.extensionName}, ${this.processDescription} (${this.totalItems}/${this.currentItem}). ${itemName}`;
     this.logPublisher.info(undefined, output);
     this.emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   done() {
-    this.logPublisher.info(undefined, `${this.extensionName}, ${this.message} (finished)`);
+    const duration = new Date().getTime() - this.start;
+    this.logPublisher.info(undefined, `${this.extensionName}, ${this.processDescription} (completed in ${duration}ms)`);
     this.emitter.emit(LONG_PROCESS_EVENT, '');
   }
 }

--- a/src/extensions/logger/long-process-logger.ts
+++ b/src/extensions/logger/long-process-logger.ts
@@ -9,25 +9,27 @@ export class LogLongProcess {
     private extensionName: string,
     private emitter: EventEmitter,
     private processDescription: string,
-    private totalItems: number,
+    private totalItems?: number,
     private currentItem = 0,
     private start = new Date().getTime()
   ) {
-    const output = `${this.extensionName}, ${this.processDescription} (total: ${this.totalItems})`;
+    const totalItemsStr = totalItems ? `(total: ${this.totalItems})` : '';
+    const output = `${this.extensionName}, ${this.processDescription} ${totalItemsStr}`;
     logPublisher.info(undefined, output);
     emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   processItem(itemName = '') {
     this.currentItem += 1;
-    const output = `${this.extensionName}, ${this.processDescription} (${this.totalItems}/${this.currentItem}). ${itemName}`;
+    const output = `${this.extensionName}, ${this.processDescription} (${this.currentItem}/${this.totalItems}). ${itemName}`;
     this.logPublisher.info(undefined, output);
     this.emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   done() {
     const duration = new Date().getTime() - this.start;
-    this.logPublisher.info(undefined, `${this.extensionName}, ${this.processDescription} (completed in ${duration}ms)`);
-    this.emitter.emit(LONG_PROCESS_EVENT, '');
+    const output = `${this.extensionName}, ${this.processDescription} (completed in ${duration}ms)`;
+    this.logPublisher.info(undefined, output);
+    this.emitter.emit(LONG_PROCESS_EVENT, output);
   }
 }

--- a/src/extensions/logger/long-process-logger.ts
+++ b/src/extensions/logger/long-process-logger.ts
@@ -1,0 +1,31 @@
+import { EventEmitter } from 'events';
+import type { LogPublisher } from '../types';
+
+const EVENT = 'setStatus';
+
+export class LogLongProcess {
+  constructor(
+    private logPublisher: LogPublisher,
+    private extensionName: string,
+    private emitter: EventEmitter,
+    private message: string,
+    private totalItems: number,
+    private currentItem = 0
+  ) {
+    const output = `${this.extensionName}, ${this.message} (total: ${this.totalItems})`;
+    logPublisher.info(undefined, output);
+    emitter.emit(EVENT, output);
+  }
+
+  processItem(itemName = '') {
+    this.currentItem += 1;
+    const output = `${this.extensionName}, ${this.message} (${this.totalItems}/${this.currentItem}). ${itemName}`;
+    this.logPublisher.info(undefined, output);
+    this.emitter.emit(EVENT, output);
+  }
+
+  done() {
+    this.logPublisher.info(undefined, `${this.extensionName}, ${this.message} (finished)`);
+    this.emitter.emit(EVENT, '');
+  }
+}

--- a/src/extensions/logger/long-process-logger.ts
+++ b/src/extensions/logger/long-process-logger.ts
@@ -3,7 +3,7 @@ import type { LogPublisher } from '../types';
 
 export const LONG_PROCESS_EVENT = 'longProcess';
 
-export class LogLongProcess {
+export class LongProcessLogger {
   constructor(
     private logPublisher: LogPublisher,
     private extensionName: string,
@@ -19,7 +19,7 @@ export class LogLongProcess {
     emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
-  processItem(itemName = '') {
+  logProgress(itemName = '') {
     this.currentItem += 1;
     const output = `${this.extensionName}, ${this.processDescription} (${this.currentItem}/${this.totalItems}). ${itemName}`;
     this.logPublisher.info(undefined, output);

--- a/src/extensions/logger/long-process-logger.ts
+++ b/src/extensions/logger/long-process-logger.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'events';
 import type { LogPublisher } from '../types';
 
-const EVENT = 'setStatus';
+export const LONG_PROCESS_EVENT = 'longProcess';
 
 export class LogLongProcess {
   constructor(
@@ -14,18 +14,18 @@ export class LogLongProcess {
   ) {
     const output = `${this.extensionName}, ${this.message} (total: ${this.totalItems})`;
     logPublisher.info(undefined, output);
-    emitter.emit(EVENT, output);
+    emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   processItem(itemName = '') {
     this.currentItem += 1;
     const output = `${this.extensionName}, ${this.message} (${this.totalItems}/${this.currentItem}). ${itemName}`;
     this.logPublisher.info(undefined, output);
-    this.emitter.emit(EVENT, output);
+    this.emitter.emit(LONG_PROCESS_EVENT, output);
   }
 
   done() {
     this.logPublisher.info(undefined, `${this.extensionName}, ${this.message} (finished)`);
-    this.emitter.emit(EVENT, '');
+    this.emitter.emit(LONG_PROCESS_EVENT, '');
   }
 }

--- a/src/extensions/reporter/reporter.ts
+++ b/src/extensions/reporter/reporter.ts
@@ -10,6 +10,7 @@ export default class Reporter {
   private statusLine = new StatusLine();
   constructor(private logger: Logger) {
     this.outputShouldBeSuppressed = process.argv.includes('--json') || process.argv.includes('-j');
+    this.logger.subscribe('setStatus', this.setStatusCallback.bind(this));
     process.on('SIGWINCH', () => {
       const columnCount = getColumnCount();
       if (columnCount < this.statusLine.minimumLength + this.statusLine.buffer) {
@@ -19,6 +20,9 @@ export default class Reporter {
         this.statusLine.reRender();
       }
     });
+  }
+  setStatusCallback(message: string) {
+    this.setStatusText(message);
   }
   suppressOutput() {
     this.outputShouldBeSuppressed = true;

--- a/src/extensions/reporter/reporter.ts
+++ b/src/extensions/reporter/reporter.ts
@@ -11,7 +11,6 @@ export default class Reporter {
   private statusLine = new StatusLine();
   constructor(private logger: Logger) {
     this.outputShouldBeSuppressed = process.argv.includes('--json') || process.argv.includes('-j');
-    this.logger.subscribe(LONG_PROCESS_EVENT, this.setStatusCallback.bind(this));
     process.on('SIGWINCH', () => {
       const columnCount = getColumnCount();
       if (columnCount < this.statusLine.minimumLength + this.statusLine.buffer) {
@@ -108,6 +107,9 @@ export default class Reporter {
 
   unsubscribe(extensionName) {
     this.logger.unsubscribe(extensionName);
+  }
+  start() {
+    this.logger.subscribe(LONG_PROCESS_EVENT, this.setStatusCallback.bind(this));
   }
   end() {
     this.statusLine.clear();

--- a/src/extensions/reporter/reporter.ts
+++ b/src/extensions/reporter/reporter.ts
@@ -4,13 +4,14 @@ import chalk from 'chalk';
 import { Logger, LogEntry, LogLevel } from '../logger';
 import StatusLine from './status-line';
 import getColumnCount from './get-column-count';
+import { LONG_PROCESS_EVENT } from '../logger/long-process-logger';
 
 export default class Reporter {
   private outputShouldBeSuppressed = false;
   private statusLine = new StatusLine();
   constructor(private logger: Logger) {
     this.outputShouldBeSuppressed = process.argv.includes('--json') || process.argv.includes('-j');
-    this.logger.subscribe('setStatus', this.setStatusCallback.bind(this));
+    this.logger.subscribe(LONG_PROCESS_EVENT, this.setStatusCallback.bind(this));
     process.on('SIGWINCH', () => {
       const columnCount = getColumnCount();
       if (columnCount < this.statusLine.minimumLength + this.statusLine.buffer) {

--- a/src/extensions/reporter/status-line.ts
+++ b/src/extensions/reporter/status-line.ts
@@ -9,12 +9,18 @@ import getColumnCount from './get-column-count';
 // up for the js runtime speed
 const SPACE_BUFFER = 10;
 
+/**
+ * time in ms.
+ * the timeout is to allow for multiple logs (or multiple `SIGWINCH` events) to pass through
+ */
+const TIME_BETWEEN_RE_RENDERING = 25;
+
 function clearStatusRow() {
   // eslint-disable-next-line no-console
   console.log(`\r${Array(getColumnCount()).fill(' ').join('')}`);
 }
 
-// we send a proxy to the spinner instance rather than proxess.stdout
+// we send a proxy to the spinner instance rather than process.stdout
 // so that we would be able to bypass our monkey-patch of process.stdout
 // this is so that we won't have a case where the stdout "write" method
 // triggers itself through the spinner by doing "spinner.start()" or "spinner.stop()"
@@ -38,7 +44,7 @@ export default class StatusLine {
   private ids: Array<string> = [];
   private ended = false;
   constructor() {
-    this.reRender = debounce(this.reRender, 100);
+    this.reRender = debounce(this.reRender, TIME_BETWEEN_RE_RENDERING);
     // @ts-ignore
     // here we monkey-patch the process.stdout stream so that whatever is printed
     // does not break the status line with the spinner, and that this line always

--- a/src/extensions/types/log-publisher.ts
+++ b/src/extensions/types/log-publisher.ts
@@ -6,5 +6,5 @@ export type LogPublisher = {
   info: (...any) => void;
   warn: (...any) => void;
   error: (...any) => void;
-  createLongProcessLogger: (message: string, totalItems: number) => LogLongProcess;
+  createLongProcessLogger: (message: string, totalItems?: number) => LogLongProcess;
 };

--- a/src/extensions/types/log-publisher.ts
+++ b/src/extensions/types/log-publisher.ts
@@ -6,5 +6,13 @@ export type LogPublisher = {
   info: (...any) => void;
   warn: (...any) => void;
   error: (...any) => void;
-  createLongProcessLogger: (message: string, totalItems?: number) => LongProcessLogger;
+  /**
+   * use it for a long running process. upon creation it logs the `processDescription`.
+   * if the process involves iteration over a list of items, such as running tag on a list of
+   * components, then pass the `totalItems` as the total of the total components in the list.
+   * later, during the iteration, call `LongProcessLogger.logProgress(componentName)`.
+   * once done, call `LongProcessLogger.end()`
+   * if the reporter is used, the status-line will show all messages in the terminal.
+   */
+  createLongProcessLogger: (processDescription: string, totalItems?: number) => LongProcessLogger;
 };

--- a/src/extensions/types/log-publisher.ts
+++ b/src/extensions/types/log-publisher.ts
@@ -1,6 +1,10 @@
+import { LogLongProcess } from '../logger/long-process-logger';
+
 export type LogPublisher = {
+  silly: (...any) => void;
+  debug: (...any) => void;
   info: (...any) => void;
   warn: (...any) => void;
   error: (...any) => void;
-  debug: (...any) => void;
+  createLongProcessLogger: (message: string, totalItems: number) => LogLongProcess;
 };

--- a/src/extensions/types/log-publisher.ts
+++ b/src/extensions/types/log-publisher.ts
@@ -1,4 +1,4 @@
-import { LogLongProcess } from '../logger/long-process-logger';
+import { LongProcessLogger } from '../logger/long-process-logger';
 
 export type LogPublisher = {
   silly: (...any) => void;
@@ -6,5 +6,5 @@ export type LogPublisher = {
   info: (...any) => void;
   warn: (...any) => void;
   error: (...any) => void;
-  createLongProcessLogger: (message: string, totalItems?: number) => LogLongProcess;
+  createLongProcessLogger: (message: string, totalItems?: number) => LongProcessLogger;
 };

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -134,8 +134,7 @@ export default class Workspace implements ComponentFactory {
    * list all workspace components.
    */
   async list(): Promise<Component[]> {
-    const consumerComponents = await this.componentList.getAuthoredAndImportedFromFS();
-    const ids = consumerComponents.map((component) => ComponentID.fromLegacy(component.id));
+    const ids = this.getAllComponentIds();
     return this.getMany(ids);
   }
 

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -318,7 +318,7 @@ export default class Workspace implements ComponentFactory {
       return this.get(id);
     });
     const components = await componentsP;
-    longProcessLogger.done();
+    longProcessLogger.end();
     return components;
   }
 

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -313,11 +313,13 @@ export default class Workspace implements ComponentFactory {
    */
   async getMany(ids: Array<ComponentID>): Promise<Component[]> {
     const idsWithoutEmpty = compact(ids);
+    const longProcessLogger = this.logger.createLongProcessLogger('loading components', ids.length);
     const componentsP = BluebirdPromise.mapSeries(idsWithoutEmpty, async (id: ComponentID) => {
+      longProcessLogger.processItem(id.toString());
       return this.get(id);
     });
     const components = await componentsP;
-
+    longProcessLogger.done();
     return components;
   }
 

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -314,7 +314,7 @@ export default class Workspace implements ComponentFactory {
     const idsWithoutEmpty = compact(ids);
     const longProcessLogger = this.logger.createLongProcessLogger('loading components', ids.length);
     const componentsP = BluebirdPromise.mapSeries(idsWithoutEmpty, async (id: ComponentID) => {
-      longProcessLogger.processItem(id.toString());
+      longProcessLogger.logProgress(id.toString());
       return this.get(id);
     });
     const components = await componentsP;


### PR DESCRIPTION
* log long processes effectively. 
* show them in the status line using the reporter

To log a long process, declare that you start a long-process-logger and give it the number of items. Then, as you continue, you will let this object know what is the current processing item. That's it.

The logger does the following for you:
* It logs everything to the logger with the extension-id and the current progress. (a big improvement from the legacy-logger that there was no progress indication).
* It fires event "logProcess", which the reporter knows to catch and show the progress in the status line nicely.
* When completed it logs the time in ms of the process.