### PR TITLE
add log messages when express failed with error 500

### DIFF
--- a/scopes/harmony/express/middlewares/error.ts
+++ b/scopes/harmony/express/middlewares/error.ts
@@ -1,4 +1,5 @@
 import * as express from 'express';
+import logger from 'bit-bin/dist/logger/logger';
 
 interface ResponseError {
   status?: number;
@@ -24,6 +25,7 @@ export function errorHandle(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   next: express.NextFunction
 ) {
+  logger.error(`express.errorHandle, url ${req.url}, error:`, err);
   err.status = err.status || 500;
   res.status(err.status);
   return res.jsonp({

--- a/scopes/preview/preview/preview.route.ts
+++ b/scopes/preview/preview/preview.route.ts
@@ -18,6 +18,7 @@ export class PreviewRoute implements Route {
     async (req: Request, res: Response) => {
       // @ts-ignore TODO: @guy please fix.
       const component: any = req.component as any;
+      if (!component) throw new Error(`preview failed to get a component object, url ${req.url}`);
       const artifact = await this.preview.getPreview(component);
       // TODO: please fix file path concatenation here.
       const file = artifact.getFile(`public/${req.params.previewPath || 'index.html'}`);


### PR DESCRIPTION
Currently, it shows the error message on the web. This PR writes the error with the stack trace into the log file.
Also, it shows a descriptive error when the preview is unable to get a component object.