### PR TITLE
allow only one fetch-with-deps at a time to avoid files corruption

### DIFF
--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -273,7 +273,9 @@ export default class ComponentLoader {
       return null; // probably doesn't exist
     }
     const bitObjectsList = await objectList.toBitObjects();
-    return bitObjectsList.getComponents()[0];
+    const components = bitObjectsList.getComponents();
+    if (!components.length) return null; // probably doesn't exist
+    return components[0];
   }
 
   private _isAngularProject(): boolean {

--- a/src/remotes/remotes.ts
+++ b/src/remotes/remotes.ts
@@ -49,7 +49,7 @@ export default class Remotes extends Map<string, Remote> {
   ): Promise<{ objectList: ObjectList; objectListPerRemote: { [remoteName: string]: ObjectList } }> {
     const fetchOptions: FETCH_OPTIONS = {
       type: 'component',
-      withoutDependencies: false,
+      withoutDependencies: true,
       includeArtifacts: false,
       ...options,
     };

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -158,6 +158,7 @@
         "apollo-link-ws": "1.0.20",
         "apollo-server": "2.19.2",
         "apollo-utilities": "1.3.4",
+        "async-mutex": "0.3.1",
         "aws-sdk": "2.756.0",
         "babel-jest": "26.6.3",
         "babel-plugin-named-asset-import": "0.3.7",


### PR DESCRIPTION
## Proposed Changes

- use mutex to ensure that "fetch-with-dependencies" runs sequentially. otherwise, on the remotes, multiple requests are fetching external dependencies at the same time, causing "refs" and "object" files to be corrupted.
- remove `getExternal` and `getExternalWithoutDependencies` apis, use the "many" counterparts. 
- use the cached scope instance for "fetch" operation to avoid high memory consumption that leads to out-of-memory error.