### PR TITLE
fix ENOENT error when running bit-start for the first time

### DIFF
--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -290,7 +290,6 @@ export class UiMain {
       uiRoot.name
     );
     if (fs.pathExistsSync(config.output.path)) return;
-    if (fs.readdirSync(config.output.path).length > 0) return;
     const hash = await this.buildUiHash(uiRoot);
     await this.build(name);
     await this.cache.set(uiRoot.path, hash);


### PR DESCRIPTION
Currently, when running `bit start` on a bare-scope for the first time, it shows an error:
```
➜  bit start
** unhandled rejection found, please make sure the promise is resolved/rejected correctly! **
ENOENT: no such file or directory, scandir '/private/tmp/sch/public'
➜  
```

@guysaar223 , please review. Not sure what's the purpose of this line `if (fs.readdirSync(config.output.path).length > 0) return;`, it can't work because in the previous line you made sure that this exact directory doesn't exist. 
