### PR TITLE
improve component-objects merge performance by running them in parallel per remote

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -386,14 +386,15 @@ export default class Component extends BitObject {
     );
   }
 
-  getTagOfRefIfExists(ref: Ref): string | undefined {
-    return Object.keys(this.versionsIncludeOrphaned).find((versionRef) =>
-      this.versionsIncludeOrphaned[versionRef].isEqual(ref)
-    );
+  getTagOfRefIfExists(ref: Ref, allTags = this.versionsIncludeOrphaned): string | undefined {
+    return Object.keys(allTags).find((versionRef) => allTags[versionRef].isEqual(ref));
   }
 
   switchHashesWithTagsIfExist(refs: Ref[]): string[] {
-    return refs.map((ref) => this.getTagOfRefIfExists(ref) || ref.toString());
+    // cache the this.versionsIncludeOrphaned results into "allTags", looks strange but it improved
+    // the performance on bit-bin with 188 components during source.merge in 4 seconds.
+    const allTags = this.versionsIncludeOrphaned;
+    return refs.map((ref) => this.getTagOfRefIfExists(ref, allTags) || ref.toString());
   }
 
   /**

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -1,5 +1,6 @@
 import fs from 'fs-extra';
 import mapSeries from 'p-map-series';
+import pMap from 'p-map';
 import * as pathLib from 'path';
 import R from 'ramda';
 import semver from 'semver';
@@ -23,6 +24,7 @@ import {
   OBJECTS_DIR,
   SCOPE_JSON,
   PENDING_OBJECTS_DIR,
+  CONCURRENT_COMPONENTS_LIMIT,
 } from '../constants';
 import Component from '../consumer/component/consumer-component';
 import Dists from '../consumer/component/sources/dists';
@@ -455,9 +457,9 @@ export default class Scope {
     const components = bitObjectList.getComponents();
     const versions = bitObjectList.getVersions();
     const laneObjects = bitObjectList.getLanes();
-    await mapSeries(components, (component: ModelComponent) =>
-      this.mergeModelComponent(component, versions, remoteName)
-    );
+    await pMap(components, (component: ModelComponent) => this.mergeModelComponent(component, versions, remoteName), {
+      concurrency: CONCURRENT_COMPONENTS_LIMIT,
+    });
     let nonLaneIds: BitId[] = ids;
     await Promise.all(
       laneObjects.map(async (lane) => {


### PR DESCRIPTION
It's not safe to run the objects merge in parallel for all components because the same component may retrieved from different scopes (origin and cache). In this PR the parallel is executed per remote, which is safe and improves the performance dramatically (from 36 sec to 18 sec for 188 components in bit-bin).