### PR TITLE
catch promise errors of connection, in pubsub

### DIFF
--- a/scopes/harmony/pubsub/pubsub.ui.runtime.ts
+++ b/scopes/harmony/pubsub/pubsub.ui.runtime.ts
@@ -16,6 +16,9 @@ export class PubsubUI {
       methods: this.pubsubMethods,
     });
 
+    // absorb valid errors like 'connection destroyed'
+    connection.promise.catch(() => {});
+
     const destroy = () => {
       connection && connection.destroy();
     };


### PR DESCRIPTION
## Proposed Changes

- add `catch()` to Penpal's `connectToChild()` promise.
- this prevents uncaught promise rejections when switching between components quickly in Scope view