### PR TITLE
Cache dependencies data for performance improvement

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1029,6 +1029,7 @@ export class Workspace implements ComponentFactory {
     // this.logger.consoleSuccess();
     // TODO: add the links results to the output
     await this.link({ linkTeambitBit: true, legacyLink: true, linkCoreAspects: true });
+    await this.consumer.componentFsCache.deleteAllDependenciesDataCache();
     return compDirMap;
   }
 

--- a/src/api/consumer/lib/feature-toggle.ts
+++ b/src/api/consumer/lib/feature-toggle.ts
@@ -52,6 +52,8 @@ export const LEGACY_SHARED_DIR_FEATURE = 'legacy-shared-dir';
 
 export const HARMONY_FEATURE = 'harmony';
 
+export const NO_FS_CACHE_FEATURE = 'no-fs-cache';
+
 export function isHarmonyEnabled() {
   return isFeatureEnabled(HARMONY_FEATURE);
 }

--- a/src/cli/commands/public-cmds/clear-cache-cmd.ts
+++ b/src/cli/commands/public-cmds/clear-cache-cmd.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import fs from 'fs-extra';
 // it's a hack, but I didn't find a better way to access the getCacheDir() function
 import { __TEST__ as v8CompileCache } from 'v8-compile-cache';
-import { COMPONENTS_CACHE_ROOT } from '../../../constants';
+import { loadConsumerIfExist } from '../../../consumer';
 
 import { LegacyCommand } from '../../legacy-command';
 
@@ -16,10 +16,14 @@ export default class ClearCache implements LegacyCommand {
   loader = false;
   skipWorkspace = true;
 
-  action(): Promise<any> {
+  async action(): Promise<any> {
     const cacheDir = v8CompileCache.getCacheDir();
     fs.removeSync(cacheDir);
-    fs.removeSync(COMPONENTS_CACHE_ROOT);
+    const consumer = await loadConsumerIfExist();
+    if (consumer) {
+      const componentCachePath = consumer.componentFsCache.basePath;
+      fs.removeSync(componentCachePath);
+    }
     return Promise.resolve();
   }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -326,7 +326,7 @@ export const CACHE_ROOT = getCacheDirectory();
 
 export const CFG_GLOBAL_REPOSITORY = 'global_repository';
 export const REPOSITORY_CACHE_ROOT = path.join(CACHE_ROOT, 'component-map');
-export const COMPONENTS_CACHE_ROOT = path.join(CACHE_ROOT, 'components-cache');
+
 /**
  * app cache directory
  */

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -1,5 +1,4 @@
-import fs, { Stats } from 'fs-extra';
-import { glob } from 'glob';
+import fs from 'fs-extra';
 import * as path from 'path';
 import R from 'ramda';
 

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -13,7 +13,6 @@ import { PathLinux, PathLinuxRelative, PathOsBased, PathOsBasedRelative } from '
 import AddComponents from '../component-ops/add-components';
 import { AddContext } from '../component-ops/add-components/add-components';
 import { EmptyDirectory, NoFiles } from '../component-ops/add-components/exceptions';
-import { getLastTrackTimestamp, setLastTrackTimestamp } from '../component/component-fs-cache';
 import ComponentNotFoundInPath from '../component/exceptions/component-not-found-in-path';
 import Consumer from '../consumer';
 import OutsideRootDir from './exceptions/outside-root-dir';
@@ -379,7 +378,7 @@ export default class ComponentMap {
     const trackDirAbsolute = path.join(consumer.getPath(), trackDir);
     const trackDirRelative = path.relative(process.cwd(), trackDirAbsolute);
     if (!fs.existsSync(trackDirAbsolute)) throw new ComponentNotFoundInPath(trackDirRelative);
-    const lastTrack = await getLastTrackTimestamp(id.toString());
+    const lastTrack = await consumer.componentFsCache.getLastTrackTimestamp(id.toString());
     const wasModifiedAfterLastTrack = async () => {
       const lastModified = await getLastModifiedDirTimestampMs(trackDirAbsolute);
       return lastModified > lastTrack;
@@ -412,7 +411,7 @@ export default class ComponentMap {
       logger.info(`new file(s) have been added to .bitmap for ${id.toString()}`);
       consumer.bitMap.hasChanged = true;
     }
-    await setLastTrackTimestamp(id.toString(), Date.now());
+    await consumer.componentFsCache.setLastTrackTimestamp(id.toString(), Date.now());
   }
 
   updateNextVersion(nextVersion: NextVersion) {

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -1,5 +1,6 @@
 import cacache, { GetCacheObject } from 'cacache';
 import path from 'path';
+import { isFeatureEnabled, NO_FS_CACHE_FEATURE } from '../../api/consumer/lib/feature-toggle';
 import { PathOsBasedAbsolute } from '../../utils/path';
 
 const WORKSPACE_CACHE = '.bit.cache';
@@ -10,8 +11,10 @@ const DEPS = 'deps';
 
 export class ComponentFsCache {
   readonly basePath: PathOsBasedAbsolute;
+  private isNoFsCacheFeatureEnabled: boolean;
   constructor(private workspacePath) {
     this.basePath = path.join(this.workspacePath, WORKSPACE_CACHE, COMPONENTS_CACHE);
+    this.isNoFsCacheFeatureEnabled = isFeatureEnabled(NO_FS_CACHE_FEATURE);
   }
 
   async getLastTrackTimestamp(idStr: string): Promise<number> {
@@ -55,6 +58,7 @@ export class ComponentFsCache {
   }
 
   private async saveDataInCache(key: string, cacheName: string, data: any, metadata?: any) {
+    if (this.isNoFsCacheFeatureEnabled) return;
     const cachePath = this.getCachePath(cacheName);
     await cacache.put(cachePath, key, data, { metadata });
   }
@@ -69,6 +73,7 @@ export class ComponentFsCache {
   }
 
   private async getFromCacheIfExist(cacheName: string, key: string): Promise<GetCacheObject | null> {
+    if (this.isNoFsCacheFeatureEnabled) return null;
     const cachePath = this.getCachePath(cacheName);
     try {
       const results = await cacache.get(cachePath, key);

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -4,6 +4,7 @@ import { COMPONENTS_CACHE_ROOT } from '../../constants';
 
 const LAST_TRACK_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'last-track');
 const DOCS_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'docs');
+const DEPS_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'deps');
 
 export async function getLastTrackTimestamp(idStr: string): Promise<number> {
   const results = await getFromCacheIfExist(LAST_TRACK_CACHE_PATH, idStr);
@@ -15,11 +16,20 @@ export async function setLastTrackTimestamp(idStr: string, timestamp: number): P
 }
 
 export async function getDocsFromCache(filePath: string): Promise<{ timestamp: number; data: string } | null> {
-  return getDataPerFileFromCache(filePath, DOCS_CACHE_PATH);
+  return getStringDataFromCache(filePath, DOCS_CACHE_PATH);
 }
 
 export async function saveDocsInCache(filePath: string, docs: Record<string, any>) {
   await saveDataPerFileInCache(filePath, DOCS_CACHE_PATH, docs);
+}
+
+export async function getDependenciesDataFromCache(idStr: string): Promise<{ timestamp: number; data: string } | null> {
+  return getStringDataFromCache(idStr, DEPS_CACHE_PATH);
+}
+
+export async function saveDependenciesDataInCache(idStr: string, dependenciesData: string) {
+  const metadata = { timestamp: Date.now() };
+  await cacache.put(DEPS_CACHE_PATH, idStr, dependenciesData, { metadata });
 }
 
 async function saveDataPerFileInCache(filePath: string, cachePath: string, data: any) {
@@ -28,11 +38,11 @@ async function saveDataPerFileInCache(filePath: string, cachePath: string, data:
   await cacache.put(cachePath, filePath, dataBuffer, { metadata });
 }
 
-async function getDataPerFileFromCache(
-  filePath: string,
+async function getStringDataFromCache(
+  key: string,
   cachePath: string
 ): Promise<{ timestamp: number; data: string } | null> {
-  const results = await getFromCacheIfExist(cachePath, filePath);
+  const results = await getFromCacheIfExist(cachePath, key);
   if (!results) return null;
   return { timestamp: results.metadata.timestamp, data: results.data.toString() };
 }

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -1,68 +1,87 @@
 import cacache, { GetCacheObject } from 'cacache';
 import path from 'path';
-import { COMPONENTS_CACHE_ROOT } from '../../constants';
+import { PathOsBasedAbsolute } from '../../utils/path';
 
-const LAST_TRACK_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'last-track');
-const DOCS_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'docs');
-const DEPS_CACHE_PATH = path.join(COMPONENTS_CACHE_ROOT, 'deps');
+const WORKSPACE_CACHE = '.bit.cache';
+const COMPONENTS_CACHE = 'components-cache';
+const LAST_TRACK = 'last-track';
+const DOCS = 'docs';
+const DEPS = 'deps';
 
-export async function getLastTrackTimestamp(idStr: string): Promise<number> {
-  const results = await getFromCacheIfExist(LAST_TRACK_CACHE_PATH, idStr);
-  return results ? parseInt(results.data.toString()) : 0;
-}
+export class ComponentFsCache {
+  readonly basePath: PathOsBasedAbsolute;
+  constructor(private workspacePath) {
+    this.basePath = path.join(this.workspacePath, WORKSPACE_CACHE, COMPONENTS_CACHE);
+  }
 
-export async function setLastTrackTimestamp(idStr: string, timestamp: number): Promise<void> {
-  await cacache.put(LAST_TRACK_CACHE_PATH, idStr, Buffer.from(timestamp.toString()));
-}
+  async getLastTrackTimestamp(idStr: string): Promise<number> {
+    const results = await this.getFromCacheIfExist(LAST_TRACK, idStr);
+    return results ? parseInt(results.data.toString()) : 0;
+  }
 
-export async function getDocsFromCache(filePath: string): Promise<{ timestamp: number; data: string } | null> {
-  return getStringDataFromCache(filePath, DOCS_CACHE_PATH);
-}
+  async setLastTrackTimestamp(idStr: string, timestamp: number): Promise<void> {
+    await this.saveDataInCache(idStr, LAST_TRACK, Buffer.from(timestamp.toString()));
+  }
 
-export async function saveDocsInCache(filePath: string, docs: Record<string, any>) {
-  await saveDataPerFileInCache(filePath, DOCS_CACHE_PATH, docs);
-}
+  async getDocsFromCache(filePath: string): Promise<{ timestamp: number; data: string } | null> {
+    return this.getStringDataFromCache(filePath, DOCS);
+  }
 
-export async function getDependenciesDataFromCache(idStr: string): Promise<{ timestamp: number; data: string } | null> {
-  return getStringDataFromCache(idStr, DEPS_CACHE_PATH);
-}
+  async saveDocsInCache(filePath: string, docs: Record<string, any>) {
+    await this.saveStringDataInCache(filePath, DOCS, docs);
+  }
 
-export async function saveDependenciesDataInCache(idStr: string, dependenciesData: string) {
-  const metadata = { timestamp: Date.now() };
-  await cacache.put(DEPS_CACHE_PATH, idStr, dependenciesData, { metadata });
-}
+  async getDependenciesDataFromCache(idStr: string): Promise<{ timestamp: number; data: string } | null> {
+    return this.getStringDataFromCache(idStr, DEPS);
+  }
 
-export async function deleteAllDependenciesDataCache() {
-  await cacache.rm.all(DEPS_CACHE_PATH);
-}
+  async saveDependenciesDataInCache(idStr: string, dependenciesData: string) {
+    const metadata = { timestamp: Date.now() };
+    await this.saveDataInCache(idStr, DEPS, dependenciesData, metadata);
+  }
 
-export async function listDependenciesDataCache() {
-  return cacache.ls(DEPS_CACHE_PATH);
-}
+  async deleteAllDependenciesDataCache() {
+    await cacache.rm.all(this.getCachePath(DEPS));
+  }
 
-async function saveDataPerFileInCache(filePath: string, cachePath: string, data: any) {
-  const dataBuffer = Buffer.from(JSON.stringify(data));
-  const metadata = { timestamp: Date.now() };
-  await cacache.put(cachePath, filePath, dataBuffer, { metadata });
-}
+  async listDependenciesDataCache() {
+    return cacache.ls(this.getCachePath(DEPS));
+  }
 
-async function getStringDataFromCache(
-  key: string,
-  cachePath: string
-): Promise<{ timestamp: number; data: string } | null> {
-  const results = await getFromCacheIfExist(cachePath, key);
-  if (!results) return null;
-  return { timestamp: results.metadata.timestamp, data: results.data.toString() };
-}
+  private async saveStringDataInCache(key: string, cacheName: string, data: any) {
+    const dataBuffer = Buffer.from(JSON.stringify(data));
+    const metadata = { timestamp: Date.now() };
+    await this.saveDataInCache(key, cacheName, dataBuffer, metadata);
+  }
 
-async function getFromCacheIfExist(cachePath: string, key: string): Promise<GetCacheObject | null> {
-  try {
-    const results = await cacache.get(cachePath, key);
-    return results;
-  } catch (err) {
-    if (err.code === 'ENOENT') {
-      return null; // cache doesn't exists
+  private async saveDataInCache(key: string, cacheName: string, data: any, metadata?: any) {
+    const cachePath = this.getCachePath(cacheName);
+    await cacache.put(cachePath, key, data, { metadata });
+  }
+
+  private async getStringDataFromCache(
+    key: string,
+    cacheName: string
+  ): Promise<{ timestamp: number; data: string } | null> {
+    const results = await this.getFromCacheIfExist(cacheName, key);
+    if (!results) return null;
+    return { timestamp: results.metadata.timestamp, data: results.data.toString() };
+  }
+
+  private async getFromCacheIfExist(cacheName: string, key: string): Promise<GetCacheObject | null> {
+    const cachePath = this.getCachePath(cacheName);
+    try {
+      const results = await cacache.get(cachePath, key);
+      return results;
+    } catch (err) {
+      if (err.code === 'ENOENT') {
+        return null; // cache doesn't exists
+      }
+      throw err;
     }
-    throw err;
+  }
+
+  private getCachePath(cacheName: string) {
+    return path.join(this.basePath, cacheName);
   }
 }

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -36,6 +36,10 @@ export async function deleteAllDependenciesDataCache() {
   await cacache.rm.all(DEPS_CACHE_PATH);
 }
 
+export async function listDependenciesDataCache() {
+  return cacache.ls(DEPS_CACHE_PATH);
+}
+
 async function saveDataPerFileInCache(filePath: string, cachePath: string, data: any) {
   const dataBuffer = Buffer.from(JSON.stringify(data));
   const metadata = { timestamp: Date.now() };

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -32,6 +32,10 @@ export async function saveDependenciesDataInCache(idStr: string, dependenciesDat
   await cacache.put(DEPS_CACHE_PATH, idStr, dependenciesData, { metadata });
 }
 
+export async function deleteAllDependenciesDataCache() {
+  await cacache.rm.all(DEPS_CACHE_PATH);
+}
+
 async function saveDataPerFileInCache(filePath: string, cachePath: string, data: any) {
   const dataBuffer = Buffer.from(JSON.stringify(data));
   const metadata = { timestamp: Date.now() };

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -134,6 +134,7 @@ export default class ComponentLoader {
       const dependenciesLoader = new DependenciesLoader(component, this.consumer, {
         cacheResolvedDependencies: this.cacheResolvedDependencies,
         cacheProjectAst: this.cacheProjectAst,
+        useDependenciesCache: true,
       });
       await dependenciesLoader.load();
       updateDependenciesVersions(this.consumer, component);

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -55,6 +55,8 @@ export default class ComponentLoader {
       const dependenciesCacheList = await this.componentFsCache.listDependenciesDataCache();
       const lastUpdateAllComps = Object.keys(dependenciesCacheList).map((key) => dependenciesCacheList[key].time);
       const firstCacheEntered = Math.min(...lastUpdateAllComps);
+      // if lastUpdateAllComps is empty, firstCacheEntered is Infinity so shouldInvalidate is
+      // always false, which is good. no need to invalidate the cache if nothing there.
       const shouldInvalidate = lastModified > firstCacheEntered;
       if (shouldInvalidate) {
         // at least one component inserted to the cache before workspace-config/node-modules

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -52,6 +52,7 @@ import ComponentOutOfSync from '../exceptions/component-out-of-sync';
 import ComponentSpecsFailed from '../exceptions/component-specs-failed';
 import SpecsResults from '../specs-results';
 import { RawTestsResults } from '../specs-results/specs-results';
+import { ComponentFsCache } from './component-fs-cache';
 import { CURRENT_SCHEMA, isSchemaSupport, SchemaFeature, SchemaName } from './component-schema';
 import { Dependencies, Dependency } from './dependencies';
 import { Issues } from './dependencies/dependency-resolver/dependencies-resolver';
@@ -1151,7 +1152,7 @@ export default class Component {
     const packageJsonFile = (componentConfig && componentConfig.packageJsonFile) || undefined;
     const packageJsonChangedProps = componentFromModel ? componentFromModel.packageJsonChangedProps : undefined;
     const files = await getLoadedFiles();
-    const docsP = _getDocsForFiles(files);
+    const docsP = _getDocsForFiles(files, consumer.componentFsCache);
     const docs = await Promise.all(docsP);
     const flattenedDocs = docs ? R.flatten(docs) : [];
 
@@ -1199,6 +1200,6 @@ export default class Component {
   }
 }
 
-function _getDocsForFiles(files: SourceFile[]): Array<Promise<Doclet[]>> {
-  return files.map((file) => (file.test ? Promise.resolve([]) : docsParser(file)));
+function _getDocsForFiles(files: SourceFile[], componentFsCache: ComponentFsCache): Array<Promise<Doclet[]>> {
+  return files.map((file) => (file.test ? Promise.resolve([]) : docsParser(file, componentFsCache)));
 }

--- a/src/consumer/component/dependencies/dependency-resolver/README.md
+++ b/src/consumer/component/dependencies/dependency-resolver/README.md
@@ -1,0 +1,29 @@
+# Dependencies Cache Mechanism
+To improve component-loading performance, the dependencies data is cached in the filesystem.
+
+### The component's cache gets invalidated in the following scenario:
+1. The component-dir or sub-dirs have been changed. (modified-date of the dirs paths)
+2. One of the component files have been changed.
+3. A component config file (component.json/package.json) has modified.
+
+### The entire cache of all component dependencies is invalidated if one of the following happened:
+1. workspace-config file (bit.json/workspace.jsonc) has changed.
+2. package.json file has changed.
+3. node_modules-dir (only root dir, not sub-dirs) has changed. - not sure if needed.
+4. On completion of "bit link".
+5. On completion of "bit install".
+6. During 'bit tag --persist', before loading the components.
+
+### A component is not entered to the cache in the first place in the following cases:
+1. No root-dir/track-dir (legacy).
+2. Component has one of the following issues: missingPackagesDependenciesOnFs, untrackedDependencies.
+
+### Limitations:
+1. If a user deleted the dists directories of a component in node-modules, we don't know about it and bit-status won't show any error.
+2. If a user deleted a package from node-modules dir manually, we don't know about it.
+
+### Disabling the cache
+set the "no-fs-cache" feature.
+For one command, prefix your command with `BIT_FEATURES=no-fs-cache`.
+Or you can configure it on the machine level for all commands/workspaces: `bit config set features='no-fs-cache'`
+

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -30,29 +30,36 @@ export class DependenciesData {
     const devDependencies = dataParsed.allDependencies.devDependencies.map(
       (dep) => new Dependency(new BitId(dep.id), dep.relativePaths, dep.packageName)
     );
-    const issues = dataParsed.issues;
-    if (issues?.relativeComponentsAuthored) {
-      Object.keys(issues.relativeComponentsAuthored).forEach((fileName) => {
-        issues.relativeComponentsAuthored[fileName] = issues.relativeComponentsAuthored[fileName].map((record) => ({
-          importSource: record.importSource,
-          componentId: new BitId(record.componentId),
-          relativePath: record.relativePath,
-        }));
-      });
-    }
-    if (issues?.relativeComponents) {
-      Object.keys(issues?.relativeComponents).forEach((filePath) => {
-        issues.relativeComponents[filePath] = issues.relativeComponents[filePath].map((id) => new BitId(id));
-      });
-    }
-
+    const issues = deserializeIssues(dataParsed.issues);
     const allDependencies = { dependencies, devDependencies };
     return new DependenciesData(
       allDependencies,
       dataParsed.allPackagesDependencies,
-      issues,
+      issues as Issues,
       dataParsed.coreAspects,
       dataParsed.overridesDependencies
     );
   }
+}
+
+function deserializeIssues(issues: Record<string, any>): Partial<Issues> {
+  if (!issues) return {};
+  if (issues.relativeComponentsAuthored) {
+    Object.keys(issues.relativeComponentsAuthored).forEach((fileName) => {
+      issues.relativeComponentsAuthored[fileName] = issues.relativeComponentsAuthored[fileName].map((record) => ({
+        importSource: record.importSource,
+        componentId: new BitId(record.componentId),
+        relativePath: record.relativePath,
+      }));
+    });
+  }
+  const fields = ['relativeComponents', 'missingComponents', 'missingLinks', 'missingCustomModuleResolutionLinks'];
+  fields.forEach((field) => {
+    if (!issues[field]) return;
+    Object.keys(issues[field]).forEach((filePath) => {
+      issues[field][filePath] = issues[field][filePath].map((id) => new BitId(id));
+    });
+  });
+
+  return issues;
 }

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -40,6 +40,11 @@ export class DependenciesData {
         }));
       });
     }
+    if (issues?.relativeComponents) {
+      Object.keys(issues?.relativeComponents).forEach((filePath) => {
+        issues.relativeComponents[filePath] = issues.relativeComponents[filePath].map((id) => new BitId(id));
+      });
+    }
 
     const allDependencies = { dependencies, devDependencies };
     return new DependenciesData(

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -30,11 +30,23 @@ export class DependenciesData {
     const devDependencies = dataParsed.allDependencies.devDependencies.map(
       (dep) => new Dependency(new BitId(dep.id), dep.relativePaths, dep.packageName)
     );
+    const relativeComponentsAuthored = dataParsed.issues?.relativeComponentsAuthored;
+    if (relativeComponentsAuthored) {
+      Object.keys(relativeComponentsAuthored).forEach((fileName) => {
+        relativeComponentsAuthored[fileName] = relativeComponentsAuthored[fileName].map((record) => ({
+          importSource: record.importSource,
+          componentId: new BitId(record.componentId),
+          relativePath: record.relativePath,
+        }));
+      });
+    }
+    const issues = { ...(dataParsed.issues || {}), relativeComponentsAuthored };
+
     const allDependencies = { dependencies, devDependencies };
     return new DependenciesData(
       allDependencies,
       dataParsed.allPackagesDependencies,
-      dataParsed.issues,
+      issues,
       dataParsed.coreAspects,
       dataParsed.overridesDependencies
     );

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -30,17 +30,16 @@ export class DependenciesData {
     const devDependencies = dataParsed.allDependencies.devDependencies.map(
       (dep) => new Dependency(new BitId(dep.id), dep.relativePaths, dep.packageName)
     );
-    const relativeComponentsAuthored = dataParsed.issues?.relativeComponentsAuthored;
-    if (relativeComponentsAuthored) {
-      Object.keys(relativeComponentsAuthored).forEach((fileName) => {
-        relativeComponentsAuthored[fileName] = relativeComponentsAuthored[fileName].map((record) => ({
+    const issues = dataParsed.issues;
+    if (issues?.relativeComponentsAuthored) {
+      Object.keys(issues.relativeComponentsAuthored).forEach((fileName) => {
+        issues.relativeComponentsAuthored[fileName] = issues.relativeComponentsAuthored[fileName].map((record) => ({
           importSource: record.importSource,
           componentId: new BitId(record.componentId),
           relativePath: record.relativePath,
         }));
       });
     }
-    const issues = { ...(dataParsed.issues || {}), relativeComponentsAuthored };
 
     const allDependencies = { dependencies, devDependencies };
     return new DependenciesData(

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -1,3 +1,5 @@
+import { BitId } from '../../../../bit-id';
+import Dependency from '../dependency';
 import { AllDependencies, AllPackagesDependencies, Issues } from './dependencies-resolver';
 import { ManuallyChangedDependencies } from './overrides-dependencies';
 
@@ -15,4 +17,26 @@ export class DependenciesData {
     public coreAspects: string[],
     public overridesDependencies: OverridesDependenciesData
   ) {}
+
+  serialize(): string {
+    return JSON.stringify(this);
+  }
+
+  static deserialize(data: string): DependenciesData {
+    const dataParsed = JSON.parse(data);
+    const dependencies = dataParsed.allDependencies.dependencies.map(
+      (dep) => new Dependency(new BitId(dep.id), dep.relativePaths, dep.packageName)
+    );
+    const devDependencies = dataParsed.allDependencies.devDependencies.map(
+      (dep) => new Dependency(new BitId(dep.id), dep.relativePaths, dep.packageName)
+    );
+    const allDependencies = { dependencies, devDependencies };
+    return new DependenciesData(
+      allDependencies,
+      dataParsed.allPackagesDependencies,
+      dataParsed.issues,
+      dataParsed.coreAspects,
+      dataParsed.overridesDependencies
+    );
+  }
 }

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-data.ts
@@ -53,7 +53,7 @@ function deserializeIssues(issues: Record<string, any>): Partial<Issues> {
       }));
     });
   }
-  const fields = ['relativeComponents', 'missingComponents', 'missingLinks', 'missingCustomModuleResolutionLinks'];
+  const fields = ['relativeComponents', 'missingComponents', 'missingLinks'];
   fields.forEach((field) => {
     if (!issues[field]) return;
     Object.keys(issues[field]).forEach((filePath) => {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -4,7 +4,6 @@ import { Consumer } from '../../..';
 import logger from '../../../../logger/logger';
 import { getLastModifiedComponentTimestampMs } from '../../../../utils/fs/last-modified';
 import { ExtensionDataEntry } from '../../../config';
-import { getDependenciesDataFromCache, saveDependenciesDataInCache } from '../../component-fs-cache';
 import Component from '../../consumer-component';
 import { DependenciesData } from './dependencies-data';
 import DependencyResolver from './dependencies-resolver';
@@ -37,7 +36,7 @@ export class DependenciesLoader {
       this.opts.cacheProjectAst
     );
     if (this.shouldSaveInCache(dependenciesData)) {
-      await saveDependenciesDataInCache(this.idStr, dependenciesData.serialize());
+      await this.consumer.componentFsCache.saveDependenciesDataInCache(this.idStr, dependenciesData.serialize());
     }
 
     return dependenciesData;
@@ -47,7 +46,7 @@ export class DependenciesLoader {
     if (!this.opts.useDependenciesCache) {
       return null;
     }
-    const cacheData = await getDependenciesDataFromCache(this.idStr);
+    const cacheData = await this.consumer.componentFsCache.getDependenciesDataFromCache(this.idStr);
     if (!cacheData) {
       return null; // probably the first time, so it wasn't entered to the cache yet.
     }

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -34,7 +34,9 @@ export class DependenciesLoader {
       this.opts.cacheResolvedDependencies,
       this.opts.cacheProjectAst
     );
-    await saveDependenciesDataInCache(this.idStr, dependenciesData.serialize());
+    if (this.shouldSaveInCache(dependenciesData)) {
+      await saveDependenciesDataInCache(this.idStr, dependenciesData.serialize());
+    }
 
     return dependenciesData;
   }
@@ -62,6 +64,13 @@ export class DependenciesLoader {
     }
     logger.debug(`dependencies-loader, getting the dependencies data for ${this.idStr} from the cache`);
     return DependenciesData.deserialize(cacheData.data);
+  }
+
+  private shouldSaveInCache(dependenciesData: DependenciesData) {
+    if (dependenciesData.issues?.missingPackagesDependenciesOnFs) {
+      return false;
+    }
+    return true;
   }
 
   private setDependenciesDataOnComponent(dependenciesData: DependenciesData) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -71,7 +71,7 @@ export class DependenciesLoader {
   }
 
   private shouldSaveInCache(dependenciesData: DependenciesData) {
-    if (dependenciesData.issues?.missingPackagesDependenciesOnFs) {
+    if (dependenciesData.issues?.missingPackagesDependenciesOnFs || dependenciesData.issues?.untrackedDependencies) {
       return false;
     }
     return true;

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -1,4 +1,5 @@
 import R from 'ramda';
+import path from 'path';
 import { Consumer } from '../../..';
 import logger from '../../../../logger/logger';
 import { getLastModifiedComponentTimestampMs } from '../../../../utils/fs/last-modified';
@@ -7,6 +8,7 @@ import { getDependenciesDataFromCache, saveDependenciesDataInCache } from '../..
 import Component from '../../consumer-component';
 import { DependenciesData } from './dependencies-data';
 import DependencyResolver from './dependencies-resolver';
+import { COMPONENT_CONFIG_FILE_NAME, PACKAGE_JSON } from '../../../../constants';
 
 type Opts = {
   cacheResolvedDependencies: Record<string, any>;
@@ -57,6 +59,9 @@ export class DependenciesLoader {
       return null;
     }
     const filesPaths = this.component.files.map((f) => f.path);
+    const componentConfigFilename = this.consumer.isLegacy ? PACKAGE_JSON : COMPONENT_CONFIG_FILE_NAME;
+    const componentConfigPath = path.join(this.consumer.getPath(), rootDir, componentConfigFilename);
+    filesPaths.push(componentConfigPath);
     const lastModifiedComponent = await getLastModifiedComponentTimestampMs(rootDir, filesPaths);
     const wasModifiedAfterCache = lastModifiedComponent > cacheData.timestamp;
     if (wasModifiedAfterCache) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -15,7 +15,9 @@ export class DependenciesLoader {
       this.opts.cacheResolvedDependencies,
       this.opts.cacheProjectAst
     );
-    this.setDependenciesDataOnComponent(dependenciesData);
+    const dataStr = dependenciesData.serialize();
+    const dataObject = DependenciesData.deserialize(dataStr);
+    this.setDependenciesDataOnComponent(dataObject);
   }
 
   private setDependenciesDataOnComponent(dependenciesData: DependenciesData) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -68,7 +68,7 @@ export type Issues = {
   untrackedDependencies: UntrackedDependenciesIssues;
   missingDependenciesOnFs: { [filePath: string]: string[] };
   missingLinks: { [filePath: string]: BitId[] };
-  missingCustomModuleResolutionLinks: { [filePath: string]: BitId[] };
+  missingCustomModuleResolutionLinks: { [filePath: string]: string[] };
   customModuleResolutionUsed: { [importSource: string]: BitIdStr }; // invalid on Harmony, { importSource: idStr }
   relativeComponents: { [filePath: string]: BitId[] };
   relativeComponentsAuthored?: RelativeComponentsAuthoredIssues; // invalid on Harmony
@@ -1253,7 +1253,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       this.issues.missingPackagesDependenciesOnFs[originFile].concat(missingPackages);
     } else this.issues.missingPackagesDependenciesOnFs[originFile] = missingPackages;
   }
-  _pushToMissingCustomModuleIssues(originFile: PathLinuxRelative, componentId: BitId) {
+  _pushToMissingCustomModuleIssues(originFile: PathLinuxRelative, componentId: string) {
     if (this.issues.missingCustomModuleResolutionLinks[originFile]) {
       this.issues.missingCustomModuleResolutionLinks[originFile].push(componentId);
     } else this.issues.missingCustomModuleResolutionLinks[originFile] = [componentId];

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -23,6 +23,7 @@ import { FileObject, ImportSpecifier, Tree } from '../files-dependency-builder/t
 import OverridesDependencies from './overrides-dependencies';
 import { ResolvedPackageData } from '../../../../utils/packages';
 import { DependenciesData } from './dependencies-data';
+import { BitIdStr } from '../../../../bit-id/bit-id';
 
 export type AllDependencies = {
   dependencies: Dependency[];
@@ -61,19 +62,19 @@ type UntrackedDependenciesIssues = Record<string, UntrackedFileDependencyEntry>;
 type RelativeComponentsAuthoredIssues = { [fileName: string]: RelativeComponentsAuthoredEntry[] };
 
 export type Issues = {
-  missingPackagesDependenciesOnFs: {};
+  missingPackagesDependenciesOnFs: { [filePath: string]: string[] };
   missingPackagesDependenciesFromOverrides: string[];
-  missingComponents: {};
+  missingComponents: { [filePath: string]: BitId[] };
   untrackedDependencies: UntrackedDependenciesIssues;
-  missingDependenciesOnFs: {};
-  missingLinks: {};
-  missingCustomModuleResolutionLinks: {};
-  customModuleResolutionUsed: {}; // invalid on Harmony, { importSource: idStr }
+  missingDependenciesOnFs: { [filePath: string]: string[] };
+  missingLinks: { [filePath: string]: BitId[] };
+  missingCustomModuleResolutionLinks: { [filePath: string]: BitId[] };
+  customModuleResolutionUsed: { [importSource: string]: BitIdStr }; // invalid on Harmony, { importSource: idStr }
   relativeComponents: { [filePath: string]: BitId[] };
   relativeComponentsAuthored?: RelativeComponentsAuthoredIssues; // invalid on Harmony
-  parseErrors: {};
-  resolveErrors: {};
-  missingBits: {};
+  parseErrors: { [filePath: string]: string };
+  resolveErrors: { [filePath: string]: string };
+  missingBits: { [filePath: string]: BitId[] }; // temporarily. it's combined later with missingComponents. see combineIssues
 };
 
 type WorkspacePolicyGetter = () => {
@@ -145,7 +146,7 @@ export default class DependencyResolver {
       relativeComponentsAuthored: {},
       parseErrors: {},
       resolveErrors: {},
-      missingBits: {}, // temporarily, will be combined with missingComponents. see combineIssues
+      missingBits: {},
     };
     this.overridesDependencies = new OverridesDependencies(component, consumer);
   }

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -69,7 +69,7 @@ export type Issues = {
   missingLinks: {};
   missingCustomModuleResolutionLinks: {};
   customModuleResolutionUsed: {}; // invalid on Harmony, { importSource: idStr }
-  relativeComponents: {};
+  relativeComponents: { [filePath: string]: BitId[] };
   relativeComponentsAuthored?: RelativeComponentsAuthoredIssues; // invalid on Harmony
   parseErrors: {};
   resolveErrors: {};

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -142,6 +142,10 @@ export default class Consumer {
     return this._dirStructure;
   }
 
+  get componentFsCache() {
+    return this.componentLoader.componentFsCache;
+  }
+
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   get bitmapIds(): BitIds {
     return this.bitMap.getAllBitIds();

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -529,6 +529,9 @@ export default class Consumer {
     const { ids, persist } = tagParams;
     logger.debug(`tagging the following components: ${ids.toString()}`);
     Analytics.addBreadCrumb('tag', `tagging the following components: ${Analytics.hashData(ids)}`);
+    if (persist) {
+      await this.componentFsCache.deleteAllDependenciesDataCache();
+    }
     const components = await this._loadComponentsForTag(ids);
     // go through the components list to check if there are missing dependencies
     // if there is at least one we won't tag anything

--- a/src/jsdoc/parser.ts
+++ b/src/jsdoc/parser.ts
@@ -1,5 +1,5 @@
 import fs from 'fs-extra';
-import { getDocsFromCache, saveDocsInCache } from '../consumer/component/component-fs-cache';
+import { ComponentFsCache } from '../consumer/component/component-fs-cache';
 import { SourceFile } from '../consumer/component/sources';
 import { getExt } from '../utils';
 import { PathOsBased } from '../utils/path';
@@ -8,8 +8,8 @@ import reactParse from './react';
 import { Doclet } from './types';
 import vueParse from './vue';
 
-export default async function parse(file: SourceFile): Promise<Doclet[]> {
-  const docsFromCache = await getDocsFromCache(file.path);
+export default async function parse(file: SourceFile, componentFsCache: ComponentFsCache): Promise<Doclet[]> {
+  const docsFromCache = await componentFsCache.getDocsFromCache(file.path);
   if (docsFromCache && docsFromCache.timestamp) {
     const stat = await fs.stat(file.path);
     const wasFileChanged = stat.mtimeMs > docsFromCache.timestamp;
@@ -19,7 +19,7 @@ export default async function parse(file: SourceFile): Promise<Doclet[]> {
   }
 
   const results = await parseFile(file.contents.toString(), file.relative);
-  await saveDocsInCache(file.path, results);
+  await componentFsCache.saveDocsInCache(file.path, results);
   return results;
 }
 

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -7,6 +7,7 @@ import { BitId } from '../bit-id';
 import { COMPONENT_ORIGINS, DEFAULT_BINDINGS_PREFIX, PACKAGE_JSON } from '../constants';
 import BitMap from '../consumer/bit-map/bit-map';
 import ComponentMap from '../consumer/bit-map/component-map';
+import { deleteAllDependenciesDataCache } from '../consumer/component/component-fs-cache';
 import ComponentsList from '../consumer/component/components-list';
 import Component from '../consumer/component/consumer-component';
 import { Dependency } from '../consumer/component/dependencies';
@@ -50,6 +51,7 @@ export default class NodeModuleLinker {
     const linksResults = this.getLinksResults();
     if (this.consumer) links.addBasePath(this.consumer.getPath());
     await links.persistAllToFS();
+    await deleteAllDependenciesDataCache();
     return linksResults;
   }
   async getLinks(): Promise<DataToPersist> {

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -7,7 +7,6 @@ import { BitId } from '../bit-id';
 import { COMPONENT_ORIGINS, DEFAULT_BINDINGS_PREFIX, PACKAGE_JSON } from '../constants';
 import BitMap from '../consumer/bit-map/bit-map';
 import ComponentMap from '../consumer/bit-map/component-map';
-import { deleteAllDependenciesDataCache } from '../consumer/component/component-fs-cache';
 import ComponentsList from '../consumer/component/components-list';
 import Component from '../consumer/component/consumer-component';
 import { Dependency } from '../consumer/component/dependencies';
@@ -51,7 +50,7 @@ export default class NodeModuleLinker {
     const linksResults = this.getLinksResults();
     if (this.consumer) links.addBasePath(this.consumer.getPath());
     await links.persistAllToFS();
-    await deleteAllDependenciesDataCache();
+    await this.consumer?.componentFsCache.deleteAllDependenciesDataCache();
     return linksResults;
   }
   async getLinks(): Promise<DataToPersist> {

--- a/src/utils/fs/last-modified.ts
+++ b/src/utils/fs/last-modified.ts
@@ -1,0 +1,22 @@
+import { glob } from 'glob';
+import fs, { Stats } from 'fs-extra';
+
+/**
+ * check recursively all the sub-directories as well
+ */
+export async function getLastModifiedDirTimestampMs(rootDir: string): Promise<number> {
+  const allDirs = glob.sync(`${rootDir}/**/`); // the trailing slash instructs glob to show only dirs
+  return getLastModifiedPathsTimestampMs(allDirs);
+}
+
+export async function getLastModifiedPathsTimestampMs(paths: string[]): Promise<number> {
+  const pathsStats: Stats[] = await Promise.all(paths.map((dir) => fs.stat(dir)));
+  const timestamps = pathsStats.map((stat) => stat.mtimeMs);
+  return Math.max(...timestamps);
+}
+
+export async function getLastModifiedComponentTimestampMs(rootDir: string, files: string[]): Promise<number> {
+  const lastModifiedDirs = await getLastModifiedDirTimestampMs(rootDir);
+  const lastModifiedFiles = await getLastModifiedPathsTimestampMs(files);
+  return Math.max(lastModifiedDirs, lastModifiedFiles);
+}

--- a/src/utils/fs/last-modified.ts
+++ b/src/utils/fs/last-modified.ts
@@ -11,8 +11,9 @@ export async function getLastModifiedDirTimestampMs(rootDir: string): Promise<nu
 }
 
 export async function getLastModifiedPathsTimestampMs(paths: string[]): Promise<number> {
-  const pathsStats: Stats[] = await Promise.all(paths.map((dir) => fs.stat(dir)));
-  const timestamps = pathsStats.map((stat) => stat.mtimeMs);
+  const pathsStats = await Promise.all(paths.map((dir) => getPathStatIfExist(dir)));
+  const statsWithoutNull = compact(pathsStats);
+  const timestamps = statsWithoutNull.map((stat) => stat.mtimeMs);
   return Math.max(...timestamps);
 }
 
@@ -20,13 +21,6 @@ export async function getLastModifiedComponentTimestampMs(rootDir: string, files
   const lastModifiedDirs = await getLastModifiedDirTimestampMs(rootDir);
   const lastModifiedFiles = await getLastModifiedPathsTimestampMs(files);
   return Math.max(lastModifiedDirs, lastModifiedFiles);
-}
-
-export async function getLastModifiedPathsIfExistTimestampMs(paths: string[]): Promise<number> {
-  const pathsStats = await Promise.all(paths.map((dir) => getPathStatIfExist(dir)));
-  const statsWithoutNull = compact(pathsStats);
-  const timestamps = statsWithoutNull.map((stat) => stat.mtimeMs);
-  return Math.max(...timestamps);
 }
 
 async function getPathStatIfExist(path: string): Promise<Stats | null> {


### PR DESCRIPTION
# Dependencies Cache Mechanism
To improve component-loading performance, the dependencies data is cached in the filesystem.

### The component's cache gets invalidated in the following scenario:
1. The component-dir or sub-dirs have been changed. (modified-date of the dirs paths)
2. One of the component files have been changed.
3. A component config file (component.json/package.json) has modified.

### The entire cache of all component dependencies is invalidated if one of the following happened:
1. workspace-config file (bit.json/workspace.jsonc) has changed.
2. package.json file has changed.
3. node_modules-dir (only root dir, not sub-dirs) has changed. - not sure if needed.
4. On completion of "bit link".
5. On completion of "bit install".
6. During 'bit tag --persist', before loading the components.

### A component is not entered to the cache in the first place in the following cases:
1. No root-dir/track-dir (legacy).
2. Component has one of the following issues: missingPackagesDependenciesOnFs, untrackedDependencies.

### Limitations:
1. If a user deleted the dists directories of a component in node-modules, we don't know about it and bit-status won't show any error.
2. If a user deleted a package from node-modules dir manually, we don't know about it.

### Clearing the cache
`bit cc`

### Disabling the cache
set the "no-fs-cache" feature.
For one command, prefix your command with `BIT_FEATURES=no-fs-cache`.
Or you can configure it on the machine level for all commands/workspaces: `bit config set features='no-fs-cache'`

