### PR TITLE
fix bindingPrefix issues

### DIFF
--- a/src/consumer/component-ops/dependency-status.ts
+++ b/src/consumer/component-ops/dependency-status.ts
@@ -13,6 +13,7 @@ async function getTopLevelDependencies(consumer: Consumer, dependencyStatusProps
     workspacePath: consumerPath,
     filePaths: paths,
     bindingPrefix: DEFAULT_BINDINGS_PREFIX,
+    isLegacyProject: consumer.isLegacy,
     resolveModulesConfig: consumer.config._resolveModules,
   });
   const topLevelDependencies = Object.keys(tree.tree).map((topLevelFile) => topLevelFile);

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -23,6 +23,7 @@ import { RelativePath } from '../dependency';
 import { getDependencyTree } from '../files-dependency-builder';
 import { FileObject, ImportSpecifier, Tree } from '../files-dependency-builder/types/dependency-tree-type';
 import OverridesDependencies from './overrides-dependencies';
+import { ResolvedPackageData } from '../../../../utils/packages';
 
 export type AllDependencies = {
   dependencies: Dependency[];
@@ -354,19 +355,7 @@ export default class DependencyResolver {
     if (this.tree[depFile].bits && !R.isEmpty(this.tree[depFile].bits)) {
       const bits = this.tree[depFile].bits || [];
       for (const bit of bits) {
-        if (bit.componentId) {
-          return bit.componentId;
-        }
-        if (bit.fullPath) {
-          const componentId = this.consumer.getComponentIdFromNodeModulesPath(
-            bit.fullPath,
-            this.component.bindingPrefix
-          );
-          if (componentId) return componentId;
-        } else {
-          const componentId = packageNameToComponentId(this.consumer, bit.name, this.component.bindingPrefix);
-          return componentId;
-        }
+        return this.getComponentIdByResolvedPackageData(bit);
       }
     }
 
@@ -381,6 +370,19 @@ export default class DependencyResolver {
       }
     }
     return undefined;
+  }
+
+  getComponentIdByResolvedPackageData(bit: ResolvedPackageData): BitId {
+    if (bit.componentId) {
+      return bit.componentId;
+    }
+    if (!this.consumer.isLegacy) {
+      throw new Error(`on Harmony resolved Bit component must have componentId prop in the package.json file`);
+    }
+    if (bit.fullPath) {
+      return this.consumer.getComponentIdFromNodeModulesPath(bit.fullPath, this.component.bindingPrefix);
+    }
+    return packageNameToComponentId(this.consumer, bit.name, this.component.bindingPrefix);
   }
 
   /**
@@ -719,18 +721,10 @@ either, use the ignore file syntax or change the require statement to have a mod
   processBits(originFile: PathLinuxRelative, fileType: FileType) {
     const bits = this.tree[originFile].bits;
     if (!bits || R.isEmpty(bits)) return;
-    let componentId;
     bits.forEach((bitDep) => {
       const version =
         this.getValidVersion(bitDep.concreteVersion) || this.getValidVersion(bitDep.versionUsedByDependent);
-      if (bitDep.componentId) {
-        componentId = bitDep.componentId;
-      } else if (bitDep.fullPath) {
-        componentId = this.consumer.getComponentIdFromNodeModulesPath(bitDep.fullPath, this.component.bindingPrefix);
-      } else {
-        // legacy components don't have componentId prop in the package.json
-        componentId = packageNameToComponentId(this.consumer, bitDep.name, this.component.bindingPrefix);
-      }
+      let componentId = this.getComponentIdByResolvedPackageData(bitDep);
       if (componentId && version) {
         componentId = componentId.changeVersion(version);
       }
@@ -828,18 +822,13 @@ either, use the ignore file syntax or change the require statement to have a mod
     if (!this.consumer.isLegacy) {
       // on Harmony we don't guess whether a path is a component or a package based on the path only,
       // see missing-handler.groupMissingByType() for more info.
-      throw new Error(`Harmony should not have any missingBits. got ${missingComponents.join(',')}`);
+      throw new Error(
+        `Harmony should not have "missing.bits" (only "missing.packages"). got ${missingComponents.join(',')}`
+      );
     }
     missingComponents.forEach((missingBit) => {
       const componentId: BitId = this.consumer.getComponentIdFromNodeModulesPath(
         missingBit,
-        // this is a bit dangerous because it send the dependent prefix and assume it's the same for the dependency
-        // sometime you might just not find it (which is totally fine) but sometime it can make a bug
-        // for example
-        // I installed a package names my-comp
-        // I have a component called @my-org/my-comp
-        // The dependent called @my-org/my-dependent
-        // Now I might resolve the package as the component
         this.component.bindingPrefix
       );
       if (this.overridesDependencies.shouldIgnoreComponent(componentId, fileType)) return;

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
@@ -16,6 +16,7 @@ describe('buildTree', () => {
       workspacePath: __dirname,
       filePaths,
       bindingPrefix: '@bit',
+      isLegacyProject: true,
       visited,
       resolveModulesConfig: undefined,
     };

--- a/src/consumer/component/dependencies/files-dependency-builder/generate-tree-madge.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/generate-tree-madge.ts
@@ -5,6 +5,7 @@ import os from 'os';
 import path from 'path';
 
 import dependencyTree from './dependency-tree';
+import { PathLinuxRelative } from '../../../../utils/path';
 
 /**
  * Check if running on Windows.
@@ -97,13 +98,27 @@ function convertTreePaths(depTree, pathCache, baseDir) {
   return tree;
 }
 
+// e.g. { 'index.ts': ['foo.ts', '../node_modules/react/index.js'] }
+// all paths are normalized to Linux
+export type MadgeTree = { [relativePath: string]: PathLinuxRelative[] };
+
+// e.g. { '/tmp/workspace': ['lodash', 'ramda'] };
+export type Missing = { [absolutePath: string]: string[] };
+
+type GenerateTreeResults = {
+  madgeTree: MadgeTree;
+  skipped: Missing;
+  pathMap: any;
+  errors: { [filePath: string]: Error };
+};
+
 /**
  * Generate the tree from the given files
  * @param  {Array} files
  * @param config
  * @return {Object}
  */
-export default function generateTree(files = [], config) {
+export default function generateTree(files = [], config): GenerateTreeResults {
   const depTree = {};
   const nonExistent = {};
   const npmPaths = {};

--- a/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -61,6 +61,7 @@ export type DependencyTreeParams = {
   workspacePath: string;
   filePaths: string[];
   bindingPrefix: string;
+  isLegacyProject: boolean;
   resolveModulesConfig?: ResolveModulesConfig;
   visited?: Record<string, any>;
   cacheResolvedDependencies?: Record<string, any>;

--- a/src/utils/packages/resolve-pkg-name-by-path.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.ts
@@ -7,7 +7,7 @@ import path from 'path';
  * @returns {string} name of the package
  */
 export function resolvePackageNameByPath(packagePath: string): string {
-  const packagePathArr = packagePath.split(path.sep); // TODO: make sure this is working on windows
+  const packagePathArr = packagePath.split(path.sep);
   // Regular package without path. example - import _ from 'lodash'
   if (packagePathArr.length === 1) return packagePath;
   // Scoped package. example - import getSymbolIterator from '@angular/core/src/util.d.ts';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -3,7 +3,7 @@
   "teambit.bit/workspace": {
     "name": "bit",
     "icon": "https://static.bit.dev/bit-logo.svg",
-    "defaultScope": "teambit3.bit",
+    "defaultScope": "teambit.bit",
     "defaultDirectory": "components"
     // "vendorDirectory": "vendor",
   },

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -3,7 +3,7 @@
   "teambit.bit/workspace": {
     "name": "bit",
     "icon": "https://static.bit.dev/bit-logo.svg",
-    "defaultScope": "teambit.bit",
+    "defaultScope": "teambit3.bit",
     "defaultDirectory": "components"
     // "vendorDirectory": "vendor",
   },


### PR DESCRIPTION
on Harmony use only package.json `componentID` prop to determine whether a dependency is a package or a component.
