### PR TITLE
babel-compiler, avoid searching for .babelrc files

### DIFF
--- a/extensions/babel/README.md
+++ b/extensions/babel/README.md
@@ -1,12 +1,14 @@
 # Babel Compiler
 
+This compiler utilizes the programmatic API of Babel to transpile files. See the compiler-options.ts for more data how to pass Babel options to the compiler.
+
+Note that to isolate the components from different Babel config files on the machine, the following two props are set to false (if they weren't passed in the options): `configFile` and `babelrc`.
+
 ## FAQ
 
 *Q*: I'm getting an error about missing plugins.
 
-*A*: There are two options:
-1. You're using this plugin in the config passed to the compiler.
-In this case, make sure that workspace.jsonc has the plugins and that you ran `bit install`.
+*A*: make sure that workspace.jsonc has the plugins and that you ran `bit install`.
 Example of the workspace.jsonc settings:
 ```
 "my-babel-env": {
@@ -24,13 +26,3 @@ Example of the workspace.jsonc settings:
       }
     },
 ```
-2. You're not using the plugin.
-The reason for the error is that Babel searches for config files in different directories. To disable this, add the following to the config you pass to the compiler:
-```
-{
-  ...
-  "babelrc": false,
-  "configFile": false,
-}
-```
-this takes care of both .babelrc and babel.config.json.

--- a/extensions/babel/babel.compiler.ts
+++ b/extensions/babel/babel.compiler.ts
@@ -127,6 +127,7 @@ export class BabelCompiler implements Compiler {
   private setConfigFileFalse() {
     this.options.babelTransformOptions = this.options.babelTransformOptions || {};
     this.options.babelTransformOptions.configFile = this.options.babelTransformOptions.configFile || false;
+    this.options.babelTransformOptions.babelrc = this.options.babelTransformOptions.babelrc || false;
   }
 
   getArtifactDefinition() {


### PR DESCRIPTION
To avoid confusion and make sure that components are isolated from different babel config on the machine, the `babelrc` prop is set to false in the babel compiler.