### PR TITLE
fix error on bit-start "Cannot find module @teambit/modules.mdx-loader"

### DIFF
--- a/scopes/compilation/bundler/bundler.main.runtime.ts
+++ b/scopes/compilation/bundler/bundler.main.runtime.ts
@@ -49,7 +49,7 @@ export class BundlerMain {
     const envRuntime = await this.envs.createEnvironment(components);
     this.devService.uiRoot = root;
     const executionResults = await envRuntime.run<ComponentServer>(this.devService);
-
+    executionResults.throwErrorsIfExist();
     this._componentServers = executionResults.results.map((res) => res.data as ComponentServer);
 
     this.indexByComponent();

--- a/scopes/react/react/webpack/webpack.config.ts
+++ b/scopes/react/react/webpack/webpack.config.ts
@@ -1,5 +1,7 @@
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 import { Configuration } from 'webpack';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import * as mdxLoader from '@teambit/modules.mdx-loader';
 
 const moduleFileExtensions = [
   'web.mjs',


### PR DESCRIPTION
## Proposed Changes

- fix `bundler.devServer()` to throw errors (if found) during the dev server load.
- fix react to have the mdx-loader as a dependency.
