### PR TITLE
fix ENOENT error when deleting multiple objects directories in parallel

### DIFF
--- a/src/utils/fs-remove-file.ts
+++ b/src/utils/fs-remove-file.ts
@@ -1,11 +1,9 @@
 import fs from 'fs-extra';
 // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import pathLib from 'path';
+import removeEmptyDir from './fs/remove-empty-dir';
 
-import logger from '../logger/logger';
-import readDirIgnoreDsStore from './fs/read-dir-ignore-ds-store';
-
-export default (async function removeFile(path: string, propagateDirs = false): Promise<boolean> {
+export default async function removeFile(path: string, propagateDirs = false): Promise<boolean> {
   try {
     await fs.unlink(path);
   } catch (err) {
@@ -17,9 +15,6 @@ export default (async function removeFile(path: string, propagateDirs = false): 
   }
   if (!propagateDirs) return true;
   const { dir } = pathLib.parse(path);
-  const files = await readDirIgnoreDsStore(dir);
-  if (files.length !== 0) return true;
-  logger.info(`fs-remove-file, deleting empty directory ${dir}`);
-  await fs.remove(dir);
+  await removeEmptyDir(dir);
   return true;
-});
+}

--- a/src/utils/fs/is-dir-empty.ts
+++ b/src/utils/fs/is-dir-empty.ts
@@ -1,6 +1,6 @@
 import readDirIgnoreDsStore from './read-dir-ignore-ds-store';
 
-export default (async function isDirEmpty(dirPath: string): Promise<boolean> {
+export default async function isDirEmpty(dirPath: string): Promise<boolean> {
   const files = await readDirIgnoreDsStore(dirPath);
   return !files.length;
-});
+}

--- a/src/utils/fs/read-dir-ignore-ds-store.ts
+++ b/src/utils/fs/read-dir-ignore-ds-store.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 
-export default (async function readDirIgnoreDsStore(dirPath: string): Promise<string[]> {
+export default async function readDirIgnoreDsStore(dirPath: string): Promise<string[]> {
   const files = await fs.readdir(dirPath);
   return files.filter((file) => file !== '.DS_Store');
-});
+}
 
 export function readDirSyncIgnoreDsStore(dirPath: string): string[] {
   const files = fs.readdirSync(dirPath);

--- a/src/utils/fs/remove-containing-dir-if-empty.ts
+++ b/src/utils/fs/remove-containing-dir-if-empty.ts
@@ -1,8 +1,0 @@
-import * as path from 'path';
-
-import removeEmptyDir from './remove-empty-dir';
-
-export default (async function removeContainingDirIfEmpty(componentDir: string): Promise<boolean> {
-  const containingDir = path.dirname(componentDir);
-  return removeEmptyDir(containingDir);
-});

--- a/src/utils/fs/remove-empty-dir.ts
+++ b/src/utils/fs/remove-empty-dir.ts
@@ -3,16 +3,18 @@ import fs from 'fs-extra';
 import logger from '../../logger/logger';
 import isDirEmpty from './is-dir-empty';
 
-export default (async function removeEmptyDir(dirPath: string): Promise<boolean> {
-  const isExist = await fs.pathExists(dirPath);
-  if (!isExist) {
-    return false;
+export default async function removeEmptyDir(dirPath: string): Promise<boolean> {
+  let isEmpty: boolean;
+  try {
+    isEmpty = await isDirEmpty(dirPath);
+  } catch (err) {
+    if (err.code === 'ENOENT') return false;
+    throw err;
   }
-  const isEmpty = await isDirEmpty(dirPath);
   if (isEmpty) {
     logger.info(`remove-empty-dir, deleting ${dirPath}`);
     await fs.remove(dirPath);
     return true;
   }
   return false;
-});
+}


### PR DESCRIPTION
Hopefully, that would be the end of the random CircleCI errors.