### PR TITLE
fix capsules installation and enable running bit-bin from CLI extension

### DIFF
--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -73,7 +73,7 @@ describe('dependency-resolver extension', function () {
         barFooOutput = helper.command.showComponentParsed('bar/foo');
       });
       it('should have the updated dependencies for bar/foo from the env', function () {
-        expect(barFooOutput.peerPackageDependencies).to.have.property('react', '^16.13.0');
+        expect(barFooOutput.peerPackageDependencies).to.have.property('react', '^16.13.1');
         expect(barFooOutput.devPackageDependencies).to.have.property('@types/react', '16.9.43');
       });
     });

--- a/scripts/dogfooding.sh
+++ b/scripts/dogfooding.sh
@@ -21,7 +21,7 @@ find components/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\//'bit-bin\/dist\
 find components/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
 find components/*/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
 mkdir extensions/cli/bin
-echo -e '#!/usr/bin/env node\nrequire("bit-bin/dist/app.js");' > extensions/cli/bin/bit.js
+echo -e '#!/usr/bin/env node\nrequire("../app");' > extensions/cli/bin/bit.js
 rm -rf node_modules/bit-bin
 ln -s `pwd` node_modules/bit-bin
 STATUS=`bit status`

--- a/scripts/dogfooding.sh
+++ b/scripts/dogfooding.sh
@@ -21,7 +21,7 @@ find components/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\//'bit-bin\/dist\
 find components/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
 find components/*/*/*/*/*.* -type f -exec sed -i '' "s/'..\/..\/..\/..\/..\//'bit-bin\/dist\//g" {} \;
 mkdir extensions/cli/bin
-echo "#!/usr/bin/env node\nrequire('bit-bin/dist/app.js');" > extensions/cli/bin/bit.js
+echo -e '#!/usr/bin/env node\nrequire("bit-bin/dist/app.js");' > extensions/cli/bin/bit.js
 rm -rf node_modules/bit-bin
 ln -s `pwd` node_modules/bit-bin
 STATUS=`bit status`

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,46 +1,16 @@
-import semver from 'semver';
-import chalk from 'chalk';
-import Bluebird from 'bluebird';
-import fs from 'fs-extra';
 import harmony from '@teambit/harmony';
-import HooksManager from './hooks';
-import { handleErrorAndExit, handleUnhandledRejection } from './cli/command-runner';
+import { handleErrorAndExit } from './cli/command-runner';
 import { ConfigExt } from './extensions/config';
 import { BitExt, registerCoreExtensions } from './extensions/bit';
 import { CLIExtension } from './extensions/cli';
-import { Analytics } from './analytics/analytics';
-import { GLOBAL_CONFIG, GLOBAL_LOGS, BIT_VERSION } from './constants';
-import { printWarning } from './logger/logger';
-
-const MINIMUM_NODE_VERSION = '10.13.0';
-
-process.env.MEMFS_DONT_WARN = 'true'; // suppress fs experimental warnings from memfs
-
-require('events').EventEmitter.defaultMaxListeners = 100; // set max listeners to a more appropriate numbers
-
-require('regenerator-runtime/runtime');
-
-process.on('unhandledRejection', (err) => handleUnhandledRejection(err));
-
-// by default Bluebird enables the longStackTraces when env is `development`, or when
-// BLUEBIRD_DEBUG is set.
-// the drawback of enabling it all the time is a performance hit. (see http://bluebirdjs.com/docs/api/promise.longstacktraces.html)
-// some commands are slower by 20% with this enabled.
-Bluebird.config({
-  longStackTraces: Boolean(process.env.BLUEBIRD_DEBUG || process.env.BIT_LOG),
-});
+import { bootstrap } from './bootstrap';
 
 initApp();
 
 async function initApp() {
   try {
-    printBitVersionIfAsked();
-    warnIfRunningAsRoot();
-    verifyNodeVersionCompatibility();
-    await ensureDirectories();
-    await Analytics.promptAnalyticsIfNeeded();
+    await bootstrap();
     registerCoreExtensions();
-    HooksManager.init();
     await harmony.run(ConfigExt);
     await harmony.set([BitExt]);
     await runCLI();
@@ -54,39 +24,4 @@ async function runCLI() {
   const cli: CLIExtension = harmony.get('CLIExtension');
   if (!cli) throw new Error(`failed to get CLIExtension from Harmony`);
   await cli.run();
-}
-
-async function ensureDirectories() {
-  await fs.ensureDir(GLOBAL_CONFIG);
-  await fs.ensureDir(GLOBAL_LOGS);
-}
-
-function verifyNodeVersionCompatibility() {
-  const nodeVersion = process.versions.node.split('-')[0];
-  const isCompatible = semver.satisfies(nodeVersion, `>=${MINIMUM_NODE_VERSION}`);
-  if (!isCompatible) {
-    // eslint-disable-next-line no-console
-    console.log(
-      chalk.red(
-        `Node version ${nodeVersion} is not supported, please use Node.js ${MINIMUM_NODE_VERSION} or higher. If you must use legacy versions of Node.js, please use our binary installation methods. https://docs.bit.dev/docs/installation`
-      )
-    );
-    process.exit(1);
-  }
-}
-
-function warnIfRunningAsRoot() {
-  const isRoot = process.getuid && process.getuid() === 0;
-  if (isRoot) {
-    printWarning('running bit as root might cause permission issues later');
-  }
-}
-
-function printBitVersionIfAsked() {
-  if (process.argv[2]) {
-    if (['-V', '-v', '--version'].includes(process.argv[2])) {
-      console.log(BIT_VERSION); // eslint-disable-line no-console
-      process.exit();
-    }
-  }
 }

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -1,0 +1,71 @@
+import semver from 'semver';
+import chalk from 'chalk';
+import Bluebird from 'bluebird';
+import fs from 'fs-extra';
+import HooksManager from './hooks';
+import { handleUnhandledRejection } from './cli/command-runner';
+import { Analytics } from './analytics/analytics';
+import { GLOBAL_CONFIG, GLOBAL_LOGS, BIT_VERSION } from './constants';
+import { printWarning } from './logger/logger';
+
+const MINIMUM_NODE_VERSION = '10.13.0';
+
+process.env.MEMFS_DONT_WARN = 'true'; // suppress fs experimental warnings from memfs
+
+require('events').EventEmitter.defaultMaxListeners = 100; // set max listeners to a more appropriate numbers
+
+require('regenerator-runtime/runtime');
+
+process.on('unhandledRejection', (err) => handleUnhandledRejection(err));
+
+// by default Bluebird enables the longStackTraces when env is `development`, or when
+// BLUEBIRD_DEBUG is set.
+// the drawback of enabling it all the time is a performance hit. (see http://bluebirdjs.com/docs/api/promise.longstacktraces.html)
+// some commands are slower by 20% with this enabled.
+Bluebird.config({
+  longStackTraces: Boolean(process.env.BLUEBIRD_DEBUG || process.env.BIT_LOG),
+});
+
+export async function bootstrap() {
+  printBitVersionIfAsked();
+  warnIfRunningAsRoot();
+  verifyNodeVersionCompatibility();
+  await ensureDirectories();
+  await Analytics.promptAnalyticsIfNeeded();
+  HooksManager.init();
+}
+
+async function ensureDirectories() {
+  await fs.ensureDir(GLOBAL_CONFIG);
+  await fs.ensureDir(GLOBAL_LOGS);
+}
+
+function verifyNodeVersionCompatibility() {
+  const nodeVersion = process.versions.node.split('-')[0];
+  const isCompatible = semver.satisfies(nodeVersion, `>=${MINIMUM_NODE_VERSION}`);
+  if (!isCompatible) {
+    // eslint-disable-next-line no-console
+    console.log(
+      chalk.red(
+        `Node version ${nodeVersion} is not supported, please use Node.js ${MINIMUM_NODE_VERSION} or higher. If you must use legacy versions of Node.js, please use our binary installation methods. https://docs.bit.dev/docs/installation`
+      )
+    );
+    process.exit(1);
+  }
+}
+
+function warnIfRunningAsRoot() {
+  const isRoot = process.getuid && process.getuid() === 0;
+  if (isRoot) {
+    printWarning('running bit as root might cause permission issues later');
+  }
+}
+
+function printBitVersionIfAsked() {
+  if (process.argv[2]) {
+    if (['-V', '-v', '--version'].includes(process.argv[2])) {
+      console.log(BIT_VERSION); // eslint-disable-line no-console
+      process.exit();
+    }
+  }
+}

--- a/src/extensions/cli/app.ts
+++ b/src/extensions/cli/app.ts
@@ -1,0 +1,27 @@
+import harmony from '@teambit/harmony';
+import { handleErrorAndExit } from '../../cli/command-runner';
+import { ConfigExt } from '../config';
+import { BitExt, registerCoreExtensions } from '../bit';
+import { CLIExtension } from './cli.extension';
+import { bootstrap } from '../../bootstrap';
+
+initApp();
+
+async function initApp() {
+  try {
+    await bootstrap();
+    registerCoreExtensions();
+    await harmony.run(ConfigExt);
+    await harmony.set([BitExt]);
+    await runCLI();
+  } catch (err) {
+    const originalError = err.originalError || err;
+    handleErrorAndExit(originalError, process.argv[2]);
+  }
+}
+
+async function runCLI() {
+  const cli: CLIExtension = harmony.get('CLIExtension');
+  if (!cli) throw new Error(`failed to get CLIExtension from Harmony`);
+  await cli.run();
+}

--- a/src/extensions/dependency-resolver/manifest/manifest.ts
+++ b/src/extensions/dependency-resolver/manifest/manifest.ts
@@ -18,7 +18,7 @@ export class Manifest {
     const devDependencies = this.dependencies.devDependencies || {};
     const peerDependencies = this.dependencies.peerDependencies || {};
     if (options.copyPeerToRuntime) {
-      dependencies = Object.assign(peerDependencies, dependencies);
+      dependencies = { ...peerDependencies, ...dependencies };
     }
     const manifest = {
       name: this.name,

--- a/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
+++ b/src/extensions/dependency-resolver/manifest/workspace-manifest.ts
@@ -137,6 +137,11 @@ async function buildComponentDependenciesMap(
     const depGraph = new DependencyGraph(component);
     const versionModifierFunc = generateVersionModifier(component, rootDependencies, mergeDependenciesFunc);
     const depObject = await depGraph.toJson(filterFn(components), versionModifierFunc);
+
+    if (depObject.dependencies) delete depObject.dependencies['bit-bin'];
+    if (depObject.devDependencies) delete depObject.devDependencies['bit-bin'];
+    if (depObject.peerDependencies) delete depObject.peerDependencies['bit-bin'];
+
     result.set(packageName, depObject);
     return Promise.resolve();
   });

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -88,13 +88,17 @@ export class IsolatorExtension {
         .map((capsuleWithPackageData) => capsuleWithPackageData.capsule);
       // await this.dependencyResolver.capsulesInstall(capsulesToInstall, { packageManager: config.packageManager });
       const installer = this.dependencyResolver.getInstaller();
-      // When using isolator we don't want to use the policy defined in the workspace directly, we only want to instal deps from components
-      await installer.install(
-        capsulesDir,
-        this.dependencyResolver.getEmptyDepsObject(),
-        this.toComponentMap(capsules),
-        { dedupe: true }
-      );
+      // When using isolator we don't want to use the policy defined in the workspace directly,
+      // we only want to instal deps from components and the peer from the workspace
+
+      const workspacePolicy = this.dependencyResolver.getWorkspacePolicy() || {};
+      const rootDepsObject = {
+        peerDependencies: {
+          ...workspacePolicy.peerDependencies,
+        },
+      };
+
+      await installer.install(capsulesDir, rootDepsObject, this.toComponentMap(capsules), { dedupe: true });
       await symlinkDependenciesToCapsules(capsulesToInstall, capsuleList, this.logger);
       // TODO: this is a hack to have access to the bit bin project in order to access core extensions from user extension
       // TODO: remove this after exporting core extensions as components

--- a/src/extensions/isolator/isolator.extension.ts
+++ b/src/extensions/isolator/isolator.extension.ts
@@ -93,7 +93,7 @@ export class IsolatorExtension {
         capsulesDir,
         this.dependencyResolver.getEmptyDepsObject(),
         this.toComponentMap(capsules),
-        { dedupe: false }
+        { dedupe: true }
       );
       await symlinkDependenciesToCapsules(capsulesToInstall, capsuleList, this.logger);
       // TODO: this is a hack to have access to the bit bin project in order to access core extensions from user extension

--- a/src/extensions/pnpm/pnpm.package-manager.ts
+++ b/src/extensions/pnpm/pnpm.package-manager.ts
@@ -47,12 +47,6 @@ export class PnpmPackageManager implements PackageManager {
       // In case of not deduping we want to install peers inside the components
       !options.dedupe
     );
-    delete rootManifest.manifest.dependencies['bit-bin'];
-    delete rootManifest.manifest.peerDependencies['bit-bin'];
-    Object.keys(componentsManifests).forEach((componentName) => {
-      if (!componentsManifests[componentName].dependencies) return;
-      delete componentsManifests[componentName].dependencies['bit-bin'];
-    });
     this.logger.debug('root manifest for installation', rootManifest);
     this.logger.debug('components manifests for installation', componentsManifests);
     this.logger.setStatusLine('installing dependencies');

--- a/src/extensions/react/react.env.ts
+++ b/src/extensions/react/react.env.ts
@@ -141,7 +141,7 @@ export class ReactEnv implements Environment {
       },
       // TODO: take version from config
       peerDependencies: {
-        react: '^16.13.0' || this.config.reactVersion,
+        react: '^16.13.1' || this.config.reactVersion,
       },
     };
   }
@@ -152,6 +152,6 @@ export class ReactEnv implements Environment {
   getPipe(): BuildTask[] {
     // return BuildPipe.from([this.compiler.task, this.tester.task]);
     // return BuildPipe.from([this.tester.task]);
-    return [this.compiler.task, this.pkg.dryRunTask];
+    return [this.compiler.task, this.pkg.preparePackagesTask, this.pkg.dryRunTask];
   }
 }

--- a/src/extensions/react/react.env.ts
+++ b/src/extensions/react/react.env.ts
@@ -152,6 +152,7 @@ export class ReactEnv implements Environment {
   getPipe(): BuildTask[] {
     // return BuildPipe.from([this.compiler.task, this.tester.task]);
     // return BuildPipe.from([this.tester.task]);
-    return [this.compiler.task, this.pkg.preparePackagesTask, this.pkg.dryRunTask];
+    // return [this.compiler.task, this.pkg.preparePackagesTask, this.pkg.dryRunTask];
+    return [this.compiler.task, this.pkg.dryRunTask];
   }
 }

--- a/src/extensions/typescript/typescript.compiler.ts
+++ b/src/extensions/typescript/typescript.compiler.ts
@@ -72,6 +72,7 @@ export class TypescriptCompiler implements Compiler {
     const componentsErrors: ComponentError[] = [];
 
     await this.runTscBuild(componentsErrors, context.capsuleGraph);
+    await this.deleteTsBuildInfoFiles(capsuleDirs);
 
     const components = capsules.map((capsule) => {
       const id = capsule.id;
@@ -124,6 +125,16 @@ export class TypescriptCompiler implements Compiler {
     if (result > 0 && !componentsErrors.length) {
       throw new Error(`typescript exited with status code ${result}, however, no errors are found in the diagnostics`);
     }
+  }
+
+  /**
+   * when using project-references, typescript adds a file "tsconfig.tsbuildinfo" which is not
+   * needed for the package.
+   */
+  private async deleteTsBuildInfoFiles(capsuleDirs: string[]) {
+    await Promise.all(
+      capsuleDirs.map((capsuleDir) => fs.remove(path.join(capsuleDir, this.getDistDir(), 'tsconfig.tsbuildinfo')))
+    );
   }
 
   private createTsSolutionBuilderHost(

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -5,8 +5,8 @@
     "defaultDirectory": "components",
     "vendorDirectory": "vendor",
     "extensions": {
-      "@teambit/envs": {
-        "env": "@teambit/react",
+      "@teambit/react": {
+        "env": "@teambit/envs",
         "config": {}
       },
       "@teambit/pkg": {
@@ -20,6 +20,9 @@
             "@types/mocha": "^5.2.7",
             // why this is needed? try to automate this
             "@types/node": "^12.12.27"
+          },
+          "peerDependencies": {
+            "react": "^16.13.1"
           }
         }
       }
@@ -28,12 +31,19 @@
   "@teambit/dependency-resolver": {
     "packageManager": "@teambit/pnpm",
     "strictPeerDependencies": true,
-    "extraArgs": []
+    "extraArgs": [],
+    "policy": {
+      "peerDependencies": {
+        "react": "^16.13.1",
+        "browserslist": "^4",
+        "mz": "^2.7.0"
+      }
+    }
   },
   "@teambit/variants": {
     "extensions/cli": {
-      "@teambit/envs": {
-        "env": "@teambit/react",
+      "@teambit/react": {
+        "env": "@teambit/envs",
         "config": {}
       },
       "@teambit/pkg": {


### PR DESCRIPTION
* add app.ts to the cli extension to be able to bootstrap bit-bin from there.
* avoid duplicating dependencies into peerDependencies when installing packages using the pnpm api.
* fix capsules to install peerDependencies
* delete tsBuildInfo files after compiling on capsules (file needed for `tsc --build` but should not be part of the package).
* add missing peerPackages to dependency-resolver policy.