### PR TITLE
throw a descriptive error when user env is compiled by non-aspect env

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -6794,6 +6794,11 @@
                 "test": false
             },
             {
+                "name": "incorrect-env-aspect.ts",
+                "relativePath": "exceptions/incorrect-env-aspect.ts",
+                "test": false
+            },
+            {
                 "name": "index.ts",
                 "relativePath": "exceptions/index.ts",
                 "test": false

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -351,7 +351,7 @@ export class PkgMain {
     // const newComponent = await this.workspace.get(newId);
     const host = await this.componentAspect.getHost();
     const id = await host.resolveComponentId(legacyComponent.id);
-    const newComponent = await host.get(id, undefined, legacyComponent);
+    const newComponent = await host.get(id);
     if (!newComponent) throw new Error(`cannot transform package.json of component: ${legacyComponent.id.toString()}`);
     const newProps = this.getPackageJsonModifications(newComponent);
     return Object.assign(packageJsonObject, newProps);

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -351,7 +351,7 @@ export class PkgMain {
     // const newComponent = await this.workspace.get(newId);
     const host = await this.componentAspect.getHost();
     const id = await host.resolveComponentId(legacyComponent.id);
-    const newComponent = await host.get(id);
+    const newComponent = await host.get(id, undefined, legacyComponent);
     if (!newComponent) throw new Error(`cannot transform package.json of component: ${legacyComponent.id.toString()}`);
     const newProps = this.getPackageJsonModifications(newComponent);
     return Object.assign(packageJsonObject, newProps);

--- a/scopes/workspace/workspace/exceptions/incorrect-env-aspect.ts
+++ b/scopes/workspace/workspace/exceptions/incorrect-env-aspect.ts
@@ -1,0 +1,8 @@
+import { BitError } from 'bit-bin/dist/error/bit-error';
+
+export class IncorrectEnvAspect extends BitError {
+  constructor(id: string, envType: string) {
+    super(`"${id}" is configured in workspace.json, but using the "${envType}" environment.
+please make sure to either apply the aspect environment or a composition of the aspect environment for the aspect to load.`);
+  }
+}

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -11,6 +11,7 @@ import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/depen
 import { Logger } from '@teambit/logger';
 import { EnvsAspect } from '@teambit/envs';
 import { ExtensionDataEntry } from 'bit-bin/dist/consumer/config';
+import ComponentNotFoundInPath from 'bit-bin/dist/consumer/component/exceptions/component-not-found-in-path';
 import { Workspace } from '../workspace';
 import { WorkspaceComponent } from './workspace-component';
 
@@ -129,7 +130,12 @@ export class WorkspaceComponentLoader {
       // file is missing) it returns the model component later unexpectedly, or if it's new, it
       // shows MissingBitMapComponent error incorrectly.
       this.logger.error(`failed loading component ${id.toString()}`, err);
-      if (err instanceof ComponentNotFound || err instanceof MissingBitMapComponent) return undefined;
+      if (
+        err instanceof ComponentNotFound ||
+        err instanceof MissingBitMapComponent ||
+        err instanceof ComponentNotFoundInPath
+      )
+        return undefined;
       throw err;
     }
   }

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -129,7 +129,7 @@ export class WorkspaceComponentLoader {
       // file is missing) it returns the model component later unexpectedly, or if it's new, it
       // shows MissingBitMapComponent error incorrectly.
       this.logger.error(`failed loading component ${id.toString()}`, err);
-      if (err instanceof ComponentNotFound) return undefined;
+      if (err instanceof ComponentNotFound || err instanceof MissingBitMapComponent) return undefined;
       throw err;
     }
   }

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -6,6 +6,7 @@ import { compact } from 'ramda-adjunct';
 import ConsumerComponent from 'bit-bin/dist/consumer/component';
 import { MissingBitMapComponent } from 'bit-bin/dist/consumer/bit-map/exceptions';
 import { getLatestVersionNumber } from 'bit-bin/dist/utils';
+import { ComponentNotFound } from 'bit-bin/dist/scope/exceptions';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import { Logger } from '@teambit/logger';
 import { EnvsAspect } from '@teambit/envs';
@@ -124,8 +125,12 @@ export class WorkspaceComponentLoader {
         ? await this.workspace.consumer.loadComponentForCapsule(id._legacy)
         : await this.workspace.consumer.loadComponent(id._legacy);
     } catch (err) {
+      // don't return undefined for any error. otherwise, if the component is invalid (e.g. main
+      // file is missing) it returns the model component later unexpectedly, or if it's new, it
+      // shows MissingBitMapComponent error incorrectly.
       this.logger.error(`failed loading component ${id.toString()}`, err);
-      return undefined;
+      if (err instanceof ComponentNotFound) return undefined;
+      throw err;
     }
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -49,7 +49,6 @@ import componentIdToPackageName from 'bit-bin/dist/utils/bit/component-id-to-pac
 import { PathOsBased, PathOsBasedRelative, PathOsBasedAbsolute } from 'bit-bin/dist/utils/path';
 import BluebirdPromise from 'bluebird';
 import findCacheDir from 'find-cache-dir';
-import { BitError } from 'bit-bin/dist/error/bit-error';
 import fs from 'fs-extra';
 import { slice } from 'lodash';
 import path, { join } from 'path';
@@ -372,6 +371,7 @@ export class Workspace implements ComponentFactory {
     useCache = true,
     storeInCache = true
   ): Promise<Component> {
+    this.logger.debug(`get ${componentId.toString()}`);
     return this.componentLoader.get(componentId, forCapsule, legacyComponent, useCache, storeInCache);
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -49,6 +49,7 @@ import componentIdToPackageName from 'bit-bin/dist/utils/bit/component-id-to-pac
 import { PathOsBased, PathOsBasedRelative, PathOsBasedAbsolute } from 'bit-bin/dist/utils/path';
 import BluebirdPromise from 'bluebird';
 import findCacheDir from 'find-cache-dir';
+import { BitError } from 'bit-bin/dist/error/bit-error';
 import fs from 'fs-extra';
 import { slice } from 'lodash';
 import path, { join } from 'path';
@@ -77,6 +78,7 @@ import {
 } from './workspace.provider';
 import { Issues } from './workspace-component/issues';
 import { WorkspaceComponentLoader } from './workspace-component/workspace-component-loader';
+import { IncorrectEnvAspect } from './exceptions/incorrect-env-aspect';
 
 export type EjectConfResult = {
   configPath: string;
@@ -808,12 +810,9 @@ export class Workspace implements ComponentFactory {
       }
 
       if (!data) return false;
-      if (data.type !== 'aspect')
-        this.logger.debug(
-          `${component.id.toString()} is configured in workspace.json, but using the ${
-            data.type
-          } environment. \n please make sure to either apply the aspect environment or a composition of the aspect environment for the aspect to load.`
-        );
+      if (data.type !== 'aspect' && idsWithoutCore.includes(component.id.toString())) {
+        throw new IncorrectEnvAspect(component.id.toString(), data.type);
+      }
       return data.type === 'aspect';
     });
 


### PR DESCRIPTION
Only envs that are configured in workspace.jsonc to use core "aspect" env (or any composition of that env) are valid. Currently, the user has no indication when the env is invalid, it falls back to the default "node" env.

