### PR TITLE
fix bit-export to not delete the node-modules content on Harmony

### DIFF
--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -1318,7 +1318,8 @@ describe('bit export command', function () {
       const scope2 = helper.command.listRemoteScopeParsed(anotherRemote);
       expect(scope2).to.have.lengthOf(1);
     });
-    // @todo
-    it('bit status should be clean', () => {});
+    it('bit status should be clean', () => {
+      helper.command.expectStatusToBeClean();
+    });
   });
 });

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -260,9 +260,11 @@ export default class NodeModuleLinker {
    * node_modules. The path doesn't have the scope-name as it doesn't exist yet. (e.g. @bit/foo).
    * Later on, when the component is exported and has a scope-name, the path is complete.
    * (e.g. @bit/scope.foo). At this stage, this function deletes the old-partial paths.
+   *
+   * This is not needed in Harmony because in Harmony the node-module has already the default-scope.
    */
   _deleteOldLinksOfIdWithoutScope(component: Component) {
-    if (component.id.scope) {
+    if (this.consumer?.isLegacy && component.id.scope) {
       const previousDest = getNodeModulesPathOfComponent({
         bindingPrefix: component.bindingPrefix,
         id: component.id.changeScope(null),


### PR DESCRIPTION
Currently, on export, the node-modules/pkg-name dir is deleted. It was needed for the legacy, but in Harmony it causes the dists files to be deleted and leaves the workspace in a problematic state. 
This makes sure to delete only for legacy workspaces.