### PR TITLE
bit-compile: remove "all" flag, add "changed" flag instead

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -445,7 +445,7 @@ describe('bit lane command', function () {
       );
       helper.command.addComponent('utils/is-string', { i: 'utils/is-string' });
       helper.command.linkAndRewire();
-      helper.command.compile('--all');
+      helper.command.compile();
       helper.command.snapAllComponents();
 
       // laneB

--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -113,7 +113,7 @@ describe('compile extension', function () {
               'dist'
             );
             fs.removeSync(distPath);
-            helper.command.compile('--all');
+            helper.command.compile();
             expect(distPath).to.be.a.directory();
             expect(path.join(distPath, 'index.js')).to.be.a.file();
           });

--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -24,7 +24,7 @@ export class CompileCmd implements Command {
   alias = '';
   group = 'component';
   options = [
-    ['a', 'all', 'all components, not only new and modified'],
+    ['c', 'changed', 'compile only new and modified components'],
     ['v', 'verbose', 'show more data, such as, dist paths'],
     ['j', 'json', 'return the compile results in json format'],
   ] as CommandOptions;

--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -25,7 +25,7 @@ import { Compiler } from './types';
 export type BuildResult = { component: string; buildResults: string[] | null | undefined };
 
 export type CompileOptions = {
-  all?: boolean;
+  changed?: boolean;
   verbose?: boolean;
 };
 
@@ -149,7 +149,7 @@ export class WorkspaceCompiler {
     noThrow?: boolean
   ): Promise<BuildResult[]> {
     if (!this.workspace) throw new ConsumerNotFound();
-    const componentIds = await this.getIdsToCompile(componentsIds, options.all);
+    const componentIds = await this.getIdsToCompile(componentsIds, options.changed);
     // const { components } = await this.workspace.consumer.loadComponents(BitIds.fromArray(bitIds));
     const components = await this.workspace.getMany(componentIds);
 
@@ -205,13 +205,13 @@ export class WorkspaceCompiler {
     return buildResults;
   }
 
-  private async getIdsToCompile(componentsIds: Array<string | BitId>, all = false): Promise<ComponentID[]> {
+  private async getIdsToCompile(componentsIds: Array<string | BitId>, changed = false): Promise<ComponentID[]> {
     if (componentsIds.length) {
       return this.workspace.resolveMultipleComponentIds(componentsIds);
     }
-    if (all) {
-      return this.workspace.getAllComponentIds();
+    if (changed) {
+      return this.workspace.getNewAndModifiedIds();
     }
-    return this.workspace.getNewAndModifiedIds();
+    return this.workspace.getAllComponentIds();
   }
 }


### PR DESCRIPTION
## Proposed Changes

- remove the `--all` flag. this will be the default behavior now - compile all components. 
- add a new flag `--changed` to compile only new and modified components.