### PR TITLE
move dry-run and prepare-publish tasks from the build-pipeline to slots

### DIFF
--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -33,7 +33,7 @@ export class AspectMain {
     const aspectEnv = envs.merge<AspectEnv>(new AspectEnv(react.reactEnv, babel, compiler), react.reactEnv);
     const coreExporterTask = new CoreExporterTask(aspectEnv, aspectLoader);
     if (!__dirname.includes('@teambit/bit')) {
-      builder.registerBuildTask(coreExporterTask);
+      builder.registerBuildTasks([coreExporterTask]);
     }
 
     envs.registerEnv(aspectEnv);

--- a/scopes/pipelines/builder/build-pipeline-order.ts
+++ b/scopes/pipelines/builder/build-pipeline-order.ts
@@ -165,7 +165,7 @@ which is invalid. the dependency must be located earlier or in the same location
 
 function getPipelineForEnv(taskSlot: TaskSlot, env: Environment, pipeNameOnEnv: string): BuildTask[] {
   const buildTasks: BuildTask[] = env[pipeNameOnEnv] ? env[pipeNameOnEnv]() : [];
-  const slotsTasks = taskSlot.values();
+  const slotsTasks = R.flatten(taskSlot.values());
   const tasksAtStart: BuildTask[] = [];
   const tasksAtEnd: BuildTask[] = [];
   slotsTasks.forEach((task) => {

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -24,7 +24,7 @@ import { TaskResultsList } from './task-results-list';
 import { ArtifactStorageError } from './exceptions';
 import { BuildPipelineResultList } from './build-pipeline-result-list';
 
-export type TaskSlot = SlotRegistry<BuildTask>;
+export type TaskSlot = SlotRegistry<BuildTask[]>;
 
 export type StorageResolverSlot = SlotRegistry<StorageResolver>;
 
@@ -183,8 +183,8 @@ export class BuilderMain {
    * register a build task to apply on all component build pipelines.
    * build happens on `bit build` and as part of `bit tag --persist`.
    */
-  registerBuildTask(task: BuildTask) {
-    this.buildTaskSlot.register(task);
+  registerBuildTasks(tasks: BuildTask[]) {
+    this.buildTaskSlot.register(tasks);
     return this;
   }
 
@@ -192,8 +192,8 @@ export class BuilderMain {
    * deploy task that doesn't get executed on `bit build`, only on `bit tag --persist'.
    * the deploy-pipeline is running once the build-pipeline has completed.
    */
-  registerDeployTask(task: BuildTask) {
-    this.deployTaskSlot.register(task);
+  registerDeployTasks(tasks: BuildTask[]) {
+    this.deployTaskSlot.register(tasks);
   }
 
   static slots = [Slot.withType<BuildTask>(), Slot.withType<StorageResolver>(), Slot.withType<BuildTask>()];

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -125,10 +125,10 @@ export class PkgMain {
 
     const dryRunTask = new PublishDryRunTask(PkgAspect.id, publisher, packer, logPublisher);
     const preparePackagesTask = new PreparePackagesTask(PkgAspect.id, logPublisher);
+    const publishTask = new PublishTask(PkgAspect.id, publisher, packer, logPublisher);
     dryRunTask.dependencies = [BuildTaskHelper.serializeId(preparePackagesTask)];
-    builder.registerBuildTask(preparePackagesTask);
-    builder.registerBuildTask(dryRunTask);
-    builder.registerDeployTask(new PublishTask(PkgAspect.id, publisher, packer, logPublisher));
+    builder.registerBuildTasks([preparePackagesTask, dryRunTask]);
+    builder.registerDeployTasks([publishTask]);
     if (workspace) {
       // workspace.onComponentLoad(pkg.mergePackageJsonProps.bind(pkg));
       workspace.onComponentLoad(async (component) => {

--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -242,7 +242,7 @@ export class PreviewMain {
       },
     ]);
 
-    if (!config.disabled) builder.registerBuildTask(new PreviewTask(bundler, preview));
+    if (!config.disabled) builder.registerBuildTasks([new PreviewTask(bundler, preview)]);
 
     if (workspace) {
       workspace.registerOnComponentAdd((c) =>

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -197,7 +197,7 @@ export class ReactEnv implements Environment {
    * returns the component build pipeline.
    */
   getBuildPipe(tsconfig?: TsConfigSourceFile): BuildTask[] {
-    return [this.getCompilerTask(tsconfig), this.tester.task, this.pkg.preparePackagesTask, this.pkg.dryRunTask];
+    return [this.getCompilerTask(tsconfig), this.tester.task];
   }
 
   private getCompilerTask(tsconfig?: TsConfigSourceFile) {


### PR DESCRIPTION
No reason for every env to configure them. They're core tasks that should be running on all components regardless of the env.