### PR TITLE
avoid re-using the scope instance for "fetch" operation

### DIFF
--- a/src/api/scope/lib/fetch.ts
+++ b/src/api/scope/lib/fetch.ts
@@ -35,7 +35,9 @@ export default async function fetch(
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     HooksManagerInstance.triggerHook(PRE_SEND_OBJECTS, args, headers);
   }
-  const scope: Scope = await loadScope(path);
+  // DO NOT use the cached scope. otherwise, multiple http "fetch" requests adding and persisting
+  // to the repository at the same time, which opens a can of worms.
+  const scope: Scope = await loadScope(path, false);
   const objectList = new ObjectList();
   switch (fetchOptions.type) {
     case 'component': {


### PR DESCRIPTION
With SSH/FS protocol this is not an issue because it load the entire Bit for every command. HTTP on the other hand, re-use the Scope instance for multiple requests, which is fine for the most cases. 
For fetch, however, this creates hard-to-find problems. For example: scopeA/compA -> scopeB/compB.
UserA asks for compA, scopeA gets a "fetch" request, finds out that it doesn't have the compB dependency and gets it from scopeB, once the components received, it's being added to the objects-cache. During the persist-on-the-filesystem phase it got an error and was unable to persist. However, the component object of compB is still in the cache. 
As a result, the next time scopeA gets a fetch request it'll assume that this component exists, as it finds it in the cache. However when it starts collecting the objects for it, it'll immediately throw ENOENT errors.
