### PR TITLE
implement deploy pipe to be running after the build pipe

### DIFF
--- a/extensions/aspect/aspect.main.runtime.ts
+++ b/extensions/aspect/aspect.main.runtime.ts
@@ -24,7 +24,7 @@ export class AspectMain {
     const aspectEnv = envs.merge<AspectEnv>(new AspectEnv(react.reactEnv), react.reactEnv);
     const coreExporterTask = new CoreExporterTask(aspectEnv, aspectLoader);
     if (!__dirname.includes('@teambit/bit')) {
-      builder.registerTask(coreExporterTask);
+      builder.registerBuildTask(coreExporterTask);
     }
 
     envs.registerEnv(aspectEnv);

--- a/extensions/builder/builder.main.runtime.ts
+++ b/extensions/builder/builder.main.runtime.ts
@@ -36,14 +36,15 @@ export type BuilderConfig = {
 };
 
 export class BuilderMain {
-  tagTasks: BuildTask[] = [];
   constructor(
     private envs: EnvsMain,
     private workspace: Workspace,
-    private service: BuilderService,
+    private buildService: BuilderService,
+    private deployService: BuilderService,
     private scope: ScopeMain,
     private aspectLoader: AspectLoaderMain,
-    private taskSlot: TaskSlot,
+    private buildTaskSlot: TaskSlot,
+    private deployTaskSlot: TaskSlot,
     private storageResolversSlot: StorageResolverSlot
   ) {}
 
@@ -106,13 +107,16 @@ export class BuilderMain {
   }
 
   async tagListener(components: Component[]): Promise<ComponentMap<AspectList>> {
-    this.tagTasks.forEach((task) => this.registerTask(task));
     // @todo: some processes needs dependencies/dependents of the given ids
     const envsExecutionResults = await this.build(components, { emptyExisting: true });
     envsExecutionResults.throwErrorsIfExist();
+    const deployEnvsExecutionResults = await this.deploy(components);
+    deployEnvsExecutionResults.throwErrorsIfExist();
     const buildPipelineResults = this.getPipelineResults(envsExecutionResults);
-    await this.storeArtifacts(buildPipelineResults);
-    return this.pipelineResultsToAspectList(components, buildPipelineResults);
+    const deployPipelineResults = this.getPipelineResults(deployEnvsExecutionResults);
+    const allPipeLineResults = [...buildPipelineResults, ...deployPipelineResults];
+    await this.storeArtifacts(allPipeLineResults);
+    return this.pipelineResultsToAspectList(components, allPipeLineResults);
   }
 
   /**
@@ -143,7 +147,14 @@ export class BuilderMain {
     const idsStr = components.map((c) => c.id.toString());
     await this.workspace.createNetwork(idsStr, isolateOptions);
     const envs = await this.envs.createEnvironment(components);
-    const buildResult = await envs.run(this.service);
+    const buildResult = await envs.run(this.buildService);
+
+    return buildResult;
+  }
+
+  async deploy(components: Component[]) {
+    const envs = await this.envs.createEnvironment(components);
+    const buildResult = await envs.run(this.deployService);
 
     return buildResult;
   }
@@ -152,16 +163,17 @@ export class BuilderMain {
    * register a build task to apply on all component build pipelines.
    * build happens on `bit build` and as part of `bit tag --persist`.
    */
-  registerTask(task: BuildTask) {
-    this.taskSlot.register(task);
+  registerBuildTask(task: BuildTask) {
+    this.buildTaskSlot.register(task);
     return this;
   }
 
   /**
-   * build task that doesn't get executed on `bit build`, only on `bit tag --persist'
+   * deploy task that doesn't get executed on `bit build`, only on `bit tag --persist'.
+   * the deploy-pipeline is running once the build-pipeline has completed.
    */
-  registerTaskOnTagOnly(task: BuildTask) {
-    this.tagTasks.push(task);
+  registerDeployTask(task: BuildTask) {
+    this.deployTaskSlot.register(task);
   }
 
   /**
@@ -181,7 +193,7 @@ export class BuilderMain {
     return extensionArtifacts;
   }
 
-  static slots = [Slot.withType<BuildTask>(), Slot.withType<StorageResolver>()];
+  static slots = [Slot.withType<BuildTask>(), Slot.withType<StorageResolver>(), Slot.withType<BuildTask>()];
 
   static runtime = MainRuntime;
   static dependencies = [
@@ -206,18 +218,28 @@ export class BuilderMain {
       GraphqlMain
     ],
     config,
-    [taskSlot, storageResolversSlot]: [TaskSlot, StorageResolverSlot]
+    [buildTaskSlot, storageResolversSlot, deployTaskSlot]: [TaskSlot, StorageResolverSlot, TaskSlot]
   ) {
     const artifactFactory = new ArtifactFactory(storageResolversSlot);
     const logger = loggerExt.createLogger(BuilderAspect.id);
-    const builderService = new BuilderService(workspace, logger, taskSlot, artifactFactory);
+    const buildService = new BuilderService(workspace, logger, buildTaskSlot, 'getBuildPipe', 'build', artifactFactory);
+    const deployService = new BuilderService(
+      workspace,
+      logger,
+      deployTaskSlot,
+      'getDeployPipe',
+      'deploy',
+      artifactFactory
+    );
     const builder = new BuilderMain(
       envs,
       workspace,
-      builderService,
+      buildService,
+      deployService,
       scope,
       aspectLoader,
-      taskSlot,
+      buildTaskSlot,
+      deployTaskSlot,
       storageResolversSlot
     );
 

--- a/extensions/environments/README.md
+++ b/extensions/environments/README.md
@@ -7,7 +7,7 @@ To create a new environment, create a new extension, add "teambit.bit/environmen
 
 The class of the environment extension needs to implement the `Environment` interface. For now, due to types/circular constrains, it doesn't require to implement anything. However, to get a working env, you must implement the following:
 ```
-getPipe(): BuildTask[];
+getBuildPipe(): BuildTask[];
 ```
 There are the tasks that will be running on "bit tag"/"bit build". If you have a compiler setup, it should include `this.compiler.task`. Also, it is recommended to add the dry-run task of the publisher: `this.pkg.dryRunTask`.
 See the react.env.ts for a detailed example.

--- a/extensions/pkg/pkg.main.runtime.ts
+++ b/extensions/pkg/pkg.main.runtime.ts
@@ -94,7 +94,7 @@ export class PkgMain {
       componentAspect
     );
 
-    builder.registerTaskOnTagOnly(new PublishTask(PkgAspect.id, publisher, logPublisher));
+    builder.registerDeployTask(new PublishTask(PkgAspect.id, publisher, logPublisher));
     if (workspace) {
       // workspace.onComponentLoad(pkg.mergePackageJsonProps.bind(pkg));
       workspace.onComponentLoad(async (component) => {

--- a/extensions/pkg/publisher.ts
+++ b/extensions/pkg/publisher.ts
@@ -71,7 +71,7 @@ export class Publisher {
       this.logger.debug(`${componentIdStr}, stdout: ${stdout}`);
       this.logger.debug(`${componentIdStr}, stderr: ${stderr}`);
       const publishedPackage = stdout.replace('+ ', ''); // npm adds "+ " prefix before the published package
-      metadata = { publishedPackage };
+      metadata = this.options.dryRun ? {} : { publishedPackage };
     } catch (err) {
       const errorMsg = `failed running ${this.packageManager} ${publishParamsStr} at ${cwd}`;
       this.logger.error(`${componentIdStr}, ${errorMsg}`);

--- a/extensions/preview/preview.main.runtime.ts
+++ b/extensions/preview/preview.main.runtime.ts
@@ -173,7 +173,7 @@ export class PreviewMain {
       },
     ]);
 
-    if (!config.disabled) builder.registerTask(new PreviewTask(bundler, preview));
+    if (!config.disabled) builder.registerBuildTask(new PreviewTask(bundler, preview));
 
     return preview;
   }

--- a/extensions/react/react.env.ts
+++ b/extensions/react/react.env.ts
@@ -174,7 +174,7 @@ export class ReactEnv implements Environment {
   /**
    * returns the component build pipeline.
    */
-  getPipe(): BuildTask[] {
+  getBuildPipe(): BuildTask[] {
     return [this.compiler.task, this.tester.task, this.pkg.preparePackagesTask, this.pkg.dryRunTask];
   }
 

--- a/extensions/react/react.main.runtime.ts
+++ b/extensions/react/react.main.runtime.ts
@@ -138,7 +138,7 @@ export class ReactMain {
    */
   overrideBuildPipe(tasks: BuildTask[]) {
     return this.envs.override({
-      getPipe: () => tasks,
+      getBuildPipe: () => tasks,
     });
   }
 

--- a/extensions/stencil/stencil.env.ts
+++ b/extensions/stencil/stencil.env.ts
@@ -75,7 +75,7 @@ export class StencilEnv implements Environment {
   /**
    * returns the component build pipeline.
    */
-  getPipe(): BuildTask[] {
+  getBuildPipe(): BuildTask[] {
     // return BuildPipe.from([this.compiler.task, this.tester.task]);
     // return BuildPipe.from([this.tester.task]);
     return [this.compiler.task];


### PR DESCRIPTION
Currently, the build-pipe does the deployment as well in case of bit-tag.
One issue with this behavior is that when a later env fails, the current env is published unexpectedly.
This makes sure to publish only once all build-pipe has completed successfully.