### PR TITLE
improve memory consumption dramatically during bit-import

### DIFF
--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -4,9 +4,8 @@ import * as path from 'path';
 import { BitId, BitIds } from '../../bit-id';
 import { ANGULAR_PACKAGE_IDENTIFIER } from '../../constants';
 import logger from '../../logger/logger';
+import ScopeComponentsImporter from '../../scope/component-ops/scope-components-importer';
 import { ModelComponent } from '../../scope/models';
-import { ObjectList } from '../../scope/objects/object-list';
-import { getScopeRemotes } from '../../scope/scope-remotes';
 import { getLatestVersionNumber } from '../../utils';
 import { getLastModifiedPathsTimestampMs } from '../../utils/fs/last-modified';
 import ComponentsPendingImport from '../component-ops/exceptions/components-pending-import';
@@ -264,18 +263,8 @@ export default class ComponentLoader {
   }
 
   private async _getRemoteComponent(id: BitId): Promise<ModelComponent | null | undefined> {
-    const remotes = await getScopeRemotes(this.consumer.scope);
-    let objectList: ObjectList;
-    try {
-      const fetchResults = await remotes.fetch({ [id.scope as string]: [id.toString()] }, this.consumer.scope);
-      objectList = fetchResults.objectList;
-    } catch (err) {
-      return null; // probably doesn't exist
-    }
-    const bitObjectsList = await objectList.toBitObjects();
-    const components = bitObjectsList.getComponents();
-    if (!components.length) return null; // probably doesn't exist
-    return components[0];
+    const scopeComponentsImporter = new ScopeComponentsImporter(this.consumer.scope);
+    return scopeComponentsImporter.getRemoteComponent(id);
   }
 
   private _isAngularProject(): boolean {

--- a/src/remotes/remote.ts
+++ b/src/remotes/remote.ts
@@ -12,7 +12,7 @@ import { ComponentLog } from '../scope/models/model-component';
 import { connect } from '../scope/network';
 import { Network } from '../scope/network/network';
 import { DEFAULT_READ_STRATEGIES, SSHConnectionStrategyName } from '../scope/network/ssh/ssh';
-import { ObjectList } from '../scope/objects/object-list';
+import { ObjectItemsStream, ObjectList } from '../scope/objects/object-list';
 import { cleanBang, isBitUrl } from '../utils';
 import { InvalidRemote } from './exceptions';
 
@@ -78,7 +78,7 @@ export default class Remote {
     fetchOptions: FETCH_OPTIONS,
     context?: Record<string, any>,
     strategiesNames: SSHConnectionStrategyName[] = DEFAULT_READ_STRATEGIES
-  ): Promise<ObjectList> {
+  ): Promise<ObjectItemsStream> {
     return this.connect(strategiesNames).then((network) => network.fetch(ids, fetchOptions, context));
   }
 

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -1,7 +1,6 @@
 import { filter } from 'bluebird';
 import { Mutex } from 'async-mutex';
 import mapSeries from 'p-map-series';
-import pMap from 'p-map';
 import groupArray from 'group-array';
 import R from 'ramda';
 import { compact, flatten } from 'lodash';
@@ -21,13 +20,13 @@ import ComponentVersion, { ObjectCollector } from '../component-version';
 import { ComponentNotFound } from '../exceptions';
 import { Lane, ModelComponent, Version } from '../models';
 import { Ref, Repository } from '../objects';
-import { ObjectItem, ObjectList } from '../objects/object-list';
+import { ObjectItem, ObjectItemsStream, ObjectList } from '../objects/object-list';
 import SourcesRepository, { ComponentDef } from '../repositories/sources';
 import { getScopeRemotes } from '../scope-remotes';
 import VersionDependencies from '../version-dependencies';
-import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
+import { DEFAULT_LANE } from '../../constants';
 import { BitObjectList } from '../objects/bit-object-list';
-import { ModelComponentMerger } from './model-components-merger';
+import { ObjectsWritable } from '../objects/objects-writable-stream';
 
 const removeNils = R.reject(R.isNil);
 
@@ -241,14 +240,14 @@ export default class ScopeComponentsImporter {
     loader.start(statusMsg);
     logger.debugAndAddBreadCrumb('importManyDeltaWithoutDeps', statusMsg);
     const remotes = await getScopeRemotes(this.scope);
-    const { objectList, objectListPerRemote } = await remotes.fetch(groupedIds, this.scope, {
+    const objectsStreamPerRemote = await remotes.fetch(groupedIds, this.scope, {
       type: 'component-delta',
       withoutDependencies: true,
       concurrency: 10,
     });
-    loader.start(`got ${objectList.count()} objects from the remotes, merging them and writing to the filesystem`);
+    loader.start(`got response from the remotes, merging them and writing to the filesystem`);
     logger.debugAndAddBreadCrumb('importManyDeltaWithoutDeps', 'writing them to the model');
-    await this.writeManyObjectListToModel(objectListPerRemote, idsToFetch);
+    await this.writeManyObjectListToModel(objectsStreamPerRemote, idsToFetch);
   }
 
   async importFromLanes(remoteLaneIds: RemoteLaneId[]): Promise<Lane[]> {
@@ -261,8 +260,9 @@ export default class ScopeComponentsImporter {
 
   async importLanes(remoteLaneIds: RemoteLaneId[]): Promise<Lane[]> {
     const remotes = await getScopeRemotes(this.scope);
-    const { objectList } = await remotes.fetch(groupByScopeName(remoteLaneIds), this.scope, { type: 'lane' });
-    const bitObjects = await objectList.toBitObjects();
+    const objectsStreamPerRemote = await remotes.fetch(groupByScopeName(remoteLaneIds), this.scope, { type: 'lane' });
+    const multipleStreams = Object.values(objectsStreamPerRemote);
+    const bitObjects = await this.multipleStreamsToBitObjects(multipleStreams);
     const lanes = bitObjects.getLanes();
     await Promise.all(lanes.map((lane) => this.repo.remoteLanes.syncWithLaneObject(lane.scope as string, lane)));
     return lanes;
@@ -288,8 +288,9 @@ export default class ScopeComponentsImporter {
     );
     if (R.isEmpty(groupedHashedMissing)) return;
     const remotes = await getScopeRemotes(this.scope);
-    const { objectList } = await remotes.fetch(groupedHashedMissing, this.scope, { type: 'object' });
-    const bitObjectsList = await objectList.toBitObjects();
+    const multipleStreams = await remotes.fetch(groupedHashedMissing, this.scope, { type: 'object' });
+
+    const bitObjectsList = await this.multipleStreamsToBitObjects(Object.values(multipleStreams));
     await this.repo.writeObjectsToTheFS(bitObjectsList.getAll());
   }
 
@@ -395,76 +396,53 @@ export default class ScopeComponentsImporter {
   }
 
   async writeManyObjectListToModel(
-    objectListPerRemote: { [remoteName: string]: ObjectList },
+    objectListPerRemote: { [remoteName: string]: ObjectItemsStream },
     ids: BitId[]
   ): Promise<BitId[]> {
-    const bitObjectsPerRemote: { [remoteName: string]: BitObjectList } = {};
-    await mapSeries(Object.keys(objectListPerRemote), async (remoteName) => {
+    const bitIds = await mapSeries(Object.keys(objectListPerRemote), async (remoteName) => {
       const objectList = objectListPerRemote[remoteName];
-      bitObjectsPerRemote[remoteName] = await objectList.toBitObjects();
-    });
-    const bitIds = await mapSeries(Object.keys(bitObjectsPerRemote), async (remoteName) => {
-      const bitObjectList = bitObjectsPerRemote[remoteName];
-      return this.addObjectListToRepo(bitObjectList, remoteName, ids);
+      return new Promise((resolve, reject) => {
+        const writable = new ObjectsWritable(this.repo, this.sources, remoteName);
+        const pipe = objectList.pipe(writable);
+        pipe.on('finish', () => {
+          let nonLaneIds: BitId[] = ids;
+          writable.lanes.forEach((lane) => {
+            nonLaneIds = nonLaneIds.filter((id) => id.name !== lane.name || id.scope !== lane.scope);
+            nonLaneIds.push(...lane.components.map((c) => c.id));
+          });
+          resolve(nonLaneIds);
+        });
+        pipe.on('error', (err) => {
+          reject(err);
+        });
+      });
     });
     await this.repo.writeRemoteLanes();
     return BitIds.uniqFromArray(R.flatten(bitIds));
   }
 
   /**
-   * this has been changed to be efficient in terms of memory and less error-prone.
-   * first, write all immutable objects, such as files/sources/versions into the filesystem.
-   * even if the process will crush later and the component-object won't be written, there is no
-   * harm of writing these objects.
-   * then, merge the component objects and write them to the filesystem. the index.json is written
-   * as well to make sure they're indexed immediately, even if the process crushes on the next remote.
-   * finally, take care of the lanes. the remote-lanes are not written at this point, only once all
-   * remotes are processed. see @writeManyObjectListToModel.
+   * get a single component from a remote without saving it locally
    */
-  private async addObjectListToRepo(bitObjectList: BitObjectList, remoteName: string, ids: BitId[]): Promise<BitId[]> {
-    const immutableObjects = bitObjectList.getAllExceptComponentsAndLanes();
-    await this.repo.writeObjectsToTheFS(immutableObjects);
-
-    const components = bitObjectList.getComponents();
-    const mergedComponents = await pMap(components, (component) => this.mergeModelComponent(component, remoteName), {
-      concurrency: CONCURRENT_COMPONENTS_LIMIT,
-    });
-    await this.repo.writeObjectsToTheFS(mergedComponents);
-    await this.repo.remoteLanes.addEntriesFromModelComponents(
-      RemoteLaneId.from(DEFAULT_LANE, remoteName),
-      mergedComponents
-    );
-
-    let nonLaneIds: BitId[] = ids;
-    const laneObjects = bitObjectList.getLanes();
-    await mapSeries(laneObjects, async (lane) => {
-      if (!lane.scope) {
-        throw new Error(`scope.addObjectListToRepo scope is missing from a lane ${lane.name}`);
-      }
-      await this.repo.remoteLanes.syncWithLaneObject(lane.scope, lane);
-      nonLaneIds = nonLaneIds.filter((id) => id.name !== lane.name || id.scope !== lane.scope);
-      nonLaneIds.push(...lane.components.map((c) => c.id));
-    });
-
-    return nonLaneIds;
+  async getRemoteComponent(id: BitId): Promise<ModelComponent | null | undefined> {
+    const remotes = await getScopeRemotes(this.scope);
+    let bitObjectsList: BitObjectList;
+    try {
+      const streams = await remotes.fetch({ [id.scope as string]: [id.toString()] }, this.scope);
+      bitObjectsList = await this.multipleStreamsToBitObjects(Object.values(streams));
+    } catch (err) {
+      return null; // probably doesn't exist
+    }
+    const components = bitObjectsList.getComponents();
+    if (!components.length) return null; // probably doesn't exist
+    return components[0];
   }
 
-  /**
-   * merge the imported component with the existing component in the local scope.
-   * when importing a component, save the remote head into the remote master ref file.
-   * unless this component arrived as a cache of the dependent, which its head might be wrong
-   */
-  private async mergeModelComponent(incomingComp: ModelComponent, remoteName: string): Promise<ModelComponent> {
-    const isIncomingFromOrigin = remoteName === incomingComp.scope;
-    const existingComp = await this.sources._findComponent(incomingComp);
-    if (!existingComp || (existingComp && incomingComp.isEqual(existingComp))) {
-      if (isIncomingFromOrigin) incomingComp.remoteHead = incomingComp.head;
-      return incomingComp;
-    }
-    const modelComponentMerger = new ModelComponentMerger(existingComp, incomingComp, true, isIncomingFromOrigin);
-    const { mergedComponent } = await modelComponentMerger.merge();
-    if (isIncomingFromOrigin) mergedComponent.remoteHead = incomingComp.head;
-    return mergedComponent;
+  private async multipleStreamsToBitObjects(streams: ObjectItemsStream[]): Promise<BitObjectList> {
+    const objectListPerRemote = await Promise.all(streams.map((stream) => ObjectList.fromReadableStream(stream)));
+    const objectList = ObjectList.mergeMultipleInstances(objectListPerRemote);
+    const bitObjects = await objectList.toBitObjects();
+    return bitObjects;
   }
 
   private async getVersionFromComponentDef(component: ModelComponent, id: BitId): Promise<Version | null> {
@@ -499,14 +477,14 @@ export default class ScopeComponentsImporter {
         throw new Error(`getExternalMany expects to get external ids only, got ${id.toString()}`);
     });
     enrichContextFromGlobal(Object.assign({}, { requestedBitIds: ids.map((id) => id.toString()) }));
-    const { objectListPerRemote } = await remotes.fetch(
+    const objectStreamsPerRemote = await remotes.fetch(
       groupByScopeName(ids),
       this.scope,
       { withoutDependencies: false },
       context
     );
     logger.debugAndAddBreadCrumb('ScopeComponentsImporter.getExternalMany', 'writing them to the model');
-    const nonLaneIds = await this.writeManyObjectListToModel(objectListPerRemote, ids);
+    const nonLaneIds = await this.writeManyObjectListToModel(objectStreamsPerRemote, ids);
     const componentDefs = await this.sources.getMany(nonLaneIds);
     const componentDefsExisting = componentDefs.filter((componentDef) => componentDef.component);
     const versionDeps = await mapSeries(componentDefsExisting, (compDef) =>
@@ -538,13 +516,13 @@ export default class ScopeComponentsImporter {
     }
     logger.debugAndAddBreadCrumb('getExternalManyWithoutDeps', `${left.length} left. Fetching them from a remote`);
     enrichContextFromGlobal(Object.assign(context, { requestedBitIds: ids.map((id) => id.toString()) }));
-    const { objectListPerRemote } = await remotes.fetch(
+    const objectStreamsPerRemote = await remotes.fetch(
       groupByScopeName(left.map((def) => def.id)),
       this.scope,
       { withoutDependencies: true },
       context
     );
-    const nonLaneIds = await this.writeManyObjectListToModel(objectListPerRemote, ids);
+    const nonLaneIds = await this.writeManyObjectListToModel(objectStreamsPerRemote, ids);
 
     const finalDefs: ComponentDef[] = await this.sources.getMany(nonLaneIds);
 

--- a/src/scope/network/fs/fs.ts
+++ b/src/scope/network/fs/fs.ts
@@ -10,7 +10,7 @@ import ScopeComponentsImporter from '../../component-ops/scope-components-import
 import DependencyGraph from '../../graph/scope-graph';
 import { LaneData } from '../../lanes/lanes';
 import { ComponentLog } from '../../models/model-component';
-import { ObjectList } from '../../objects/object-list';
+import { ObjectItemsStream, ObjectList } from '../../objects/object-list';
 import Scope, { ScopeDescriptor } from '../../scope';
 import loadScope from '../../scope-loader';
 import { FsScopeNotLoaded } from '../exceptions';
@@ -65,8 +65,9 @@ export default class Fs implements Network {
     return undeprecate({ path: this.scopePath, ids });
   }
 
-  async fetch(ids: string[], fetchOptions: FETCH_OPTIONS): Promise<ObjectList> {
-    return fetch(this.scopePath, ids, fetchOptions);
+  async fetch(ids: string[], fetchOptions: FETCH_OPTIONS): Promise<ObjectItemsStream> {
+    const objectList = await fetch(this.scopePath, ids, fetchOptions);
+    return objectList.toReadableStream();
   }
 
   latestVersions(componentIds: BitId[]): Promise<string[]> {

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -14,7 +14,7 @@ import globalFlags from '../../../cli/global-flags';
 import { getSync } from '../../../api/consumer/lib/global-config';
 import { CFG_HTTPS_PROXY, CFG_PROXY, CFG_USER_TOKEN_KEY } from '../../../constants';
 import logger from '../../../logger/logger';
-import { ObjectList } from '../../objects/object-list';
+import { ObjectItemsStream, ObjectList } from '../../objects/object-list';
 import { FETCH_OPTIONS } from '../../../api/scope/lib/fetch';
 import { remoteErrorHandler } from '../remote-error-handler';
 import { PushOptions } from '../../../api/scope/lib/put';
@@ -168,7 +168,7 @@ export class Http implements Network {
     return results;
   }
 
-  async fetch(ids: string[], fetchOptions: FETCH_OPTIONS): Promise<ObjectList> {
+  async fetch(ids: string[], fetchOptions: FETCH_OPTIONS): Promise<ObjectItemsStream> {
     const route = 'api/scope/fetch';
     const scopeData = `scopeName: ${this.scopeName}, url: ${this.url}/${route}`;
     logger.debug(`Http.fetch, ${scopeData}`);
@@ -185,8 +185,9 @@ export class Http implements Network {
     const res = await fetch(`${this.url}/${route}`, opts);
     logger.debug(`Http.fetch got a response, ${scopeData}, status ${res.status}, statusText ${res.statusText}`);
     await this.throwForNonOkStatus(res);
-    const objectList = await ObjectList.fromTar(res.body);
-    return objectList;
+    const objectListReadable = ObjectList.fromTarToObjectStream(res.body);
+
+    return objectListReadable;
   }
 
   private async getJsonResponse(res: Response) {

--- a/src/scope/network/network.ts
+++ b/src/scope/network/network.ts
@@ -6,7 +6,7 @@ import { ListScopeResult } from '../../consumer/component/components-list';
 import DependencyGraph from '../graph/scope-graph';
 import { LaneData } from '../lanes/lanes';
 import { ComponentLog } from '../models/model-component';
-import { ObjectList } from '../objects/object-list';
+import { ObjectItemsStream, ObjectList } from '../objects/object-list';
 import { ScopeDescriptor } from '../scope';
 import { SSHConnectionStrategyName } from './ssh/ssh';
 
@@ -16,7 +16,7 @@ export interface Network {
   close(): void;
   describeScope(): Promise<ScopeDescriptor>;
   deleteMany(ids: string[], force: boolean, context: Record<string, any>, idsAreLanes: boolean);
-  fetch(ids: string[], fetchOptions: FETCH_OPTIONS, context?: Record<string, any>): Promise<ObjectList>;
+  fetch(ids: string[], fetchOptions: FETCH_OPTIONS, context?: Record<string, any>): Promise<ObjectItemsStream>;
   pushMany(objectList: ObjectList, pushOptions: PushOptions, context?: Record<string, any>): Promise<string[]>;
   action<Options, Result>(name: string, options: Options): Promise<Result>;
   list(namespacesUsingWildcards?: string, strategiesNames?: SSHConnectionStrategyName[]): Promise<ListScopeResult[]>;

--- a/src/scope/objects/objects-writable-stream.ts
+++ b/src/scope/objects/objects-writable-stream.ts
@@ -1,0 +1,89 @@
+import pMap from 'p-map';
+import pMapSeries from 'p-map-series';
+import { Writable } from 'stream';
+import { BitObject, Repository } from '.';
+import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
+import { RemoteLaneId } from '../../lane-id/lane-id';
+import { ModelComponentMerger } from '../component-ops/model-components-merger';
+import { Lane, ModelComponent } from '../models';
+import { SourceRepository } from '../repositories';
+
+/**
+ * first, write all immutable objects, such as files/sources/versions into the filesystem, as they arrive.
+ * even if the process will crush later and the component-object won't be written, there is no
+ * harm of writing these objects.
+ * then, merge the component objects and write them to the filesystem. the index.json is written
+ * as well to make sure they're indexed immediately, even if the process crushes on the next remote.
+ * finally, take care of the lanes. the remote-lanes are not written at this point, only once all
+ * remotes are processed. see @writeManyObjectListToModel.
+ */
+export class ObjectsWritable extends Writable {
+  private mutableObjects: BitObject[] = [];
+  lanes: Lane[] = [];
+  constructor(private repo: Repository, private sources: SourceRepository, private remoteName: string) {
+    super({ objectMode: true });
+  }
+  async _write(obj, encoding, callback) {
+    if (!obj.ref || !obj.buffer) {
+      return callback(new Error('objectItem expected to have "ref" and "buffer" props'));
+    }
+    await this.writeImmutableObjectToFs(obj);
+    return callback();
+  }
+  async _final(callback) {
+    try {
+      await this.writeMutableObjectsToFS();
+      callback();
+    } catch (err) {
+      callback(err);
+    }
+  }
+  private async writeImmutableObjectToFs(obj) {
+    const bitObject = await BitObject.parseObject(obj.buffer);
+    const isImmutable = !(bitObject instanceof ModelComponent) && !(bitObject instanceof Lane);
+    if (isImmutable) await this.repo.writeObjectsToTheFS([bitObject]);
+    else this.mutableObjects.push(bitObject);
+  }
+  private async writeMutableObjectsToFS() {
+    const components = this.mutableObjects.filter((obj) => obj instanceof ModelComponent);
+    const mergedComponents = await pMap(
+      components,
+      (component) => this.mergeModelComponent(component as ModelComponent, this.remoteName),
+      {
+        concurrency: CONCURRENT_COMPONENTS_LIMIT,
+      }
+    );
+    await this.repo.writeObjectsToTheFS(mergedComponents);
+    await this.repo.remoteLanes.addEntriesFromModelComponents(
+      RemoteLaneId.from(DEFAULT_LANE, this.remoteName),
+      mergedComponents
+    );
+
+    const laneObjects = this.mutableObjects.filter((obj) => obj instanceof Lane) as Lane[];
+    await pMapSeries(laneObjects, async (lane) => {
+      if (!lane.scope) {
+        throw new Error(`scope.addObjectListToRepo scope is missing from a lane ${lane.name}`);
+      }
+      await this.repo.remoteLanes.syncWithLaneObject(lane.scope, lane);
+      this.lanes.push(lane);
+    });
+  }
+
+  /**
+   * merge the imported component with the existing component in the local scope.
+   * when importing a component, save the remote head into the remote master ref file.
+   * unless this component arrived as a cache of the dependent, which its head might be wrong
+   */
+  private async mergeModelComponent(incomingComp: ModelComponent, remoteName: string): Promise<ModelComponent> {
+    const isIncomingFromOrigin = remoteName === incomingComp.scope;
+    const existingComp = await this.sources._findComponent(incomingComp);
+    if (!existingComp || (existingComp && incomingComp.isEqual(existingComp))) {
+      if (isIncomingFromOrigin) incomingComp.remoteHead = incomingComp.head;
+      return incomingComp;
+    }
+    const modelComponentMerger = new ModelComponentMerger(existingComp, incomingComp, true, isIncomingFromOrigin);
+    const { mergedComponent } = await modelComponentMerger.merge();
+    if (isIncomingFromOrigin) mergedComponent.remoteHead = incomingComp.head;
+    return mergedComponent;
+  }
+}

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -396,11 +396,11 @@ export default class Repository {
   async writeObjectsToTheFS(objects: BitObject[]): Promise<void> {
     const count = objects.length;
     if (!count) return;
-    logger.debug(`Repository.writeObjectsToTheFS: started writing ${count} objects`);
+    logger.trace(`Repository.writeObjectsToTheFS: started writing ${count} objects`);
     await pMap(objects, (obj) => this._writeOne(obj), {
       concurrency: CONCURRENT_IO_LIMIT,
     });
-    logger.debug(`Repository.writeObjectsToTheFS: completed writing ${count} objects`);
+    logger.trace(`Repository.writeObjectsToTheFS: completed writing ${count} objects`);
 
     const added = this.scopeIndex.addMany(objects);
     if (added) await this.scopeIndex.write();


### PR DESCRIPTION
Currently, the `fetch` operation gets all objects from the remotes, store them in-memory and then process them and write to the filesystem. 
This PR utilizes streams to write the objects as soon as they arrive from the remote scope.

Bit supports 3 protocols: FS, SSH and HTTP.
Since these three don't get the data in the same way, a new `stream.Readable` (aliased as `ObjectItemsStream` type ) was created to have them all use the exact same interface. This Stream Readable works with `objectMode: true` and emits an `ObjectItem` object upon `data` event.
For SSH and FS, since we get the data as `ObjectItem[]` it just converts them to Readable using the built-in `Readable.from` method.
For HTTP, the data is coming as [tar-stream](https://github.com/mafintosh/tar-stream). To convert them to our `ObjectItemsStream`, the stream.PassThrough was used. It reads the `tar-stream` and writes the `ObjectItem`.