### PR TITLE
Package manager proxy

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -8,7 +8,7 @@ import { Slot, SlotRegistry } from '@teambit/harmony';
 import type { LoggerMain } from '@teambit/logger';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { Logger, LoggerAspect } from '@teambit/logger';
-import { CFG_PACKAGE_MANAGER_CACHE, CFG_USER_TOKEN_KEY } from 'bit-bin/dist/constants';
+import { CFG_PACKAGE_MANAGER_CACHE, CFG_USER_TOKEN_KEY, CFG_PROXY, CFG_HTTPS_PROXY } from 'bit-bin/dist/constants';
 // TODO: it's weird we take it from here.. think about it../workspace/utils
 import { DependencyResolver } from 'bit-bin/dist/consumer/component/dependencies/dependency-resolver';
 import { ExtensionDataList } from 'bit-bin/dist/consumer/config/extension-data';
@@ -78,6 +78,19 @@ export interface DependencyResolverWorkspaceConfig {
    * and totally removes the need of a 'node_modules' directory in your project.
    */
   packageManager: string;
+
+  /**
+   * A proxy server for out going network requests by the package manager
+   * Used for both http and https requests (unless the httpsProxy is defined)
+   */
+  proxy?: string;
+
+  /**
+   * A proxy server for outgoing https requests by the package manager (fallback to proxy server if not defined)
+   * Use this in case you want different proxy for http and https requests.
+   */
+  httpsProxy?: string;
+
   /**
    * If true, then Bit will add the "--strict-peer-dependencies" option when invoking package managers.
    * This causes "bit install" to fail if there are unsatisfied peer dependencies, which is
@@ -126,6 +139,11 @@ export type GetLinkerOptions = {
 
 export type GetVersionResolverOptions = {
   cacheRootDirectory?: string;
+};
+
+export type ProxyConfig = {
+  httpProxy?: string;
+  httpsProxy?: string;
 };
 
 const defaultLinkingOptions: LinkingOptions = {
@@ -397,11 +415,51 @@ export class DependencyResolverMain {
     return packageManager;
   }
 
+  async getProxyConfig(): Promise<ProxyConfig> {
+    let proxy = this.config.proxy;
+    let httpsProxy = this.config.httpsProxy || proxy;
+
+    // Take config from the aspect config if defined
+    if (proxy || httpsProxy) {
+      this.logger.debug(`proxy config taken from the dep resolver config. proxy: ${proxy} httpsProxy: ${httpsProxy}`);
+      return {
+        httpProxy: proxy,
+        httpsProxy,
+      };
+    }
+
+    // Take config from the package manager (npmrc) config if defined
+    const packageManager = this.packageManagerSlot.get(this.config.packageManager);
+    let proxyConfig: ProxyConfig = {};
+    if (packageManager?.getProxyConfig && typeof packageManager?.getProxyConfig === 'function') {
+      proxyConfig = await packageManager?.getProxyConfig();
+    } else {
+      const systemPm = this.getSystemPackageManager();
+      if (!systemPm.getProxyConfig) throw new Error('system package manager must implement `getProxyConfig()`');
+      proxyConfig = await systemPm.getProxyConfig();
+    }
+    if (proxyConfig?.httpProxy || proxyConfig?.httpsProxy) {
+      this.logger.debug(
+        `proxy config taken from the package manager config (npmrc). proxy: ${proxyConfig.httpProxy} httpsProxy: ${proxyConfig.httpsProxy}`
+      );
+      return proxyConfig;
+    }
+
+    proxy = this.globalConfig.getSync(CFG_PROXY);
+    httpsProxy = this.globalConfig.getSync(CFG_HTTPS_PROXY) || proxy;
+    if (proxy || httpsProxy) {
+      this.logger.debug(`proxy config taken from the global bit config. proxy: ${proxy} httpsProxy: ${httpsProxy}`);
+      return {
+        httpProxy: proxy,
+        httpsProxy,
+      };
+    }
+    return {};
+  }
+
   async getRegistries(): Promise<Registries> {
     const packageManager = this.packageManagerSlot.get(this.config.packageManager);
     let registries;
-    // eslint-disable-next-line global-require, import/no-dynamic-require
-    // TODO: support getting from default package manager
     if (packageManager?.getRegistries && typeof packageManager?.getRegistries === 'function') {
       registries = await packageManager?.getRegistries();
     } else {

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -17,7 +17,7 @@ export type {
   DependencyResolverWorkspaceConfig,
   DependencyResolverVariantConfig,
 } from './dependency-resolver.main.runtime';
-export { BIT_DEV_REGISTRY, NPM_REGISTRY } from './dependency-resolver.main.runtime';
+export { BIT_DEV_REGISTRY, NPM_REGISTRY, ProxyConfig as InstallProxyConfig } from './dependency-resolver.main.runtime';
 export { DependencyResolverAspect } from './dependency-resolver.aspect';
 export {
   DependencyLifecycleType,

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -17,7 +17,11 @@ export type {
   DependencyResolverWorkspaceConfig,
   DependencyResolverVariantConfig,
 } from './dependency-resolver.main.runtime';
-export { BIT_DEV_REGISTRY, NPM_REGISTRY, ProxyConfig as InstallProxyConfig } from './dependency-resolver.main.runtime';
+export {
+  BIT_DEV_REGISTRY,
+  NPM_REGISTRY,
+  ProxyConfig as PackageManagerProxyConfig,
+} from './dependency-resolver.main.runtime';
 export { DependencyResolverAspect } from './dependency-resolver.aspect';
 export {
   DependencyLifecycleType,

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -2,6 +2,7 @@ import { ComponentMap } from '@teambit/component';
 import { Registries } from './registry';
 import { DepsFilterFn } from './manifest';
 import { WorkspacePolicy } from './policy';
+import { ProxyConfig } from './dependency-resolver.main.runtime';
 
 export type PackageManagerInstallOptions = {
   cacheRootDir?: string;
@@ -49,4 +50,6 @@ export interface PackageManager {
   ): Promise<ResolvedPackageVersion>;
 
   getRegistries?(): Promise<Registries>;
+
+  getProxyConfig?(): Promise<ProxyConfig>;
 }

--- a/scopes/dependencies/pnpm/get-proxy-config.ts
+++ b/scopes/dependencies/pnpm/get-proxy-config.ts
@@ -1,11 +1,11 @@
-import { InstallProxyConfig } from '@teambit/dependency-resolver';
+import { PackageManagerProxyConfig } from '@teambit/dependency-resolver';
 import { readConfig } from './read-config';
 
-export async function getProxyConfig(): Promise<InstallProxyConfig> {
+export async function getProxyConfig(): Promise<PackageManagerProxyConfig> {
   const config = await readConfig();
   const httpProxy = config.config.httpProxy;
   const httpsProxy = config.config.httpsProxy || httpProxy;
-  const proxyConfig: InstallProxyConfig = {
+  const proxyConfig: PackageManagerProxyConfig = {
     httpProxy,
     httpsProxy,
   };

--- a/scopes/dependencies/pnpm/get-proxy-config.ts
+++ b/scopes/dependencies/pnpm/get-proxy-config.ts
@@ -1,0 +1,13 @@
+import { InstallProxyConfig } from '@teambit/dependency-resolver';
+import { readConfig } from './read-config';
+
+export async function getProxyConfig(): Promise<InstallProxyConfig> {
+  const config = await readConfig();
+  const httpProxy = config.config.httpProxy;
+  const httpsProxy = config.config.httpsProxy || httpProxy;
+  const proxyConfig: InstallProxyConfig = {
+    httpProxy,
+    httpsProxy,
+  };
+  return proxyConfig;
+}

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -13,7 +13,13 @@ import { createNewStoreController } from '@pnpm/store-connection-manager';
 // it's not taken from there since it's not exported.
 // here is a bug in pnpm about it https://github.com/pnpm/pnpm/issues/2748
 import { CreateNewStoreControllerOptions } from '@pnpm/store-connection-manager/lib/createNewStoreController';
-import { ResolvedPackageVersion, Registries, NPM_REGISTRY, Registry } from '@teambit/dependency-resolver';
+import {
+  ResolvedPackageVersion,
+  Registries,
+  NPM_REGISTRY,
+  Registry,
+  PackageManagerProxyConfig,
+} from '@teambit/dependency-resolver';
 // import execa from 'execa';
 // import createFetcher from '@pnpm/tarball-fetcher';
 import { MutatedProject, mutateModules } from 'supi';
@@ -21,7 +27,7 @@ import { MutatedProject, mutateModules } from 'supi';
 // import { createResolver } from './create-resolver';
 // import {isValidPath} from 'bit-bin/dist/utils';
 // import {createResolver} from '@pnpm/default-resolver';
-import createResolverAndFetcher from '@pnpm/client';
+import createResolverAndFetcher, { ClientOptions } from '@pnpm/client';
 import pickRegistryForPackage from '@pnpm/pick-registry-for-package';
 import { Logger } from '@teambit/logger';
 import toNerfDart from 'nerf-dart';
@@ -40,7 +46,11 @@ type RegistriesMap = {
 //   });
 // }
 
-async function createStoreController(storeDir: string, registries: Registries): Promise<StoreController> {
+async function createStoreController(
+  storeDir: string,
+  registries: Registries,
+  proxyConfig: PackageManagerProxyConfig = {}
+): Promise<StoreController> {
   // const fetchFromRegistry = createFetchFromRegistry({});
   // const getCredentials = () => ({ authHeaderValue: '', alwaysAuth: false });
   // const resolver: ResolveFunction = createResolver(fetchFromRegistry, getCredentials, {
@@ -66,17 +76,25 @@ async function createStoreController(storeDir: string, registries: Registries): 
     storeDir,
     rawConfig: authConfig,
     verifyStoreIntegrity: true,
+    httpProxy: proxyConfig?.httpProxy,
+    httpsProxy: proxyConfig?.httpsProxy,
   };
   const { ctrl } = await createNewStoreController(opts);
   return ctrl;
 }
 
-async function generateResolverAndFetcher(storeDir: string, registries: Registries) {
+async function generateResolverAndFetcher(
+  storeDir: string,
+  registries: Registries,
+  proxyConfig: PackageManagerProxyConfig = {}
+) {
   const pnpmConfig = await readConfig();
   const authConfig = getAuthConfig(registries);
-  const opts = {
+  const opts: ClientOptions = {
     authConfig: Object.assign({}, pnpmConfig.config.rawConfig, authConfig),
     storeDir,
+    httpProxy: proxyConfig?.httpProxy,
+    httpsProxy: proxyConfig?.httpsProxy,
   };
   const result = createResolverAndFetcher(opts);
   return result;
@@ -87,6 +105,7 @@ export async function install(
   pathsToManifests,
   storeDir: string,
   registries: Registries,
+  proxyConfig: PackageManagerProxyConfig = {},
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   logger?: Logger
 ) {
@@ -125,7 +144,7 @@ export async function install(
   });
   const registriesMap = getRegistriesMap(registries);
   const authConfig = getAuthConfig(registries);
-  const storeController = await createStoreController(storeDir, registries);
+  const storeController = await createStoreController(storeDir, registries, proxyConfig);
   const opts = {
     storeDir,
     dir: rootPathToManifest.rootDir,
@@ -157,9 +176,10 @@ export async function resolveRemoteVersion(
   packageName: string,
   rootDir: string,
   storeDir: string,
-  registries: Registries
+  registries: Registries,
+  proxyConfig: PackageManagerProxyConfig = {}
 ): Promise<ResolvedPackageVersion> {
-  const { resolve } = await generateResolverAndFetcher(storeDir, registries);
+  const { resolve } = await generateResolverAndFetcher(storeDir, registries, proxyConfig);
   const resolveOpts = {
     projectDir: rootDir,
     registry: '',

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -67,6 +67,7 @@ export class PnpmPackageManager implements PackageManager {
     // turn off the logger because it interrupts the pnpm output
     this.logger.off();
     const registries = await this.depResolver.getRegistries();
+    const proxyConfig = await this.depResolver.getProxyConfig();
     await install(rootManifest, componentsManifests, storeDir, registries, this.logger);
     this.logger.on();
     // Make a divider row to improve output
@@ -98,6 +99,12 @@ export class PnpmPackageManager implements PackageManager {
     const storeDir = options?.cacheRootDir ? join(options?.cacheRootDir, '.pnpm-store') : defaultStoreDir;
     const registries = await this.depResolver.getRegistries();
     return resolveRemoteVersion(packageName, options.rootDir, storeDir, registries);
+  }
+
+  async getProxyConfig?(): Promise<ProxyConfig> {
+    // eslint-disable-next-line global-require, import/no-dynamic-require
+    const { getProxyConfig } = require('./get-proxy-config');
+    return getProxyConfig();
   }
 
   async getRegistries(): Promise<Registries> {

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -11,6 +11,7 @@ import {
   Registries,
   Registry,
   BIT_DEV_REGISTRY,
+  PackageManagerProxyConfig,
 } from '@teambit/dependency-resolver';
 import { Logger } from '@teambit/logger';
 import { omit } from 'lodash';
@@ -68,7 +69,7 @@ export class PnpmPackageManager implements PackageManager {
     this.logger.off();
     const registries = await this.depResolver.getRegistries();
     const proxyConfig = await this.depResolver.getProxyConfig();
-    await install(rootManifest, componentsManifests, storeDir, registries, this.logger);
+    await install(rootManifest, componentsManifests, storeDir, registries, proxyConfig, this.logger);
     this.logger.on();
     // Make a divider row to improve output
     this.logger.console('-------------------------');
@@ -98,10 +99,11 @@ export class PnpmPackageManager implements PackageManager {
     const { resolveRemoteVersion } = require('./lynx');
     const storeDir = options?.cacheRootDir ? join(options?.cacheRootDir, '.pnpm-store') : defaultStoreDir;
     const registries = await this.depResolver.getRegistries();
-    return resolveRemoteVersion(packageName, options.rootDir, storeDir, registries);
+    const proxyConfig = await this.depResolver.getProxyConfig();
+    return resolveRemoteVersion(packageName, options.rootDir, storeDir, registries, proxyConfig);
   }
 
-  async getProxyConfig?(): Promise<ProxyConfig> {
+  async getProxyConfig?(): Promise<PackageManagerProxyConfig> {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const { getProxyConfig } = require('./get-proxy-config');
     return getProxyConfig();

--- a/scopes/dependencies/yarn/yarn.package-manager.ts
+++ b/scopes/dependencies/yarn/yarn.package-manager.ts
@@ -251,6 +251,7 @@ export class YarnPackageManager implements PackageManager {
   // TODO: implement this to automate configuration.
   private async computeConfiguration(rootDirPath: PortablePath, cacheFolder: string): Promise<Configuration> {
     const registries = await this.depResolver.getRegistries();
+    const proxyConfig = await this.depResolver.getProxyConfig();
     const pluginConfig = getPluginConfiguration();
     const config = await Configuration.find(rootDirPath, pluginConfig);
     const scopedRegistries = await this.getScopedRegistries(registries);
@@ -267,6 +268,8 @@ export class YarnPackageManager implements PackageManager {
       virtualFolder: `${rootDirPath}/.yarn/$$virtual`,
       npmRegistryServer: defaultRegistry.uri || 'https://registry.yarnpkg.com',
       npmAlwaysAuth: defaultRegistry.alwaysAuth,
+      httpProxy: proxyConfig?.httpProxy,
+      httpsProxy: proxyConfig?.httpsProxy,
       // enableInlineBuilds: true,
       globalFolder: `${userHome}/.yarn/global`,
     };

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -247,6 +247,9 @@ export const CFG_FEATURE_TOGGLE = 'features';
 
 export const CFG_PACKAGE_MANAGER_CACHE = 'package-manager.cache';
 
+export const CFG_PROXY = 'proxy';
+export const CFG_HTTPS_PROXY = 'https_proxy';
+
 /**
  * git hooks
  */


### PR DESCRIPTION
## Proposed Changes

- read proxy config from bit's global config, npmrc config and dep-resolver config
- support proxy for pnpm
- support proxy yarn
