### PR TITLE
re-set react version

### DIFF
--- a/scopes/design/ui/external-link/external-link.tsx
+++ b/scopes/design/ui/external-link/external-link.tsx
@@ -6,7 +6,6 @@ export type ExternalLinkProps = {} & React.AnchorHTMLAttributes<HTMLAnchorElemen
 
 export function ExternalLink({ href, children, className, ...rest }: ExternalLinkProps) {
   return (
-    // @ts-ignore TOOD: @Uri please check this
     <a {...rest} target="_blank" rel="noreferrer" href={href} className={classNames(styles.link, className)}>
       {children}
     </a>

--- a/scopes/react/react-native/component.json
+++ b/scopes/react/react-native/component.json
@@ -7,7 +7,9 @@
   "propagate": false,
   "extensions": {
     "teambit.pkg/pkg": {
-      "packageManagerPublishArgs": ["--access public"],
+      "packageManagerPublishArgs": [
+        "--access public"
+      ],
       "packageJson": {
         "name": "@teambit/{name}",
         "private": false,
@@ -41,9 +43,9 @@
           "@teambit/legacy": "-"
         },
         "peerDependencies": {
-          "react": "16.13.1",
-          "@teambit/legacy": "1.0.10",
-          "react-dom": "16.13.1"
+          "react": "^16.8.0",
+          "react-dom": "^16.8.0",
+          "@teambit/legacy": "1.0.10"
         }
       }
     },

--- a/scopes/react/react-native/react-native.main.runtime.ts
+++ b/scopes/react/react-native/react-native.main.runtime.ts
@@ -116,8 +116,8 @@ function getReactNativeDeps() {
       'react-native-web': '0.14.8',
     },
     peerDependencies: {
-      react: '16.13.1',
-      'react-native': '0.63.4',
+      react: '^16.8.0',
+      'react-dom': '^16.8.0',
     },
   };
 }

--- a/scopes/react/react/component.json
+++ b/scopes/react/react/component.json
@@ -54,9 +54,9 @@
           "react-dom": "-"
         },
         "peerDependencies": {
-          "react": "16.13.1",
-          "@teambit/legacy": "1.0.10",
-          "react-dom": "16.13.1"
+          "react": "^16.8.0",
+          "react-dom": "^16.8.0",
+          "@teambit/legacy": "1.0.10"
         }
       }
     }

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -255,7 +255,7 @@ export class ReactEnv implements Environment {
       // TODO: add this only if using ts
       devDependencies: {
         '@types/node': '12.20.4',
-        '@types/react': '16.9.43',
+        '@types/react': '^16.8.0',
         '@types/jest': '26.0.20',
         '@types/mocha': '-',
         '@types/react-router-dom': '5.1.7',
@@ -264,8 +264,8 @@ export class ReactEnv implements Environment {
       },
       // TODO: take version from config
       peerDependencies: {
-        react: '16.13.1',
-        'react-dom': '16.13.1',
+        react: '^16.8.0',
+        'react-dom': '^16.8.0',
       },
     };
   }

--- a/scopes/ui-foundation/routing/native-link/native-link.tsx
+++ b/scopes/ui-foundation/routing/native-link/native-link.tsx
@@ -30,6 +30,5 @@ export function NativeLink({ href = '', external, replace, onClick, ...rest }: L
     [href, replace, onClick]
   );
 
-  // @ts-ignore TOOD: @Uri please check this
   return <a {...rest} {...externalProps} onClick={handleClick} href={href} />;
 }

--- a/scopes/ui-foundation/ui/component.json
+++ b/scopes/ui-foundation/ui/component.json
@@ -40,8 +40,8 @@
           "@teambit/legacy": "-"
         },
         "peerDependencies": {
-          "react": "16.13.1",
-          "react-dom": "16.13.1",
+          "react": "^16.8.0",
+          "react-dom": "^16.8.0",
           "@teambit/legacy": "1.0.10"
         }
       }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -137,8 +137,8 @@
         "@types/node": "14.14.13",
         "@types/proper-lockfile": "4.1.1",
         "@types/puppeteer": "3.0.5",
-        "@types/react": "16.9.43",
-        "@types/react-dom": "16.9.10",
+        "@types/react": "^16.14.4",
+        "@types/react-dom": "^16.9.11",
         "@types/react-router-dom": "5.1.7",
         "@types/react-tabs": "2.3.2",
         "@types/react-transition-group": "4.4.1",
@@ -239,6 +239,7 @@
         "proper-lockfile": "4.1.2",
         "react-animate-height": "2.0.23",
         "react-dev-utils": "10.2.1",
+        "react": "16.14.0",
         "react-dom": "16.14.0",
         "react-error-overlay": "6.0.9",
         "react-flow-renderer": "8.3.7",
@@ -289,9 +290,7 @@
         "@teambit/legacy": "1.0.10",
         "browserslist": "4.16.3",
         "graphql": "14.7.0",
-        "mz": "2.7.0",
-        "react": "16.13.1",
-        "react-dom": "16.13.1"
+        "mz": "2.7.0"
       }
     },
     "packageManagerArgs": [],
@@ -343,9 +342,7 @@
             "@teambit/legacy": "-"
           },
           "peerDependencies": {
-            "react": "16.13.1",
-            "@teambit/legacy": "1.0.10",
-            "react-dom": "16.13.1"
+            "@teambit/legacy": "1.0.10"
           }
         }
       },
@@ -489,8 +486,6 @@
             "@teambit/legacy": "1.0.10",
             // TODO: remove this later
             "core-js": "3.8.3",
-            "react": "16.13.1",
-            "react-dom": "16.13.1",
             "graphql": "14.7.0",
             "browserslist": "4.16.3",
             "reflect-metadata": "0.1.13",
@@ -500,7 +495,6 @@
             "graceful-fs": "4.2.4"
           },
           "devDependencies": {
-            "@types/react": "16.14.4",
             "@types/mocha": "5.2.7",
             // why this is needed? try to automate this
             "@types/node": "12.20.4"
@@ -509,8 +503,6 @@
             "@teambit/legacy": "-",
             "browserslist": "-",
             "graphql": "-",
-            "react": "-",
-            "react-dom": "-"
           }
         }
       }


### PR DESCRIPTION
## Proposed Changes

- set `16.14.0` as fixed react/react-dom version  in workspace.jsonc, to enforce version in our runtime.
- for components, assume `react-env` sets the version.
- remove all other configs about `react`, `react-dom`, `@types/react` and `@types/react-dom`.
- Use flexible react version in react-env (>= 16.8, the one with the hooks).


## To do
- [x] check why components get react/react-dom version `^16.13.1` (should be either 16.14.0 or 16.8.0). Where is this coming from?  
--> Probably coming from `bd`, so it will be fixed after 2 tags.
   - [ ] verify with another bit clone
- [ ] Regular components should not have a peerDep on `@teambit/legacy`.
- [ ] Support for React 15, <16.8 components (maybe a "react 15" env?).