### PR TITLE
enable export to multiple scopes even when components have circular dependencies

### DIFF
--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1316,7 +1316,7 @@ describe('bit export command', function () {
       helper.command.tagAllComponents();
       exportOutput = helper.command.export();
     });
-    it.only('should export them successfully with no errors', () => {
+    it('should export them successfully with no errors', () => {
       expect(exportOutput).to.have.string('exported the following 2 component');
       const scope1 = helper.command.listRemoteScopeParsed();
       expect(scope1).to.have.lengthOf(1);

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -743,7 +743,6 @@ describe('bit export command', function () {
           expect(output).to.have.string('exported the following 2 component');
         });
       });
-      // @todo: change the tagLegacy to tag once librarian is the package-manager for capsule to support cyclic
       describe('circular dependencies between the scopes', () => {
         let output;
         before(() => {
@@ -756,10 +755,8 @@ describe('bit export command', function () {
           helper.scopeHelper.addRemoteScope(anotherRemotePath, helper.scopes.remotePath);
           output = helper.general.runWithTryCatch('bit export');
         });
-        it('should throw an error about circle dependencies', () => {
-          expect(output).to.have.string(
-            'unable to export. the following components have circular dependencies between two or more scopes'
-          );
+        it('should export them successfully', () => {
+          expect(output).to.have.string('exported the following 2 component');
         });
       });
       describe('circular dependencies between the scopes in different versions', () => {
@@ -779,10 +776,8 @@ describe('bit export command', function () {
           helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, anotherRemotePath);
           output = helper.general.runWithTryCatch('bit export');
         });
-        it('should throw an error about circle dependencies', () => {
-          expect(output).to.have.string(
-            'unable to export. the following components have circular dependencies between two or more scopes'
-          );
+        it('should export them successfully', () => {
+          expect(output).to.have.string('exported the following 2 component');
         });
       });
       // @todo: change the tagLegacy to tag once librarian is the package-manager for capsule to support cyclic

--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import fs from 'fs-extra';
 import * as path from 'path';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
 
 import { CURRENT_UPSTREAM } from '../../src/constants';
 import Helper, { VERSION_DELIMITER } from '../../src/e2e-helper/e2e-helper';
@@ -1293,5 +1294,36 @@ describe('bit export command', function () {
     it('should not show the "fork" prompt', () => {
       expect(output).to.have.string('exported 1 components');
     });
+  });
+  describe('Harmony - export first time to multiple scope', () => {
+    let anotherRemote;
+    let exportOutput;
+    before(() => {
+      helper.command.setFeatures(HARMONY_FEATURE);
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.disablePreview();
+      helper.bitJsonc.addDefaultScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.fs.outputFile('bar1/foo1.js', `require('@${anotherRemote}/bar2');`);
+      helper.fs.outputFile('bar2/foo2.js', `require('@${helper.scopes.remote}/bar1');`);
+      helper.command.addComponent('bar1');
+      helper.command.addComponent('bar2');
+      helper.bitJsonc.addToVariant(undefined, 'bar2', 'defaultScope', anotherRemote);
+      helper.command.linkAndRewire();
+      helper.command.compile();
+      helper.command.tagAllComponents();
+      exportOutput = helper.command.export();
+    });
+    it.only('should export them successfully with no errors', () => {
+      expect(exportOutput).to.have.string('exported the following 2 component');
+      const scope1 = helper.command.listRemoteScopeParsed();
+      expect(scope1).to.have.lengthOf(1);
+      const scope2 = helper.command.listRemoteScopeParsed(anotherRemote);
+      expect(scope2).to.have.lengthOf(1);
+    });
+    // @todo
+    it('bit status should be clean', () => {});
   });
 });

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -81,7 +81,7 @@ export async function exportMany({
     .join(', ');
   logger.debug(`export-scope-components, export to the following scopes ${groupedByScopeString}`);
   const manyObjectsPerRemote = await mapSeries(Object.keys(idsGroupedByScope), (scopeName) =>
-    getUpdatedObjectsToExport(scopeName, idsGroupedByScope[scopeName], lanesObjects)
+    getUpdatedObjectsToExport(remoteName || scopeName, idsGroupedByScope[scopeName], lanesObjects)
   );
   manyObjectsPerRemote.forEach((objectsPerRemote) => {
     objectsPerRemote.componentsAndObjects.forEach((componentAndObjects) =>

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -325,7 +325,7 @@ async function mergeObjects(scope: Scope, objectList: ObjectList): Promise<BitId
   const mergeResults = await Promise.all(
     components.map(async (component) => {
       try {
-        const result = await scope.sources.merge(component, versions, true, false);
+        const result = await scope.sources.merge(component, versions, false);
         return result;
       } catch (err) {
         if (err instanceof MergeConflict || err instanceof ComponentNeedsUpdate) {

--- a/src/scope/objects/object-list.ts
+++ b/src/scope/objects/object-list.ts
@@ -18,12 +18,14 @@ export class ObjectList {
     return this.objects.length;
   }
 
-  static mergeMultipleInstances(ObjectLists: ObjectList[]): ObjectList {
+  static mergeMultipleInstances(objectLists: ObjectList[]): ObjectList {
     const objectList = new ObjectList();
-    ObjectLists.forEach((objList) => objectList.addIfNotExist(objList.objects));
+    objectLists.forEach((objList) => objectList.mergeObjectList(objList));
     return objectList;
   }
-
+  mergeObjectList(objectList: ObjectList) {
+    this.addIfNotExist(objectList.objects);
+  }
   static fromJsonString(jsonStr: string): ObjectList {
     const jsonParsed = JSON.parse(jsonStr);
     if (!Array.isArray(jsonParsed)) {

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -525,10 +525,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   async merge(
     component: ModelComponent,
     versionObjects: Version[],
-    inScope = false,
     local = true
   ): Promise<{ mergedComponent: ModelComponent; mergedVersions: string[] }> {
-    // if (inScope) component.scope = this.scope.name;
     const existingComponent: ModelComponent | null | undefined = await this._findComponent(component);
     // @ts-ignore
     // const versionObjects: Version[] = objects.filter((o) => o instanceof Version);

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -528,7 +528,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     inScope = false,
     local = true
   ): Promise<{ mergedComponent: ModelComponent; mergedVersions: string[] }> {
-    if (inScope) component.scope = this.scope.name;
+    // if (inScope) component.scope = this.scope.name;
     const existingComponent: ModelComponent | null | undefined = await this._findComponent(component);
     // @ts-ignore
     // const versionObjects: Version[] = objects.filter((o) => o instanceof Version);


### PR DESCRIPTION
There are two issues currently when exporting components to different scopes.
1. a bug. when the components are new and have different `defaultScope`, it changes the dependencies scope to the component scope unexpectedly. 
2. by design. when there is a circular dependency between the components from different scopes, it throws an error that the toposort failed and that is unable to export.

This PR fixes both issues.
To enable circulars, it sends the dependencies along with the components. So then scopeA doesn't need to go to scopeB to import the dependencies, it gets them from the client already.
It introduces a new issue. What if after exporting to scopeA, scopeB fails. Then, scopeA has a component that its dependencies don't exist. We'll fix this issue in the next phase of this task.