### PR TITLE
introduce a new flag "--reset-new" to "bit init" to reset .bitmap to new components

### DIFF
--- a/e2e/harmony/init-harmony.e2e.ts
+++ b/e2e/harmony/init-harmony.e2e.ts
@@ -1,0 +1,39 @@
+import chai, { expect } from 'chai';
+import path from 'path';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('init command on Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('init --reset-new', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.init('--reset-new');
+    });
+    it('should change the .bitmap entries as if they are new', () => {
+      const bitMap = helper.bitMap.readComponentsMapOnly();
+      expect(bitMap).to.have.property('comp1');
+      expect(bitMap).not.to.have.property(`${helper.scopes.remote}/comp1@0.0.1`);
+      const compMap = bitMap.comp1;
+      expect(compMap.exported).to.be.false;
+    });
+    it('should remove all objects from the scope', () => {
+      const objectsPath = path.join(helper.scopes.localPath, '.bit/objects');
+      expect(objectsPath).to.be.a.directory().and.empty;
+    });
+  });
+});

--- a/src/api/consumer/lib/init.ts
+++ b/src/api/consumer/lib/init.ts
@@ -10,6 +10,7 @@ export default async function init(
   absPath: string = process.cwd(),
   noGit = false,
   reset = false,
+  resetNew = false,
   resetHard = false,
   force = false,
   workspaceConfigProps: WorkspaceConfigProps
@@ -20,6 +21,9 @@ export default async function init(
   const consumer: Consumer = await Consumer.create(absPath, noGit, workspaceConfigProps);
   if (!force) {
     await throwForOutOfSyncScope(consumer);
+  }
+  if (resetNew) {
+    await consumer.resetNew();
   }
   return consumer.write();
 }

--- a/src/cli/commands/public-cmds/init-cmd.ts
+++ b/src/cli/commands/public-cmds/init-cmd.ts
@@ -27,6 +27,7 @@ export default class Init implements LegacyCommand {
       'do not nest component store within .git directory and do not write config data inside package.json',
     ],
     ['r', 'reset', 'write missing or damaged Bit files'],
+    ['', 'reset-new', 'reset .bitmap file as if the components were newly added and remove all model data (objects)'],
     [
       '',
       'reset-hard',
@@ -56,6 +57,7 @@ export default class Init implements LegacyCommand {
       shared,
       standalone,
       reset,
+      resetNew,
       resetHard,
       force,
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -84,7 +86,7 @@ export default class Init implements LegacyCommand {
       componentsDefaultDirectory: defaultDirectory,
       packageManager,
     };
-    return init(path, standalone, reset, resetHard, force, workspaceConfigFileProps).then(
+    return init(path, standalone, reset, resetNew, resetHard, force, workspaceConfigFileProps).then(
       ({ created, addedGitHooks, existingGitHooks }) => {
         return {
           created,

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -222,6 +222,22 @@ export default class BitMap {
     }
   }
 
+  resetToNewComponents() {
+    this.components = this.components.map(
+      (component) =>
+        new ComponentMap({
+          id: component.id.changeVersion(undefined).changeScope(undefined),
+          mainFile: component.mainFile,
+          rootDir: component.rootDir,
+          exported: false,
+          trackDir: component.trackDir,
+          files: component.files,
+          origin: COMPONENT_ORIGINS.AUTHORED,
+          onLanesOnly: false,
+        })
+    );
+  }
+
   private throwForDuplicateRootDirs(componentsJson: Record<string, any>) {
     const rootDirs = compact(Object.keys(componentsJson).map((c) => componentsJson[c].rootDir));
     if (uniq(rootDirs).length === rootDirs.length) {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -881,6 +881,11 @@ export default class Consumer {
     await Promise.all([scopeP, configP]);
   }
 
+  async resetNew() {
+    this.bitMap.resetToNewComponents();
+    await Scope.reset(this.scope.path, true);
+  }
+
   static async createIsolatedWithExistingScope(consumerPath: PathOsBased, scope: Scope): Promise<Consumer> {
     // if it's an isolated environment, it's normal to have already the consumer
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -592,6 +592,10 @@ export default class CommandHelper {
     return value;
   }
 
+  init(options = '') {
+    return this.runCmd(`bit init ${options}`);
+  }
+
   async runInteractiveCmd({
     args = [],
     inputs = [],

--- a/src/interactive/commands/init-interactive.ts
+++ b/src/interactive/commands/init-interactive.ts
@@ -218,13 +218,15 @@ export default (async function initInteractive() {
     actualCompiler = undefined;
   }
   answers.compiler = actualCompiler;
-  return init(undefined, false, false, false, false, answers).then(({ created, addedGitHooks, existingGitHooks }) => {
-    return {
-      created,
-      addedGitHooks,
-      existingGitHooks,
-      reset: false,
-      resetHard: false,
-    };
-  });
+  return init(undefined, false, false, false, false, false, answers).then(
+    ({ created, addedGitHooks, existingGitHooks }) => {
+      return {
+        created,
+        addedGitHooks,
+        existingGitHooks,
+        reset: false,
+        resetHard: false,
+      };
+    }
+  );
 });


### PR DESCRIPTION
At times, it can be useful to start Bit from scratch but to keep .bitmap file to map the directories to the components.
This flag does the following:
1. changes all components in the .bitmap file as if they were just added. (removed data about tagging/exporting).
2. removes all objects in the scope.