### PR TITLE
compile aspects on load failure

### DIFF
--- a/e2e/fixtures/extensions/extension-add-dependencies/extension-add-dependencies.main.runtime.ts
+++ b/e2e/fixtures/extensions/extension-add-dependencies/extension-add-dependencies.main.runtime.ts
@@ -9,13 +9,13 @@ export class ExtensionAddDependenciesMain {
   static async provider([dependencyResolver]) {
     dependencyResolver.registerDependenciesPolicies({
       dependencies: {
-        'lodash.get': '1.0.0'
+        'lodash.get': '4.0.0'
       },
       devDependencies: {
-        'lodash.words': '1.0.0'
+        'lodash.words': '4.0.0'
       },
       peerDependencies: {
-        'lodash.set': '1.0.0'
+        'lodash.set': '4.0.0'
       }
     });
   }

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -13,7 +13,6 @@ const assertArrays = require('chai-arrays');
 
 chai.use(assertArrays);
 
-// @TODO: REMOVE THE SKIP ASAP
 describe('dependency-resolver extension', function () {
   let helper: Helper;
   this.timeout(0);
@@ -39,13 +38,13 @@ describe('dependency-resolver extension', function () {
         const depResolverConfig = {
           policy: {
             dependencies: {
-              'lodash.get': '1.0.0',
+              'lodash.get': '4.0.0',
             },
             devDependencies: {
-              'lodash.words': '1.0.0',
+              'lodash.words': '4.0.0',
             },
             peerDependencies: {
-              'lodash.set': '1.0.0',
+              'lodash.set': '4.0.0',
             },
           },
         };
@@ -54,9 +53,9 @@ describe('dependency-resolver extension', function () {
         isTypeOutput = helper.command.showComponentParsed('utils/is-type');
       });
       it('should have the updated dependencies for bar/foo', function () {
-        expect(barFooOutput.packageDependencies).to.have.property('lodash.get', '1.0.0');
-        expect(barFooOutput.devPackageDependencies).to.have.property('lodash.words', '1.0.0');
-        expect(barFooOutput.peerPackageDependencies).to.have.property('lodash.set', '1.0.0');
+        expect(barFooOutput.packageDependencies).to.have.property('lodash.get', '4.0.0');
+        expect(barFooOutput.devPackageDependencies).to.have.property('lodash.words', '4.0.0');
+        expect(barFooOutput.peerPackageDependencies).to.have.property('lodash.set', '4.0.0');
       });
       it('should not put the dependencies for not configured component', function () {
         expect(isTypeOutput.packageDependencies).to.not.have.key('lodash.get');
@@ -109,9 +108,9 @@ describe('dependency-resolver extension', function () {
           isTypeOutput = helper.command.showComponentParsed('utils/is-type');
         });
         it('should have the updated dependencies for bar/foo', function () {
-          expect(barFooOutput.packageDependencies).to.have.property('lodash.get', '1.0.0');
-          expect(barFooOutput.devPackageDependencies).to.have.property('lodash.words', '1.0.0');
-          expect(barFooOutput.peerPackageDependencies).to.have.property('lodash.set', '1.0.0');
+          expect(barFooOutput.packageDependencies).to.have.property('lodash.get', '4.0.0');
+          expect(barFooOutput.devPackageDependencies).to.have.property('lodash.words', '4.0.0');
+          expect(barFooOutput.peerPackageDependencies).to.have.property('lodash.set', '4.0.0');
         });
         it('should not put the dependencies for not configured component', function () {
           expect(isTypeOutput.packageDependencies).to.not.have.key('lodash.get');

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -3,6 +3,7 @@ import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { LoggerAspect, LoggerMain } from '@teambit/logger';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { PubsubAspect, PubsubMain } from '@teambit/pubsub';
+import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import { Component } from '@teambit/component';
 import { BitId } from 'bit-bin/dist/bit-id';
 import { CompilerService } from './compiler.service';
@@ -44,16 +45,17 @@ export class CompilerMain {
 
   static runtime = MainRuntime;
 
-  static dependencies = [CLIAspect, WorkspaceAspect, EnvsAspect, LoggerAspect, PubsubAspect];
+  static dependencies = [CLIAspect, WorkspaceAspect, EnvsAspect, LoggerAspect, PubsubAspect, AspectLoaderAspect];
 
-  static async provider([cli, workspace, envs, loggerMain, pubsub]: [
+  static async provider([cli, workspace, envs, loggerMain, pubsub, aspectLoader]: [
     CLIMain,
     Workspace,
     EnvsMain,
     LoggerMain,
-    PubsubMain
+    PubsubMain,
+    AspectLoaderMain
   ]) {
-    const workspaceCompiler = new WorkspaceCompiler(workspace, envs, pubsub);
+    const workspaceCompiler = new WorkspaceCompiler(workspace, envs, pubsub, aspectLoader);
     envs.registerService(new CompilerService());
     const compilerMain = new CompilerMain(pubsub, workspaceCompiler, envs);
     const logger = loggerMain.createLogger(CompilerAspect.id);

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -1,12 +1,12 @@
 import { join } from 'path';
 import { MainRuntime } from '@teambit/cli';
-import { Component } from '@teambit/component';
-import { ExtensionManifest, Harmony, Aspect } from '@teambit/harmony';
+import { Component, ComponentID } from '@teambit/component';
+import { ExtensionManifest, Harmony, Aspect, SlotRegistry, Slot } from '@teambit/harmony';
 import type { LoggerMain } from '@teambit/logger';
 import { Logger, LoggerAspect } from '@teambit/logger';
 import { RequireableComponent } from '@teambit/modules.requireable-component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
-
+import { mapSeries } from 'bluebird';
 import { difference } from 'ramda';
 import { AspectDefinition, AspectDefinitionProps } from './aspect-definition';
 import { AspectLoaderAspect } from './aspect-loader.aspect';
@@ -32,6 +32,9 @@ export type ResolvedAspect = {
   aspectPath: string;
   runtimesPath: string | null;
 };
+
+type OnAspectLoadError = (err: Error, id: ComponentID) => Promise<boolean>;
+export type OnAspectLoadErrorSlot = SlotRegistry<OnAspectLoadError>;
 
 export type MainAspect = {
   /**
@@ -66,11 +69,34 @@ export type MainAspect = {
 };
 
 export class AspectLoaderMain {
-  constructor(private logger: Logger, private envs: EnvsMain, private harmony: Harmony) {}
+  constructor(
+    private logger: Logger,
+    private envs: EnvsMain,
+    private harmony: Harmony,
+    private onAspectLoadErrorSlot: OnAspectLoadErrorSlot
+  ) {}
 
-  private async getCompiler(component: Component) {
+  private getCompiler(component: Component) {
     const env = this.envs.getEnv(component)?.env;
     return env?.getCompiler();
+  }
+
+  registerOnAspectLoadErrorSlot(onAspectLoadError: OnAspectLoadError) {
+    this.onAspectLoadErrorSlot.register(onAspectLoadError);
+  }
+
+  /**
+   * returns whether the aspect-load issue has been fixed.
+   */
+  async triggerOnAspectLoadError(err: Error, component: Component): Promise<boolean> {
+    const entries = this.onAspectLoadErrorSlot.toArray(); // e.g. [ [ 'teambit.bit/compiler', [Function: bound onAspectLoadError] ] ]
+    let isFixed = false;
+    await mapSeries(entries, async ([, onAspectFailFunc]) => {
+      const result = await onAspectFailFunc(err, component.id);
+      if (result) isFixed = true;
+    });
+
+    return isFixed;
   }
 
   async getRuntimePath(component: Component, modulePath: string, runtime: string): Promise<string | null> {
@@ -80,7 +106,7 @@ export class AspectLoaderMain {
 
     // @david we should add a compiler api for this.
     if (!runtimeFile) return null;
-    const compiler = await this.getCompiler(component);
+    const compiler = this.getCompiler(component);
     const dist = compiler.getDistPathBySrcPath(runtimeFile.relative);
 
     return join(modulePath, dist);
@@ -211,29 +237,41 @@ export class AspectLoaderMain {
    * in some cases, such as "bit tag", it's better not to tag if an extension changes the model.
    */
   async loadRequireableExtensions(requireableExtensions: RequireableComponent[], throwOnError = false): Promise<void> {
+    const doRequire = async (requireableExtension: RequireableComponent, idStr: string) => {
+      const aspect = await requireableExtension.require();
+      const manifest = aspect.default || aspect;
+      manifest.id = idStr;
+      return manifest;
+    };
     const manifestsP = requireableExtensions.map(async (requireableExtension) => {
       if (!requireableExtensions) return undefined;
-      const id = requireableExtension.component.id.toString();
+      const idStr = requireableExtension.component.id.toString();
       try {
-        // TODO: @gilad compile before or skip running on bit compile? we need to do this properly
-        const aspect = await requireableExtension.require();
-        const manifest = aspect.default || aspect;
-        manifest.id = id;
-        return manifest;
+        return await doRequire(requireableExtension, idStr);
       } catch (e) {
-        this.addFailure(id);
-        const errorMsg = UNABLE_TO_LOAD_EXTENSION(id);
+        this.addFailure(idStr);
+        const errorMsg = UNABLE_TO_LOAD_EXTENSION(idStr);
+        this.logger.error(errorMsg, e);
+        const isFixed = await this.triggerOnAspectLoadError(e, requireableExtension.component);
+        let errAfterReLoad;
+        if (isFixed) {
+          this.logger.info(`the loading issue has been fixed, re-loading ${idStr}`);
+          try {
+            return await doRequire(requireableExtension, idStr);
+          } catch (err) {
+            this.logger.error('re-load of the aspect failed as well', err);
+            errAfterReLoad = err;
+          }
+        }
+        const error = errAfterReLoad || e;
+        if (throwOnError) {
+          throw new CannotLoadExtension(idStr, error);
+        }
         if (this.logger.isLoaderStarted) {
           this.logger.consoleFailure(errorMsg);
-        }
-        this.logger.error(errorMsg, e);
-        if (throwOnError) {
-          // console.log(e);
-          throw new CannotLoadExtension(id, e);
-        }
-        if (!this.logger.isLoaderStarted) {
+        } else {
           this.logger.console(errorMsg);
-          this.logger.console(e.message);
+          this.logger.console(error.message);
         }
       }
       return undefined;
@@ -289,10 +327,16 @@ export class AspectLoaderMain {
 
   static runtime = MainRuntime;
   static dependencies = [LoggerAspect, EnvsAspect];
+  static slots = [Slot.withType<OnAspectLoadError>()];
 
-  static async provider([loggerExt, envs]: [LoggerMain, EnvsMain], config, slots, harmony: Harmony) {
+  static async provider(
+    [loggerExt, envs]: [LoggerMain, EnvsMain],
+    config,
+    [onAspectLoadErrorSlot]: [OnAspectLoadErrorSlot],
+    harmony: Harmony
+  ) {
     const logger = loggerExt.createLogger(AspectLoaderAspect.id);
-    const aspectLoader = new AspectLoaderMain(logger, envs, harmony);
+    const aspectLoader = new AspectLoaderMain(logger, envs, harmony, onAspectLoadErrorSlot);
     return aspectLoader;
   }
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -819,8 +819,8 @@ export class Workspace implements ComponentFactory {
 
     // no need to filter core aspects as they are not included in the graph
     // here we are trying to load extensions from the workspace.
+    const requireableExtensions: any = await this.requireComponents(aspects);
     try {
-      const requireableExtensions: any = await this.requireComponents(aspects);
       await this.aspectLoader.loadRequireableExtensions(requireableExtensions, throwOnError);
     } catch (err) {
       // if extensions does not exist on workspace, try and load them from the local scope.


### PR DESCRIPTION
In case an aspect failed to load due to module-not-found error, it probably happened because the dists are missing. 
Let the compiler register to AspectLoader slot and compile it on failure.