### PR TITLE
show warning on bit-status when a component has trackDir in Harmony

### DIFF
--- a/e2e/commands/show.e2e.2.ts
+++ b/e2e/commands/show.e2e.2.ts
@@ -417,7 +417,7 @@ describe('bit show command', function () {
     });
     describe('when the component is AUTHORED', () => {
       before(() => {
-        helper.command.tagAllComponentsNew();
+        helper.command.tagAllComponents();
       });
       it('should not throw an error "nothing to compare no previous versions found"', () => {
         const showCmd = () => helper.command.showComponent('bar/foo --compare');
@@ -639,7 +639,7 @@ Circle.defaultProps = {
       helper.fs.createFile('baz', 'baz.js'); // a component that not related to other dependencies/dependents
       helper.command.addComponent('baz/baz.js');
       helper.command.linkAndRewire();
-      helper.command.tagAllComponentsNew();
+      helper.command.tagAllComponents();
       helper.command.exportAllComponentsAndRewire();
       helper.scopeHelper.reInitLocalScope();
       helper.scopeHelper.addRemoteScope();

--- a/e2e/harmony/relative-paths.e2e.3.ts
+++ b/e2e/harmony/relative-paths.e2e.3.ts
@@ -47,7 +47,7 @@ describe('relative paths flow (components requiring each other by relative paths
       describe('tagging the component', () => {
         let tagOutput;
         before(() => {
-          tagOutput = helper.command.tagAllComponentsNew();
+          tagOutput = helper.command.tagAllComponents();
         });
         it('should allow tagging the component', () => {
           expect(tagOutput).to.have.string('2 component(s) tagged');

--- a/src/api/consumer/lib/status.ts
+++ b/src/api/consumer/lib/status.ts
@@ -22,6 +22,7 @@ export type StatusResult = {
   mergePendingComponents: DivergedComponent[];
   componentsDuringMergeState: BitIds;
   componentsWithIndividualFiles: Component[];
+  componentsWithTrackDirs: Component[];
 };
 
 export default (async function status(): Promise<StatusResult> {
@@ -78,5 +79,6 @@ export default (async function status(): Promise<StatusResult> {
     mergePendingComponents,
     componentsDuringMergeState,
     componentsWithIndividualFiles: await componentsList.listComponentsWithIndividualFiles(),
+    componentsWithTrackDirs: await componentsList.listComponentsWithTrackDir(),
   };
 });

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -109,6 +109,7 @@ import OutsideRootDir from '../consumer/bit-map/exceptions/outside-root-dir';
 import { FailedLoadForTag } from '../consumer/component/exceptions/failed-load-for-tag';
 import { PaperError } from '../extensions/cli';
 import FlagHarmonyOnly from '../api/consumer/lib/exceptions/flag-harmony-only';
+import { NoComponentDir } from '../consumer/component/exceptions/no-component-dir';
 
 const reportIssueToGithubMsg =
   'This error should have never happened. Please report this issue on Github https://github.com/teambit/bit/issues';
@@ -386,6 +387,11 @@ please make sure it's not absolute and doesn't contain invalid characters`,
       `error: the component ${chalk.bold(
         err.componentId
       )} does not contain a main file.\nplease either use --id to group all added files as one component or use our DSL to define the main file dynamically.\nsee troubleshooting at https://${BASE_DOCS_DOMAIN}/docs/add-and-isolate-components#component-entry-points`,
+  ],
+  [
+    NoComponentDir,
+    (err) => `"${err.id}" doesn't have a component directory, which is invalid on Harmony.
+please run "bit status" to get more info`,
   ],
   [
     MissingMainFileMultipleComponents,

--- a/src/cli/templates/component-issues-template.ts
+++ b/src/cli/templates/component-issues-template.ts
@@ -42,6 +42,8 @@ export function getInvalidComponentLabel(error: Error) {
       return 'component objects are missing from the scope (use "bit import [component_id] --objects" to get them back)';
     case 'IncorrectRootDir':
       return `component has relative import statements (replace to module paths or use "bit link --rewire" to replace.`;
+    case 'NoComponentDir':
+      return `component files were added individually without root directory (invalid on Harmony. re-add as a directory or use "bit move --component" to help with the move)`;
     default:
       return error.name;
   }

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -352,6 +352,9 @@ export default class ComponentsList {
     return this._invalidComponents;
   }
 
+  /**
+   * valid on legacy only. Harmony requires components to have their own directories
+   */
   async listComponentsWithIndividualFiles(): Promise<Component[]> {
     if (this.consumer.isLegacy) return [];
     const workspaceComponents = await this.getFromFileSystem(COMPONENT_ORIGINS.AUTHORED);
@@ -359,6 +362,19 @@ export default class ComponentsList {
       const componentMap = component.componentMap;
       if (!componentMap) throw new Error('listComponentsWithIndividualFiles componentMap is missing');
       return Boolean(!componentMap.trackDir && !componentMap.rootDir);
+    });
+  }
+
+  /**
+   * valid on legacy only. Harmony creates `rootDir` instead of the `trackDir`.
+   */
+  async listComponentsWithTrackDir() {
+    if (this.consumer.isLegacy) return [];
+    const workspaceComponents = await this.getFromFileSystem(COMPONENT_ORIGINS.AUTHORED);
+    return workspaceComponents.filter((component) => {
+      const componentMap = component.componentMap;
+      if (!componentMap) throw new Error('listComponentsWithIndividualFiles componentMap is missing');
+      return Boolean(componentMap.trackDir);
     });
   }
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -67,6 +67,7 @@ import { Issues } from './dependencies/dependency-resolver/dependencies-resolver
 import IncorrectRootDir from './exceptions/incorrect-root-dir';
 import { ExtensionDataList } from '../config/extension-data';
 import { isSchemaSupport, SchemaFeature, CURRENT_SCHEMA, SchemaName } from './component-schema';
+import { NoComponentDir } from './exceptions/no-component-dir';
 
 export type CustomResolvedPath = { destinationPath: PathLinux; importSource: string };
 
@@ -873,6 +874,7 @@ export default class Component {
       ComponentsPendingImport,
       IncorrectRootDir,
       ExtensionFileNotFound,
+      NoComponentDir,
     ];
     return invalidComponentErrors.some((errorType) => err instanceof errorType);
   }

--- a/src/consumer/component/exceptions/no-component-dir.ts
+++ b/src/consumer/component/exceptions/no-component-dir.ts
@@ -1,0 +1,9 @@
+import AbstractError from '../../../error/abstract-error';
+
+export class NoComponentDir extends AbstractError {
+  id: string;
+  constructor(id: string) {
+    super();
+    this.id = id;
+  }
+}

--- a/src/consumer/migrations/harmony-migrator.ts
+++ b/src/consumer/migrations/harmony-migrator.ts
@@ -45,7 +45,7 @@ before starting the migration, please re-init the workspace as harmony by follow
       logger.console(results.changedToRootDir.join('\n'));
     }
     logger.console(
-      chalk.white.bold('please run "bit status" to make sure the workspace is error-free before continue working')
+      chalk.white.bold('\nplease run "bit status" to make sure the workspace is error-free before continue working')
     );
   }
 }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -148,15 +148,9 @@ export default class CommandHelper {
     if (assertTagged) expect(result).to.not.have.string(NOTHING_TO_TAG_MSG);
     return result;
   }
-  // @todo: change to tagAllComponents
-  tagAllComponentsNew(options = '', version = '', assertTagged = true) {
-    const result = this.runCmd(`bit tag -a ${version} ${options}`);
-    if (assertTagged) expect(result).to.not.have.string(NOTHING_TO_TAG_MSG);
-    return result;
-  }
   rewireAndTagAllComponents(options = '', version = '', assertTagged = true) {
     this.linkAndRewire();
-    return this.tagAllComponentsNew(options, version, assertTagged);
+    return this.tagAllComponents(options, version, assertTagged);
   }
   tagScope(version: string, message = 'tag-message', options = '') {
     return this.runCmd(`bit tag -s ${version} -m ${message} ${options}`);

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -63,6 +63,10 @@ export default class ScopeHelper {
   }
   reInitLocalScopeHarmony() {
     this.cleanLocalScope();
+    this.initHarmonyWorkspace();
+  }
+
+  initHarmonyWorkspace() {
     this.command.runCmd('bit init', undefined, undefined, HARMONY_FEATURE);
   }
 
@@ -222,5 +226,10 @@ export default class ScopeHelper {
 
   getClonedRemoteScope(clonedScopePath: string) {
     return this.getClonedScope(clonedScopePath, this.scopes.remotePath);
+  }
+
+  switchFromLegacyToHarmony() {
+    fs.removeSync(path.join(this.scopes.localPath, 'bit.json'));
+    this.initHarmonyWorkspace();
   }
 }

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -33,6 +33,7 @@ import { OnComponentLoadSlot, OnComponentChangeSlot } from './workspace.provider
 import { OnComponentLoad } from './on-component-load';
 import { OnComponentChange, OnComponentChangeResult } from './on-component-change';
 import { IsolateComponentsOptions } from '../isolator/isolator.extension';
+import { NoComponentDir } from '../../consumer/component/exceptions/no-component-dir';
 
 export type EjectConfResult = {
   configPath: string;
@@ -357,8 +358,7 @@ export default class Workspace implements ComponentFactory {
     const componentMap = this.consumer.bitMap.getComponent(componentId._legacy, bitMapOptions);
     const relativeComponentDir = componentMap.getComponentDir();
     if (!relativeComponentDir) {
-      throw new GeneralError(`workspace.componentDir failed finding the component directory for ${componentId.toString()}.
-if you migrated to Harmony, please run "bit status" to fix such errors`);
+      throw new NoComponentDir(componentId.toString());
     }
     if (options.relative) {
       return relativeComponentDir;

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -24,7 +24,6 @@ import legacyLogger from '../../logger/logger';
 import { removeExistingLinksInNodeModules, symlinkCapsulesInNodeModules } from './utils';
 import { ComponentConfigFile } from './component-config-file';
 import { ExtensionDataList, ExtensionDataEntry } from '../../consumer/config/extension-data';
-import GeneralError from '../../error/general-error';
 import { GetBitMapComponentOptions } from '../../consumer/bit-map/bit-map';
 import { pathIsInside } from '../../utils';
 import Config from '../component/config';


### PR DESCRIPTION
* show warning on bit-status when a component has trackDir in Harmony, suggest to run `bit migrate --harmony`.
* fix the error of no-component-dir to be caught on bit-status and show a descriptive message with suggestions on how to fix.