### PR TITLE
Aspect graph loading

### DIFF
--- a/extensions/workspace/workspace.ts
+++ b/extensions/workspace/workspace.ts
@@ -733,7 +733,7 @@ export class Workspace implements ComponentFactory {
       const currIds = curr.state.aspects.ids;
       acc = acc.concat(currIds);
       return acc;
-    }, []);
+    }, [] as any);
     const otherDependenciesMap = components.reduce((acc, curr) => {
       // const currIds = curr.state.dependencies.dependencies.map(dep => dep.id.toString());
       const currMap = curr.state.dependencies.getIdsMap();
@@ -746,7 +746,7 @@ export class Workspace implements ComponentFactory {
     // We only want to load into the graph components which are aspects and not regular dependencies
     // This come to solve a circular loop when an env aspect use an aspect (as regular dep) and the aspect use the env aspect as its env
     const ignoredIds = coreAspectsBitIds.concat(depsWhichAreNotAspectsBitIds);
-    return buildOneGraphForComponents(ids, this.consumer, 'normal', loadComponentsFunc, ignoredIds);
+    return buildOneGraphForComponents(ids, this.consumer, 'normal', loadComponentsFunc, BitIds.fromArray(ignoredIds));
   }
 
   // TODO: refactor to aspect-loader after handling of default scope.

--- a/extensions/workspace/workspace.ts
+++ b/extensions/workspace/workspace.ts
@@ -729,7 +729,24 @@ export class Workspace implements ComponentFactory {
     const coreAspectsStringIds = this.aspectLoader.getCoreAspectIds();
     const coreAspectsComponentIds = await Promise.all(coreAspectsStringIds.map((id) => BitId.parse(id, true)));
     const coreAspectsBitIds = BitIds.fromArray(coreAspectsComponentIds.map((id) => id.changeScope(null)));
-    return buildOneGraphForComponents(ids, this.consumer, 'normal', loadComponentsFunc, coreAspectsBitIds);
+    const aspectsIds = components.reduce((acc, curr) => {
+      const currIds = curr.state.aspects.ids;
+      acc = acc.concat(currIds);
+      return acc;
+    }, []);
+    const otherDependenciesMap = components.reduce((acc, curr) => {
+      // const currIds = curr.state.dependencies.dependencies.map(dep => dep.id.toString());
+      const currMap = curr.state.dependencies.getIdsMap();
+      Object.assign(acc, currMap);
+      return acc;
+    }, {});
+
+    const depsWhichAreNotAspects = difference(Object.keys(otherDependenciesMap), aspectsIds);
+    const depsWhichAreNotAspectsBitIds = depsWhichAreNotAspects.map(strId => otherDependenciesMap[strId]);
+    // We only want to load into the graph components which are aspects and not regular dependencies
+    // This come to solve a circular loop when an env aspect use an aspect (as regular dep) and the aspect use the env aspect as its env
+    const ignoredIds = coreAspectsBitIds.concat(depsWhichAreNotAspectsBitIds);
+    return buildOneGraphForComponents(ids, this.consumer, 'normal', loadComponentsFunc, ignoredIds);
   }
 
   // TODO: refactor to aspect-loader after handling of default scope.

--- a/src/bit-id/bit-ids.spec.ts
+++ b/src/bit-id/bit-ids.spec.ts
@@ -80,4 +80,16 @@ describe('bitIds', () => {
       });
     });
   });
+  describe('difference', () => {
+    it('should remove entries from the provided array', () => {
+      const a = new BitId({ name: 'a' });
+      const b = new BitId({ name: 'b' });
+      const c = new BitId({ name: 'c' });
+      const bitIds = BitIds.fromArray([a, b]);
+      const bitIds2 = BitIds.fromArray([b, c]);
+      const res = bitIds.difference(bitIds2);
+      expect(res).to.have.lengthOf(1);
+      expect(res.serialize()[0].toString()).to.equal('a');
+    });
+  });
 });

--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -81,6 +81,14 @@ export default class BitIds extends Array<BitId> {
     return BitIds.fromArray(this.filter((id) => !id.isEqual(bitId)));
   }
 
+  /**
+   * Return ids which are on the current instance and not in the passed list
+   * @param bitIds
+   */
+  difference(bitIds: BitIds): BitIds {
+    return BitIds.fromArray(this.filter((id) => !bitIds.search(id)));
+  }
+
   removeIfExistWithoutVersion(bitId: BitId): BitIds {
     return BitIds.fromArray(this.filter((id) => !id.isEqualWithoutVersion(bitId)));
   }

--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -17,8 +17,12 @@ export class FlattenedDependencyLoader {
   ) {}
   async load(component: Component) {
     const dependencies = await this.loadManyDependencies(component.dependencies.getAllIds().difference(this.ignoreIds));
-    const devDependencies = await this.loadManyDependencies(component.devDependencies.getAllIds().difference(this.ignoreIds));
-    const extensionDependencies = await this.loadManyDependencies(component.extensions.extensionsBitIds.difference(this.ignoreIds));
+    const devDependencies = await this.loadManyDependencies(
+      component.devDependencies.getAllIds().difference(this.ignoreIds)
+    );
+    const extensionDependencies = await this.loadManyDependencies(
+      component.extensions.extensionsBitIds.difference(this.ignoreIds)
+    );
 
     const filterIgnoreIds = (comps: any[]) => {
       if (!this.ignoreIds.length) {

--- a/src/consumer/component-ops/load-flattened-dependencies.ts
+++ b/src/consumer/component-ops/load-flattened-dependencies.ts
@@ -16,9 +16,9 @@ export class FlattenedDependencyLoader {
     private loadComponentsFunc?: (ids: BitId[]) => Promise<Component[]>
   ) {}
   async load(component: Component) {
-    const dependencies = await this.loadManyDependencies(component.dependencies.getAllIds());
-    const devDependencies = await this.loadManyDependencies(component.devDependencies.getAllIds());
-    const extensionDependencies = await this.loadManyDependencies(component.extensions.extensionsBitIds);
+    const dependencies = await this.loadManyDependencies(component.dependencies.getAllIds().difference(this.ignoreIds));
+    const devDependencies = await this.loadManyDependencies(component.devDependencies.getAllIds().difference(this.ignoreIds));
+    const extensionDependencies = await this.loadManyDependencies(component.extensions.extensionsBitIds.difference(this.ignoreIds));
 
     const filterIgnoreIds = (comps: any[]) => {
       if (!this.ignoreIds.length) {

--- a/src/consumer/component/dependencies/dependencies.ts
+++ b/src/consumer/component/dependencies/dependencies.ts
@@ -130,6 +130,14 @@ export default class Dependencies {
     return BitIds.fromArray(this.dependencies.map((dependency) => dependency.id));
   }
 
+  getIdsMap(): Record<string, BitId> {
+    const result = {};
+    this.dependencies.forEach(dep => {
+      result[dep.id.toString()] = dep.id
+    });
+    return result;
+  }
+
   async addRemoteAndLocalVersions(scope: Scope, modelDependencies: Dependencies) {
     const dependenciesIds = this.dependencies.map((dependency) => dependency.id);
     const localDependencies = await scope.latestVersions(dependenciesIds);


### PR DESCRIPTION
## Proposed Changes

- new difference api for bitIds class
- new getIdsMap api on dependencies class
- filter ignore ids on load flattened dependencies prior to the actual loading
- filter components which are not aspects of the aspects we try to load 