### PR TITLE
fix node env define

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -344,7 +344,6 @@ export default function createWebpackConfig(
       ],
     },
     plugins: [
-      new EnvironmentPlugin(['NODE_ENV', 'production']),
       new MiniCssExtractPlugin({
         // Options similar to the same options in webpackOptions.output
         // both options are optional

--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -1,4 +1,4 @@
-import webpack, { EnvironmentPlugin, Configuration } from 'webpack';
+import webpack, { Configuration } from 'webpack';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import ManifestPlugin from 'webpack-manifest-plugin';
 import WorkboxWebpackPlugin from 'workbox-webpack-plugin';


### PR DESCRIPTION
## Proposed Changes

- remove "environment plugin in main webpack config (ui.ui's)
- the plugin is automatically configured by webpack when setting 'mode'
- mode is 'production' by default

This fixes the `using minified ... outside mode === "production"` error