### PR TITLE
fix ComponentNotFound when tagging after export for author

### DIFF
--- a/e2e/commands/show.e2e.2.ts
+++ b/e2e/commands/show.e2e.2.ts
@@ -146,7 +146,6 @@ describe('bit show command', function () {
       // TODO: get the version dynamically
       it('should include the compiler correctly', () => {
         const outputCompiler = output.compiler;
-        expect(outputCompiler.files).to.be.an('array').that.is.empty;
         expect(outputCompiler.config).to.be.an('object').that.is.empty;
         expect(outputCompiler.name).have.string(`${helper.scopes.env}/compilers/babel${VERSION_DELIMITER}0.0.1`);
       });
@@ -206,7 +205,6 @@ describe('bit show command', function () {
         });
         it('should display the compiler of the component', () => {
           const outputCompiler = output.compiler;
-          expect(outputCompiler.files).to.be.an('array').that.is.empty;
           expect(outputCompiler.config).to.be.an('object').that.is.empty;
           expect(outputCompiler.name).have.string(`${helper.scopes.env}/compilers/babel${VERSION_DELIMITER}0.0.1`);
         });

--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -957,4 +957,25 @@ describe('bit tag command', function () {
       expect(output).to.have.string('this dependency was not included in the tag command');
     });
   });
+  describe('tag on Harmony', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.addDefaultScope();
+      helper.fixtures.populateComponents();
+      helper.command.linkAndRewire();
+      helper.command.tagAllComponents();
+      helper.command.exportAllComponents();
+      helper.command.tagScope('0.0.2');
+    });
+    it('should not show the component as modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponent).to.be.empty;
+    });
+    // this happens as a result of package.json in the node_modules for author point to the wrong
+    // version. currently, the version is removed.
+    it('should not show the dependency with an older version', () => {
+      const show = helper.command.showComponentParsed('comp1');
+      expect(show.dependencies[0].id).to.equal(`${helper.scopes.remote}/comp2@0.0.2`);
+    });
+  });
 });

--- a/src/cli/commands/public-cmds/show-cmd.ts
+++ b/src/cli/commands/public-cmds/show-cmd.ts
@@ -103,30 +103,15 @@ export default class Show implements LegacyCommand {
       component.scopesList = component.componentFromModel.scopesList;
     }
     if (json) {
-      const makeEnvFilesReadable = (env) => {
-        if (!env) return undefined;
-        if (env.files && env.files.length) {
-          const readableFiles = env.files.map((file) => file.toReadableString());
-          return readableFiles;
-        }
-        return [];
-      };
-
       const makeComponentReadable = (comp: ConsumerComponent) => {
         if (!comp) return comp;
         const componentObj = comp.toObject();
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         componentObj.files = comp.files.map((file) => file.toReadableString());
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         componentObj.dists = componentObj.dists.getAsReadable();
-        if (comp.compiler) {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          componentObj.compiler.files = makeEnvFilesReadable(comp.compiler);
-        }
-        if (comp.tester) {
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          componentObj.tester.files = makeEnvFilesReadable(comp.tester);
+        if (comp.extensions && comp.extensions.length) {
+          componentObj.extensions.forEach(
+            (extension) => (extension.artifacts = extension.artifacts.map((file) => file.toReadableString()))
+          );
         }
 
         if (comp.componentMap) {

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
@@ -74,7 +74,9 @@ function groupDependencyList(list, componentDir: string, bindingPrefix: string):
       // If the package is actually a component add it to the components (bits) list
       if (resolvedPackage) {
         const version = resolvedPackage.versionUsedByDependent || resolvedPackage.concreteVersion;
-        if (!version) throw new Error(`unable to find the version for a package ${packagePath}`);
+        // @todo: currently, for author, the package.json doesn't have any version.
+        // we might change this decision later. see https://github.com/teambit/bit/pull/2924
+        // if (!version) throw new Error(`unable to find the version for a package ${packagePath}`);
         if (resolvedPackage.componentId) {
           resultGroups.bits.push(resolvedPackage);
         } else {

--- a/src/extensions/isolator/symlink-dependencies-to-capsules.ts
+++ b/src/extensions/isolator/symlink-dependencies-to-capsules.ts
@@ -6,17 +6,18 @@ import { BitId } from '../../bit-id';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
 import Symlink from '../../links/symlink';
 import { ComponentID } from '../component';
-import logger from '../../logger/logger';
+import { Logger } from '../logger';
 
-export async function symlinkDependenciesToCapsules(capsules: Capsule[], capsuleList: CapsuleList) {
+export async function symlinkDependenciesToCapsules(capsules: Capsule[], capsuleList: CapsuleList, logger: Logger) {
+  logger.debug(`symlinkDependenciesToCapsules, ${capsules.length} capsules`);
   await Promise.all(
     capsules.map((capsule) => {
-      return symlinkComponent(capsule.component.state._consumer, capsuleList);
+      return symlinkComponent(capsule.component.state._consumer, capsuleList, logger);
     })
   );
 }
 
-async function symlinkComponent(component: ConsumerComponent, capsuleList: CapsuleList) {
+async function symlinkComponent(component: ConsumerComponent, capsuleList: CapsuleList, logger: Logger) {
   const componentCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(new ComponentID(component.id));
   if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
   const allDeps = component.getAllDependenciesIds();

--- a/src/extensions/workspace/capsule-list.cmd.ts
+++ b/src/extensions/workspace/capsule-list.cmd.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command, CommandOptions } from '../cli';
-import { IsolatorExtension, ListResults } from '../isolator/isolator.extension';
-import { loadConsumerIfExist } from '../../consumer';
+import { IsolatorExtension } from '../isolator/isolator.extension';
+import { Workspace } from './workspace';
 
 export class CapsuleListCmd implements Command {
   name = 'capsule-list';
@@ -12,25 +12,19 @@ export class CapsuleListCmd implements Command {
   alias = '';
   options = [['j', 'json', 'json format']] as CommandOptions;
 
-  constructor(private isolator: IsolatorExtension) {}
-
-  async getList(): Promise<ListResults> {
-    // TODO: remove this consumer loading from here. it shouldn't be here
-    const consumer = await loadConsumerIfExist();
-    // TODO: throw a proper error instance
-    if (!consumer) throw new Error('no consumer found');
-    const results = await this.isolator.list(consumer);
-    return results;
-  }
+  constructor(private isolator: IsolatorExtension, private workspace: Workspace) {}
 
   async report() {
-    const list = await this.getList();
+    const list = await this.isolator.list(this.workspace.path);
+    const rootDir = this.isolator.getCapsulesRootDir(this.workspace.path);
     // TODO: improve output
-    return chalk.green(`found ${list.capsules.length} capsule(s) for workspace ${list.workspace}`);
+    return chalk.green(`found ${list.capsules.length} capsule(s) for workspace ${list.workspace}.
+capsules root-dir: ${rootDir}
+use --json to get the list of all capsules`);
   }
 
   async json() {
-    const list = await this.getList();
+    const list = await this.isolator.list(this.workspace.path);
     return list;
   }
 }

--- a/src/extensions/workspace/workspace.provider.ts
+++ b/src/extensions/workspace/workspace.provider.ts
@@ -108,7 +108,7 @@ export default async function provideWorkspace(
       cli.register(new InstallCmd(workspace));
       cli.register(new EjectConfCmd(workspace));
 
-      const capsuleListCmd = new CapsuleListCmd(isolator);
+      const capsuleListCmd = new CapsuleListCmd(isolator, workspace);
       const capsuleCreateCmd = new CapsuleCreateCmd(workspace);
       cli.register(capsuleListCmd);
       cli.register(capsuleCreateCmd);

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -379,6 +379,9 @@ export default class NodeModuleLinker {
     );
     const packageJson = PackageJsonFile.createFromComponent(dest, component);
     packageJson.mergePropsFromExtensions(component);
+    // delete the version, otherwise, we have to maintains it. such as, when tagging, it should be
+    // changed to the new tagged version.
+    delete packageJson.packageJsonObject.version;
     this.dataToPersist.addFile(packageJson.toVinylFile());
   }
 

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -79,8 +79,10 @@ function enrichDataFromDependency(packageData: ResolvedPackageData) {
   const packageInfo = PackageJson.loadSync(packageDir);
 
   // when running 'bitjs get-dependencies' command, packageInfo is sometimes empty
-  // or when using custom-module-resolution it may be empty or the name/version are empty
-  if (!packageInfo || !packageInfo.name || !packageInfo.version) {
+  // or when using custom-module-resolution it may be empty
+  // the version can be empty when creating the package.json for author, that's fine, we still
+  // need the component-id in this case.
+  if (!packageInfo || !packageInfo.name) {
     return;
   }
   packageData.name = packageInfo.name;


### PR DESCRIPTION
* On Harmony when exporting a component, the package.json for authored was changed to include the version. However, when tagging later, that version wasn't changed. 
As a result, the dependency-version-resolution was using the wrong version on the package.json.
This was fixed by removing the version field altogether, so then no need to maintain it.

* improve the capsule-list command to show the rootDir of the capsules.

* fix bit show --json to show the artifacts as strings and not as buffers.
