### PR TITLE
block exporting outdated components

### DIFF
--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -701,4 +701,33 @@ describe('bit snap command', function () {
       expect(() => helper.command.catObject(fileObj)).to.not.throw();
     });
   });
+  describe('merge tags', () => {
+    let authorFirstTag;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.exportAllComponents();
+      authorFirstTag = helper.scopeHelper.cloneLocalScope();
+      helper.fixtures.populateComponents(1, undefined, ' v2');
+      helper.command.tagAllWithoutBuild();
+      helper.command.exportAllComponents();
+      helper.scopeHelper.getClonedLocalScope(authorFirstTag);
+      helper.fixtures.populateComponents(1, undefined, ' v3');
+      helper.command.tagAllWithoutBuild('-s 0.0.3');
+      helper.command.importAllComponents();
+    });
+    it('should prevent exporting the component', () => {
+      const exportFunc = () => helper.command.exportAllComponents();
+      const ids = [{ id: `${helper.scopes.remote}/comp1` }];
+      const error = new MergeConflictOnRemote([], ids);
+      helper.general.expectToThrow(exportFunc, error);
+
+      // also it should not delete versions.
+      const compData = helper.command.catComponent('comp1');
+      const firstTag = compData.versions['0.0.1'];
+      expect(() => helper.command.catObject(firstTag)).to.not.throw();
+    });
+  });
 });

--- a/src/cli/commands/private-cmds/cat-object-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-object-cmd.ts
@@ -9,7 +9,7 @@ export default class CatObject implements LegacyCommand {
   opts = [
     ['p', 'pretty', 'pretty print for the objects'],
     ['s', 'stringify', 'JSON.stringify the object to see special characters, such as "\n"'],
-    ['h', 'headers', 'shows the headers only'],
+    ['', 'headers', 'shows the headers only'],
   ] as CommandOptions;
 
   action(

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -251,9 +251,10 @@ once your changes are merged with the new remote version, you can tag and export
       }
       if (err.idsNeedUpdate) {
         output += `error: merge error occurred when exporting the component(s) ${err.idsNeedUpdate
-          .map((i) => `${chalk.bold(i.id)} (lane: ${i.lane})`)
+          .map((i) => `${chalk.bold(i.id)}${i.lane ? ` (lane: ${i.lane})` : ''}`)
           .join(', ')} to the remote scope.
-to resolve this error, please re-import the above components`;
+to resolve this error, please re-import the above components.
+if the component is up to date, run "bit status" to make sure it's not merge-pending`;
       }
       return output;
     },

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -6,7 +6,7 @@ import rightpad from 'pad-right';
 import * as path from 'path';
 import tar from 'tar';
 
-import { ENV_VAR_FEATURE_TOGGLE } from '../api/consumer/lib/feature-toggle';
+import { BUILD_ON_CI, ENV_VAR_FEATURE_TOGGLE } from '../api/consumer/lib/feature-toggle';
 import { NOTHING_TO_TAG_MSG } from '../api/consumer/lib/tag';
 import { NOTHING_TO_SNAP_MSG } from '../cli/commands/public-cmds/snap-cmd';
 import { CURRENT_UPSTREAM, LANE_REMOTE_DELIMITER } from '../constants';
@@ -149,6 +149,11 @@ export default class CommandHelper {
     if (assertTagged) expect(result).to.not.have.string(NOTHING_TO_TAG_MSG);
     return result;
   }
+  tagAllWithoutBuild(options = '') {
+    const result = this.runCmd(`bit tag -a ${options}`, undefined, undefined, BUILD_ON_CI);
+    expect(result).to.not.have.string(NOTHING_TO_TAG_MSG);
+    return result;
+  }
   rewireAndTagAllComponents(options = '', version = '', assertTagged = true) {
     this.linkAndRewire();
     return this.tagAllComponents(options, version, assertTagged);
@@ -164,6 +169,9 @@ export default class CommandHelper {
   }
   snapComponent(id: string, tagMsg = 'snap-message', options = '') {
     return this.runCmd(`bit snap ${id} -m ${tagMsg} ${options}`);
+  }
+  snapComponentWithoutBuild(id: string, options = '') {
+    return this.runCmd(`bit snap ${id} ${options}`, undefined, undefined, BUILD_ON_CI);
   }
   snapAllComponents(options = '', assertSnapped = true) {
     const result = this.runCmd(`bit snap -a ${options} `);

--- a/src/scope/component-ops/traverse-versions.ts
+++ b/src/scope/component-ops/traverse-versions.ts
@@ -14,7 +14,18 @@ import { HeadNotFound, ParentNotFound, VersionNotFound } from '../exceptions';
 import { ModelComponent, Version } from '../models';
 import { Ref, Repository } from '../objects';
 
-type VersionInfo = { ref: Ref; tag?: string; version?: Version; error?: Error };
+type VersionInfo = {
+  ref: Ref;
+  tag?: string;
+  version?: Version;
+  error?: Error;
+  /**
+   * can be 'false' when retrieved from the tags data on the component-object and the Version is
+   * not legacy. It can happen when running "bit import" on a diverge component and before the
+   * merge. the component itself is merged, but the head wasn't changed.
+   */
+  isPartOfHistory?: boolean;
+};
 
 /**
  * by default it starts the traverse from the head or lane-head, unless "startFrom" is passed.
@@ -59,7 +70,11 @@ export async function getAllVersionsInfo({
       await Promise.all(
         version.parents.map(async (parent) => {
           const parentVersion = await getVersionObj(parent);
-          const versionInfo: VersionInfo = { ref: parent, tag: modelComponent.getTagOfRefIfExists(parent) };
+          const versionInfo: VersionInfo = {
+            ref: parent,
+            tag: modelComponent.getTagOfRefIfExists(parent),
+            isPartOfHistory: true,
+          };
           if (parentVersion) {
             versionInfo.version = parentVersion;
             await addParentsRecursively(parentVersion);
@@ -85,8 +100,12 @@ export async function getAllVersionsInfo({
         const ref = modelComponent.versions[version];
         const versionObj = await getVersionObj(ref);
         const versionInfo: VersionInfo = { ref, tag: version };
-        if (versionObj) versionInfo.version = versionObj;
-        else {
+        if (versionObj) {
+          versionInfo.version = versionObj;
+          // legacy versions didn't have the "parents" concept and they're part of the history.
+          // for new versions, since we didn't find this tag during the traversal, they're not part of history.
+          versionInfo.isPartOfHistory = Boolean(versionObj.isLegacy);
+        } else {
           versionInfo.error = new VersionNotFound(version, modelComponent.id());
           if (throws) throw versionInfo.error;
         }

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -48,7 +48,6 @@ type State = {
   };
 };
 
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 type Versions = { [version: string]: Ref };
 export type ScopeListItem = { url: string; name: string; date: string };
 


### PR DESCRIPTION
This is working properly when snapping. However, with tags, when the local and the remote components have diverged and the component is exported, the export was going through unexpectedly. 