### PR TITLE
differentiate export on Harmony to not change version hashes and avoid codemod

### DIFF
--- a/scopes/scope/scope/export/export-cmd.ts
+++ b/scopes/scope/scope/export/export-cmd.ts
@@ -33,20 +33,20 @@ export class ExportCmd implements Command {
     [
       'd',
       'include-dependencies',
-      "EXPERIMENTAL. include the component's dependencies as part of the export to the remote scope",
+      "LEGACY ONLY. include the component's dependencies as part of the export to the remote scope",
     ],
     [
       's',
       'set-current-scope',
-      "EXPERIMENTAL. ensure the component's remote scope is set according to the target location",
+      "LEGACY ONLY. ensure the component's remote scope is set according to the target location",
     ],
     [
       'r',
       'rewire',
-      'EXPERIMENTAL. when exporting to a different or new scope, replace import/require statements in the source code to match the new scope',
+      'LEGACY ONLY. when exporting to a different or new scope, replace import/require statements in the source code to match the new scope',
     ],
     ['f', 'force', 'force changing a component remote without asking for a confirmation'],
-    ['l', 'lanes', 'EXPERIMENTAL. export lanes'],
+    ['l', 'lanes', 'HARMONY ONLY. export lanes'],
     ['', 'all-versions', 'export not only staged versions but all of them'],
   ] as CommandOptions;
   loader = true;

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -168,7 +168,7 @@ export async function exportMany({
         }
       });
       componentAndObject.component.clearStateData();
-      const didConvertScope = await convertToCorrectScope(
+      const didConvertScope = await convertToCorrectScopeLegacy(
         scope,
         componentAndObject,
         remoteNameStr,
@@ -256,15 +256,7 @@ export async function exportMany({
       const objectItems = await modelComponent.collectVersionsObjects(scope.objects, localVersions);
       const objectsList = await new ObjectList(objectItems).toBitObjects();
       const componentAndObject = { component: modelComponent, objects: objectsList.getAll() };
-      await convertToCorrectScope(
-        scope,
-        componentAndObject,
-        remoteNameStr,
-        includeDependencies, // always false in Harmony
-        bitIds,
-        codemod, // always false in Harmony
-        idsWithFutureScope
-      );
+      await convertToCorrectScopeHarmony(scope, componentAndObject, remoteNameStr, bitIds, idsWithFutureScope);
       const remoteObj = { url: remote.host, name: remote.name, date: Date.now().toString() };
       modelComponent.addScopeListItem(remoteObj);
       componentsAndObjects.push(componentAndObject);
@@ -576,7 +568,7 @@ async function throwForMissingLocalDependencies(scope: Scope, versions: Version[
  * when "--rewire" flag is used, import/require statement should be changed from the old scope-name
  * to the new scope-name. Or from no-scope to the new scope.
  */
-async function convertToCorrectScope(
+async function convertToCorrectScopeLegacy(
   scope: Scope,
   componentsObjects: ModelComponentAndObjects,
   remoteScope: string,
@@ -784,5 +776,100 @@ the current import/require module has no scope-name, which result in an invalid 
       return Source.from(Buffer.from(newFileString));
     }
     return null;
+  }
+}
+
+/**
+ * Component and dependencies id changes:
+ * When exporting components with dependencies to a bare-scope, some of the dependencies may be created locally and as
+ * a result their scope-name is null. Before the bare-scope gets the components, convert these scope names
+ * to the bare-scope name.
+ *
+ * This is the Harmony version of "convertToCorrectScope". No more codemod and no more hash changes.
+ */
+async function convertToCorrectScopeHarmony(
+  scope: Scope,
+  componentsObjects: ModelComponentAndObjects,
+  remoteScope: string,
+  exportingIds: BitIds,
+  idsWithFutureScope: BitIds
+): Promise<boolean> {
+  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  const versionsObjects: Version[] = componentsObjects.objects.filter((object) => object instanceof Version);
+  const haveVersionsChanged = await Promise.all(
+    versionsObjects.map(async (objectVersion: Version) => {
+      const didDependencyChange = changeDependencyScope(objectVersion);
+      changeExtensionsScope(objectVersion);
+      if (updateDependenciesOnExport && typeof updateDependenciesOnExport === 'function') {
+        // @ts-ignore
+        objectVersion = updateDependenciesOnExport(objectVersion, getIdWithUpdatedScope.bind(this));
+      }
+      return didDependencyChange;
+    })
+  );
+  const hasComponentChanged = remoteScope !== componentsObjects.component.scope;
+  componentsObjects.component.scope = remoteScope;
+
+  // return true if one of the versions has changed or the component itself
+  return haveVersionsChanged.some((x) => x) || hasComponentChanged;
+
+  function changeDependencyScope(version: Version): boolean {
+    let hasChanged = false;
+    version.getAllDependencies().forEach((dependency) => {
+      const updatedScope = getIdWithUpdatedScope(dependency.id);
+      if (!updatedScope.isEqual(dependency.id)) {
+        hasChanged = true;
+        dependency.id = updatedScope;
+      }
+    });
+    const flattenedFields = ['flattenedDependencies', 'flattenedDevDependencies'];
+    flattenedFields.forEach((flattenedField) => {
+      const ids: BitIds = version[flattenedField];
+      const needsChange = ids.some((id) => id.scope !== remoteScope);
+      if (needsChange) {
+        version[flattenedField] = getBitIdsWithUpdatedScope(ids);
+        hasChanged = true;
+      }
+    });
+    return hasChanged;
+  }
+
+  function changeExtensionsScope(version: Version): boolean {
+    let hasChanged = false;
+    version.extensions.forEach((ext) => {
+      if (ext.extensionId) {
+        const updatedScope = getIdWithUpdatedScope(ext.extensionId);
+        if (!updatedScope.isEqual(ext.extensionId)) {
+          hasChanged = true;
+          ext.extensionId = updatedScope;
+        }
+      }
+    });
+    return hasChanged;
+  }
+
+  function getIdWithUpdatedScope(dependencyId: BitId): BitId {
+    if (dependencyId.scope === remoteScope) {
+      return dependencyId; // nothing has changed
+    }
+    if (!dependencyId.scope || exportingIds.hasWithoutVersion(dependencyId)) {
+      const depId = ModelComponent.fromBitId(dependencyId);
+      // todo: use 'load' for async and switch the foreach with map.
+      const dependencyObject = scope.objects.loadSync(depId.hash());
+      if (dependencyObject instanceof Symlink) {
+        return dependencyId.changeScope(dependencyObject.realScope);
+      }
+      const currentlyExportedDep = idsWithFutureScope.searchWithoutScopeAndVersion(dependencyId);
+      if (currentlyExportedDep && currentlyExportedDep.scope) {
+        // it's possible that a dependency has a different defaultScope settings.
+        return dependencyId.changeScope(currentlyExportedDep.scope);
+      }
+      return dependencyId.changeScope(remoteScope);
+    }
+    return dependencyId;
+  }
+  function getBitIdsWithUpdatedScope(bitIds: BitIds): BitIds {
+    const updatedIds = bitIds.map((id) => getIdWithUpdatedScope(id));
+    return BitIds.fromArray(updatedIds);
   }
 }


### PR DESCRIPTION
On Harmony, there is no need to do codemod anymore because the fork feature is gone and the typescript is now compiled without the need for the link files.
Also, the versions refs should not be changed because on Harmony their hash is not determined by the content.