### PR TITLE
enter last-track data to the cache only during bitmap.write process not before

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -429,7 +429,7 @@ export class Workspace implements ComponentFactory {
     // if a new file was added, upon component-load, its .bitmap entry is updated to include the
     // new file. write these changes to the .bitmap file so then other processes have access to
     // this new file. If the .bitmap wasn't change, it won't do anything.
-    await this.consumer.bitMap.write();
+    await this.consumer.bitMap.write(this.consumer.componentFsCache);
     const onChangeEntries = this.onComponentChangeSlot.toArray(); // e.g. [ [ 'teambit.bit/compiler', [Function: bound onComponentChange] ] ]
     const results: Array<{ extensionId: string; results: SerializableResults }> = [];
     await BluebirdPromise.mapSeries(onChangeEntries, async ([extension, onChangeFunc]) => {
@@ -555,7 +555,7 @@ export class Workspace implements ComponentFactory {
     const addResults = await addComponent.add();
     // @todo: the legacy commands have `consumer.onDestroy()` on command completion, it writes the
     //  .bitmap file. workspace needs a similar mechanism. once done, remove the next line.
-    await this.consumer.bitMap.write();
+    await this.consumer.bitMap.write(this.consumer.componentFsCache);
     return addResults;
   }
 

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -76,6 +76,7 @@ export default class ComponentMap {
   defaultVersion?: string | null;
   isAvailableOnCurrentLane? = true; // if a component was created on another lane, it might not be available on the current lane
   nextVersion?: NextVersion; // for soft-tag (harmony only), this data is used in the CI to persist
+  recentlyTracked?: boolean; // eventually the timestamp is saved in the filesystem cache so it won't be re-tracked if not changed
   constructor({
     id,
     files,
@@ -411,7 +412,7 @@ export default class ComponentMap {
       logger.info(`new file(s) have been added to .bitmap for ${id.toString()}`);
       consumer.bitMap.hasChanged = true;
     }
-    await consumer.componentFsCache.setLastTrackTimestamp(id.toString(), Date.now());
+    this.recentlyTracked = true;
   }
 
   updateNextVersion(nextVersion: NextVersion) {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -221,7 +221,7 @@ export default class Consumer {
     result.bitMap.markAsChanged();
     // Update the version of the bitmap instance of the consumer (to prevent duplicate migration)
     this.bitMap.version = result.bitMap.version;
-    await result.bitMap.write();
+    await result.bitMap.write(this.componentFsCache);
 
     loader.stop();
 
@@ -234,7 +234,7 @@ export default class Consumer {
   async write(): Promise<Consumer> {
     await Promise.all([this.config.write({ workspaceDir: this.projectPath }), this.scope.ensureDir()]);
     this.bitMap.markAsChanged();
-    await this.bitMap.write();
+    await this.bitMap.write(this.componentFsCache);
     return this;
   }
 
@@ -1001,6 +1001,6 @@ export default class Consumer {
   async onDestroy() {
     await this.cleanTmpFolder();
     await this.scope.scopeJson.writeIfChanged(this.scope.path);
-    return this.bitMap.write();
+    return this.bitMap.write(this.componentFsCache);
   }
 }


### PR DESCRIPTION
currently, the lastTrack entered to the cache even if the .bitmap changes were not written