### PR TITLE
improve import performance by writing the objects as soon as they arrive

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -444,7 +444,7 @@ export const MISSING_NESTED_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT + 2
 
 export const CONCURRENT_IO_LIMIT = 100; // limit number of files to read/write/delete/symlink at the same time
 export const CONCURRENT_COMPONENTS_LIMIT = 50; // limit number of components to load at the same time
-export const CONCURRENT_FETCH_LIMIT = 10; // limit number of scopes to fetch from at the same time
+export const CONCURRENT_FETCH_LIMIT = 15; // limit number of scopes to fetch from at the same time
 
 // todo: move the following two lines to the watch extension once its e2e moved to the extension dir
 export const STARTED_WATCHING_MSG = 'started watching for component changes to rebuild';

--- a/src/remotes/remotes.ts
+++ b/src/remotes/remotes.ts
@@ -42,7 +42,7 @@ export default class Remotes extends Map<string, Remote> {
   async fetch(
     idsGroupedByScope: { [scopeName: string]: string[] }, // option.type determines the id: component-id/lane-id/object-id (hash)
     thisScope: Scope,
-    options: Partial<FETCH_OPTIONS> & { concurrency?: number } = {},
+    options: Partial<FETCH_OPTIONS> = {},
     context?: Record<string, any>
   ): Promise<{ [remoteName: string]: ObjectItemsStream }> {
     const fetchOptions: FETCH_OPTIONS = {
@@ -78,7 +78,7 @@ export default class Remotes extends Map<string, Remote> {
           return null;
         }
       },
-      { concurrency: options.concurrency || CONCURRENT_FETCH_LIMIT }
+      { concurrency: CONCURRENT_FETCH_LIMIT }
     );
     if (Object.keys(failedScopes).length) {
       const failedScopesErr = Object.keys(failedScopes).map(

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -3,9 +3,6 @@ import { Mutex } from 'async-mutex';
 import mapSeries from 'p-map-series';
 import groupArray from 'group-array';
 import R from 'ramda';
-import { promisify } from 'util';
-import { pipeline } from 'stream';
-import chalk from 'chalk';
 import { compact, flatten } from 'lodash';
 import loader from '../../cli/loader';
 import { Scope } from '..';
@@ -29,8 +26,7 @@ import { getScopeRemotes } from '../scope-remotes';
 import VersionDependencies from '../version-dependencies';
 import { DEFAULT_LANE } from '../../constants';
 import { BitObjectList } from '../objects/bit-object-list';
-import { ObjectsWritable } from '../objects/objects-writable-stream';
-import { ErrorFromRemote } from '../exceptions/error-from-remote';
+import { ObjectFetcher } from '../objects-fetcher/objects-fetcher';
 
 const removeNils = R.reject(R.isNil);
 
@@ -244,14 +240,16 @@ export default class ScopeComponentsImporter {
     loader.start(statusMsg);
     logger.debugAndAddBreadCrumb('importManyDeltaWithoutDeps', statusMsg);
     const remotes = await getScopeRemotes(this.scope);
-    const objectsStreamPerRemote = await remotes.fetch(groupedIds, this.scope, {
-      type: 'component-delta',
-      withoutDependencies: true,
-      concurrency: 10,
-    });
-    loader.start(`got response from the remotes, merging them and writing to the filesystem`);
-    logger.debugAndAddBreadCrumb('importManyDeltaWithoutDeps', 'writing them to the model');
-    await this.writeManyObjectListToModel(objectsStreamPerRemote);
+    await new ObjectFetcher(
+      this.repo,
+      this.scope,
+      remotes,
+      {
+        type: 'component-delta',
+        withoutDependencies: true,
+      },
+      idsToFetch
+    ).fetchFromRemoteAndWrite();
   }
 
   async importFromLanes(remoteLaneIds: RemoteLaneId[]): Promise<Lane[]> {
@@ -387,46 +385,6 @@ export default class ScopeComponentsImporter {
   }
 
   /**
-   * due to the use of streams, this is memory efficient and can handle easily GBs of objects.
-   * until this point, no data was fetched from a remote, only the connection was established,
-   * once the readable piped into the ObjectsWritable, the data starts flowing.
-   * the remotes are processed in sequence, not in parallel. mostly because two remotes can bring
-   * the same component and if both components executing the "merge" operation at the same time,
-   * the result is unpredictable. (see model-component-merger). for other objects file it's
-   * probably also safer to not write potentially the same file from two different remote at the
-   * same time.
-   * ideally, we'd maintain a queue, which allows concurrent of say, 100, and make sure that no two
-   * identical files are written at the same time.
-   */
-  async writeManyObjectListToModel(objectListPerRemote: { [remoteName: string]: ObjectItemsStream }): Promise<void> {
-    await mapSeries(Object.keys(objectListPerRemote), async (remoteName) => {
-      loader.start(`streaming objects from ${chalk.bold(remoteName)} into the filesystem`);
-      const objectList = objectListPerRemote[remoteName];
-      const writable = new ObjectsWritable(this.repo, this.sources, remoteName);
-      const pipelinePromise = promisify(pipeline);
-      // add an error listener for the ObjectList to differentiate between errors coming from the
-      // remote and errors happening inside the Writable.
-      let readableError: Error | undefined;
-      objectList.on('error', (err) => {
-        readableError = err;
-      });
-      try {
-        await pipelinePromise(objectList, writable);
-      } catch (err) {
-        if (readableError) {
-          if (!readableError.message) {
-            logger.error(`error coming from a remote has no message, please fix!`, readableError);
-          }
-          throw new ErrorFromRemote(remoteName, readableError.message || 'unknown error');
-        }
-        // the error is coming from the writable, no need to treat it specially. just throw it.
-        throw err;
-      }
-    });
-    await this.repo.writeRemoteLanes();
-  }
-
-  /**
    * get a single component from a remote without saving it locally
    */
   async getRemoteComponent(id: BitId): Promise<ModelComponent | null | undefined> {
@@ -482,14 +440,16 @@ export default class ScopeComponentsImporter {
         throw new Error(`getExternalMany expects to get external ids only, got ${id.toString()}`);
     });
     enrichContextFromGlobal(Object.assign({}, { requestedBitIds: ids.map((id) => id.toString()) }));
-    const objectStreamsPerRemote = await remotes.fetch(
-      groupByScopeName(ids),
+    await new ObjectFetcher(
+      this.repo,
       this.scope,
-      { withoutDependencies: false },
+      remotes,
+      {
+        withoutDependencies: false,
+      },
+      ids,
       context
-    );
-    logger.debugAndAddBreadCrumb('ScopeComponentsImporter.getExternalMany', 'writing them to the model');
-    await this.writeManyObjectListToModel(objectStreamsPerRemote);
+    ).fetchFromRemoteAndWrite();
     const componentDefs = await this.sources.getMany(ids);
     const componentDefsExisting = componentDefs.filter((componentDef) => componentDef.component);
     const versionDeps = await mapSeries(componentDefsExisting, (compDef) =>
@@ -521,13 +481,16 @@ export default class ScopeComponentsImporter {
     }
     logger.debugAndAddBreadCrumb('getExternalManyWithoutDeps', `${left.length} left. Fetching them from a remote`);
     enrichContextFromGlobal(Object.assign(context, { requestedBitIds: ids.map((id) => id.toString()) }));
-    const objectStreamsPerRemote = await remotes.fetch(
-      groupByScopeName(left.map((def) => def.id)),
+    await new ObjectFetcher(
+      this.repo,
       this.scope,
-      { withoutDependencies: true },
+      remotes,
+      {
+        withoutDependencies: true,
+      },
+      left.map((def) => def.id),
       context
-    );
-    await this.writeManyObjectListToModel(objectStreamsPerRemote);
+    ).fetchFromRemoteAndWrite();
 
     const finalDefs: ComponentDef[] = await this.sources.getMany(ids);
 
@@ -669,7 +632,7 @@ please make sure that the scope-resolver points to the right scope.`);
   }
 }
 
-function groupByScopeName(ids: Array<BitId | RemoteLaneId>): { [scopeName: string]: string[] } {
+export function groupByScopeName(ids: Array<BitId | RemoteLaneId>): { [scopeName: string]: string[] } {
   const grouped = groupArray(ids, 'scope');
   Object.keys(grouped).forEach((scopeName) => {
     grouped[scopeName] = grouped[scopeName].map((id) => id.toString());

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -1,0 +1,156 @@
+import { BitId } from '@teambit/legacy-bit-id';
+import { pipeline } from 'stream';
+import { promisify } from 'util';
+import pMap from 'p-map';
+import { Scope } from '..';
+import { FETCH_OPTIONS } from '../../api/scope/lib/fetch';
+import loader from '../../cli/loader';
+import { CONCURRENT_FETCH_LIMIT } from '../../constants';
+import logger from '../../logger/logger';
+import { Remotes } from '../../remotes';
+import { ScopeNotFound } from '../exceptions';
+import { ErrorFromRemote } from '../exceptions/error-from-remote';
+import { UnexpectedNetworkError } from '../network/exceptions';
+import { Repository } from '../objects';
+import { ObjectItemsStream } from '../objects/object-list';
+import { ObjectsWritable } from './objects-writable-stream';
+import { WriteComponentsQueue } from './write-components-queue';
+import { WriteObjectsQueue } from './write-objects-queue';
+import { groupByScopeName } from '../component-ops/scope-components-importer';
+
+/**
+ * due to the use of streams, this is memory efficient and can handle easily GBs of objects.
+ * this class first fetches objects from remotes and as soon as the remote returns a stream, it
+ * pipes it into the Writable stream, which in turn, adds the objects into the queue, which writes
+ * them into the filesystem.
+ *
+ * the immutable objects (such as files/versions) are processed with a high concurrency, see
+ * WriteObjectsQueue. the mutable objects, such as components, are written serially mostly because
+ * two remotes can bring the same component and if both components executing the "merge" operation
+ * at the same time, the result is unpredictable. (see model-component-merger).
+ */
+export class ObjectFetcher {
+  private failedScopes: { [scopeName: string]: Error } = {};
+  constructor(
+    private repo: Repository,
+    private scope: Scope,
+    private remotes: Remotes,
+    private fetchOptions: Partial<FETCH_OPTIONS>,
+    private ids: BitId[],
+    private context = {}
+  ) {}
+
+  public async fetchFromRemoteAndWrite() {
+    this.fetchOptions = {
+      type: 'component',
+      withoutDependencies: true,
+      includeArtifacts: false,
+      ...this.fetchOptions,
+    };
+    const idsGroupedByScope = groupByScopeName(this.ids);
+    logger.debug('[-] Running fetch on remotes, with the following options', this.fetchOptions);
+    const objectsQueue = new WriteObjectsQueue();
+    const componentsQueue = new WriteComponentsQueue();
+    this.showProgress(objectsQueue, componentsQueue);
+    await pMap(
+      Object.keys(idsGroupedByScope),
+      async (scopeName) => {
+        const readableStream = await this.fetchFromSingleRemote(scopeName, idsGroupedByScope[scopeName]);
+        if (!readableStream) return;
+        await this.writeFromSingleRemote(readableStream, scopeName, objectsQueue, componentsQueue);
+      },
+      { concurrency: CONCURRENT_FETCH_LIMIT }
+    );
+    if (Object.keys(this.failedScopes).length) {
+      const failedScopesErr = Object.keys(this.failedScopes).map(
+        (failedScope) => `${failedScope} - ${this.failedScopes[failedScope].message}`
+      );
+      throw new Error(`unexpected network error has occurred during fetching scopes: ${Object.keys(
+        this.failedScopes
+      ).join(', ')}
+server responded with the following error messages:
+${failedScopesErr.join('\n')}`);
+    }
+    await Promise.all([objectsQueue.onIdle(), componentsQueue.onIdle()]);
+    logger.debug('[-] fetchFromRemoteAndWrite, completed writing all objects');
+    loader.start('all objects were processed and written to the filesystem successfully');
+    await this.repo.writeRemoteLanes();
+  }
+
+  private async fetchFromSingleRemote(scopeName: string, ids: string[]): Promise<ObjectItemsStream | null> {
+    // when importing directly from a remote scope, throw for ScopeNotFound. otherwise, when
+    // fetching flattened dependencies (withoutDependencies=true), ignore this error
+    const shouldThrowOnUnavailableScope = !this.fetchOptions.withoutDependencies;
+    const remote = await this.remotes.resolve(scopeName, this.scope);
+    try {
+      return await remote.fetch(ids, this.fetchOptions as FETCH_OPTIONS, this.context);
+    } catch (err) {
+      if (err instanceof ScopeNotFound && !shouldThrowOnUnavailableScope) {
+        logger.error(`failed accessing the scope "${scopeName}". continuing without this scope.`);
+      } else if (err instanceof UnexpectedNetworkError) {
+        logger.error(`failed fetching from ${scopeName}`, err);
+        this.failedScopes[scopeName] = err;
+      } else {
+        throw err;
+      }
+      return null;
+    }
+  }
+
+  private async writeFromSingleRemote(
+    objectsStream: ObjectItemsStream,
+    scopeName: string,
+    objectsQueue: WriteObjectsQueue,
+    componentsQueue: WriteComponentsQueue
+  ) {
+    const writable = new ObjectsWritable(this.repo, this.scope.sources, scopeName, objectsQueue, componentsQueue);
+    const pipelinePromise = promisify(pipeline);
+    // add an error listener for the ObjectList to differentiate between errors coming from the
+    // remote and errors happening inside the Writable.
+    let readableError: Error | undefined;
+    objectsStream.on('error', (err) => {
+      readableError = err;
+    });
+    try {
+      await pipelinePromise(objectsStream, writable);
+    } catch (err) {
+      if (readableError) {
+        if (!readableError.message) {
+          logger.error(`error coming from a remote has no message, please fix!`, readableError);
+        }
+        throw new ErrorFromRemote(scopeName, readableError.message || 'unknown error');
+      }
+      // the error is coming from the writable, no need to treat it specially. just throw it.
+      throw err;
+    }
+  }
+
+  private showProgress(objectsQueue: WriteObjectsQueue, componentsQueue: WriteComponentsQueue) {
+    let objectsAdded = 0;
+    let objectsCompleted = 0;
+    let componentsAdded = 0;
+    let componentsCompleted = 0;
+    objectsQueue.getQueue().on('add', () => {
+      objectsAdded += 1;
+      if (objectsAdded % 100 === 0) {
+        loader.start(
+          `Downloaded ${objectsAdded} objects, ${componentsAdded} components. Processed successfully ${objectsCompleted} objects, ${componentsCompleted} components`
+        );
+      }
+    });
+    objectsQueue.getQueue().on('next', () => {
+      objectsCompleted += 1;
+      if (objectsAdded % 100 === 0) {
+        loader.start(
+          `Downloaded ${objectsAdded} objects, ${componentsAdded} components. Processed successfully ${objectsCompleted} objects, ${componentsCompleted} components`
+        );
+      }
+    });
+    componentsQueue.getQueue().on('add', () => {
+      componentsAdded += 1;
+    });
+    componentsQueue.getQueue().on('next', () => {
+      componentsCompleted += 1;
+    });
+  }
+}

--- a/src/scope/objects-fetcher/objects-writable-stream.ts
+++ b/src/scope/objects-fetcher/objects-writable-stream.ts
@@ -1,13 +1,15 @@
 import pMap from 'p-map';
 import { Writable } from 'stream';
-import { BitObject, Repository } from '.';
+import { BitObject, Repository } from '../objects';
 import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
 import { RemoteLaneId } from '../../lane-id/lane-id';
 import logger from '../../logger/logger';
 import { ModelComponentMerger } from '../component-ops/model-components-merger';
 import { Lane, ModelComponent } from '../models';
 import { SourceRepository } from '../repositories';
-import { ObjectItem } from './object-list';
+import { ObjectItem } from '../objects/object-list';
+import { WriteObjectsQueue } from './write-objects-queue';
+import { WriteComponentsQueue } from './write-components-queue';
 
 /**
  * first, write all immutable objects, such as files/sources/versions into the filesystem, as they arrive.
@@ -20,7 +22,13 @@ import { ObjectItem } from './object-list';
  */
 export class ObjectsWritable extends Writable {
   private mutableObjects: BitObject[] = [];
-  constructor(private repo: Repository, private sources: SourceRepository, private remoteName: string) {
+  constructor(
+    private repo: Repository,
+    private sources: SourceRepository,
+    private remoteName: string,
+    private objectsQueue: WriteObjectsQueue,
+    private componentsQueue: WriteComponentsQueue
+  ) {
     super({ objectMode: true });
   }
   async _write(obj: ObjectItem, _, callback: Function) {
@@ -43,11 +51,17 @@ export class ObjectsWritable extends Writable {
       callback(err);
     }
   }
-  private async writeImmutableObjectToFs(obj) {
+  private async writeImmutableObjectToFs(obj: ObjectItem) {
     const bitObject = await BitObject.parseObject(obj.buffer);
-    const isImmutable = !(bitObject instanceof ModelComponent) && !(bitObject instanceof Lane);
-    if (isImmutable) await this.repo.writeObjectsToTheFS([bitObject]);
-    else this.mutableObjects.push(bitObject);
+    if (bitObject instanceof Lane) {
+      throw new Error('ObjectsWritable does not support lanes');
+    }
+    if (bitObject instanceof ModelComponent) {
+      this.componentsQueue.addComponent(bitObject.id(), () => this.writeComponentObject(bitObject));
+    } else {
+      this.objectsQueue.addImmutableObject(obj.ref.toString(), () => this.repo.writeObjectsToTheFS([bitObject]));
+    }
+    // else this.mutableObjects.push(bitObject);
   }
   private async writeMutableObjectsToFS() {
     const components = this.mutableObjects.filter((obj) => obj instanceof ModelComponent);
@@ -63,6 +77,14 @@ export class ObjectsWritable extends Writable {
       RemoteLaneId.from(DEFAULT_LANE, this.remoteName),
       mergedComponents
     );
+  }
+
+  private async writeComponentObject(modelComponent: ModelComponent) {
+    const component = await this.mergeModelComponent(modelComponent, this.remoteName);
+    await this.repo.writeObjectsToTheFS([component]);
+    await this.repo.remoteLanes.addEntriesFromModelComponents(RemoteLaneId.from(DEFAULT_LANE, this.remoteName), [
+      component,
+    ]);
   }
 
   /**

--- a/src/scope/objects-fetcher/write-components-queue.ts
+++ b/src/scope/objects-fetcher/write-components-queue.ts
@@ -1,0 +1,23 @@
+import PQueue from 'p-queue';
+
+export class WriteComponentsQueue {
+  private queue: PQueue;
+  private processedIds: string[] = [];
+  constructor(concurrency = 1) {
+    this.queue = new PQueue({ concurrency, autoStart: true });
+  }
+  addComponent(id: string, fn: () => Promise<void>) {
+    this.processedIds.push(id);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.add(fn);
+  }
+  getQueue() {
+    return this.queue;
+  }
+  add<T>(fn: () => T, priority?: number): Promise<T> {
+    return this.queue.add(fn, { priority });
+  }
+  onIdle(): Promise<void> {
+    return this.queue.onIdle();
+  }
+}

--- a/src/scope/objects-fetcher/write-objects-queue.ts
+++ b/src/scope/objects-fetcher/write-objects-queue.ts
@@ -1,0 +1,27 @@
+import PQueue from 'p-queue';
+import { CONCURRENT_IO_LIMIT } from '../../constants';
+
+export class WriteObjectsQueue {
+  private queue: PQueue;
+  private addedHashes: string[] = [];
+  constructor(concurrency = CONCURRENT_IO_LIMIT) {
+    this.queue = new PQueue({ concurrency, autoStart: true });
+  }
+  addImmutableObject(hash: string, fn: () => Promise<void>) {
+    if (this.addedHashes.includes(hash)) {
+      return;
+    }
+    this.addedHashes.push(hash);
+    // eslint-disable-next-line @typescript-eslint/no-floating-promises
+    this.add(fn);
+  }
+  getQueue() {
+    return this.queue;
+  }
+  add<T>(fn: () => T, priority?: number): Promise<T> {
+    return this.queue.add(fn, { priority });
+  }
+  onIdle(): Promise<void> {
+    return this.queue.onIdle();
+  }
+}


### PR DESCRIPTION
Up until now, the fetch process would wait for all remotes to return an answer and then it would process them one by one, mainly to avoid merging the same component-object from multiple remotes.

This PR takes advantage of the recent changes in the Fetch process (https://github.com/teambit/bit/pull/3916 and https://github.com/teambit/bit/pull/3909) and as soon as the remote responses with a stream, it pipes it to a `writable` stream, which sends the objects to a central queue.
This queue is shared between all remotes and is responsible to limit the concurrency and to make sure the same files are not written at the same time and that each component is merged in sequence.

This PR cut the import time in a half since the last https://github.com/teambit/bit/pull/3916 change.