### PR TITLE
ensure trailing slash at the end of preview urls

### DIFF
--- a/scopes/preview/ui/component-preview/urls.spec.ts
+++ b/scopes/preview/ui/component-preview/urls.spec.ts
@@ -69,8 +69,7 @@ describe('toPreviewServer()', () => {
   it('should use explicit server url, when available', () => {
     const result = toPreviewServer(componentWithExplicitServer);
 
-    // TODO - check trailing slash
-    expect(result).to.equal('/preview/teambit.bit/overview');
+    expect(result).to.equal('/preview/teambit.bit/overview/');
   });
 
   it('should make from component without version (latest), when explicit url is not available', () => {
@@ -127,7 +126,7 @@ describe('toPreviewUrl()', () => {
     const result = toPreviewUrl(componentWithExplicitServer, 'overview', 'who=ami');
 
     expect(result).to.equal(
-      '/preview/teambit.bit/overview#teambit.base-ui/input/button@0.6.2?preview=overview&who=ami'
+      '/preview/teambit.bit/overview/#teambit.base-ui/input/button@0.6.2?preview=overview&who=ami'
     );
   });
 

--- a/scopes/preview/ui/component-preview/urls.ts
+++ b/scopes/preview/ui/component-preview/urls.ts
@@ -15,7 +15,9 @@ export function toPreviewUrl(component: ComponentModel, previewName?: string, ad
  * generates preview server path from component data
  */
 export function toPreviewServer(component: ComponentModel) {
-  const explicitUrl = component.server?.url;
+  let explicitUrl = component.server?.url;
+  // quickfix - preview urls in `start` (without `--dev`) won't work without trailing '/'
+  if (explicitUrl && !explicitUrl.endsWith('/')) explicitUrl += '/';
 
   // // not fully working in bare-scope, and does not support version
   // const envId = component.environment?.id;


### PR DESCRIPTION
## Proposed Changes

- preview urls will not work without trailing '/', specifically when running bit start on workspaces
- this fix ensures trailing slash as a quick fix
- a fix to the preview regex might follow
