### PR TITLE
re-import components if their build status is pending or failed

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -43,6 +43,15 @@ describe('sign command', function () {
       const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`, helper.scopes.remotePath);
       expect(comp1.buildStatus).to.equal('succeed');
     });
+    describe('running bit import on the workspace', () => {
+      before(() => {
+        helper.command.importAllComponents();
+      });
+      it('should bring the updated Version from the remote', () => {
+        const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
+        expect(comp1.buildStatus).to.equal('succeed');
+      });
+    });
   });
   describe.skip('circular dependencies between two scopes', () => {
     let signOutput: string;


### PR DESCRIPTION
When running `bit import`, existing components are not fetched from a remote. 
This PR checks whether the existing component has already built (using bit-sign) and if not, it fetches it from the remote because the remote might have it build.