### PR TITLE
help recovering from bootstrap errors

### DIFF
--- a/e2e/harmony/clear-cache.e2e.ts
+++ b/e2e/harmony/clear-cache.e2e.ts
@@ -1,0 +1,38 @@
+import path from 'path';
+import fs from 'fs-extra';
+import { expect } from 'chai';
+import { glob } from 'glob';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+describe('bit clear-cache', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('fs cache corrupted', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.status(); // to populate the cache.
+
+      const cachePath = path.join(helper.scopes.localPath, '.bit/cache/components/file-paths/content-v2/sha512');
+      const files = glob.sync('**/*', { cwd: cachePath, nodir: true });
+      if (!files.length) throw new Error('no cache files found');
+      const cacheFile = path.join(cachePath, files[0]);
+      fs.chmodSync(cacheFile, '755');
+      fs.appendFileSync(cacheFile, '  ');
+
+      // as an intermediate step, make sure the cache is corrupted
+      expect(() => helper.command.status()).to.throw('Integrity verification failed');
+    });
+    it('bit cc should be able to clear the cache and fix the issue', () => {
+      helper.command.clearCache();
+      expect(() => helper.command.status()).not.to.throw();
+    });
+  });
+});

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -85,7 +85,7 @@ export default async function provideWorkspace(
   const bitConfig: any = harmony.config.get('teambit.harmony/bit');
   const consumer = await getConsumer(bitConfig.cwd);
   if (!consumer) return undefined;
-  // TODO: get the 'worksacpe' name in a better way
+  // TODO: get the 'workspace' name in a better way
   const logger = loggerExt.createLogger(EXT_NAME);
   const workspace = new Workspace(
     pubsub,
@@ -203,20 +203,7 @@ export default async function provideWorkspace(
  * is passed to the provider, so before using it, make sure it exists.
  * keep in mind that you can't verify it in the provider itself, because the provider is running
  * always for all commands before anything else is happening.
- *
- * the reason for the try/catch when loading the consumer is because some bit files (e.g. bit.json)
- * can be corrupted and in this case we do want to throw an error explaining this. the only command
- * allow in such a case is `bit init --reset`, which fixes the corrupted files. sadly, at this
- * stage we don't have the commands objects, so we can't check the command/flags from there. we
- * need to check the `process.argv.` directly instead, which is not 100% accurate.
  */
 async function getConsumer(path?: string): Promise<Consumer | undefined> {
-  try {
-    return await loadConsumerIfExist(path);
-  } catch (err) {
-    if (process.argv.includes('init') && !process.argv.includes('-r')) {
-      return undefined;
-    }
-    throw err;
-  }
+  return loadConsumerIfExist(path);
 }

--- a/src/api/consumer/index.ts
+++ b/src/api/consumer/index.ts
@@ -35,6 +35,7 @@ import { tagAction } from './lib/tag';
 import test from './lib/test';
 import unTagAction from './lib/untag';
 import untrack from './lib/untrack';
+import { clearCache } from './lib/clear-cache';
 
 export {
   init,
@@ -79,4 +80,5 @@ export {
   lane,
   switchAction,
   fetch,
+  clearCache,
 };

--- a/src/api/consumer/lib/clear-cache.ts
+++ b/src/api/consumer/lib/clear-cache.ts
@@ -1,0 +1,75 @@
+import fs from 'fs-extra';
+// it's a hack, but I didn't find a better way to access the getCacheDir() function
+import { __TEST__ as v8CompileCache } from 'v8-compile-cache';
+import { Consumer, getConsumerInfo, loadConsumerIfExist } from '../../../consumer';
+import { ComponentFsCache } from '../../../consumer/component/component-fs-cache';
+import { Scope } from '../../../scope';
+import { loadScopeIfExist } from '../../../scope/scope-loader';
+
+class CacheClearer {
+  private cacheCleared: string[] = [];
+  async clear() {
+    this.clearV8CompiledCode();
+    await this.clearFSCache();
+    await this.clearScopeIndex();
+
+    return this.cacheCleared;
+  }
+
+  private clearV8CompiledCode() {
+    const cacheDir = v8CompileCache.getCacheDir();
+    fs.removeSync(cacheDir);
+    this.cacheCleared.push('v8-compile-cache code');
+  }
+
+  private async clearFSCache() {
+    const fsCachePath = await this.getFSCachePath();
+    if (fsCachePath) {
+      fs.removeSync(fsCachePath);
+      this.cacheCleared.push('components cache on the filesystem');
+    }
+  }
+
+  private async getConsumerGracefully(): Promise<Consumer | undefined> {
+    try {
+      return await loadConsumerIfExist();
+    } catch (err) {
+      return undefined;
+    }
+  }
+
+  private async getScopeGracefully(): Promise<Scope | undefined> {
+    try {
+      return await loadScopeIfExist();
+    } catch (err) {
+      return undefined;
+    }
+  }
+
+  private async getFSCachePath(): Promise<string | null> {
+    const consumer = await this.getConsumerGracefully();
+    if (consumer) {
+      return consumer.componentFsCache.basePath;
+    }
+    const consumerInfo = await getConsumerInfo(process.cwd());
+    if (!consumerInfo) {
+      return null; // no workspace around, nothing to do.
+    }
+    const scope = await this.getScopeGracefully();
+    if (!scope) return null;
+    const componentFsCache = new ComponentFsCache(scope.path);
+    return componentFsCache.basePath;
+  }
+
+  private async clearScopeIndex() {
+    const scope = await loadScopeIfExist();
+    if (scope) {
+      await scope.objects.scopeIndex.deleteFile();
+      this.cacheCleared.push('scope-index file');
+    }
+  }
+}
+
+export async function clearCache(): Promise<string[]> {
+  return new CacheClearer().clear();
+}

--- a/src/cli/command-registry.ts
+++ b/src/cli/command-registry.ts
@@ -99,11 +99,18 @@ export function register(command: Command, commanderCmd, packageManagerArgs?: st
     command.options.push(['', TOKEN_FLAG, 'authentication token']);
   }
   if (!command.internal) {
-    command.options.push([
-      '',
-      'log [level]',
-      'print log messages to the screen, options are: [trace, debug, info, warn, error], the default is info',
-    ]);
+    command.options.push(
+      [
+        '',
+        'log [level]',
+        'print log messages to the screen, options are: [trace, debug, info, warn, error, fatal], the default is info',
+      ],
+      [
+        '',
+        'safe-mode',
+        'bootstrap the bare-minimum with only the CLI aspect. useful mainly for low-level commands when bit refuses to load',
+      ]
+    );
   }
 
   if (packageManagerArgs) {

--- a/src/cli/commands/public-cmds/clear-cache-cmd.ts
+++ b/src/cli/commands/public-cmds/clear-cache-cmd.ts
@@ -1,13 +1,7 @@
 import chalk from 'chalk';
-import fs from 'fs-extra';
-// it's a hack, but I didn't find a better way to access the getCacheDir() function
-import { __TEST__ as v8CompileCache } from 'v8-compile-cache';
-import { loadConsumerIfExist } from '../../../consumer';
-import { loadScopeIfExist } from '../../../scope/scope-loader';
-
+import { clearCache } from '../../../api/consumer';
 import { LegacyCommand } from '../../legacy-command';
-
-const { BASE_DOCS_DOMAIN } = require('../../../constants');
+import { BASE_DOCS_DOMAIN } from '../../../constants';
 
 export default class ClearCache implements LegacyCommand {
   name = 'clear-cache';
@@ -17,23 +11,8 @@ export default class ClearCache implements LegacyCommand {
   loader = false;
   skipWorkspace = true;
 
-  async action(): Promise<any> {
-    const cacheCleared: string[] = [];
-    const cacheDir = v8CompileCache.getCacheDir();
-    fs.removeSync(cacheDir);
-    cacheCleared.push('v8-compile-cache code');
-    const consumer = await loadConsumerIfExist();
-    if (consumer) {
-      const componentCachePath = consumer.componentFsCache.basePath;
-      fs.removeSync(componentCachePath);
-      cacheCleared.push('components cache on the filesystem');
-    }
-    const scope = await loadScopeIfExist();
-    if (scope) {
-      await scope.objects.scopeIndex.deleteFile();
-      cacheCleared.push('scope-index file');
-    }
-    return cacheCleared;
+  async action(): Promise<string[]> {
+    return clearCache();
   }
 
   report(cacheCleared: string[]): string {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -200,6 +200,9 @@ export default class CommandHelper {
   createLane(laneName = 'dev') {
     return this.runCmd(`bit switch ${laneName} --create`);
   }
+  clearCache() {
+    return this.runCmd('bit clear-cache');
+  }
   removeLane(laneName = 'dev', options = '') {
     return this.runCmd(`bit remove ${laneName} ${options} --lane --silent`);
   }


### PR DESCRIPTION
## Background
During Bit bootstrap phase, all core-aspects and user aspects are loaded. This is done before commands are registered to the CLI aspect. As a result, if anything goes wrong in the core/user aspects, there is no way to recover by any of the commands as they weren't registered yet. 
Sometimes, a simple command such as `bit clear-cache` can fix the issue, or, at times, some low-level commands, such as `bit cat-scope` are needed to debug the issues.

## Proposed Changes
- entirely skip the aspect loading phase and load only the CLI aspect for the following commands: `clear-cache`, `cat-scope`, `cat-object`, `init`, `cat-component`, `cat-lane`.
- introduce a new global flag `--safe-mode`, which does the above (load only the CLI aspect) for any command. Keep in mind that for most commands this won't be helpful as they need all aspects to be loaded beforehand.
- fix `clear-cache` command to gracefully recover from consumer errors and be able to clear the fs-cache.
