### PR TITLE
remove the types/node from the general and add to react-env

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -197,6 +197,7 @@ export class ReactEnv implements Environment {
       },
       // TODO: add this only if using ts
       devDependencies: {
+        '@types/node': '^12.12.27',
         'core-js': '^3.6.5',
         '@types/react': '16.9.43',
         '@types/jest': '~26.0.9',

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -302,8 +302,6 @@
           },
           "devDependencies": {
             "@types/mocha": "^5.2.7",
-            // why this is needed? try to automate this
-            "@types/node": "^12.12.27",
             "bit-bin": "-"
           },
           "peerDependencies": {


### PR DESCRIPTION
Otherwise, users will need to manually add this dependency for every typescript project.