### PR TITLE
delete index.json file in the scope by bit clear-cache

### DIFF
--- a/src/cli/commands/public-cmds/clear-cache-cmd.ts
+++ b/src/cli/commands/public-cmds/clear-cache-cmd.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 // it's a hack, but I didn't find a better way to access the getCacheDir() function
 import { __TEST__ as v8CompileCache } from 'v8-compile-cache';
 import { loadConsumerIfExist } from '../../../consumer';
+import { loadScopeIfExist } from '../../../scope/scope-loader';
 
 import { LegacyCommand } from '../../legacy-command';
 
@@ -17,17 +18,27 @@ export default class ClearCache implements LegacyCommand {
   skipWorkspace = true;
 
   async action(): Promise<any> {
+    const cacheCleared: string[] = [];
     const cacheDir = v8CompileCache.getCacheDir();
     fs.removeSync(cacheDir);
+    cacheCleared.push('v8-compile-cache code');
     const consumer = await loadConsumerIfExist();
     if (consumer) {
       const componentCachePath = consumer.componentFsCache.basePath;
       fs.removeSync(componentCachePath);
+      cacheCleared.push('components cache on the filesystem');
     }
-    return Promise.resolve();
+    const scope = await loadScopeIfExist();
+    if (scope) {
+      await scope.objects.scopeIndex.deleteFile();
+      cacheCleared.push('scope-index file');
+    }
+    return cacheCleared;
   }
 
-  report(): string {
-    return chalk.green('cache cleared');
+  report(cacheCleared: string[]): string {
+    const title = 'the following cache(s) have been cleared:';
+    const output = cacheCleared.map((str) => `  ✔ ${str}`).join('\n');
+    return chalk.green(`${chalk.bold(title)}\n${output}`);
   }
 }


### PR DESCRIPTION
## Proposed Changes

- support deleting .bit/index.json using `bit cc`
- improve the clear-cache output to show what type of cashes were cleared
