### PR TITLE
catch graphql-client errors and show a formatted message instead

### DIFF
--- a/src/scope/network/exceptions/graphql-client-error.ts
+++ b/src/scope/network/exceptions/graphql-client-error.ts
@@ -1,0 +1,17 @@
+import { ClientError } from 'graphql-request';
+import { BitError } from '../../../error/bit-error';
+
+/**
+ * @see https://www.npmjs.com/package/graphql-request#error-handling
+ */
+export class GraphQLClientError extends BitError {
+  constructor(private err: ClientError) {
+    super(JSON.stringify(err, undefined, 2));
+    this.stack = err.stack;
+  }
+  report() {
+    if (!this.err.response.errors) return this.message;
+    const errors = this.err.response.errors.map((error) => error.message).join('\n');
+    return `fatal: graphql found the following error(s), use --log to see the request, response and the full stack\n\n${errors}`;
+  }
+}

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -155,7 +155,7 @@ export class Http implements Network {
   private async graphClientRequest(query: string, variables?: Record<string, any>) {
     try {
       return await this.graphClient.request(query, variables);
-    } catch (err: unknown) {
+    } catch (err) {
       if (err instanceof ClientError) {
         throw new GraphQLClientError(err);
       }


### PR DESCRIPTION
Errors coming from the GraphQL are not clear. 
This PR shows the most important info from the error object and logs the rest, so then `--log` can be used to show the full error formatted.