### PR TITLE
fix tag without build to not save the old builder data

### DIFF
--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -71,7 +71,7 @@ describe('compile extension', function () {
       it('should save the dists in the objects', () => {
         const catComp2 = helper.command.catComponent('comp2@latest');
         expect(catComp2).to.have.property('extensions');
-        const builderExt = catComp2.extensions.find((e) => e.name === Extensions.builder);
+        const builderExt = helper.general.getExtension(catComp2, Extensions.builder);
         expect(builderExt.data).to.have.property('artifacts');
         const compilerArtifacts = builderExt.data.artifacts.find((a) => a.task.id === Extensions.compiler);
         const files = compilerArtifacts.files.map((d) => d.relativePath);

--- a/e2e/harmony/harmony-tag.e2e.ts
+++ b/e2e/harmony/harmony-tag.e2e.ts
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { Extensions } from '../../src/constants';
 import { SchemaName } from '../../src/consumer/component/component-schema';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
@@ -34,6 +35,20 @@ describe('tag components on Harmony', function () {
     it('bit status should work and not show modified', () => {
       const status = helper.command.statusJson();
       expect(status.modifiedComponent).to.be.empty;
+    });
+    describe('tag without build after full tag', () => {
+      before(() => {
+        helper.command.tagAllWithoutBuild('-s 1.0.0');
+      });
+      it('should not save the builder data from the previous version', () => {
+        const comp = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
+        const builder = helper.general.getExtension(comp, Extensions.builder);
+        expect(builder.data).to.not.have.property('pipeline');
+        expect(builder.data).to.not.have.property('artifacts');
+      });
+      it('should be able to export successfully', () => {
+        expect(() => helper.command.export()).to.not.throw();
+      });
     });
   });
 });

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -20,7 +20,6 @@ export default class GeneralHelper {
     this.npm = npmHelper;
     this.command = commandHelper;
   }
-
   indexJsonPath() {
     return path.join(this.scopes.localPath, '.bit/index.json');
   }
@@ -98,5 +97,9 @@ export default class GeneralHelper {
 
   generateRandomTmpDirName() {
     return path.join(this.scopes.e2eDir, generateRandomStr());
+  }
+
+  getExtension(component, extName: string) {
+    return component.extensions.find((e) => e.name === extName);
   }
 }

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -280,6 +280,7 @@ export default async function tagModelComponent({
   } else {
     if (!skipTests) addSpecsResultsToComponents(allComponentsToTag, testsResults);
     await addFlattenedDependenciesToComponents(consumer.scope, allComponentsToTag);
+    emptyBuilderData(allComponentsToTag);
     addBuildStatus(consumer, allComponentsToTag, BuildStatus.Pending);
     await addComponentsToScope(consumer, allComponentsToTag, Boolean(resolveUnmerged));
     validateDirManipulation(allComponentsToTag);
@@ -314,6 +315,13 @@ async function addComponentsToScope(consumer: Consumer, components: Component[],
       lane,
       resolveUnmerged,
     });
+  });
+}
+
+function emptyBuilderData(components: Component[]) {
+  components.forEach((component) => {
+    const existingBuilder = component.extensions.findCoreExtension(Extensions.builder);
+    if (existingBuilder) existingBuilder.data = {};
   });
 }
 


### PR DESCRIPTION
Currently, it saves the builder data of the older versions unexpectedly. 
As a result, the following export failed due to missing artifact files.