### PR TITLE
remove @babel/plugin-transform-async-to-generator plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -27,7 +27,6 @@ module.exports = function (api) {
     ['@babel/plugin-transform-runtime'],
     ['@babel/plugin-proposal-object-rest-spread'],
     ['@babel/plugin-proposal-class-properties'],
-    ['@babel/plugin-transform-async-to-generator'],
   ];
 
   return {

--- a/package.json
+++ b/package.json
@@ -213,7 +213,6 @@
     "@babel/plugin-proposal-class-properties": "^7.8.3",
     "@babel/plugin-proposal-decorators": "^7.8.3",
     "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/plugin-transform-async-to-generator": "^7.8.3",
     "@babel/plugin-transform-modules-commonjs": "^7.8.3",
     "@babel/plugin-transform-runtime": "^7.8.3",
     "@babel/preset-env": "^7.10.1",

--- a/scopes/harmony/aspect/babel/babel-config.ts
+++ b/scopes/harmony/aspect/babel/babel-config.ts
@@ -26,7 +26,6 @@ const plugins = [
   [require.resolve('@babel/plugin-transform-runtime')],
   [require.resolve('@babel/plugin-proposal-object-rest-spread')],
   [require.resolve('@babel/plugin-proposal-class-properties')],
-  [require.resolve('@babel/plugin-transform-async-to-generator')],
 ];
 
 export const babelConfig = {

--- a/scopes/react/react/jest/transformer.js
+++ b/scopes/react/react/jest/transformer.js
@@ -22,7 +22,6 @@ const plugins = [
   [require.resolve('@babel/plugin-transform-runtime')],
   [require.resolve('@babel/plugin-proposal-object-rest-spread')],
   [require.resolve('@babel/plugin-proposal-class-properties')],
-  [require.resolve('@babel/plugin-transform-async-to-generator')],
 ];
 
 module.exports = {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -396,7 +396,6 @@
             "@babel/plugin-proposal-class-properties": "^7.8.3",
             "@babel/plugin-proposal-decorators": "^7.8.3",
             "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-            "@babel/plugin-transform-async-to-generator": "^7.8.3",
             "@babel/plugin-transform-modules-commonjs": "^7.8.3",
             "@babel/plugin-transform-runtime": "^7.8.3",
             "@babel/preset-env": "^7.10.1",


### PR DESCRIPTION
It was needed in the past to support old node versions. Now that we support node 10+, the async/await syntax is backed in.