### PR TITLE
load components aspects when running update-dependencies command

### DIFF
--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -114,7 +114,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     componentsToSign: ComponentID[];
   }> {
     // using `loadComponents` instead of `getMany` to make sure component aspects are loaded.
-    this.logger.setStatusLine(`loading ${ids.length} components and their extensions...`);
+    this.logger.setStatusLine(`loading ${ids.length} components and their aspects...`);
     const components = await this.scope.loadMany(ids);
     this.logger.clearStatusLine();
     const componentsToSign: ComponentID[] = [];

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -158,9 +158,10 @@ export class UpdateDependenciesMain {
   }
 
   private async parseDevUpdatesItems(depsUpdateItemsRaw: DepUpdateItemRaw[]): Promise<DepUpdateItem[]> {
+    this.logger.setStatusLine(`loading ${depsUpdateItemsRaw.length} components and their aspects...`);
     return mapSeries(depsUpdateItemsRaw, async (depUpdateItemRaw) => {
       const componentId = ComponentID.fromString(depUpdateItemRaw.componentId);
-      const component = await this.scope.get(componentId);
+      const component = await this.scope.load(componentId);
       if (!component) throw new ComponentNotFound(componentId);
       const dependencies = await Promise.all(
         depUpdateItemRaw.dependencies.map((dep) => this.getDependencyWithExactVersion(dep))
@@ -181,6 +182,7 @@ export class UpdateDependenciesMain {
   }
 
   private async updateFutureVersion() {
+    this.logger.setStatusLine(`updateFutureVersion...`);
     await mapSeries(this.depsUpdateItems, async (depUpdateItem) => {
       const legacyComp: ConsumerComponent = depUpdateItem.component.state._consumer;
       const modelComponent = await this.scope.legacyScope.getModelComponent(legacyComp.id);


### PR DESCRIPTION
Currently, it loads the components from the scope without the aspects (using `scope.get` instead of `scope.load`).