### PR TITLE
Fix source maps

### DIFF
--- a/scopes/compilation/cli/webpack/error/error.tsx
+++ b/scopes/compilation/cli/webpack/error/error.tsx
@@ -12,13 +12,16 @@ export type ErrorProps = {
 };
 
 export function Error({ errors, level }: ErrorProps) {
+  const color = level === ErrorLevel.WARNING ? 'yellow' : 'red';
+
   return (
     <>
       {errors.map((warning, index) => (
-        <Text key={index} color={level === ErrorLevel.WARNING ? 'yellow' : 'red'}>
-          {warning.message}
+        <Text key={index} color={color}>
+          <Text>{warning.message}</Text>
+          {warning.stack && <Newline />}
+          <Text>{warning.stack}</Text>
           <Newline />
-          {warning.stack}
         </Text>
       ))}
     </>

--- a/scopes/preview/cli/preview-server-status/preview-server-status.tsx
+++ b/scopes/preview/cli/preview-server-status/preview-server-status.tsx
@@ -15,6 +15,7 @@ export type PreviewServerStatusProps = {
 
 export function PreviewServerStatus({ previewServers, pubsub }: PreviewServerStatusProps) {
   const { errors, warnings, compiling } = usePreviewServer({ pubsub });
+
   if (errors.length) {
     return <Error errors={errors} level={ErrorLevel.ERROR} />;
   }
@@ -29,7 +30,7 @@ export function PreviewServerStatus({ previewServers, pubsub }: PreviewServerSta
         return <PreviewServerRow key={key} previewServer={server} />;
       })}
       {warnings.length ? (
-        <Box marginTop={1}>
+        <Box marginTop={1} flexDirection="column">
           <Newline />
           <Error errors={warnings} level={ErrorLevel.WARNING} />
         </Box>

--- a/scopes/react/react/typescript/tsconfig.json
+++ b/scopes/react/react/typescript/tsconfig.json
@@ -10,7 +10,8 @@
     "sourceMap": true,
     "skipLibCheck": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "rootDir": "."
   },
   "exclude": [
     "dist"

--- a/scopes/stencil/stencil/typescript/tsconfig.json
+++ b/scopes/stencil/stencil/typescript/tsconfig.json
@@ -14,7 +14,8 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "jsx": "react",
-    "jsxFactory": "h"
+    "jsxFactory": "h",
+    "rootDir": "."
   },
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Proposed Changes

- add `"rootDir": "."` to tsconfig of the react env. This only changes the dists for the local (workspace) components, and is already included in the build `tsconfig.json`
- this will fix source maps for all components with folders in workspace start
- also fix outputs for errors and warnings. (used to show them in columns)