### PR TITLE
fix import on Harmony to wait for the install() promise

### DIFF
--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -365,7 +365,7 @@ to move all component files to a different directory, run bit remove and then bi
         installProdPackagesOnly: this.installProdPackagesOnly,
       });
     } else {
-      ManyComponentsWriter.externalInstaller?.install();
+      await ManyComponentsWriter.externalInstaller?.install();
     }
   }
   async _getAllLinks(): Promise<DataToPersist> {


### PR DESCRIPTION
This fixes the randomly failed e2e-test of bit-snap.