### PR TITLE
enable init legacy workspace as Harmony using bit migrate command

### DIFF
--- a/e2e/harmony/migrate.e2e.ts
+++ b/e2e/harmony/migrate.e2e.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+import { WORKSPACE_JSONC } from '../../src/constants';
+
+chai.use(require('chai-fs'));
+
+describe('migrating legacy workspace to Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('running bit migrate --harmony on a legacy workspace with multiple components', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents();
+      output = helper.command.runCmd('bit migrate --harmony');
+    });
+    it('should keep .bitmap file', () => {
+      const bitmap = helper.bitMap.readComponentsMapOnly();
+      expect(Object.keys(bitmap).length).to.equal(3);
+    });
+    it('should backup and remove bit.json file', () => {
+      expect(path.join(helper.scopes.localPath, 'bit.json')).to.not.be.a.path();
+      expect(path.join(helper.scopes.localPath, 'bit.json.legacy')).to.be.a.file();
+    });
+    it('should create workspace.jsonc file', () => {
+      expect(path.join(helper.scopes.localPath, WORKSPACE_JSONC)).to.be.a.file();
+    });
+    it('should indicate in the output about moving the bit.json file', () => {
+      expect(output).to.have.string('has been renamed to include ".legacy" suffix');
+    });
+  });
+});

--- a/src/api/consumer/lib/init.ts
+++ b/src/api/consumer/lib/init.ts
@@ -5,7 +5,7 @@ import { isDirEmpty } from '../../../utils';
 import ObjectsWithoutConsumer from './exceptions/objects-without-consumer';
 import { WorkspaceConfigProps } from '../../../consumer/config/workspace-config';
 
-export default (async function init(
+export default async function init(
   absPath: string = process.cwd(),
   noGit = false,
   reset = false,
@@ -21,7 +21,7 @@ export default (async function init(
     await throwForOutOfSyncScope(consumer);
   }
   return consumer.write();
-});
+}
 
 /**
  * throw an error when .bitmap is empty but a scope has objects.

--- a/src/api/consumer/lib/migrate.ts
+++ b/src/api/consumer/lib/migrate.ts
@@ -43,7 +43,7 @@ export default async function migrate(
 export async function migrateToHarmony() {
   const consumer = await loadConsumer();
   const harmonyMigrator = new HarmonyMigrator(consumer);
-  const results = harmonyMigrator.migrate();
+  const results = await harmonyMigrator.migrate();
   await consumer.onDestroy();
   return results;
 }

--- a/src/consumer/config/workspace-config.ts
+++ b/src/consumer/config/workspace-config.ts
@@ -184,17 +184,17 @@ export default class WorkspaceConfig extends AbstractConfig {
   }
 
   static async _ensure(
-    dirPath: PathOsBasedAbsolute,
+    workspacePath: PathOsBasedAbsolute,
     standAlone: boolean,
     workspaceConfigProps: WorkspaceConfigProps = {} as any
   ): Promise<WorkspaceConfig> {
     try {
-      const workspaceConfig = await this.load(dirPath);
+      const workspaceConfig = await this.load(workspacePath);
       return workspaceConfig;
     } catch (err) {
       if (err instanceof BitConfigNotFound || err instanceof InvalidBitJson) {
         const consumerBitJson = this.create(workspaceConfigProps);
-        const packageJsonExists = await AbstractConfig.pathHasPackageJson(dirPath);
+        const packageJsonExists = await AbstractConfig.pathHasPackageJson(workspacePath);
         if (packageJsonExists && !standAlone) {
           consumerBitJson.writeToPackageJson = true;
         } else {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -860,7 +860,8 @@ export default class Consumer {
     if (!consumerInfo) {
       return Promise.reject(new ConsumerNotFound());
     }
-    let consumer;
+    let consumer: Consumer | undefined;
+
     if ((!consumerInfo.hasConsumerConfig || !consumerInfo.hasScope) && consumerInfo.hasBitMap) {
       consumer = await Consumer.create(consumerInfo.path);
       await Promise.all([consumer.config.write({ workspaceDir: consumer.projectPath }), consumer.scope.ensureDir()]);

--- a/src/consumer/migrations/harmony-migrator.ts
+++ b/src/consumer/migrations/harmony-migrator.ts
@@ -1,17 +1,22 @@
+import fs from 'fs-extra';
+import path from 'path';
 import chalk from 'chalk';
 import { Consumer } from '..';
-import { COMPONENT_ORIGINS } from '../../constants';
+import { COMPONENT_ORIGINS, WORKSPACE_JSONC } from '../../constants';
 import logger from '../../logger/logger';
 import { individualFilesDesc } from '../../cli/commands/public-cmds/status-cmd';
 import GeneralError from '../../error/general-error';
+import PackageJsonFile from '../component/package-json-file';
+import { addFeature, HARMONY_FEATURE } from '../../api/consumer/lib/feature-toggle';
 
 type MigrateResult = { individualFiles: string[]; changedToRootDir: string[] };
 
 export class HarmonyMigrator {
+  private messages: string[] = [];
   constructor(private consumer: Consumer) {}
 
-  migrate(): MigrateResult {
-    this.throwOnLegacy();
+  async migrate() {
+    await this.initAsHarmony();
     const status: MigrateResult = { individualFiles: [], changedToRootDir: [] };
     const authorComponents = this.consumer.bitMap.getAllComponents(COMPONENT_ORIGINS.AUTHORED);
     authorComponents.forEach((componentMap) => {
@@ -25,7 +30,38 @@ export class HarmonyMigrator {
       this.consumer.bitMap.markAsChanged();
     });
     this.printResults(status);
-    return status;
+    this.printMessages();
+  }
+  private async initAsHarmony() {
+    if (!this.consumer.isLegacy) return; // it's already Harmony.
+    this.backupAndRemoveBitJson();
+    this.backupAndRemoveBitPropInPkgJson();
+    addFeature(HARMONY_FEATURE);
+    const workspacePath = this.consumer.getPath();
+    // because Harmony feature is added, the load writes the workspace.jsonc because the configuration
+    // files are now missing.
+    const consumer = await Consumer.load(workspacePath);
+    if (!fs.existsSync(path.join(workspacePath, WORKSPACE_JSONC))) {
+      throw new Error('failed initializing the workspace as Harmony');
+    }
+    this.messages.push('congratulations! your workspace has been initialized as Harmony');
+    this.consumer = consumer;
+  }
+  private async backupAndRemoveBitPropInPkgJson() {
+    const packageJsonFile = await PackageJsonFile.load(this.consumer.getPath());
+    if (!packageJsonFile.packageJsonObject.bit) return;
+    packageJsonFile.packageJsonObject['bit-legacy'] = packageJsonFile.packageJsonObject.bit;
+    delete packageJsonFile.packageJsonObject.bit;
+    await packageJsonFile.write();
+    this.messages.push(`Harmony doesn't work with the previous "bit" property in the package.json.
+this property has been renamed to "bit-legacy". delete it once you don't need it.`);
+  }
+  private backupAndRemoveBitJson() {
+    const bitJsonPath = path.join(this.consumer.getPath(), 'bit.json');
+    if (!fs.existsSync(bitJsonPath)) return;
+    fs.moveSync(bitJsonPath, `${bitJsonPath}.legacy`);
+    this.messages.push(`Harmony doesn't work with your previous configuration file ${bitJsonPath}.
+this file has been renamed to include ".legacy" suffix. delete it once you don't need it.`);
   }
   private throwOnLegacy() {
     if (this.consumer.isLegacy) {
@@ -44,8 +80,11 @@ before starting the migration, please re-init the workspace as harmony by follow
       logger.console(chalk.green('the following components were successfully converted from trackDir to rootDir'));
       logger.console(results.changedToRootDir.join('\n'));
     }
-    logger.console(
-      chalk.white.bold('\nplease run "bit status" to make sure the workspace is error-free before continue working')
-    );
+    this.messages.push('please run "bit status" to make sure the workspace is error-free before continue working');
+  }
+  printMessages() {
+    this.messages.forEach((message) => {
+      logger.console(chalk.bold(`\n[-] ${message}`));
+    });
   }
 }


### PR DESCRIPTION
Currently, the `.bitmap` file must be deleted and the legacy configuration files must be removed in order to init the workspace as Harmony.
This is fixed to let `bit migrate --harmony` backup the configuration files and init harmony while keeping the .bitmap file.