### PR TITLE
prevent persisting objects in parallel to avoid files corruption

### DIFF
--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -84,8 +84,8 @@ export class GraphqlMain {
 
     // TODO: @guy please consider to refactor to express extension.
     const app = options.app || express();
-    // @ts-ignore todo: it's not clear what's the issue.
     app.use(
+      // @ts-ignore todo: it's not clear what's the issue.
       cors({
         origin(origin, callback) {
           callback(null, true);


### PR DESCRIPTION
files such as `refs` and `index.json` could be corrupted if for some reason, `repository.persist()` gets called by multiple requests at the same time.