### PR TITLE
enable Lanes/Snaps features on Harmony workspace without a feature flag

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from 'chai';
 import fs from 'fs-extra';
 import path from 'path';
-import { HARMONY_FEATURE, LANES_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
 
 import { AUTO_SNAPPED_MSG } from '../../src/cli/commands/public-cmds/snap-cmd';
 import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
@@ -18,7 +18,7 @@ describe('bit lane command', function () {
   let helper: Helper;
   before(() => {
     helper = new Helper();
-    helper.command.setFeatures([HARMONY_FEATURE, LANES_FEATURE]);
+    helper.command.setFeatures([HARMONY_FEATURE]);
   });
   after(() => {
     helper.scopeHelper.destroy();

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -559,7 +559,7 @@ describe('bit snap command', function () {
       let secondSnap: string;
       let localScope;
       before(() => {
-        helper.scopeHelper.reInitLocalScope();
+        helper.scopeHelper.reInitLocalScopeHarmony();
         helper.fixtures.createComponentBarFoo();
         helper.fixtures.addComponentBarFooAsDir();
         helper.command.snapAllComponents();
@@ -571,7 +571,7 @@ describe('bit snap command', function () {
       });
       it('bit diff should show the differences', () => {
         const diff = helper.command.diff(` bar/foo ${firstSnap}`);
-        const barFooFile = path.join('bar', 'foo.js');
+        const barFooFile = 'foo.js';
         expect(diff).to.have.string(`--- ${barFooFile} (${firstSnap})`);
         expect(diff).to.have.string(`+++ ${barFooFile} (${secondSnap})`);
 
@@ -667,7 +667,7 @@ describe('bit snap command', function () {
       before(() => {
         helper.command.exportAllComponents();
 
-        helper.scopeHelper.reInitLocalScope();
+        helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();
         helper.command.importComponent('comp1');
       });

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -1,7 +1,7 @@
 import chai, { expect } from 'chai';
 import fs from 'fs-extra';
 import path from 'path';
-import { HARMONY_FEATURE, LANES_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
 import { AUTO_SNAPPED_MSG } from '../../src/cli/commands/public-cmds/snap-cmd';
 import { statusWorkspaceIsCleanMsg } from '../../src/cli/commands/public-cmds/status-cmd';
 import { HASH_SIZE } from '../../src/constants';
@@ -17,7 +17,7 @@ describe('bit snap command', function () {
   let helper: Helper;
   before(() => {
     helper = new Helper();
-    helper.command.setFeatures([LANES_FEATURE, HARMONY_FEATURE]);
+    helper.command.setFeatures([HARMONY_FEATURE]);
   });
   after(() => {
     helper.scopeHelper.destroy();
@@ -559,7 +559,6 @@ describe('bit snap command', function () {
       let secondSnap: string;
       let localScope;
       before(() => {
-        helper.command.setFeatures([LANES_FEATURE]);
         helper.scopeHelper.reInitLocalScope();
         helper.fixtures.createComponentBarFoo();
         helper.fixtures.addComponentBarFooAsDir();
@@ -625,7 +624,6 @@ describe('bit snap command', function () {
     let snapOutput;
     let isTypeHead;
     before(() => {
-      helper.command.setFeatures([LANES_FEATURE]);
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.disablePreview();
       helper.fixtures.populateComponents();

--- a/scopes/scope/scope/export/export-cmd.ts
+++ b/scopes/scope/scope/export/export-cmd.ts
@@ -1,6 +1,5 @@
 import { Command, CommandOptions } from '@teambit/cli';
 import { exportAction } from 'bit-bin/dist/api/consumer';
-import { throwForUsingLaneIfDisabled } from 'bit-bin/dist/api/consumer/lib/feature-toggle';
 import { BitId } from 'bit-bin/dist/bit-id';
 import ejectTemplate from 'bit-bin/dist/cli/templates/eject-template';
 import { BASE_DOCS_DOMAIN, CURRENT_UPSTREAM, WILDCARD_HELP } from 'bit-bin/dist/constants';
@@ -69,7 +68,6 @@ export class ExportCmd implements Command {
       lanes = false,
     }: any
   ): Promise<string> {
-    if (lanes) throwForUsingLaneIfDisabled();
     const currentScope = !remote || remote === CURRENT_UPSTREAM;
     if (currentScope && remote) {
       remote = '';

--- a/src/api/consumer/lib/export.ts
+++ b/src/api/consumer/lib/export.ts
@@ -30,6 +30,7 @@ import { exportMany } from '../../../scope/component-ops/export-scope-components
 import { Lane } from '../../../scope/models';
 import hasWildcard from '../../../utils/string/has-wildcard';
 import IdExportedAlready from './exceptions/id-exported-already';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 
 const HooksManagerInstance = HooksManager.getInstance();
 
@@ -96,6 +97,7 @@ async function exportComponents({
   newIdsOnRemote: BitId[];
 }> {
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy && lanes) throw new LanesIsDisabled();
   const { idsToExport, missingScope, idsWithFutureScope, lanesObjects } = await getComponentsToExport(
     ids,
     consumer,

--- a/src/api/consumer/lib/feature-toggle.ts
+++ b/src/api/consumer/lib/feature-toggle.ts
@@ -53,19 +53,6 @@ export const LEGACY_SHARED_DIR_FEATURE = 'legacy-shared-dir';
 
 export const HARMONY_FEATURE = 'harmony';
 
-export const LANES_FEATURE = 'lanes';
-
-export function isLaneEnabled() {
-  return isFeatureEnabled(LANES_FEATURE);
-}
-
 export function isHarmonyEnabled() {
   return isFeatureEnabled(HARMONY_FEATURE);
-}
-
-export function throwForUsingLaneIfDisabled() {
-  if (isLaneEnabled()) return;
-  throw new GeneralError(`lanes/snaps features are disabled.
-keep in mind that enabling these features could damage your components objects with no option to roll back.
-do not enable them unless you're testing them. `);
 }

--- a/src/api/consumer/lib/feature-toggle.ts
+++ b/src/api/consumer/lib/feature-toggle.ts
@@ -13,7 +13,6 @@
  */
 
 import { CFG_FEATURE_TOGGLE } from '../../../constants';
-import GeneralError from '../../../error/general-error';
 import { getSync } from './global-config';
 
 export const ENV_VAR_FEATURE_TOGGLE = 'BIT_FEATURES';

--- a/src/api/consumer/lib/fetch.ts
+++ b/src/api/consumer/lib/fetch.ts
@@ -4,6 +4,7 @@ import { Analytics } from '../../../analytics/analytics';
 import loader from '../../../cli/loader';
 import { Consumer, loadConsumer } from '../../../consumer';
 import ImportComponents, { ImportOptions } from '../../../consumer/component-ops/import-components';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import GeneralError from '../../../error/general-error';
 import { RemoteLaneId } from '../../../lane-id/lane-id';
 
@@ -15,6 +16,9 @@ export default async function fetch(ids: string[], lanes: boolean, components: b
   }
   loader.start('fetching objects...');
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy) {
+    throw new LanesIsDisabled();
+  }
   const importOptions: ImportOptions = {
     ids,
     objectsOnly: true,

--- a/src/api/consumer/lib/import.ts
+++ b/src/api/consumer/lib/import.ts
@@ -10,6 +10,7 @@ import loader from '../../../cli/loader';
 import { BEFORE_IMPORT_ENVIRONMENT } from '../../../cli/loader/loader-messages';
 import { Consumer, loadConsumer } from '../../../consumer';
 import ImportComponents, { ImportOptions } from '../../../consumer/component-ops/import-components';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import GeneralError from '../../../error/general-error';
 import { flattenDependencies } from '../../../scope/flatten-dependencies';
 import FlagHarmonyOnly from './exceptions/flag-harmony-only';
@@ -55,6 +56,7 @@ export default async function importAction(
   }
 
   const consumer: Consumer = await loadConsumer();
+  if (importOptions.skipLane && consumer.isLegacy) throw new LanesIsDisabled();
   consumer.packageManagerArgs = packageManagerArgs;
   if (environmentOptions.tester || environmentOptions.compiler) {
     return importEnvironment(consumer);

--- a/src/api/consumer/lib/lane.ts
+++ b/src/api/consumer/lib/lane.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_LANE } from '../../../constants';
 import { Consumer, loadConsumer, loadConsumerIfExist } from '../../../consumer';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import getRemoteByName from '../../../remotes/get-remote-by-name';
 import { LaneData } from '../../../scope/lanes/lanes';
 
@@ -24,11 +25,13 @@ export default async function lane({
   const showMergeData = Boolean(merged || notMerged);
   if (remote) {
     const consumer = await loadConsumerIfExist();
+    if (consumer && consumer.isLegacy) throw new LanesIsDisabled();
     const remoteObj = await getRemoteByName(remote, consumer);
     const lanes = await remoteObj.listLanes(name, showMergeData);
     return { lanes };
   }
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy) throw new LanesIsDisabled();
   const lanes = await consumer.scope.lanes.getLanesData(consumer.scope, name, showMergeData);
 
   if (showDefaultLane) {

--- a/src/api/consumer/lib/merge.ts
+++ b/src/api/consumer/lib/merge.ts
@@ -3,6 +3,7 @@ import R from 'ramda';
 import { BitId } from '../../../bit-id';
 import { Consumer, loadConsumer } from '../../../consumer';
 import ComponentsList from '../../../consumer/component/components-list';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import { mergeLanes } from '../../../consumer/lanes/merge-lanes';
 import { ApplyVersionResults, MergeStrategy, mergeVersion } from '../../../consumer/versions-ops/merge-version';
 import {
@@ -24,6 +25,9 @@ export default async function merge(
   existingOnWorkspaceOnly: boolean
 ): Promise<ApplyVersionResults> {
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy && (idIsLane || existingOnWorkspaceOnly || noSnap || message || abort || resolve)) {
+    throw new LanesIsDisabled();
+  }
   let mergeResults;
   const firstValue = R.head(values);
   if (resolve) {

--- a/src/api/consumer/lib/remove.ts
+++ b/src/api/consumer/lib/remove.ts
@@ -6,12 +6,13 @@ import { BEFORE_REMOVE } from '../../../cli/loader/loader-messages';
 import { Consumer, loadConsumer, loadConsumerIfExist } from '../../../consumer';
 import removeComponents from '../../../consumer/component-ops/remove-components';
 import ComponentsList from '../../../consumer/component/components-list';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import removeLanes from '../../../consumer/lanes/remove-lanes';
 import hasWildcard from '../../../utils/string/has-wildcard';
 import NoIdMatchWildcard from './exceptions/no-id-match-wildcard';
 import { getRemoteBitIdsByWildcards } from './list-scope';
 
-export default (async function remove({
+export default async function remove({
   ids,
   force,
   remote,
@@ -30,6 +31,7 @@ export default (async function remove({
   const consumer: Consumer | undefined = remote ? await loadConsumerIfExist() : await loadConsumer();
   let removeResults;
   if (lane) {
+    if (consumer?.isLegacy) throw new LanesIsDisabled();
     removeResults = await removeLanes(consumer, ids, remote, force);
   } else {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -45,7 +47,7 @@ export default (async function remove({
   }
   if (consumer) await consumer.onDestroy();
   return removeResults;
-});
+}
 
 async function getLocalBitIdsToRemove(consumer: Consumer, ids: string[]): Promise<BitId[]> {
   if (hasWildcard(ids)) {

--- a/src/api/consumer/lib/snap.ts
+++ b/src/api/consumer/lib/snap.ts
@@ -4,6 +4,7 @@ import { BitIds } from '../../../bit-id';
 import { Consumer, loadConsumer } from '../../../consumer';
 import Component from '../../../consumer/component';
 import ComponentsList from '../../../consumer/component/components-list';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import { AutoTagResult } from '../../../scope/component-ops/auto-tag';
 import hasWildcard from '../../../utils/string/has-wildcard';
 
@@ -25,6 +26,7 @@ export async function snapAction(args: {
 }): Promise<SnapResults | null> {
   const { id, message, force, verbose, ignoreUnresolvedDependencies, skipTests, skipAutoSnap } = args;
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy) throw new LanesIsDisabled();
   const componentsList = new ComponentsList(consumer);
   const newComponents = await componentsList.listNewComponents();
   const ids = await getIdsToSnap();

--- a/src/api/consumer/lib/switch.ts
+++ b/src/api/consumer/lib/switch.ts
@@ -3,6 +3,7 @@ import { BEFORE_CHECKOUT } from '../../../cli/loader/loader-messages';
 import { DEFAULT_LANE } from '../../../constants';
 import { Consumer, loadConsumer } from '../../../consumer';
 import createLane from '../../../consumer/lanes/create-lane';
+import { LanesIsDisabled } from '../../../consumer/lanes/exceptions/lanes-is-disabled';
 import switchLanes, { SwitchProps } from '../../../consumer/lanes/switch-lanes';
 import { CheckoutProps } from '../../../consumer/versions-ops/checkout-version';
 import { ApplyVersionResults } from '../../../consumer/versions-ops/merge-version';
@@ -16,6 +17,7 @@ export default async function switchAction(
 ): Promise<ApplyVersionResults> {
   loader.start(BEFORE_CHECKOUT);
   const consumer: Consumer = await loadConsumer();
+  if (consumer.isLegacy) throw new LanesIsDisabled();
   let results;
   if (switchProps.create) {
     await createLane(consumer, switchProps.laneName);

--- a/src/cli/commands/public-cmds/fetch-cmd.ts
+++ b/src/cli/commands/public-cmds/fetch-cmd.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import R from 'ramda';
 
 import { fetch } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { ImportDetails } from '../../../consumer/component-ops/import-components';
 import { ComponentWithDependencies } from '../../../scope';
 import { formatPlainComponentItemWithVersions } from '../../chalk-box';
@@ -32,7 +31,6 @@ export default class Fetch implements LegacyCommand {
       json?: boolean;
     }
   ): Promise<{}> {
-    if (lanes) throwForUsingLaneIfDisabled();
     return fetch(ids, lanes, components).then((results) => ({ ...results, json }));
   }
 

--- a/src/cli/commands/public-cmds/import-cmd.ts
+++ b/src/cli/commands/public-cmds/import-cmd.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import R from 'ramda';
 
 import { importAction } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { EnvironmentOptions } from '../../../api/consumer/lib/import';
 import { BASE_DOCS_DOMAIN, WILDCARD_HELP } from '../../../constants';
 import Component from '../../../consumer/component';
@@ -104,7 +103,6 @@ export default class Import implements LegacyCommand {
     },
     packageManagerArgs: string[]
   ): Promise<any> {
-    if (skipLane) throwForUsingLaneIfDisabled();
     if (tester && compiler) {
       throw new GeneralError('you cant use tester and compiler flags combined');
     }

--- a/src/cli/commands/public-cmds/lane-cmd.ts
+++ b/src/cli/commands/public-cmds/lane-cmd.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { lane } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { LaneResults } from '../../../api/consumer/lib/lane';
 import { BASE_DOCS_DOMAIN } from '../../../constants';
 import { LaneData } from '../../../scope/lanes/lanes';
@@ -41,7 +40,6 @@ export default class Lane implements LegacyCommand {
       json: boolean;
     }
   ): Promise<any> {
-    throwForUsingLaneIfDisabled();
     return lane({
       name,
       remote,

--- a/src/cli/commands/public-cmds/merge-cmd.ts
+++ b/src/cli/commands/public-cmds/merge-cmd.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { merge } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { WILDCARD_HELP } from '../../../constants';
 import {
   ApplyVersionResult,
@@ -82,7 +81,6 @@ export default class Merge implements LegacyCommand {
       message: string;
     }
   ): Promise<ApplyVersionResults> {
-    if (lane || existing || noSnap || message || abort || resolve) throwForUsingLaneIfDisabled();
     const mergeStrategy = getMergeStrategy(ours, theirs, manual);
     if (abort && resolve) throw new GeneralError('unable to use "abort" and "resolve" flags together');
     if (noSnap && message) throw new GeneralError('unable to use "noSnap" and "message" flags together');

--- a/src/cli/commands/public-cmds/remove-cmd.ts
+++ b/src/cli/commands/public-cmds/remove-cmd.ts
@@ -1,8 +1,6 @@
 import chalk from 'chalk';
 import yn from 'yn';
-
 import { remove } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { BASE_DOCS_DOMAIN, WILDCARD_HELP } from '../../../constants';
 import GeneralError from '../../../error/general-error';
 import { removePrompt } from '../../../prompts';
@@ -49,7 +47,6 @@ export default class Remove implements LegacyCommand {
       lane = false,
     }: { force: boolean; remote: boolean; track: boolean; deleteFiles: boolean; silent: boolean; lane: boolean }
   ): Promise<any> {
-    if (lane) throwForUsingLaneIfDisabled();
     if (!silent) {
       const removePromptResult = await removePrompt();
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/cli/commands/public-cmds/snap-cmd.ts
+++ b/src/cli/commands/public-cmds/snap-cmd.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { snapAction } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { SnapResults } from '../../../api/consumer/lib/snap';
 import { BASE_DOCS_DOMAIN, WILDCARD_HELP } from '../../../constants';
 import GeneralError from '../../../error/general-error';
@@ -49,7 +48,6 @@ export default class Snap implements LegacyCommand {
       skipAutoSnap?: boolean;
     }
   ): Promise<any> {
-    throwForUsingLaneIfDisabled();
     if (!id && !all) {
       throw new GeneralError('missing [id]. to snap all components, please use --all flag');
     }

--- a/src/cli/commands/public-cmds/switch-cmd.ts
+++ b/src/cli/commands/public-cmds/switch-cmd.ts
@@ -2,7 +2,6 @@ import chalk from 'chalk';
 import R from 'ramda';
 
 import { switchAction } from '../../../api/consumer';
-import { throwForUsingLaneIfDisabled } from '../../../api/consumer/lib/feature-toggle';
 import { SwitchProps } from '../../../consumer/lanes/switch-lanes';
 import { CheckoutProps } from '../../../consumer/versions-ops/checkout-version';
 import { ApplyVersionResults, MergeOptions, MergeStrategy } from '../../../consumer/versions-ops/merge-version';
@@ -64,7 +63,6 @@ export default class Switch implements LegacyCommand {
       ignoreDist?: boolean;
     }
   ): Promise<ApplyVersionResults> {
-    throwForUsingLaneIfDisabled();
     let mergeStrategy;
     if (merge && R.is(String, merge)) {
       const options = Object.keys(MergeOptions);

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -59,6 +59,7 @@ import {
   NewerVersionFound,
   NothingToImport,
 } from '../consumer/exceptions';
+import { LanesIsDisabled } from '../consumer/lanes/exceptions/lanes-is-disabled';
 import { PathToNpmrcNotExist, WriteToNpmrcError } from '../consumer/login/exceptions';
 import { BitError } from '../error/bit-error';
 import GeneralError from '../error/general-error';
@@ -145,6 +146,7 @@ const errorsMap: Array<[Class<Error>, (err: Class<Error>) => string]> = [
   //   err => `error: The compiler "${err.plugin}" is not installed, please use "bit install ${err.plugin}" to install it.`
   // ],
   [FileSourceNotFound, (err) => `file or directory "${err.path}" was not found`],
+  [LanesIsDisabled, () => `lanes/snaps features are disabled. upgrade your workspace to Harmony to enable them`],
   [
     OutsideRootDir,
     (err) => `unable to add file ${err.filePath} because it's located outside the component root dir ${err.rootDir}`,

--- a/src/consumer/lanes/exceptions/lanes-is-disabled.ts
+++ b/src/consumer/lanes/exceptions/lanes-is-disabled.ts
@@ -1,0 +1,3 @@
+import AbstractError from '../../../error/abstract-error';
+
+export class LanesIsDisabled extends AbstractError {}

--- a/src/consumer/versions-ops/merge-version/merge-snaps.ts
+++ b/src/consumer/versions-ops/merge-version/merge-snaps.ts
@@ -358,7 +358,7 @@ export async function applyVersion({
   } else {
     // this is master
     const modelComponent = await consumer.scope.getModelComponent(id);
-    modelComponent.setHead(remoteHead);
+    if (!consumer.isLegacy) modelComponent.setHead(remoteHead);
     consumer.scope.objects.add(modelComponent);
   }
 

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1,8 +1,6 @@
 import { clone, equals, forEachObjIndexed, isEmpty } from 'ramda';
 import * as semver from 'semver';
 import { v4 } from 'uuid';
-
-import { isLaneEnabled } from '../../api/consumer/lib/feature-toggle';
 import BitId from '../../bit-id/bit-id';
 import {
   COMPILER_ENV_TYPE,
@@ -136,7 +134,6 @@ export default class Component extends BitObject {
   }
 
   setHead(head: Ref | undefined) {
-    if (!isLaneEnabled()) return;
     this.head = head;
   }
 
@@ -405,7 +402,7 @@ export default class Component extends BitObject {
       // @todo: fix it in a more elegant way
       version.addAsOnlyParent(head);
     }
-    this.setHead(version.hash());
+    if (!version.isLegacy) this.setHead(version.hash());
     if (isTag(versionToAdd)) {
       this.versions[versionToAdd] = version.hash();
     }

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -1,6 +1,4 @@
 import R from 'ramda';
-
-import { isLaneEnabled } from '../../api/consumer/lib/feature-toggle';
 import { BitId, BitIds } from '../../bit-id';
 import { DEFAULT_BINDINGS_PREFIX, DEFAULT_BUNDLE_FILENAME, DEPENDENCIES_FIELDS } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
@@ -673,7 +671,7 @@ export default class Version extends BitObject {
   }
 
   addParent(ref: Ref) {
-    if (!isLaneEnabled()) return;
+    if (this.isLegacy) return;
     if (this.hasParent(ref)) {
       return; // make sure to not add twice
     }
@@ -681,7 +679,7 @@ export default class Version extends BitObject {
   }
 
   addAsOnlyParent(ref: Ref) {
-    if (!isLaneEnabled()) return;
+    if (this.isLegacy) return;
     this.parents = [ref];
   }
 


### PR DESCRIPTION
Currently, a feature flag `lanes` is needed to enable snaps/lanes features.
This `lanes` feature-flag has been removed and it's enabled by default when the workspace is Harmony.