### PR TITLE
change fetch implementation to use streams to keep the memory usage low

### DIFF
--- a/scopes/scope/scope/routes/fetch.route.ts
+++ b/scopes/scope/scope/routes/fetch.route.ts
@@ -1,9 +1,13 @@
 import { Route, Verb, Request, Response } from '@teambit/express';
 import { fetch } from '@teambit/legacy/dist/api/scope';
+import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';
+import { Logger } from '@teambit/logger';
+import { promisify } from 'util';
+import { pipeline } from 'stream';
 import { ScopeMain } from '../scope.main.runtime';
 
 export class FetchRoute implements Route {
-  constructor(private scope: ScopeMain) {}
+  constructor(private scope: ScopeMain, private logger: Logger) {}
 
   route = '/scope/fetch';
   method = 'post';
@@ -12,9 +16,19 @@ export class FetchRoute implements Route {
   middlewares = [
     async (req: Request, res: Response) => {
       req.setTimeout(this.scope.config.httpTimeOut);
-      const objectList = await fetch(this.scope.path, req.body.ids, req.body.fetchOptions);
-      const pack = objectList.toTar();
-      pack.pipe(res as any);
+      const readable = await fetch(this.scope.path, req.body.ids, req.body.fetchOptions);
+      const pack = ObjectList.fromObjectStreamToTar(readable);
+      const pipelinePromise = promisify(pipeline);
+      try {
+        await pipelinePromise(pack, res);
+      } catch (err) {
+        this.logger.error(
+          `FetchRoute encountered an error during the pipeline streaming, this should never happen.
+make sure the error is caught in fromObjectStreamToTar and it streamed using the name "ERROR"`,
+          err
+        );
+        throw err;
+      }
     },
   ];
 }

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -711,7 +711,7 @@ export class ScopeMain implements ComponentFactory {
 
     express.register([
       new PutRoute(scope, postPutSlot),
-      new FetchRoute(scope),
+      new FetchRoute(scope, logger),
       new ActionRoute(scope),
       new DeleteRoute(scope),
     ]);

--- a/src/api/scope/lib/fetch.ts
+++ b/src/api/scope/lib/fetch.ts
@@ -1,16 +1,17 @@
-import mapSeries from 'p-map-series';
-import { flatten } from 'lodash';
+import { Readable } from 'stream';
 import { BitIds } from '../../../bit-id';
 import { POST_SEND_OBJECTS, PRE_SEND_OBJECTS } from '../../../constants';
 import HooksManager from '../../../hooks';
 import { RemoteLaneId } from '../../../lane-id/lane-id';
 import logger from '../../../logger/logger';
 import { loadScope, Scope } from '../../../scope';
-// import logger from '../../../logger/logger';
 import ScopeComponentsImporter from '../../../scope/component-ops/scope-components-importer';
-import { CollectObjectsOpts } from '../../../scope/component-version';
 import { Ref } from '../../../scope/objects';
-import { ObjectList, ObjectItem } from '../../../scope/objects/object-list';
+import { ObjectList } from '../../../scope/objects/object-list';
+import {
+  ComponentWithCollectOptions,
+  ObjectsReadableGenerator,
+} from '../../../scope/objects/objects-readable-generator';
 
 export type FETCH_TYPE = 'component' | 'lane' | 'object' | 'component-delta';
 export type FETCH_OPTIONS = {
@@ -26,7 +27,7 @@ export default async function fetch(
   ids: string[], // ids type are determined by the fetchOptions.type
   fetchOptions: FETCH_OPTIONS,
   headers?: Record<string, any> | null | undefined
-): Promise<ObjectList> {
+): Promise<Readable> {
   logger.debug(`scope.fetch started, path ${path}, options`, fetchOptions);
   if (!fetchOptions.type) fetchOptions.type = 'component'; // for backward compatibility
   const args = { path, ids, ...fetchOptions };
@@ -42,24 +43,44 @@ export default async function fetch(
   const useCachedScope = true;
   const scope: Scope = await loadScope(path, useCachedScope);
   const objectList = new ObjectList();
+  const objectsReadableGenerator = new ObjectsReadableGenerator(scope.objects);
   switch (fetchOptions.type) {
     case 'component': {
       const bitIds: BitIds = BitIds.deserialize(ids);
       const { withoutDependencies, includeArtifacts } = fetchOptions;
-      const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
-      const importedComponents = withoutDependencies
-        ? await scopeComponentsImporter.fetchWithoutDeps(bitIds)
-        : await scopeComponentsImporter.fetchWithDeps(bitIds);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const clientVersion = headers ? headers.version : null;
       const collectParents = !withoutDependencies;
-      const componentObjects = await scopeComponentsImporter.componentsToComponentsObjects(
-        importedComponents,
-        clientVersion,
-        collectParents,
-        includeArtifacts
-      );
-      objectList.addIfNotExist(componentObjects);
+      const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
+      const getComponentsWithOptions = async (): Promise<ComponentWithCollectOptions[]> => {
+        if (withoutDependencies) {
+          const componentsVersions = await scopeComponentsImporter.fetchWithoutDeps(bitIds);
+          return componentsVersions.map((compVersion) => ({
+            component: compVersion.component,
+            version: compVersion.version,
+            collectArtifacts: includeArtifacts,
+            collectParents,
+          }));
+        }
+        const versionsDependencies = await scopeComponentsImporter.fetchWithDeps(bitIds);
+        return versionsDependencies
+          .map((versionDep) => [
+            {
+              component: versionDep.component.component,
+              version: versionDep.component.version,
+              collectArtifacts: includeArtifacts,
+              collectParents,
+            },
+            ...versionDep.allDependencies.map((verDep) => ({
+              component: verDep.component,
+              version: verDep.version,
+              collectArtifacts: includeArtifacts,
+              collectParents: false, // for dependencies, no need to traverse the entire history
+            })),
+          ])
+          .flat();
+      };
+      const componentsWithOptions = await getComponentsWithOptions();
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      objectsReadableGenerator.pushObjectsToReadable(componentsWithOptions);
       break;
     }
     case 'component-delta': {
@@ -67,17 +88,18 @@ export default async function fetch(
       const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
       const bitIdsLatest = bitIdsWithHashToStop.toVersionLatest();
       const importedComponents = await scopeComponentsImporter.fetchWithoutDeps(bitIdsLatest);
-      const options: CollectObjectsOpts = {
-        collectParents: true,
-        collectArtifacts: fetchOptions.includeArtifacts,
-      };
-      const clientVersion = headers ? headers.version : null;
-      const allObjects = await mapSeries(importedComponents, (component) => {
-        const hashToStop = bitIdsWithHashToStop.searchWithoutVersion(component.id)?.version;
-        options.collectParentsUntil = hashToStop ? Ref.from(hashToStop) : null;
-        return component.collectObjects(scope.objects, clientVersion, options);
+      const componentsWithOptions: ComponentWithCollectOptions[] = importedComponents.map((compVersion) => {
+        const hashToStop = bitIdsWithHashToStop.searchWithoutVersion(compVersion.id)?.version;
+        return {
+          component: compVersion.component,
+          version: compVersion.version,
+          collectArtifacts: fetchOptions.includeArtifacts,
+          collectParents: true,
+          collectParentsUntil: hashToStop ? Ref.from(hashToStop) : null,
+        };
       });
-      objectList.addIfNotExist(flatten(allObjects));
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      objectsReadableGenerator.pushObjectsToReadable(componentsWithOptions);
       break;
     }
     case 'lane': {
@@ -89,20 +111,17 @@ export default async function fetch(
         if (!laneToFetch) throw new Error(`lane ${laneId.name} was not found in scope ${scope.name}`);
         return laneToFetch;
       });
-      const lanesObjects: ObjectItem[] = await Promise.all(
-        lanesToFetch.map(async (laneToFetch) => {
-          laneToFetch.scope = scope.name;
-          const laneBuffer = await laneToFetch.compress();
-          return { ref: laneToFetch.hash(), buffer: laneBuffer };
-        })
-      );
-      objectList.addIfNotExist(lanesObjects);
+      lanesToFetch.forEach((laneToFetch) => {
+        laneToFetch.scope = scope.name;
+      });
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      objectsReadableGenerator.pushLanes(lanesToFetch);
       break;
     }
     case 'object': {
       const refs = ids.map((id) => new Ref(id));
-      const objectsItems = await scope.getObjectItems(refs);
-      objectList.addIfNotExist(objectsItems);
+      // eslint-disable-next-line @typescript-eslint/no-floating-promises
+      objectsReadableGenerator.pushObjects(refs, scope);
       break;
     }
     default:
@@ -122,6 +141,6 @@ export default async function fetch(
       headers
     );
   }
-  logger.debug('scope.fetch completed');
-  return objectList;
+  logger.debug('scope.fetch returns readable');
+  return objectsReadableGenerator.readable;
 }

--- a/src/cli/commands/private-cmds/_fetch-cmd.ts
+++ b/src/cli/commands/private-cmds/_fetch-cmd.ts
@@ -44,9 +44,9 @@ export default class Fetch implements LegacyCommand {
       withoutDependencies: noDependencies,
       includeArtifacts,
     };
-    return migrate(scopePath, false).then(() => {
-      return fetch(scopePath, payload, fetchOptions, headers);
-    });
+    return migrate(scopePath, false)
+      .then(() => fetch(scopePath, payload, fetchOptions, headers))
+      .then((readable) => ObjectList.fromReadableStream(readable));
   }
 
   report(objectList: ObjectList): string {

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -3,6 +3,8 @@ import { Mutex } from 'async-mutex';
 import mapSeries from 'p-map-series';
 import groupArray from 'group-array';
 import R from 'ramda';
+import { promisify } from 'util';
+import { pipeline } from 'stream';
 import chalk from 'chalk';
 import { compact, flatten } from 'lodash';
 import loader from '../../cli/loader';
@@ -17,17 +19,18 @@ import { RemoteLaneId } from '../../lane-id/lane-id';
 import logger from '../../logger/logger';
 import { Remotes } from '../../remotes';
 import { splitBy } from '../../utils';
-import ComponentVersion, { ObjectCollector } from '../component-version';
+import ComponentVersion from '../component-version';
 import { ComponentNotFound } from '../exceptions';
 import { Lane, ModelComponent, Version } from '../models';
 import { Ref, Repository } from '../objects';
-import { ObjectItem, ObjectItemsStream, ObjectList } from '../objects/object-list';
+import { ObjectItemsStream, ObjectList } from '../objects/object-list';
 import SourcesRepository, { ComponentDef } from '../repositories/sources';
 import { getScopeRemotes } from '../scope-remotes';
 import VersionDependencies from '../version-dependencies';
 import { DEFAULT_LANE } from '../../constants';
 import { BitObjectList } from '../objects/bit-object-list';
 import { ObjectsWritable } from '../objects/objects-writable-stream';
+import { ErrorFromRemote } from '../exceptions/error-from-remote';
 
 const removeNils = R.reject(R.isNil);
 
@@ -362,20 +365,7 @@ export default class ScopeComponentsImporter {
       } found, going to collect its dependencies`
     );
     const dependencies = await this.importWithoutDeps(version.flattenedDependencies);
-    const source = id.scope as string;
-    return new VersionDependencies(versionComp, dependencies, source, version);
-  }
-
-  async componentsToComponentsObjects(
-    components: ObjectCollector[],
-    clientVersion: string | null | undefined,
-    collectParents: boolean,
-    collectArtifacts: boolean
-  ): Promise<ObjectItem[]> {
-    const allObjects = await mapSeries(components, (component) =>
-      component.collectObjects(this.scope.objects, clientVersion, { collectParents, collectArtifacts })
-    );
-    return R.flatten(allObjects);
+    return new VersionDependencies(versionComp, dependencies, version);
   }
 
   /**
@@ -415,21 +405,19 @@ export default class ScopeComponentsImporter {
     const bitIds = await mapSeries(Object.keys(objectListPerRemote), async (remoteName) => {
       loader.start(`streaming objects from ${chalk.bold(remoteName)} into the filesystem`);
       const objectList = objectListPerRemote[remoteName];
-      return new Promise((resolve, reject) => {
-        const writable = new ObjectsWritable(this.repo, this.sources, remoteName);
-        const pipe = objectList.pipe(writable);
-        pipe.on('finish', () => {
-          let nonLaneIds: BitId[] = ids;
-          writable.lanes.forEach((lane) => {
-            nonLaneIds = nonLaneIds.filter((id) => id.name !== lane.name || id.scope !== lane.scope);
-            nonLaneIds.push(...lane.components.map((c) => c.id));
-          });
-          resolve(nonLaneIds);
-        });
-        pipe.on('error', (err) => {
-          reject(err);
-        });
+      const writable = new ObjectsWritable(this.repo, this.sources, remoteName);
+      const pipelinePromise = promisify(pipeline);
+      try {
+        await pipelinePromise(objectList, writable);
+      } catch (err) {
+        throw new ErrorFromRemote(remoteName, err.message);
+      }
+      let nonLaneIds: BitId[] = ids;
+      writable.lanes.forEach((lane) => {
+        nonLaneIds = nonLaneIds.filter((id) => id.name !== lane.name || id.scope !== lane.scope);
+        nonLaneIds.push(...lane.components.map((c) => c.id));
       });
+      return nonLaneIds;
     });
     await this.repo.writeRemoteLanes();
     return BitIds.uniqFromArray(R.flatten(bitIds));
@@ -641,8 +629,7 @@ export default class ScopeComponentsImporter {
         // should have been fetched before by getExternalMany(). probably doesn't exist on the remote.
         throw new ShowDoctorError(`Version ${versionComp.version} of ${component.id().toString()} was not found`);
       }
-      const source = id.scope as string;
-      return new VersionDependencies(versionComp, [], source, version);
+      return new VersionDependencies(versionComp, [], version);
     });
     const versionDeps = compact(versionDepsWithNulls);
     const allFlattened = versionDeps.map((v) => v.version.getAllFlattenedDependencies());

--- a/src/scope/component-version.ts
+++ b/src/scope/component-version.ts
@@ -1,21 +1,12 @@
-import R from 'ramda';
-import semver from 'semver';
-
 import { BitId, BitIds } from '../bit-id';
 import ConsumerComponent from '../consumer/component';
 import { ManipulateDirItem } from '../consumer/component-ops/manipulate-dir';
-import CustomError from '../error/custom-error';
-import ShowDoctorError from '../error/show-doctor-error';
-import logger from '../logger/logger';
-import { getAllVersionHashes } from './component-ops/traverse-versions';
-import { HashMismatch } from './exceptions';
 import ModelComponent from './models/model-component';
 import Version from './models/version';
 import { Ref } from './objects';
-import { ObjectItem } from './objects/object-list';
 import Repository from './objects/repository';
 
-export default class ComponentVersion implements ObjectCollector {
+export default class ComponentVersion {
   readonly component: ModelComponent;
   readonly version: string;
 
@@ -52,76 +43,6 @@ export default class ComponentVersion implements ObjectCollector {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.component.toConsumerComponent(this.version, this.component.scope, repo, manipulateDirData);
   }
-
-  async collectObjects(
-    repo: Repository,
-    clientVersion: string | null | undefined,
-    options: CollectObjectsOpts
-  ): Promise<ObjectItem[]> {
-    const { collectParents, collectArtifacts, collectParentsUntil } = options;
-    const version = await this.getVersion(repo, false);
-    if (!version) throw new ShowDoctorError(`failed loading version ${this.version} of ${this.component.id()}`);
-    // @todo: remove this customError once upgrading to v15, because when the server has v15
-    // and the client has < 15, the client will get anyway an error to upgrade the version
-    if (clientVersion && version.overrides && !R.isEmpty(version.overrides) && semver.lt(clientVersion, '14.1.0')) {
-      throw new CustomError(`Your components were created with a newer version and use the "overrides" feature.
-Please upgrade your bit client to version >= v14.1.0`);
-    }
-    if (collectParentsUntil && version.hash().isEqual(collectParentsUntil)) {
-      return [];
-    }
-    const collectVersionObjects = async (ver: Version): Promise<ObjectItem[]> => {
-      const versionRefs = ver.refsWithOptions(collectParents, collectArtifacts);
-      const versionObjects = await ver.collectManyObjects(repo, versionRefs);
-      const versionData = { ref: ver.hash(), buffer: await ver.asRaw(repo), type: ver.getType() };
-      return [...versionObjects, versionData];
-    };
-    try {
-      const componentData = {
-        ref: this.component.hash(),
-        buffer: await this.component.asRaw(repo),
-        type: this.component.getType(),
-      };
-      const parentsObjects: ObjectItem[] = [];
-      if (collectParents) {
-        const allParentsHashes = await getAllVersionHashes(
-          this.component,
-          repo,
-          true,
-          version.hash(),
-          collectParentsUntil
-        );
-        const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
-        await Promise.all(
-          missingParentsHashes.map(async (parentHash) => {
-            const parentVersion = (await parentHash.load(repo)) as Version;
-            const parentsObj = await collectVersionObjects(parentVersion);
-            parentsObjects.push(...parentsObj);
-          })
-        );
-      }
-      const versionObjects = await collectVersionObjects(version);
-      const scopeMeta = await repo.getScopeMetaObject();
-      return [componentData, ...versionObjects, ...parentsObjects, scopeMeta];
-    } catch (err) {
-      logger.error(`component-version.toObjects ${this.id.toString()} got an error`, err);
-      // @ts-ignore
-      const originalVersionHash = this.component.getRef(this.version).toString();
-      const currentVersionHash = version.hash().toString();
-      if (originalVersionHash !== currentVersionHash) {
-        throw new HashMismatch(this.component.id(), this.version, originalVersionHash, currentVersionHash);
-      }
-      throw err;
-    }
-  }
-}
-
-export interface ObjectCollector {
-  collectObjects(
-    repo: Repository,
-    clientVersion: string | null | undefined,
-    options: CollectObjectsOpts
-  ): Promise<ObjectItem[]>;
 }
 
 export type CollectObjectsOpts = {

--- a/src/scope/exceptions/error-from-remote.ts
+++ b/src/scope/exceptions/error-from-remote.ts
@@ -1,0 +1,9 @@
+import { BitError } from '@teambit/bit-error';
+import chalk from 'chalk';
+
+export class ErrorFromRemote extends BitError {
+  constructor(remoteName: string, errMessage: string) {
+    super(`remote ${chalk.bold(remoteName)} responded with the following error:
+${errMessage}`);
+  }
+}

--- a/src/scope/flatten-dependencies.ts
+++ b/src/scope/flatten-dependencies.ts
@@ -1,8 +1,5 @@
-import { BitIds } from '../bit-id';
 import { flatten } from '../utils';
 import ComponentWithDependencies from './component-dependencies';
-import Repository from './objects/repository';
-import VersionDependencies from './version-dependencies';
 
 export function flattenDependencies(dependencies: ComponentWithDependencies[]) {
   return Object.values(
@@ -11,15 +8,4 @@ export function flattenDependencies(dependencies: ComponentWithDependencies[]) {
       return components;
     }, {})
   );
-}
-
-export async function flattenDependencyIds(dependencies: VersionDependencies[], repo: Repository): Promise<BitIds> {
-  const ids = await Promise.all(
-    dependencies.map((dep) => {
-      const depCompId = dep.component.id.changeScope(dep.sourceScope);
-      return dep.component.flattenedDependencies(repo).then((flattenedDeps) => flattenedDeps.concat(depCompId));
-    })
-  );
-  const flattenedIds = flatten(ids);
-  return BitIds.uniqFromArray(flattenedIds);
 }

--- a/src/scope/network/fs/fs.ts
+++ b/src/scope/network/fs/fs.ts
@@ -66,8 +66,8 @@ export default class Fs implements Network {
   }
 
   async fetch(ids: string[], fetchOptions: FETCH_OPTIONS): Promise<ObjectItemsStream> {
-    const objectList = await fetch(this.scopePath, ids, fetchOptions);
-    return objectList.toReadableStream();
+    const objectsReadable = await fetch(this.scopePath, ids, fetchOptions);
+    return objectsReadable;
   }
 
   latestVersions(componentIds: BitId[]): Promise<string[]> {

--- a/src/scope/objects/objects-readable-generator.ts
+++ b/src/scope/objects/objects-readable-generator.ts
@@ -1,0 +1,123 @@
+import pMapSeries from 'p-map-series';
+import { Readable } from 'stream';
+import { Ref, Repository } from '.';
+import { Scope } from '..';
+import ShowDoctorError from '../../error/show-doctor-error';
+import logger from '../../logger/logger';
+import { getAllVersionHashes } from '../component-ops/traverse-versions';
+import { CollectObjectsOpts } from '../component-version';
+import { HashMismatch } from '../exceptions';
+import { Lane, ModelComponent, Version } from '../models';
+import { ObjectItem } from './object-list';
+
+export type ComponentWithCollectOptions = {
+  component: ModelComponent;
+  version: string;
+} & CollectObjectsOpts;
+
+export class ObjectsReadableGenerator {
+  public readable: Readable;
+  private pushed: string[] = [];
+  constructor(private repo: Repository) {
+    this.readable = new Readable({ objectMode: true, read() {} });
+  }
+  async pushObjectsToReadable(componentsWithOptions: ComponentWithCollectOptions[]) {
+    try {
+      await this.pushScopeMeta();
+      await pMapSeries(componentsWithOptions, async (componentWithOptions) =>
+        this.pushComponentObjects(componentWithOptions)
+      );
+      this.readable.push(null);
+    } catch (err) {
+      this.readable.destroy(err);
+    }
+  }
+
+  async pushLanes(lanesToFetch: Lane[]) {
+    await Promise.all(
+      lanesToFetch.map(async (laneToFetch) => {
+        const laneBuffer = await laneToFetch.compress();
+        this.push({ ref: laneToFetch.hash(), buffer: laneBuffer });
+      })
+    );
+  }
+
+  async pushObjects(refs: Ref[], scope: Scope) {
+    await pMapSeries(refs, async (ref) => {
+      const objectItem = await scope.getObjectItem(ref);
+      this.push(objectItem);
+    });
+  }
+
+  private async pushScopeMeta() {
+    const scopeMeta = await this.repo.getScopeMetaObject();
+    this.push(scopeMeta);
+  }
+
+  private push(obj: ObjectItem) {
+    const hashStr = obj.ref.toString();
+    if (this.pushed.includes(hashStr)) {
+      return;
+    }
+    logger.trace('ObjectsReadableGenerator.push', hashStr);
+    this.readable.push(obj);
+    this.pushed.push(hashStr);
+  }
+  private pushManyObjects(objects: ObjectItem[]) {
+    objects.map((obj) => this.push(obj));
+  }
+
+  private async pushComponentObjects(componentWithOptions: ComponentWithCollectOptions): Promise<void> {
+    const { component, collectParents, collectArtifacts, collectParentsUntil } = componentWithOptions;
+    const version = await component.loadVersion(componentWithOptions.version, this.repo, false);
+    if (!version)
+      throw new ShowDoctorError(`failed loading version ${componentWithOptions.version} of ${component.id()}`);
+    if (collectParentsUntil && version.hash().isEqual(collectParentsUntil)) {
+      return;
+    }
+    const collectVersionObjects = async (ver: Version): Promise<ObjectItem[]> => {
+      const versionRefs = ver.refsWithOptions(collectParents, collectArtifacts);
+      const versionObjects = await ver.collectManyObjects(this.repo, versionRefs);
+      const versionData = { ref: ver.hash(), buffer: await ver.asRaw(this.repo), type: ver.getType() };
+      return [...versionObjects, versionData];
+    };
+    try {
+      const componentData = {
+        ref: component.hash(),
+        buffer: await component.asRaw(this.repo),
+        type: component.getType(),
+      };
+      if (collectParents) {
+        const parentsObjects: ObjectItem[] = [];
+        const allParentsHashes = await getAllVersionHashes(
+          component,
+          this.repo,
+          true,
+          version.hash(),
+          collectParentsUntil
+        );
+        const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
+        await Promise.all(
+          missingParentsHashes.map(async (parentHash) => {
+            const parentVersion = (await parentHash.load(this.repo)) as Version;
+            const parentsObj = await collectVersionObjects(parentVersion);
+            parentsObjects.push(...parentsObj);
+          })
+        );
+        this.pushManyObjects(parentsObjects);
+      }
+      const versionObjects = await collectVersionObjects(version);
+      this.pushManyObjects(versionObjects);
+      this.push(componentData);
+    } catch (err) {
+      logger.error(`component-version.toObjects ${componentWithOptions.component.id()} got an error`, err);
+      // @ts-ignore
+      const originalVersionHash = component.getRef(componentWithOptions.version).toString();
+      const currentVersionHash = version.hash().toString();
+      if (originalVersionHash !== currentVersionHash) {
+        throw new HashMismatch(component.id(), componentWithOptions.version, originalVersionHash, currentVersionHash);
+      }
+      throw err;
+    }
+  }
+}

--- a/src/scope/objects/objects-readable-generator.ts
+++ b/src/scope/objects/objects-readable-generator.ts
@@ -34,19 +34,29 @@ export class ObjectsReadableGenerator {
   }
 
   async pushLanes(lanesToFetch: Lane[]) {
-    await Promise.all(
-      lanesToFetch.map(async (laneToFetch) => {
-        const laneBuffer = await laneToFetch.compress();
-        this.push({ ref: laneToFetch.hash(), buffer: laneBuffer });
-      })
-    );
+    try {
+      await Promise.all(
+        lanesToFetch.map(async (laneToFetch) => {
+          const laneBuffer = await laneToFetch.compress();
+          this.push({ ref: laneToFetch.hash(), buffer: laneBuffer });
+        })
+      );
+      this.readable.push(null);
+    } catch (err) {
+      this.readable.destroy(err);
+    }
   }
 
   async pushObjects(refs: Ref[], scope: Scope) {
-    await pMapSeries(refs, async (ref) => {
-      const objectItem = await scope.getObjectItem(ref);
-      this.push(objectItem);
-    });
+    try {
+      await pMapSeries(refs, async (ref) => {
+        const objectItem = await scope.getObjectItem(ref);
+        this.push(objectItem);
+      });
+      this.readable.push(null);
+    } catch (err) {
+      this.readable.destroy(err);
+    }
   }
 
   private async pushScopeMeta() {

--- a/src/scope/objects/objects-writable-stream.ts
+++ b/src/scope/objects/objects-writable-stream.ts
@@ -6,7 +6,6 @@ import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
 import { RemoteLaneId } from '../../lane-id/lane-id';
 import logger from '../../logger/logger';
 import { ModelComponentMerger } from '../component-ops/model-components-merger';
-import { ErrorFromRemote } from '../exceptions/error-from-remote';
 import { Lane, ModelComponent } from '../models';
 import { SourceRepository } from '../repositories';
 import { ObjectItem } from './object-list';

--- a/src/scope/objects/objects-writable-stream.ts
+++ b/src/scope/objects/objects-writable-stream.ts
@@ -4,9 +4,11 @@ import { Writable } from 'stream';
 import { BitObject, Repository } from '.';
 import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
 import { RemoteLaneId } from '../../lane-id/lane-id';
+import logger from '../../logger/logger';
 import { ModelComponentMerger } from '../component-ops/model-components-merger';
 import { Lane, ModelComponent } from '../models';
 import { SourceRepository } from '../repositories';
+import { ObjectItem } from './object-list';
 
 /**
  * first, write all immutable objects, such as files/sources/versions into the filesystem, as they arrive.
@@ -23,7 +25,8 @@ export class ObjectsWritable extends Writable {
   constructor(private repo: Repository, private sources: SourceRepository, private remoteName: string) {
     super({ objectMode: true });
   }
-  async _write(obj, encoding, callback) {
+  async _write(obj: ObjectItem, _, callback: Function) {
+    logger.trace('ObjectsWritable.write', obj.ref);
     if (!obj.ref || !obj.buffer) {
       return callback(new Error('objectItem expected to have "ref" and "buffer" props'));
     }

--- a/src/scope/objects/objects-writable-stream.ts
+++ b/src/scope/objects/objects-writable-stream.ts
@@ -6,6 +6,7 @@ import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
 import { RemoteLaneId } from '../../lane-id/lane-id';
 import logger from '../../logger/logger';
 import { ModelComponentMerger } from '../component-ops/model-components-merger';
+import { ErrorFromRemote } from '../exceptions/error-from-remote';
 import { Lane, ModelComponent } from '../models';
 import { SourceRepository } from '../repositories';
 import { ObjectItem } from './object-list';
@@ -30,8 +31,12 @@ export class ObjectsWritable extends Writable {
     if (!obj.ref || !obj.buffer) {
       return callback(new Error('objectItem expected to have "ref" and "buffer" props'));
     }
-    await this.writeImmutableObjectToFs(obj);
-    return callback();
+    try {
+      await this.writeImmutableObjectToFs(obj);
+      return callback();
+    } catch (err) {
+      return callback(err);
+    }
   }
   async _final(callback) {
     try {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -469,6 +469,13 @@ export default class Scope {
     );
   }
 
+  async getObjectItem(ref: Ref): Promise<ObjectItem> {
+    return {
+      ref,
+      buffer: await this.objects.loadRaw(ref),
+    };
+  }
+
   async getModelComponentIfExist(id: BitId): Promise<ModelComponent | undefined> {
     const modelComponent = await this.sources.get(id);
     if (modelComponent) {

--- a/src/scope/version-dependencies.ts
+++ b/src/scope/version-dependencies.ts
@@ -1,22 +1,14 @@
-import mapSeries from 'p-map-series';
-import R from 'ramda';
 import { BitId, BitIds } from '../bit-id';
 import { ManipulateDirItem } from '../consumer/component-ops/manipulate-dir';
 import ComponentWithDependencies from './component-dependencies';
-import ComponentVersion, { ObjectCollector, CollectObjectsOpts } from './component-version';
+import ComponentVersion from './component-version';
 import { DependenciesNotFound } from './exceptions/dependencies-not-found';
 import { Version } from './models';
-import { ObjectItem } from './objects/object-list';
 import Repository from './objects/repository';
 import ConsumerComponent from '../consumer/component';
 
-export default class VersionDependencies implements ObjectCollector {
-  constructor(
-    public component: ComponentVersion,
-    public dependencies: ComponentVersion[],
-    public sourceScope: string,
-    public version: Version
-  ) {}
+export default class VersionDependencies {
+  constructor(public component: ComponentVersion, public dependencies: ComponentVersion[], public version: Version) {}
 
   get allDependencies(): ComponentVersion[] {
     return this.dependencies;
@@ -56,19 +48,6 @@ export default class VersionDependencies implements ObjectCollector {
       extensionDependencies: [],
       missingDependencies: this.getMissingDependencies(),
     });
-  }
-
-  async collectObjects(
-    repo: Repository,
-    clientVersion: string | null | undefined,
-    options: CollectObjectsOpts
-  ): Promise<ObjectItem[]> {
-    // for the dependencies, don't collect parents they might not exist
-    const depOptions: CollectObjectsOpts = { ...options, collectParents: false };
-    const depsP = mapSeries(this.allDependencies, (dep) => dep.collectObjects(repo, clientVersion, depOptions));
-    const compP = this.component.collectObjects(repo, clientVersion, options);
-    const [component, dependencies] = await Promise.all([compP, depsP]);
-    return [...component, ...R.flatten(dependencies)];
   }
 }
 


### PR DESCRIPTION
The consumer of the fetch API already uses streams, see https://github.com/teambit/bit/pull/3909.
This PR is to make a similar change for the Fetch API implementation, which normally happens on the remote.

Currently, all objects are cached in-memory and pushed all in once into the client. For large scopes this can cause out-of-memory.
This PR changes the implementation to use streams instead. It implements a `Readable` stream, which processes the objects that need to be sent and pushes them as soon as they're ready.
With this change, the `fetch` API returns `stream.Readable`, instead of `ObjectList`. Here is how it works for each one of the network protocol.
**HTTP** - the `fetch` API returns `Readable`, then, it is piped into `tar-stream`, which eventually piped into the response.
**FS** - no need for tar-stream here. The `Readable` is piped directly to the `Writable`. 
**SSH** - still uses the old format, which converts the objects into a huge JSON string, so once the `Readable` is obtained from the `fetch` api, it converts it to `ObjectList` and sends it. As such, it doesn't get this memory improvement.

### A few words about the error handling
Since it starts streaming immediately, and error can be found along the way, the only way I found to signal the client that error had occurred is to pass a new "file" with a special name: `.BIT_ERROR` and the error message as the content.  Once the client (the writable stream) finds out that the file name indicates an error, it emits an error event, which finally causes the pipeline to throw an error.

The flow is as following:
Remote:
1. Readable (of `ObjectItem[]`) is piped into tar-stream. Start streaming.
2. During the Readable process, an error occurred.
3. This Readable terminates the stream by calling: `Readable.terminate(err)`.
4. The tar-stream gets the error event from the Readable and sends a new file `.BIT_ERROR` with the error message.

Client:
1. The tar-stream is piped into the Writable (of `ObjectItem[]`). Start consuming.
2. During the read of tar-stream, if a file name is `.BIT_ERROR`, it emits an error event.
3. The error event is caught in the try/catch of the promisified pipeline and handled correctly.
