### PR TITLE
fix pubsub lag

### DIFF
--- a/scopes/harmony/pubsub/pubsub.preview.runtime.ts
+++ b/scopes/harmony/pubsub/pubsub.preview.runtime.ts
@@ -26,7 +26,7 @@ export class PubsubPreview {
     }
   }
 
-  private connectToParentPubSub = (retries = 3) => {
+  private connectToParentPubSub = (retries = 10) => {
     if (retries <= 0) return undefined;
 
     return connectToParent<ParentMethods>({ timeout: 300 })
@@ -56,8 +56,9 @@ export class PubsubPreview {
 
   static async provider() {
     const pubsubPreview = new PubsubPreview();
+
     if (pubsubPreview.inIframe()) {
-      window.addEventListener('load', () => pubsubPreview.connectToParentPubSub());
+      return pubsubPreview.connectToParentPubSub();
     }
 
     return pubsubPreview;

--- a/scopes/harmony/pubsub/pubsub.ui.runtime.ts
+++ b/scopes/harmony/pubsub/pubsub.ui.runtime.ts
@@ -1,7 +1,6 @@
 import { UIRuntime, UIAspect, UiUI } from '@teambit/ui';
 
 import { connectToChild } from 'penpal';
-import type { Connection } from 'penpal/lib/types';
 
 import { BitBaseEvent } from './bit-base-event';
 import { PubsubAspect } from './pubsub.aspect';
@@ -11,28 +10,11 @@ import { createProvider } from './pubsub-context';
 export class PubsubUI {
   private topicMap = {};
 
-  private connectToIframeWithRetry = (iframe: HTMLIFrameElement, update: (c: Connection) => void, retries = 3) => {
+  private connectToIframe = (iframe: HTMLIFrameElement) => {
     const connection = connectToChild({
-      timeout: 500,
       iframe,
       methods: this.pubsubMethods,
     });
-
-    connection.promise.catch((e) => {
-      // make sure not to retry when code === "ConnectionDestroyed"
-      if (e.code !== 'ConnectionTimeout') return;
-
-      if (retries <= 0) return;
-      this.connectToIframeWithRetry(iframe, update, retries - 1); // recursion!
-    });
-
-    update(connection);
-  };
-
-  private connectToIframe = (iframe: HTMLIFrameElement) => {
-    let connection: Connection;
-
-    this.connectToIframeWithRetry(iframe, (c) => (connection = c));
 
     const destroy = () => {
       connection && connection.destroy();


### PR DESCRIPTION
## Proposed Changes

Improvements to the pubsub setup for docs/preview:
- Remove timeout from parent setup (now waits indefinitely, without having to retry)
- Start docs setup asap, instead of the slow window.onLoad()
- Increase child retries to 10, in case the iframe loads before the parent (e.g. due to ssr). In most cases, it will connect on first try.