### PR TITLE
dep graph api - fix inconsistent edge id

### DIFF
--- a/scopes/component/graph/ui/graph-page/graph-page.tsx
+++ b/scopes/component/graph/ui/graph-page/graph-page.tsx
@@ -22,7 +22,7 @@ type GraphPageProps = {
 export function GraphPage({ componentWidgets }: GraphPageProps) {
   const component = useContext(ComponentContext);
 
-  const [filter, setFilter] = useState<GraphFilter>(undefined);
+  const [filter, setFilter] = useState<GraphFilter>('runtimeOnly');
   const onCheckFilter = (isFiltered: boolean) => {
     setFilter(isFiltered ? 'runtimeOnly' : undefined);
   };


### PR DESCRIPTION
## Proposed Changes

- ComponentGraph.buildFromLegacy() - resolve componentID for edge ids.
- This fixes "node not in graph" errors
