### PR TITLE
remove the alias "i" from bit-import and add it to bit-install

### DIFF
--- a/src/cli/commands/public-cmds/import-cmd.ts
+++ b/src/cli/commands/public-cmds/import-cmd.ts
@@ -18,7 +18,7 @@ export default class Import implements LegacyCommand {
   description = `import components into your current workspace.
   https://${BASE_DOCS_DOMAIN}/docs/sourcing-components
   ${WILDCARD_HELP('import')}`;
-  alias = 'i';
+  alias = '';
   opts = [
     ['t', 'tester', 'import a tester environment component'],
     ['c', 'compiler', 'import a compiler environment component'],

--- a/src/cli/commands/public-cmds/install-cmd.ts
+++ b/src/cli/commands/public-cmds/install-cmd.ts
@@ -7,7 +7,7 @@ import linkTemplate from '../../templates/link-template';
 export default class Install implements LegacyCommand {
   name = 'install [ids...]';
   description = `Installs all dependencies for all the imported components (or for a specific one), whether they were defined in your package.json or in each of the imported components, and links them. \n  https://${BASE_DOCS_DOMAIN}/docs/installing-components`;
-  alias = '';
+  alias = 'i';
   opts = [['v', 'verbose', 'show a more verbose output when possible']] as CommandOptions;
   loader = true;
 


### PR DESCRIPTION
Currently, `bit install` doesn't have any alias. Add the alias `i` and remove it from `bit import`. (as per @ranm8  request).