### PR TITLE
Extensions ids legacy

### DIFF
--- a/extensions/bit/bit.provider.ts
+++ b/extensions/bit/bit.provider.ts
@@ -1,10 +1,20 @@
+import { getCoreAspectPackageName } from '@teambit/aspect-loader';
+import { DependencyResolver } from 'bit-bin/dist/consumer/component/dependencies/dependency-resolver';
 import { manifestsMap } from './manifests';
+
 
 export type BitDeps = [];
 
 export type BitConfig = {};
 
 export async function provideBit() {
+  const allCoreAspectsIds = Object.keys(manifestsMap);
+  const coreAspectsPackagesAndIds = {};
+  allCoreAspectsIds.forEach(id => {
+    const packageName = getCoreAspectPackageName(id);
+    coreAspectsPackagesAndIds[packageName] = id;
+  });
+  DependencyResolver.getCoreAspectsPackagesAndIds = () => coreAspectsPackagesAndIds;
   return {
     manifestsMap,
   };

--- a/extensions/bit/manifests.ts
+++ b/extensions/bit/manifests.ts
@@ -42,6 +42,7 @@ import { ChangelogAspect } from '@teambit/changelog';
 import { BitAspect } from './bit.aspect';
 
 export const manifestsMap = {
+  [AspectLoaderAspect.id]: AspectLoaderAspect,
   [CLIAspect.id]: CLIAspect,
   [WorkspaceAspect.id]: WorkspaceAspect,
   [CompilerAspect.id]: CompilerAspect,
@@ -72,7 +73,6 @@ export const manifestsMap = {
   [AspectAspect.id]: AspectAspect,
   [WebpackAspect.id]: WebpackAspect,
   [SchemaAspect.id]: SchemaAspect,
-  [AspectLoaderAspect.id]: AspectLoaderAspect,
   [ReactRouterAspect.id]: ReactRouterAspect,
   [PanelUiAspect.id]: PanelUiAspect,
   [TypescriptAspect.id]: TypescriptAspect,

--- a/extensions/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/extensions/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -367,6 +367,7 @@ export class DependencyResolverMain {
       aspectLoader,
       packageManagerSlot
     );
+    DependencyResolver.getDepResolverAspectName = () => DependencyResolverAspect.id;
     ConsumerComponent.registerOnComponentOverridesLoading(
       DependencyResolverAspect.id,
       async (configuredExtensions: ExtensionDataList) => {

--- a/extensions/pkg/publisher.ts
+++ b/extensions/pkg/publisher.ts
@@ -10,6 +10,7 @@ import { PublishPostExportResult } from 'bit-bin/dist/scope/component-ops/publis
 import Bluebird from 'bluebird';
 import execa from 'execa';
 import R from 'ramda';
+import { PkgAspect } from './pkg.aspect';
 
 export type PublisherOptions = {
   dryRun?: boolean;
@@ -131,13 +132,13 @@ export class Publisher {
   }
 
   public shouldPublish(extensions: ExtensionDataList): boolean {
-    const pkgExt = extensions.findExtension('teambit.bit/pkg');
+    const pkgExt = extensions.findExtension(PkgAspect.id);
     if (!pkgExt) return false;
     return pkgExt.config?.packageJson?.name || pkgExt.config?.packageJson?.publishConfig;
   }
 
   private getExtraArgsFromConfig(component: Component): string | undefined {
-    const pkgExt = component.config.extensions.findExtension('teambit.bit/pkg');
+    const pkgExt = component.config.extensions.findExtension(PkgAspect.id);
     return pkgExt?.config?.packageManagerPublishArgs;
   }
 

--- a/extensions/tester/utils/detect-spec-files.ts
+++ b/extensions/tester/utils/detect-spec-files.ts
@@ -1,5 +1,5 @@
 import { Component } from '@teambit/component';
-import TesterAspect from '../tester.aspect';
+import { TesterAspect } from '../tester.aspect';
 
 /**
  * detect test files in components

--- a/extensions/tester/utils/detect-spec-files.ts
+++ b/extensions/tester/utils/detect-spec-files.ts
@@ -7,7 +7,7 @@ export function detectTestFiles(components: Component[]) {
   return components.map((component) => {
     const paths = component.filesystem.files
       .filter((file) => {
-        const testerConfig = component.config.extensions.findExtension('teambit.bit/tester')?.config;
+        const testerConfig = component.config.extensions.findExtension(TesterAspect.id)?.config;
         // should be used as a default value.
         return file.relative.match(testerConfig?.testRegex || '(/__tests__/.*|(\\.|/)(test|spec))\\.[jt]sx?$');
       })

--- a/extensions/tester/utils/detect-spec-files.ts
+++ b/extensions/tester/utils/detect-spec-files.ts
@@ -1,4 +1,5 @@
 import { Component } from '@teambit/component';
+import TesterAspect from '../tester.aspect';
 
 /**
  * detect test files in components

--- a/extensions/workspace/workspace.provider.ts
+++ b/extensions/workspace/workspace.provider.ts
@@ -129,8 +129,8 @@ export default async function provideWorkspace(
     const extensionsWithLegacyIdsP = extensions.map(async extension => {
       const legacyEntry = extension.clone();
       if (legacyEntry.extensionId){
-        const componentId = await workspace.resolveComponentId(legacyEntry.extensionId);
-        legacyEntry.extensionId = componentId._legacy;
+        const resolvedComponentId = await workspace.resolveComponentId(legacyEntry.extensionId);
+        legacyEntry.extensionId = resolvedComponentId._legacy;
       }
       return legacyEntry;
     })

--- a/extensions/workspace/workspace.provider.ts
+++ b/extensions/workspace/workspace.provider.ts
@@ -14,6 +14,7 @@ import type { VariantsMain } from '@teambit/variants';
 import { Consumer, loadConsumerIfExist } from 'bit-bin/dist/consumer';
 import ConsumerComponent from 'bit-bin/dist/consumer/component';
 import ManyComponentsWriter from 'bit-bin/dist/consumer/component-ops/many-components-writer';
+import { ExtensionDataList } from 'bit-bin/dist/consumer/config/extension-data';
 
 import { CapsuleCreateCmd } from './capsule-create.cmd';
 import { CapsuleListCmd } from './capsule-list.cmd';
@@ -125,9 +126,19 @@ export default async function provideWorkspace(
     const extensions = await workspace.componentExtensions(componentId, componentFromScope);
     const defaultScope = await workspace.componentDefaultScope(componentId);
     await workspace.loadExtensions(extensions);
+    const extensionsWithLegacyIdsP = extensions.map(async extension => {
+      const legacyEntry = extension.clone();
+      if (legacyEntry.extensionId){
+        const componentId = await workspace.resolveComponentId(legacyEntry.extensionId);
+        legacyEntry.extensionId = componentId._legacy;
+      }
+      return legacyEntry;
+    })
+    const extensionsWithLegacyIds = await Promise.all(extensionsWithLegacyIdsP);
+
     return {
       defaultScope,
-      extensions,
+      extensions: ExtensionDataList.fromArray(extensionsWithLegacyIds),
     };
   });
 

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -5,7 +5,7 @@ import semver from 'semver';
 
 import { Dependency } from '..';
 import { BitId, BitIds } from '../../../../bit-id';
-import { COMPONENT_ORIGINS, DEPENDENCIES_FIELDS, Extensions } from '../../../../constants';
+import { COMPONENT_ORIGINS, DEPENDENCIES_FIELDS } from '../../../../constants';
 import { ExtensionDataEntry } from '../../../../consumer/config';
 import Consumer from '../../../../consumer/consumer';
 import GeneralError from '../../../../error/general-error';


### PR DESCRIPTION
## Proposed Changes

- use resolved legacy ids for extensions on components
- remove core extensions from unidentified packages
- add used core aspects to dependency resolver extension data
