### PR TITLE
fix exporting lanes to only export the local snaps

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -780,6 +780,29 @@ describe('bit lane command', function () {
       });
     });
   });
+  // this makes sure that when exporting lanes, it only exports the local snaps.
+  // in this test, the second snap is done on a clean scope without the objects of the first snap.
+  describe('snap on lane, export, clear project, snap and export', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.addDefaultScope();
+      // Do not add "disablePreview()" here. It's important to generate the preview here.
+      // this is the file that exists on the first snap but not on the second.
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponents();
+      helper.command.exportLane('dev');
+      helper.git.mimicGitCloneLocalProjectHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.switchRemoteLane('dev');
+      helper.fixtures.populateComponents(1, undefined, ' v2');
+      helper.bitJsonc.disablePreview();
+      helper.command.snapAllComponents();
+    });
+    it('should export with no errors about missing artifact files from the first snap', () => {
+      expect(() => helper.command.exportAllComponents()).to.not.throw();
+    });
+  });
   describe('auto-snap when on a lane', () => {
     let snapOutput;
     let comp3Head;

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -701,21 +701,4 @@ describe('bit snap command', function () {
       expect(() => helper.command.catObject(fileObj)).to.not.throw();
     });
   });
-  describe('tag, export, clear, tag and export', () => {
-    before(() => {
-      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.disablePreview();
-      helper.fixtures.populateComponents(1);
-      helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
-      helper.git.mimicGitCloneLocalProjectHarmony();
-      helper.scopeHelper.addRemoteScope();
-      helper.command.importAllComponents();
-      helper.fixtures.populateComponents(1, undefined, ' v2');
-      helper.command.tagAllComponents();
-    });
-    it('should export with no errors', () => {
-      expect(() => helper.command.exportAllComponents()).to.not.throw();
-    });
-  });
 });

--- a/e2e/harmony/harmony-import.e2e.ts
+++ b/e2e/harmony/harmony-import.e2e.ts
@@ -1,8 +1,5 @@
 import chai, { expect } from 'chai';
-import path from 'path';
-
 import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
-import { SchemaName } from '../../src/consumer/component/component-schema';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
 chai.use(require('chai-fs'));
@@ -17,35 +14,21 @@ describe('import component on Harmony', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('workspace with standard components', () => {
+  describe('tag, export, clean scope objects, tag and export', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.setupDefault();
-      helper.fixtures.populateComponents();
+      helper.bitJsonc.disablePreview();
+      helper.fixtures.populateComponents(1);
       helper.command.tagAllComponents();
       helper.command.exportAllComponents();
-      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.git.mimicGitCloneLocalProjectHarmony();
       helper.scopeHelper.addRemoteScope();
-      helper.command.importComponent('comp1');
+      helper.command.importAllComponents();
+      helper.fixtures.populateComponents(1, undefined, ' v2');
+      helper.command.tagAllComponents();
     });
-    it('should import successfully with the schema prop', () => {
-      const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
-      expect(comp1).to.have.property('schema');
-      expect(comp1.schema).to.equal(SchemaName.Harmony);
-    });
-    it('bit status should work and not show modified', () => {
-      const status = helper.command.statusJson();
-      expect(status.modifiedComponent).to.be.empty;
-    });
-    it('should create symlink from the workspace node_modules to the component node_modules after bit link', () => {
-      // before the link, the node_modules is created for the dependencies. as such, it happens
-      // at the same time this link is generated, which causes race condition. in a real world
-      // this won't happen because "bit install" will create the node_modules dir before the link
-      // starts.
-      helper.command.link();
-      expect(
-        path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}/comp1/node_modules`)
-      ).to.be.a.directory();
+    it('should export with no errors about missing artifacts (pkg file) from the first tag', () => {
+      expect(() => helper.command.exportAllComponents()).to.not.throw();
     });
   });
 });

--- a/e2e/harmony/harmony-tag.e2e.ts
+++ b/e2e/harmony/harmony-tag.e2e.ts
@@ -1,0 +1,51 @@
+import chai, { expect } from 'chai';
+import path from 'path';
+
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { SchemaName } from '../../src/consumer/component/component-schema';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('tag components on Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('workspace with standard components', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents();
+      helper.command.tagAllComponents();
+      helper.command.exportAllComponents();
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importComponent('comp1');
+    });
+    it('should import successfully with the schema prop', () => {
+      const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
+      expect(comp1).to.have.property('schema');
+      expect(comp1.schema).to.equal(SchemaName.Harmony);
+    });
+    it('bit status should work and not show modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponent).to.be.empty;
+    });
+    it('should create symlink from the workspace node_modules to the component node_modules after bit link', () => {
+      // before the link, the node_modules is created for the dependencies. as such, it happens
+      // at the same time this link is generated, which causes race condition. in a real world
+      // this won't happen because "bit install" will create the node_modules dir before the link
+      // starts.
+      helper.command.link();
+      expect(
+        path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}/comp1/node_modules`)
+      ).to.be.a.directory();
+    });
+  });
+});

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -685,9 +685,11 @@ export default class Component extends BitObject {
     this.state.versions[version].local = true;
   }
 
+  /**
+   * local versions that are not exported. to get also local snaps, use `getLocalTagsOrHashes()`.
+   */
   getLocalVersions(): string[] {
     if (isEmpty(this.state) || isEmpty(this.state.versions)) return [];
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return Object.keys(this.state.versions).filter((version) => this.state.versions[version].local);
   }


### PR DESCRIPTION
## Proposed Changes

- currently, if the second snap is done on a clean scope, it throws an error in case artifacts are missing.
- this PR makes sure to not search for exported parents, export only the local snaps.