### PR TITLE
wait for post-sign and post-update-dependencies to complete

### DIFF
--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -80,7 +80,6 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
   }
 
   async triggerOnPostSign(components: Component[]) {
-    // don't wait for the promise to complete.
     await Promise.all(this.onPostSignSlot.values().map((fn) => fn(components))).catch((err) => {
       this.logger.error('failed running onPostSignSlot', err);
     });

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -66,7 +66,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
       await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
     }
     await this.clearScopesCaches(legacyComponents);
-    this.triggerOnPostSign(components);
+    await this.triggerOnPostSign(components);
 
     return {
       components,
@@ -79,9 +79,9 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     this.onPostSignSlot.register(fn);
   }
 
-  triggerOnPostSign(components: Component[]) {
+  async triggerOnPostSign(components: Component[]) {
     // don't wait for the promise to complete.
-    Promise.all(this.onPostSignSlot.values().map((fn) => fn(components))).catch((err) => {
+    await Promise.all(this.onPostSignSlot.values().map((fn) => fn(components))).catch((err) => {
       this.logger.error('failed running onPostSignSlot', err);
     });
   }

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -98,7 +98,7 @@ export class UpdateDependenciesMain {
     const buildStatus = pipeWithError ? BuildStatus.Failed : BuildStatus.Succeed;
     await this.saveDataIntoLocalScope(buildStatus);
     await this.export();
-    this.triggerOnPostUpdateDependencies();
+    await this.triggerOnPostUpdateDependencies();
 
     return {
       depsUpdateItems: this.depsUpdateItems,
@@ -118,9 +118,9 @@ export class UpdateDependenciesMain {
     this.onPostUpdateDependenciesSlot.register(fn);
   }
 
-  private triggerOnPostUpdateDependencies() {
+  private async triggerOnPostUpdateDependencies() {
     // don't wait for the promise to resolve.
-    Promise.all(this.onPostUpdateDependenciesSlot.values().map((fn) => fn(this.components))).catch((err) =>
+    await Promise.all(this.onPostUpdateDependenciesSlot.values().map((fn) => fn(this.components))).catch((err) =>
       this.logger.error('got an error during on-post-updates hook', err)
     );
   }

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -119,7 +119,6 @@ export class UpdateDependenciesMain {
   }
 
   private async triggerOnPostUpdateDependencies() {
-    // don't wait for the promise to resolve.
     await Promise.all(this.onPostUpdateDependenciesSlot.values().map((fn) => fn(this.components))).catch((err) =>
       this.logger.error('got an error during on-post-updates hook', err)
     );


### PR DESCRIPTION
It is needed to wait for the slots to wait until completion, otherwise, the artifacts data could be gone during the process