### PR TITLE
fix http-export to clear the objects after export

### DIFF
--- a/src/scope/actions/export-persist.ts
+++ b/src/scope/actions/export-persist.ts
@@ -21,9 +21,14 @@ export class ExportPersist implements Action<Options, string[]> {
 
     const componentsIds: string[] = bitIds.map((id) => id.toString());
     await scope.removePendingDir(options.clientId);
-    if (ExportPersist.onPutHook) ExportPersist.onPutHook(componentsIds);
+    if (ExportPersist.onPutHook) {
+      ExportPersist.onPutHook(componentsIds).catch((err) => {
+        logger.error('fatal: onPutHook encountered an error (this error does not stop the process)', err);
+        // let the process continue. we don't want to stop it when onPutHook failed.
+      });
+    }
     return componentsIds;
   }
 
-  static onPutHook: (ids: string[]) => void;
+  static onPutHook: (ids: string[]) => Promise<void>;
 }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -306,6 +306,17 @@ export default class Repository {
     await this._writeMany();
     await this.remoteLanes.write();
     await this.unmergedComponents.write();
+    this.clearObjects();
+  }
+
+  /**
+   * this is especially critical for http server, where one process lives long and serves multiple
+   * exports. without this, the objects get accumulated over time and being rewritten over and over
+   * again.
+   */
+  private clearObjects() {
+    this.objects = {};
+    this.objectsToRemove = [];
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- clear Repository objects after persisting the data, so then the next export using HTTP won't rewrite the same objects.
- catch `onPutHook` errors and log the process.
