### PR TITLE
change Network API to clearly differentiate between seeder-capsules and graph-capsules

### DIFF
--- a/scopes/compilation/babel/babel.compiler.ts
+++ b/scopes/compilation/babel/babel.compiler.ts
@@ -74,7 +74,7 @@ export class BabelCompiler implements Compiler {
    * compile multiple components on the capsules
    */
   async build(context: BuildContext): Promise<BuiltTaskResult> {
-    const capsules = context.capsuleGraph.seedersCapsules;
+    const capsules = context.capsuleNetwork.seedersCapsules;
     const componentsResults: ComponentResult[] = [];
     this.setConfigFileFalse();
     const longProcessLogger = this.logger.createLongProcessLogger('compile babel components', capsules.length);

--- a/scopes/compilation/compiler/compiler.task.ts
+++ b/scopes/compilation/compiler/compiler.task.ts
@@ -25,7 +25,7 @@ export class CompilerTask implements BuildTask {
     const buildResults = await this.compilerInstance.build(context);
 
     await Promise.all(
-      context.capsuleGraph.capsules.map((capsule) => this.copyNonSupportedFiles(capsule, this.compilerInstance))
+      context.capsuleNetwork.graphCapsules.map((capsule) => this.copyNonSupportedFiles(capsule, this.compilerInstance))
     );
 
     return buildResults;

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -1,30 +1,35 @@
 import { ComponentID } from '@teambit/component';
-import Graph from 'bit-bin/dist/scope/graph/graph';
-import { Capsule } from './capsule';
+import { PathOsBasedAbsolute } from 'bit-bin/dist/utils/path';
 import CapsuleList from './capsule-list';
 
-/**
- * todo: this class is confusing.
- * it has the entire graph including the dependencies of the seeder components.
- * the `capsules` should be maybe `capsuleListOfEntireGraph`, and `seederCapsules` should be `capsules`.
- * Also, the CapsuleList should be refactored to be just Array<Capsule>.
- */
 export class Network {
   constructor(
-    /**
-     * all capsules, including the dependencies of the seeders.
-     */
-    public capsules: CapsuleList,
-    public components: Graph,
-    public seedersIds: ComponentID[],
-    public capsulesRootDir: string
+    private _graphCapsules: CapsuleList,
+    private seedersIds: ComponentID[],
+    private _capsulesRootDir: string
   ) {}
 
-  get seedersCapsules(): Capsule[] {
-    return this.seedersIds.map((seederId) => {
-      const capsule = this.capsules.getCapsule(seederId);
+  /**
+   * seeders capsules only without the entire graph. normally, this includes the capsules of one
+   * env.
+   */
+  get seedersCapsules(): CapsuleList {
+    const capsules = this.seedersIds.map((seederId) => {
+      const capsule = this.graphCapsules.getCapsule(seederId);
       if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
       return capsule;
     });
+    return CapsuleList.fromArray(capsules);
+  }
+
+  /**
+   * all capsules, including the dependencies of the seeders. (even when they belong to another env)
+   */
+  get graphCapsules(): CapsuleList {
+    return this._graphCapsules;
+  }
+
+  get capsulesRootDir(): PathOsBasedAbsolute {
+    return this._capsulesRootDir;
   }
 }

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -32,7 +32,7 @@ export class TesterTask implements BuildTask {
       if (!componentSpecFiles) throw new Error('capsule not found');
       const [, specs] = componentSpecFiles;
       return specs.map((specFile) => {
-        const capsule = context.capsuleGraph.capsules.getCapsule(component.id);
+        const capsule = context.capsuleNetwork.graphCapsules.getCapsule(component.id);
         if (!capsule) throw new Error('capsule not found');
         const compiler: Compiler = context.env.getCompiler();
         const distPath = compiler.getDistPathBySrcPath(specFile.relative);
@@ -45,7 +45,7 @@ export class TesterTask implements BuildTask {
     const testerContext = Object.assign(context, {
       release: true,
       specFiles: specFilesWithCapsule,
-      rootPath: context.capsuleGraph.capsulesRootDir,
+      rootPath: context.capsuleNetwork.capsulesRootDir,
     });
 
     // TODO: remove after fix AbstractVinyl on capsule
@@ -54,7 +54,7 @@ export class TesterTask implements BuildTask {
     return {
       artifacts: [], // @ts-ignore
       componentsResults: testsResults.components.map((componentTests) => ({
-        component: context.capsuleGraph.capsules.getCapsule(componentTests.componentId)?.component,
+        component: context.capsuleNetwork.graphCapsules.getCapsule(componentTests.componentId)?.component,
         metadata: { tests: componentTests.results },
         errors: testsResults.errors ? testsResults.errors : [],
       })),

--- a/scopes/harmony/aspect/core-exporter.task.ts
+++ b/scopes/harmony/aspect/core-exporter.task.ts
@@ -15,7 +15,7 @@ export class CoreExporterTask implements BuildTask {
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const mainAspect = this.aspectLoader.mainAspect;
-    const capsules = context.capsuleGraph.seedersCapsules;
+    const capsules = context.capsuleNetwork.seedersCapsules;
     const mainAspectCapsule = capsules.find((capsule) => capsule.component.id.name === mainAspect.name);
     if (mainAspectCapsule) {
       const distDir = this.env.getCompiler().distDir;

--- a/scopes/pipelines/builder/artifact/artifact-factory.ts
+++ b/scopes/pipelines/builder/artifact/artifact-factory.ts
@@ -33,12 +33,12 @@ export class ArtifactFactory {
   private getArtifactContextPath(context: BuildContext, component: Component, def: ArtifactDefinition) {
     const artifactContext = this.getArtifactContext(def);
     if (artifactContext === 'component') {
-      const capsulePath = context.capsuleGraph.capsules.getCapsule(component.id)?.path;
+      const capsulePath = context.capsuleNetwork.graphCapsules.getCapsule(component.id)?.path;
       if (!capsulePath) throw new CapsuleNotFound(component.id);
       return capsulePath;
     }
 
-    return context.capsuleGraph.capsulesRootDir;
+    return context.capsuleNetwork.capsulesRootDir;
   }
 
   private getArtifactContext(def: ArtifactDefinition) {
@@ -88,7 +88,7 @@ export class ArtifactFactory {
     defs.forEach((def) => {
       const artifactContext = this.getArtifactContext(def);
       if (artifactContext === 'env') {
-        const capsuleDir = context.capsuleGraph.capsulesRootDir;
+        const capsuleDir = context.capsuleNetwork.capsulesRootDir;
         const rootDir = this.getRootDir(capsuleDir, def);
         const paths = this.resolvePaths(rootDir, def);
         if (paths && paths.length) {

--- a/scopes/pipelines/builder/build-task.ts
+++ b/scopes/pipelines/builder/build-task.ts
@@ -19,9 +19,9 @@ export interface BuildContext extends ExecutionContext {
   components: Component[];
 
   /**
-   * graph of capsules ready to be built.
+   * network of capsules ready to be built.
    */
-  capsuleGraph: Network;
+  capsuleNetwork: Network;
 }
 
 export interface BuildTask {

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -171,7 +171,7 @@ export class BuilderMain {
   async build(components: Component[], isolateOptions?: IsolateComponentsOptions): Promise<TaskResultsList> {
     const idsStr = components.map((c) => c.id.toString());
     const network = await this.workspace.createNetwork(idsStr, isolateOptions);
-    const envs = await this.envs.createEnvironment(network.capsules.getAllComponents());
+    const envs = await this.envs.createEnvironment(network.graphCapsules.getAllComponents());
     const buildResult = await envs.runOnce(this.buildService);
     return buildResult;
   }

--- a/scopes/pipelines/builder/builder.service.tsx
+++ b/scopes/pipelines/builder/builder.service.tsx
@@ -70,7 +70,7 @@ export class BuilderService implements EnvService<BuildServiceResults, BuilderDe
       envsExecutionContext.map(async (executionContext) => {
         const componentIds = executionContext.components.map((component) => component.id.toString());
         const buildContext = Object.assign(executionContext, {
-          capsuleGraph: await this.workspace.createNetwork(componentIds, { getExistingAsIs: true }),
+          capsuleNetwork: await this.workspace.createNetwork(componentIds, { getExistingAsIs: true }),
         });
         envsBuildContext[executionContext.id] = buildContext;
       })

--- a/scopes/pkg/pkg/prepare-packages.task.ts
+++ b/scopes/pkg/pkg/prepare-packages.task.ts
@@ -36,7 +36,7 @@ export class PreparePackagesTask implements BuildTask {
     const distDir = compilerInstance.distDir;
 
     await Promise.all(
-      context.capsuleGraph.capsules.map(async (capsule) => {
+      context.capsuleNetwork.graphCapsules.map(async (capsule) => {
         await this.removeSourceFiles(capsule, distDir);
         await this.moveDistToRoot(capsule, distDir);
         await this.updatePackageJson(capsule, compilerInstance, distDir);

--- a/scopes/pkg/pkg/publish-dry-run.task.ts
+++ b/scopes/pkg/pkg/publish-dry-run.task.ts
@@ -20,7 +20,7 @@ export class PublishDryRunTask implements BuildTask {
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     this.publisher.options.dryRun = true;
-    const capsules = context.capsuleGraph.seedersCapsules;
+    const capsules = context.capsuleNetwork.seedersCapsules;
     // const capsulesToPublish = capsules.filter((c) => this.publisher.shouldPublish(c.component.config.extensions));
     const capsulesToPublish: Capsule[] = [];
     capsules.forEach((c) => {

--- a/scopes/pkg/pkg/publish.task.ts
+++ b/scopes/pkg/pkg/publish.task.ts
@@ -19,7 +19,7 @@ export class PublishTask implements BuildTask {
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     this.publisher.options.dryRun = false;
-    const capsules = context.capsuleGraph.seedersCapsules;
+    const capsules = context.capsuleNetwork.seedersCapsules;
     // const capsulesToPublish = capsules.filter((c) => this.publisher.shouldPublish(c.component.config.extensions));
     const capsulesToPublish: Capsule[] = [];
     capsules.forEach((c) => {

--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -9,7 +9,7 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
 
   computeTargets(context: BuildContext, previewDefs: PreviewDefinition[], previewTask: PreviewTask): Promise<Target[]> {
     return Promise.all(
-      context.capsuleGraph.capsules.map(async (capsule) => {
+      context.capsuleNetwork.graphCapsules.map(async (capsule) => {
         return {
           entries: await previewTask.computePaths(capsule, previewDefs, context),
           components: [capsule.component],

--- a/scopes/preview/preview/strategies/env-strategy.ts
+++ b/scopes/preview/preview/strategies/env-strategy.ts
@@ -69,7 +69,7 @@ export class EnvBundlingStrategy implements BundlingStrategy {
   }
 
   private getOutputPath(context: BuildContext) {
-    return resolve(`${context.capsuleGraph.capsulesRootDir}/${this.getDirName(context)}`);
+    return resolve(`${context.capsuleNetwork.capsulesRootDir}/${this.getDirName(context)}`);
   }
 
   private getPaths(context: BuildContext, files: AbstractVinyl[], capsule: Capsule) {
@@ -83,7 +83,7 @@ export class EnvBundlingStrategy implements BundlingStrategy {
       const moduleMap = await previewDef.getModuleMap(context.components);
 
       const paths = ComponentMap.as(context.components, (component) => {
-        const capsule = context.capsuleGraph.capsules.getCapsule(component.id);
+        const capsule = context.capsuleNetwork.graphCapsules.getCapsule(component.id);
         const maybeFiles = moduleMap.byComponent(component);
         if (!maybeFiles || !capsule) return [];
         const [, files] = maybeFiles;

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -83,7 +83,7 @@ export class TypescriptCompiler implements Compiler {
   }
 
   async preBuild(context: BuildContext) {
-    const capsules = context.capsuleGraph.seedersCapsules;
+    const capsules = context.capsuleNetwork.seedersCapsules;
     const capsuleDirs = capsules.map((capsule) => capsule.path);
     await this.writeTsConfig(capsuleDirs);
     await this.writeTypes(capsuleDirs);
@@ -94,7 +94,7 @@ export class TypescriptCompiler implements Compiler {
    * compile multiple components on the capsules
    */
   async build(context: BuildContext): Promise<BuiltTaskResult> {
-    const componentsResults = await this.runTscBuild(context.capsuleGraph);
+    const componentsResults = await this.runTscBuild(context.capsuleNetwork);
 
     return {
       artifacts: this.getArtifactDefinition(),
@@ -104,7 +104,7 @@ export class TypescriptCompiler implements Compiler {
 
   async postBuild(context: BuildContext) {
     await Promise.all(
-      context.capsuleGraph.seedersCapsules.map(async (capsule) => {
+      context.capsuleNetwork.seedersCapsules.map(async (capsule) => {
         const packageJson = PackageJsonFile.loadFromCapsuleSync(capsule.path);
         // the types['index.ts'] is needed only during the build to avoid errors when tsc finds the
         // same type once in the d.ts and once in the ts file.
@@ -149,9 +149,9 @@ export class TypescriptCompiler implements Compiler {
    * we went with option #2 because it'll be easier for users to go to the capsule-root and run
    * `tsc --build` to debug issues.
    */
-  private async runTscBuild(capsuleGraph: Network): Promise<ComponentResult[]> {
-    const rootDir = capsuleGraph.capsulesRootDir;
-    const capsules = capsuleGraph.capsules;
+  private async runTscBuild(network: Network): Promise<ComponentResult[]> {
+    const rootDir = network.capsulesRootDir;
+    const capsules = network.graphCapsules;
     const capsuleDirs = capsules.getAllCapsuleDirs();
     const formatHost = {
       getCanonicalFileName: (p) => p,

--- a/scopes/workspace/workspace/capsule-create.cmd.ts
+++ b/scopes/workspace/workspace/capsule-create.cmd.ts
@@ -38,7 +38,7 @@ export class CapsuleCreateCmd implements Command {
     if (componentIds && !Array.isArray(componentIds)) componentIds = [componentIds];
     const capsuleOptions = { baseDir, installPackages, alwaysNew, name: id, packageManager };
     const isolatedEnvironment = await this.workspace.createNetwork(componentIds, capsuleOptions);
-    const capsules = isolatedEnvironment.capsules;
+    const capsules = isolatedEnvironment.graphCapsules;
     return capsules;
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -317,7 +317,6 @@ export class Workspace implements ComponentFactory {
     this.logger.consoleSuccess();
     return new Network(
       capsuleList,
-      graph,
       await Promise.all(seederIdsWithVersions.map(async (legacyId) => this.resolveComponentId(legacyId))),
       this.isolateEnv.getCapsulesRootDir(this.path)
     );
@@ -338,7 +337,7 @@ export class Workspace implements ComponentFactory {
     const components = await this.getMany(componentIds);
     const isolatedEnvironment = await this.createNetwork(components.map((c) => c.id.toString()));
     const resolvedComponents = components.map((component) => {
-      const capsule = isolatedEnvironment.capsules.getCapsule(component.id);
+      const capsule = isolatedEnvironment.graphCapsules.getCapsule(component.id);
       if (!capsule) throw new Error(`unable to find capsule for ${component.id.toString()}`);
       return new ResolvedComponent(component, capsule);
     });


### PR DESCRIPTION
Currently, it's confusing. It has `capsules` and `seedersCapsules`. 

## Proposed changes
- Changed `capsules` to `graphCapsules`. 
- Changed `seedersCapsules` to return `CapsuleList` (same as `graphCapsules`).
- Removed `components` prop. The components can be easily retrieved by the `getAllComponents` of `CapsuleList`.