### PR TITLE
delete capsule-root-dir before build/tag

### DIFF
--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -65,6 +65,9 @@ describe('compile extension', function () {
         expect(path.join(capsule, 'dist')).to.be.a.directory();
         expect(path.join(capsule, 'dist/index.js')).to.be.a.file();
       });
+      it('should delete previous capsules before the tag (this test is not related to compile)', () => {
+        expect(() => helper.command.getCapsuleOfComponent('comp1')).to.throw();
+      });
       it('should save the dists in the objects', () => {
         const catComp2 = helper.command.catComponent('comp2@latest');
         expect(catComp2).to.have.property('extensions');

--- a/e2e/harmony/pkg.e2e.ts
+++ b/e2e/harmony/pkg.e2e.ts
@@ -11,7 +11,6 @@ const assertArrays = require('chai-arrays');
 
 chai.use(assertArrays);
 
-// @TODO: REMOVE THE SKIP ASAP
 describe('pkg extension', function () {
   this.timeout(0);
   let helper: Helper;
@@ -64,7 +63,7 @@ describe('pkg extension', function () {
       it('should have the updated config in the package.json of the configured component in capsule', () => {
         helper.command.createCapsuleHarmony('bar/foo');
         // We do this because the create capsule dir with json is not working because of pnpm output
-        barFooCapsuleDir = helper.command.getCapsuleOfComponent('bar/foo');
+        barFooCapsuleDir = helper.command.getCapsuleOfComponent('bar/foo@0.0.1');
         const packageJson = helper.packageJson.read(barFooCapsuleDir);
         expect(packageJson).to.have.property('some-key', 'some-val');
       });

--- a/scopes/pipelines/builder/build.cmd.ts
+++ b/scopes/pipelines/builder/build.cmd.ts
@@ -14,7 +14,6 @@ export class BuilderCmd implements Command {
   private = true;
   shortDescription = '';
   options = [
-    ['', 'rebuild', 'rebuild capsules'],
     ['', 'install', 'install core aspects in capsules'],
     ['', 'include-deps', 'include all component dependencies in the capsule context'],
   ] as CommandOptions;
@@ -23,11 +22,7 @@ export class BuilderCmd implements Command {
 
   async report(
     [userPattern]: [string],
-    {
-      rebuild = false,
-      install = false,
-      includeDeps = false,
-    }: { rebuild: boolean; install: boolean; includeDeps: boolean }
+    { install = false, includeDeps = false }: { rebuild: boolean; install: boolean; includeDeps: boolean }
   ): Promise<string> {
     const longProcessLogger = this.logger.createLongProcessLogger('build');
     const pattern = userPattern && userPattern.toString();
@@ -35,7 +30,7 @@ export class BuilderCmd implements Command {
     const components = pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list();
     const envsExecutionResults = await this.builder.build(components, {
       linkingOptions: { bitLinkType: install ? 'install' : 'link' },
-      emptyExisting: rebuild,
+      emptyRootDir: true,
       includeDeps,
     });
     longProcessLogger.end();

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -89,7 +89,7 @@ export class BuilderMain {
   }
 
   async tagListener(components: Component[], options: OnTagOpts = {}): Promise<ComponentMap<AspectList>> {
-    const envsExecutionResults = await this.build(components, { emptyExisting: true });
+    const envsExecutionResults = await this.build(components, { emptyRootDir: true });
     envsExecutionResults.throwErrorsIfExist();
     const allTasksResults = [...envsExecutionResults.tasksResults];
     if (!options.disableDeployPipeline) {


### PR DESCRIPTION
Currently, it only empties the capsules it's about to build but it may have capsules from different versions. 
This makes sure that build and tag start fresh with no previous capsules. 
Also, removed the `--rebuild` flag of bit-build, it's not needed anymore because by default it deletes the root dir of the capsules.