### PR TITLE
simplify gql client factory

### DIFF
--- a/scopes/harmony/express/express.main.runtime.ts
+++ b/scopes/harmony/express/express.main.runtime.ts
@@ -52,6 +52,7 @@ export class ExpressMain {
 
   /**
    * register a new express routes.
+   * route will be added as `/api/${route}`
    */
   register(routes: Route[]) {
     this.moduleSlot.register(routes);

--- a/scopes/harmony/graphql/render-lifecycle.tsx
+++ b/scopes/harmony/graphql/render-lifecycle.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { getDataFromTree } from '@apollo/client/react/ssr';
-import { NormalizedCacheObject } from '@apollo/client';
+import type { NormalizedCacheObject } from '@apollo/client';
 import pick from 'lodash.pick';
 
 import { isBrowser } from '@teambit/ui.is-browser';
@@ -64,7 +64,11 @@ export class GraphqlRenderLifecycle implements RenderLifecycle<RenderContext, { 
   };
 
   browserInit = ({ state }: { state?: NormalizedCacheObject } = {}) => {
-    const client = this.graphqlUI.createClient(window.location.host, { state });
+    const { location } = window;
+    const isInsecure = location.protocol === 'http:';
+    const wsUrl = `${isInsecure ? 'ws:' : 'wss:'}//${location.host}/subscriptions`;
+
+    const client = this.graphqlUI.createClient('/graphql', { state, subscriptionUri: wsUrl, legacy: false });
 
     this.graphqlUI._setClient(client);
 


### PR DESCRIPTION
## Proposed Changes

- `gql.createClient()`: extract uri generation to consumer, and separate WebSocket uri to its own option.
- add `legacy=true` option, to use old method until fully replaced
- @KutnerUri will remove the legacy code in a separate commit (after updating Symphony)