### PR TITLE
Nested deps links

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -68,6 +68,12 @@ export type LinkResults = {
   nestedDepsInNmLinks?: NestedNMDepsLinksResult[];
 };
 
+type NestedModuleFolderEntry = {
+  moduleName: string;
+  path: string;
+  origPath?: string;
+};
+
 export class DependencyLinker {
   constructor(
     private dependencyResolver: DependencyResolverMain,
@@ -154,7 +160,7 @@ export class DependencyLinker {
     componentDirectoryMap: ComponentMap<string>
   ): NestedNMDepsLinksResult[] {
     const rootNodeModules = path.join(rootDir, 'node_modules');
-    const getPackagesFoldersToLink = (dir: string, parent?: string) => {
+    const getPackagesFoldersToLink = (dir: string, parent?: string): NestedModuleFolderEntry[] => {
       const folders = fs
         .readdirSync(dir, { withFileTypes: true })
         .filter((dirent) => {
@@ -203,10 +209,10 @@ export class DependencyLinker {
       if (isPathSymlink(innerNMofComponentInNM)) {
         return undefined;
       }
-      const packagesFoldersToLink = getPackagesFoldersToLink(compDirNM);
+      const packagesFoldersToLink: NestedModuleFolderEntry[] = getPackagesFoldersToLink(compDirNM);
       fs.ensureDirSync(innerNMofComponentInNM);
 
-      const oneComponentLinks: LinkDetail[] = packagesFoldersToLink.map((folderEntry) => {
+      const oneComponentLinks: LinkDetail[] = packagesFoldersToLink.map((folderEntry: NestedModuleFolderEntry) => {
         const linkTarget = path.join(innerNMofComponentInNM, 'node_modules', folderEntry?.moduleName);
         const linkSrc = folderEntry.path;
         // This works as well, consider using it instead

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -499,10 +499,10 @@ function resolveModuleDirFromFile(resolvedModulePath: string, moduleId: string):
   return path.join(resolvedModulePath.slice(0, resolvedModulePath.lastIndexOf(NM) + NM.length), moduleId);
 }
 
-function isPathSymlink(path: string): boolean | undefined {
+function isPathSymlink(folderPath: string): boolean | undefined {
   // TODO: change to fs.lstatSync(dest, {throwIfNoEntry: false}); once upgrade fs-extra
   try {
-    const stat = fs.lstatSync(path);
+    const stat = fs.lstatSync(folderPath);
     return stat.isSymbolicLink();
   } catch (e) {
     return undefined;

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -200,8 +200,6 @@ export class DependencyLinker {
       const componentPackageName = componentIdToPackageName(component.state._consumer);
       const innerNMofComponentInNM = path.join(rootNodeModules, componentPackageName);
       // If the folder itself is a symlink, do not try to symlink inside it
-      console.log(innerNMofComponentInNM);
-      console.log(isPathSymlink(innerNMofComponentInNM));
       if (isPathSymlink(innerNMofComponentInNM)) {
         return undefined;
       }

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -193,6 +193,8 @@ export class DependencyLinker {
       const oneComponentLinks: LinkDetail[] = folders.map((folderEntry) => {
         const linkTarget = path.join(innerNMofComponentInNM, 'node_modules', folderEntry?.moduleName);
         const linkSrc = folderEntry.path;
+        // This works as well, consider using it instead
+        // const linkSrc = folderEntry.origPath || folderEntry.path;
         const linkDetail: LinkDetail = {
           from: `${linkSrc} ${folderEntry.origPath ? '(' + folderEntry.origPath + ')' : ''}`,
           to: linkTarget,

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -7,7 +7,6 @@ import { ComponentMap, Component, ComponentMain } from '@teambit/component';
 import { Logger } from '@teambit/logger';
 import { PathAbsolute } from 'bit-bin/dist/utils/path';
 import { BitError } from 'bit-bin/dist/error/bit-error';
-import { stripTrailingChar } from 'bit-bin/dist/utils';
 import { createSymlinkOrCopy } from 'bit-bin/dist/utils';
 import { LinksResult as LegacyLinksResult } from 'bit-bin/dist/links/node-modules-linker';
 import { CodemodResult } from 'bit-bin/dist/consumer/component-ops/codemod-components';
@@ -204,8 +203,9 @@ export class DependencyLinker {
         const linkSrc = folderEntry.path;
         // This works as well, consider using it instead
         // const linkSrc = folderEntry.origPath || folderEntry.path;
+        const origPath = folderEntry.origPath ? `(${folderEntry.origPath})` : '';
         const linkDetail: LinkDetail = {
-          from: `${linkSrc} ${folderEntry.origPath ? '(' + folderEntry.origPath + ')' : ''}`,
+          from: `${linkSrc} ${origPath}`,
           to: linkTarget,
         };
         const resolvedTarget = path.resolve(linkTarget, '..');
@@ -279,7 +279,6 @@ export class DependencyLinker {
           this.logger.console(`could not resolve ${depEntry.dependencyId} from env directory ${envDir}`);
           return undefined;
         }
-        const NM = 'node_modules';
         const linkSrc = resolveModuleDirFromFile(resolvedModule, depEntry.dependencyId);
         const linkDetail: LinkDetail = {
           from: linkSrc,

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -30,5 +30,12 @@ export {
   ComponentDependency,
 } from './dependencies';
 export { WorkspacePolicyEntry, WorkspacePolicy, VariantPolicyConfigObject } from './policy';
-export { CoreAspectLinkResult, LinkDetail, LinkResults, LinkingOptions } from './dependency-linker';
+export {
+  CoreAspectLinkResult,
+  LinkDetail,
+  LinkResults,
+  LinkingOptions,
+  DepsLinkedToEnvResult,
+  NestedNMDepsLinksResult,
+} from './dependency-linker';
 export { InstallOptions } from './dependency-installer';

--- a/scopes/workspace/workspace/link/link.cmd.tsx
+++ b/scopes/workspace/workspace/link/link.cmd.tsx
@@ -9,6 +9,7 @@ import chalk from 'chalk';
 import { Workspace, WorkspaceLinkOptions } from '../workspace';
 import { ComponentListLinks } from './component-list-links';
 import { CoreAspectsLinks } from './core-aspects-links';
+import { NestedComponentLinksLinks } from './nested-deps-in-nm-links';
 import { RewireRow } from './rewire-row';
 
 type LinkCommandOpts = {
@@ -68,6 +69,7 @@ export class LinkCommand implements Command {
         <CoreAspectsLinks coreAspectsLinks={coreAspectsLinksWithMainAspect} verbose={opts.verbose} />
         <ComponentListLinks componentListLinks={linkResults.legacyLinkResults} verbose={opts.verbose} />
         <RewireRow legacyCodemodResults={linkResults.legacyLinkCodemodResults} />
+        <NestedComponentLinksLinks nestedDepsInNmLinks={linkResults.nestedDepsInNmLinks} verbose={opts.verbose} />
         <Text>Finished. {timeDiff}</Text>
       </Box>
     );

--- a/scopes/workspace/workspace/link/nested-deps-in-nm-links.tsx
+++ b/scopes/workspace/workspace/link/nested-deps-in-nm-links.tsx
@@ -1,0 +1,58 @@
+import { Text, Box } from 'ink';
+import React from 'react';
+import { NestedNMDepsLinksResult } from '@teambit/dependency-resolver';
+import { VerboseLinkRow } from './link-row';
+
+type NestedComponentLinksLinksProps = {
+  nestedDepsInNmLinks?: NestedNMDepsLinksResult[];
+  verbose: boolean;
+};
+
+export function NestedComponentLinksLinks({ nestedDepsInNmLinks, verbose = false }: NestedComponentLinksLinksProps) {
+  if (!verbose) return null;
+  if (!nestedDepsInNmLinks || !nestedDepsInNmLinks.length) {
+    return null;
+  }
+  return (
+    <Box key="nested-links" flexDirection="column">
+      <Text bold color="cyan">
+        Nested dependencies links
+      </Text>
+      {nestedDepsInNmLinks.map((nestedComponentLinks) => (
+        <NestedComponentLinks
+          key={nestedComponentLinks.componentId.toString()}
+          nestedComponentLinks={nestedComponentLinks}
+          verbose={verbose}
+        />
+      ))}
+    </Box>
+  );
+}
+
+type NestedComponentLinksProps = {
+  nestedComponentLinks: NestedNMDepsLinksResult;
+  verbose: boolean;
+};
+function NestedComponentLinks({ nestedComponentLinks, verbose = false }: NestedComponentLinksProps) {
+  if (!nestedComponentLinks.linksDetail || nestedComponentLinks.linksDetail.length < 1) return null;
+  if (verbose) return <VerboseNestedComponentLinks nestedComponentLinks={nestedComponentLinks} />;
+  return null;
+}
+
+type VerboseNestedComponentLinksProps = {
+  nestedComponentLinks: NestedNMDepsLinksResult;
+};
+function VerboseNestedComponentLinks({ nestedComponentLinks }: VerboseNestedComponentLinksProps) {
+  const id = nestedComponentLinks.componentId.toString();
+  if (!nestedComponentLinks.linksDetail || nestedComponentLinks.linksDetail.length < 1) return null;
+  return (
+    <Box key={id} flexDirection="column">
+      <Text bold color="cyan">
+        {id}
+      </Text>
+      {nestedComponentLinks.linksDetail.map((link) => (
+        <VerboseLinkRow key={`${link.from}-${link.to}`} from={link.from} to={link.to} />
+      ))}
+    </Box>
+  );
+}

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1040,7 +1040,12 @@ export class Workspace implements ComponentFactory {
     // TODO: this make duplicate
     // this.logger.consoleSuccess();
     // TODO: add the links results to the output
-    await this.link({ linkTeambitBit: true, legacyLink: true, linkCoreAspects: true });
+    await this.link({
+      linkTeambitBit: true,
+      legacyLink: true,
+      linkCoreAspects: true,
+      linkNestedDepsInNM: !this.isLegacy,
+    });
     await this.consumer.componentFsCache.deleteAllDependenciesDataCache();
     return compDirMap;
   }

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -179,7 +179,8 @@ export default class NodeModuleLinker {
       this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId));
     });
     this._deleteExistingLinksRootIfSymlink(componentNodeModulesPath);
-    this.addSymlinkFromComponentDirNMToWorkspaceDirNM(component, componentNodeModulesPath);
+    // remove this for now, it should be handled by dependency-linker.addSymlinkFromComponentDirNMToWorkspaceDirNM
+    // this.addSymlinkFromComponentDirNMToWorkspaceDirNM(component, componentNodeModulesPath);
     await this._populateDependenciesAndMissingLinks(component);
   }
 
@@ -188,19 +189,19 @@ export default class NodeModuleLinker {
    * of the component. e.g.
    * ws-root/node_modules/comp1/node_modules -> ws-root/components/comp1/node_modules
    */
-  private addSymlinkFromComponentDirNMToWorkspaceDirNM(
-    component: Component,
-    componentNodeModulesPath: PathOsBasedRelative
-  ) {
-    const componentMap = component.componentMap as ComponentMap;
-    if (!componentMap.rootDir || !this.consumer) return;
-    const nodeModulesInCompRoot = path.join(componentMap.rootDir, 'node_modules');
-    if (!fs.existsSync(this.consumer.toAbsolutePath(nodeModulesInCompRoot))) return;
-    const nodeModulesInWorkspaceRoot = path.join(componentNodeModulesPath, 'node_modules');
-    this.dataToPersist.addSymlink(
-      Symlink.makeInstance(nodeModulesInCompRoot, nodeModulesInWorkspaceRoot, component.id)
-    );
-  }
+  // private addSymlinkFromComponentDirNMToWorkspaceDirNM(
+  //   component: Component,
+  //   componentNodeModulesPath: PathOsBasedRelative
+  // ) {
+  //   const componentMap = component.componentMap as ComponentMap;
+  //   if (!componentMap.rootDir || !this.consumer) return;
+  //   const nodeModulesInCompRoot = path.join(componentMap.rootDir, 'node_modules');
+  //   if (!fs.existsSync(this.consumer.toAbsolutePath(nodeModulesInCompRoot))) return;
+  //   const nodeModulesInWorkspaceRoot = path.join(componentNodeModulesPath, 'node_modules');
+  //   this.dataToPersist.addSymlink(
+  //     Symlink.makeInstance(nodeModulesInCompRoot, nodeModulesInWorkspaceRoot, component.id)
+  //   );
+  // }
 
   /**
    * even when an authored component has rootDir, we can't just symlink that rootDir to

--- a/src/links/symlink.ts
+++ b/src/links/symlink.ts
@@ -32,6 +32,7 @@ export default class Symlink {
     let exists;
     try {
       exists = fs.lstatSync(dest);
+      // eslint-disable-next-line no-empty
     } catch (e) {}
     if (exists) {
       fs.unlinkSync(dest);

--- a/src/links/symlink.ts
+++ b/src/links/symlink.ts
@@ -11,7 +11,7 @@ export default class Symlink {
   componentId: BitId | null | undefined;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   forDistOutsideComponentsDir: boolean;
-  constructor(src: string, dest: string, componentId?: BitId, forDistOutsideComponentsDir: boolean) {
+  constructor(src: string, dest: string, componentId?: BitId, forDistOutsideComponentsDir = false) {
     this.src = src;
     this.dest = dest;
     this.componentId = componentId;

--- a/src/links/symlink.ts
+++ b/src/links/symlink.ts
@@ -11,10 +11,11 @@ export default class Symlink {
   componentId: BitId | null | undefined;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   forDistOutsideComponentsDir: boolean;
-  constructor(src: string, dest: string, componentId?: BitId) {
+  constructor(src: string, dest: string, componentId?: BitId, forDistOutsideComponentsDir: boolean) {
     this.src = src;
     this.dest = dest;
     this.componentId = componentId;
+    this.forDistOutsideComponentsDir = forDistOutsideComponentsDir;
   }
   write() {
     this._throwForMissingDistOutsideComponent();
@@ -24,7 +25,14 @@ export default class Symlink {
   writeWithNativeFS() {
     const dest = this.dest;
     this._throwForMissingDistOutsideComponent();
-    const exists = fs.pathExistsSync(dest);
+    // TODO: change to fs.lstatSync(dest, {throwIfNoEntry: false});
+    // TODO: this requires to upgrade fs-extra to have the throwIfNoEntry property
+    // TODO: we don't use fs.pathExistsSync since it will return false in case the dest is a symlink which will result error on write
+    // const exists = fs.pathExistsSync(dest);
+    let exists;
+    try {
+      exists = fs.lstatSync(dest);
+    } catch (e) {}
     if (exists) {
       fs.unlinkSync(dest);
     }


### PR DESCRIPTION
This pr will add links from 
`componentSrcDir/node_modules/*` to `root/node_modules/componentPackageName/node_modules/*`
This is important since:
when we have a conflict of dependency between components, we nest some of the packages into the component.
we write those nested dependencies in the component src folder (in order to have correct types and autocomplete in the ide)
but the dists are running from `root/node_modules/componentPackageName` which doesn't have access to those nested dependencies, so it will resolve in action the wrong version (the conflicted one).
This PR will link all the packages from node modules in component src to the node_modules inside the package name of the component in the root node modules