### PR TITLE
fix multiple fetching during tag

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -43,8 +43,7 @@ describe('sign command', function () {
       const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`, helper.scopes.remotePath);
       expect(comp1.buildStatus).to.equal('succeed');
     });
-    // @todo: fix it as soon as possible
-    describe.skip('running bit import on the workspace', () => {
+    describe('running bit import on the workspace', () => {
       before(() => {
         helper.command.importAllComponents();
       });

--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -143,6 +143,12 @@ export default class BitIds extends Array<BitId> {
     return duplications;
   }
 
+  add(bitIds: BitId[]) {
+    bitIds.forEach((bitId) => {
+      if (!this.search(bitId)) this.push(bitId);
+    });
+  }
+
   static fromObject(dependencies: { [key: string]: string }) {
     const array = [];
 

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -329,8 +329,7 @@ export default class Consumer {
 
     const versionDependencies = (await scopeComponentsImporter.componentToVersionDependencies(
       modelComponent,
-      id,
-      true
+      id
     )) as VersionDependencies;
     const manipulateDirData = await getManipulateDirWhenImportingComponents(
       this.bitMap,

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -1,5 +1,6 @@
 import { filter } from 'bluebird';
 import { Mutex } from 'async-mutex';
+import pMap from 'p-map';
 import mapSeries from 'p-map-series';
 import groupArray from 'group-array';
 import R from 'ramda';
@@ -24,7 +25,7 @@ import { ObjectItemsStream, ObjectList } from '../objects/object-list';
 import SourcesRepository, { ComponentDef } from '../repositories/sources';
 import { getScopeRemotes } from '../scope-remotes';
 import VersionDependencies from '../version-dependencies';
-import { DEFAULT_LANE } from '../../constants';
+import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
 import { BitObjectList } from '../objects/bit-object-list';
 import { ObjectFetcher } from '../objects-fetcher/objects-fetcher';
 
@@ -115,23 +116,21 @@ export default class ScopeComponentsImporter {
     if (R.isEmpty(idsToImport)) return [];
 
     const externalsToFetch: BitId[] = [];
-    const localDefs = await this.sources.getMany(idsToImport);
-    const versionDeps = await mapSeries(localDefs, ({ id, component }) => {
-      if (!component) {
-        if (id.isLocal(this.scope.name)) throw new ComponentNotFound(id.toString());
-        externalsToFetch.push(id);
-        return null;
-      }
-      return this.componentToVersionDependencies(component, id);
+    const defs = await this.sources.getMany(idsToImport);
+    const existingDefs = defs.filter(({ id, component }) => {
+      if (component) return true;
+      if (id.isLocal(this.scope.name)) throw new ComponentNotFound(id.toString());
+      externalsToFetch.push(id);
+      return false;
     });
+    const versionDeps = await this.multipleCompsDefsToVersionDeps(existingDefs);
     const remotes = await getScopeRemotes(this.scope);
-    const versionDepsWithoutNull = compact(versionDeps);
     logger.debugAndAddBreadCrumb(
       'importManyFromOriginalScopes',
       'successfully fetched local components and their dependencies. Going to fetch externals'
     );
     const externalDeps = await this.getExternalMany(externalsToFetch, remotes);
-    return [...versionDepsWithoutNull, ...externalDeps];
+    return [...versionDeps, ...externalDeps];
   }
 
   async importWithoutDeps(ids: BitIds, cache = true): Promise<ComponentVersion[]> {
@@ -319,28 +318,13 @@ export default class ScopeComponentsImporter {
     return this.fetchWithDepsMutex.runExclusive(async () => {
       logger.debug('fetchWithDeps, acquiring a lock');
       const localDefs: ComponentDef[] = await this.sources.getMany(ids);
-      const versionDeps = await mapSeries(localDefs, async (compDef) => {
-        if (!compDef.component) return null;
-        return this.componentToVersionDependencies(compDef.component as ModelComponent, compDef.id);
-      });
+      const versionDeps = await this.multipleCompsDefsToVersionDeps(localDefs);
       logger.debug('fetchWithDeps, releasing the lock');
-      return compact(versionDeps);
+      return versionDeps;
     });
   }
 
-  async componentToVersionDependencies(
-    component: ModelComponent,
-    id: BitId,
-    throwForNoVersion = false
-  ): Promise<VersionDependencies | null> {
-    if (!throwForNoVersion) {
-      if (component.isEmpty() && !id.hasVersion() && !component.laneHeadLocal) {
-        // this happens for example when importing a remote lane and then running "bit fetch --components"
-        // the head is empty because it exists on the lane only, it was never tagged and
-        // laneHeadLocal was never set as it originated from the scope, not the consumer.
-        return null;
-      }
-    }
+  async componentToVersionDependencies(component: ModelComponent, id: BitId): Promise<VersionDependencies | null> {
     const versionComp: ComponentVersion = component.toComponentVersion(id.version);
 
     const version = await this.getVersionFromComponentDef(component, id);
@@ -420,6 +404,45 @@ export default class ScopeComponentsImporter {
     return null;
   }
 
+  private async multipleCompsDefsToVersionDeps(compsDefs: ComponentDef[]): Promise<VersionDependencies[]> {
+    const componentsWithVersionsWithNulls = await pMap(
+      compsDefs,
+      async ({ component, id }) => {
+        if (!component) return null;
+        if (component.isEmpty() && !id.hasVersion() && !component.laneHeadLocal) {
+          // this happens for example when importing a remote lane and then running "bit fetch --components"
+          // the head is empty because it exists on the lane only, it was never tagged and
+          // laneHeadLocal was never set as it originated from the scope, not the consumer.
+          return null;
+        }
+        const versionComp: ComponentVersion = component.toComponentVersion(id.version);
+        const version = await this.getVersionFromComponentDef(component, id);
+        if (!version) {
+          throw new Error(`ScopeComponentImporter, expect ${id.toString()} to have a Version object`);
+        }
+
+        return { componentVersion: versionComp, versionObj: version };
+      },
+      { concurrency: CONCURRENT_COMPONENTS_LIMIT }
+    );
+    const componentsWithVersion = compact(componentsWithVersionsWithNulls);
+
+    const idsToFetch = new BitIds();
+    componentsWithVersion.forEach((compWithVer) => {
+      idsToFetch.add(compWithVer.versionObj.flattenedDependencies);
+    });
+
+    const compVersionsOfDeps = await this.importWithoutDeps(idsToFetch);
+
+    const versionDeps = componentsWithVersion.map(({ componentVersion, versionObj }) => {
+      const dependencies = versionObj.flattenedDependencies.map((dep) =>
+        compVersionsOfDeps.find((c) => c.id.isEqual(dep))
+      );
+      return new VersionDependencies(componentVersion, compact(dependencies), versionObj);
+    });
+    return versionDeps;
+  }
+
   /**
    * get multiple components from remotes with their dependencies.
    * never checks if exist locally. always fetches from remote and then, save into the model.
@@ -450,15 +473,11 @@ export default class ScopeComponentsImporter {
       context
     ).fetchFromRemoteAndWrite();
     const componentDefs = await this.sources.getMany(ids);
-    const componentDefsExisting = componentDefs.filter((componentDef) => componentDef.component);
-    const versionDeps = await mapSeries(componentDefsExisting, (compDef) =>
-      this.componentToVersionDependencies(compDef.component as ModelComponent, compDef.id)
-    );
-    const versionDepsNoNull = compact(versionDeps);
+    const versionDeps = await this.multipleCompsDefsToVersionDeps(componentDefs);
     if (throwForDependencyNotFound) {
-      versionDepsNoNull.forEach((verDep) => verDep.throwForMissingDependencies());
+      versionDeps.forEach((verDep) => verDep.throwForMissingDependencies());
     }
-    return versionDepsNoNull;
+    return versionDeps;
   }
 
   private async getExternalManyWithoutDeps(

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -798,6 +798,11 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
     return localVersions.includes(tag);
   }
 
+  hasLocalVersion(version: string): boolean {
+    const localVersions = this.getLocalTagsOrHashes();
+    return localVersions.includes(version);
+  }
+
   getLocalTagsOrHashes(): string[] {
     const localVersions = this.getLocalVersions();
     if (!this.divergeData) return localVersions;

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -77,21 +77,21 @@ export default class SourceRepository {
    * to be fetched from the remote again.
    */
   async get(bitId: BitId, versionShouldBeBuilt = false): Promise<ModelComponent | undefined> {
-    versionShouldBeBuilt = false; // a temporal workaround to get the tag working.
-    const component = ModelComponent.fromBitId(bitId);
-    const foundComponent: ModelComponent | undefined = await this._findComponent(component);
-    if (!foundComponent) return undefined;
-    if (!bitId.hasVersion()) return foundComponent;
+    const emptyComponent = ModelComponent.fromBitId(bitId);
+    const component: ModelComponent | undefined = await this._findComponent(emptyComponent);
+    if (!component) return undefined;
+    if (!bitId.hasVersion()) return component;
 
     const returnComponent = (version: Version): ModelComponent | undefined => {
       if (
         versionShouldBeBuilt &&
         !bitId.isLocal(this.scope.name) &&
+        !component.hasLocalVersion(bitId.version as string) && // e.g. during tag
         (version.buildStatus === BuildStatus.Pending || version.buildStatus === BuildStatus.Failed)
       ) {
         return undefined;
       }
-      return foundComponent;
+      return component;
     };
 
     // @ts-ignore
@@ -108,12 +108,12 @@ export default class SourceRepository {
       return returnComponent(snap as Version);
     }
     // @ts-ignore
-    if (!foundComponent.hasTagIncludeOrphaned(bitId.version)) {
+    if (!component.hasTagIncludeOrphaned(bitId.version)) {
       logger.debugAndAddBreadCrumb('sources.get', `${msg} is not in the component versions array`);
       return undefined;
     }
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const versionHash = foundComponent.versionsIncludeOrphaned[bitId.version];
+    const versionHash = component.versionsIncludeOrphaned[bitId.version];
     const version = await this.objects().load(versionHash);
     if (!version) {
       logger.debugAndAddBreadCrumb('sources.get', `${msg} object was not found on the filesystem`);


### PR DESCRIPTION
Due to a recent change, `bit import` re-fetch a component when its Version object has a build-status of Pending/Failed.
During tag, the build-status is pending, as such it tried to re-import it again and again from a remote. In this PR it checks whether a version exists only locally and then it won't try to re-fetch it.

Another issue was that `getExternalMany()` used to go to the remotes for each one of the components for its flattened-dependencies. With this PR it first accumulate all ids and then go to the remote once.