### PR TITLE
added @babel/runtime as dev dep to all components that uses react-env

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -203,6 +203,8 @@ export class ReactEnv implements Environment {
         '@types/jest': '~26.0.9',
         '@types/mocha': '-',
         '@types/react-router-dom': '^5.1.5',
+        // This is added as dev dep since our jest file transformer uses babel plugins that require this to be installed
+        '@babel/runtime': '^7.11.2'
       },
       // TODO: take version from config
       peerDependencies: {


### PR DESCRIPTION
This meant to make sure that the jest tests will work.
Since we have a jest transformer in the react env that uses babel to compile the source code on the fly.
Those plugins added `@babel/runtime` in the compiled code, but this must be installed.
Now all components will have this as dev dependnecy.