### PR TITLE
change Circle bit-build task to use resource:large

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -453,6 +453,7 @@ jobs:
           path: ~/Library/Caches/Bit/logs
 
   bit_build:
+    resource_class: large
     <<: *defaults
     environment:
       # change the npm config to avoid using sudo


### PR DESCRIPTION
It currently fails due to out-of-memory errors.