### PR TITLE
fix dependencies version resolution to use the dependent package.json

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-versions-resolver.ts
@@ -132,11 +132,16 @@ export default function updateDependenciesVersions(consumer: Consumer, component
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const packageObject = resolveNodePackage(basePath, modulePath);
     if (!packageObject || R.isEmpty(packageObject)) return null;
-    const packageId = Object.keys(packageObject)[0];
-    const version = packageObject[packageId];
+    const version =
+      getValidVersion(packageObject.concreteVersion) || getValidVersion(packageObject.versionUsedByDependent);
+    if (!version) return null;
+    return componentId.changeVersion(version);
+  }
+
+  function getValidVersion(version) {
+    if (!version) return null;
     if (!semver.valid(version) && !semver.validRange(version)) return null; // it's probably a relative path to the component
-    const validVersion = version.replace(/[^0-9.]/g, ''); // allow only numbers and dots to get an exact version
-    return componentId.changeVersion(validVersion);
+    return version.replace(/[^0-9.]/g, '');
   }
 
   function getIdFromDependentPackageJson(componentId: BitId): BitId | null | undefined {


### PR DESCRIPTION
The issue started once the `resolveNodePackage` has changed to return an object with the package-json data. The way how to get the version from that data is different. 
This PR fetches the data correctly according to the `ResolvedNodePackage` interface. It first tries to use the concrete installed version in the node-modules and if not found, it uses the version written in the dependent package-json file.
