### PR TITLE
avoid printing the entire object-list into the log

### DIFF
--- a/src/hooks/hooks-manager.ts
+++ b/src/hooks/hooks-manager.ts
@@ -179,6 +179,9 @@ function _stripArgs(args) {
   if (res.componentObjects) {
     res.componentObjects = res.componentObjects.length;
   }
+  if (res.objectList) {
+    res.objectList = res.objectList.count();
+  }
   return res;
 }
 


### PR DESCRIPTION
Currently, it prints them during the export, which is useless and makes it hard to navigate through the log. 
Instead, show only the number of objects.