### PR TITLE
add a task to copy dists to the capsule root to support importing from internal paths

### DIFF
--- a/scripts/dogfooding.sh
+++ b/scripts/dogfooding.sh
@@ -20,6 +20,8 @@ find extensions/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\//'bit-bin\
 find components/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\//'bit-bin\/dist\//g" {} \;
 find components/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
 find components/*/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
+mkdir extensions/cli/bin
+echo "#!/usr/bin/env node\nrequire('bit-bin/dist/app.js');" > extensions/cli/bin/bit.js
 rm -rf node_modules/bit-bin
 ln -s `pwd` node_modules/bit-bin
 STATUS=`bit status`

--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -100,8 +100,8 @@ export default class PackageJsonFile {
   }
 
   static loadFromCapsuleSync(capsuleRootDir: string) {
-    const filePath = composePath(capsuleRootDir);
-    const filePathAbsolute = filePath;
+    const filePath = composePath('.');
+    const filePathAbsolute = path.join(capsuleRootDir, filePath);
     const packageJsonStr = PackageJsonFile.getPackageJsonStrIfExistSync(filePathAbsolute);
     if (!packageJsonStr) {
       throw new Error(`capsule ${capsuleRootDir} is missing package.json`);

--- a/src/extensions/builder/task-process.ts
+++ b/src/extensions/builder/task-process.ts
@@ -1,6 +1,4 @@
-import glob from 'glob';
 import { flatten } from 'ramda';
-import path from 'path';
 import { BuildTask, BuildResults, BuildContext } from './types';
 import GeneralError from '../../error/general-error';
 import { ExtensionDataEntry } from '../../consumer/config/extension-data';

--- a/src/extensions/builder/task-process.ts
+++ b/src/extensions/builder/task-process.ts
@@ -77,19 +77,8 @@ export class TaskProcess {
 
   private async getFilesByArtifacts(capsule: Capsule): Promise<string[]> {
     const filesP = this.taskResult.artifacts.map(async (artifact) => {
-      return getFilesFromCapsule(capsule, artifact.dirName);
+      return capsule.getAllFilesPaths(artifact.dirName);
     });
     return flatten(await Promise.all(filesP));
   }
-}
-
-// @todo: fix.
-// it skips the capsule fs because for some reason `capsule.fs.promises.readdir` doesn't work
-// the same as `capsule.fs.readdir` and it doesn't have the capsule dir as pwd.
-/**
- * returns the paths inside the capsule
- */
-async function getFilesFromCapsule(capsule: Capsule, dir: string): Promise<string[]> {
-  const files = glob.sync('**', { cwd: path.join(capsule.wrkDir, dir), nodir: true });
-  return files.map((file) => path.join(dir, file));
 }

--- a/src/extensions/compiler/compiler.extension.ts
+++ b/src/extensions/compiler/compiler.extension.ts
@@ -1,3 +1,4 @@
+import { ExtensionManifest } from '@teambit/harmony';
 import { WorkspaceExt } from '../workspace';
 import { Environments } from '../environments';
 import { Workspace } from '../workspace';
@@ -10,7 +11,7 @@ import { BitId } from '../../bit-id';
 
 export class CompilerExtension {
   static id = Extensions.compiler;
-  static dependencies = [CLIExtension, WorkspaceExt, Environments];
+  static dependencies = [CLIExtension, WorkspaceExt, Environments] as ExtensionManifest[];
   constructor(private workspaceCompiler: WorkspaceCompiler, readonly task: CompilerTask) {}
   compileOnWorkspace(
     componentsIds: string[] | BitId[], // when empty, it compiles all

--- a/src/extensions/isolator/capsule/capsule.ts
+++ b/src/extensions/isolator/capsule/capsule.ts
@@ -1,4 +1,5 @@
 import v4 from 'uuid';
+import glob from 'glob';
 import path from 'path';
 import filenamify from 'filenamify';
 import { realpathSync } from 'fs';
@@ -98,6 +99,18 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
         stderr += data;
       });
     });
+  }
+
+  /**
+   * @todo: fix.
+   * it skips the capsule fs because for some reason `capsule.fs.promises.readdir` doesn't work
+   * the same as `capsule.fs.readdir` and it doesn't have the capsule dir as pwd.
+   *
+   * returns the paths inside the capsule
+   */
+  getAllFilesPaths(dir = '.', options: { ignore?: string[] } = {}) {
+    const files = glob.sync('**', { cwd: path.join(this.path, dir), nodir: true, ...options });
+    return files.map((file) => path.join(dir, file));
   }
 
   static async createFromComponent(

--- a/src/extensions/pkg/pkg.extension.ts
+++ b/src/extensions/pkg/pkg.extension.ts
@@ -15,6 +15,7 @@ import { PublishDryRunTask } from './publish-dry-run.task';
 import { Component } from '../component';
 import { WorkspaceExt, Workspace } from '../workspace';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
+import { PreparePackagesTask } from './prepare-packages.task';
 
 export interface PackageJsonProps {
   [key: string]: any;
@@ -56,7 +57,8 @@ export class PkgExtension {
     const packer = new Packer(isolator, scope?.legacyScope, workspace);
     const publisher = new Publisher(isolator, logPublisher, scope?.legacyScope, workspace);
     const dryRunTask = new PublishDryRunTask(PkgExtension.id, publisher, logPublisher);
-    const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs, dryRunTask);
+    const preparePackagesTask = new PreparePackagesTask(PkgExtension.id, logPublisher);
+    const pkg = new PkgExtension(config, packageJsonPropsRegistry, packer, envs, dryRunTask, preparePackagesTask);
 
     const postExportFunc = publisher.postExportListener.bind(publisher);
     if (scope) scope.onPostExport(postExportFunc);
@@ -105,7 +107,9 @@ export class PkgExtension {
      */
     private envs: Environments,
 
-    readonly dryRunTask: PublishDryRunTask
+    readonly dryRunTask: PublishDryRunTask,
+
+    readonly preparePackagesTask: PreparePackagesTask
   ) {}
 
   /**

--- a/src/extensions/pkg/prepare-packages.task.ts
+++ b/src/extensions/pkg/prepare-packages.task.ts
@@ -1,0 +1,68 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { BuildContext } from '../builder';
+import { BuildTask, BuildResults } from '../builder';
+import { Logger } from '../logger';
+import { Compiler } from '../compiler';
+import { Capsule } from '../isolator';
+import PackageJsonFile from '../../consumer/component/package-json-file';
+
+/**
+ * prepare packages for publishing. practically. remove the source files and copy the dists files
+ * into the root of the capsule.
+ * this is needed when components import from other components internal paths. without this task,
+ * the internal paths are the source, so node will throw an error when trying to use them. this
+ * task makes sure that the internal paths point to the consumable code (dists).
+ */
+export class PreparePackagesTask implements BuildTask {
+  readonly description = '';
+  constructor(readonly extensionId: string, private logger: Logger) {}
+
+  async execute(context: BuildContext): Promise<BuildResults> {
+    const result = {
+      components: [],
+      artifacts: [],
+    };
+    if (!context.env.getCompiler) return result;
+    const compilerInstance: Compiler = context.env.getCompiler();
+    const distDir = compilerInstance.getDistDir();
+
+    await Promise.all(
+      context.capsuleGraph.capsules.map(async (capsule) => {
+        await this.removeSourceFiles(capsule.capsule, distDir);
+        await this.moveDistToRoot(capsule.capsule, distDir);
+        await this.updatePackageJson(capsule.capsule, compilerInstance, distDir);
+      })
+    );
+
+    return result;
+  }
+
+  async removeSourceFiles(capsule: Capsule, distDir: string) {
+    const excludeDirs = [distDir, 'node_modules', 'public', 'bin'].map((dir) => `${dir}/**`);
+    const excludeFiles = ['package.json'];
+    const allFiles = capsule.getAllFilesPaths('.', { ignore: [...excludeDirs, ...excludeFiles] });
+    this.logger.debug(`delete the following files:\n${allFiles.join('\n')}`);
+    await Promise.all(allFiles.map((file) => fs.remove(path.join(capsule.path, file))));
+  }
+
+  async moveDistToRoot(capsule: Capsule, distDir: string) {
+    const from = path.join(capsule.path, distDir);
+    const to = capsule.path;
+    this.logger.debug(`move from ${from} to: ${to}`);
+    // for some reason `fs.move` throws an error "dest already exists.".
+    fs.moveSync(from, to);
+  }
+
+  /**
+   * by default, the "main" prop points to the dist file (e.g. "dist/index./js").
+   * here, we have to change it because there is no dist dir anymore.
+   */
+  async updatePackageJson(capsule: Capsule, compiler: Compiler, distDir: string) {
+    const distMainFile = compiler.getDistPathBySrcPath(capsule.component.state._consumer.mainFile);
+    const distMainFileWithoutDistDir = distMainFile.replace(`${distDir}${path.sep}`, '');
+    const packageJson = PackageJsonFile.loadFromCapsuleSync(capsule.path);
+    packageJson.addOrUpdateProperty('main', distMainFileWithoutDistDir);
+    await packageJson.write();
+  }
+}

--- a/src/extensions/pnpm/pnpm.package-manager.ts
+++ b/src/extensions/pnpm/pnpm.package-manager.ts
@@ -49,6 +49,10 @@ export class PnpmPackageManager implements PackageManager {
     );
     delete rootManifest.manifest.dependencies['bit-bin'];
     delete rootManifest.manifest.peerDependencies['bit-bin'];
+    Object.keys(componentsManifests).forEach((componentName) => {
+      if (!componentsManifests[componentName].dependencies) return;
+      delete componentsManifests[componentName].dependencies['bit-bin'];
+    });
     this.logger.debug('root manifest for installation', rootManifest);
     this.logger.debug('components manifests for installation', componentsManifests);
     this.logger.setStatusLine('installing dependencies');

--- a/src/extensions/stencil/stencil.extension.ts
+++ b/src/extensions/stencil/stencil.extension.ts
@@ -1,3 +1,4 @@
+import { ExtensionManifest } from '@teambit/harmony';
 import { TranspileOptions } from '@stencil/core/compiler';
 import { StencilCompiler } from './stencil.compiler';
 import { Environments } from '../environments';
@@ -30,7 +31,7 @@ export class StencilExtension {
     // return new StencilDevServer({}, this.workspace);
   }
 
-  static dependencies = [Environments, CompilerExtension, WorkspaceExt, WebpackExtension];
+  static dependencies = [Environments, CompilerExtension, WorkspaceExt, WebpackExtension] as ExtensionManifest[];
 
   static async provider([envs, compiler, workspace, webpack]: [
     Environments,

--- a/src/extensions/typescript/typescript.extension.ts
+++ b/src/extensions/typescript/typescript.extension.ts
@@ -21,7 +21,10 @@ export class TypescriptExtension {
    * :TODO @gilad why do we need this DSL? can't I just get the args here.
    */
   getPackageJsonProps() {
-    return { main: 'dist/{main}.js' };
+    return {
+      main: 'dist/{main}.js',
+      types: '{main}.ts',
+    };
   }
 
   static id = '@teambit/typescript';

--- a/src/extensions/webpack/webpack.extension.ts
+++ b/src/extensions/webpack/webpack.extension.ts
@@ -1,3 +1,4 @@
+import { ExtensionManifest } from '@teambit/harmony';
 import { Configuration } from 'webpack';
 import merge from 'webpack-merge';
 import { WebpackDevServer } from './webpack.dev-server';
@@ -51,7 +52,7 @@ export class WebpackExtension {
 
   static slots = [];
 
-  static dependencies = [WorkspaceExt, BundlerExtension, LoggerExtension];
+  static dependencies = [WorkspaceExt, BundlerExtension, LoggerExtension] as ExtensionManifest[];
 
   static async provide([workspace, bundler, logger]: [Workspace, BundlerExtension, LoggerExtension]) {
     const logPublisher = logger.createLogger(WebpackExtension.id);

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -30,5 +30,27 @@
     "strictPeerDependencies": true,
     "extraArgs": []
   },
-  "@teambit/variants": {}
+  "@teambit/variants": {
+    "extensions/cli": {
+      "@teambit/envs": {
+        "env": "@teambit/react",
+        "config": {}
+      },
+      "@teambit/pkg": {
+        "packageJson": {
+          "name": "@teambit/{name}",
+          "bin": "bin/bit.js"
+        }
+      },
+      "@teambit/dependency-resolver": {
+        "policy": {
+          "devDependencies": {
+            "@types/mocha": "^5.2.7",
+            // why this is needed? try to automate this
+            "@types/node": "^12.12.27"
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
To support components that import from internal paths of other components, we need to copy the dist files into the capsule root.  See this [repo](https://github.com/davidfirst/typescript-internal-paths-monorepo) for more info.