### PR TITLE
introduce a new command "bit dependents" to help debug component-not-found errors

### DIFF
--- a/e2e/commands/diff.e2e.1.ts
+++ b/e2e/commands/diff.e2e.1.ts
@@ -273,7 +273,7 @@ describe('bit diff command', function () {
     });
     describe('diff between a non-exist version and current version', () => {
       it('should throw an VersionNotFound error', () => {
-        const error = new VersionNotFound('1.0.6');
+        const error = new VersionNotFound('1.0.6', 'bar/foo');
         const diffFunc = () => helper.command.diff('bar/foo 1.0.6');
         helper.general.expectToThrow(diffFunc, error);
       });

--- a/src/api/consumer/lib/dependents.ts
+++ b/src/api/consumer/lib/dependents.ts
@@ -1,0 +1,33 @@
+import { BitId } from '../../../bit-id';
+import { loadConsumerIfExist, Consumer } from '../../../consumer';
+import ConsumerNotFound from '../../../consumer/exceptions/consumer-not-found';
+import GeneralError from '../../../error/general-error';
+import DependencyGraph, { DependenciesInfo } from '../../../scope/graph/scope-graph';
+
+export type DependentsResults = {
+  scopeDependents: DependenciesInfo[];
+  workspaceDependents: DependenciesInfo[];
+  id: BitId;
+};
+
+export async function dependents(id: string): Promise<DependentsResults> {
+  const consumer = await loadConsumerIfExist();
+  if (!consumer) throw new ConsumerNotFound(); // @todo: supports this on bare-scope.
+  throwForNewComponent(id, consumer);
+  const bitId = BitId.parse(id, true);
+  const scopeGraph = await DependencyGraph.buildGraphFromScope(consumer.scope);
+  const scopeDependencyGraph = new DependencyGraph(scopeGraph);
+  const scopeDependents = scopeDependencyGraph.getDependentsInfo(bitId);
+  const workspaceGraph = await DependencyGraph.buildGraphFromWorkspace(consumer, true);
+  const workspaceDependencyGraph = new DependencyGraph(workspaceGraph);
+  const workspaceDependents = workspaceDependencyGraph.getDependentsInfo(bitId);
+  return { scopeDependents, workspaceDependents, id: bitId };
+}
+
+function throwForNewComponent(id: string, consumer: Consumer) {
+  const bitId = consumer.bitMap.getExistingBitId(id, false);
+  if (!bitId) return;
+  if (!bitId.hasScope()) {
+    throw new GeneralError(`${id} is a new component, there is no data about it in the scope`);
+  }
+}

--- a/src/api/consumer/lib/get-scope-component.ts
+++ b/src/api/consumer/lib/get-scope-component.ts
@@ -8,7 +8,7 @@ import { loadScope, Scope } from '../../../scope';
 import ScopeComponentsImporter from '../../../scope/component-ops/scope-components-importer';
 import { DependenciesInfo } from '../../../scope/graph/scope-graph';
 
-export default (async function getScopeComponent({
+export default async function getScopeComponent({
   id,
   allVersions,
   scopePath,
@@ -60,4 +60,4 @@ export default (async function getScopeComponent({
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
     return scopeComponentsImporter.loadRemoteComponent(bitId);
   }
-});
+}

--- a/src/cli/command-registry-builder.ts
+++ b/src/cli/command-registry-builder.ts
@@ -39,6 +39,7 @@ import InjectConf from './commands/public-cmds/inject-conf-cmd';
 import Isolate from './commands/public-cmds/isolate-cmd';
 import Lane from './commands/public-cmds/lane-cmd';
 import Link from './commands/public-cmds/link-cmd';
+import Dependents from './commands/public-cmds/dependents-cmd';
 import List from './commands/public-cmds/list-cmd';
 import Log from './commands/public-cmds/log-cmd';
 import Login from './commands/public-cmds/login-cmd';
@@ -86,6 +87,7 @@ export default function registerCommands(extensionsCommands: Array<Commands>): C
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       new CatComponent(),
       new CatLane(),
+      new Dependents(),
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       new Show(),
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/cli/commands/public-cmds/dependents-cmd.ts
+++ b/src/cli/commands/public-cmds/dependents-cmd.ts
@@ -1,0 +1,29 @@
+import chalk from 'chalk';
+import { dependents, DependentsResults } from '../../../api/consumer/lib/dependents';
+import { CommandOptions, LegacyCommand } from '../../legacy-command';
+import { generateDependentsInfoTable } from '../../templates/component-template';
+
+export default class Dependents implements LegacyCommand {
+  name = 'dependents <id>';
+  description = 'EXPERIMENTAL. show dependents of the given component';
+  alias = '';
+  opts = [] as CommandOptions;
+
+  action([id]: [string]): Promise<any> {
+    return dependents(id);
+  }
+
+  report(results: DependentsResults): string {
+    if (!results.scopeDependents.length && !results.workspaceDependents.length) {
+      return `no dependents found for ${results.id.toString()}.
+try running "bit cat-component ${results.id.toStringWithoutVersion()}" to see whether the component/version exists locally`;
+    }
+    const scopeTable = generateDependentsInfoTable(results.scopeDependents, results.id);
+    const workspaceTable = generateDependentsInfoTable(results.workspaceDependents, results.id);
+    return `${chalk.bold('Dependents originated from workspace')}
+${workspaceTable || '<none>'}
+
+${chalk.bold('Dependents originated from scope')}
+${scopeTable || '<none>'}`;
+  }
+}

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -412,7 +412,13 @@ please use "bit remove" to delete the component or "bit add" with "--main" and "
   [WriteToNpmrcError, (err) => `unable to add @bit as a scoped registry at "${chalk.bold(err.path)}"`],
   [PathToNpmrcNotExist, (err) => `error: file or directory "${chalk.bold(err.path)}" was not found.`],
 
-  [VersionNotFound, (err) => `error: version "${chalk.bold(err.version)}" was not found.`],
+  [
+    VersionNotFound,
+    (err) =>
+      `error: version "${chalk.bold(err.version)}"${
+        err.componentId ? ` of component ${chalk.bold(err.componentId)}` : ''
+      } was not found.`,
+  ],
   [
     ParentNotFound,
     (err) =>

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -193,11 +193,12 @@ const errorsMap: Array<[Class<Error>, (err: Class<Error>) => string]> = [
   [
     ComponentNotFound,
     (err) => {
-      const msg = err.dependentId
+      const baseMsg = err.dependentId
         ? `error: the component dependency "${chalk.bold(err.id)}" required by "${chalk.bold(
             err.dependentId
           )}" was not found`
         : `error: component "${chalk.bold(err.id)}" was not found`;
+      const msg = `${baseMsg}\nconsider running "bit dependents ${err.id}" to understand why this component was needed`;
       return msg;
     },
   ],

--- a/src/cli/templates/all-help.ts
+++ b/src/cli/templates/all-help.ts
@@ -51,6 +51,10 @@ const allCommands = [
         name: 'untrack',
         description: 'Untrack a new component(s).',
       },
+      {
+        name: 'dependents',
+        description: 'Show all dependents of a given component-id',
+      },
     ],
   },
   {

--- a/src/cli/templates/component-template.ts
+++ b/src/cli/templates/component-template.ts
@@ -1,6 +1,7 @@
 import c from 'chalk';
 import rightpad from 'pad-right';
 import { table } from 'table';
+import { BitId } from '../../bit-id';
 
 import {
   componentToPrintableForDiff,
@@ -68,7 +69,7 @@ export default function paintComponent(
 
     const componentTable = table(rows, tableColumnConfig);
     const dependenciesTableStr = showRemoteVersion ? generateDependenciesTable() : '';
-    const dependentsInfoTableStr = generateDependentsInfoTable();
+    const dependentsInfoTableStr = generateDependentsInfoTable(dependentsInfo, component.id);
     const dependenciesInfoTableStr = generateDependenciesInfoTable();
     return (
       componentTable +
@@ -205,28 +206,6 @@ export default function paintComponent(
     return dependenciesTable;
   }
 
-  function generateDependentsInfoTable() {
-    if (!dependentsInfo.length) {
-      return '';
-    }
-    const dependentsHeader = [];
-    dependentsHeader.push([
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      c.cyan('Dependent ID'),
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      c.cyan('Depth'),
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      c.cyan('Immediate Dependency'),
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      c.cyan('Dependent type'),
-    ]);
-    const allDependenciesRows = getAllDependenciesRows(dependentsInfo);
-
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const dependentsTable = table(dependentsHeader.concat(allDependenciesRows));
-    return `\n${c.bold('Dependents Details')}\n${dependentsTable}`;
-  }
-
   function generateDependenciesInfoTable() {
     if (!dependenciesInfo.length) {
       return '';
@@ -243,26 +222,11 @@ export default function paintComponent(
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       c.cyan('Dependency type'),
     ]);
-    const allDependenciesRows = getAllDependenciesRows(dependenciesInfo);
+    const allDependenciesRows = getAllDependenciesRows(dependenciesInfo, component.id);
 
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const dependenciesTable = table(dependenciesHeader.concat(allDependenciesRows));
     return `\n${c.bold('Dependencies Details')}\n${dependenciesTable}`;
-  }
-
-  function getAllDependenciesRows(dependenciesInfoArray: DependenciesInfo[]): Array<string[]> {
-    return dependenciesInfoArray.map((dependency: DependenciesInfo) => {
-      const row = [];
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      row.push(dependency.id.toString());
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      row.push(dependency.depth.toString());
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      row.push(dependency.parent === component.id.toString() ? '<self>' : dependency.parent);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      row.push(dependency.dependencyType);
-      return row;
-    });
   }
 
   function calculatePadRightLength(str: string, columnWidth: number): string {
@@ -270,4 +234,31 @@ export default function paintComponent(
     const padRightCount = Math.ceil(str.length / columnWidth) * columnWidth;
     return str.length > columnWidth ? rightpad(str, padRightCount, ' ') : rightpad(str, columnWidth, ' ');
   }
+}
+
+function getAllDependenciesRows(dependenciesInfoArray: DependenciesInfo[], id: BitId): Array<string[]> {
+  return dependenciesInfoArray.map((dependency: DependenciesInfo) => {
+    const row: string[] = [];
+    row.push(dependency.id.toString());
+    row.push(dependency.depth.toString());
+    row.push(dependency.parent === id.toString() ? '<self>' : dependency.parent);
+    row.push(dependency.dependencyType);
+    return row;
+  });
+}
+
+export function generateDependentsInfoTable(dependentsInfo: DependenciesInfo[], id: BitId) {
+  if (!dependentsInfo.length) {
+    return '';
+  }
+  const dependentsHeader: string[][] = [];
+  dependentsHeader.push([
+    c.cyan('Dependent ID'),
+    c.cyan('Depth'),
+    c.cyan('Immediate Dependency'),
+    c.cyan('Dependent type'),
+  ]);
+  const allDependenciesRows = getAllDependenciesRows(dependentsInfo, id);
+  const dependentsTable = table(dependentsHeader.concat(allDependenciesRows));
+  return `\n${c.bold('Dependents Details')}\n${dependentsTable}`;
 }

--- a/src/scope/component-ops/get-flattened-dependencies.ts
+++ b/src/scope/component-ops/get-flattened-dependencies.ts
@@ -7,6 +7,7 @@ import { BitId, BitIds } from '../../bit-id';
 import { BitIdStr } from '../../bit-id/bit-id';
 import Component from '../../consumer/component/consumer-component';
 import GeneralError from '../../error/general-error';
+import logger from '../../logger/logger';
 import { buildComponentsGraphCombined } from '../graph/components-graph';
 import Graph from '../graph/graph';
 import VersionDependencies from '../version-dependencies';
@@ -41,6 +42,7 @@ export class FlattenedDependenciesGetter {
    * if there is even only one devDependency in the chain, then it's a devDependency.
    */
   async populateFlattenedDependencies() {
+    logger.debug(`populateFlattenedDependencies starts with ${this.components.length} components`);
     this.createGraphs(this.components);
     await this.importExternalDependenciesInBulk();
     await mapSeries(this.components, async (component) => {

--- a/src/scope/component-ops/traverse-versions.ts
+++ b/src/scope/component-ops/traverse-versions.ts
@@ -65,7 +65,7 @@ export async function getAllVersionsInfo({
             await addParentsRecursively(parentVersion);
           } else {
             versionInfo.error = versionInfo.tag
-              ? new VersionNotFound(versionInfo.tag)
+              ? new VersionNotFound(versionInfo.tag, modelComponent.id())
               : new ParentNotFound(modelComponent.id(), version.hash().toString(), parent.toString());
             if (throws) throw versionInfo.error;
           }
@@ -87,7 +87,7 @@ export async function getAllVersionsInfo({
         const versionInfo: VersionInfo = { ref, tag: version };
         if (versionObj) versionInfo.version = versionObj;
         else {
-          versionInfo.error = new VersionNotFound(version);
+          versionInfo.error = new VersionNotFound(version, modelComponent.id());
           if (throws) throw versionInfo.error;
         }
         results.push(versionInfo);

--- a/src/scope/exceptions/version-not-found.ts
+++ b/src/scope/exceptions/version-not-found.ts
@@ -1,9 +1,7 @@
 import AbstractError from '../../error/abstract-error';
 
 export default class VersionNotFound extends AbstractError {
-  version: string;
-  constructor(version: string) {
+  constructor(public version: string, public componentId: string) {
     super();
-    this.version = version;
   }
 }

--- a/src/scope/graph/scope-graph.ts
+++ b/src/scope/graph/scope-graph.ts
@@ -56,7 +56,7 @@ export default class DependencyGraph {
    * @todo: refactor this to work with the newer method `buildGraphFromScope`.
    */
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  static async buildGraphWithAllVersions(scope: Scope): Graph {
+  static async buildGraphWithAllVersions(scope: Scope): Promise<Graph> {
     const graph = new Graph({ compound: true });
     const depObj: { [id: string]: Version } = {};
     const allComponents = await scope.list();

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -475,14 +475,14 @@ export default class Component extends BitObject {
 
   async loadVersion(version: string, repository: Repository): Promise<Version> {
     const versionRef = this.getRef(version);
-    if (!versionRef) throw new VersionNotFound(version);
+    if (!versionRef) throw new VersionNotFound(version, this.id());
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return versionRef.load(repository);
   }
 
   loadVersionSync(version: string, repository: Repository, throws = true): Version {
     const versionRef = this.getRef(version);
-    if (!versionRef) throw new VersionNotFound(version);
+    if (!versionRef) throw new VersionNotFound(version, this.id());
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return versionRef.loadSync(repository, throws);
   }


### PR DESCRIPTION
* Introduce a new command `bit dependents`, it shows the dependents of the given component-id nicely with the level of how far is it from the id.
* improve `ComponentNotFound` error to suggest using this command.
* improve `VersionNotFound` error to include the component-id.