### PR TITLE
fix out-of-memory during preview

### DIFF
--- a/extensions/builder/storage/default-resolver.ts
+++ b/extensions/builder/storage/default-resolver.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { flatten } from 'ramda';
+import { Artifacts } from 'bit-bin/dist/consumer/component/sources/artifacts';
 import { ArtifactVinyl } from 'bit-bin/dist/consumer/component/sources/artifact';
 import { AspectEntry, Component, ComponentID } from '@teambit/component';
 import { StorageResolver } from './storage-resolver';
@@ -14,7 +15,7 @@ export class DefaultResolver implements StorageResolver {
     const artifactsGrouped = this.groupArtifactsByTaskId(artifacts);
     Object.keys(artifactsGrouped).forEach((taskId) => {
       const aspectEntry = this.getAspectEntry(component, taskId);
-      aspectEntry.artifacts = this.transformToVinyl(artifactsGrouped[taskId]);
+      aspectEntry.legacy.artifacts = new Artifacts(this.transformToVinyl(artifactsGrouped[taskId]));
     });
   }
 

--- a/extensions/component/aspect-entry.ts
+++ b/extensions/component/aspect-entry.ts
@@ -1,6 +1,4 @@
 import { ExtensionDataEntry } from 'bit-bin/dist/consumer/config/extension-data';
-import { AbstractVinyl } from 'bit-bin/dist/consumer/component/sources';
-import { Artifacts } from 'bit-bin/dist/consumer/component/sources/artifacts';
 import { ComponentID } from './id';
 
 export type Serializable = {
@@ -37,11 +35,7 @@ export class AspectEntry {
 
   get artifacts() {
     // @ts-ignore todo: this is going to be completely changed very soon.
-    return this.legacy.artifacts;
-  }
-
-  set artifacts(val: Array<AbstractVinyl>) {
-    this.legacy.artifacts = new Artifacts(val);
+    return this.legacy.artifacts.vinyls;
   }
 
   transform(newData: SerializableMap): AspectEntry {


### PR DESCRIPTION
Happened as a result of the `Artifacts` class leaking into the UI.