### PR TITLE
fix VersionNotFound to show the error message when thrown by the remote

### DIFF
--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -89,7 +89,6 @@ import {
   ScopeJsonNotFound,
   ScopeNotFound,
   VersionAlreadyExists,
-  VersionNotFound,
 } from '../scope/exceptions';
 import {
   AuthenticationFailed,
@@ -412,14 +411,6 @@ please use "bit remove" to delete the component or "bit add" with "--main" and "
   [FlagHarmonyOnly, (err) => `the flag: "${chalk.bold(err.flag)}" allowed only on harmony workspace`],
   [WriteToNpmrcError, (err) => `unable to add @bit as a scoped registry at "${chalk.bold(err.path)}"`],
   [PathToNpmrcNotExist, (err) => `error: file or directory "${chalk.bold(err.path)}" was not found.`],
-
-  [
-    VersionNotFound,
-    (err) =>
-      `error: version "${chalk.bold(err.version)}"${
-        err.componentId ? ` of component ${chalk.bold(err.componentId)}` : ''
-      } was not found.`,
-  ],
   [
     ParentNotFound,
     (err) =>

--- a/src/scope/exceptions/version-not-found.ts
+++ b/src/scope/exceptions/version-not-found.ts
@@ -1,7 +1,12 @@
-import AbstractError from '../../error/abstract-error';
+import { BitError } from '@teambit/bit-error';
+import chalk from 'chalk';
 
-export default class VersionNotFound extends AbstractError {
+export default class VersionNotFound extends BitError {
   constructor(public version: string, public componentId: string) {
-    super();
+    super(
+      `error: version "${chalk.bold(version)}"${
+        componentId ? ` of component ${chalk.bold(componentId)}` : ''
+      } was not found.`
+    );
   }
 }


### PR DESCRIPTION
Currently, it doesn't show the error message only the class name.