### PR TITLE
fix text color in env tooltip

### DIFF
--- a/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.module.scss
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.module.scss
@@ -81,7 +81,4 @@
     font-weight: bold;
     margin-bottom: 4px;
   }
-  .componentEnv {
-    color: var(--border-color);
-  }
 }

--- a/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
@@ -36,7 +36,7 @@ export function ComponentView(props: ComponentViewProps<PayloadType>) {
   const envTooltip = (
     <>
       <div className={styles.componentEnvTitle}>Environment</div>
-      <div className={styles.componentEnv}>{component.environment?.id}</div>
+      <div>{component.environment?.id}</div>
     </>
   );
 


### PR DESCRIPTION
## Proposed Changes

- Fixed text color in the Env Tooltip.

Before:
<img width="212" alt="Screen Shot 2021-02-15 at 12 18 41" src="https://user-images.githubusercontent.com/5400361/107934115-522f5080-6f88-11eb-898f-f9cc1bfac599.png">

Fixed:
<img width="219" alt="Screen Shot 2021-02-15 at 12 19 59" src="https://user-images.githubusercontent.com/5400361/107934131-58253180-6f88-11eb-88ed-6f69be5d35ed.png">

### Explanation:
Tooltip text had text color set to `--border-color`. When I applied `DarkTheme` to the tooltips, this color has changed from `#ededed` (pearl) to `#414141` (darkness).
Default text color in `DarkTheme` is already pearl, so just removing the css.
