### PR TITLE
fix unique gql ids

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -210,6 +210,7 @@
         "mutation-observer": "1.0.3",
         "nerf-dart": "1.0.0",
         "node-fetch": "2.6.0",
+        "object-hash": "2.1.1",
         "optimize-css-assets-webpack-plugin": "^5.0.3",
         "parallel-webpack": "^2.6.0",
         "parse-es6-imports": "1.0.1",


### PR DESCRIPTION
## Proposed Changes

- fix different gql objects having the same id
- prefix gql id with typename (e.g. fixes conflict between graphNodeComponent and component)
- fallback to typename + hash when id is an object