### PR TITLE
attach aspects versions from bitmap to aspect ids during harmony config load

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -84,7 +84,8 @@ function attachVersionsFromBitmap(config: Config, consumerInfo: ConsumerInfo): C
   const result = Object.entries(rawConfig).reduce((acc, [aspectId, aspectConfig]) => {
     let newAspectEntry = aspectId;
     // In case the id already has a version we don't want to get it from the bitmap
-    if (!aspectId.includes(VERSION_DELIMITER)) {
+    // We also don't want to add versions for core aspects
+    if (!aspectId.includes(VERSION_DELIMITER) && !manifestsMap[aspectId]) {
       const versionFromBitmap = getVersionFromBitMapIds(allBitmapIds, aspectId);
       if (versionFromBitmap) {
         newAspectEntry = `${aspectId}${VERSION_DELIMITER}${versionFromBitmap}`;

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -82,10 +82,13 @@ function attachVersionsFromBitmap(config: Config, consumerInfo: ConsumerInfo): C
   const parsedBitMap = rawBitmap ? json.parse(rawBitmap?.toString('utf8'), undefined, true) : {};
   const allBitmapIds = Object.keys(parsedBitMap);
   const result = Object.entries(rawConfig).reduce((acc, [aspectId, aspectConfig]) => {
-    const versionFromBitmap = getVersionFromBitMapIds(allBitmapIds, aspectId);
     let newAspectEntry = aspectId;
-    if (versionFromBitmap) {
-      newAspectEntry = `${aspectId}${VERSION_DELIMITER}${versionFromBitmap}`;
+    // In case the id already has a version we don't want to get it from the bitmap
+    if (!aspectId.includes(VERSION_DELIMITER)) {
+      const versionFromBitmap = getVersionFromBitMapIds(allBitmapIds, aspectId);
+      if (versionFromBitmap) {
+        newAspectEntry = `${aspectId}${VERSION_DELIMITER}${versionFromBitmap}`;
+      }
     }
     acc[newAspectEntry] = aspectConfig;
     return acc;

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -79,7 +79,12 @@ function attachVersionsFromBitmap(config: Config, consumerInfo: ConsumerInfo): C
   }
   const rawConfig = config.toObject();
   const rawBitmap = BitMap.loadRawSync(consumerInfo.path);
-  const parsedBitMap = rawBitmap ? json.parse(rawBitmap?.toString('utf8'), undefined, true) : {};
+  let parsedBitMap = {};
+  try {
+    parsedBitMap = rawBitmap ? json.parse(rawBitmap?.toString('utf8'), undefined, true) : {};
+    // Do nothing here, invalid bitmaps will be handled later
+    // eslint-disable-next-line no-empty
+  } catch (e) {}
   const allBitmapIds = Object.keys(parsedBitMap);
   const result = Object.entries(rawConfig).reduce((acc, [aspectId, aspectConfig]) => {
     let newAspectEntry = aspectId;


### PR DESCRIPTION
## Proposed Changes

- support configuring local aspects in the workspace.jsonc without specifying a version and still get the config from the workspace.jsonc

