### PR TITLE
Fix env config calculation

### DIFF
--- a/scopes/component/component/aspect-entry.ts
+++ b/scopes/component/component/aspect-entry.ts
@@ -9,6 +9,10 @@ export type SerializableMap = {
   [key: string]: Serializable;
 };
 
+export type AspectData = {
+  [key: string]: any;
+};
+
 export class AspectEntry {
   constructor(public id: ComponentID, private legacyEntry: ExtensionDataEntry) {}
 

--- a/scopes/component/component/index.ts
+++ b/scopes/component/component/index.ts
@@ -7,7 +7,7 @@ export { default as ComponentFS } from './component-fs';
 export type { default as ComponentConfig } from './config';
 export type { ComponentFactory } from './component-factory';
 export type { AspectList } from './aspect-list';
-export { AspectEntry } from './aspect-entry';
+export { AspectEntry, AspectData } from './aspect-entry';
 // TODO: check why it's not working when using the index in snap dir like this:
 // export { Snap, Author } from './snap';
 export { Snap } from './snap/snap';

--- a/scopes/component/dev-files/dev-files.main.runtime.ts
+++ b/scopes/component/dev-files/dev-files.main.runtime.ts
@@ -46,7 +46,7 @@ export class DevFilesMain {
   computeDevPatterns(component: Component) {
     const entry = component.state.aspects.get(DevFilesAspect.id);
     const configuredPatterns = entry?.config.devFilePatterns || [];
-    const envDef = this.envs.getEnv(component);
+    const envDef = this.envs.calculateEnv(component);
     const envPatterns: DevPatterns[] = envDef.env?.getDevPatterns ? envDef.env.getDevPatterns() : [];
 
     const patternSlot = this.devPatternSlot.toArray();

--- a/scopes/compositions/compositions/compositions.main.runtime.ts
+++ b/scopes/compositions/compositions/compositions.main.runtime.ts
@@ -1,10 +1,10 @@
 import { join } from 'path';
 import { MainRuntime } from '@teambit/cli';
-import { Component, ComponentAspect, ComponentMap } from '@teambit/component';
+import { Component, ComponentAspect, ComponentMap, AspectData } from '@teambit/component';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { PreviewAspect, PreviewMain } from '@teambit/preview';
 import { SchemaAspect, SchemaMain } from '@teambit/schema';
-import { ExtensionData, Workspace, WorkspaceAspect } from '@teambit/workspace';
+import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { AbstractVinyl } from 'bit-bin/dist/consumer/component/sources';
 import { flatten } from 'bit-bin/dist/utils';
 import { DevFilesAspect, DevFilesMain } from '@teambit/dev-files';
@@ -81,7 +81,7 @@ export class CompositionsMain {
     );
   }
 
-  async onComponentLoad(component: Component): Promise<ExtensionData> {
+  async onComponentLoad(component: Component): Promise<AspectData> {
     const compositions = this.readCompositions(component);
     return {
       compositions: compositions.map((composition) => composition.toObject()),

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -482,7 +482,7 @@ export class DependencyResolverMain {
     let policiesFromEnv: VariantPolicy = variantPolicyFactory.getEmpty();
     let policiesFromSlots: VariantPolicy = variantPolicyFactory.getEmpty();
     let policiesFromConfig: VariantPolicy = variantPolicyFactory.getEmpty();
-    const env = this.envs.getEnvFromExtensions(configuredExtensions).env;
+    const env = this.envs.calculateEnvFromExtensions(configuredExtensions).env;
     if (env.getDependencies && typeof env.getDependencies === 'function') {
       const policiesFromEnvConfig = await env.getDependencies();
       if (policiesFromEnvConfig) {

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -130,6 +130,7 @@ export class EnvsMain {
 
   /**
    * get the env of the given component.
+   * In case you are asking for the env during on load you should use calculateEnv instead
    */
   getEnv(component: Component): EnvDefinition {
     const id = this.getEnvId(component);

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -1,5 +1,5 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
-import { Component, ComponentAspect, ComponentMain, ComponentID } from '@teambit/component';
+import { Component, ComponentAspect, ComponentMain, ComponentID, AspectData } from '@teambit/component';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { Harmony, Slot, SlotRegistry } from '@teambit/harmony';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
@@ -14,7 +14,7 @@ import { EnvDefinition } from './env-definition';
 import { EnvServiceList } from './env-service-list';
 import { EnvsCmd } from './envs.cmd';
 import { EnvFragment } from './env.fragment';
-// import { EnvNotConfiguredForComponent, EnvNotFound } from './exceptions';
+import { EnvNotConfiguredForComponent, EnvNotFound } from './exceptions';
 
 export type EnvsRegistry = SlotRegistry<Environment>;
 
@@ -110,10 +110,55 @@ export class EnvsMain {
     };
   }
 
+  getEnvData(component: Component): AspectData {
+    let envsData = component.state.aspects.get(EnvsAspect.id);
+    if (!envsData) {
+      // TODO: remove this once we re-export old components used to store the data here
+      envsData = component.state.aspects.get('teambit.workspace/workspace');
+    }
+    if (!envsData) throw new Error(`env was not configured on component ${component.id.toString()}`);
+    return envsData.data;
+  }
+
+  /**
+   * get the env id of the given component.
+   */
+  getEnvId(component: Component): string {
+    const envsData = this.getEnvData(component);
+    return envsData.id;
+  }
+
   /**
    * get the env of the given component.
    */
   getEnv(component: Component): EnvDefinition {
+    const id = this.getEnvId(component);
+    const envDef = this.getEnvDefinitionByStringId(id);
+    if (envDef) {
+      return envDef;
+    }
+    // Do not allow a non existing env
+    throw new EnvNotFound(id, component.id.toString());
+  }
+
+  /**
+   * get an environment Descriptor.
+   */
+  getDescriptor(component: Component): Descriptor | null {
+    const envsData = this.getEnvData(component);
+    return {
+      id: envsData.id,
+      icon: envsData.icon,
+      services: envsData.services,
+    };
+  }
+
+  /**
+   * This used to calculate the actual env during the component load.
+   * Do not use it to get the env (use getEnv instead)
+   * This should be used only during on load
+   */
+  calculateEnv(component: Component): EnvDefinition {
     // Search first for env configured via envs aspect itself
     const envsAspect = component.state.aspects.get(EnvsAspect.id);
     const envIdFromEnvsConfig = envsAspect?.config.env;
@@ -142,10 +187,10 @@ export class EnvsMain {
           return envDef;
         }
         // Do not allow a non existing env
-        // throw new EnvNotFound(matchedEntry.id.toString(), component.id.toString());
+        throw new EnvNotFound(matchedEntry.id.toString(), component.id.toString());
       }
       // Do not allow configure teambit.envs/envs on the component without configure the env aspect itself
-      // throw new EnvNotConfiguredForComponent(envIdFromEnvsConfig, component.id.toString());
+      throw new EnvNotConfiguredForComponent(envIdFromEnvsConfig, component.id.toString());
     }
 
     // in case there is no config in teambit.envs/envs search the aspects for the first env that registered as env
@@ -165,9 +210,9 @@ export class EnvsMain {
   }
 
   /**
-   * @deprecated DO NOT USE THIS METHOD ANYMORE!!! (PLEASE USE .getEnv() instead!)
+   * @deprecated DO NOT USE THIS METHOD ANYMORE!!! (PLEASE USE .calculateEnv() instead!)
    */
-  getEnvFromExtensions(extensions: ExtensionDataList): EnvDefinition {
+  calculateEnvFromExtensions(extensions: ExtensionDataList): EnvDefinition {
     // Search first for env configured via envs aspect itself
     const envsAspect = extensions.findCoreExtension(EnvsAspect.id);
     const envIdFromEnvsConfig = envsAspect?.config.env;
@@ -206,10 +251,10 @@ export class EnvsMain {
           return envDef;
         }
         // Do not allow a non existing env
-        // throw new EnvNotFound(matchedEntry.id.toString());
+        throw new EnvNotFound(matchedEntry.id.toString());
       }
       // Do not allow configure teambit.envs/envs on the component without configure the env aspect itself
-      // throw new EnvNotConfiguredForComponent(envIdFromEnvsConfig);
+      throw new EnvNotConfiguredForComponent(envIdFromEnvsConfig);
     }
 
     // in case there is no config in teambit.envs/envs search the aspects for the first env that registered as env
@@ -274,24 +319,6 @@ export class EnvsMain {
     // TODO: remove this after refactoring everything and remove getDescriptor from being optional.
     if (!service.getDescriptor) return false;
     return !!service.getDescriptor(env);
-  }
-
-  /**
-   * get an environment Descriptor.
-   */
-  getDescriptor(component: Component): Descriptor | null {
-    let envsData = component.state.aspects.get(EnvsAspect.id);
-    if (!envsData) {
-      // TODO: remove this once we re-export old components used to store the data here
-      envsData = component.state.aspects.get('teambit.workspace/workspace');
-    }
-    if (!envsData) throw new Error(`env was not configured on component ${component.id.toString()}`);
-
-    return {
-      id: envsData.data.id,
-      icon: envsData.data.icon,
-      services: envsData.data.services,
-    };
   }
 
   /**

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -228,7 +228,7 @@ export class PkgMain {
    */
   async mergePackageJsonProps(component: Component): Promise<PackageJsonProps> {
     let newProps = {};
-    const env = this.envs.getEnv(component)?.env;
+    const env = this.envs.calculateEnv(component)?.env;
     if (env?.getPackageJsonProps && typeof env.getPackageJsonProps === 'function') {
       const propsFromEnv = env.getPackageJsonProps();
       newProps = Object.assign(newProps, propsFromEnv);

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -138,11 +138,47 @@ export class ScopeMain implements ComponentFactory {
    * register to the tag slot.
    */
   onTag(tagFn: OnTag) {
+    const host = this.componentExtension.getHost();
+
+    // Based on the list of components to be tagged return those who are loaded to harmony with their used version
+    const getAspectsByPreviouslyUsedVersion = async (components: ConsumerComponent[]): Promise<string[]> => {
+      const harmonyIds = this.harmony.extensionsIds;
+      const aspectsIds: string[] = [];
+      const aspectsP = components.map(async (component) => {
+        const newId = await host.resolveComponentId(component.id);
+        if (
+          component.previouslyUsedVersion &&
+          component.version &&
+          component.previouslyUsedVersion !== component.version
+        ) {
+          const newIdWithPreviouslyUsedVersion = newId.changeVersion(component.previouslyUsedVersion);
+          if (harmonyIds.includes(newIdWithPreviouslyUsedVersion.toString())) {
+            aspectsIds.push(newId.toString());
+          }
+        }
+      });
+      await Promise.all(aspectsP);
+      return aspectsIds;
+    };
+
+    // Reload the aspects with their new version
+    const reloadAspectsWithNewVersion = async (components: ConsumerComponent[]): Promise<void> => {
+      const idsToLoad = await getAspectsByPreviouslyUsedVersion(components);
+      await host.loadAspects(idsToLoad, false);
+    };
+
     const legacyOnTagFunc: OnTagFunc = async (
       legacyComponents: ConsumerComponent[],
       options?: OnTagOpts
     ): Promise<LegacyOnTagResult[]> => {
-      const host = this.componentExtension.getHost();
+      // We need to reload the aspects with their new version since:
+      // during get many by legacy, we go load component which in turn go to getEnv
+      // get env validates that the env written on the component is really exist by checking the envs slot registry
+      // when we load here, it's env version in the aspect list already has the new version in case the env itself is being tagged
+      // so we are search for the env in the registry with the new version number
+      // but since the env only registered during the on load of the bit process (before the tag) it's version in the registry is only the old one
+      // once we reload them we will have it registered with the new version as well
+      await reloadAspectsWithNewVersion(legacyComponents);
       const components = await host.getManyByLegacy(legacyComponents);
       const { builderDataMap } = await tagFn(components, options);
       return this.builderDataMapToLegacyOnTagResults(builderDataMap);

--- a/scopes/workspace/workspace/index.ts
+++ b/scopes/workspace/workspace/index.ts
@@ -8,7 +8,7 @@ export type { WorkspaceMain } from './workspace.main.runtime';
 
 export * from './events';
 export type { WorkspaceUI } from './workspace.ui.runtime';
-export type { SerializableResults, OnComponentEventResult, ExtensionData } from './on-component-events';
+export type { SerializableResults, OnComponentEventResult } from './on-component-events';
 export { ComponentStatus } from './workspace-component';
 export { WorkspaceModelComponent } from './ui/workspace/workspace-model';
 export { WorkspaceContext } from './ui/workspace/workspace-context';

--- a/scopes/workspace/workspace/on-component-events.ts
+++ b/scopes/workspace/workspace/on-component-events.ts
@@ -1,4 +1,4 @@
-import { Component, ComponentID } from '@teambit/component';
+import { Component, ComponentID, AspectData } from '@teambit/component';
 
 export type SerializableResults = { results: any; toString: () => string };
 export type OnComponentChange = (component: Component) => Promise<SerializableResults>;
@@ -6,8 +6,4 @@ export type OnComponentAdd = (component: Component) => Promise<SerializableResul
 export type OnComponentRemove = (componentId: ComponentID) => Promise<SerializableResults>;
 export type OnComponentEventResult = { extensionId: string; results: SerializableResults };
 
-export type ExtensionData = {
-  [key: string]: any;
-};
-
-export type OnComponentLoad = (component: Component) => Promise<ExtensionData>;
+export type OnComponentLoad = (component: Component) => Promise<AspectData>;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -374,7 +374,7 @@ export class Workspace implements ComponentFactory {
 
   // TODO: @gilad we should refactor this asap into to the envs aspect.
   async getEnvSystemDescriptor(component: Component): Promise<AspectData> {
-    const env = this.envs.getEnv(component);
+    const env = this.envs.calculateEnv(component);
     if (env.env.__getDescriptor && typeof env.env.__getDescriptor === 'function') {
       const systemDescriptor = await env.env.__getDescriptor();
       // !important persist services only on the env itself.

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -12,6 +12,7 @@ import {
   ComponentID,
   ComponentMap,
   AspectList,
+  AspectData,
 } from '@teambit/component';
 import { ComponentScopeDirMap } from '@teambit/config';
 import {
@@ -58,7 +59,6 @@ import ConsumerComponent from 'bit-bin/dist/consumer/component';
 import { ComponentConfigFile } from './component-config-file';
 import { DependencyTypeNotSupportedInPolicy } from './exceptions';
 import {
-  ExtensionData,
   OnComponentAdd,
   OnComponentChange,
   OnComponentEventResult,
@@ -373,7 +373,7 @@ export class Workspace implements ComponentFactory {
   }
 
   // TODO: @gilad we should refactor this asap into to the envs aspect.
-  async getEnvSystemDescriptor(component: Component): Promise<ExtensionData> {
+  async getEnvSystemDescriptor(component: Component): Promise<AspectData> {
     const env = this.envs.getEnv(component);
     if (env.env.__getDescriptor && typeof env.env.__getDescriptor === 'function') {
       const systemDescriptor = await env.env.__getDescriptor();

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -126,6 +126,7 @@ export default class Component {
 
   name: string;
   version: string | undefined;
+  previouslyUsedVersion: string | undefined;
   scope: string | null | undefined;
   lang: string;
   bindingPrefix: string;

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -84,8 +84,7 @@ async function setFutureVersions(
         if (exactVersionOrReleaseType.releaseType) releaseType = exactVersionOrReleaseType.releaseType;
       }
       const version = modelComponent.getVersionToAdd(releaseType, exactVersion);
-      // @ts-ignore usedVersion is needed only for this, that's why it's not declared on the instance
-      componentToTag.usedVersion = componentToTag.version;
+      componentToTag.previouslyUsedVersion = componentToTag.version;
       componentToTag.version = version;
     })
   );


### PR DESCRIPTION
## Proposed Changes

- fix loading user envs during tagging them 
- throw an error in case a non-existing env defined on the component
- add an aspect data type
- add previously used version prop to consumer component during component tag
- change the get env to get the calculated data instead of re-calc it from config

