### PR TITLE
improve loading performance by importing only the needed methods from ramda-adjunct

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
 import R from 'ramda';
-import * as RA from 'ramda-adjunct';
+import { isNilOrEmpty } from 'ramda-adjunct';
 import semver from 'semver';
 import { Dependency } from '..';
 import { BitId, BitIds } from '../../../../bit-id';
@@ -824,7 +824,7 @@ either, use the ignore file syntax or change the require statement to have a mod
     if (!missing) return;
     const processMissingFiles = () => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      if (RA.isNilOrEmpty(missing.files)) return;
+      if (isNilOrEmpty(missing.files)) return;
       const absOriginFile = this.consumer.toAbsolutePath(originFile);
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       const missingFiles = missing.files.filter((missingFile) => {
@@ -837,7 +837,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       this._pushToMissingDependenciesOnFs(originFile, missingFiles);
     };
     const processMissingPackages = () => {
-      if (RA.isNilOrEmpty(missing.packages)) return;
+      if (isNilOrEmpty(missing.packages)) return;
       const missingPackages = missing.packages.filter(
         (pkg) => !this.overridesDependencies.shouldIgnorePackage(pkg, fileType)
       );
@@ -858,7 +858,7 @@ either, use the ignore file syntax or change the require statement to have a mod
       }
     };
     const processMissingComponents = () => {
-      if (RA.isNilOrEmpty(missing.bits)) return;
+      if (isNilOrEmpty(missing.bits)) return;
       this._addToMissingComponentsIfNeeded(missing.bits, originFile, fileType);
     };
     processMissingFiles();

--- a/src/consumer/config/abstract-config.ts
+++ b/src/consumer/config/abstract-config.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import * as path from 'path';
 import R from 'ramda';
-import * as RA from 'ramda-adjunct';
+import { isNilOrEmpty } from 'ramda-adjunct';
 
 import { BitIds } from '../../bit-id';
 import {
@@ -135,7 +135,7 @@ export default class AbstractConfig {
     if (!envObj) return undefined;
     if (Object.keys(envObj).length !== 1) return envObj; // it has more than one id
     const envId = Object.keys(envObj)[0];
-    if (RA.isNilOrEmpty(envObj[envId].rawConfig) && RA.isNilOrEmpty(envObj[envId].options)) {
+    if (isNilOrEmpty(envObj[envId].rawConfig) && isNilOrEmpty(envObj[envId].options)) {
       return envId;
     }
     return envObj;

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -1,9 +1,8 @@
 import mapSeries from 'p-map-series';
 import R from 'ramda';
-import * as RA from 'ramda-adjunct';
+import { isNilOrEmpty, compact } from 'ramda-adjunct';
 import { ReleaseType } from 'semver';
 import { v4 } from 'uuid';
-import { compact } from 'ramda-adjunct';
 import * as globalConfig from '../../api/consumer/lib/global-config';
 import { Scope } from '..';
 import { BitId, BitIds } from '../../bit-id';
@@ -232,7 +231,7 @@ export default async function tagModelComponent({
     });
     const newestVersions = await Promise.all(newestVersionsP);
     const newestVersionsWithoutEmpty = newestVersions.filter((newest) => newest);
-    if (!RA.isNilOrEmpty(newestVersionsWithoutEmpty)) {
+    if (!isNilOrEmpty(newestVersionsWithoutEmpty)) {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       throw new NewerVersionFound(newestVersionsWithoutEmpty);
     }


### PR DESCRIPTION
I observed this while watching process-monitor on a Windows machine. It reads 400+ files from `ramda-adjunct` package.
In this PR I removed all occurrences we had of `import * as RA from 'ramda-adjunct'`.