### PR TITLE
temporarily change loading components from scope to merge the data from the model 

### DIFF
--- a/extensions/react/component.json
+++ b/extensions/react/component.json
@@ -3,7 +3,7 @@
     "name": "react",
     "version": "0.0.10"
   },
-  "propagate": false,
+  "propagate": true,
   "extensions": {
     "teambit.bit/pkg": {
       "packageJson": {

--- a/extensions/ui/component.json
+++ b/extensions/ui/component.json
@@ -3,7 +3,7 @@
     "name": "ui",
     "version": "0.0.10"
   },
-  "propagate": false,
+  "propagate": true,
   "extensions": {
     "teambit.bit/pkg": {
       "packageJson": {

--- a/extensions/workspace/workspace.ts
+++ b/extensions/workspace/workspace.ts
@@ -580,9 +580,9 @@ export class Workspace implements ComponentFactory {
     if (variantConfig) {
       variantsExtensions = variantConfig.extensions;
       // Do not merge from scope when there is specific variant (which is not *) that match the component
-      if (variantConfig.maxSpecificity > 0) {
-        mergeFromScope = false;
-      }
+      // if (variantConfig.maxSpecificity > 0) {
+      //   mergeFromScope = false;
+      // }
     }
     const isVendor = this.isVendorComponentByComponentDir(relativeComponentDir);
     if (!isVendor) {

--- a/extensions/workspace/workspace.ts
+++ b/extensions/workspace/workspace.ts
@@ -564,16 +564,14 @@ export class Workspace implements ComponentFactory {
     let configFileExtensions;
     let variantsExtensions;
     let wsDefaultExtensions;
-    let scopeExtensions;
-    let mergeFromScope = true;
+    const mergeFromScope = true;
+    const scopeExtensions = componentFromScope?.config?.extensions || new ExtensionDataList();
 
     const componentConfigFile = await this.componentConfigFile(componentId);
     if (componentConfigFile) {
       configFileExtensions = componentConfigFile.extensions;
       // do not merge from scope data when there is component config file
-      mergeFromScope = false;
-    } else {
-      scopeExtensions = componentFromScope?.config?.extensions || new ExtensionDataList();
+      // mergeFromScope = false;
     }
     const relativeComponentDir = this.componentDir(componentId, { ignoreVersion: true }, { relative: true });
     const variantConfig = this.variants.byRootDir(relativeComponentDir);


### PR DESCRIPTION
even when it has overrides in workspace.jsonc or component.json file.

@GiladShoham , see the commit. I commented-out your code.
The problem is that when I tag the bit-bin extensions and then load the extensions, the data from the model is gone. This is because they have override data in the workspace.jsonc. (some also have their own component.json file).
We need to figure out how to tackle this. For example, the "compiler" extension is not set in the workspace.jsonc, so we do want to merge its data (the artifacts = dists) from the scope.
Please let me know if you have a suggestion. I'll be merging this for now, so we could publish bit-bin.