### PR TITLE
disable pushing flattened dependencies to the remotes

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -51,6 +51,8 @@ describe('sign command', function () {
       helper.bitJsonc.setupDefault();
       const secondRemote = helper.scopeHelper.getNewBareScope();
       helper.scopeHelper.addRemoteScope(secondRemote.scopePath);
+      helper.scopeHelper.addRemoteScope(secondRemote.scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, secondRemote.scopePath);
       helper.fs.outputFile('comp1/index.js', `require('@${secondRemote.scopeName}/comp2');`);
       helper.fs.outputFile('comp2/index.js', `require('@${helper.scopes.remote}/comp1');`);
       helper.command.addComponent('comp1');

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -113,11 +113,14 @@ export async function exportMany({
         );
   }
 
-  manyObjectsPerRemote.forEach((objectsPerRemote) => {
-    objectsPerRemote.componentsAndObjects.forEach((componentAndObjects) =>
-      addDependenciesToObjectList(objectsPerRemote, componentAndObjects)
-    );
-  });
+  // @todo: make sure it works fine without pushing the flattened to the remote.
+  // we're going to change many things in this area very soon. currently, it seems to do more harm
+  // then good, so we disable it for now.
+  // manyObjectsPerRemote.forEach((objectsPerRemote) => {
+  //   objectsPerRemote.componentsAndObjects.forEach((componentAndObjects) =>
+  //     addDependenciesToObjectList(objectsPerRemote, componentAndObjects)
+  //   );
+  // });
   const remotes = manyObjectsPerRemote.map((o) => o.remote);
   const clientId = Date.now().toString();
   await pushRemotesPendingDir();

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -292,32 +292,32 @@ export async function exportMany({
     return { remote, objectList, objectListPerName, idsToChangeLocally, componentsAndObjects };
   }
 
-  function addDependenciesToObjectList(
-    objectsPerRemote: ObjectsPerRemote,
-    componentAndObjects: ModelComponentAndObjects
-  ): void {
-    const addDepsIfCurrentlyExported = (id: BitId) => {
-      const depScope = id.scope;
-      if (!depScope) throw new Error(`export-scope-components, unable to export ${id.toString()}, it has no scope`);
-      if (depScope === componentAndObjects.component.scope) {
-        return; // it's already included in the ObjectList.
-      }
-      const dependencyObjects = manyObjectsPerRemote.find((obj) => obj.remote.name === depScope);
-      if (!dependencyObjects) {
-        return; // this id is not currently exported. the remote will import it during the push.
-      }
-      const dependencyObjectList = dependencyObjects.objectListPerName[id.name];
-      if (!dependencyObjectList) {
-        return; // this id is not currently exported. the remote will import it during the push.
-      }
-      objectsPerRemote.objectList.mergeObjectList(dependencyObjectList);
-    };
-    // @ts-ignore
-    const versionsObjects: Version[] = componentAndObjects.objects.filter((object) => object instanceof Version);
-    versionsObjects.forEach((version: Version) => {
-      version.flattenedDependencies.forEach((id: BitId) => addDepsIfCurrentlyExported(id));
-    });
-  }
+  // function addDependenciesToObjectList(
+  //   objectsPerRemote: ObjectsPerRemote,
+  //   componentAndObjects: ModelComponentAndObjects
+  // ): void {
+  //   const addDepsIfCurrentlyExported = (id: BitId) => {
+  //     const depScope = id.scope;
+  //     if (!depScope) throw new Error(`export-scope-components, unable to export ${id.toString()}, it has no scope`);
+  //     if (depScope === componentAndObjects.component.scope) {
+  //       return; // it's already included in the ObjectList.
+  //     }
+  //     const dependencyObjects = manyObjectsPerRemote.find((obj) => obj.remote.name === depScope);
+  //     if (!dependencyObjects) {
+  //       return; // this id is not currently exported. the remote will import it during the push.
+  //     }
+  //     const dependencyObjectList = dependencyObjects.objectListPerName[id.name];
+  //     if (!dependencyObjectList) {
+  //       return; // this id is not currently exported. the remote will import it during the push.
+  //     }
+  //     objectsPerRemote.objectList.mergeObjectList(dependencyObjectList);
+  //   };
+  //   // @ts-ignore
+  //   const versionsObjects: Version[] = componentAndObjects.objects.filter((object) => object instanceof Version);
+  //   versionsObjects.forEach((version: Version) => {
+  //     version.flattenedDependencies.forEach((id: BitId) => addDepsIfCurrentlyExported(id));
+  //   });
+  // }
 
   async function pushRemotesPendingDir(): Promise<void> {
     const pushOptions = { clientId };


### PR DESCRIPTION
we're going to change many things in this area very soon. currently, it seems to do more harm than good, so we disable it for now.