### PR TITLE
add break line in scope description

### DIFF
--- a/scopes/react/react/docs/component-overview/component-overview.module.scss
+++ b/scopes/react/react/docs/component-overview/component-overview.module.scss
@@ -1,0 +1,3 @@
+.subTitle {
+  white-space: break-spaces;
+}

--- a/scopes/react/react/docs/component-overview/component-overview.tsx
+++ b/scopes/react/react/docs/component-overview/component-overview.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { textColumn } from '@teambit/base-ui.layout.page-frame';
 import { ConsumableLink } from '@teambit/documenter.ui.consumable-link';
 import { H1 } from '@teambit/documenter.ui.heading';
@@ -5,7 +6,7 @@ import { LabelList } from '@teambit/documenter.ui.label-list';
 import { Section } from '@teambit/documenter.ui.section';
 import { Separator } from '@teambit/documenter.ui.separator';
 import { Subtitle } from '@teambit/documenter.ui.sub-title';
-import React from 'react';
+import styles from './component-overview.module.scss';
 
 export type ComponentOverviewProps = {
   displayName: string;
@@ -20,7 +21,7 @@ export function ComponentOverview({ displayName, abstract, labels, packageName, 
     <Section {...rest}>
       <div className={textColumn}>
         <H1>{displayName}</H1>
-        {abstract && <Subtitle>{abstract}</Subtitle>}
+        {abstract && <Subtitle className={styles.subTitle}>{abstract}</Subtitle>}
         <LabelList>{labels}</LabelList>
         <ConsumableLink title="Package name" link={packageName}></ConsumableLink>
       </div>


### PR DESCRIPTION
## Proposed Changes

- Add break line in scope description.
At the moment, descriptions that have breaks lines are shown as a single line.
example: https://bit.dev/teambit/mdx