### PR TITLE
on harmony: "bit run" => "bit build". "bit test-new" => "bit test"

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -181,7 +181,7 @@ describe('publish functionality', function () {
       npmCiRegistry.configureCustomNameInPackageJsonHarmony('invalid/name/{name}');
     });
     it('builder should show the npm error about invalid name', () => {
-      const output = helper.general.runWithTryCatch('bit run');
+      const output = helper.general.runWithTryCatch('bit build');
       expect(output).to.have.string('npm ERR! Invalid name: "invalid/name/comp1"');
     });
   });

--- a/src/extensions/builder/builder.extension.ts
+++ b/src/extensions/builder/builder.extension.ts
@@ -135,8 +135,10 @@ export class BuilderExtension {
     graphql.register(builderSchema(builder));
     const func = builder.tagListener.bind(builder);
     if (scope) scope.onTag(func);
-
-    cli.register(new BuilderCmd(builder, workspace, logger));
+    if (workspace && !workspace.consumer.isLegacy) {
+      cli.unregister('build');
+      cli.register(new BuilderCmd(builder, workspace, logger));
+    }
     cli.register(new TagCmd(logger));
     return builder;
   }

--- a/src/extensions/builder/run.cmd.tsx
+++ b/src/extensions/builder/run.cmd.tsx
@@ -6,7 +6,7 @@ import { Logger } from '../logger';
 import { ConsumerNotFound } from '../../consumer/exceptions';
 
 export class BuilderCmd implements Command {
-  name = 'run [pattern]';
+  name = 'build [pattern]';
   description = 'run set of tasks for build';
   alias = '';
   group = '';

--- a/src/extensions/cli/cli.extension.ts
+++ b/src/extensions/cli/cli.extension.ts
@@ -44,13 +44,20 @@ export class CLIExtension {
     }
   }
   /**
-   * registers a new command in to `Paper`.
+   * registers a new command in to the CLI.
    */
   register(command: Command) {
     this.setDefaults(command);
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     command.commands!.forEach((cmd) => this.setDefaults(cmd));
     this.registry.register(command);
+  }
+
+  /**
+   * helpful for having the same command name in different environments (legacy and Harmony)
+   */
+  unregister(commandName: string) {
+    delete this.commands[commandName];
   }
 
   /**

--- a/src/extensions/compiler/README.md
+++ b/src/extensions/compiler/README.md
@@ -3,7 +3,7 @@
 The compiler is configured inside an environment and not directly on the component level.
 
 ## As a task
-A task is running with `bit run` or during the tag process on the capsules or the workspace (depends on the specific compiler implementation).
+A task is running with `bit build` or during the tag process on the capsules or the workspace (depends on the specific compiler implementation).
 The env extension should have this compiler extension as a dependency first, then add to the `build()` array the following: `this.compiler.task`.
 
 ## As a command

--- a/src/extensions/environments/README.md
+++ b/src/extensions/environments/README.md
@@ -9,7 +9,7 @@ The class of the environment extension needs to implement the `Environment` inte
 ```
 getPipe(): BuildTask[];
 ```
-There are the tasks that will be running on "bit tag"/"bit run". If you have a compiler setup, it should include `this.compiler.task`. Also, it is recommended to add the dry-run task of the publisher: `this.pkg.dryRunTask`.
+There are the tasks that will be running on "bit tag"/"bit build". If you have a compiler setup, it should include `this.compiler.task`. Also, it is recommended to add the dry-run task of the publisher: `this.pkg.dryRunTask`.
 See the react.env.ts for a detailed example.
 
 Also, it is recommended to implement the following:

--- a/src/extensions/tester/test.cmd.tsx
+++ b/src/extensions/tester/test.cmd.tsx
@@ -8,7 +8,7 @@ import { Workspace } from '../workspace';
 import { ConsumerNotFound } from '../../consumer/exceptions';
 
 export class TestCmd implements Command {
-  name = 'test-new [pattern]';
+  name = 'test [pattern]';
   description = 'test set of components in your workspace';
   alias = 'at';
   private = true;

--- a/src/extensions/tester/tester.extension.ts
+++ b/src/extensions/tester/tester.extension.ts
@@ -61,7 +61,10 @@ export class TesterExtension {
       new TesterService(workspace, config.testRegex),
       new TesterTask(TesterExtension.id)
     );
-    cli.register(new TestCmd(tester, workspace));
+    if (workspace && !workspace.consumer.isLegacy) {
+      cli.unregister('test');
+      cli.register(new TestCmd(tester, workspace));
+    }
 
     return tester;
   }


### PR DESCRIPTION
These commands: build and test are used in the legacy workspace differently.
This PR makes sure that on Harmony the old commands are unregistered and the new are registered.
