### PR TITLE
cache components loaded from the scope

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -1,0 +1,105 @@
+import { Component, ComponentFS, ComponentID, Config, Snap, State, Tag, TagMap } from '@teambit/component';
+import { Logger } from '@teambit/logger';
+import { SemVer } from 'semver';
+import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
+import { ModelComponent, Version } from '@teambit/legacy/dist/scope/models';
+import { Ref } from '@teambit/legacy/dist/scope/objects';
+import type { ScopeMain } from './scope.main.runtime';
+
+export class ScopeComponentLoader {
+  private componentsCache: { [idStr: string]: Component } = {};
+  constructor(private scope: ScopeMain, private logger: Logger) {}
+
+  async get(id: ComponentID): Promise<Component | undefined> {
+    const idStr = id.toString();
+    if (this.componentsCache[idStr]) {
+      return this.componentsCache[idStr];
+    }
+    this.logger.debug(`ScopeComponentLoader.get, loading ${idStr}`);
+    const legacyId = id._legacy;
+    let modelComponent = await this.scope.legacyScope.getModelComponentIfExist(id._legacy);
+    // Search with scope name for bare scopes
+    if (!modelComponent && !legacyId.scope) {
+      id = id.changeScope(this.scope.name);
+      modelComponent = await this.scope.legacyScope.getModelComponentIfExist(id._legacy);
+    }
+    if (!modelComponent) return undefined;
+
+    // :TODO move to head snap once we have it merged, for now using `latest`.
+    const versionStr = id.version && id.version !== 'latest' ? id.version : modelComponent.latest();
+    const newId = id.changeVersion(versionStr);
+    const version = await modelComponent.loadVersion(versionStr, this.scope.legacyScope.objects);
+    const snap = this.createSnapFromVersion(version);
+    const state = await this.createStateFromVersion(id, version);
+    const tagMap = await this.getTagMap(modelComponent);
+
+    const component = new Component(newId, snap, state, tagMap, this.scope);
+    this.componentsCache[idStr] = component;
+    return component;
+  }
+
+  async getFromConsumerComponent(consumerComponent: ConsumerComponent): Promise<Component> {
+    const legacyId = consumerComponent.id;
+    const modelComponent = await this.scope.legacyScope.getModelComponent(legacyId);
+    // :TODO move to head snap once we have it merged, for now using `latest`.
+    const id = await this.scope.resolveComponentId(legacyId);
+    const version =
+      consumerComponent.pendingVersion ||
+      (await modelComponent.loadVersion(legacyId.version as string, this.scope.legacyScope.objects));
+    const snap = this.createSnapFromVersion(version);
+    const state = await this.createStateFromVersion(id, version);
+    const tagMap = await this.getTagMap(modelComponent);
+
+    return new Component(id, snap, state, tagMap, this.scope);
+  }
+
+  async getState(id: ComponentID, hash: string): Promise<State> {
+    const version = (await this.scope.legacyScope.objects.load(new Ref(hash))) as Version;
+    return this.createStateFromVersion(id, version);
+  }
+
+  async getSnap(id: ComponentID, hash: string): Promise<Snap> {
+    const version = (await this.scope.legacyScope.objects.load(new Ref(hash))) as Version;
+    return this.createSnapFromVersion(version);
+  }
+
+  clearCache() {
+    this.componentsCache = {};
+  }
+
+  private async getTagMap(modelComponent: ModelComponent): Promise<TagMap> {
+    const tagMap = new TagMap();
+    Object.keys(modelComponent.versions).forEach((versionStr: string) => {
+      const tag = new Tag(modelComponent.versions[versionStr].toString(), new SemVer(versionStr));
+      tagMap.set(tag.version, tag);
+    });
+    return tagMap;
+  }
+
+  private createSnapFromVersion(version: Version): Snap {
+    return new Snap(
+      version.hash().toString(),
+      new Date(parseInt(version.log.date)),
+      version.parents.map((p) => p.toString()),
+      {
+        displayName: version.log.username || 'unknown',
+        email: version.log.email || 'unknown@anywhere',
+      },
+      version.log.message
+    );
+  }
+
+  private async createStateFromVersion(id: ComponentID, version: Version): Promise<State> {
+    const consumerComponent = await this.scope.legacyScope.getConsumerComponent(id._legacy);
+    const state = new State(
+      // We use here the consumerComponent.extensions instead of version.extensions
+      // because as part of the conversion to consumer component the artifacts are initialized as Artifact instances
+      new Config(version.mainFile, consumerComponent.extensions),
+      this.scope.componentExtension.createAspectList(consumerComponent.extensions, this.scope.name),
+      ComponentFS.fromVinyls(consumerComponent.files),
+      version.dependencies,
+      consumerComponent
+    );
+    return state;
+  }
+}

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1,4 +1,5 @@
 import mapSeries from 'p-map-series';
+import semver from 'semver';
 import type { AspectLoaderMain } from '@teambit/aspect-loader';
 import { difference } from 'ramda';
 import { TaskResultsList, BuilderData, BuilderAspect } from '@teambit/builder';
@@ -550,9 +551,7 @@ export class ScopeMain implements ComponentFactory {
   async getExactVersionBySemverRange(id: ComponentID, range: string): Promise<string | undefined> {
     const modelComponent = await this.legacyScope.getModelComponent(id._legacy);
     const versions = modelComponent.listVersions();
-    // TODO - @david
-    return semver.maxSatisfying(versions, range)?.toString();
-    // return semver.maxSatisfying<string>(versions, range);
+    return semver.maxSatisfying<string>(versions, range)?.toString();
   }
 
   async resumeExport(exportId: string, remotes: string[]): Promise<string[]> {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -7,18 +7,7 @@ import { resolve, join } from 'path';
 import { AspectLoaderAspect, AspectDefinition } from '@teambit/aspect-loader';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import type { ComponentMain, ComponentMap } from '@teambit/component';
-import {
-  Component,
-  ComponentAspect,
-  ComponentFactory,
-  ComponentFS,
-  ComponentID,
-  Config,
-  Snap,
-  State,
-  Tag,
-  TagMap,
-} from '@teambit/component';
+import { Component, ComponentAspect, ComponentFactory, ComponentID, Snap, State } from '@teambit/component';
 import type { GraphqlMain } from '@teambit/graphql';
 import { GraphqlAspect } from '@teambit/graphql';
 import { Harmony, Slot, SlotRegistry } from '@teambit/harmony';
@@ -30,8 +19,8 @@ import { UIAspect } from '@teambit/ui';
 import { RequireableComponent } from '@teambit/modules.requireable-component';
 import { BitId } from '@teambit/legacy-bit-id';
 import { BitIds as ComponentsIds } from '@teambit/legacy/dist/bit-id';
-import { ModelComponent, Version, Lane } from '@teambit/legacy/dist/scope/models';
-import { Ref, Repository } from '@teambit/legacy/dist/scope/objects';
+import { ModelComponent, Lane } from '@teambit/legacy/dist/scope/models';
+import { Repository } from '@teambit/legacy/dist/scope/objects';
 import LegacyScope, { LegacyOnTagResult, OnTagFunc, OnTagOpts } from '@teambit/legacy/dist/scope/scope';
 import { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
 import { loadScopeIfExist } from '@teambit/legacy/dist/scope/scope-loader';
@@ -47,12 +36,12 @@ import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { resumeExport } from '@teambit/legacy/dist/scope/component-ops/export-scope-components';
 import { ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config';
 import { compact, slice, uniqBy } from 'lodash';
-import semver, { SemVer } from 'semver';
 import { ComponentNotFound } from './exceptions';
 import { ScopeAspect } from './scope.aspect';
 import { scopeSchema } from './scope.graphql';
 import { ScopeUIRoot } from './scope.ui-root';
 import { PutRoute, FetchRoute, ActionRoute, DeleteRoute } from './routes';
+import { ScopeComponentLoader } from './scope-component-loader';
 
 type TagRegistry = SlotRegistry<OnTag>;
 
@@ -78,6 +67,7 @@ export type ScopeConfig = {
 };
 
 export class ScopeMain implements ComponentFactory {
+  componentLoader: ScopeComponentLoader;
   constructor(
     /**
      * private reference to the instance of Harmony.
@@ -112,7 +102,9 @@ export class ScopeMain implements ComponentFactory {
     private aspectLoader: AspectLoaderMain,
 
     private logger: Logger
-  ) {}
+  ) {
+    this.componentLoader = new ScopeComponentLoader(this, this.logger);
+  }
 
   /**
    * name of the scope
@@ -427,44 +419,12 @@ export class ScopeMain implements ComponentFactory {
     return this.getMany(ids);
   }
 
-  /**
-   * get a component.
-   * @param id component id
-   */
   async get(id: ComponentID): Promise<Component | undefined> {
-    const legacyId = id._legacy;
-    let modelComponent = await this.legacyScope.getModelComponentIfExist(id._legacy);
-    // Search with scope name for bare scopes
-    if (!modelComponent && !legacyId.scope) {
-      id = id.changeScope(this.name);
-      modelComponent = await this.legacyScope.getModelComponentIfExist(id._legacy);
-    }
-    if (!modelComponent) return undefined;
-
-    // :TODO move to head snap once we have it merged, for now using `latest`.
-    const versionStr = id.version && id.version !== 'latest' ? id.version : modelComponent.latest();
-    const newId = id.changeVersion(versionStr);
-    const version = await modelComponent.loadVersion(versionStr, this.legacyScope.objects);
-    const snap = this.createSnapFromVersion(version);
-    const state = await this.createStateFromVersion(id, version);
-    const tagMap = await this.getTagMap(modelComponent);
-
-    return new Component(newId, snap, state, tagMap, this);
+    return this.componentLoader.get(id);
   }
 
   async getFromConsumerComponent(consumerComponent: ConsumerComponent): Promise<Component> {
-    const legacyId = consumerComponent.id;
-    const modelComponent = await this.legacyScope.getModelComponent(legacyId);
-    // :TODO move to head snap once we have it merged, for now using `latest`.
-    const id = await this.resolveComponentId(legacyId);
-    const version =
-      consumerComponent.pendingVersion ||
-      (await modelComponent.loadVersion(legacyId.version as string, this.legacyScope.objects));
-    const snap = this.createSnapFromVersion(version);
-    const state = await this.createStateFromVersion(id, version);
-    const tagMap = await this.getTagMap(modelComponent);
-
-    return new Component(id, snap, state, tagMap, this);
+    return this.componentLoader.getFromConsumerComponent(consumerComponent);
   }
 
   /**
@@ -551,14 +511,11 @@ export class ScopeMain implements ComponentFactory {
    * @param hash state hash.
    */
   async getState(id: ComponentID, hash: string): Promise<State> {
-    const version = (await this.legacyScope.objects.load(new Ref(hash))) as Version;
-    return this.createStateFromVersion(id, version);
+    return this.componentLoader.getState(id, hash);
   }
 
   async getSnap(id: ComponentID, hash: string): Promise<Snap> {
-    // TODO: add cache by hash
-    const version = (await this.legacyScope.objects.load(new Ref(hash))) as Version;
-    return this.createSnapFromVersion(version);
+    return this.componentLoader.getSnap(id, hash);
   }
 
   async getLogs(id: ComponentID): Promise<ComponentLog[]> {
@@ -600,42 +557,6 @@ export class ScopeMain implements ComponentFactory {
 
   async resumeExport(exportId: string, remotes: string[]): Promise<string[]> {
     return resumeExport(this.legacyScope, exportId, remotes);
-  }
-
-  private async getTagMap(modelComponent: ModelComponent): Promise<TagMap> {
-    const tagMap = new TagMap();
-    Object.keys(modelComponent.versions).forEach((versionStr: string) => {
-      const tag = new Tag(modelComponent.versions[versionStr].toString(), new SemVer(versionStr));
-      tagMap.set(tag.version, tag);
-    });
-    return tagMap;
-  }
-
-  private createSnapFromVersion(version: Version): Snap {
-    return new Snap(
-      version.hash().toString(),
-      new Date(parseInt(version.log.date)),
-      version.parents.map((p) => p.toString()),
-      {
-        displayName: version.log.username || 'unknown',
-        email: version.log.email || 'unknown@anywhere',
-      },
-      version.log.message
-    );
-  }
-
-  private async createStateFromVersion(id: ComponentID, version: Version): Promise<State> {
-    const consumerComponent = await this.legacyScope.getConsumerComponent(id._legacy);
-    const state = new State(
-      // We use here the consumerComponent.extensions instead of version.extensions
-      // because as part of the conversion to consumer component the artifacts are initialized as Artifact instances
-      new Config(version.mainFile, consumerComponent.extensions),
-      this.componentExtension.createAspectList(consumerComponent.extensions, this.name),
-      ComponentFS.fromVinyls(consumerComponent.files),
-      version.dependencies,
-      consumerComponent
-    );
-    return state;
   }
 
   async resolveId(id: string): Promise<ComponentID> {
@@ -733,6 +654,7 @@ export class ScopeMain implements ComponentFactory {
 
     const onPutHook = async (ids: string[], lanes: Lane[], authData?: AuthData): Promise<void> => {
       logger.debug(`onPutHook, started. (${ids.length} components)`);
+      scope.componentLoader.clearCache();
       const componentIds = await scope.resolveMultipleComponentIds(ids);
       const fns = postPutSlot.values();
       const data = {


### PR DESCRIPTION
## Proposed Changes

- refactoring: extract all component-load of the scope aspect to a new class `ScopeComponentLoader`
- cache components once loaded from the scope.
