### PR TITLE
configure Ora to avoid messing with Ctrl+C

### DIFF
--- a/src/cli/loader/loader.ts
+++ b/src/cli/loader/loader.ts
@@ -79,7 +79,7 @@ export class Loader {
 
   private createNewSpinner(): Ora {
     // for some reason the stream defaults to stderr.
-    return ora({ spinner: SPINNER_TYPE, text: '', stream: process.stdout });
+    return ora({ spinner: SPINNER_TYPE, text: '', stream: process.stdout, discardStdin: false, hideCursor: false });
   }
 }
 


### PR DESCRIPTION
Currently, it's mostly noticeable during `bit build` command at the typescript compilation step.
It seems to be a bug in Ora package, see here for more info: https://github.com/sindresorhus/ora/issues/156
I tried the suggested workaround there and it's working.