### PR TITLE
fix dir-tracking-cache to take sub-dirs into account

### DIFF
--- a/e2e/functionalities/track-directories.e2e.3.ts
+++ b/e2e/functionalities/track-directories.e2e.3.ts
@@ -297,4 +297,21 @@ describe('track directories functionality', function () {
       });
     });
   });
+  describe('adding files to sub-directories', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fs.outputFile('bar/foo.ts');
+      helper.command.addComponent('bar');
+      helper.fs.outputFile('bar/baz/index.ts');
+      helper.command.status(); // this adds the last file to .bitmap
+      helper.fs.outputFile('bar/baz/baz.ts');
+      helper.command.status(); // this should add the last file
+    });
+    it('the files on the sub-dir should be auto-tracked', () => {
+      const bitMap = helper.bitMap.read();
+      const bar = bitMap.bar;
+      const paths = bar.files.map((f) => f.relativePath);
+      expect(paths).to.include('baz/baz.ts');
+    });
+  });
 });

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -378,7 +378,7 @@ export default class ComponentMap {
     }
     const trackDirAbsolute = path.join(consumer.getPath(), trackDir);
     const trackDirRelative = path.relative(process.cwd(), trackDirAbsolute);
-    if (!fs.existsSync) throw new ComponentNotFoundInPath(trackDirRelative);
+    if (!fs.existsSync(trackDirAbsolute)) throw new ComponentNotFoundInPath(trackDirRelative);
     const lastTrack = await getLastTrackTimestamp(id.toString());
     const wasModifiedAfterLastTrack = async () => {
       const allDirs = glob.sync(`${trackDirAbsolute}/**/`); // the trailing slash instructs glob to show only dirs

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -382,7 +382,7 @@ export default class ComponentMap {
     const lastTrack = await getLastTrackTimestamp(id.toString());
     const wasModifiedAfterLastTrack = async () => {
       const allDirs = glob.sync(`${trackDirAbsolute}/**/`); // the trailing slash instructs glob to show only dirs
-      const dirsStats = await Promise.all(allDirs.map((dir) => fs.stat(dir)));
+      const dirsStats: Stats[] = await Promise.all(allDirs.map((dir) => fs.stat(dir)));
       return dirsStats.some((dirStat) => dirStat.mtimeMs > lastTrack);
     };
     if (!(await wasModifiedAfterLastTrack())) {


### PR DESCRIPTION
As a result of a new cache mechanism, sub-dir changes weren't tracked. This PR checks all subdirectories modified data and avoid using the cache if they were modified after the last track.