### PR TITLE
fixes #2362, remove up-to-date components from bit-checkout output

### DIFF
--- a/e2e/commands/checkout.e2e.1.ts
+++ b/e2e/commands/checkout.e2e.1.ts
@@ -720,7 +720,7 @@ describe('bit checkout command', function () {
           expect(bitMap).to.not.have.property('bar/foo2@0.0.1');
         });
         it('should show a failure message when trying to checkout again to the latest versions', () => {
-          output = helper.command.checkout('latest --all');
+          output = helper.command.checkout('latest --all --verbose');
           expect(output).to.have.string('component bar/foo2 is already at the latest version, which is 0.0.3');
           expect(output).to.have.string('component bar/foo is already at the latest version, which is 0.0.2');
         });

--- a/src/api/consumer/lib/checkout.ts
+++ b/src/api/consumer/lib/checkout.ts
@@ -13,7 +13,7 @@ import hasWildcard from '../../../utils/string/has-wildcard';
 import FlagHarmonyOnly from './exceptions/flag-harmony-only';
 import NoIdMatchWildcard from './exceptions/no-id-match-wildcard';
 
-export default (async function checkout(values: string[], checkoutProps: CheckoutProps): Promise<ApplyVersionResults> {
+export default async function checkout(values: string[], checkoutProps: CheckoutProps): Promise<ApplyVersionResults> {
   loader.start(BEFORE_CHECKOUT);
   const consumer: Consumer = await loadConsumer();
   if (checkoutProps.writeConfig && consumer.config.isLegacy) {
@@ -23,7 +23,7 @@ export default (async function checkout(values: string[], checkoutProps: Checkou
   const checkoutResults = await checkoutVersion(consumer, checkoutProps);
   await consumer.onDestroy();
   return checkoutResults;
-});
+}
 
 async function parseValues(consumer: Consumer, values: string[], checkoutProps: CheckoutProps) {
   const firstValue = R.head(values);

--- a/src/consumer/lanes/switch-lanes.ts
+++ b/src/consumer/lanes/switch-lanes.ts
@@ -12,7 +12,7 @@ import { Tmp } from '../../scope/repositories';
 import WorkspaceLane from '../bit-map/workspace-lane';
 import ManyComponentsWriter from '../component-ops/many-components-writer';
 import { applyVersion, CheckoutProps, ComponentStatus } from '../versions-ops/checkout-version';
-import { getMergeStrategyInteractive } from '../versions-ops/merge-version';
+import { FailedComponents, getMergeStrategyInteractive } from '../versions-ops/merge-version';
 import threeWayMerge, { MergeResultsThreeWay } from '../versions-ops/merge-version/three-way-merge';
 import createNewLane from './create-lane';
 
@@ -44,10 +44,9 @@ export default async function switchLanes(consumer: Consumer, switchProps: Switc
     }
     if (!checkoutProps.mergeStrategy) checkoutProps.mergeStrategy = await getMergeStrategyInteractive();
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const failedComponents: FailedComponents[] = allComponentsStatus
-    .filter((componentStatus) => componentStatus.failureMessage) // $FlowFixMe componentStatus.failureMessage is set
-    .map((componentStatus) => ({ id: componentStatus.id, failureMessage: componentStatus.failureMessage }));
+    .filter((componentStatus) => componentStatus.failureMessage)
+    .map((componentStatus) => ({ id: componentStatus.id, failureMessage: componentStatus.failureMessage as string }));
 
   const succeededComponents = allComponentsStatus.filter((componentStatus) => !componentStatus.failureMessage);
   // do not use Promise.all for applyVersion. otherwise, it'll write all components in parallel,

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -44,6 +44,7 @@ export type ComponentStatus = {
   componentFromModel?: Version;
   id: BitId;
   failureMessage?: string;
+  unchangedLegitimately?: boolean; // failed to checkout but for a legitimate reason, such as, up-to-date
   mergeResults?: MergeResultsThreeWay | null | undefined;
 };
 
@@ -66,10 +67,13 @@ export default async function checkoutVersion(
     }
     if (!checkoutProps.mergeStrategy) checkoutProps.mergeStrategy = await getMergeStrategyInteractive();
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const failedComponents: FailedComponents[] = allComponentsStatus
-    .filter((componentStatus) => componentStatus.failureMessage) // $FlowFixMe componentStatus.failureMessage is set
-    .map((componentStatus) => ({ id: componentStatus.id, failureMessage: componentStatus.failureMessage }));
+    .filter((componentStatus) => componentStatus.failureMessage)
+    .map((componentStatus) => ({
+      id: componentStatus.id,
+      failureMessage: componentStatus.failureMessage as string,
+      unchangedLegitimately: componentStatus.unchangedLegitimately,
+    }));
 
   const succeededComponents = allComponentsStatus.filter((componentStatus) => !componentStatus.failureMessage);
   // do not use Promise.all for applyVersion. otherwise, it'll write all components in parallel,
@@ -123,8 +127,9 @@ async function getComponentStatus(
   const { version, latestVersion, reset } = checkoutProps;
   const componentModel = await consumer.scope.getModelComponentIfExist(component.id);
   const componentStatus: ComponentStatus = { id: component.id };
-  const returnFailure = (msg: string) => {
+  const returnFailure = (msg: string, unchangedLegitimately = false) => {
     componentStatus.failureMessage = msg;
+    componentStatus.unchangedLegitimately = unchangedLegitimately;
     return componentStatus;
   };
   if (!componentModel) {
@@ -157,7 +162,8 @@ async function getComponentStatus(
   }
   if (latestVersion && currentlyUsedVersion === newVersion) {
     return returnFailure(
-      `component ${component.id.toStringWithoutVersion()} is already at the latest version, which is ${newVersion}`
+      `component ${component.id.toStringWithoutVersion()} is already at the latest version, which is ${newVersion}`,
+      true
     );
   }
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/versions-ops/merge-version/merge-snaps.ts
+++ b/src/consumer/versions-ops/merge-version/merge-snaps.ts
@@ -21,6 +21,7 @@ import checkoutVersion, { applyModifiedVersion } from '../checkout-version';
 import {
   ApplyVersionResult,
   ApplyVersionResults,
+  FailedComponents,
   FileStatus,
   getMergeStrategyInteractive,
   MergeOptions,
@@ -126,10 +127,9 @@ export async function merge({
   if (componentWithConflict && !mergeStrategy) {
     mergeStrategy = await getMergeStrategyInteractive();
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const failedComponents: FailedComponents[] = allComponentsStatus
     .filter((componentStatus) => componentStatus.failureMessage)
-    .map((componentStatus) => ({ id: componentStatus.id, failureMessage: componentStatus.failureMessage }));
+    .map((componentStatus) => ({ id: componentStatus.id, failureMessage: componentStatus.failureMessage as string }));
   const succeededComponents = allComponentsStatus.filter((componentStatus) => !componentStatus.failureMessage);
   // do not use Promise.all for applyVersion. otherwise, it'll write all components in parallel,
   // which can be an issue when some components are also dependencies of others

--- a/src/consumer/versions-ops/merge-version/merge-version.ts
+++ b/src/consumer/versions-ops/merge-version/merge-version.ts
@@ -28,7 +28,7 @@ export const FileStatus = {
 // fileName is PathLinux. TS doesn't let anything else in the keys other than string and number
 export type FilesStatus = { [fileName: string]: keyof typeof FileStatus };
 export type ApplyVersionResult = { id: BitId; filesStatus: FilesStatus };
-export type FailedComponents = { id: BitId; failureMessage: string };
+export type FailedComponents = { id: BitId; failureMessage: string; unchangedLegitimately?: boolean };
 export type ApplyVersionResults = {
   components?: ApplyVersionResult[];
   version?: string;


### PR DESCRIPTION
Remove up-to-date components from bit-checkout output when `--all` flag was used as this is too verbose and confusing.
Show them only when the `--verbose` flag is used.
