### PR TITLE
fix creating babel task to not require adding "!"

### DIFF
--- a/e2e/fixtures/extensions/babel-env/babel-env.extension.ts
+++ b/e2e/fixtures/extensions/babel-env/babel-env.extension.ts
@@ -13,7 +13,7 @@ export class BabelEnv {
     const babelCompiler = babel.createCompiler({ babelTransformOptions: babelConfig });
     const harmonyReactEnv = react.compose([
       react.overrideCompiler(babelCompiler),
-      react.overrideCompilerTasks([babelCompiler.createTask!()])
+      react.overrideCompilerTasks([babelCompiler.createTask()])
     ]);
 
     envs.registerEnv(harmonyReactEnv);

--- a/scopes/compilation/babel/babel.main.runtime.ts
+++ b/scopes/compilation/babel/babel.main.runtime.ts
@@ -1,5 +1,5 @@
 import { MainRuntime } from '@teambit/cli';
-import { Compiler, CompilerAspect, CompilerMain } from '@teambit/compiler';
+import { CompilerAspect, CompilerMain } from '@teambit/compiler';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import * as babel from '@babel/core';
 import { BabelCompilerOptions } from './compiler-options';
@@ -9,7 +9,7 @@ import { BabelCompiler } from './babel.compiler';
 export class BabelMain {
   constructor(private logger: Logger, private compiler: CompilerMain) {}
 
-  createCompiler(options: BabelCompilerOptions, babelModule = babel): Compiler {
+  createCompiler(options: BabelCompilerOptions, babelModule = babel): BabelCompiler {
     return new BabelCompiler(BabelAspect.id, this.logger, this.compiler, options, babelModule);
   }
 


### PR DESCRIPTION
Currently, you have to use the following syntax `babelCompiler.createTask!()` with the `!`. This PR fixes it.