### PR TITLE
Avoid creating capsules for the same components with different versions

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -327,7 +327,9 @@ export class Workspace implements ComponentFactory {
     const seedersStr = seederIdsWithVersions.map((s) => s.toString());
     const compsAndDeps = graph.findSuccessorsInGraph(seedersStr);
     const consumerComponents = compsAndDeps.filter((c) =>
-      this.consumer.bitMap.getComponentIfExist(c.id, { ignoreVersion: true })
+      // do not ignore the version here. a component might be in .bitmap with one version and
+      // installed as a package with another version. we don't want them both.
+      this.consumer.bitMap.getComponentIfExist(c.id)
     );
     const ids = await this.resolveMultipleComponentIds(consumerComponents.map((c) => c.id));
     const components = await this.getMany(ids, true);


### PR DESCRIPTION
when a component is directly imported and installed as a package with a different version, create only one capsule for the imported.