### PR TITLE
enable re-sign failed components

### DIFF
--- a/scopes/scope/sign/sign.cmd.ts
+++ b/scopes/scope/sign/sign.cmd.ts
@@ -2,47 +2,57 @@ import chalk from 'chalk';
 import { Command, CommandOptions } from '@teambit/cli';
 import { ComponentID } from '@teambit/component';
 import { ScopeMain } from '@teambit/scope';
-import { Workspace } from '@teambit/workspace';
 import { BuildStatus } from 'bit-bin/dist/constants';
-import { BitError } from '@teambit/bit-error';
 import { SignMain } from './sign.main.runtime';
 
 export class SignCmd implements Command {
-  name = 'sign [component...]';
+  name = 'sign <component...>';
   description = 'complete the build process for components';
   alias = '';
   group = 'component';
   options = [] as CommandOptions;
 
-  constructor(private signMain: SignMain, private scope: ScopeMain, private workspace?: Workspace) {}
+  constructor(private signMain: SignMain, private scope: ScopeMain) {}
 
   async report([components]: [string[]]) {
-    const compIds = await this.getComponentIdsToSign(components);
-    if (!compIds.length) return chalk.bold(`no pending-build components were found`);
-    const results = await this.signMain.sign(compIds);
+    const { componentsToSkip, componentsToSign } = await this.getComponentIdsToSign(components);
+    if (componentsToSkip.length) {
+      // eslint-disable-next-line no-console
+      console.log(`the following component(s) were already signed successfully:
+${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
+    }
+    if (!componentsToSign.length) {
+      return chalk.bold('no more components left to sign');
+    }
+    const results = await this.signMain.sign(componentsToSign);
     const status = results.error ? BuildStatus.Failed : BuildStatus.Succeed;
     const error = results.error ? `${results.error}\n\n` : '';
     const color = error ? 'red' : 'green';
-    const signed = `signed total ${results.components.length} components, with build-status ${status}`;
-    return error + chalk.bold[color](signed);
+    const signed = `the following ${results.components.length} component(s) were signed with build-status "${status}"
+${componentsToSign.map((c) => c.toString()).join('\n')}`;
+    return {
+      data: error + chalk.bold[color](signed),
+      code: error ? 1 : 0,
+    };
   }
 
-  async getComponentIdsToSign(ids: string[]): Promise<ComponentID[]> {
-    if (ids.length) {
-      const compIds = await this.scope.resolveMultipleComponentIds(ids);
-      const components = await this.scope.getMany(compIds);
-      components.forEach((component) => {
-        if (component.state._consumer.buildStatus !== BuildStatus.Pending) {
-          throw new BitError(`unable to sign "${component.id.toString()}" its build-status is not "pending"`);
-        }
-      });
-      return compIds;
-    }
-    if (!this.workspace) {
-      throw new Error('please specify component ids to sign');
-    }
-    const allComponents = await this.workspace.list();
-    const buildPending = allComponents.filter((comp) => comp.state._consumer.buildStatus === BuildStatus.Pending);
-    return buildPending.map((comp) => comp.id);
+  async getComponentIdsToSign(
+    ids: string[]
+  ): Promise<{
+    componentsToSkip: ComponentID[];
+    componentsToSign: ComponentID[];
+  }> {
+    const compIds = await this.scope.resolveMultipleComponentIds(ids);
+    const components = await this.scope.getMany(compIds);
+    const componentsToSign: ComponentID[] = [];
+    const componentsToSkip: ComponentID[] = [];
+    components.forEach((component) => {
+      if (component.state._consumer.buildStatus === BuildStatus.Succeed) {
+        componentsToSkip.push(component.id);
+      } else {
+        componentsToSign.push(component.id);
+      }
+    });
+    return { componentsToSkip, componentsToSign };
   }
 }

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -3,7 +3,6 @@ import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { LoggerAspect, LoggerMain, Logger } from '@teambit/logger';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
-import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { Component, ComponentID } from '@teambit/component';
 import {
   getPublishedPackages,
@@ -46,18 +45,12 @@ export class SignMain {
 
   static runtime = MainRuntime;
 
-  static dependencies = [CLIAspect, WorkspaceAspect, ScopeAspect, LoggerAspect, BuilderAspect];
+  static dependencies = [CLIAspect, ScopeAspect, LoggerAspect, BuilderAspect];
 
-  static async provider([cli, workspace, scope, loggerMain, builder]: [
-    CLIMain,
-    Workspace,
-    ScopeMain,
-    LoggerMain,
-    BuilderMain
-  ]) {
+  static async provider([cli, scope, loggerMain, builder]: [CLIMain, ScopeMain, LoggerMain, BuilderMain]) {
     const logger = loggerMain.createLogger(SignAspect.id);
     const signMain = new SignMain(scope, logger, builder);
-    cli.register(new SignCmd(signMain, scope, workspace));
+    cli.register(new SignCmd(signMain, scope));
     return signMain;
   }
 }


### PR DESCRIPTION
## Proposed Changes

- if the previous sign has failed, allow re-try. 
- if the previous sign has succeed, don't throw an error. instead, show a message saying that it was signed already.
- if the build failed, exit with status code 1.
