### PR TITLE
compile only new and modified components unless --all flag is used

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -445,7 +445,7 @@ describe('bit lane command', function () {
       );
       helper.command.addComponent('utils/is-string', { i: 'utils/is-string' });
       helper.command.linkAndRewire();
-      helper.command.compile();
+      helper.command.compile('--all');
       helper.command.snapAllComponents();
 
       // laneB

--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -113,7 +113,7 @@ describe('compile extension', function () {
               'dist'
             );
             fs.removeSync(distPath);
-            helper.command.runCmd('bit compile');
+            helper.command.compile('--all');
             expect(distPath).to.be.a.directory();
             expect(path.join(distPath, 'index.js')).to.be.a.file();
           });

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -289,6 +289,11 @@ export class Workspace implements ComponentFactory {
     return Promise.all(ids);
   }
 
+  async getNewAndModifiedIds(): Promise<ComponentID[]> {
+    const ids = await this.componentList.listTagPendingComponents();
+    return this.resolveMultipleComponentIds(ids);
+  }
+
   // TODO: refactor asap to get seeders as ComponentID[] not strings (most of the places already has it that way)
   async createNetwork(seeders: string[], opts: IsolateComponentsOptions = {}): Promise<Network> {
     const longProcessLogger = this.logger.createLongProcessLogger('create capsules network');

--- a/scripts/soft-tag-teambit.js
+++ b/scripts/soft-tag-teambit.js
@@ -9,7 +9,8 @@ const nextTeambitVersion = nextTeambitSevVer.version;
 console.log('nextTeambitSemVer', nextTeambitVersion);
 
 try {
-  const output = execSync(`bit tag -a -s ${nextTeambitVersion}`);
+  // const output = execSync(`bit tag -a -s ${nextTeambitVersion}`);
+  const output = execSync(`bit tag -a`);
   console.log(output.toString());
 } catch (err) {
   console.log(err);


### PR DESCRIPTION
## Proposed Changes

- `bit compile` with no ids compiles only new and modified components.
- introduce a new `--all` flag to compile all components.
- set the CI to tag only modified components, not all.
