### PR TITLE
improve performance of flattened-dependency-loader dramatically

### DIFF
--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -7,67 +7,70 @@ import BitIds from '../../bit-id/bit-ids';
 import BitId from '../../bit-id/bit-id';
 import { COMPONENT_ORIGINS } from '../../constants';
 
-export default async function loadFlattenedDependenciesForCapsule(
-  consumer: Consumer,
-  component: Component
-): Promise<ComponentWithDependencies> {
-  const dependencies = await loadManyDependencies(component.dependencies.getAllIds());
-  const devDependencies = await loadManyDependencies(component.devDependencies.getAllIds());
-  const extensionDependencies = await loadManyDependencies(component.extensions.extensionsBitIds);
-  await loadFlattened(dependencies);
-  await loadFlattened(devDependencies);
-  await loadFlattened(extensionDependencies);
+export class FlattenedDependencyLoader {
+  private cache: { [bitIdStr: string]: Component } = {};
+  constructor(private consumer: Consumer) {}
+  async load(component: Component) {
+    const dependencies = await this.loadManyDependencies(component.dependencies.getAllIds());
+    const devDependencies = await this.loadManyDependencies(component.devDependencies.getAllIds());
+    const extensionDependencies = await this.loadManyDependencies(component.extensions.extensionsBitIds);
+    await this.loadFlattened(dependencies);
+    await this.loadFlattened(devDependencies);
+    await this.loadFlattened(extensionDependencies);
 
-  return new ComponentWithDependencies({
-    component,
-    dependencies,
-    devDependencies,
-    extensionDependencies,
-  });
-
-  async function loadManyDependencies(dependenciesIds: BitId[]): Promise<Component[]> {
-    return pMapSeries(dependenciesIds, (dep: BitId) => loadDependency(dep));
+    return new ComponentWithDependencies({
+      component,
+      dependencies,
+      devDependencies,
+      extensionDependencies,
+    });
+  }
+  async loadManyDependencies(dependenciesIds: BitId[]): Promise<Component[]> {
+    return pMapSeries(dependenciesIds, (dep: BitId) => this.loadDependency(dep));
   }
 
-  async function loadDependency(dependencyId: BitId): Promise<Component> {
-    const componentMap = consumer.bitMap.getComponentIfExist(dependencyId);
-    const couldBeModified = componentMap && componentMap.origin !== COMPONENT_ORIGINS.NESTED;
-    if (couldBeModified) {
-      return consumer.loadComponentForCapsule(dependencyId);
+  async loadDependency(dependencyId: BitId): Promise<Component> {
+    if (!this.cache[dependencyId.toString()]) {
+      const componentMap = this.consumer.bitMap.getComponentIfExist(dependencyId);
+      const couldBeModified = componentMap && componentMap.origin !== COMPONENT_ORIGINS.NESTED;
+      if (couldBeModified) {
+        return this.consumer.loadComponentForCapsule(dependencyId);
+      }
+      // for capsule, a dependency might have been installed as a package in the workspace, and as
+      // such doesn't have a componentMap, which result in not stripping the sharedDir.
+      // using the loadComponentWithDependenciesFromModel, all dependencies are loaded and their
+      // shared dir is stripped. (see e2e-test of 'isolating with capsule' in dependencies-as-packages.e2e file)
+      const componentWithDependenciesFromModel = await this.consumer.loadComponentWithDependenciesFromModel(
+        dependencyId,
+        false
+      );
+      this.cache[dependencyId.toString()] = componentWithDependenciesFromModel.component.clone();
     }
-    // for capsule, a dependency might have been installed as a package in the workspace, and as
-    // such doesn't have a componentMap, which result in not stripping the sharedDir.
-    // using the loadComponentWithDependenciesFromModel, all dependencies are loaded and their
-    // shared dir is stripped. (see e2e-test of 'isolating with capsule' in dependencies-as-packages.e2e file)
-    const componentWithDependenciesFromModel = await consumer.loadComponentWithDependenciesFromModel(
-      dependencyId,
-      false
-    );
-    return componentWithDependenciesFromModel.component.clone();
+    return this.cache[dependencyId.toString()];
   }
 
-  async function loadFlattened(deps: Component[]) {
+  async loadFlattened(deps: Component[]) {
     if (R.isEmpty(deps)) return;
-    await loadFlattenedFromModel(deps);
-    await loadFlattenedFromFsRecursively(deps);
+    await this.loadFlattenedFromModel(deps);
+    await this.loadFlattenedFromFsRecursively(deps);
   }
 
-  async function loadFlattenedFromModel(deps: Component[]) {
+  async loadFlattenedFromModel(deps: Component[]) {
     const dependenciesFromModel = deps.filter((d) => !d.loadedFromFileSystem);
     const flattenedIdsFromModel = dependenciesFromModel.map((d) => d.flattenedDependencies);
-    const flattenedFromModel = await loadManyDependencies(R.flatten(flattenedIdsFromModel));
+    const flattenedFromModel = await this.loadManyDependencies(R.flatten(flattenedIdsFromModel));
     deps.push(...flattenedFromModel);
   }
 
-  async function loadFlattenedFromFsRecursively(components: Component[]) {
+  async loadFlattenedFromFsRecursively(components: Component[]) {
     const currentIds = BitIds.fromArray(components.map((c) => c.id));
     const ids = R.flatten(components.filter((c) => c.loadedFromFileSystem).map((c) => c.getAllDependenciesIds()));
     const idsUniq = BitIds.uniqFromArray(ids);
     const newIds = idsUniq.filter((id) => !currentIds.has(id));
     if (R.isEmpty(newIds)) return;
-    const deps = await loadManyDependencies(newIds);
+    const deps = await this.loadManyDependencies(newIds);
     if (R.isEmpty(deps)) return;
     components.push(...deps);
-    await loadFlattened(components);
+    await this.loadFlattened(components);
   }
 }

--- a/src/environment/isolator.ts
+++ b/src/environment/isolator.ts
@@ -10,7 +10,7 @@ import { Scope, ComponentWithDependencies } from '../scope';
 import { BitId } from '../bit-id';
 import ManyComponentsWriter, { ManyComponentsWriterParams } from '../consumer/component-ops/many-components-writer';
 import logger from '../logger/logger';
-import loadFlattenedDependenciesForCapsule from '../consumer/component-ops/load-flattened-dependencies';
+import { FlattenedDependencyLoader } from '../consumer/component-ops/load-flattened-dependencies';
 import PackageJsonFile from '../consumer/component/package-json-file';
 import Component from '../consumer/component/consumer-component';
 import { convertToValidPathForPackageManager } from '../consumer/component/package-json-utils';
@@ -196,7 +196,8 @@ export default class Isolator {
     const consumer = this.consumer;
     if (!consumer) throw new Error('missing consumer');
     const component = await consumer.loadComponentForCapsule(id);
-    return loadFlattenedDependenciesForCapsule(consumer, component);
+    const flattenedDependencyLoader = new FlattenedDependencyLoader(consumer);
+    return flattenedDependencyLoader.load(component);
   }
 
   async _persistComponentsDataToCapsule(opts = { keepExistingCapsule: false }) {

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -4,9 +4,7 @@ import graphLib, { Graph as GraphLib } from 'graphlib';
 import Graph from './graph';
 import Component from '../../consumer/component/consumer-component';
 import Dependencies from '../../consumer/component/dependencies/dependencies';
-import loadFlattenedDependenciesForCapsule, {
-  FlattenedDependencyLoader,
-} from '../../consumer/component-ops/load-flattened-dependencies';
+import { FlattenedDependencyLoader } from '../../consumer/component-ops/load-flattened-dependencies';
 import ComponentWithDependencies from '../component-dependencies';
 import GeneralError from '../../error/general-error';
 import { ComponentsAndVersions } from '../scope';

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -4,7 +4,9 @@ import graphLib, { Graph as GraphLib } from 'graphlib';
 import Graph from './graph';
 import Component from '../../consumer/component/consumer-component';
 import Dependencies from '../../consumer/component/dependencies/dependencies';
-import loadFlattenedDependenciesForCapsule from '../../consumer/component-ops/load-flattened-dependencies';
+import loadFlattenedDependenciesForCapsule, {
+  FlattenedDependencyLoader,
+} from '../../consumer/component-ops/load-flattened-dependencies';
 import ComponentWithDependencies from '../component-dependencies';
 import GeneralError from '../../error/general-error';
 import { ComponentsAndVersions } from '../scope';
@@ -71,8 +73,9 @@ export async function buildOneGraphForComponents(
   direction: 'normal' | 'reverse' = 'normal'
 ): Promise<Graph> {
   const { components } = await consumer.loadComponents(BitIds.fromArray(ids));
+  const flattenedDependencyLoader = new FlattenedDependencyLoader(consumer);
   const componentsWithDeps = await pMapSeries(components, (component: Component) =>
-    loadFlattenedDependenciesForCapsule(consumer, component)
+    flattenedDependencyLoader.load(component)
   );
   const allComponents: Component[] = R.flatten(componentsWithDeps.map((c) => [c.component, ...c.allDependencies]));
 


### PR DESCRIPTION
Huge performance improvement when loading bit-bin extensions as components. (from 15 minutes to 30 seconds).
The mechanism of the loading the flattened dependencies was inefficient and repetitive. Improve it by caching the results.