### PR TITLE
change task.id to task.aspectId, make task.name mandatory

### DIFF
--- a/e2e/fixtures/extensions/babel-env/babel-env.extension.ts
+++ b/e2e/fixtures/extensions/babel-env/babel-env.extension.ts
@@ -17,13 +17,16 @@ export class BabelEnv {
   static dependencies: any = [EnvsAspect, ReactAspect, BabelAspect];
 
   static async provider([envs, react, babel]: [EnvsMain, ReactMain, BabelMain]) {
+    const babelCompiler = babel.createCompiler({ babelTransformOptions: babelConfig });
     const compilerOverride = envs.override({
       getCompiler: () => {
-        return babel.createCompiler({ babelTransformOptions: babelConfig })
+        return babelCompiler;
       },
     });
+    const compilerTaskOverride = react.overrideCompilerTasks([babelCompiler.createTask()]);
     const harmonyReactEnv = react.compose([
-      compilerOverride
+      compilerOverride,
+      compilerTaskOverride
     ]);
 
     envs.registerEnv(harmonyReactEnv);

--- a/e2e/fixtures/extensions/multiple-compilers-env/multiple-compilers-env.extension.ts
+++ b/e2e/fixtures/extensions/multiple-compilers-env/multiple-compilers-env.extension.ts
@@ -32,8 +32,8 @@ export class MultipleCompilersEnv {
     tsCompiler.distGlobPatterns = [`${tsCompiler.distDir}/**/*.d.ts`];
     tsCompiler.shouldCopyNonSupportedFiles = false;
     const buildPipeOverride = react.overrideBuildPipe([
-      compiler.createTask(babelCompiler),
-      compiler.createTask(tsCompiler),
+      compiler.createTask('BabelCompiler', babelCompiler),
+      compiler.createTask('TypescriptCompiler', tsCompiler),
     ]);
 
     const harmonyReactEnv = react.compose([

--- a/extensions/aspect/core-exporter.task.ts
+++ b/extensions/aspect/core-exporter.task.ts
@@ -9,7 +9,8 @@ export class CoreExporterTask implements BuildTask {
   constructor(private env: Environment, private aspectLoader: AspectLoaderMain) {}
 
   location: TaskLocation = 'start';
-  readonly id = 'teambit.bit/aspect';
+  readonly aspectId = 'teambit.bit/aspect';
+  readonly name = 'CoreExporter';
   readonly description = 'export all core aspects via the main aspects';
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {

--- a/extensions/babel/babel.compiler.ts
+++ b/extensions/babel/babel.compiler.ts
@@ -7,7 +7,6 @@ import { Capsule } from '@teambit/isolator';
 import { Logger } from '@teambit/logger';
 import path from 'path';
 import { BabelCompilerOptions } from './compiler-options';
-import { BabelAspect } from './babel.aspect';
 
 export class BabelCompiler implements Compiler {
   constructor(readonly id, private logger: Logger, private options: BabelCompilerOptions) {}
@@ -106,7 +105,7 @@ export class BabelCompiler implements Compiler {
   getArtifactDefinition() {
     return [
       {
-        generatedBy: BabelAspect.id,
+        generatedBy: this.id,
         name: this.artifactName,
         globPatterns: this.distGlobPatterns,
       },

--- a/extensions/babel/babel.compiler.ts
+++ b/extensions/babel/babel.compiler.ts
@@ -2,14 +2,19 @@ import * as babel from '@babel/core';
 import { mapSeries } from 'bluebird';
 import fs from 'fs-extra';
 import { BuildContext, BuiltTaskResult, ComponentResult } from '@teambit/builder';
-import { Compiler, TranspileOpts, TranspileOutput } from '@teambit/compiler';
+import { Compiler, CompilerMain, TranspileOpts, TranspileOutput } from '@teambit/compiler';
 import { Capsule } from '@teambit/isolator';
 import { Logger } from '@teambit/logger';
 import path from 'path';
 import { BabelCompilerOptions } from './compiler-options';
 
 export class BabelCompiler implements Compiler {
-  constructor(readonly id, private logger: Logger, private options: BabelCompilerOptions) {}
+  constructor(
+    readonly id,
+    private logger: Logger,
+    private compiler: CompilerMain,
+    private options: BabelCompilerOptions
+  ) {}
   distDir = 'dist';
   distGlobPatterns = [`${this.distDir}/**`];
   shouldCopyNonSupportedFiles = true;
@@ -69,6 +74,10 @@ export class BabelCompiler implements Compiler {
       artifacts: this.getArtifactDefinition(),
       componentsResults,
     };
+  }
+
+  createTask(name = 'BabelCompiler') {
+    return this.compiler.createTask(name, this);
   }
 
   private async buildOneCapsule(capsule: Capsule, componentResult: ComponentResult) {

--- a/extensions/babel/babel.main.runtime.ts
+++ b/extensions/babel/babel.main.runtime.ts
@@ -1,5 +1,5 @@
 import { MainRuntime } from '@teambit/cli';
-import { Compiler } from '@teambit/compiler';
+import { Compiler, CompilerAspect, CompilerMain } from '@teambit/compiler';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import type { SchemaMain } from '@teambit/schema';
 import { SchemaAspect } from '@teambit/schema';
@@ -10,10 +10,10 @@ import { BabelCompiler } from './babel.compiler';
 import { BabelParser } from './babel.parser';
 
 export class BabelMain {
-  constructor(private logger: Logger) {}
+  constructor(private logger: Logger, private compiler: CompilerMain) {}
 
   createCompiler(options: BabelCompilerOptions): Compiler {
-    return new BabelCompiler(BabelAspect.id, this.logger, options);
+    return new BabelCompiler(BabelAspect.id, this.logger, this.compiler, options);
   }
 
   getPackageJsonProps() {
@@ -23,12 +23,12 @@ export class BabelMain {
   }
 
   static runtime = MainRuntime;
-  static dependencies = [SchemaAspect, LoggerAspect];
+  static dependencies = [SchemaAspect, LoggerAspect, CompilerAspect];
 
-  static async provider([schema, loggerExt]: [SchemaMain, LoggerMain]) {
+  static async provider([schema, loggerExt, compiler]: [SchemaMain, LoggerMain, CompilerMain]) {
     schema.registerParser(new BabelParser());
     const logger = loggerExt.createLogger(BabelAspect.id);
-    return new BabelMain(logger);
+    return new BabelMain(logger, compiler);
   }
 }
 

--- a/extensions/builder/artifact/artifact-list.ts
+++ b/extensions/builder/artifact/artifact-list.ts
@@ -40,7 +40,7 @@ export class ArtifactList {
 
   groupByTaskId() {
     return this.artifacts.reduce((acc: { [key: string]: Artifact }, artifact) => {
-      const taskId = artifact.task.id;
+      const taskId = artifact.task.aspectId;
       acc[taskId] = artifact;
       return acc;
     }, {});

--- a/extensions/builder/artifact/artifact.ts
+++ b/extensions/builder/artifact/artifact.ts
@@ -57,7 +57,7 @@ export class Artifact {
    * aspect id (string) that generated the artifact
    */
   get generatedBy(): string {
-    return this.def.generatedBy || this.task.id;
+    return this.def.generatedBy || this.task.aspectId;
   }
 
   /**
@@ -72,7 +72,7 @@ export class Artifact {
       generatedBy: this.generatedBy,
       storage: this.storageResolver.name,
       task: {
-        id: this.task.id,
+        id: this.task.aspectId,
         name: this.task.name,
       },
       files: this.files,

--- a/extensions/builder/build-pipe.ts
+++ b/extensions/builder/build-pipe.ts
@@ -83,7 +83,7 @@ export class BuildPipe {
       if (!task) {
         throw new InvalidTask(task);
       }
-      const taskName = `${task.id} ${task.description || ''}`;
+      const taskName = `${task.aspectId} ${task.name} ${task.description || ''}`;
       longProcessLogger.logProgress(taskName);
       const startTask = process.hrtime();
       const taskStartTime = Date.now();
@@ -112,8 +112,8 @@ export class BuildPipe {
   private throwIfErrorsFound(task: BuildTask, taskResult: BuiltTaskResult) {
     const compsWithErrors = taskResult.componentsResults.filter((c) => c.errors?.length);
     if (compsWithErrors.length) {
-      this.logger.consoleFailure(`task "${task.id}" has failed`);
-      const title = `Builder found the following errors while running "${task.id}" task\n`;
+      this.logger.consoleFailure(`task "${task.aspectId} ${task.name}" has failed`);
+      const title = `Builder found the following errors while running "${task.aspectId}" task\n`;
       let totalErrors = 0;
       const errorsStr = compsWithErrors
         .map((c) => {

--- a/extensions/builder/build-pipe.ts
+++ b/extensions/builder/build-pipe.ts
@@ -83,7 +83,7 @@ export class BuildPipe {
       if (!task) {
         throw new InvalidTask(task);
       }
-      const taskName = `${task.aspectId} ${task.name} ${task.description || ''}`;
+      const taskName = `${task.aspectId}:${task.name}${task.description ? ` (${task.description})` : ''}`;
       longProcessLogger.logProgress(taskName);
       const startTask = process.hrtime();
       const taskStartTime = Date.now();

--- a/extensions/builder/build-pipeline-result-list.ts
+++ b/extensions/builder/build-pipeline-result-list.ts
@@ -45,7 +45,7 @@ export class BuildPipelineResultList {
   public getMetadataFromTaskResults(componentId: ComponentID): { [taskId: string]: TaskMetadata } {
     const compResults = this.flattenedTasksResults.reduce((acc, current: TaskResults) => {
       const foundComponent = current.componentsResults.find((c) => c.component.id.isEqual(componentId));
-      const taskId = current.task.id;
+      const taskId = current.task.aspectId;
       if (foundComponent && foundComponent.metadata) {
         acc[taskId] = this.mergeDataIfPossible(foundComponent.metadata, acc[taskId], taskId);
       }
@@ -59,7 +59,7 @@ export class BuildPipelineResultList {
       const foundComponent = taskResults.componentsResults.find((c) => c.component.id.isEqual(componentId));
       if (!foundComponent) return null;
       const pipelineReport: PipelineReport = {
-        taskId: taskResults.task.id,
+        taskId: taskResults.task.aspectId,
         taskName: taskResults.task.name,
         taskDescription: taskResults.task.description,
         errors: foundComponent.errors,

--- a/extensions/builder/build-task.ts
+++ b/extensions/builder/build-task.ts
@@ -20,19 +20,21 @@ export interface BuildContext extends ExecutionContext {
 
 export interface BuildTask {
   /**
-   * id of the task. this is the extension/aspect id serialized.
+   * aspect id serialized of the creator of the task.
+   * todo: automate this so then it won't be needed to pass manually.
    */
-  id: string;
+  aspectId: string;
 
   /**
-   * name of the task.
+   * name of the task. function as an identifier among other tasks of the same aspectId.
+   * spaces and special characters are not allowed. as a convention, use UpperCamelCase style.
+   * (e.g. TypescriptCompiler).
    */
-  name?: string;
+  name: string;
 
   /**
    * description of what the task does.
    * if available, the logger will log it show it in the status-line.
-   * it's helpful to distinguish multiple tasks of the same extension.
    */
   description?: string;
 

--- a/extensions/compiler/README.md
+++ b/extensions/compiler/README.md
@@ -4,7 +4,7 @@ The compiler is configured inside an environment and not directly on the compone
 
 ## As a task
 A task is running with `bit build` or during the tag process on the capsules or the workspace (depends on the specific compiler implementation).
-The env extension should have this compiler extension as a dependency first, then add to the `build()` array the following: `this.compiler.task`.
+The env extension should have this compiler extension as a dependency first, then add to the `getBuildPipe()` array the following: `this.compiler.createTask()`.
 
 ## As a command
 A command is running on the workspace.

--- a/extensions/compiler/compiler.main.runtime.ts
+++ b/extensions/compiler/compiler.main.runtime.ts
@@ -11,7 +11,7 @@ import { Compiler } from './types';
 import { WorkspaceCompiler } from './workspace-compiler';
 
 export class CompilerMain {
-  constructor(private workspaceCompiler: WorkspaceCompiler, readonly task: CompilerTask) {}
+  constructor(private workspaceCompiler: WorkspaceCompiler) {}
   compileOnWorkspace(
     componentsIds: string[] | BitId[], // when empty, it compiles all
     options: {
@@ -25,14 +25,13 @@ export class CompilerMain {
    * API to create a new compiler task, it facilitates the usage of multiple compilers.
    * with this method you can create any number of compilers and add them to the buildPipeline.
    */
-  createTask(compiler: Compiler) {
-    return new CompilerTask(CompilerAspect.id, compiler);
+  createTask(name: string, compiler: Compiler): CompilerTask {
+    return new CompilerTask(CompilerAspect.id, name, compiler);
   }
   static async provider([cli, workspace, envs, loggerMain]: [CLIMain, Workspace, EnvsMain, LoggerMain]) {
-    const compilerTask = new CompilerTask(CompilerAspect.id);
     const workspaceCompiler = new WorkspaceCompiler(workspace, envs);
     envs.registerService(new CompilerService());
-    const compilerMain = new CompilerMain(workspaceCompiler, compilerTask);
+    const compilerMain = new CompilerMain(workspaceCompiler);
     const logger = loggerMain.createLogger(CompilerAspect.id);
     cli.register(new CompileCmd(workspaceCompiler, logger));
     return compilerMain;

--- a/extensions/compiler/compiler.task.ts
+++ b/extensions/compiler/compiler.task.ts
@@ -10,7 +10,7 @@ import { Compiler } from './types';
  */
 export class CompilerTask implements BuildTask {
   readonly description = 'compile components';
-  constructor(readonly id: string, private compilerInstance?: Compiler) {
+  constructor(readonly aspectId: string, readonly name: string, private compilerInstance?: Compiler) {
     if (compilerInstance && compilerInstance.artifactName) {
       this.description += ` for artifact ${compilerInstance.artifactName}`;
     }

--- a/extensions/compiler/types.ts
+++ b/extensions/compiler/types.ts
@@ -1,4 +1,4 @@
-import { BuildContext, BuiltTaskResult } from '@teambit/builder';
+import { BuildContext, BuildTask, BuiltTaskResult } from '@teambit/builder';
 import { ConcreteService } from '@teambit/environments';
 
 export type TranspileOpts = {
@@ -85,4 +85,9 @@ export interface Compiler extends ConcreteService {
    * enable changing the capsule package.json before publishing the package
    */
   changePackageJsonBeforePublish?(packageJson: Record<string, any>): void;
+
+  /**
+   * sugar to create a Compiler task via the concrete compiler
+   */
+  createTask?(name?: string): BuildTask;
 }

--- a/extensions/pkg/prepare-packages.task.ts
+++ b/extensions/pkg/prepare-packages.task.ts
@@ -12,8 +12,8 @@ const NPM_IGNORE_FILE = '.npmignore';
  * prepare packages for publishing.
  */
 export class PreparePackagesTask implements BuildTask {
-  readonly description = 'prepare packages';
-  constructor(readonly id: string, private logger: Logger) {}
+  readonly name = 'PreparePackages';
+  constructor(readonly aspectId: string, private logger: Logger) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     await this.executeNpmIgnoreTask(context);

--- a/extensions/pkg/publish-dry-run.task.ts
+++ b/extensions/pkg/publish-dry-run.task.ts
@@ -9,8 +9,13 @@ import { Packer } from './packer';
  * publish build task is running "publish --dry-run" to avoid later npm errors during export
  */
 export class PublishDryRunTask implements BuildTask {
-  readonly description = 'publish dry-run';
-  constructor(readonly id: string, private publisher: Publisher, private packer: Packer, private logger: Logger) {}
+  readonly name = 'PublishDryRun';
+  constructor(
+    readonly aspectId: string,
+    private publisher: Publisher,
+    private packer: Packer,
+    private logger: Logger
+  ) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     this.publisher.options.dryRun = true;

--- a/extensions/pkg/publish.task.ts
+++ b/extensions/pkg/publish.task.ts
@@ -12,9 +12,14 @@ import { Packer } from './packer';
  * publish components by running "npm publish"
  */
 export class PublishTask implements BuildTask {
-  readonly description = 'publish components';
+  readonly name = 'PublishComponents';
   readonly location: TaskLocation = 'end';
-  constructor(readonly id: string, private publisher: Publisher, private packer: Packer, private logger: Logger) {}
+  constructor(
+    readonly aspectId: string,
+    private publisher: Publisher,
+    private packer: Packer,
+    private logger: Logger
+  ) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     this.publisher.options.dryRun = false;

--- a/extensions/preview/preview.task.ts
+++ b/extensions/preview/preview.task.ts
@@ -23,8 +23,8 @@ export class PreviewTask implements BuildTask {
     private preview: PreviewMain
   ) {}
 
-  id = 'teambit.bit/preview';
-
+  aspectId = 'teambit.bit/preview';
+  name = 'GeneratePreview';
   location: TaskLocation = 'end';
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {

--- a/extensions/react/react.env.ts
+++ b/extensions/react/react.env.ts
@@ -181,7 +181,7 @@ export class ReactEnv implements Environment {
   }
 
   private getCompilerTask() {
-    return this.compiler.createTask(this.getCompiler(buildTsConfig));
+    return this.compiler.createTask('TypescriptCompiler', this.getCompiler(buildTsConfig));
   }
 
   async __getDescriptor() {

--- a/extensions/react/react.main.runtime.ts
+++ b/extensions/react/react.main.runtime.ts
@@ -143,6 +143,16 @@ export class ReactMain {
   }
 
   /**
+   * override the build pipeline of the component environment.
+   */
+  overrideCompilerTasks(tasks: BuildTask[]) {
+    const pipeWithoutCompiler = this.reactEnv.getBuildPipe().filter((task) => task.aspectId !== CompilerAspect.id);
+    return this.envs.override({
+      getBuildPipe: () => [...tasks, ...pipeWithoutCompiler],
+    });
+  }
+
+  /**
    * override the dependency configuration of the component environment.
    */
   overrideDependencies(dependencyPolicy: DependenciesPolicy) {

--- a/extensions/stencil/stencil.env.ts
+++ b/extensions/stencil/stencil.env.ts
@@ -76,8 +76,6 @@ export class StencilEnv implements Environment {
    * returns the component build pipeline.
    */
   getBuildPipe(): BuildTask[] {
-    // return BuildPipe.from([this.compiler.task, this.tester.task]);
-    // return BuildPipe.from([this.tester.task]);
-    return [this.compiler.task];
+    return [this.compiler.createTask('StencilCompiler', this.getCompiler())];
   }
 }

--- a/extensions/tester/tester.task.ts
+++ b/extensions/tester/tester.task.ts
@@ -9,8 +9,8 @@ import { detectTestFiles } from './utils';
  * tester build task. Allows to test components during component build.
  */
 export class TesterTask implements BuildTask {
-  readonly description = 'test components';
-  constructor(readonly id: string) {}
+  readonly name = 'TestComponents';
+  constructor(readonly aspectId: string) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const tester: Tester = context.env.getTester();

--- a/extensions/typescript/typescript.compiler.ts
+++ b/extensions/typescript/typescript.compiler.ts
@@ -7,7 +7,6 @@ import path from 'path';
 import ts from 'typescript';
 
 import { TypeScriptCompilerOptions } from './compiler-options';
-import { TypescriptAspect } from './typescript.aspect';
 
 export class TypescriptCompiler implements Compiler {
   distDir = 'dist';
@@ -96,7 +95,7 @@ export class TypescriptCompiler implements Compiler {
   getArtifactDefinition() {
     return [
       {
-        generatedBy: TypescriptAspect.id,
+        generatedBy: this.id,
         name: this.artifactName,
         globPatterns: this.distGlobPatterns,
       },


### PR DESCRIPTION
## Proposed Changes

- change task.id to task.aspectId
- make `task.name` mandatory. otherwise, there is no way to distinguish between "babel" and "typescript" tasks as they're both have `aspectId` of "tambit.bit/compiler".
- remove `compiler.task` prop. instead, use `compiler.createTask()` to create a new task.
- add a new React-env API `overrideCompilerTasks` to easily override only the compiler tasks in the buildPipe and leave other tasks intact.
- add a sugar syntax `createTask` to a specific compiler (e.g. babel/typescript).