### PR TITLE
fix bit-log --remote on http

### DIFF
--- a/e2e/harmony/http.e2e.ts
+++ b/e2e/harmony/http.e2e.ts
@@ -35,6 +35,17 @@ describe('http protocol', function () {
     it('should export successfully', () => {
       expect(exportOutput).to.have.string('exported 3 components');
     });
+    describe('bit log', () => {
+      let logOutput: string;
+      before(() => {
+        logOutput = helper.command.log(`${helper.scopes.remote}/comp1 --remote`);
+      });
+      it('should show the log correctly', () => {
+        expect(logOutput).to.have.string('tag 0.0.1');
+        expect(logOutput).to.have.string('author');
+        expect(logOutput).to.have.string('date');
+      });
+    });
     describe('bit import', () => {
       let importOutput;
       before(() => {

--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -48,8 +48,11 @@ export function scopeSchema(scopeMain: ScopeMain) {
 
       type Log {
         message: String
+        username: String
+        email: String
         date: String
-        hash: String
+        hash: String!
+        tag: String
       }
 
       type LegacyMeta {
@@ -102,7 +105,7 @@ export function scopeSchema(scopeMain: ScopeMain) {
 
         getLogs: async (scope: ScopeMain, { id }: { id: string }) => {
           const logs = await log(scope.path, id);
-          return logs;
+          return JSON.parse(logs);
         },
 
         getMany: async (scope: ScopeMain, { idStrings }: { idStrings: string[] }) => {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -29,7 +29,7 @@ import { BitId, BitIds as ComponentsIds } from 'bit-bin/dist/bit-id';
 import { ModelComponent, Version } from 'bit-bin/dist/scope/models';
 import { Ref } from 'bit-bin/dist/scope/objects';
 import LegacyScope, { OnTagResult, OnTagFunc, OnTagOpts } from 'bit-bin/dist/scope/scope';
-import { ComponentLogs } from 'bit-bin/dist/scope/models/model-component';
+import { ComponentLog } from 'bit-bin/dist/scope/models/model-component';
 import { loadScopeIfExist } from 'bit-bin/dist/scope/scope-loader';
 import { PersistOptions } from 'bit-bin/dist/scope/types';
 import BluebirdPromise from 'bluebird';
@@ -365,7 +365,7 @@ export class ScopeMain implements ComponentFactory {
     return this.createStateFromVersion(id, version);
   }
 
-  async getLogs(id: ComponentID): Promise<ComponentLogs> {
+  async getLogs(id: ComponentID): Promise<ComponentLog[]> {
     return this.legacyScope.loadComponentLogs(id._legacy);
   }
 

--- a/src/api/consumer/lib/get-component-logs.ts
+++ b/src/api/consumer/lib/get-component-logs.ts
@@ -1,8 +1,9 @@
 import { BitId } from '../../../bit-id';
 import { loadConsumer, loadConsumerIfExist } from '../../../consumer';
 import getRemoteByName from '../../../remotes/get-remote-by-name';
+import { ComponentLog } from '../../../scope/models/model-component';
 
-export default async function getComponentLogs(id: string, isRemote: boolean) {
+export default async function getComponentLogs(id: string, isRemote: boolean): Promise<ComponentLog[]> {
   if (isRemote) {
     const consumer = await loadConsumerIfExist();
     const bitId: BitId = BitId.parse(id, true);

--- a/src/cli/chalk-box.ts
+++ b/src/cli/chalk-box.ts
@@ -9,7 +9,6 @@ import SpecsResults, {
 } from '../consumer/specs-results/specs-results';
 import { FileStatus } from '../consumer/versions-ops/merge-version/merge-version';
 import { ComponentLog } from '../scope/models/model-component';
-import { isHash } from '../version/version-parser';
 
 export const formatNewBit = ({ name }: any): string => c.white('     > ') + c.cyan(name);
 

--- a/src/cli/chalk-box.ts
+++ b/src/cli/chalk-box.ts
@@ -8,6 +8,7 @@ import SpecsResults, {
   SpecsResultsWithMetaData,
 } from '../consumer/specs-results/specs-results';
 import { FileStatus } from '../consumer/versions-ops/merge-version/merge-version';
+import { ComponentLog } from '../scope/models/model-component';
 import { isHash } from '../version/version-parser';
 
 export const formatNewBit = ({ name }: any): string => c.white('     > ') + c.cyan(name);
@@ -66,22 +67,11 @@ const paintAuthor = (email: string | null | undefined, username: string | null |
   return '';
 };
 
-export const paintLog = ({
-  message,
-  date,
-  tag,
-  username,
-  email,
-}: {
-  message: string;
-  tag: string;
-  date: string;
-  username: string | null | undefined;
-  email: string | null | undefined;
-}): string => {
-  const type = isHash(tag) ? 'snap' : 'tag';
+export const paintLog = (log: ComponentLog): string => {
+  const { message, date, tag, hash, username, email } = log;
+  const title = tag ? `tag ${tag} (${hash})\n` : `snap ${hash}\n`;
   return (
-    c.yellow(`${type} ${tag}\n`) +
+    c.yellow(title) +
     paintAuthor(email, username) +
     (date ? c.white(`date: ${date}\n`) : '') +
     (message ? c.white(`\n      ${message}\n`) : '')

--- a/src/cli/commands/public-cmds/log-cmd.ts
+++ b/src/cli/commands/public-cmds/log-cmd.ts
@@ -2,6 +2,7 @@ import R from 'ramda';
 
 import { getComponentLogs } from '../../../api/consumer';
 import { BASE_DOCS_DOMAIN } from '../../../constants';
+import { ComponentLog } from '../../../scope/models/model-component';
 import { paintLog } from '../../chalk-box';
 import { CommandOptions, LegacyCommand } from '../../legacy-command';
 
@@ -14,26 +15,15 @@ export default class Log implements LegacyCommand {
   remoteOp = true; // should support log against remote
   skipWorkspace = true;
 
-  action([id]: [string], { remote = false }: { remote: boolean }): Promise<any> {
-    return getComponentLogs(id, remote).then((logs) => {
-      Object.keys(logs).forEach((key) => (logs[key].tag = key));
-      return R.reverse(R.values(logs)).map(
-        R.evolve({
-          date: (n) => new Date(parseInt(n)).toLocaleString(),
-        })
-      );
+  async action([id]: [string], { remote = false }: { remote: boolean }): Promise<any> {
+    const logs = await getComponentLogs(id, remote);
+    logs.forEach((log) => {
+      log.date = log.date ? new Date(parseInt(log.date)).toLocaleString() : undefined;
     });
+    return logs.reverse();
   }
 
-  report(
-    logs: Array<{
-      message: string;
-      tag: string;
-      date: string;
-      username: string | null | undefined;
-      email: string | null | undefined;
-    }>
-  ): string {
+  report(logs: ComponentLog[]): string {
     return logs.map(paintLog).join('\n');
   }
 }

--- a/src/cli/commands/public-cmds/log-cmd.ts
+++ b/src/cli/commands/public-cmds/log-cmd.ts
@@ -1,5 +1,3 @@
-import R from 'ramda';
-
 import { getComponentLogs } from '../../../api/consumer';
 import { BASE_DOCS_DOMAIN } from '../../../constants';
 import { ComponentLog } from '../../../scope/models/model-component';

--- a/src/remotes/remote.ts
+++ b/src/remotes/remote.ts
@@ -7,7 +7,7 @@ import logger from '../logger/logger';
 import ComponentObjects from '../scope/component-objects';
 import DependencyGraph from '../scope/graph/scope-graph';
 import { LaneData } from '../scope/lanes/lanes';
-import { ComponentLogs } from '../scope/models/model-component';
+import { ComponentLog } from '../scope/models/model-component';
 import { connect } from '../scope/network';
 import { Network } from '../scope/network/network';
 import { DEFAULT_READ_STRATEGIES, SSHConnectionStrategyName } from '../scope/network/ssh/ssh';
@@ -120,7 +120,7 @@ export default class Remote {
   undeprecateMany(ids: string[], context: Record<string, any> | null | undefined): Promise<Record<string, any>[]> {
     return connect(this.host).then((network) => network.undeprecateMany(ids, context));
   }
-  log(id: BitId): Promise<ComponentLogs> {
+  log(id: BitId): Promise<ComponentLog[]> {
     return connect(this.host).then((network) => network.log(id));
   }
   listLanes(name?: string, mergeData?: boolean): Promise<LaneData[]> {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -52,7 +52,14 @@ type State = {
 type Versions = { [version: string]: Ref };
 export type ScopeListItem = { url: string; name: string; date: string };
 
-export type ComponentLogs = { [key: number]: { message: string; date: string; hash: string } | null | undefined };
+export type ComponentLog = {
+  message: string;
+  username?: string;
+  email?: string;
+  date?: string;
+  hash: string;
+  tag?: string;
+};
 
 export type ComponentProps = {
   scope: string | null | undefined;
@@ -326,13 +333,16 @@ export default class Component extends BitObject {
     return versionStr || VERSION_ZERO;
   }
 
-  async collectLogs(repo: Repository): Promise<ComponentLogs> {
+  async collectLogs(repo: Repository): Promise<ComponentLog[]> {
     const versionsInfo = await getAllVersionsInfo({ modelComponent: this, repo, throws: false });
-    return versionsInfo.reduce((acc, current) => {
-      const log = current.version ? current.version.log : { message: '<no-data-available>' };
-      acc[current.tag || current.ref.toString()] = log;
-      return acc;
-    }, {});
+    return versionsInfo.map((versionInfo) => {
+      const log = versionInfo.version ? versionInfo.version.log : { message: '<no-data-available>' };
+      return {
+        ...log,
+        tag: versionInfo.tag,
+        hash: versionInfo.ref.toString(),
+      };
+    });
   }
 
   collectVersions(repo: Repository): Promise<ConsumerComponent[]> {

--- a/src/scope/network/fs/fs.ts
+++ b/src/scope/network/fs/fs.ts
@@ -9,7 +9,7 @@ import ComponentObjects from '../../component-objects';
 import ScopeComponentsImporter from '../../component-ops/scope-components-importer';
 import DependencyGraph from '../../graph/scope-graph';
 import { LaneData } from '../../lanes/lanes';
-import { ComponentLogs } from '../../models/model-component';
+import { ComponentLog } from '../../models/model-component';
 import { ObjectList } from '../../objects/object-list';
 import Scope, { ScopeDescriptor } from '../../scope';
 import loadScope from '../../scope-loader';
@@ -84,7 +84,7 @@ export default class Fs implements Network {
     return scopeComponentsImporter.loadComponent(bitId);
   }
 
-  log(bitId: BitId): Promise<ComponentLogs> {
+  log(bitId: BitId): Promise<ComponentLog[]> {
     return this.getScope().loadComponentLogs(bitId);
   }
 

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -6,7 +6,7 @@ import Component from '../../../consumer/component';
 import { ListScopeResult } from '../../../consumer/component/components-list';
 import DependencyGraph from '../../graph/scope-graph';
 import { LaneData } from '../../lanes/lanes';
-import { ComponentLogs } from '../../models/model-component';
+import { ComponentLog } from '../../models/model-component';
 import { ScopeDescriptor } from '../../scope';
 import globalFlags from '../../../cli/global-flags';
 import { getSync } from '../../../api/consumer/lib/global-config';
@@ -219,15 +219,17 @@ export class Http implements Network {
     return res;
   }
 
-  // TODO: @david please fix this.
-  async log(id: BitId): Promise<ComponentLogs> {
+  async log(id: BitId): Promise<ComponentLog[]> {
     const GET_LOG_QUERY = gql`
       query getLogs($id: String!) {
         scope {
           getLogs(id: $id) {
             message
-            hash
+            username
+            email
             date
+            hash
+            tag
           }
         }
       }

--- a/src/scope/network/network.ts
+++ b/src/scope/network/network.ts
@@ -5,7 +5,7 @@ import Component from '../../consumer/component';
 import { ListScopeResult } from '../../consumer/component/components-list';
 import DependencyGraph from '../graph/scope-graph';
 import { LaneData } from '../lanes/lanes';
-import { ComponentLogs } from '../models/model-component';
+import { ComponentLog } from '../models/model-component';
 import { ObjectList } from '../objects/object-list';
 import { ScopeDescriptor } from '../scope';
 import { SSHConnectionStrategyName } from './ssh/ssh';
@@ -23,7 +23,7 @@ export interface Network {
   show(bitId: BitId): Promise<Component | null | undefined>;
   deprecateMany(ids: string[], context: Record<string, any> | null | undefined): Promise<Record<string, any>[]>;
   undeprecateMany(ids: string[], context: Record<string, any> | null | undefined): Promise<Record<string, any>[]>;
-  log(id: BitId): Promise<ComponentLogs>;
+  log(id: BitId): Promise<ComponentLog[]>;
   latestVersions(bitIds: BitIds): Promise<string[]>;
   graph(bitId?: BitId): Promise<DependencyGraph>;
   listLanes(name?: string, mergeData?: boolean): Promise<LaneData[]>;

--- a/src/scope/network/ssh/ssh.ts
+++ b/src/scope/network/ssh/ssh.ts
@@ -19,7 +19,7 @@ import { buildCommandMessage, packCommand, toBase64, unpackCommand } from '../..
 import ComponentObjects from '../../component-objects';
 import DependencyGraph from '../../graph/scope-graph';
 import { LaneData } from '../../lanes/lanes';
-import { ComponentLogs } from '../../models/model-component';
+import { ComponentLog } from '../../models/model-component';
 import RemovedObjects from '../../removed-components';
 import { ScopeDescriptor } from '../../scope';
 import checkVersionCompatibilityFunction from '../check-version-compatibility';
@@ -460,7 +460,7 @@ export default class SSH implements Network {
     });
   }
 
-  log(id: BitId): Promise<ComponentLogs> {
+  log(id: BitId): Promise<ComponentLog[]> {
     return this.exec('_log', id.toString()).then((str: string) => {
       const { payload, headers } = this._unpack(str);
       checkVersionCompatibility(headers.version);

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -48,7 +48,7 @@ import migrate, { ScopeMigrationResult } from './migrations/scope-migrator';
 import migratonManifest from './migrations/scope-migrator-manifest';
 import { ModelComponent, Symlink, Version } from './models';
 import Lane from './models/lane';
-import { ComponentLogs } from './models/model-component';
+import { ComponentLog } from './models/model-component';
 import { BitObject, BitRawObject, Ref, Repository } from './objects';
 import { ComponentItem, IndexType } from './objects/components-index';
 import RemovedObjects from './removed-components';
@@ -593,12 +593,10 @@ export default class Scope {
     return removeNils(components);
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  loadComponentLogs(id: BitId): Promise<ComponentLogs> {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return this.getModelComponent(id).then((componentModel) => {
-      return componentModel.collectLogs(this.objects);
-    });
+  async loadComponentLogs(id: BitId): Promise<ComponentLog[]> {
+    const componentModel = await this.getModelComponent(id);
+    const logs = await componentModel.collectLogs(this.objects);
+    return logs;
   }
 
   loadAllVersions(id: BitId): Promise<Component[]> {


### PR DESCRIPTION
## Proposed Changes

- refactor log() methods to use an array instead of an object.
- implement `log` for HTTP protocol. 

