### PR TITLE
avoid caching data during bit-remove

### DIFF
--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -413,7 +413,7 @@ export async function exportMany({
       // (could be removed in the future by some garbage collection).
       const removeComponentVersions = false;
       const refsToRemove = await Promise.all(
-        idsToChangeLocally.map((id) => scope.sources.removeComponentById(id, removeComponentVersions))
+        idsToChangeLocally.map((id) => scope.sources.getRefsForComponentRemoval(id, removeComponentVersions))
       );
       scope.objects.removeManyObjects(refsToRemove.flat());
       // @ts-ignore

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -412,7 +412,10 @@ export async function exportMany({
       // on the legacy, even when the hash changed, it's fine to have the old objects laying around.
       // (could be removed in the future by some garbage collection).
       const removeComponentVersions = false;
-      await Promise.all(idsToChangeLocally.map((id) => scope.sources.removeComponentById(id, removeComponentVersions)));
+      const refsToRemove = await Promise.all(
+        idsToChangeLocally.map((id) => scope.sources.removeComponentById(id, removeComponentVersions))
+      );
+      scope.objects.removeManyObjects(refsToRemove.flat());
       // @ts-ignore
       idsToChangeLocally.forEach((id) => scope.createSymlink(id, remoteNameStr));
       componentsAndObjects.forEach((componentObject) => scope.sources.put(componentObject));

--- a/src/scope/component-ops/remove-model-components.ts
+++ b/src/scope/component-ops/remove-model-components.ts
@@ -39,18 +39,24 @@ export default class RemoveModelComponents {
       // do not run this in parallel (promise.all), otherwise, it may throw an error when
       // trying to delete the same file at the same time (happens when removing a component with
       // a dependency and the dependency itself)
-      const removedComponents = await mapSeries(foundComponents, (bitId) => this._removeSingle(bitId));
-      const refsToRemoveAll = removedComponents.map((removed) => removed.refsToRemove).flat();
+      const removalData = await mapSeries(foundComponents, (bitId) => this.getRemoveSingleData(bitId));
+      const compIds = new BitIds(...removalData.map((x) => x.compId));
+      const depsIds = new BitIds(...removalData.map((x) => x.depIds).flat());
+      const allIds = [...compIds, ...depsIds];
+      const refsToRemoveAll = removalData.map((removed) => removed.refsToRemove).flat();
       if (this.currentLane) {
         await this.scope.objects.writeObjectsToTheFS([this.currentLane]);
       }
       await this.scope.objects.deleteObjectsFromFS(refsToRemoveAll);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const ids = new BitIds(...removedComponents.map((x) => x.bitId));
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const removedDependencies = new BitIds(...R.flatten(removedComponents.map((x) => x.removedDependencies)));
+      await this.scope.objects.deleteRecordsFromUnmergedComponents(allIds.map((id) => id.name));
+
       const removedFromLane = Boolean(this.currentLane);
-      return new RemovedObjects({ removedComponentIds: ids, missingComponents, removedDependencies, removedFromLane });
+      return new RemovedObjects({
+        removedComponentIds: compIds,
+        missingComponents,
+        removedDependencies: depsIds,
+        removedFromLane,
+      });
     }
     // some of the components have dependents, don't remove them
     return new RemovedObjects({ missingComponents, dependentBits });
@@ -61,7 +67,7 @@ export default class RemoveModelComponents {
    * @param {BitId} bitId - list of remote component ids to delete
    * @param {boolean} removeSameOrigin - remove component dependencies from same origin
    */
-  async _removeSingle(bitId: BitId): Promise<{ bitId: BitId; removedDependencies: BitIds; refsToRemove: Ref[] }> {
+  async getRemoveSingleData(bitId: BitId): Promise<{ compId: BitId; depIds: BitIds; refsToRemove: Ref[] }> {
     logger.debug(`scope.removeSingle ${bitId.toString()}, remove dependencies: ${this.removeSameOrigin.toString()}`);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const component = (await this.scope.getModelComponentIfExist(bitId)).toComponentVersion();
@@ -74,31 +80,31 @@ export default class RemoveModelComponents {
       bitId.version !== LATEST_BIT_VERSION
     );
 
-    const { ids: removedDependencies, refs: depsRefs } = await this._removeComponentsDependencies(
+    const { ids: depIds, refs: depsRefs } = await this.getDataForDependenciesRemoval(
       dependentBits,
       componentList,
       consumerComponentToRemove,
       bitId
     );
 
-    const componentsRefs = await this._removeComponent(bitId, componentList);
+    const componentsRefs = await this.getDataForRemovingComponent(bitId, componentList);
     const version = Object.keys(component.component.versions).length <= 1 ? LATEST_BIT_VERSION : bitId.version;
 
     return {
-      bitId: bitId.changeVersion(version),
-      removedDependencies,
+      compId: bitId.changeVersion(version),
+      depIds,
       refsToRemove: [...componentsRefs, ...depsRefs],
     };
   }
 
-  async _removeComponentsDependencies(
+  private async getDataForDependenciesRemoval(
     dependentBits: Record<string, any>,
     componentList: Array<ModelComponent | Symlink>,
     consumerComponentToRemove: ConsumerComponent,
     bitId: BitId
   ): Promise<{ ids: BitIds; refs: Ref[] }> {
     const refsToRemove: Ref[] = [];
-    const removedDependenciesP = consumerComponentToRemove.flattenedDependencies.map(async (dependencyId: BitId) => {
+    const depsToRemoveP = consumerComponentToRemove.flattenedDependencies.map(async (dependencyId: BitId) => {
       const dependentsIds: BitId[] = dependentBits[dependencyId.toStringWithoutVersion()];
       const relevantDependents = R.reject(
         (dependent) => dependent.isEqual(bitId) || dependent.scope !== dependencyId.scope,
@@ -121,17 +127,17 @@ export default class RemoveModelComponents {
         (dependencyId.scope !== bitId.scope || this.removeSameOrigin) &&
         isNested
       ) {
-        const refs = await this._removeComponent(dependencyId, componentList);
+        const refs = await this.getDataForRemovingComponent(dependencyId, componentList);
         refsToRemove.push(...refs);
         return dependencyId;
       }
       return null;
     });
-    const removedDependencies = await Promise.all(removedDependenciesP);
-    return { ids: BitIds.fromArray(compact(removedDependencies)), refs: refsToRemove };
+    const depsToRemove = await Promise.all(depsToRemoveP);
+    return { ids: BitIds.fromArray(compact(depsToRemove)), refs: refsToRemove };
   }
 
-  async _removeComponent(id: BitId, componentList: Array<ModelComponent | Symlink>): Promise<Ref[]> {
+  private async getDataForRemovingComponent(id: BitId, componentList: Array<ModelComponent | Symlink>): Promise<Ref[]> {
     if (this.currentLane) {
       const result = this.currentLane.removeComponent(id);
       if (!result) throw new Error(`failed deleting ${id.toString()}, the component was not found on the lane`);
@@ -140,7 +146,7 @@ export default class RemoveModelComponents {
     const symlink = componentList.find(
       (component) => component instanceof Symlink && id.isEqualWithoutScopeAndVersion(component.toBitId())
     );
-    const refs = await this.scope.sources.removeComponentById(id);
+    const refs = await this.scope.sources.getRefsForComponentRemoval(id);
     if (symlink) refs.push(symlink.hash());
     return refs;
   }

--- a/src/scope/component-ops/remove-model-components.ts
+++ b/src/scope/component-ops/remove-model-components.ts
@@ -1,3 +1,4 @@
+import { compact } from 'lodash';
 import mapSeries from 'p-map-series';
 import R from 'ramda';
 
@@ -7,6 +8,7 @@ import ConsumerComponent from '../../consumer/component';
 import Consumer from '../../consumer/consumer';
 import logger from '../../logger/logger';
 import { Lane, ModelComponent, Symlink } from '../models';
+import { Ref } from '../objects';
 import RemovedObjects from '../removed-components';
 import Scope from '../scope';
 
@@ -38,8 +40,11 @@ export default class RemoveModelComponents {
       // trying to delete the same file at the same time (happens when removing a component with
       // a dependency and the dependency itself)
       const removedComponents = await mapSeries(foundComponents, (bitId) => this._removeSingle(bitId));
-      if (this.currentLane) await this.scope.lanes.saveLane(this.currentLane);
-      await this.scope.objects.persist();
+      const refsToRemoveAll = removedComponents.map((removed) => removed.refsToRemove).flat();
+      if (this.currentLane) {
+        await this.scope.objects.writeObjectsToTheFS([this.currentLane]);
+      }
+      await this.scope.objects.deleteObjectsFromFS(refsToRemoveAll);
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const ids = new BitIds(...removedComponents.map((x) => x.bitId));
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -56,7 +61,7 @@ export default class RemoveModelComponents {
    * @param {BitId} bitId - list of remote component ids to delete
    * @param {boolean} removeSameOrigin - remove component dependencies from same origin
    */
-  async _removeSingle(bitId: BitId): Promise<{ bitId: BitId; removedDependencies: BitIds }> {
+  async _removeSingle(bitId: BitId): Promise<{ bitId: BitId; removedDependencies: BitIds; refsToRemove: Ref[] }> {
     logger.debug(`scope.removeSingle ${bitId.toString()}, remove dependencies: ${this.removeSameOrigin.toString()}`);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const component = (await this.scope.getModelComponentIfExist(bitId)).toComponentVersion();
@@ -69,17 +74,21 @@ export default class RemoveModelComponents {
       bitId.version !== LATEST_BIT_VERSION
     );
 
-    const removedDependencies = await this._removeComponentsDependencies(
+    const { ids: removedDependencies, refs: depsRefs } = await this._removeComponentsDependencies(
       dependentBits,
       componentList,
       consumerComponentToRemove,
       bitId
     );
 
-    await this._removeComponent(bitId, componentList);
+    const componentsRefs = await this._removeComponent(bitId, componentList);
     const version = Object.keys(component.component.versions).length <= 1 ? LATEST_BIT_VERSION : bitId.version;
 
-    return { bitId: bitId.changeVersion(version), removedDependencies };
+    return {
+      bitId: bitId.changeVersion(version),
+      removedDependencies,
+      refsToRemove: [...componentsRefs, ...depsRefs],
+    };
   }
 
   async _removeComponentsDependencies(
@@ -87,8 +96,9 @@ export default class RemoveModelComponents {
     componentList: Array<ModelComponent | Symlink>,
     consumerComponentToRemove: ConsumerComponent,
     bitId: BitId
-  ): Promise<BitIds> {
-    const removedComponents = consumerComponentToRemove.flattenedDependencies.map(async (dependencyId: BitId) => {
+  ): Promise<{ ids: BitIds; refs: Ref[] }> {
+    const refsToRemove: Ref[] = [];
+    const removedDependenciesP = consumerComponentToRemove.flattenedDependencies.map(async (dependencyId: BitId) => {
       const dependentsIds: BitId[] = dependentBits[dependencyId.toStringWithoutVersion()];
       const relevantDependents = R.reject(
         (dependent) => dependent.isEqual(bitId) || dependent.scope !== dependencyId.scope,
@@ -111,27 +121,27 @@ export default class RemoveModelComponents {
         (dependencyId.scope !== bitId.scope || this.removeSameOrigin) &&
         isNested
       ) {
-        await this._removeComponent(dependencyId, componentList);
+        const refs = await this._removeComponent(dependencyId, componentList);
+        refsToRemove.push(...refs);
         return dependencyId;
       }
       return null;
     });
-    let removedDependencies = await Promise.all(removedComponents);
-    removedDependencies = removedDependencies.filter((x) => !R.isNil(x));
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return BitIds.fromArray(removedDependencies);
+    const removedDependencies = await Promise.all(removedDependenciesP);
+    return { ids: BitIds.fromArray(compact(removedDependencies)), refs: refsToRemove };
   }
 
-  async _removeComponent(id: BitId, componentList: Array<ModelComponent | Symlink>) {
+  async _removeComponent(id: BitId, componentList: Array<ModelComponent | Symlink>): Promise<Ref[]> {
     if (this.currentLane) {
       const result = this.currentLane.removeComponent(id);
       if (!result) throw new Error(`failed deleting ${id.toString()}, the component was not found on the lane`);
-      return;
+      return [];
     }
-    const symlink = componentList.filter(
+    const symlink = componentList.find(
       (component) => component instanceof Symlink && id.isEqualWithoutScopeAndVersion(component.toBitId())
     );
-    await this.scope.sources.removeComponentById(id);
-    if (!R.isEmpty(symlink)) this.scope.objects.removeObject(symlink[0].hash());
+    const refs = await this.scope.sources.removeComponentById(id);
+    if (symlink) refs.push(symlink.hash());
+    return refs;
   }
 }

--- a/src/scope/exceptions/merge-conflict-on-remote.ts
+++ b/src/scope/exceptions/merge-conflict-on-remote.ts
@@ -19,7 +19,7 @@ to resolve this conflict and merge your remote and local changes, please do the 
 3) bit checkout [version] [id]
 once your changes are merged with the new remote version, please tag and export a new version of the component to the remote scope.`;
     }
-    if (idsNeedUpdate) {
+    if (idsNeedUpdate.length) {
       output += `error: merge error occurred when exporting the component(s) ${idsNeedUpdate
         .map((i) => `${chalk.bold(i.id)}${i.lane ? ` (lane: ${i.lane})` : ''}`)
         .join(', ')} to the remote scope.

--- a/src/scope/lanes/unmerged-components.ts
+++ b/src/scope/lanes/unmerged-components.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import { compact } from 'lodash';
 import path from 'path';
 import R from 'ramda';
 
@@ -72,6 +73,14 @@ export default class UnmergedComponents {
     const found = this.getEntry(componentName);
     if (!found) return false;
     this.unmerged = R.without([found], this.unmerged);
+    this.hasChanged = true;
+    return true;
+  }
+
+  removeMultipleComponents(componentNames: string[]): boolean {
+    const found = compact(componentNames.map((comp) => this.getEntry(comp)));
+    if (!found.length) return false;
+    this.unmerged = R.without(found, this.unmerged);
     this.hasChanged = true;
     return true;
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -380,6 +380,11 @@ export default class Repository {
     if (removed) await this.scopeIndex.write();
   }
 
+  async deleteRecordsFromUnmergedComponents(componentNames: string[]) {
+    this.unmergedComponents.removeMultipleComponents(componentNames);
+    await this.unmergedComponents.write();
+  }
+
   /**
    * write all objects to the FS and index the components/lanes/symlink objects
    */

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -478,27 +478,20 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   }
 
   /**
-   * @see this.removeComponent()
-   */
-  async removeComponentById(bitId: BitId, includeVersions = true): Promise<void> {
-    logger.debug(`sources.removeComponentById: ${bitId.toString()}, includeVersions: ${includeVersions}`);
-    const component = await this.get(bitId);
-    if (!component) return;
-    this.removeComponent(component, includeVersions);
-  }
-
-  /**
    * remove a component (and all versions objects if includeVersions=true) from local scope.
    * it doesn't physically delete from the filesystem.
    * the actual delete is done at a later phase, once Repository.persist() is called.
    */
-  removeComponent(component: ModelComponent, includeVersions = true): void {
+  async removeComponentById(bitId: BitId, includeVersions = true): Promise<Ref[]> {
+    logger.debug(`sources.removeComponentById: ${bitId.toString()}, includeVersions: ${includeVersions}`);
+    const component = await this.get(bitId);
+    if (!component) return [];
     const repo = this.objects();
     logger.debug(`sources.removeComponent: removing a component ${component.id()} from a local scope`);
     const objectRefs = [component.hash()];
     if (includeVersions) objectRefs.push(...component.versionArray);
-    repo.removeManyObjects(objectRefs);
     repo.unmergedComponents.removeComponent(component.name);
+    return objectRefs;
   }
 
   /**

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -478,19 +478,14 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   }
 
   /**
-   * remove a component (and all versions objects if includeVersions=true) from local scope.
-   * it doesn't physically delete from the filesystem.
-   * the actual delete is done at a later phase, once Repository.persist() is called.
+   * get hashes needed for removing a component from a local scope.
    */
-  async removeComponentById(bitId: BitId, includeVersions = true): Promise<Ref[]> {
+  async getRefsForComponentRemoval(bitId: BitId, includeVersions = true): Promise<Ref[]> {
     logger.debug(`sources.removeComponentById: ${bitId.toString()}, includeVersions: ${includeVersions}`);
     const component = await this.get(bitId);
     if (!component) return [];
-    const repo = this.objects();
-    logger.debug(`sources.removeComponent: removing a component ${component.id()} from a local scope`);
     const objectRefs = [component.hash()];
     if (includeVersions) objectRefs.push(...component.versionArray);
-    repo.unmergedComponents.removeComponent(component.name);
     return objectRefs;
   }
 


### PR DESCRIPTION
Similar to https://github.com/teambit/bit/pull/3885. Make the "remove" process stateless in order for multiple processes to work concurrently.