### PR TITLE
disable source map loader for compositions and docs

### DIFF
--- a/scopes/react/react/webpack/webpack.config.preview.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.dev.ts
@@ -49,12 +49,12 @@ export default function ({ envId, fileMapPath, distPaths }: Options): WebpackCon
           include: /node_modules/,
           type: 'javascript/auto',
         },
-        {
-          test: /\.js$/,
-          enforce: 'pre',
-          include: distPaths,
-          use: [require.resolve('source-map-loader')],
-        },
+        // {
+        //   test: /\.js$/,
+        //   enforce: 'pre',
+        //   include: distPaths,
+        //   use: [require.resolve('source-map-loader')],
+        // },
         {
           test: /\.(mjs|js|jsx|tsx|ts)$/,
           // TODO: use a more specific exclude for our selfs
@@ -70,12 +70,12 @@ export default function ({ envId, fileMapPath, distPaths }: Options): WebpackCon
             plugins: [
               require.resolve('react-refresh/babel'),
               // for component highlighting in preview.
-              [
-                require.resolve('@teambit/babel.bit-react-transformer'),
-                {
-                  componentFilesPath: fileMapPath,
-                },
-              ],
+              // [
+              //   require.resolve('@teambit/babel.bit-react-transformer'),
+              //   {
+              //     componentFilesPath: fileMapPath,
+              //   },
+              // ],
             ],
           },
         },

--- a/scopes/react/react/webpack/webpack.config.preview.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.dev.ts
@@ -31,7 +31,7 @@ const moduleFileExtensions = [
 
 type Options = { envId: string; fileMapPath: string; distPaths: string[] };
 
-export default function ({ envId, fileMapPath, distPaths }: Options): WebpackConfigWithDevServer {
+export default function ({ envId /* , fileMapPath, distPaths */ }: Options): WebpackConfigWithDevServer {
   return {
     devServer: {
       sockPath: `_hmr/${envId}`,


### PR DESCRIPTION
## Proposed Changes

- comment out source-map-loader for docs/compositions
- also disable bit id transformer, which is currently unused
