### PR TITLE
make the bit-create command atomic and avoid overriding existing components/files

### DIFF
--- a/e2e/harmony/create.e2e.4.ts
+++ b/e2e/harmony/create.e2e.4.ts
@@ -16,44 +16,6 @@ describe('create extension', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  // describe.skip('react template', () => {
-  //   let implFilePath;
-  //   let testFilePath;
-  //   let implContents;
-  //   let testContents;
-  //   const COMPONENT_NAME = 'foo';
-  //   before(() => {
-  //     helper.scopeHelper.initHarmonyWorkspace();
-  //     helper.fixtures.copyFixtureExtensions('react-create-template');
-  //     helper.command.addComponent('react-create-template');
-  //     helper.extensions.addExtensionToWorkspace('my-scope/react-create-template', {});
-  //     helper.extensions.addExtensionToWorkspace('teambit.generator/generator', { template: 'react-create-template' });
-  //     helper.scopeHelper.linkBitLegacy();
-  //     helper.command.link();
-  //     helper.command.create(COMPONENT_NAME);
-  //     const compDir = path.join(helper.scopes.localPath, `components/${COMPONENT_NAME}`);
-  //     implFilePath = path.join(compDir, `${COMPONENT_NAME}.js`);
-  //     testFilePath = path.join(compDir, `${COMPONENT_NAME}.spec.js`);
-  //     implContents = fs.readFileSync(implFilePath).toString();
-  //     testContents = fs.readFileSync(testFilePath).toString();
-  //   });
-  //   it('should create the component files', () => {
-  //     expect(implFilePath).to.be.a.file();
-  //     expect(testFilePath).to.be.a.file();
-  //   });
-  //   it('should add the files to bitmap', () => {
-  //     const status = helper.command.status();
-  //     expect(status).to.have.string('foo');
-  //   });
-  //   it('should use the template for the files', () => {
-  //     expect(implContents).to.have.string(
-  //       `export default function ${COMPONENT_NAME}() { console.log('hello react template'); }`
-  //     );
-  //     expect(testContents).to.have.string(
-  //       `export default function ${COMPONENT_NAME}() { console.log('hello react template test'); }`
-  //     );
-  //   });
-  // });
   describe('with --namespace flag', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
@@ -106,6 +68,33 @@ describe('create extension', function () {
     it('should add the component correctly', () => {
       const bitMap = helper.bitMap.read();
       expect(bitMap).to.have.property('another/level/ui/my-aspect');
+    });
+  });
+  describe('when a component already exist on that dir', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.command.create('aspect', 'my-aspect');
+    });
+    it('should throw an error', () => {
+      expect(() => helper.command.create('aspect', 'my-aspect')).to.throw('this path already exist');
+
+      // make sure the dir still exists and the rollback mechanism did not delete it.
+      const compRootDir = path.join(helper.scopes.localPath, helper.scopes.remote, 'my-aspect');
+      expect(compRootDir).to.be.a.directory();
+    });
+  });
+  describe('when an error is thrown during the add/track phase', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      expect(() => helper.command.create('aspect', 'myAspect')).to.throw(
+        'component names can only contain alphanumeric, lowercase characters'
+      );
+    });
+    it('should not leave the generated component in the filesystem', () => {
+      const compRootDir = path.join(helper.scopes.localPath, helper.scopes.remote, 'my-aspect');
+      expect(compRootDir).to.not.be.a.path();
     });
   });
 });

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -1,0 +1,103 @@
+import Vinyl from 'vinyl';
+import fs from 'fs-extra';
+import pMapSeries from 'p-map-series';
+import path from 'path';
+import { Workspace } from '@teambit/workspace';
+import camelcase from 'camelcase';
+import { PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
+import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
+import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
+import { ComponentID } from '@teambit/component-id';
+import { ComponentTemplate, File } from './component-template';
+import { GeneratorOptions } from './create.cmd';
+
+export type GenerateResult = { id: ComponentID; dir: string; files: string[] };
+
+export class ComponentGenerator {
+  constructor(
+    private workspace: Workspace,
+    private componentIds: ComponentID[],
+    private options: GeneratorOptions,
+    private template: ComponentTemplate
+  ) {}
+
+  async generate(): Promise<GenerateResult[]> {
+    const dirsToDeleteIfFailed: string[] = [];
+    const generateResults = await pMapSeries(this.componentIds, async (componentId) => {
+      try {
+        const componentPath = this.getComponentPath(componentId);
+        if (fs.existsSync(path.join(this.workspace.path, componentPath))) {
+          throw new Error(`unable to create a component at "${componentPath}", this path already exist`);
+        }
+        dirsToDeleteIfFailed.push(componentPath);
+        return await this.generateOneComponent(componentId, componentPath);
+      } catch (err) {
+        await this.deleteGeneratedComponents(dirsToDeleteIfFailed);
+        throw err;
+      }
+    });
+
+    await this.workspace.consumer.writeBitMap();
+
+    return generateResults;
+  }
+
+  private async deleteGeneratedComponents(dirs: string[]) {
+    await Promise.all(
+      dirs.map(async (dir) => {
+        const absoluteDir = path.join(this.workspace.path, dir);
+        try {
+          await fs.remove(absoluteDir);
+        } catch (err) {
+          if (err.code !== 'ENOENT') {
+            // if not exist, it's fine
+            throw err;
+          }
+        }
+      })
+    );
+  }
+
+  private async generateOneComponent(componentId: ComponentID, componentPath: string): Promise<GenerateResult> {
+    const name = componentId.name;
+    const componentNameCamelCase = camelcase(name, { pascalCase: true });
+    const files = this.template.generateFiles({ componentName: name, componentNameCamelCase, componentId });
+    const mainFile = files.find((file) => file.isMain);
+    await this.writeComponentFiles(componentPath, files);
+    const addResults = await this.workspace.track({
+      rootDir: componentPath,
+      mainFile: mainFile?.relativePath,
+      componentName: componentId.fullName,
+    });
+    return {
+      id: componentId,
+      dir: componentPath,
+      files: addResults.files,
+    };
+  }
+
+  /**
+   * writes the generated template files to the default directory set in the workspace config
+   */
+  private async writeComponentFiles(componentPath: string, templateFiles: File[]): Promise<PathOsBasedRelative[]> {
+    const dataToPersist = new DataToPersist();
+    const vinylFiles = templateFiles.map((templateFile) => {
+      const templateFileVinyl = new Vinyl({
+        base: componentPath,
+        path: path.join(componentPath, templateFile.relativePath),
+        contents: Buffer.from(templateFile.content),
+      });
+      return AbstractVinyl.fromVinyl(templateFileVinyl);
+    });
+    const results = vinylFiles.map((v) => v.path);
+    dataToPersist.addManyFiles(vinylFiles);
+    dataToPersist.addBasePath(this.workspace.path);
+    await dataToPersist.persistAllToFS();
+    return results;
+  }
+
+  private getComponentPath(componentId: ComponentID) {
+    if (this.options.path) return path.join(this.options.path, componentId.fullName);
+    return path.join(componentId.scope, componentId.fullName);
+  }
+}

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -1,23 +1,16 @@
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
-import Vinyl from 'vinyl';
-import path from 'path';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
-import camelcase from 'camelcase';
-import { PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
-import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
-import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
 import { ComponentID } from '@teambit/component-id';
 import { Slot, SlotRegistry } from '@teambit/harmony';
-import { ComponentTemplate, File } from './component-template';
+import { ComponentTemplate } from './component-template';
 import { GeneratorAspect } from './generator.aspect';
 import { CreateCmd, GeneratorOptions } from './create.cmd';
 import { TemplatesCmd } from './templates.cmd';
 import { generatorSchema } from './generator.graphql';
+import { ComponentGenerator, GenerateResult } from './component-generator';
 
 export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
-
-export type GenerateResult = { id: ComponentID; dir: string; files: string[] };
 
 export type TemplateDescriptor = { aspectId: string; name: string };
 
@@ -75,16 +68,6 @@ export class GeneratorMain {
     return found?.template;
   }
 
-  private getAllTemplatesFlattened(): Array<{ id: string; template: ComponentTemplate }> {
-    const templatesByAspects = this.componentTemplateSlot.toArray();
-    return templatesByAspects.flatMap(([id, componentTemplates]) => {
-      return componentTemplates.map((template) => ({
-        id,
-        template,
-      }));
-    });
-  }
-
   async generateComponentTemplate(
     componentNames: string[],
     templateName: string,
@@ -97,55 +80,29 @@ export class GeneratorMain {
     const scope = options.scope || this.workspace.defaultScope;
     if (!scope) throw new Error(`failed finding defaultScope`);
 
-    return Promise.all(
-      componentNames.map(async (componentName) => {
-        const fullComponentName = namespace ? `${namespace}/${componentName}` : componentName;
-        const componentId = ComponentID.fromObject({ name: fullComponentName }, scope);
-        const name = componentId.name;
-        const componentNameCamelCase = camelcase(name, { pascalCase: true });
-        const files = template.generateFiles({ componentName: name, componentNameCamelCase, componentId });
-        const mainFile = files.find((file) => file.isMain);
-        const componentPath = this.getComponentPath(componentId, options.path);
-        await this.writeComponentFiles(componentPath, files);
-        const addResults = await this.workspace.add([componentPath], componentId.fullName, mainFile?.relativePath);
-        return {
-          id: componentId,
-          dir: componentPath,
-          files: addResults.addedComponents[0].files.map((f) => f.relativePath),
-        };
-      })
-    );
+    const componentIds = componentNames.map((componentName) => {
+      const fullComponentName = namespace ? `${namespace}/${componentName}` : componentName;
+      return ComponentID.fromObject({ name: fullComponentName }, scope);
+    });
+
+    const componentGenerator = new ComponentGenerator(this.workspace, componentIds, options, template);
+    return componentGenerator.generate();
+  }
+
+  private getAllTemplatesFlattened(): Array<{ id: string; template: ComponentTemplate }> {
+    const templatesByAspects = this.componentTemplateSlot.toArray();
+    return templatesByAspects.flatMap(([id, componentTemplates]) => {
+      return componentTemplates.map((template) => ({
+        id,
+        template,
+      }));
+    });
   }
 
   private async loadAspects() {
     if (this.aspectLoaded) return;
     await this.workspace.loadAspects(this.config.aspects);
     this.aspectLoaded = true;
-  }
-
-  /**
-   * writes the generated template files to the default directory set in the workspace config
-   */
-  private async writeComponentFiles(componentPath: string, templateFiles: File[]): Promise<PathOsBasedRelative[]> {
-    const dataToPersist = new DataToPersist();
-    const vinylFiles = templateFiles.map((templateFile) => {
-      const templateFileVinyl = new Vinyl({
-        base: componentPath,
-        path: path.join(componentPath, templateFile.relativePath),
-        contents: Buffer.from(templateFile.content),
-      });
-      return AbstractVinyl.fromVinyl(templateFileVinyl);
-    });
-    const results = vinylFiles.map((v) => v.path);
-    dataToPersist.addManyFiles(vinylFiles);
-    dataToPersist.addBasePath(this.workspace.path);
-    await dataToPersist.persistAllToFS();
-    return results;
-  }
-
-  private getComponentPath(componentId: ComponentID, customPath?: string) {
-    if (customPath) return path.join(customPath, componentId.fullName);
-    return path.join(componentId.scope, componentId.fullName);
   }
 
   static slots = [Slot.withType<ComponentTemplate[]>()];

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -42,7 +42,10 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { Consumer, loadConsumer } from '@teambit/legacy/dist/consumer';
 import { GetBitMapComponentOptions } from '@teambit/legacy/dist/consumer/bit-map/bit-map';
 import AddComponents from '@teambit/legacy/dist/consumer/component-ops/add-components';
-import { AddActionResults } from '@teambit/legacy/dist/consumer/component-ops/add-components/add-components';
+import type {
+  AddActionResults,
+  Warnings,
+} from '@teambit/legacy/dist/consumer/component-ops/add-components/add-components';
 import ComponentsList from '@teambit/legacy/dist/consumer/component/components-list';
 import { NoComponentDir } from '@teambit/legacy/dist/consumer/component/exceptions/no-component-dir';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
@@ -104,6 +107,14 @@ export type WorkspaceInstallOptions = {
 };
 
 export type WorkspaceLinkOptions = LinkingOptions;
+
+export type TrackData = {
+  rootDir: PathOsBasedRelative; // path relative to the workspace
+  componentName?: string; // if empty, it'll be generated from the path
+  mainFile?: string; // if empty, attempts will be made to guess the best candidate
+};
+
+export type TrackResult = { componentName: string; files: string[]; warnings: Warnings };
 
 const DEFAULT_VENDOR_DIR = 'vendor';
 
@@ -547,6 +558,7 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
+   * @deprecated use this.track() instead
    * track a new component. (practically, add it to .bitmap).
    *
    * @param componentPaths component paths relative to the workspace dir
@@ -566,6 +578,23 @@ export class Workspace implements ComponentFactory {
     //  .bitmap file. workspace needs a similar mechanism. once done, remove the next line.
     await this.consumer.bitMap.write(this.consumer.componentFsCache);
     return addResults;
+  }
+
+  /**
+   * add a new component to the .bitmap file.
+   * this method only adds the records in memory but doesn't persist to the filesystem.
+   * to write the .bitmap file once completed, run "await this.consumer.writeBitMap();"
+   */
+  async track(trackData: TrackData): Promise<TrackResult> {
+    const addComponent = new AddComponents(
+      { consumer: this.consumer },
+      { componentPaths: [trackData.rootDir], id: trackData.componentName, main: trackData.mainFile, override: false }
+    );
+    const result = await addComponent.add();
+    const addedComponent = result.addedComponents[0];
+    const componentName = addedComponent?.id.name || (trackData.componentName as string);
+    const files = addedComponent?.files.map((f) => f.relativePath) || [];
+    return { componentName, files, warnings: result.warnings };
   }
 
   /**

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -51,7 +51,7 @@ import PathOutsideConsumer from './exceptions/path-outside-consumer';
 import VersionShouldBeRemoved from './exceptions/version-should-be-removed';
 
 export type AddResult = { id: BitId; files: ComponentMapFile[] };
-type Warnings = {
+export type Warnings = {
   alreadyUsed: Record<string, any>;
   emptyDirectory: string[];
   existInScope: BitId[];


### PR DESCRIPTION
Fixes #4016.

- in case a component was written but failed to be added to the .bitmap file, make sure to delete the created component.
- if the component-path exists, throw an error and avoid overriding that dir.
- refactoring: extract the component-generator logic to a new class.


