### PR TITLE
fix saving a component with incorrect dependency version

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
@@ -73,7 +73,7 @@ export default function updateDependenciesVersions(consumer: Consumer, component
       ];
     } else {
       // @todo: change this once vendors feature is in.
-      const getCurrentVersion = () => (id.hasVersion() ? id.version : null);
+      const getCurrentVersion = () => (id.hasVersion() ? id : null);
       strategies = [getFromComponentConfig, getCurrentVersion, getFromBitMap, getFromModel];
     }
 

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -27,9 +27,7 @@ import { CURRENT_SCHEMA } from '../../consumer/component/component-schema';
 
 function updateDependenciesVersions(componentsToTag: Component[]): void {
   const getNewDependencyVersion = (id: BitId): BitId | null => {
-    const foundDependency = componentsToTag.find(
-      (component) => component.id.isEqualWithoutVersion(id) || component.id.isEqualWithoutScopeAndVersion(id)
-    );
+    const foundDependency = componentsToTag.find((component) => component.id.isEqualWithoutVersion(id));
     return foundDependency ? id.changeVersion(foundDependency.version) : null;
   };
   componentsToTag.forEach((oneComponentToTag) => {


### PR DESCRIPTION
when a scope has the same name with different scope-name.