### PR TITLE
avoid traversing the entire component graph when merging a component-object

### DIFF
--- a/src/scope/component-ops/model-components-merger.spec.ts
+++ b/src/scope/component-ops/model-components-merger.spec.ts
@@ -25,8 +25,6 @@ describe('ModelComponentMerger', () => {
       const { mergedComponent, mergedVersions } = await new ModelComponentMerger(
         existingComponent,
         incomingComponent,
-        [],
-        [],
         false,
         true,
         false
@@ -55,8 +53,6 @@ describe('ModelComponentMerger', () => {
       const { mergedComponent, mergedVersions } = await new ModelComponentMerger(
         existingComponent,
         incomingComponent,
-        [],
-        [],
         true,
         true,
         false
@@ -91,8 +87,6 @@ describe('ModelComponentMerger', () => {
       const { mergedComponent, mergedVersions } = await new ModelComponentMerger(
         existingComponent,
         incomingComponent,
-        [],
-        [],
         true,
         true,
         false
@@ -118,8 +112,6 @@ describe('ModelComponentMerger', () => {
       const { mergedComponent, mergedVersions } = await new ModelComponentMerger(
         existingComponent,
         incomingComponent,
-        [],
-        [],
         true,
         true,
         false
@@ -148,8 +140,6 @@ describe('ModelComponentMerger', () => {
       const { mergedComponent, mergedVersions } = await new ModelComponentMerger(
         existingComponent,
         incomingComponent,
-        [],
-        [],
         true,
         true,
         false
@@ -463,8 +453,6 @@ async function merge(
   const modelComponentMerger = new ModelComponentMerger(
     existingComponent,
     incomingComponent,
-    [],
-    [],
     isImport,
     isIncomingFromOrigin,
     existingHeadIsMissingInIncomingComponent

--- a/src/scope/component-ops/model-components-merger.ts
+++ b/src/scope/component-ops/model-components-merger.ts
@@ -13,8 +13,6 @@ export class ModelComponentMerger {
   constructor(
     private existingComponent: ModelComponent,
     private incomingComponent: ModelComponent,
-    private existingTagsAndSnaps: string[],
-    private incomingTagsAndSnaps: string[],
     private isImport: boolean,
     private isIncomingFromOrigin: boolean, // import: incoming from original scope. export: component belong to current scope
     private existingHeadIsMissingInIncomingComponent: boolean
@@ -33,7 +31,6 @@ export class ModelComponentMerger {
     this.throwMergeConflictIfNeeded(locallyChanged);
     this.replaceTagHashIfDifferentOnIncoming();
     this.moveTagToOrphanedIfNotExistOnOrigin();
-    this.addSnapsToMergedVersions();
     this.addNonExistTagFromIncoming();
     this.addOrphanedVersionFromIncoming();
     this.setHead(locallyChanged);
@@ -45,15 +42,6 @@ export class ModelComponentMerger {
   private deleteOrphanedVersionsOnExport() {
     // makes sure that components received with orphanedVersions, this property won't be saved
     if (this.isExport) this.existingComponent.orphanedVersions = {};
-  }
-
-  private addSnapsToMergedVersions() {
-    if (this.incomingComponent.hasHead()) {
-      const mergedSnaps = this.incomingTagsAndSnaps.filter(
-        (tagOrSnap) => !this.existingTagsAndSnaps.includes(tagOrSnap) && !this.mergedVersions.includes(tagOrSnap)
-      );
-      this.mergedVersions.push(...mergedSnaps);
-    }
   }
 
   private setHead(locallyChanged: boolean) {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -24,6 +24,7 @@ import {
   OBJECTS_DIR,
   SCOPE_JSON,
   PENDING_OBJECTS_DIR,
+  CONCURRENT_COMPONENTS_LIMIT,
 } from '../constants';
 import Component from '../consumer/component/consumer-component';
 import Dists from '../consumer/component/sources/dists';
@@ -479,8 +480,7 @@ export default class Scope {
     const versions = bitObjectList.getVersions();
     const laneObjects = bitObjectList.getLanes();
     await pMap(components, (component: ModelComponent) => this.mergeModelComponent(component, versions, remoteName), {
-      // concurrency: CONCURRENT_COMPONENTS_LIMIT,
-      concurrency: 7, // temporarily limit the concurrency to a minimal number, optimize it ASAP
+      concurrency: CONCURRENT_COMPONENTS_LIMIT,
     });
     let nonLaneIds: BitId[] = ids;
     await Promise.all(


### PR DESCRIPTION
Currently, when importing components and merging the objects into the local scope, Bit traverse the entire history in order to find the diff between the incoming component and existing component. 
Instead, traverse the incoming component only (which is already in-memory) until you find the existing head, this way, it's easy to get the added snaps without traversing the local component.