### PR TITLE
clear scopes caches after bit-sign

### DIFF
--- a/scopes/scope/sign/sign.cmd.ts
+++ b/scopes/scope/sign/sign.cmd.ts
@@ -3,6 +3,7 @@ import { Command, CommandOptions } from '@teambit/cli';
 import { ComponentID } from '@teambit/component';
 import { ScopeMain } from '@teambit/scope';
 import { BuildStatus } from 'bit-bin/dist/constants';
+import { Logger } from '@teambit/logger';
 import { SignMain } from './sign.main.runtime';
 
 export class SignCmd implements Command {
@@ -12,7 +13,7 @@ export class SignCmd implements Command {
   group = 'component';
   options = [] as CommandOptions;
 
-  constructor(private signMain: SignMain, private scope: ScopeMain) {}
+  constructor(private signMain: SignMain, private scope: ScopeMain, private logger: Logger) {}
 
   async report([components]: [string[]]) {
     const { componentsToSkip, componentsToSign } = await this.getComponentIdsToSign(components);
@@ -44,6 +45,7 @@ ${componentsToSign.map((c) => c.toString()).join('\n')}`;
   }> {
     const compIds = await this.scope.resolveMultipleComponentIds(ids);
     // using `loadComponents` instead of `getMany` to make sure component aspects are loaded.
+    this.logger.setStatusLine(`loading ${ids.length} components and their extensions...`);
     const components = await this.scope.loadMany(compIds);
     const componentsToSign: ComponentID[] = [];
     const componentsToSkip: ComponentID[] = [];

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -1,4 +1,5 @@
 import mapSeries from 'p-map-series';
+import { uniq } from 'lodash';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { LoggerAspect, LoggerMain, Logger } from '@teambit/logger';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
@@ -10,6 +11,9 @@ import {
 } from 'bit-bin/dist/scope/component-ops/tag-model-component';
 import ConsumerComponent from 'bit-bin/dist/consumer/component';
 import { BuildStatus } from 'bit-bin/dist/constants';
+import { getScopeRemotes } from 'bit-bin/dist/scope/scope-remotes';
+import { ClearScopeCache } from 'bit-bin/dist/scope/actions';
+import { Remotes } from 'bit-bin/dist/remotes';
 import { SignCmd } from './sign.cmd';
 import { SignAspect } from './sign.aspect';
 
@@ -28,11 +32,23 @@ export class SignMain {
     const pipeWithError = pipeResults.find((pipe) => pipe.hasErrors());
     const buildStatus = pipeWithError ? BuildStatus.Failed : BuildStatus.Succeed;
     await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+    await this.clearScopesCaches(legacyComponents);
     return {
       components,
       publishedPackages,
       error: pipeWithError ? pipeWithError.getErrorMessageFormatted() : null,
     };
+  }
+
+  private async clearScopesCaches(components: ConsumerComponent[]) {
+    const scopes = uniq(components.map((c) => c.scope as string));
+    const scopeRemotes: Remotes = await getScopeRemotes(this.scope.legacyScope);
+    await Promise.all(
+      scopes.map(async (scopeName) => {
+        const remote = await scopeRemotes.resolve(scopeName, this.scope.legacyScope);
+        return remote.action(ClearScopeCache.name);
+      })
+    );
   }
 
   private async saveExtensionsDataIntoScope(components: ConsumerComponent[], buildStatus: BuildStatus) {
@@ -50,7 +66,7 @@ export class SignMain {
   static async provider([cli, scope, loggerMain, builder]: [CLIMain, ScopeMain, LoggerMain, BuilderMain]) {
     const logger = loggerMain.createLogger(SignAspect.id);
     const signMain = new SignMain(scope, logger, builder);
-    cli.register(new SignCmd(signMain, scope));
+    cli.register(new SignCmd(signMain, scope, logger));
     return signMain;
   }
 }

--- a/src/api/scope/lib/action.ts
+++ b/src/api/scope/lib/action.ts
@@ -1,12 +1,25 @@
 import { loadScope, Scope } from '../../../scope';
-import { Action, ExportValidate, ExportPersist, RemovePendingDir, FetchMissingDeps } from '../../../scope/actions';
+import {
+  Action,
+  ExportValidate,
+  ExportPersist,
+  RemovePendingDir,
+  FetchMissingDeps,
+  ClearScopeCache,
+} from '../../../scope/actions';
 import ActionNotFound from '../../../scope/exceptions/action-not-found';
 
 type ActionClassesList = new () => Action<any, any>;
 
 export async function action(scopePath: string, name: string, options: Record<string, any>): Promise<any> {
   const scope: Scope = await loadScope(scopePath);
-  const actionList: ActionClassesList[] = [ExportValidate, ExportPersist, RemovePendingDir, FetchMissingDeps];
+  const actionList: ActionClassesList[] = [
+    ExportValidate,
+    ExportPersist,
+    RemovePendingDir,
+    FetchMissingDeps,
+    ClearScopeCache,
+  ];
   const ActionClass = actionList.find((a) => a.name === name);
   if (!ActionClass) {
     throw new ActionNotFound(name);

--- a/src/remotes/remote.ts
+++ b/src/remotes/remote.ts
@@ -126,7 +126,7 @@ export default class Remote {
   listLanes(name?: string, mergeData?: boolean): Promise<LaneData[]> {
     return this.connect().then((network) => network.listLanes(name, mergeData));
   }
-  async action<Options, Result>(name: string, options: Options): Promise<Result> {
+  async action<Options, Result>(name: string, options?: Options): Promise<Result> {
     const network = await this.connect();
     logger.debug(`[-] Running action ${name} on a remote ${this.name}, options: ${JSON.stringify(options)}`);
     const results: Result = await network.action(name, options);

--- a/src/scope/actions/action.ts
+++ b/src/scope/actions/action.ts
@@ -1,5 +1,5 @@
 import type { Scope } from '..';
 
-export interface Action<Options, Result> {
-  execute(scope: Scope, options: Options): Promise<Result>;
+export interface Action<Options = undefined, Result = void> {
+  execute(scope: Scope, options?: Options): Promise<Result>;
 }

--- a/src/scope/actions/clear-scope-cache.ts
+++ b/src/scope/actions/clear-scope-cache.ts
@@ -1,0 +1,12 @@
+import { Scope } from '..';
+import { Action } from './action';
+
+/**
+ * load objects from pending-dir by a client-id and persist them to the object directory.
+ * once done, remove the pending-dir to free the resource.
+ */
+export class ClearScopeCache implements Action {
+  async execute(scope: Scope): Promise<void> {
+    scope.objects.clearCache();
+  }
+}

--- a/src/scope/actions/export-validate.ts
+++ b/src/scope/actions/export-validate.ts
@@ -18,7 +18,7 @@ const WAIT_BEFORE_RETRY_IN_MS = 1000;
  * once done, clear the objects from the memory so then they won't be used by mistake later on.
  * this also makes sure that non-external dependencies are not missing.
  */
-export class ExportValidate implements Action<Options, void> {
+export class ExportValidate implements Action<Options> {
   scope: Scope;
   clientId: string;
   async execute(scope: Scope, options: Options) {

--- a/src/scope/actions/fetch-missing-deps.ts
+++ b/src/scope/actions/fetch-missing-deps.ts
@@ -10,7 +10,7 @@ type Options = { ids: string[] };
  * to avoid left-pad kind of situation, make sure that all external dependencies are cached. if
  * they don't exist, import them.
  */
-export class FetchMissingDeps implements Action<Options, void> {
+export class FetchMissingDeps implements Action<Options> {
   async execute(scope: Scope, options: Options): Promise<void> {
     logger.debugAndAddBreadCrumb('FetchMissingDeps', 'trying to importMany in case there are missing dependencies');
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);

--- a/src/scope/actions/index.ts
+++ b/src/scope/actions/index.ts
@@ -3,3 +3,4 @@ export { ExportPersist } from './export-persist';
 export { ExportValidate } from './export-validate';
 export { RemovePendingDir } from './remove-pending-dir';
 export { FetchMissingDeps } from './fetch-missing-deps';
+export { ClearScopeCache } from './clear-scope-cache';

--- a/src/scope/actions/remove-pending-dir.ts
+++ b/src/scope/actions/remove-pending-dir.ts
@@ -6,7 +6,7 @@ type Options = { clientId: string };
 /**
  * used mainly to free the resources when the export process failed.
  */
-export class RemovePendingDir implements Action<Options, void> {
+export class RemovePendingDir implements Action<Options> {
   async execute(scope: Scope, options: Options) {
     await scope.removePendingDir(options.clientId);
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -255,6 +255,7 @@ export default class Repository {
   }
 
   clearCache() {
+    logger.debug('repository.clearCache');
     this._cache = {};
   }
 


### PR DESCRIPTION
## Proposed Changes

- with this change, once bit-sign changes the objects, the main bit-start process could fetch the updated data. (these two are running in two different processes).
