### PR TITLE
fix import delta to not fetch existing tags and to show only the newly added version

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -112,4 +112,29 @@ describe('import functionality on Harmony', function () {
       expect(() => helper.command.exportAllComponents()).to.not.throw();
     });
   });
+  describe('import delta (bit import without ids) when local is behind', () => {
+    let afterFirstExport: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.fixtures.populateComponents(1, undefined, ' v2');
+      helper.command.tagAllWithoutBuild();
+      helper.command.exportAllComponents();
+      helper.command.importAllComponents(); // to save all refs.
+      afterFirstExport = helper.scopeHelper.cloneLocalScope();
+      helper.fixtures.populateComponents(1, undefined, ' v3');
+      helper.command.tagAllWithoutBuild();
+      helper.command.exportAllComponents();
+      const bitMap = helper.bitMap.read();
+      helper.scopeHelper.getClonedLocalScope(afterFirstExport);
+      helper.bitMap.write(bitMap);
+    });
+    it('should not fetch existing versions, only the missing', () => {
+      const importOutput = helper.command.import();
+      expect(importOutput).to.not.include('new versions: 0.0.1, 0.0.2, 0.0.3');
+      expect(importOutput).to.include('new versions: 0.0.3');
+    });
+  });
 });

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -320,7 +320,7 @@ export default class ImportComponents {
 
   async _getCurrentVersions(ids: BitIds): Promise<ImportedVersions> {
     const versionsP = ids.map(async (id) => {
-      const modelComponent = await this.consumer.scope.getModelComponentIfExist(id);
+      const modelComponent = await this.consumer.scope.getModelComponentIfExist(id.changeVersion(undefined));
       const idStr = id.toStringWithoutVersion();
       if (!modelComponent) return [idStr, []];
       return [idStr, modelComponent.listVersions()];


### PR DESCRIPTION
currently it has two bugs:
1. the import-delta brings all old tags (not snaps) due to some backward compatibility code.
2. the output of `bit import` doesn't show the newly added tags correctly.

This PR fixes both.