### PR TITLE
enable source-map-loader only for dists in the current workspae

### DIFF
--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -1,5 +1,6 @@
 import R from 'ramda';
 import { compact } from 'ramda-adjunct';
+import { join } from 'path';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import ComponentAspect, { Component, ComponentMain, Snap } from '@teambit/component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
@@ -16,6 +17,7 @@ import { BitError } from '@teambit/bit-error';
 import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
 import { GraphqlMain, GraphqlAspect } from '@teambit/graphql';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
+
 import { Packer, PackOptions, PackResult, TAR_FILE_ARTIFACT_NAME } from './packer';
 // import { BitCli as CLI, BitCliExt as CLIExtension } from '@teambit/cli';
 import { PackCmd } from './pack.cmd';
@@ -158,6 +160,15 @@ export class PkgMain {
    */
   getPackageName(component: Component) {
     return componentIdToPackageName(component.state._consumer);
+  }
+
+  /**
+   * returns the package path in the /node_modules/ folder
+   */
+  getModulePath(component: Component) {
+    const pgkName = this.getPackageName(component);
+    const path = join('node_modules', pgkName);
+    return path;
   }
 
   /**

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -21,7 +21,7 @@ import { outputFileSync } from 'fs-extra';
 import { Configuration } from 'webpack';
 import { merge as webpackMerge } from 'webpack-merge';
 import { ReactMainConfig } from './react.main.runtime';
-import webpackConfigFactory from './webpack/webpack.config.preview.dev';
+import devPreviewConfigFactory from './webpack/webpack.config.preview.dev';
 import previewConfigFactory from './webpack/webpack.config.preview';
 import eslintConfig from './eslint/eslintrc';
 import { ReactAspect } from './react.aspect';
@@ -151,10 +151,19 @@ export class ReactEnv implements Environment {
   /**
    * get the default react webpack config.
    */
-  getWebpackConfig(context: DevServerContext): Configuration {
+  private getDevWebpackConfig(context: DevServerContext): Configuration {
     const fileMapPath = this.writeFileMap(context.components);
 
-    return webpackConfigFactory(context.id, fileMapPath);
+    const components = context.components;
+    const distDir = this.getCompiler().distDir;
+
+    const distPaths = components.map((comp) => {
+      const modulePath = this.pkg.getModulePath(comp);
+      const dist = join(this.workspace.path, modulePath, distDir);
+      return dist;
+    });
+
+    return devPreviewConfigFactory({ envId: context.id, fileMapPath, distPaths });
   }
 
   getDevEnvId(id?: string) {
@@ -173,7 +182,7 @@ export class ReactEnv implements Environment {
    * returns and configures the React component dev server.
    */
   getDevServer(context: DevServerContext, targetConfig?: Configuration): DevServer {
-    const defaultConfig = this.getWebpackConfig(context);
+    const defaultConfig = this.getDevWebpackConfig(context);
     const config = targetConfig ? webpackMerge(targetConfig as any, defaultConfig as any) : defaultConfig;
 
     return this.webpack.createDevServer(context, config);

--- a/scopes/react/react/webpack/webpack.config.preview.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.dev.ts
@@ -29,7 +29,9 @@ const moduleFileExtensions = [
   'md',
 ];
 
-export default function (envId: string, fileMapPath: string): WebpackConfigWithDevServer {
+type Options = { envId: string; fileMapPath: string; distPaths: string[] };
+
+export default function ({ envId, fileMapPath, distPaths }: Options): WebpackConfigWithDevServer {
   return {
     devServer: {
       sockPath: `_hmr/${envId}`,
@@ -50,7 +52,7 @@ export default function (envId: string, fileMapPath: string): WebpackConfigWithD
         {
           test: /\.js$/,
           enforce: 'pre',
-          include: /node_modules/,
+          include: distPaths,
           use: [require.resolve('source-map-loader')],
         },
         {

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.js
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.js
@@ -135,11 +135,11 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths) {
       // Public path is root of content base
       publicPath: publicUrlOrPath.slice(0, -1),
 
-      stats: {
-        // - for webpack-dev-server, this property needs to be in the devServer configuration object.
-        // - webpack 5 will replace `stats.warningFilter` with `ignoreWarnings`.
-        warningsFilter: [/Failed to parse source map/],
-      },
+      // stats: {
+      //   // - for webpack-dev-server, this property needs to be in the devServer configuration object.
+      //   // - webpack 5 will replace `stats.warningFilter` with `ignoreWarnings`.
+      //   warningsFilter: [/Failed to parse source map/],
+      // },
     },
 
     resolve: {
@@ -164,12 +164,12 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths) {
 
     module: {
       rules: [
-        {
-          test: /\.js$/,
-          enforce: 'pre',
-          include: /node_modules/,
-          use: [require.resolve('source-map-loader')],
-        },
+        // {
+        //   test: /\.js$/,
+        //   enforce: 'pre',
+        //   include: /node_modules/,
+        //   use: [require.resolve('source-map-loader')],
+        // },
         {
           test: /\.(js|jsx|tsx|ts)$/,
           exclude: /node_modules/,


### PR DESCRIPTION
## Proposed Changes

- limit source-map-loader to apply only dist files in the current workspace
- disable source-map-loader in internal dev webpack (i.e. `start --dev`)