### PR TITLE
fix terminal stdout to not be taken by bit-bin

### DIFF
--- a/src/cli/loader/loader.ts
+++ b/src/cli/loader/loader.ts
@@ -73,47 +73,7 @@ export class Loader {
   }
 
   private createNewSpinner(): Ora {
-    // we send a proxy to the spinner instance rather than process.stdout
-    // so that we would be able to bypass our monkey-patch of process.stdout
-    // this is so that we won't have a case where the stdout "write" method
-    // triggers itself through the spinner by doing "spinner.start()" or "spinner.stop()"
-    const originalStdoutWrite = process.stdout.write.bind(process.stdout);
-    const originalStderrWrite = process.stderr.write.bind(process.stderr);
-    const stdoutProxy = new Proxy(process.stdout, {
-      get(obj, prop) {
-        if (prop === 'write') {
-          return originalStdoutWrite;
-        }
-        return obj[prop];
-      },
-    });
-    const spinner = ora({ spinner: SPINNER_TYPE, text: '', stream: stdoutProxy });
-    // @ts-ignore
-    // here we monkey-patch the process.stdout stream so that whatever is printed
-    // does not break the status line with the spinner, and that this line always
-    // remains at the bottom of the screen
-    process.stdout.write = (buffer, encoding, callback) => {
-      const wasSpinning = spinner.isSpinning;
-      if (wasSpinning) {
-        spinner.stop();
-      }
-      originalStdoutWrite(buffer, encoding, callback);
-      if (wasSpinning) {
-        spinner.start();
-      }
-    };
-    // @ts-ignore
-    process.stderr.write = (buffer, encoding, callback) => {
-      const wasSpinning = spinner.isSpinning;
-      if (wasSpinning) {
-        spinner.stop();
-      }
-      originalStderrWrite(buffer, encoding, callback);
-      if (wasSpinning) {
-        spinner.start();
-      }
-    };
-    return spinner;
+    return ora({ spinner: SPINNER_TYPE, text: '' });
   }
 }
 


### PR DESCRIPTION
This happened probably due to the proxies of process.stdout in the loader. It was part of the old Reporter and probably is not needed anymore.
In a quick test, running `bit build` and stopping it with Ctrl+C multiple times, it seems to fix the issue.