### PR TITLE
remove "multiple" flag from bit update-dependencies

### DIFF
--- a/scopes/scope/update-dependencies/update-dependencies.cmd.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.cmd.ts
@@ -13,7 +13,8 @@ export class UpdateDependenciesCmd implements Command {
   name = 'update-dependencies <data>';
   private = true;
   shortDescription = 'update dependencies for components and tag/snap the results';
-  description = `update dependencies for components and tag/snap the results.
+  description = `update versions dependencies for components and optionally tag/snap the results.
+this command should be running from a new bare scope, it first imports the components it needs and then processes the update.
 the input data is a stringified JSON of an array of the following object.
 {
   componentId: string; // ids always have scope, so it's safe to parse them from string
@@ -25,10 +26,8 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","dependencies
   alias = '';
   group = 'component';
   options = [
-    ['', 'tag', 'tag once the build is completed'],
-    ['', 'snap', 'snap once the build is completed'],
-    ['', 'output <dir>', 'save the updated objects to the given dir'],
-    ['', 'multiple', 'components are from different scopes'],
+    ['', 'tag', 'tag once the build is completed and export to the remote scopes'],
+    ['', 'snap', 'snap once the build is completed and export to the remote scopes'],
     ['', 'message <string>', 'message to be saved as part of the version log'],
     ['', 'username <string>', 'username to be saved as part of the version log'],
     ['', 'email <string>', 'email to be saved as part of the version log'],

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -12,9 +12,6 @@ import {
 } from 'bit-bin/dist/scope/component-ops/tag-model-component';
 import ConsumerComponent from 'bit-bin/dist/consumer/component';
 import { BuildStatus, LATEST } from 'bit-bin/dist/constants';
-import { getScopeRemotes } from 'bit-bin/dist/scope/scope-remotes';
-import { PostSign } from 'bit-bin/dist/scope/actions';
-import { Remotes } from 'bit-bin/dist/remotes';
 import { BitIds, BitId } from 'bit-bin/dist/bit-id';
 import { getValidVersionOrReleaseType } from 'bit-bin/dist/utils/semver-helper';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
@@ -27,7 +24,6 @@ export type UpdateDepsOptions = {
   tag?: boolean;
   snap?: boolean;
   output?: string;
-  multiple?: boolean;
   message?: string;
   username?: string;
   email?: string;
@@ -61,6 +57,13 @@ export class UpdateDependenciesMain {
     private dependencyResolver: DependencyResolverMain
   ) {}
 
+  /**
+   * we assume this is running from a new bare scope. so we import everything and then start working.
+   * we don't want this to be running from the original scope (like bit-sign). this command tags or
+   * snaps the results, a process that takes some time due to the build pipeline. if we start the
+   * tag on the original scope, build and then save the tag to the filesystem, we might get another
+   * tag during the process and our tag could override it.
+   */
   async updateDependenciesVersions(
     depsUpdateItemsRaw: DepUpdateItemRaw[],
     updateDepsOptions: UpdateDepsOptions
@@ -86,11 +89,7 @@ export class UpdateDependenciesMain {
     const pipeWithError = pipeResults.find((pipe) => pipe.hasErrors());
     const buildStatus = pipeWithError ? BuildStatus.Failed : BuildStatus.Succeed;
     await this.saveDataIntoLocalScope(buildStatus);
-    if (updateDepsOptions.multiple) {
-      await this.export();
-    } else {
-      await this.clearScopesCaches();
-    }
+    await this.export();
 
     return {
       depsUpdateItems: this.depsUpdateItems,
@@ -111,8 +110,7 @@ export class UpdateDependenciesMain {
     const dependenciesIds = depsUpdateItemsRaw.map((item) =>
       item.dependencies.map((dep) => ComponentID.fromString(dep)).map((id) => id.changeVersion(LATEST))
     );
-    const idsToImport = flatten(dependenciesIds);
-    if (this.updateDepsOptions.multiple) idsToImport.push(...componentIds);
+    const idsToImport = [...flatten(dependenciesIds), ...componentIds];
     // do not use cache. for dependencies we must fetch the latest ModelComponent from the remote
     // in order to match the semver later.
     await this.scope.import(idsToImport, false);
@@ -189,6 +187,7 @@ export class UpdateDependenciesMain {
         const { releaseType, exactVersion } = getValidVersionOrReleaseType(depUpdateItem.versionToTag || 'patch');
         legacyComp.version = modelComponent.getVersionToAdd(releaseType, exactVersion);
       } else {
+        // snap is the default. When the "--snap" flag wasn't used it still should snap but not export.
         legacyComp.version = modelComponent.getSnapToAdd();
       }
     });
@@ -246,18 +245,6 @@ export class UpdateDependenciesMain {
     });
   }
 
-  private async clearScopesCaches() {
-    const bitIds = BitIds.fromArray(this.legacyComponents.map((c) => c.id));
-    const idsGroupedByScope = bitIds.toGroupByScopeName(new BitIds());
-    const scopeRemotes: Remotes = await getScopeRemotes(this.scope.legacyScope);
-    await Promise.all(
-      Object.keys(idsGroupedByScope).map(async (scopeName) => {
-        const remote = await scopeRemotes.resolve(scopeName, this.scope.legacyScope);
-        return remote.action(PostSign.name, { ids: idsGroupedByScope[scopeName].map((id) => id.toString()) });
-      })
-    );
-  }
-
   private async saveDataIntoLocalScope(buildStatus: BuildStatus) {
     await mapSeries(this.legacyComponents, async (component) => {
       component.buildStatus = buildStatus;
@@ -267,6 +254,8 @@ export class UpdateDependenciesMain {
   }
 
   private async export() {
+    const shouldExport = this.updateDepsOptions.tag || this.updateDepsOptions.snap;
+    if (!shouldExport) return;
     const ids = BitIds.fromArray(this.legacyComponents.map((c) => c.id));
     await exportMany({
       scope: this.scope.legacyScope,

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -213,8 +213,8 @@ export default class CommandHelper {
     const parsed = JSON.parse(results);
     return parsed.lanes[0];
   }
-  getHead(id: string) {
-    const comp = this.catComponent(id);
+  getHead(id: string, cwd?: string) {
+    const comp = this.catComponent(id, cwd);
     return comp.head;
   }
   getHeadOfLane(laneName: string, componentName: string) {


### PR DESCRIPTION
We don't want this to be running from the original scope (like bit-sign). 
This command tags or snaps the results, a process that takes some time due to the build pipeline. If we start the tag on the original scope, build and then save the tag to the filesystem, we might get another tag during the process and our tag could override it.