### PR TITLE
simplify auto-tag process to behave the same as tag

### DIFF
--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -619,10 +619,7 @@ describe('bit snap command', function () {
       });
     });
   });
-  // @todo: fix. needs to make a decision about the auto-tag process. whether it should load from
-  // the workspace or not. currently the OnTag re-load from workspace the auto-tag candidate with
-  // the old dependencies.
-  describe.skip('auto snap', () => {
+  describe('auto snap', () => {
     let snapOutput;
     let isTypeHead;
     before(() => {
@@ -675,10 +672,13 @@ describe('bit snap command', function () {
         helper.command.importComponent('comp1');
       });
       it('should use the updated dependencies and print the results from the latest versions', () => {
-        fs.outputFileSync(path.join(helper.scopes.localPath, 'app.js'), fixtures.appPrintBarFoo);
+        fs.outputFileSync(
+          path.join(helper.scopes.localPath, 'app.js'),
+          `const comp1 = require('./components/comp1');\nconsole.log(comp1())`
+        );
         const result = helper.command.runCmd('node app.js');
         // notice the "v2" (!)
-        expect(result.trim()).to.equal('got is-type v2 and got is-string and got foo');
+        expect(result.trim()).to.equal('comp1 and comp2 and comp3 v2');
       });
     });
   });

--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -139,9 +139,9 @@ describe('bit tag command', function () {
         });
         expect(listOutput).to.deep.include({
           id: 'components/dependent',
-          localVersion: '0.0.2',
+          localVersion: '1.0.0',
           deprecated: false,
-          currentVersion: '0.0.2',
+          currentVersion: '1.0.0',
           remoteVersion: 'N/A',
         });
       });

--- a/e2e/functionalities/auto-tagging.e2e.2.ts
+++ b/e2e/functionalities/auto-tagging.e2e.2.ts
@@ -472,8 +472,8 @@ describe('auto tagging functionality', function () {
       });
       it('should auto tag all dependents', () => {
         expect(tagOutput).to.have.string(AUTO_TAGGED_MSG);
-        expect(tagOutput).to.have.string('bar/a@0.0.2');
-        expect(tagOutput).to.have.string('bar/b@0.0.2');
+        expect(tagOutput).to.have.string('bar/a@2.0.0');
+        expect(tagOutput).to.have.string('bar/b@2.0.0');
         expect(tagOutput).to.have.string('bar/c@2.0.0');
       });
       it('should update the dependencies and the flattenedDependencies of the all dependents with the new versions', () => {
@@ -481,10 +481,10 @@ describe('auto tagging functionality', function () {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(barA.dependencies[0].id.name).to.equal('bar/b');
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barA.dependencies[0].id.version).to.equal('0.0.2');
+        expect(barA.dependencies[0].id.version).to.equal('2.0.0');
 
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barA.flattenedDependencies).to.deep.include({ name: 'bar/b', version: '0.0.2' });
+        expect(barA.flattenedDependencies).to.deep.include({ name: 'bar/b', version: '2.0.0' });
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(barA.flattenedDependencies).to.deep.include({ name: 'bar/c', version: '2.0.0' });
 
@@ -497,19 +497,19 @@ describe('auto tagging functionality', function () {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(barB.flattenedDependencies).to.deep.include({ name: 'bar/c', version: '2.0.0' });
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barB.flattenedDependencies).to.deep.include({ name: 'bar/a', version: '0.0.2' });
+        expect(barB.flattenedDependencies).to.deep.include({ name: 'bar/a', version: '2.0.0' });
       });
       it('should update the dependencies and the flattenedDependencies of the modified component according to the specified version', () => {
         const barC = helper.command.catComponent('bar/c@latest');
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(barC.dependencies[0].id.name).to.equal('bar/a');
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barC.dependencies[0].id.version).to.equal('0.0.2');
+        expect(barC.dependencies[0].id.version).to.equal('2.0.0');
 
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barC.flattenedDependencies).to.deep.include({ name: 'bar/a', version: '0.0.2' });
+        expect(barC.flattenedDependencies).to.deep.include({ name: 'bar/a', version: '2.0.0' });
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        expect(barC.flattenedDependencies).to.deep.include({ name: 'bar/b', version: '0.0.2' });
+        expect(barC.flattenedDependencies).to.deep.include({ name: 'bar/b', version: '2.0.0' });
 
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(barC.flattenedDependencies).to.have.lengthOf(2);

--- a/e2e/functionalities/workspace-config.e2e.3.ts
+++ b/e2e/functionalities/workspace-config.e2e.3.ts
@@ -1029,6 +1029,7 @@ describe('workspace config', function () {
           helper.fs.createFile('', 'foo.js');
           helper.command.addComponent('bar.js');
           helper.command.addComponent('foo.js');
+          helper.command.tagAllComponents();
           const overrides = {
             bar: {
               dependencies: {
@@ -1116,11 +1117,11 @@ describe('workspace config', function () {
               });
               it('bit diff should show the removed dependency', () => {
                 const diff = helper.command.diff();
-                expect(diff).to.have.string('--- Dependencies (0.0.1 original)');
-                expect(diff).to.have.string('+++ Dependencies (0.0.1 modified)');
+                expect(diff).to.have.string('--- Dependencies (0.0.2 original)');
+                expect(diff).to.have.string('+++ Dependencies (0.0.2 modified)');
                 expect(diff).to.have.string(`- [ ${helper.scopes.remote}/foo@0.0.1 ]`);
-                expect(diff).to.have.string('--- Overrides Dependencies (0.0.1 original)');
-                expect(diff).to.have.string('+++ Overrides Dependencies (0.0.1 modified)');
+                expect(diff).to.have.string('--- Overrides Dependencies (0.0.2 original)');
+                expect(diff).to.have.string('+++ Overrides Dependencies (0.0.2 modified)');
                 expect(diff).to.have.string(`- [ ${OVERRIDE_COMPONENT_PREFIX}foo@0.0.1 ]`);
               });
               describe('tagging, exporting the component and then re-import for original author', () => {
@@ -1139,7 +1140,7 @@ describe('workspace config', function () {
                   expect(bitJson.overrides.bar.dependencies).to.be.empty;
                 });
                 it('should remove the dependency from the model', () => {
-                  catBar = helper.command.catComponent('bar@0.0.2');
+                  catBar = helper.command.catComponent('bar@0.0.3');
                   expect(catBar.dependencies).to.deep.equal([]);
                   expect(catBar.overrides.dependencies).to.deep.equal({});
                 });

--- a/extensions/workspace/workspace.ts
+++ b/extensions/workspace/workspace.ts
@@ -213,8 +213,8 @@ export class Workspace implements ComponentFactory {
   async hasModifiedDependencies(component: Component) {
     const componentsList = new ComponentsList(this.consumer);
     const listAutoTagPendingComponents = await componentsList.listAutoTagPendingComponents();
-    const isAutoTag = listAutoTagPendingComponents.find(
-      (componentModal) => componentModal.id() === component.id._legacy.toStringWithoutVersion()
+    const isAutoTag = listAutoTagPendingComponents.find((consumerComponent) =>
+      consumerComponent.id.isEqualWithoutVersion(component.id._legacy)
     );
     if (isAutoTag) return true;
     return false;

--- a/src/api/consumer/lib/status.ts
+++ b/src/api/consumer/lib/status.ts
@@ -37,7 +37,7 @@ export default (async function status(): Promise<StatusResult> {
   const modifiedComponent = await componentsList.listModifiedComponents(true);
   const stagedComponents: ModelComponent[] = await componentsList.listExportPendingComponents(laneObj);
   const autoTagPendingComponents = await componentsList.listAutoTagPendingComponents();
-  const autoTagPendingComponentsIds = autoTagPendingComponents.map((component) => component.toBitIdWithLatestVersion());
+  const autoTagPendingComponentsIds = autoTagPendingComponents.map((component) => component.id);
   const allInvalidComponents = await componentsList.listInvalidComponents();
   const importPendingComponents = allInvalidComponents
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/cli/commands/public-cmds/merge-cmd.ts
+++ b/src/cli/commands/public-cmds/merge-cmd.ts
@@ -126,7 +126,7 @@ export default class Merge implements LegacyCommand {
               result.triggeredBy.searchWithoutScopeAndVersion(component.id)
             );
             if (autoTag.length) {
-              const autoTagComp = autoTag.map((a) => a.component.toBitIdWithLatestVersion().toString());
+              const autoTagComp = autoTag.map((a) => a.component.id.toString());
               componentOutput += `\n       ${AUTO_SNAPPED_MSG}: ${autoTagComp.join(', ')}`;
             }
             return componentOutput;

--- a/src/cli/commands/public-cmds/snap-cmd.ts
+++ b/src/cli/commands/public-cmds/snap-cmd.ts
@@ -91,7 +91,7 @@ export default class Snap implements LegacyCommand {
             result.triggeredBy.searchWithoutScopeAndVersion(component.id)
           );
           if (autoTag.length) {
-            const autoTagComp = autoTag.map((a) => a.component.toBitIdWithLatestVersion().toString());
+            const autoTagComp = autoTag.map((a) => a.component.id.toString());
             componentOutput += `\n       ${AUTO_SNAPPED_MSG}: ${autoTagComp.join(', ')}`;
           }
           return componentOutput;

--- a/src/cli/commands/public-cmds/tag-cmd.ts
+++ b/src/cli/commands/public-cmds/tag-cmd.ts
@@ -142,7 +142,7 @@ bit tag [id] --persist or bit tag --all --persist, executes the persist on the g
             result.triggeredBy.searchWithoutScopeAndVersion(component.id)
           );
           if (autoTag.length) {
-            const autoTagComp = autoTag.map((a) => a.component.toBitIdWithLatestVersion().toString());
+            const autoTagComp = autoTag.map((a) => a.component.id.toString());
             componentOutput += `\n       ${AUTO_TAGGED_MSG}:
             ${autoTagComp.join('\n            ')}`;
           }

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -292,11 +292,9 @@ export default class ComponentsList {
   }
 
   async listAutoTagPendingComponents(): Promise<Component[]> {
-    const modifiedComponents = await this.listModifiedComponents();
+    const modifiedComponents = (await this.listModifiedComponents()) as BitId[];
     if (!modifiedComponents || !modifiedComponents.length) return [];
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const modifiedComponentsLatestVersions = await this.scope.latestVersions(modifiedComponents);
-    return this.consumer.listComponentsForAutoTagging(modifiedComponentsLatestVersions);
+    return this.consumer.listComponentsForAutoTagging(BitIds.fromArray(modifiedComponents));
   }
 
   idsFromBitMap(origin?: ComponentOrigin): BitId[] {

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -186,8 +186,7 @@ export default class ComponentsList {
       this.listModifiedComponents(true),
     ]);
 
-    const autoTagPendingModel: ModelComponent[] = await this.listAutoTagPendingComponents();
-    const autoTagPending: Component[] = await this.scope.toConsumerComponents(autoTagPendingModel);
+    const autoTagPending: Component[] = await this.listAutoTagPendingComponents();
 
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const components: Component[] = [...newComponents, ...modifiedComponents, ...autoTagPending];
@@ -292,7 +291,7 @@ export default class ComponentsList {
     return Promise.all(exportPendingComponentsIds.map((id) => this.scope.getModelComponentIfExist(id)));
   }
 
-  async listAutoTagPendingComponents(): Promise<ModelComponent[]> {
+  async listAutoTagPendingComponents(): Promise<Component[]> {
     const modifiedComponents = await this.listModifiedComponents();
     if (!modifiedComponents || !modifiedComponents.length) return [];
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -392,22 +392,8 @@ export default class Consumer {
     return !this.config._distEntry && !this.config._distTarget;
   }
 
-  potentialComponentsForAutoTagging(modifiedComponents: BitIds): BitIds {
-    const candidateComponents = this.bitMap.getAuthoredAndImportedBitIds();
-    const modifiedComponentsWithoutVersions = modifiedComponents.map((modifiedComponent) =>
-      modifiedComponent.toStringWithoutVersion()
-    );
-    // if a modified component is in candidates array, remove it from the array as it will be already tagged with the
-    // correct version
-    const idsWithoutModified = candidateComponents.filter(
-      (component) => !modifiedComponentsWithoutVersions.includes(component.toStringWithoutVersion())
-    );
-    return BitIds.fromArray(idsWithoutModified);
-  }
-
-  async listComponentsForAutoTagging(modifiedComponents: BitIds): Promise<ModelComponent[]> {
-    const candidateComponents = this.potentialComponentsForAutoTagging(modifiedComponents);
-    return getAutoTagPending(this.scope, candidateComponents, modifiedComponents);
+  async listComponentsForAutoTagging(modifiedComponents: BitIds): Promise<Component[]> {
+    return getAutoTagPending(this, modifiedComponents);
   }
 
   /**

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -564,12 +564,7 @@ export default class Consumer {
     return { taggedComponents, autoTaggedResults, isSoftTag: !persist, publishedPackages };
   }
 
-  updateNextVersionOnBitmap(
-    taggedComponents: Component[],
-    autoTaggedResults: AutoTagResult[],
-    exactVersion,
-    releaseType
-  ) {
+  updateNextVersionOnBitmap(taggedComponents: Component[], exactVersion, releaseType) {
     taggedComponents.forEach((taggedComponent) => {
       const pendingVersionLog = taggedComponent.pendingVersion.log;
       if (!pendingVersionLog) throw new Error('updateNextVersionOnBitmap, unable to get endingVersion.log');
@@ -582,18 +577,7 @@ export default class Consumer {
       if (!taggedComponent.componentMap) throw new Error('updateNextVersionOnBitmap componentMap is missing');
       taggedComponent.componentMap.updateNextVersion(nextVersion);
     });
-    autoTaggedResults.forEach((autoTaggedResult) => {
-      const versionLog = autoTaggedResult.version.log;
-      const nextVersion = {
-        version: exactVersion || releaseType,
-        message: versionLog.message,
-        username: versionLog.username,
-        email: versionLog.email,
-      };
-      const id = autoTaggedResult.component.toBitIdWithLatestVersionAllowNull();
-      const componentMap = this.bitMap.getComponent(id, { ignoreVersion: true });
-      componentMap.updateNextVersion(nextVersion);
-    });
+
     if (taggedComponents.length) this.bitMap.markAsChanged();
   }
 

--- a/src/scope/component-ops/auto-tag.spec.ts
+++ b/src/scope/component-ops/auto-tag.spec.ts
@@ -4,10 +4,13 @@ import { getAutoTagPending } from './auto-tag';
 
 describe('AutoTag', () => {
   describe('getAutoTagPending', () => {
-    it('should return an empty array when there are no components in the scope', async () => {
-      const scope = { getComponentsAndVersions: () => Promise.resolve([]) };
+    it('should return an empty array when there are no components in the workspace', async () => {
+      const consumer = {
+        bitMap: { getAuthoredAndImportedBitIds: () => [] },
+        loadComponents: () => Promise.resolve({ components: [] }),
+      };
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const test = await getAutoTagPending(scope, [], []);
+      const test = await getAutoTagPending(consumer, []);
       expect(test).to.be.an('array').and.empty;
     });
   });

--- a/src/scope/component-ops/auto-tag.ts
+++ b/src/scope/component-ops/auto-tag.ts
@@ -15,6 +15,7 @@ export async function getAutoTagPending(consumer: Consumer, changedComponents: B
 export type AutoTagResult = { component: Component; triggeredBy: BitIds };
 
 export async function getAutoTagInfo(consumer: Consumer, changedComponents: BitIds): Promise<AutoTagResult[]> {
+  if (!changedComponents.length) return [];
   const potentialComponents = potentialComponentsForAutoTagging(consumer, changedComponents);
   const idsToLoad = new BitIds(...potentialComponents, ...changedComponents);
   const { components } = await consumer.loadComponents(idsToLoad);

--- a/src/scope/component-ops/auto-tag.ts
+++ b/src/scope/component-ops/auto-tag.ts
@@ -16,7 +16,8 @@ export type AutoTagResult = { component: Component; triggeredBy: BitIds };
 
 export async function getAutoTagInfo(consumer: Consumer, changedComponents: BitIds): Promise<AutoTagResult[]> {
   const potentialComponents = potentialComponentsForAutoTagging(consumer, changedComponents);
-  const { components } = await consumer.loadComponents(new BitIds(...potentialComponents, ...changedComponents));
+  const idsToLoad = new BitIds(...potentialComponents, ...changedComponents);
+  const { components } = await consumer.loadComponents(idsToLoad);
   const graph = buildGraph(components);
 
   const autoTagResults: AutoTagResult[] = [];

--- a/src/scope/component-ops/auto-tag.ts
+++ b/src/scope/component-ops/auto-tag.ts
@@ -7,12 +7,10 @@ import { Consumer } from '../../consumer';
 import Component from '../../consumer/component/consumer-component';
 import { Dependency } from '../../consumer/component/dependencies';
 import { isTag } from '../../version/version-parser';
-import { buildComponentsGraphForComponentsAndVersion, buildOneGraphForComponents } from '../graph/components-graph';
+import { buildOneGraphForComponents } from '../graph/components-graph';
 import DependencyGraph from '../graph/scope-graph';
-import { Version } from '../models';
 import ModelComponent from '../models/model-component';
 import Scope, { ComponentsAndVersions } from '../scope';
-import { getAllFlattenedDependencies } from './get-flattened-dependencies';
 
 const removeNils = R.reject(R.isNil);
 

--- a/src/scope/component-ops/auto-tag.ts
+++ b/src/scope/component-ops/auto-tag.ts
@@ -1,5 +1,4 @@
 import graphlib, { Graph } from 'graphlib';
-import R from 'ramda';
 import semver from 'semver';
 
 import { BitId, BitIds } from '../../bit-id';
@@ -7,82 +6,31 @@ import { Consumer } from '../../consumer';
 import Component from '../../consumer/component/consumer-component';
 import { Dependency } from '../../consumer/component/dependencies';
 import { isTag } from '../../version/version-parser';
-import { buildOneGraphForComponents } from '../graph/components-graph';
-import DependencyGraph from '../graph/scope-graph';
-import ModelComponent from '../models/model-component';
-import Scope, { ComponentsAndVersions } from '../scope';
 
-const removeNils = R.reject(R.isNil);
+export async function getAutoTagPending(consumer: Consumer, changedComponents: BitIds): Promise<Component[]> {
+  const autoTagInfo = await getAutoTagInfo(consumer, changedComponents);
+  return autoTagInfo.map((a) => a.component);
+}
 
 export type AutoTagResult = { component: Component; triggeredBy: BitIds };
 
-export async function getAutoTagData(consumer: Consumer, ids: BitIds): Promise<AutoTagResult[]> {
-  const potentialIds = consumer.bitMap.getAuthoredAndImportedBitIds();
-  const depGraphConsumer = await buildOneGraphForComponents(potentialIds, consumer);
-  const dependencyGraph = new DependencyGraph(depGraphConsumer);
-  const autoTagData: AutoTagResult[] = [];
-  const addToAutoTagData = (component: Component, triggeredBy: BitId) => {
-    const existingItem = autoTagData.find((autoTagItem) => autoTagItem.component.id.isEqual(component.id));
-    if (existingItem) {
-      existingItem.triggeredBy.push(triggeredBy);
-    } else {
-      autoTagData.push({ component, triggeredBy: new BitIds(triggeredBy) });
-    }
-  };
-  ids.forEach((id) => {
-    const idStr = id.toString();
-    const dependentsIdsStr = dependencyGraph.getRecursiveDependents([idStr]);
-    const dependents: Component[] = dependentsIdsStr.map((dependentId) => depGraphConsumer.node(dependentId));
-    const autoTagDependents = dependents
-      .filter((dependent) => !ids.has(dependent.id))
-      .filter((dependent) => potentialIds.has(dependent.id)); // removes nested
-    autoTagDependents.forEach((dependent) => {
-      addToAutoTagData(dependent, id);
-    });
-  });
+export async function getAutoTagInfo(consumer: Consumer, changedComponents: BitIds): Promise<AutoTagResult[]> {
+  const potentialComponents = potentialComponentsForAutoTagging(consumer, changedComponents);
+  const { components } = await consumer.loadComponents(new BitIds(...potentialComponents, ...changedComponents));
+  const graph = buildGraph(components);
 
-  return autoTagData;
-}
-
-function buildGraph(componentsAndVersions: ComponentsAndVersions[]): Graph {
-  const graph = new Graph();
-  const componentsIds = BitIds.fromArray(componentsAndVersions.map((c) => c.component.toBitId()));
-  componentsAndVersions.forEach(({ component, version, versionStr }) => {
-    const id = component.id();
-    version.getAllDependencies().forEach((dependency: Dependency) => {
-      if (componentsIds.searchWithoutVersion(dependency.id)) {
-        const depId = dependency.id.toStringWithoutVersion();
-        // save the full BitId of a string id to be able to retrieve it later with no confusion
-        if (!graph.hasNode(id)) graph.setNode(id, component.toBitId().changeVersion(versionStr));
-        if (!graph.hasNode(depId)) graph.setNode(depId, dependency.id);
-        graph.setEdge(id, depId);
-      }
-    });
-  });
-  return graph;
-}
-
-export async function getAutoTagPending(
-  scope: Scope,
-  potentialComponents: BitIds,
-  changedComponents: BitIds
-): Promise<ModelComponent[]> {
-  const componentsAndVersions: ComponentsAndVersions[] = await scope.getComponentsAndVersions(
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    new BitIds(...potentialComponents, ...changedComponents)
-  );
-  const graph = buildGraph(componentsAndVersions);
-
-  const autoTagPendingComponents = componentsAndVersions.map(({ component }) => {
-    const bitId = component.toBitId();
+  const autoTagResults: AutoTagResult[] = [];
+  components.forEach((component) => {
+    const bitId = component.id;
     const idStr = bitId.toStringWithoutVersion();
-    if (!graph.hasNode(idStr)) return null;
-    // edges are dependencies. we loop over the dependencies of a component
+    if (!graph.hasNode(idStr)) return;
+    // preorder gets all dependencies and dependencies of dependencies and so on.
+    // we loop over the dependencies of a component
     // @ts-ignore
-    const edges = graphlib.alg.preorder(graph, idStr);
-    const isAutoTagPending = edges.some((edge) => {
-      const edgeId: BitId = graph.node(edge);
-      const changedComponentId = changedComponents.searchWithoutVersion(edgeId);
+    const dependenciesStr = graphlib.alg.preorder(graph, idStr);
+    const dependenciesBitIds = dependenciesStr.map((depStr) => graph.node(depStr));
+    const triggeredDependencies = dependenciesBitIds.filter((dependencyId: BitId) => {
+      const changedComponentId = changedComponents.searchWithoutVersion(dependencyId);
       if (!changedComponentId) {
         // the dependency hasn't changed, so the component is not auto-tag pending
         return false;
@@ -99,16 +47,49 @@ export async function getAutoTagPending(
       // a candidate. A has the B dependency saved in the model with version 2.0.0 and B is now
       // tagged with 1.0.1. So, because A has B with a higher version already, we don't want to
       // auto-tag it and downgrade its B version.
-      if (isTag(changedComponentId.version) && isTag(edgeId.version)) {
+      if (isTag(changedComponentId.version) && isTag(dependencyId.version)) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        return semver.gte(changedComponentId.version!, edgeId.version!);
+        return semver.gte(changedComponentId.version!, dependencyId.version!);
       }
       // when they're not tags but snaps, it is impossible to snap from a detached head so a
       // component is always candidate when its dependencies have changed.
       return true;
     });
-    return isAutoTagPending ? component : null;
+    if (triggeredDependencies.length) {
+      autoTagResults.push({ component, triggeredBy: BitIds.fromArray(triggeredDependencies) });
+    }
   });
 
-  return removeNils(autoTagPendingComponents);
+  return autoTagResults;
+}
+
+function buildGraph(components: Component[]): Graph {
+  const graph = new Graph();
+  const componentsIds = BitIds.fromArray(components.map((c) => c.id));
+  components.forEach((component) => {
+    const idStr = component.id.toStringWithoutVersion();
+    component.getAllDependencies().forEach((dependency: Dependency) => {
+      if (componentsIds.searchWithoutVersion(dependency.id)) {
+        const depId = dependency.id.toStringWithoutVersion();
+        // save the full BitId of a string id to be able to retrieve it later with no confusion
+        if (!graph.hasNode(idStr)) graph.setNode(idStr, component.id);
+        if (!graph.hasNode(depId)) graph.setNode(depId, dependency.id);
+        graph.setEdge(idStr, depId);
+      }
+    });
+  });
+  return graph;
+}
+
+function potentialComponentsForAutoTagging(consumer: Consumer, modifiedComponents: BitIds): BitIds {
+  const candidateComponents = consumer.bitMap.getAuthoredAndImportedBitIds();
+  const modifiedComponentsWithoutVersions = modifiedComponents.map((modifiedComponent) =>
+    modifiedComponent.toStringWithoutVersion()
+  );
+  // if a modified component is in candidates array, remove it from the array as it will be already tagged with the
+  // correct version
+  const idsWithoutModified = candidateComponents.filter(
+    (component) => !modifiedComponentsWithoutVersions.includes(component.toStringWithoutVersion())
+  );
+  return BitIds.fromArray(idsWithoutModified);
 }

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -196,9 +196,9 @@ export default async function tagModelComponent({
     consumerComponentsIdsMap[componentIdString] = consumerComponent;
   });
   const componentsToTag: Component[] = R.values(consumerComponentsIdsMap); // consumerComponents unique
-  const componentsToTagIds = componentsToTag.map((c) => c.id);
+  const idsToTriggerAutoTag = componentsToTag.map((c) => c.id).filter((id) => id.hasVersion());
 
-  const autoTagData = skipAutoTag ? [] : await getAutoTagInfo(consumer, BitIds.fromArray(componentsToTagIds));
+  const autoTagData = skipAutoTag ? [] : await getAutoTagInfo(consumer, BitIds.fromArray(idsToTriggerAutoTag));
   const autoTagConsumerComponents = autoTagData.map((autoTagItem) => autoTagItem.component);
   const allComponentsToTag = componentsToTag.concat(autoTagConsumerComponents);
 

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -20,7 +20,7 @@ import logger from '../../logger/logger';
 import { pathJoinLinux, sha1 } from '../../utils';
 import { PathLinux } from '../../utils/path';
 import { buildComponentsGraph } from '../graph/components-graph';
-import { AutoTagResult, getAutoTagData } from './auto-tag';
+import { AutoTagResult, getAutoTagInfo } from './auto-tag';
 import { getAllFlattenedDependencies } from './get-flattened-dependencies';
 import { getValidVersionOrReleaseType } from '../../utils/semver-helper';
 import { OnTagResult } from '../scope';
@@ -198,7 +198,7 @@ export default async function tagModelComponent({
   const componentsToTag: Component[] = R.values(consumerComponentsIdsMap); // consumerComponents unique
   const componentsToTagIds = componentsToTag.map((c) => c.id);
 
-  const autoTagData = skipAutoTag ? [] : await getAutoTagData(consumer, BitIds.fromArray(componentsToTagIds));
+  const autoTagData = skipAutoTag ? [] : await getAutoTagInfo(consumer, BitIds.fromArray(componentsToTagIds));
   const autoTagConsumerComponents = autoTagData.map((autoTagItem) => autoTagItem.component);
   const allComponentsToTag = componentsToTag.concat(autoTagConsumerComponents);
 

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -1,5 +1,4 @@
 import graphLib, { Graph as GraphLib } from 'graphlib';
-import pMapSeries from 'p-map-series';
 import bluebird from 'bluebird';
 import R from 'ramda';
 

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -1,5 +1,6 @@
 import graphLib, { Graph as GraphLib } from 'graphlib';
 import pMapSeries from 'p-map-series';
+import bluebird from 'bluebird';
 import R from 'ramda';
 
 import { Scope } from '..';
@@ -84,7 +85,7 @@ export async function buildOneGraphForComponents(
   };
   const components = await getComponents();
   const flattenedDependencyLoader = new FlattenedDependencyLoader(consumer, ignoreIds, loadComponentsFunc);
-  const componentsWithDeps = await pMapSeries(components, (component: Component) =>
+  const componentsWithDeps = await bluebird.mapSeries(components, (component: Component) =>
     flattenedDependencyLoader.load(component)
   );
   const allComponents: Component[] = R.flatten(componentsWithDeps.map((c) => [c.component, ...c.allDependencies]));

--- a/src/scope/graph/components-graph.ts
+++ b/src/scope/graph/components-graph.ts
@@ -65,6 +65,8 @@ export function buildOneGraphForComponentsAndMultipleVersions(components: Compon
 /**
  * returns one graph that includes all dependencies types. each edge has a label of the dependency
  * type. the nodes content is the Component object.
+ * note that the graph only includes the dependencies of the gives ids, but not the dependents,
+ * regardless the `direction` parameter.
  */
 export async function buildOneGraphForComponents(
   ids: BitId[],

--- a/src/scope/graph/scope-graph.ts
+++ b/src/scope/graph/scope-graph.ts
@@ -1,5 +1,4 @@
 import GraphLib, { Graph } from 'graphlib';
-import R from 'ramda';
 
 import { BitId, BitIds } from '../../bit-id';
 import { VERSION_DELIMITER } from '../../constants';
@@ -259,19 +258,6 @@ export default class DependencyGraph {
     if (!nodeEdges) return [];
     const idsStr = nodeEdges.map((node) => node.v);
     return returnNodeValue ? idsStr.map((idStr) => this.graph.node(idStr)) : idsStr;
-  }
-
-  getRecursiveDependents(ids: string[], dependents: string[] = []): string[] {
-    const dependentOfId = (idStr: string): string[] => {
-      const nodeEdges = this.graph.inEdges(idStr);
-      if (!nodeEdges) return [];
-      return nodeEdges.map((node) => node.v);
-    };
-    const dependentsResults: string[] = R.uniq(R.flatten(ids.map(dependentOfId)));
-    const newDependents = dependentsResults.filter((idStr) => !dependents.includes(idStr));
-    if (!newDependents.length) return dependents;
-    dependents.push(...newDependents);
-    return this.getRecursiveDependents(newDependents, dependents);
   }
 
   getImmediateDependenciesPerId(id: BitId): string[] {


### PR DESCRIPTION
To understand why this is needed, consider the following case:
comp1 depends on comp2. The user has modified comp2 and tagged comp2. During the tag of comp2, we find that comp1 is a dependent and we auto-tag it as well.
The way how we do auto-tag is as follows: we load comp1 from the model (not workspace), change only the dependency version of comp2, and tag/snap.
On Harmony, after changing the dependencies of comp1, we run the OnTag hook, which runs the build-pipeline. During the build pipeline, we load all components from the workspace, including this auto-tag candidate "comp1". The problem is that the component from the workspace has the old dependency version of comp2, because only the model component of comp1 got updated.
To resolve this issue, this PR simplifies the super complex auto-tag process and treat all auto-tag candidates same as tag candidates. This way, all these components will be loaded from the workspace in the first place and be consistent with other processes we run on the workspace components.
If we go this way, we remove tons of complex code related to tagging the auto-tag. The only implication I see is that, before, if comp1 was modified and you tagged comp2 only, it wouldn't save the file changes of comp1, it'd leave it modified after the auto-tag. Now, it will save it and leave it staged. 