### PR TITLE
Skip dedupe dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5112,21 +5112,21 @@
       }
     },
     "@teambit/explorer-temp.ui.base-component-card": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/@teambit/explorer-temp.ui.base-component-card/-/explorer-temp.ui.base-component-card-0.0.1.tgz",
-      "integrity": "sha512-+C3yT8H6OKp/lHURmOlStOl5syOghvG2bATen3vYnC57J9r7bUWI9+jn/lPLjCyD1BFl96WyoS0TZPt95zCmWw==",
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@teambit/explorer-temp.ui.base-component-card/-/explorer-temp.ui.base-component-card-0.0.3.tgz",
+      "integrity": "sha512-ZNAdilwpBrl++rCksWeBczQsOQweXmSDt6Mj+1g8+55dKSJfMzIeRIl9lEQ8J+11vvSdeGtRiI77MsZhkVtayw==",
       "requires": {
         "classnames": "^2.2.6"
       }
     },
     "@teambit/explorer-temp.ui.component-card": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/@teambit/explorer-temp.ui.component-card/-/explorer-temp.ui.component-card-0.0.2.tgz",
-      "integrity": "sha512-HLxX7t9jfqxIqow7gguDUYBTbu0gerEFCcf3yHErY/YB9o9BPeR/4S+r7GO61IIgr7SHUyAlZTqNJYovP1anIw==",
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@teambit/explorer-temp.ui.component-card/-/explorer-temp.ui.component-card-0.0.4.tgz",
+      "integrity": "sha512-E0jQTKlQJ6SZvwyEWS6E6VbSjRxfylTy3c8tDgFtEXXlYqY8eK4qcHWVQrf8Y3PSVp8WwyB+W63dMUoTDc0gMw==",
       "requires": {
         "@teambit/evangelist-temp.elements.icon": "0.0.1",
         "@teambit/evangelist-temp.elements.image": "0.0.1",
-        "@teambit/explorer-temp.ui.base-component-card": "0.0.1",
+        "@teambit/explorer-temp.ui.base-component-card": "0.0.3",
         "filesize": "^6.1.0"
       },
       "dependencies": {
@@ -7444,7 +7444,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
     },
     "arr-union": {
       "version": "3.1.0",
@@ -8259,7 +8259,7 @@
     "base": {
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-      "integrity": "sha1-e95c7RRbbVUakNuH+DxVi060io8=",
+      "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -8281,7 +8281,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -8289,7 +8289,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -8297,7 +8297,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -8843,7 +8843,7 @@
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-      "integrity": "sha1-Cn9GQWgxyLZi7jb+TnxZ129marI=",
+      "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -9007,7 +9007,7 @@
     "chai-arrays": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/chai-arrays/-/chai-arrays-1.1.0.tgz",
-      "integrity": "sha1-KrQKjbWjSH1RJPC9PA/oVANYiAc=",
+      "integrity": "sha512-Ob93Mlyf9norrtaMeBh3ZosjOFTEuViNFMT4HT8nG5aG9oBKigdHmyt8s6JXVuigD8jxNxNXyE5gj2loXskMWw==",
       "dev": true
     },
     "chai-fs": {
@@ -9125,7 +9125,7 @@
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-      "integrity": "sha1-+TNprouafOAv1B+q0MqDAzGQxGM=",
+      "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -10413,7 +10413,7 @@
     "deep-eql": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
-      "integrity": "sha1-38lARACtHI/gI+faHfHBR8S0RN8=",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "requires": {
         "type-detect": "^4.0.0"
       }
@@ -10513,7 +10513,7 @@
     "define-property": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-      "integrity": "sha1-1Flono1lS6d+AqgX+HENcCyxbp0=",
+      "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -10522,7 +10522,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -10530,7 +10530,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -10538,7 +10538,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -12233,7 +12233,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -12561,7 +12561,7 @@
     "extglob": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-      "integrity": "sha1-rQD+TcYSqSMuhxhxHcXLWrAoVUM=",
+      "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
       "requires": {
         "array-unique": "^0.3.2",
         "define-property": "^1.0.0",
@@ -12592,7 +12592,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -12600,7 +12600,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -12608,7 +12608,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -13361,7 +13361,7 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs-write-stream-atomic": {
@@ -13431,7 +13431,7 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -14257,7 +14257,7 @@
     "has-own-property-x": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/has-own-property-x/-/has-own-property-x-3.2.0.tgz",
-      "integrity": "sha1-HEsRKld8jLWAVGlVblS26Vnk3tk=",
+      "integrity": "sha512-HtRQTYpRFz/YVaQ7jh2mU5iorMAxFcML9FNOLMI1f8VNJ2K0hpOlXoi1a+nmVl6oUcGnhd6zYOFAVe7NUFStyQ==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "to-object-x": "^1.5.0",
@@ -14277,7 +14277,7 @@
     "has-to-string-tag-x": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha1-oEWrOD17SyASoAFIqwql8pAETU0=",
+      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
       "requires": {
         "has-symbol-support-x": "^1.4.1"
       }
@@ -14810,7 +14810,7 @@
     "husky": {
       "version": "0.14.3",
       "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
-      "integrity": "sha1-xp7XTi0neXaaF7qDmbVM4LY8EsM=",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
       "dev": true,
       "requires": {
         "is-ci": "^1.0.10",
@@ -15399,7 +15399,7 @@
     "is-array-buffer-x": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/is-array-buffer-x/-/is-array-buffer-x-1.7.0.tgz",
-      "integrity": "sha1-SwsQQntkqjQ3dnrfT8B3AsWbI3E=",
+      "integrity": "sha512-ufSZRMY2WZX5xyNvk0NOZAG7cgi35B/sGQDGqv8w0X7MoQ2GC9vedanJhuYTPaC4PUCqLQsda1w7NF+dPZmAJw==",
       "requires": {
         "attempt-x": "^1.1.0",
         "has-to-string-tag-x": "^1.4.1",
@@ -15424,7 +15424,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-bzip2": {
       "version": "1.0.0",
@@ -15478,7 +15478,7 @@
     "is-descriptor": {
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
-      "integrity": "sha1-Nm2CQN3kh8pRgjsaufB6EKeCUco=",
+      "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -15488,7 +15488,7 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha1-cpyR4thXt6QZofmqZWhcTDP1hF0="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
         }
       }
     },
@@ -15542,7 +15542,7 @@
     "is-function-x": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/is-function-x/-/is-function-x-3.3.0.tgz",
-      "integrity": "sha1-fRa8EThT2yBtXkCosyyvmb1P98A=",
+      "integrity": "sha512-SreSSU1dlgYaXR5c0mm4qJHKYHIiGiEY+7Cd8/aRLLoMP/VvofD2XcWgBnP833ajpU5XzXbUSpfysnfKZLJFlg==",
       "requires": {
         "attempt-x": "^1.1.1",
         "has-to-string-tag-x": "^1.4.1",
@@ -15582,7 +15582,7 @@
     "is-index-x": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-index-x/-/is-index-x-1.1.0.tgz",
-      "integrity": "sha1-Q9rJezoE8wGRUwgz9FrDUAFoLuI=",
+      "integrity": "sha512-qULKLMepQLGC8rSVdi8uF2vI4LiDrU9XSDg1D+Aa657GIB7GV1jHpga7uXgQvkt/cpQ5mVBHUFTpSehYSqT6+A==",
       "requires": {
         "math-clamp-x": "^1.2.0",
         "max-safe-integer": "^1.0.1",
@@ -15709,7 +15709,7 @@
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha1-LBY7P6+xtgbZ0Xko8FwqHDjgdnc=",
+      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
         "isobject": "^3.0.1"
       }
@@ -15829,7 +15829,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -20308,7 +20308,7 @@
     "math-clamp-x": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/math-clamp-x/-/math-clamp-x-1.2.0.tgz",
-      "integrity": "sha1-i1N74GRbu6fuc+4WCR59YBjF7c8=",
+      "integrity": "sha512-tqpjpBcIf9UulApz3EjWXqTZpMlr2vLN9PryC9ghoyCuRmqZaf3JJhPddzgQpJnKLi2QhoFnvKBFtJekAIBSYg==",
       "requires": {
         "to-number-x": "^2.0.0"
       }
@@ -20316,7 +20316,7 @@
     "math-sign-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/math-sign-x/-/math-sign-x-3.0.0.tgz",
-      "integrity": "sha1-1ShgIrSOFQw4RymoYELgg1Jkw+0=",
+      "integrity": "sha512-OzPas41Pn4d16KHnaXmGxxY3/l3zK4OIXtmIwdhgZsxz4FDDcNnbrABYPg2vGfxIkaT9ezGnzDviRH7RfF44jQ==",
       "requires": {
         "is-nan-x": "^1.0.1",
         "to-number-x": "^2.0.0"
@@ -20785,7 +20785,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -21076,7 +21076,7 @@
     "mockery": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mockery/-/mockery-2.1.0.tgz",
-      "integrity": "sha1-WwrvH/Vk8PgTlEXhZVNseQlxNHA="
+      "integrity": "sha512-9VkOmxKlWXoDO/h1jDZaS4lH33aWfRiJiNT/tKj+8OGzrcFDLo8d0syGdbsc3Bc4GvRXPb+NMMvojotmuGJTvA=="
     },
     "module-definition": {
       "version": "3.3.0",
@@ -21717,7 +21717,7 @@
     "normalize-space-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-space-x/-/normalize-space-x-3.0.0.tgz",
-      "integrity": "sha1-F5B9bHxySk+VZ0ccuzGVU7wPiII=",
+      "integrity": "sha512-tbCJerqZCCHPst4rRKgsTanLf45fjOyeAU5zE3mhDxJtFJKt66q39g2XArWhXelgTFVib8mNBUm6Wrd0LxYcfQ==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "trim-x": "^3.0.0",
@@ -21928,7 +21928,7 @@
     "object-get-own-property-descriptor-x": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/object-get-own-property-descriptor-x/-/object-get-own-property-descriptor-x-3.2.0.tgz",
-      "integrity": "sha1-RkWFrQPmYQjtFmyZMluNLFupNxI=",
+      "integrity": "sha512-Z/0fIrptD9YuzN+SNK/1kxAEaBcPQM4gSrtOSMSi9eplnL/AbyQcAyAlreAoAzmBon+DQ1Z+AdhxyQSvav5Fyg==",
       "requires": {
         "attempt-x": "^1.1.0",
         "has-own-property-x": "^3.1.1",
@@ -22645,7 +22645,7 @@
     "parse-int-x": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-int-x/-/parse-int-x-2.0.0.tgz",
-      "integrity": "sha1-n5edQRWTDfL0cGpBgQuccSQFVS8=",
+      "integrity": "sha512-NIMm52gmd1+0qxJK8lV3OZ4zzWpRH1xcz9xCHXl+DNzddwUdS4NEtd7BmTeK7iCIXoaK5e6BoDMHgieH2eNIhg==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -24923,7 +24923,7 @@
     "property-is-enumerable-x": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/property-is-enumerable-x/-/property-is-enumerable-x-1.1.0.tgz",
-      "integrity": "sha1-fKSJF0ds0JFLN4Cb/QV3ag2UL28=",
+      "integrity": "sha512-22cKy3w3OpRswU6to9iKWDDlg+F9vF2REcwGlGW23jyLjHb1U/jJEWA44sWupOnkhGfDgotU6Lw+N2oyhNi+5A==",
       "requires": {
         "to-object-x": "^1.4.1",
         "to-property-key-x": "^2.0.1"
@@ -25816,7 +25816,7 @@
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-      "integrity": "sha1-H07OJ+ALC2XgJHpoEOaoXYOldSw=",
+      "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
@@ -25989,7 +25989,7 @@
     "replace-comments-x": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/replace-comments-x/-/replace-comments-x-2.0.0.tgz",
-      "integrity": "sha1-pc7Bjv2RKq14p8PEtp0BdoVW0UA=",
+      "integrity": "sha512-+vMP4jqU+8HboLWms6YMNEiaZG5hh1oR6ENCnGYDF/UQ7aYiJUK/8tcl3+KZAHRCKKa3gqzrfiarlUBHQSgRlg==",
       "requires": {
         "require-coercible-to-string-x": "^1.0.0",
         "to-string-x": "^1.4.2"
@@ -26407,7 +26407,7 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha1-uKSCXVvbH8P29Twrwz+BOIaBx7w="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
     },
     "retry": {
       "version": "0.10.1",
@@ -27006,7 +27006,7 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha1-jR2TUOJWItow3j5EumkrUiGrfFA=",
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
       "dev": true
     },
     "sane": {
@@ -27884,7 +27884,7 @@
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-      "integrity": "sha1-ZJIufFZbDhQgS6GqfWlkJ40lGC0=",
+      "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -27899,7 +27899,7 @@
         "debug": {
           "version": "2.6.9",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
           }
@@ -27930,7 +27930,7 @@
     "snapdragon-node": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-      "integrity": "sha1-bBdfhv8UvbByRWPo88GwIaKGhTs=",
+      "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -27948,7 +27948,7 @@
         "is-accessor-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
-          "integrity": "sha1-FpwvbT3x+ZJhgHI2XJsOofaHhlY=",
+          "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -27956,7 +27956,7 @@
         "is-data-descriptor": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
-          "integrity": "sha1-2Eh2Mh0Oet0DmQQGq7u9NrqSaMc=",
+          "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -27964,7 +27964,7 @@
         "is-descriptor": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
-          "integrity": "sha1-OxWXRqZmBLBPjIFSS6NlxfFNhuw=",
+          "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -27981,7 +27981,7 @@
     "snapdragon-util": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-      "integrity": "sha1-+VZHlIbyrNeXAGk/b3uAXkWrVuI=",
+      "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
       "requires": {
         "kind-of": "^3.2.0"
       }
@@ -29557,7 +29557,7 @@
     "to-integer-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/to-integer-x/-/to-integer-x-3.0.0.tgz",
-      "integrity": "sha1-nzuA5mjH8K5F5pJrQNlfUsGt3HQ=",
+      "integrity": "sha512-794L2Lpwjtynm7RxahJi2YdbRY75gTxUW27TMuN26UgwPkmJb/+HPhkFEFbz+E4vNoiP0dxq5tq5fkXoXLaK/w==",
       "requires": {
         "is-finite-x": "^3.0.2",
         "is-nan-x": "^1.0.1",
@@ -29568,7 +29568,7 @@
     "to-number-x": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-number-x/-/to-number-x-2.0.0.tgz",
-      "integrity": "sha1-yQmdfe2P0ycTKimH3y3Mi682300=",
+      "integrity": "sha512-lGOnCoccUoSzjZ/9Uen8TC4+VFaQcFGhTroWTv2tYWxXgyJV1zqAZ8hEIMkez/Eo790fBMOjidTnQ/OJSCvAoQ==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "nan-x": "^1.0.0",
@@ -29588,7 +29588,7 @@
     "to-object-x": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/to-object-x/-/to-object-x-1.5.0.tgz",
-      "integrity": "sha1-vWndThBNd6zAzA2E9axI9jCuvjw=",
+      "integrity": "sha512-AKn5GQcdWky+s20vjWkt+Wa6y3dxQH3yQyMBhOfBOPldUwqwhgvlqcIg5H092ntNc+TX8/Cxzs1kMHH19pyCnA==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-object-coercible-x": "^1.4.1"
@@ -29597,7 +29597,7 @@
     "to-primitive-x": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-primitive-x/-/to-primitive-x-1.1.0.tgz",
-      "integrity": "sha1-Qc4sE+PiRuDl0KiCmgVnxgFYM/g=",
+      "integrity": "sha512-gyMY0gi3wjK3e4MUBKqv9Zl8QGcWguIkaUr2VJmoBEsOpDcpDZSEyljR773eVG4maS48uX7muLkoQoh/BA82OQ==",
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "is-date-object": "^1.0.1",
@@ -29619,7 +29619,7 @@
     "to-property-key-x": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/to-property-key-x/-/to-property-key-x-2.0.2.tgz",
-      "integrity": "sha1-sZqo4i+qD/fRwQLPvGV69zQTz6E=",
+      "integrity": "sha512-YISLpZFYIazNm0P8hLsKEEUEZ3m8U3+eDysJZqTu3+B9tQp+2TrMpaEGT8Agh4fZ5LSoums60/glNEzk5ozqrg==",
       "requires": {
         "has-symbol-support-x": "^1.4.1",
         "to-primitive-x": "^1.1.0",
@@ -29629,7 +29629,7 @@
     "to-regex": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-      "integrity": "sha1-E8/dmzNlUvMLUfM6iuG0Knp1mc4=",
+      "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -29727,7 +29727,7 @@
     "trim-left-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-left-x/-/trim-left-x-3.0.0.tgz",
-      "integrity": "sha1-NWzwVYlnJrl1RCXoQTmIQukLTN8=",
+      "integrity": "sha512-+m6cqkppI+CxQBTwWEZliOHpOBnCArGyMnS1WCLb6IRgukhTkiQu/TNEN5Lj2eM9jk8ewJsc7WxFZfmwNpRXWQ==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-coercible-to-string-x": "^1.0.0",
@@ -29750,7 +29750,7 @@
     "trim-right-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-right-x/-/trim-right-x-3.0.0.tgz",
-      "integrity": "sha1-KMTNN9WYH1Cs6bUuPOkQb00tIsA=",
+      "integrity": "sha512-iIqEsWEbWVodqdixJHi4FoayJkUxhoL4AvSNGp4FF4FfQKRPGizt8++/RnyC9od75y7P/S6EfONoVqP+NddiKA==",
       "requires": {
         "cached-constructors-x": "^1.0.0",
         "require-coercible-to-string-x": "^1.0.0",
@@ -29760,7 +29760,7 @@
     "trim-x": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-x/-/trim-x-3.0.0.tgz",
-      "integrity": "sha1-JO/c0Ce3SLv8JGoBOa0XSb7+8CQ=",
+      "integrity": "sha512-w8s38RAUScQ6t3XqMkS75iz5ZkIYLQpVnv2lp3IuTS36JdlVzC54oe6okOf4Wz3UH4rr3XAb2xR3kR5Xei82fw==",
       "requires": {
         "trim-left-x": "^3.0.0",
         "trim-right-x": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -133,7 +133,6 @@
     "@teambit/documenter-temp.ui.sub-title": "^0.0.2",
     "@teambit/documenter-temp.ui.separator": "^0.0.2",
     "@teambit/documenter-temp.ui.consumable-link": "^0.0.4",
-    
     "@teambit/documenter-temp.ui.linked-heading": "^0.0.2",
     "@teambit/explorer-temp.ui.component-grid": "^0.0.1",
     "@teambit/explorer-temp.ui.component-card": "^0.0.4",

--- a/src/extensions/dependency-resolver/dependency-installer.ts
+++ b/src/extensions/dependency-resolver/dependency-installer.ts
@@ -16,11 +16,13 @@ export class DependencyInstaller {
   async install(
     rootDir: string,
     rootDepsObject: DependenciesObjectDefinition,
-    componentDirectoryMap: ComponentMap<string>
+    componentDirectoryMap: ComponentMap<string>,
+    dedup = true
   ) {
     // TODO: the cache should be probably passed to the package manager constructor not to the install function
     await this.packageManager.install(rootDir, rootDepsObject, componentDirectoryMap, {
       cacheRootDir: this.cacheRootDir,
+      dedup,
     });
     return componentDirectoryMap;
   }

--- a/src/extensions/dependency-resolver/dependency-installer.ts
+++ b/src/extensions/dependency-resolver/dependency-installer.ts
@@ -1,7 +1,11 @@
-import { PackageManager } from './package-manager';
+import { PackageManager, PackageManagerInstallOptions } from './package-manager';
 import { ComponentMap } from '../component/component-map';
 import { DependenciesObjectDefinition } from './types';
 import { PathAbsolute } from '../../utils/path';
+
+const DEFAULT_INSTALL_OPTIONS: PackageManagerInstallOptions = {
+  dedupe: true,
+};
 
 export class DependencyInstaller {
   constructor(
@@ -17,13 +21,12 @@ export class DependencyInstaller {
     rootDir: string,
     rootDepsObject: DependenciesObjectDefinition,
     componentDirectoryMap: ComponentMap<string>,
-    dedup = true
+    options: PackageManagerInstallOptions = DEFAULT_INSTALL_OPTIONS
   ) {
+    // Make sure to take other default if passed options with only one option
+    const calculatedOpts = Object.assign({}, DEFAULT_INSTALL_OPTIONS, { cacheRootDir: this.cacheRootDir }, options);
     // TODO: the cache should be probably passed to the package manager constructor not to the install function
-    await this.packageManager.install(rootDir, rootDepsObject, componentDirectoryMap, {
-      cacheRootDir: this.cacheRootDir,
-      dedup,
-    });
+    await this.packageManager.install(rootDir, rootDepsObject, componentDirectoryMap, calculatedOpts);
     return componentDirectoryMap;
   }
 }

--- a/src/extensions/dependency-resolver/manifest/deduping/dedupe-dependencies.ts
+++ b/src/extensions/dependency-resolver/manifest/deduping/dedupe-dependencies.ts
@@ -3,6 +3,7 @@ import { hoistDependencies } from './hoist-dependencies';
 import { mergeWithRootDeps } from './merge-with-root';
 import { PackageName, DependenciesObjectDefinition, SemverVersion } from '../../types';
 import { ComponentDependenciesMap } from '../workspace-manifest';
+
 export { getEmptyDedupedDependencies } from './hoist-dependencies';
 
 export type conflictedComponent = {

--- a/src/extensions/dependency-resolver/manifest/deduping/dedupe-dependencies.ts
+++ b/src/extensions/dependency-resolver/manifest/deduping/dedupe-dependencies.ts
@@ -3,6 +3,7 @@ import { hoistDependencies } from './hoist-dependencies';
 import { mergeWithRootDeps } from './merge-with-root';
 import { PackageName, DependenciesObjectDefinition, SemverVersion } from '../../types';
 import { ComponentDependenciesMap } from '../workspace-manifest';
+export { getEmptyDedupedDependencies } from './hoist-dependencies';
 
 export type conflictedComponent = {
   componentPackageName: PackageName;

--- a/src/extensions/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/src/extensions/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -47,17 +47,7 @@ type VersionWithTotal = {
  * @returns {DedupedDependencies}
  */
 export function hoistDependencies(depIdIndex: PackageNameIndex): DedupedDependencies {
-  const result: DedupedDependencies = {
-    rootDependencies: {
-      dependencies: {},
-      devDependencies: {},
-      peerDependencies: {},
-    },
-    componentDependenciesMap: new Map<PackageName, DependenciesObjectDefinition>(),
-    issus: {
-      peerConflicts: [],
-    },
-  };
+  const result: DedupedDependencies = getEmptyDedupedDependencies();
 
   // TODO: handle git urls
 
@@ -445,4 +435,19 @@ function arrayCombinations<T>(array: Array<T>): Array<T[]> {
   }
   all.push(array);
   return all;
+}
+
+export function getEmptyDedupedDependencies(): DedupedDependencies {
+  const result: DedupedDependencies = {
+    rootDependencies: {
+      dependencies: {},
+      devDependencies: {},
+      peerDependencies: {},
+    },
+    componentDependenciesMap: new Map<PackageName, DependenciesObjectDefinition>(),
+    issus: {
+      peerConflicts: [],
+    },
+  };
+  return result;
 }

--- a/src/extensions/dependency-resolver/manifest/deduping/index.ts
+++ b/src/extensions/dependency-resolver/manifest/deduping/index.ts
@@ -1,1 +1,1 @@
-export { dedupeDependencies, DedupedDependencies } from './dedupe-dependencies';
+export { dedupeDependencies, DedupedDependencies, getEmptyDedupedDependencies } from './dedupe-dependencies';

--- a/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
+++ b/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
@@ -24,7 +24,7 @@ export interface WorkspaceManifestToJsonOptions extends ManifestToJsonOptions {
 export type CreateFromComponentsOptions = {
   filterComponentsFromManifests: boolean;
   createManifestForComponentsWithoutDependencies: boolean;
-  dedupe: boolean;
+  dedupe?: boolean;
 };
 
 const DEFAULT_CREATE_OPTIONS: CreateFromComponentsOptions = {

--- a/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
+++ b/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
@@ -11,7 +11,7 @@ import { ComponentManifest } from './component-manifest';
 import { Component, ComponentID } from '../../component';
 import componentIdToPackageName from '../../../utils/bit/component-id-to-package-name';
 import { DependencyGraph, DepVersionModifierFunc } from '../dependency-graph';
-import { dedupeDependencies, DedupedDependencies } from './deduping';
+import { dedupeDependencies, DedupedDependencies, getEmptyDedupedDependencies } from './deduping';
 import { Dependency, DependenciesFilterFunction } from '../../../consumer/component/dependencies';
 import { MergeDependenciesFunc } from '../dependency-resolver.extension';
 import { BitId } from '../../../bit-id';
@@ -24,6 +24,13 @@ export interface WorkspaceManifestToJsonOptions extends ManifestToJsonOptions {
 export type CreateFromComponentsOptions = {
   filterComponentsFromManifests: boolean;
   createManifestForComponentsWithoutDependencies: boolean;
+  dedupe: boolean;
+};
+
+const DEFAULT_CREATE_OPTIONS: CreateFromComponentsOptions = {
+  filterComponentsFromManifests: true,
+  createManifestForComponentsWithoutDependencies: true,
+  dedupe: true,
 };
 export class WorkspaceManifest extends Manifest {
   constructor(
@@ -46,23 +53,28 @@ export class WorkspaceManifest extends Manifest {
     rootDependencies: DependenciesObjectDefinition,
     rootDir: string,
     components: Component[],
-    options: CreateFromComponentsOptions = {
-      filterComponentsFromManifests: true,
-      createManifestForComponentsWithoutDependencies: true,
-    },
+    options: CreateFromComponentsOptions = DEFAULT_CREATE_OPTIONS,
     mergeDependenciesFunc: MergeDependenciesFunc
   ): Promise<WorkspaceManifest> {
+    // Make sure to take other default if passed options with only one option
+    const optsWithDefaults = Object.assign({}, DEFAULT_CREATE_OPTIONS, options);
     const componentDependenciesMap: ComponentDependenciesMap = await buildComponentDependenciesMap(
       components,
-      options.filterComponentsFromManifests,
+      optsWithDefaults.filterComponentsFromManifests,
       rootDependencies,
       mergeDependenciesFunc
     );
-    const dedupedDependencies = dedupeDependencies(rootDependencies, componentDependenciesMap);
+    let dedupedDependencies = getEmptyDedupedDependencies();
+    if (options.dedupe) {
+      dedupedDependencies = dedupeDependencies(rootDependencies, componentDependenciesMap);
+    } else {
+      dedupedDependencies.rootDependencies = rootDependencies;
+      dedupedDependencies.componentDependenciesMap = componentDependenciesMap;
+    }
     const componentsManifestsMap = getComponentsManifests(
       dedupedDependencies,
       components,
-      options.createManifestForComponentsWithoutDependencies
+      optsWithDefaults.createManifestForComponentsWithoutDependencies
     );
     const workspaceManifest = new WorkspaceManifest(
       name,

--- a/src/extensions/dependency-resolver/package-manager.ts
+++ b/src/extensions/dependency-resolver/package-manager.ts
@@ -3,6 +3,10 @@ import { DependenciesObjectDefinition } from './types';
 
 export type PackageManagerInstallOptions = {
   cacheRootDir?: string;
+  /**
+   * decide whether to dedup dependencies.
+   */
+  dedup?: boolean;
 };
 
 export interface PackageManager {

--- a/src/extensions/dependency-resolver/package-manager.ts
+++ b/src/extensions/dependency-resolver/package-manager.ts
@@ -6,7 +6,7 @@ export type PackageManagerInstallOptions = {
   /**
    * decide whether to dedup dependencies.
    */
-  dedup?: boolean;
+  dedupe?: boolean;
 };
 
 export interface PackageManager {

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -89,7 +89,12 @@ export class IsolatorExtension {
       // await this.dependencyResolver.capsulesInstall(capsulesToInstall, { packageManager: config.packageManager });
       const installer = this.dependencyResolver.getInstaller();
       // When using isolator we don't want to use the policy defined in the workspace directly, we only want to instal deps from components
-      await installer.install(capsulesDir, this.dependencyResolver.getEmptyDepsObject(), this.toComponentMap(capsules));
+      await installer.install(
+        capsulesDir,
+        this.dependencyResolver.getEmptyDepsObject(),
+        this.toComponentMap(capsules),
+        false
+      );
       await symlinkDependenciesToCapsules(capsulesToInstall, capsuleList, this.logger);
       // TODO: this is a hack to have access to the bit bin project in order to access core extensions from user extension
       // TODO: remove this after exporting core extensions as components

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -93,7 +93,7 @@ export class IsolatorExtension {
         capsulesDir,
         this.dependencyResolver.getEmptyDepsObject(),
         this.toComponentMap(capsules),
-        false
+        { dedupe: false }
       );
       await symlinkDependenciesToCapsules(capsulesToInstall, capsuleList, this.logger);
       // TODO: this is a hack to have access to the bit bin project in order to access core extensions from user extension

--- a/src/extensions/pnpm/pnpm.package-manager.ts
+++ b/src/extensions/pnpm/pnpm.package-manager.ts
@@ -57,9 +57,9 @@ export class PnpmPackageManager implements PackageManager {
   ) {
     return componentDirectoryMap.toArray().reduce((acc, [component, dir]) => {
       const packageName = this.pkg.getPackageName(component);
-      // if (componentsManifestsFromWorkspace.has(packageName)) {
-      acc[dir] = componentsManifestsFromWorkspace.get(packageName)?.toJson();
-      // }
+      if (componentsManifestsFromWorkspace.has(packageName)) {
+        acc[dir] = componentsManifestsFromWorkspace.get(packageName)?.toJson();
+      }
       return acc;
     }, {});
   }

--- a/src/extensions/pnpm/pnpm.package-manager.ts
+++ b/src/extensions/pnpm/pnpm.package-manager.ts
@@ -34,7 +34,7 @@ export class PnpmPackageManager implements PackageManager {
     const workspaceManifest = await this.depResolver.getWorkspaceManifest(
       undefined,
       undefined,
-      installOptions.dedup ? rootDepsObject : {},
+      rootDepsObject,
       rootDir,
       components,
       options

--- a/src/extensions/pnpm/pnpm.package-manager.ts
+++ b/src/extensions/pnpm/pnpm.package-manager.ts
@@ -25,6 +25,7 @@ export class PnpmPackageManager implements PackageManager {
     const storeDir = installOptions?.cacheRootDir
       ? join(installOptions?.cacheRootDir, '.pnpm-store')
       : join(userHome, '.pnpm-store');
+
     const components = componentDirectoryMap.toArray().map(([component]) => component);
     const options: CreateFromComponentsOptions = {
       filterComponentsFromManifests: true,
@@ -33,7 +34,7 @@ export class PnpmPackageManager implements PackageManager {
     const workspaceManifest = await this.depResolver.getWorkspaceManifest(
       undefined,
       undefined,
-      rootDepsObject,
+      installOptions.dedup ? rootDepsObject : {},
       rootDir,
       components,
       options
@@ -56,9 +57,9 @@ export class PnpmPackageManager implements PackageManager {
   ) {
     return componentDirectoryMap.toArray().reduce((acc, [component, dir]) => {
       const packageName = this.pkg.getPackageName(component);
-      if (componentsManifestsFromWorkspace.has(packageName)) {
-        acc[dir] = componentsManifestsFromWorkspace.get(packageName)?.toJson();
-      }
+      // if (componentsManifestsFromWorkspace.has(packageName)) {
+      acc[dir] = componentsManifestsFromWorkspace.get(packageName)?.toJson();
+      // }
       return acc;
     }, {});
   }

--- a/src/extensions/workspace/workspace.ts
+++ b/src/extensions/workspace/workspace.ts
@@ -16,7 +16,7 @@ import { IsolatorExtension, Network } from '../isolator';
 import AddComponents from '../../consumer/component-ops/add-components';
 import { PathOsBasedRelative, PathOsBased } from '../../utils/path';
 import { AddActionResults } from '../../consumer/component-ops/add-components/add-components';
-import { DependencyResolverExtension } from '../dependency-resolver';
+import { DependencyResolverExtension, PackageManagerInstallOptions } from '../dependency-resolver';
 import { WorkspaceExtConfig } from './types';
 import { Logger } from '../logger';
 import { Variants } from '../variants';
@@ -55,6 +55,7 @@ export interface EjectConfOptions {
 export type WorkspaceInstallOptions = {
   variants: string;
   lifecycleType: DependencyLifecycleType;
+  dedupe: boolean;
 };
 
 const DEFAULT_VENDOR_DIR = 'vendor';
@@ -617,7 +618,10 @@ export class Workspace implements ComponentFactory {
         ...workspacePolicy.peerDependencies,
       },
     };
-    await installer.install(this.path, rootDepsObject, installationMap);
+    const installOptions: PackageManagerInstallOptions = {
+      dedupe: options?.dedupe,
+    };
+    await installer.install(this.path, rootDepsObject, installationMap, installOptions);
     // TODO: add the links results to the output
     this.logger.setStatusLine('linking components');
     await link(stringIds, false);


### PR DESCRIPTION
## Proposed Changes

- add an option to not deduping when installing dependencies
- do not dedupe when installing dependencies on capsules by default
- when no deduping installing the peer dependencies in the subdirectories 
