### PR TITLE
preview iframe - ignore hotkeys focusing input

### DIFF
--- a/scopes/explorer/command-bar/command-bar.preview.runtime.tsx
+++ b/scopes/explorer/command-bar/command-bar.preview.runtime.tsx
@@ -11,6 +11,9 @@ export class CommandBarPreview {
   }
 
   handleKeyEvent = (e: KeyboardEvent) => {
+    const { target } = e;
+    if (!target || isEditable(target as HTMLElement)) return;
+
     this.pubSub.pub(CommandBarAspect.id, new KeyEvent(e))?.catch(() => {});
   };
 
@@ -20,6 +23,11 @@ export class CommandBarPreview {
     const pubsubPreview = new CommandBarPreview(pubSub);
     return pubsubPreview;
   }
+}
+
+const editableTags = ['INPUT', 'SELECT', 'TEXTAREA'];
+function isEditable(element: HTMLElement) {
+  return editableTags.includes(element.tagName) || element.isContentEditable;
 }
 
 CommandBarAspect.addRuntime(CommandBarPreview);


### PR DESCRIPTION
## Proposed Changes

- do not trigger hotkeys, or pass any key events, from preview iframe, when target element is an input (including textarea, select, and content-editable)
