### PR TITLE
introduce a new flag "--disable-deploy-pipeline" for bit tag

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -28,7 +28,7 @@ import { RequireableComponent } from '@teambit/modules.requireable-component';
 import { BitId, BitIds as ComponentsIds } from 'bit-bin/dist/bit-id';
 import { ModelComponent, Version } from 'bit-bin/dist/scope/models';
 import { Ref } from 'bit-bin/dist/scope/objects';
-import LegacyScope, { OnTagResult, OnTagFunc } from 'bit-bin/dist/scope/scope';
+import LegacyScope, { OnTagResult, OnTagFunc, OnTagOpts } from 'bit-bin/dist/scope/scope';
 import { ComponentLogs } from 'bit-bin/dist/scope/models/model-component';
 import { loadScopeIfExist } from 'bit-bin/dist/scope/scope-loader';
 import { PersistOptions } from 'bit-bin/dist/scope/types';
@@ -44,7 +44,7 @@ import { PutRoute, FetchRoute } from './routes';
 
 type TagRegistry = SlotRegistry<OnTag>;
 
-export type OnTag = (components: Component[]) => Promise<ComponentMap<AspectList>>;
+export type OnTag = (components: Component[], options?: OnTagOpts) => Promise<ComponentMap<AspectList>>;
 
 export type OnPostPut = (ids: ComponentID[]) => void;
 
@@ -110,12 +110,12 @@ export class ScopeMain implements ComponentFactory {
    * register to the tag slot.
    */
   onTag(tagFn: OnTag) {
-    const legacyOnTagFunc: OnTagFunc = async (legacyIds: BitId[]): Promise<OnTagResult[]> => {
+    const legacyOnTagFunc: OnTagFunc = async (legacyIds: BitId[], options?: OnTagOpts): Promise<OnTagResult[]> => {
       const host = this.componentExtension.getHost();
       const ids = await Promise.all(legacyIds.map((legacyId) => host.resolveComponentId(legacyId)));
       const components = await host.getMany(ids);
       // TODO: fix what legacy tag accepts to just extension name and files.
-      const aspectListComponentMap = await tagFn(components);
+      const aspectListComponentMap = await tagFn(components, options);
       const extensionsToLegacy = (aspectList: AspectList) => {
         const extensionsDataList = aspectList.toLegacy();
         extensionsDataList.forEach((extension) => {

--- a/src/api/consumer/lib/tag.ts
+++ b/src/api/consumer/lib/tag.ts
@@ -27,38 +27,38 @@ export type TagResults = {
 export const NOTHING_TO_TAG_MSG = 'nothing to tag';
 export const AUTO_TAGGED_MSG = 'auto-tagged dependents';
 
-type TagParams = {
+export type BasicTagParams = {
   message: string;
-  exactVersion: string | undefined;
-  releaseType: semver.ReleaseType;
   force: boolean;
-  verbose?: boolean;
-  ignoreUnresolvedDependencies: boolean;
   ignoreNewestVersion: boolean;
   skipTests: boolean;
+  verbose: boolean;
   skipAutoTag: boolean;
   persist: boolean;
+  disableDeployPipeline: boolean;
+};
+
+type TagParams = {
+  exactVersion: string | undefined;
+  releaseType: semver.ReleaseType;
+  ignoreUnresolvedDependencies: boolean;
+  ignoreNewestVersion: boolean;
   id: string;
   all: boolean;
   scope?: string;
   includeImported: boolean;
-};
+} & BasicTagParams;
 
 export async function tagAction(tagParams: TagParams) {
   const {
     id,
     all,
-    message,
     exactVersion,
     releaseType,
     force,
-    verbose,
     ignoreUnresolvedDependencies,
-    ignoreNewestVersion,
-    skipTests,
     scope,
     includeImported,
-    skipAutoTag,
     persist,
   } = tagParams;
 
@@ -86,17 +86,11 @@ export async function tagAction(tagParams: TagParams) {
   if (R.isEmpty(bitIds)) return null;
 
   const consumerTagParams = {
+    ...tagParams,
     ids: BitIds.fromArray(bitIds),
-    message,
     exactVersion: validExactVersion,
     releaseType,
-    force,
-    verbose,
     ignoreUnresolvedDependencies,
-    ignoreNewestVersion,
-    skipTests,
-    skipAutoTag,
-    persist,
   };
   const tagResults = await consumer.tag(consumerTagParams);
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/cli/commands/public-cmds/tag-cmd.ts
+++ b/src/cli/commands/public-cmds/tag-cmd.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import { ReleaseType } from 'semver';
 import { LegacyCommand, CommandOptions } from '../../legacy-command';
 import { tagAction } from '../../../api/consumer';
-import { TagResults, NOTHING_TO_TAG_MSG, AUTO_TAGGED_MSG } from '../../../api/consumer/lib/tag';
+import { TagResults, NOTHING_TO_TAG_MSG, AUTO_TAGGED_MSG, BasicTagParams } from '../../../api/consumer/lib/tag';
 import { isString } from '../../../utils';
 import { DEFAULT_BIT_RELEASE_TYPE, BASE_DOCS_DOMAIN, WILDCARD_HELP } from '../../../constants';
 import GeneralError from '../../../error/general-error';
@@ -32,6 +32,7 @@ bit tag [id] --persist or bit tag --all --persist, executes the persist on the g
     ['', 'skip-tests', 'skip running component tests during tag process'],
     ['', 'skip-auto-tag', 'EXPERIMENTAL. skip auto tagging dependents'],
     ['', 'persist', 'Harmony only. persist the changes. (same as "bit tag" in the legacy workspace)'],
+    ['', 'disable-deploy-pipeline', 'Harmony only. skip the deploy pipeline to avoid publishing the components'],
   ] as CommandOptions;
   migration = true;
   remoteOp = true; // In case a compiler / tester is not installed
@@ -45,7 +46,7 @@ bit tag [id] --persist or bit tag --all --persist, executes the persist on the g
       minor,
       major,
       force = false,
-      verbose,
+      verbose = false,
       ignoreMissingDependencies = false,
       ignoreUnresolvedDependencies = false,
       ignoreNewestVersion = false,
@@ -53,22 +54,16 @@ bit tag [id] --persist or bit tag --all --persist, executes the persist on the g
       skipAutoTag = false,
       scope,
       persist = false,
+      disableDeployPipeline = false,
     }: {
-      message?: string;
       all?: boolean;
       patch?: boolean;
       minor?: boolean;
       major?: boolean;
-      force?: boolean;
-      verbose?: boolean;
       ignoreMissingDependencies?: boolean;
       ignoreUnresolvedDependencies?: boolean;
-      ignoreNewestVersion?: boolean;
-      skipTests?: boolean;
-      skipAutoTag?: boolean;
       scope?: string;
-      persist?: boolean;
-    }
+    } & Partial<BasicTagParams>
   ): Promise<any> {
     function getVersion(): string | undefined {
       if (scope) return scope;
@@ -114,6 +109,7 @@ bit tag [id] --persist or bit tag --all --persist, executes the persist on the g
       persist,
       scope,
       includeImported,
+      disableDeployPipeline,
     };
 
     return tagAction(params);

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -67,6 +67,7 @@ import DirStructure from './dir-structure/dir-structure';
 import { ConsumerNotFound, MissingDependencies } from './exceptions';
 import migrate, { ConsumerMigrationResult } from './migrations/consumer-migrator';
 import migratonManifest from './migrations/consumer-migrator-manifest';
+import { BasicTagParams } from '../api/consumer/lib/tag';
 
 type ConsumerProps = {
   projectPath: string;
@@ -496,19 +497,14 @@ export default class Consumer {
     return this.componentStatusLoader.getComponentStatusById(id);
   }
 
-  async tag(tagParams: {
-    ids: BitIds;
-    message: string;
-    exactVersion: string | undefined;
-    releaseType: semver.ReleaseType;
-    force: boolean | undefined;
-    verbose: boolean | undefined;
-    ignoreUnresolvedDependencies: boolean | undefined;
-    ignoreNewestVersion: boolean;
-    skipTests: boolean;
-    skipAutoTag: boolean;
-    persist: boolean;
-  }): Promise<{
+  async tag(
+    tagParams: {
+      ids: BitIds;
+      exactVersion: string | undefined;
+      releaseType: semver.ReleaseType;
+      ignoreUnresolvedDependencies: boolean | undefined;
+    } & BasicTagParams
+  ): Promise<{
     taggedComponents: Component[];
     autoTaggedResults: AutoTagResult[];
     isSoftTag: boolean;
@@ -546,10 +542,10 @@ export default class Consumer {
     }
 
     const { taggedComponents, autoTaggedResults, publishedPackages } = await tagModelComponent({
+      ...tagParams,
       consumerComponents: components,
       scope: this.scope,
       consumer: this,
-      ...tagParams,
     });
 
     return { taggedComponents, autoTaggedResults, isSoftTag: !persist, publishedPackages };
@@ -624,17 +620,18 @@ export default class Consumer {
 
     const { taggedComponents, autoTaggedResults } = await tagModelComponent({
       consumerComponents: components,
+      ignoreNewestVersion: false,
       scope: this.scope,
       message,
       force,
       consumer: this,
       skipTests,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       verbose,
       skipAutoTag: skipAutoSnap,
       persist: true,
       resolveUnmerged,
       isSnap: true,
+      disableDeployPipeline: false,
     });
 
     return { snappedComponents: taggedComponents, autoSnappedResults: autoTaggedResults };

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -24,6 +24,7 @@ import { FlattenedDependenciesGetter } from './get-flattened-dependencies';
 import { getValidVersionOrReleaseType } from '../../utils/semver-helper';
 import { OnTagResult } from '../scope';
 import { Log } from '../models/version';
+import { BasicTagParams } from '../../api/consumer/lib/tag';
 
 function updateDependenciesVersions(componentsToTag: Component[]): void {
   const getNewDependencyVersion = (id: BitId): BitId | null => {
@@ -170,22 +171,20 @@ export default async function tagModelComponent({
   persist,
   resolveUnmerged,
   isSnap = false,
+  disableDeployPipeline,
 }: {
   consumerComponents: Component[];
   scope: Scope;
-  message: string;
   exactVersion?: string | null | undefined;
   releaseType?: ReleaseType;
-  force: boolean | null | undefined;
   consumer: Consumer;
-  ignoreNewestVersion?: boolean;
-  skipTests: boolean;
-  verbose?: boolean;
-  skipAutoTag: boolean;
-  persist: boolean;
   resolveUnmerged?: boolean;
   isSnap?: boolean;
-}): Promise<{ taggedComponents: Component[]; autoTaggedResults: AutoTagResult[]; publishedPackages: string[] }> {
+} & BasicTagParams): Promise<{
+  taggedComponents: Component[];
+  autoTaggedResults: AutoTagResult[];
+  publishedPackages: string[];
+}> {
   if (!persist) skipTests = true;
   const consumerComponentsIdsMap = {};
   // Concat and unique all the dependencies from all the components so we will not import
@@ -281,7 +280,10 @@ export default async function tagModelComponent({
   const publishedPackages: string[] = [];
   if (!consumer.isLegacy && persist) {
     const ids = allComponentsToTag.map((consumerComponent) => consumerComponent.id);
-    const results: Array<OnTagResult[]> = await bluebird.mapSeries(scope.onTag, (func) => func(ids));
+
+    const results: Array<OnTagResult[]> = await bluebird.mapSeries(scope.onTag, (func) =>
+      func(ids, { disableDeployPipeline })
+    );
     results.forEach((tagResult) => updateComponentsByTagResult(allComponentsToTag, tagResult));
     allComponentsToTag.forEach((comp) => {
       const pkgExt = comp.extensions.findCoreExtension('teambit.pkg/pkg');

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -94,7 +94,8 @@ export type OnTagResult = {
   id: BitId;
   extensions: ExtensionDataList;
 };
-export type OnTagFunc = (ids: BitId[]) => Promise<OnTagResult[]>;
+export type OnTagOpts = { disableDeployPipeline?: boolean };
+export type OnTagFunc = (ids: BitId[], options?: OnTagOpts) => Promise<OnTagResult[]>;
 
 export default class Scope {
   created = false;


### PR DESCRIPTION
This way it'll be possible to run "bit tag" without publishing the components.

Also, refactor the tag parameters to avoid passing the same params multiple times.