### PR TITLE
cancel the step of fetch-missing-dependencies-on-remote 

### DIFF
--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -379,7 +379,8 @@ describe('bit export command', function () {
       helper.scopeHelper.addRemoteScope(scopePath);
       helper.command.exportComponent('utils/is-string2', remote2, true, '--force');
     });
-    it('should have is-type@0.0.2 on that remote', () => {
+    // doesn't happen currently on bit-bin, it'll be part of bit-dev.
+    it.skip('should have is-type@0.0.2 on that remote', () => {
       const isType = helper.command.catComponent(`${helper.scopes.remote}/utils/is-type@0.0.2`, remote2Path);
       expect(isType).to.have.property('files');
     });
@@ -408,7 +409,8 @@ describe('bit export command', function () {
       it('should show a successful message', () => {
         expect(output).to.have.string('exported 1 components to scope');
       });
-      it('should fetch is-type@0.0.1 from remote1', () => {
+      // doesn't happen currently on bit-bin, it'll be part of bit-dev.
+      it.skip('should fetch is-type@0.0.1 from remote1', () => {
         const isType = helper.command.catComponent(`${helper.scopes.remote}/utils/is-type@0.0.1`, remote2Path);
         expect(isType).to.have.property('files');
       });

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -59,6 +59,7 @@ describe('recovery after component/scope deletion', function () {
         helper.command.linkAndCompile();
         helper.command.tagAllComponents();
         helper.command.export();
+        helper.command.importAllComponents();
         localClone = helper.scopeHelper.cloneLocalScope();
         helper.scopeHelper.reInitRemoteScope(remote2Path);
         remote2Clone = helper.scopeHelper.cloneScope(remote2Path);

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -59,7 +59,7 @@ describe('recovery after component/scope deletion', function () {
         helper.command.linkAndCompile();
         helper.command.tagAllComponents();
         helper.command.export();
-        helper.command.importAllComponents();
+        helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
         localClone = helper.scopeHelper.cloneLocalScope();
         helper.scopeHelper.reInitRemoteScope(remote2Path);
         remote2Clone = helper.scopeHelper.cloneScope(remote2Path);

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -113,7 +113,7 @@ describe('recovery after component/scope deletion', function () {
               expect(comp3).to.not.be.undefined;
             });
           });
-          describe('bit export to another remote', () => {
+          describe.skip('bit export to another remote', () => {
             let compNewRemote;
             before(() => {
               helper.scopeHelper.getClonedLocalScope(scopeWithMissingDep);
@@ -126,7 +126,6 @@ describe('recovery after component/scope deletion', function () {
               helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, compNewRemote.scopePath);
               helper.scopeHelper.addRemoteScope(remote2Path, compNewRemote.scopePath);
               helper.command.export();
-              helper.command.importAllComponents();
             });
             it('this new remote should bring the flattened dependency (comp3) from the dependent scope', () => {
               const scope = helper.command.catScope(true, compNewRemote.scopePath);
@@ -217,7 +216,7 @@ describe('recovery after component/scope deletion', function () {
               expect(comp3).to.not.be.undefined;
             });
           });
-          describe('bit export to another remote', () => {
+          describe.skip('bit export to another remote', () => {
             let compNewRemote;
             before(() => {
               helper.scopeHelper.getClonedLocalScope(scopeWithMissingDep);
@@ -372,9 +371,9 @@ describe('recovery after component/scope deletion', function () {
           helper.bitJsonc.addToVariant('comp3', 'defaultScope', remote2Name);
           helper.command.tagAllComponents('', '0.0.2');
           helper.command.export();
-          helper.command.importAllComponents();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope(remote2Path);
+          helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           helper.bitJsonc.disablePreview();
           npmCiRegistry.setResolver();
           beforeImportScope = helper.scopeHelper.cloneLocalScope();
@@ -492,7 +491,7 @@ describe('recovery after component/scope deletion', function () {
             helper.command.import(`${helper.scopes.remote}/comp2 ${remote2Name}/comp3`);
             helper.command.tagAllComponents('', '0.0.7'); // tag comp2 with the updated comp3 version - 0.0.7
             helper.command.export();
-            helper.command.importAllComponents();
+            helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           });
           it('comp3: should save 0.0.1 of in the orphanedVersions prop on the remote', () => {
             const comp3 = helper.command.catComponent(`${remote2Name}/comp3`, helper.scopes.remotePath);
@@ -551,7 +550,7 @@ describe('recovery after component/scope deletion', function () {
           });
         });
       });
-      describe('dealing with snaps, indirect dependency (comp3) has re-created with a new snap', () => {
+      describe.skip('dealing with snaps, indirect dependency (comp3) has re-created with a new snap', () => {
         let beforeImportScope: string;
         before(() => {
           helper.scopeHelper.getClonedScope(remote2Clone, remote2Path);
@@ -573,7 +572,7 @@ describe('recovery after component/scope deletion', function () {
           helper.command.snapAllComponentsWithoutBuild();
 
           helper.command.export();
-          helper.command.importAllComponents();
+          helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope(remote2Path);
           helper.bitJsonc.disablePreview();

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -373,9 +373,9 @@ describe('recovery after component/scope deletion', function () {
           helper.command.export();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope(remote2Path);
-          helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           helper.bitJsonc.disablePreview();
           npmCiRegistry.setResolver();
+          helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           beforeImportScope = helper.scopeHelper.cloneLocalScope();
         });
         it('should import comp1 successfully and bring comp3@0.0.1 from the cache of comp1', () => {

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -378,7 +378,7 @@ describe('recovery after component/scope deletion', function () {
           helper.command.runCmd(`bit import ${helper.scopes.remote}/* ${remote2Name}/* --objects`);
           beforeImportScope = helper.scopeHelper.cloneLocalScope();
         });
-        it('should import comp1 successfully and bring comp3@0.0.1 from the cache of comp1', () => {
+        it.skip('should import comp1 successfully and bring comp3@0.0.1 from the cache of comp1', () => {
           helper.command.importComponent('comp1');
           const scope = helper.command.catScope(true);
           const comp3 = scope.find((item) => item.name === 'comp3');
@@ -386,7 +386,7 @@ describe('recovery after component/scope deletion', function () {
           expect(comp3.versions).to.have.property('0.0.1');
           expect(comp3.versions).to.not.have.property('0.0.2');
         });
-        it('should import comp2 successfully and bring comp3@0.0.1 from the cache of comp2', () => {
+        it.skip('should import comp2 successfully and bring comp3@0.0.1 from the cache of comp2', () => {
           helper.scopeHelper.getClonedLocalScope(beforeImportScope);
           helper.command.importComponent('comp2');
           const scope = helper.command.catScope(true);

--- a/e2e/harmony/recovery-after-deletion.e2e.ts
+++ b/e2e/harmony/recovery-after-deletion.e2e.ts
@@ -126,6 +126,7 @@ describe('recovery after component/scope deletion', function () {
               helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, compNewRemote.scopePath);
               helper.scopeHelper.addRemoteScope(remote2Path, compNewRemote.scopePath);
               helper.command.export();
+              helper.command.importAllComponents();
             });
             it('this new remote should bring the flattened dependency (comp3) from the dependent scope', () => {
               const scope = helper.command.catScope(true, compNewRemote.scopePath);
@@ -228,6 +229,7 @@ describe('recovery after component/scope deletion', function () {
               helper.scopeHelper.addRemoteScope(compNewRemote.scopePath);
               helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, compNewRemote.scopePath);
               helper.command.export();
+              helper.command.importAllComponents();
             });
             it('this new remote should bring the flattened dependency (comp3) from the dependent scope', () => {
               const scope = helper.command.catScope(true, compNewRemote.scopePath);
@@ -370,6 +372,7 @@ describe('recovery after component/scope deletion', function () {
           helper.bitJsonc.addToVariant('comp3', 'defaultScope', remote2Name);
           helper.command.tagAllComponents('', '0.0.2');
           helper.command.export();
+          helper.command.importAllComponents();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope(remote2Path);
           helper.bitJsonc.disablePreview();
@@ -489,6 +492,7 @@ describe('recovery after component/scope deletion', function () {
             helper.command.import(`${helper.scopes.remote}/comp2 ${remote2Name}/comp3`);
             helper.command.tagAllComponents('', '0.0.7'); // tag comp2 with the updated comp3 version - 0.0.7
             helper.command.export();
+            helper.command.importAllComponents();
           });
           it('comp3: should save 0.0.1 of in the orphanedVersions prop on the remote', () => {
             const comp3 = helper.command.catComponent(`${remote2Name}/comp3`, helper.scopes.remotePath);
@@ -537,6 +541,7 @@ describe('recovery after component/scope deletion', function () {
             helper.command.import(`${helper.scopes.remote}/comp1 ${remote2Name}/comp3`);
             helper.command.tagComponent(`${remote2Name}/comp3`, undefined, '0.0.8 --force');
             helper.command.export();
+            helper.command.importAllComponents();
           });
           it('the remote of comp3 should not get this orphanedVersions prop', () => {
             const comp3 = helper.command.catComponent(`${remote2Name}/comp3`, remote2Path);
@@ -568,6 +573,7 @@ describe('recovery after component/scope deletion', function () {
           helper.command.snapAllComponentsWithoutBuild();
 
           helper.command.export();
+          helper.command.importAllComponents();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope(remote2Path);
           helper.bitJsonc.disablePreview();

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -145,7 +145,7 @@ export async function exportMany({
   await validateRemotes(remotes, clientId, Boolean(resumeExportId));
   triggerPrePersistHook();
   await persistRemotes(manyObjectsPerRemote, clientId);
-  await fetchMissingDependenciesOnRemotes(manyObjectsPerRemote);
+  // await fetchMissingDependenciesOnRemotes(manyObjectsPerRemote);
   loader.start('updating data locally...');
   const results = await updateLocalObjects(lanesObjects);
   return {
@@ -903,30 +903,30 @@ async function persistRemotes(
   });
 }
 
-async function fetchMissingDependenciesOnRemotes(manyObjectsPerRemote: RemotesForPersist[]) {
-  loader.start('fetching missing dependencies (if any) on the remotes...');
-  await Promise.all(
-    manyObjectsPerRemote.map(async (objectsPerRemote: RemotesForPersist) => {
-      const { remote } = objectsPerRemote;
-      try {
-        await remote.action(FetchMissingDeps.name, { ids: objectsPerRemote.exportedIds });
-        logger.debugAndAddBreadCrumb(
-          'fetchMissingDependenciesOnRemotes',
-          `successfully fetched dependencies from a remote ${remote.name}`
-        );
-      } catch (err) {
-        // do not throw an error, the remote-scope of a dependency can be down for a while
-        // next time a component is exported, the client will fetch the dependency from the original remote
-        logger.warnAndAddBreadCrumb(
-          'fetchMissingDependenciesOnRemotes',
-          `failed fetching dependencies on ${remote.name}`,
-          {},
-          err
-        );
-      }
-    })
-  );
-}
+// async function fetchMissingDependenciesOnRemotes(manyObjectsPerRemote: RemotesForPersist[]) {
+//   loader.start('fetching missing dependencies (if any) on the remotes...');
+//   await Promise.all(
+//     manyObjectsPerRemote.map(async (objectsPerRemote: RemotesForPersist) => {
+//       const { remote } = objectsPerRemote;
+//       try {
+//         await remote.action(FetchMissingDeps.name, { ids: objectsPerRemote.exportedIds });
+//         logger.debugAndAddBreadCrumb(
+//           'fetchMissingDependenciesOnRemotes',
+//           `successfully fetched dependencies from a remote ${remote.name}`
+//         );
+//       } catch (err) {
+//         // do not throw an error, the remote-scope of a dependency can be down for a while
+//         // next time a component is exported, the client will fetch the dependency from the original remote
+//         logger.warnAndAddBreadCrumb(
+//           'fetchMissingDependenciesOnRemotes',
+//           `failed fetching dependencies on ${remote.name}`,
+//           {},
+//           err
+//         );
+//       }
+//     })
+//   );
+// }
 
 export async function resumeExport(scope: Scope, exportId: string, remotes: string[]): Promise<string[]> {
   const scopeRemotes: Remotes = await getScopeRemotes(scope);
@@ -934,6 +934,6 @@ export async function resumeExport(scope: Scope, exportId: string, remotes: stri
   const remotesForPersist: RemotesForPersist[] = remotesObj.map((remote) => ({ remote }));
   await validateRemotes(remotesObj, exportId, true);
   await persistRemotes(remotesForPersist, exportId, true);
-  await fetchMissingDependenciesOnRemotes(remotesForPersist);
+  // await fetchMissingDependenciesOnRemotes(remotesForPersist);
   return R.flatten(remotesForPersist.map((r) => r.exportedIds));
 }

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -20,7 +20,6 @@ import { getScopeRemotes } from '../scope-remotes';
 import ScopeComponentsImporter from './scope-components-importer';
 import { ObjectItem, ObjectList } from '../objects/object-list';
 import { ExportPersist, ExportValidate, RemovePendingDir } from '../actions';
-import { FetchMissingDeps } from '../actions/fetch-missing-deps';
 import loader from '../../cli/loader';
 import { getAllVersionHashes } from './traverse-versions';
 import { PersistFailed } from '../exceptions/persist-failed';
@@ -145,7 +144,6 @@ export async function exportMany({
   await validateRemotes(remotes, clientId, Boolean(resumeExportId));
   triggerPrePersistHook();
   await persistRemotes(manyObjectsPerRemote, clientId);
-  // await fetchMissingDependenciesOnRemotes(manyObjectsPerRemote);
   loader.start('updating data locally...');
   const results = await updateLocalObjects(lanesObjects);
   return {
@@ -903,37 +901,11 @@ async function persistRemotes(
   });
 }
 
-// async function fetchMissingDependenciesOnRemotes(manyObjectsPerRemote: RemotesForPersist[]) {
-//   loader.start('fetching missing dependencies (if any) on the remotes...');
-//   await Promise.all(
-//     manyObjectsPerRemote.map(async (objectsPerRemote: RemotesForPersist) => {
-//       const { remote } = objectsPerRemote;
-//       try {
-//         await remote.action(FetchMissingDeps.name, { ids: objectsPerRemote.exportedIds });
-//         logger.debugAndAddBreadCrumb(
-//           'fetchMissingDependenciesOnRemotes',
-//           `successfully fetched dependencies from a remote ${remote.name}`
-//         );
-//       } catch (err) {
-//         // do not throw an error, the remote-scope of a dependency can be down for a while
-//         // next time a component is exported, the client will fetch the dependency from the original remote
-//         logger.warnAndAddBreadCrumb(
-//           'fetchMissingDependenciesOnRemotes',
-//           `failed fetching dependencies on ${remote.name}`,
-//           {},
-//           err
-//         );
-//       }
-//     })
-//   );
-// }
-
 export async function resumeExport(scope: Scope, exportId: string, remotes: string[]): Promise<string[]> {
   const scopeRemotes: Remotes = await getScopeRemotes(scope);
   const remotesObj = await Promise.all(remotes.map((r) => scopeRemotes.resolve(r, scope)));
   const remotesForPersist: RemotesForPersist[] = remotesObj.map((remote) => ({ remote }));
   await validateRemotes(remotesObj, exportId, true);
   await persistRemotes(remotesForPersist, exportId, true);
-  // await fetchMissingDependenciesOnRemotes(remotesForPersist);
   return R.flatten(remotesForPersist.map((r) => r.exportedIds));
 }


### PR DESCRIPTION
because it causes race-condition on multiple remotes with circular dependencies.