### PR TITLE
log graphql errors to the debug.log file

### DIFF
--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -82,7 +82,12 @@ export class GraphqlMain {
     app.use(cors());
     app.use(
       '/graphql',
-      graphqlHTTP((request) => ({
+      graphqlHTTP((request, res, param) => ({
+        customFormatErrorFn: (err) => {
+          this.logger.error('graphql got an error during running the following query:', param);
+          this.logger.error('graphql error ', err);
+          return err;
+        },
         schema,
         rootValue: request,
         graphiql,

--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -82,9 +82,9 @@ export class GraphqlMain {
     app.use(cors());
     app.use(
       '/graphql',
-      graphqlHTTP((request, res, param) => ({
+      graphqlHTTP((request, res, params) => ({
         customFormatErrorFn: (err) => {
-          this.logger.error('graphql got an error during running the following query:', param);
+          this.logger.error('graphql got an error during running the following query:', params);
           this.logger.error('graphql error ', err);
           return err;
         },


### PR DESCRIPTION
Currently, the errors are shown in the UI only and without important data, which makes it difficult to debug.