### PR TITLE
introduce a new flag "--path" to bit-create

### DIFF
--- a/scopes/generator/generator/create.cmd.ts
+++ b/scopes/generator/generator/create.cmd.ts
@@ -6,6 +6,7 @@ export type GeneratorOptions = {
   namespace?: string;
   aspect?: string;
   scope?: string;
+  path?: string;
 };
 
 export class CreateCmd implements Command {
@@ -19,6 +20,7 @@ export class CreateCmd implements Command {
     ['n', 'namespace <string>', `sets the component's namespace and nested dirs inside the scope`],
     ['s', 'scope <string>', `sets the component's scope-name. if not entered, the default-scope will be used`],
     ['a', 'aspect <string>', 'aspect-id of the template. helpful when multiple aspects use the same template name'],
+    ['p', 'path <string>', 'relative path in the workspace. by default the path is <scope>/<namespace>/<name>'],
   ] as CommandOptions;
 
   constructor(private generator: GeneratorMain) {}

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -101,7 +101,7 @@ export class GeneratorMain {
         const componentNameCamelCase = camelcase(componentName, { pascalCase: true });
         const files = template.generateFiles({ componentName, componentNameCamelCase, componentId });
         const mainFile = files.find((file) => file.isMain);
-        const componentPath = this.getComponentPath(componentId);
+        const componentPath = this.getComponentPath(componentId, options.path);
         await this.writeComponentFiles(componentPath, files);
         const addResults = await this.workspace.add([componentPath], componentName, mainFile?.relativePath);
         return {
@@ -139,7 +139,8 @@ export class GeneratorMain {
     return results;
   }
 
-  private getComponentPath(componentId: ComponentID) {
+  private getComponentPath(componentId: ComponentID, customPath?: string) {
+    if (customPath) return path.join(customPath, componentId.fullName);
     return path.join(componentId.scope, componentId.fullName);
   }
 


### PR DESCRIPTION
In order to create a component not in the default directory (scope/namespace/name).