### PR TITLE
fix IncorrectEnvAspect to not be thrown when bit defaults to the node-env

### DIFF
--- a/scopes/envs/envs/index.ts
+++ b/scopes/envs/envs/index.ts
@@ -1,4 +1,4 @@
-export { Descriptor } from './environments.main.runtime';
+export { Descriptor, DEFAULT_ENV } from './environments.main.runtime';
 export { Environment } from './environment';
 export { ExecutionContext } from './context';
 export { EnvService, ConcreteService } from './services';

--- a/scopes/workspace/workspace/exceptions/incorrect-env-aspect.ts
+++ b/scopes/workspace/workspace/exceptions/incorrect-env-aspect.ts
@@ -1,8 +1,8 @@
 import { BitError } from 'bit-bin/dist/error/bit-error';
 
 export class IncorrectEnvAspect extends BitError {
-  constructor(id: string, envType: string) {
-    super(`"${id}" is configured in workspace.json, but using the "${envType}" environment.
+  constructor(id: string, envType: string, envId: string) {
+    super(`"${id}" is configured in workspace.json, but using the "${envId}" environment, which is type "${envType}".
 please make sure to either apply the aspect environment or a composition of the aspect environment for the aspect to load.`);
   }
 }


### PR DESCRIPTION
The IncorrectEnvAspect is thrown when a custom env is compiled by a non-aspect core env. However, when the node-modules is empty, all components include custom-env are default to node-env, which is not an aspect env. 
This PR prevents the error to be thrown in such a case and let Bit compiles the custom-envs.