### PR TITLE
fix source-map files when a component has nested directories

### DIFF
--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -183,4 +183,19 @@ describe('compile extension', function () {
       });
     });
   });
+  describe('component with nested directories', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponentsTS(1);
+      helper.fs.outputFile('comp1/nested/foo.ts');
+      helper.command.compile();
+    });
+    it('the sourceMap should include the path to the nested dir properly', () => {
+      // before, the "sources" was just ["foo.ts"] without the "nested" dir
+      // it has been fixed once the typescript compiler programmatically added "rootDir": "."
+      const sourceMapPath = 'node_modules/@my-scope/comp1/dist/nested/foo.js.map';
+      const sourceMapPathContent = helper.fs.readJsonFile(sourceMapPath);
+      expect(sourceMapPathContent.sources).to.deep.equal(['nested/foo.ts']);
+    });
+  });
 });

--- a/e2e/npm-ci-registry.ts
+++ b/e2e/npm-ci-registry.ts
@@ -196,7 +196,6 @@ EOD`;
     const scopeJsonPath = '.bit/scope.json';
     const scopeJson = this.helper.fs.readJsonFile(scopeJsonPath);
     const resolverPath = path.join(this.helper.scopes.localPath, 'resolver.js');
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     scopeJson.resolverPath = resolverPath;
     this.helper.fs.createJsonFile(scopeJsonPath, scopeJson);
     this.helper.fs.createFile('', 'resolver.js', this._getResolverContent(extraScopes));

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -57,6 +57,7 @@ export class TypescriptCompiler implements Compiler {
 
     const compilerOptions = compilerOptionsFromTsconfig.options;
     compilerOptions.sourceRoot = options.componentDir;
+    compilerOptions.rootDir = '.';
     const result = this.tsModule.transpileModule(fileContent, {
       compilerOptions,
       fileName: options.filePath,

--- a/scopes/typescript/typescript/typescript.docs.md
+++ b/scopes/typescript/typescript/typescript.docs.md
@@ -1,0 +1,13 @@
+Typescript aspect implements the `Compiler` interface and provides the ability to transpile files on the workspace and build components in the isolated capsules.
+
+## Configuration - tsconfig.json
+An env that uses typescript compiler can have two tsconfig.json files, one for the workspace and one for the build process.
+
+On the workspace, the following two configurations are overridden:
+```
+compilerOptions.sourceRoot = componentDir;
+compilerOptions.rootDir = '.';
+```
+The reason to override them is to make the source-map working on the workspace.
+
+As a reminder, the `dists` are written into the node_modules and not in the component-dir, without the configuration above, the source-map won't have the correct `sourceRoot` and `sources` values, and as a result, the debugger won't work.

--- a/src/e2e-helper/e2e-fs-helper.ts
+++ b/src/e2e-helper/e2e-fs-helper.ts
@@ -49,7 +49,7 @@ export default class FsHelper {
     return fs.readFileSync(path.join(this.scopes.localPath, filePathRelativeToLocalScope)).toString();
   }
 
-  readJsonFile(filePathRelativeToLocalScope: string): string {
+  readJsonFile(filePathRelativeToLocalScope: string): Record<string, any> {
     return fs.readJsonSync(path.join(this.scopes.localPath, filePathRelativeToLocalScope));
   }
 

--- a/src/e2e-helper/e2e-fs-helper.ts
+++ b/src/e2e-helper/e2e-fs-helper.ts
@@ -34,7 +34,7 @@ export default class FsHelper {
     fs.outputFileSync(filePath, impl);
   }
 
-  createJsonFile(filePathRelativeToLocalScope: string, jsonContent: string) {
+  createJsonFile(filePathRelativeToLocalScope: string, jsonContent: Record<string, any>) {
     const filePath = path.join(this.scopes.localPath, filePathRelativeToLocalScope);
     ensureAndWriteJson(filePath, jsonContent);
   }


### PR DESCRIPTION
Currently, for nested-dir the `sources` value of the source-map file is incorrect as a result of removing the `rootDir` prop from the tsconfig.json file of the workspace.
This PR adds the `rootDir` value programmatically during the compilation so then the tsconfig file could be kept without the rootDir.
The reason not to add it directly to the tsconfig.json file is that in some cases it's advisable to extend this tsconfig for the IDE to have the auto-complete and other features.