### PR TITLE
fix component-not-found upon bit-import (no id) with staged components

### DIFF
--- a/e2e/commands/import-all.e2e.1.ts
+++ b/e2e/commands/import-all.e2e.1.ts
@@ -101,6 +101,19 @@ describe('bit import command with no ids', function () {
         expect(statusOutput).to.have.string('modified components');
       });
     });
+    describe('after tagging', () => {
+      let output;
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(localScope);
+        helper.command.tagAllComponents();
+        output = helper.command.runCmd('bit import --merge=manual');
+      });
+      it('should display a successful message', () => {
+        // before, it'd throw an error component-not-found as the tag exists only locally
+        expect(output).to.have.string('successfully imported');
+        expect(output).to.have.string('bar/foo');
+      });
+    });
   });
 
   describe('with an AUTHORED component which was only tagged but not exported', () => {


### PR DESCRIPTION
Currently, if a component was exported and then tagged locally, `bit import` throws component-not-found. 
It happens because Bit searches for this local tag in the remote and unable to find it. This PR changes the version to be "latest" before searching in the remote.