### PR TITLE
fix tsc errors on Circle

### DIFF
--- a/scopes/explorer/command-bar/ui/command-searcher/command-searcher.ts
+++ b/scopes/explorer/command-bar/ui/command-searcher/command-searcher.ts
@@ -21,6 +21,7 @@ export class CommandSearcher implements SearchProvider {
   search(term: string, limit: number): CommanderSearchResult[] {
     const unprefixedPattern = term.replace(/^>/, '');
     const searchResults = this.fuseCommands.search(unprefixedPattern, { limit });
+    // @ts-ignore this shows error on Circle for some weird reason
     return searchResults.map((x) => x.item);
   }
 

--- a/scopes/explorer/command-bar/ui/component-searcher/component-searcher.ts
+++ b/scopes/explorer/command-bar/ui/component-searcher/component-searcher.ts
@@ -34,6 +34,7 @@ export class ComponentSearcher implements SearchProvider {
 
   search(term: string, limit: number): ComponentSearchResult[] {
     const searchResults = this.fuseCommands.search(term, { limit });
+    // @ts-ignore this shows error on Circle for some weird reason
     return searchResults.map((x) => x.item);
   }
 


### PR DESCRIPTION
On Circle it shows these errors for some reason:
```
scopes/explorer/command-bar/ui/command-searcher/command-searcher.ts:24:5 - error TS2322: Type 'unknown[]' is not assignable to type 'CommanderSearchResult[]'.
  Type 'unknown' is not assignable to type 'CommanderSearchResult'.

24     return searchResults.map((x) => x.item);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

scopes/explorer/command-bar/ui/component-searcher/component-searcher.ts:37:5 - error TS2322: Type 'unknown[]' is not assignable to type 'ComponentSearchResult[]'.
  Type 'unknown' is not assignable to type 'ComponentSearchResult'.
    Type 'unknown' is not assignable to type 'CommanderSearchResult'.

37     return searchResults.map((x) => x.item);
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 2 errors.
```