### PR TITLE
change component-templates API to accommodate the different cases

### DIFF
--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -60,8 +60,9 @@ export class ComponentGenerator {
 
   private async generateOneComponent(componentId: ComponentID, componentPath: string): Promise<GenerateResult> {
     const name = componentId.name;
-    const componentNameCamelCase = camelcase(name, { pascalCase: true });
-    const files = this.template.generateFiles({ componentName: name, componentNameCamelCase, componentId });
+    const namePascalCase = camelcase(name, { pascalCase: true });
+    const nameCamelCase = camelcase(name);
+    const files = this.template.generateFiles({ name, namePascalCase, nameCamelCase, componentId });
     const mainFile = files.find((file) => file.isMain);
     await this.writeComponentFiles(componentPath, files);
     const addResults = await this.workspace.track({

--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -19,16 +19,22 @@ export interface File {
 
 export interface GeneratorContext {
   /**
-   * component name of the generating component. e.g. `button` or `use-date`.
+   * component-name as entered by the user, e.g. `use-date`.
    * without the scope and the namespace.
    */
-  componentName: string;
+  name: string;
 
   /**
-   * e.g. `use-date` becomes `useDate`.
-   * useful when generating the file content, for example for a function name.
+   * component-name as upper camel case, e.g. `use-date` becomes `UseDate`.
+   * useful when generating the file content, for example for a class name.
    */
-  componentNameCamelCase: string;
+  namePascalCase: string;
+
+  /**
+   * component-name as lower camel case, e.g. `use-date` becomes `useDate`.
+   * useful when generating the file content, for example for a function/variable name.
+   */
+  nameCamelCase: string;
 
   /**
    * component id.

--- a/scopes/harmony/aspect/templates/aspect/files/aspect-file.ts
+++ b/scopes/harmony/aspect/templates/aspect/files/aspect-file.ts
@@ -1,9 +1,9 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function aspectFile({ componentNameCamelCase, componentId }: GeneratorContext) {
+export function aspectFile({ namePascalCase, componentId }: GeneratorContext) {
   return `import { Aspect } from '@teambit/harmony';
 
-export const ${componentNameCamelCase}Aspect = Aspect.create({
+export const ${namePascalCase}Aspect = Aspect.create({
   id: '${componentId}',
 });
   `;

--- a/scopes/harmony/aspect/templates/aspect/files/index.ts
+++ b/scopes/harmony/aspect/templates/aspect/files/index.ts
@@ -1,10 +1,10 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function indexFile({ componentNameCamelCase, componentName }: GeneratorContext) {
-  return `import { ${componentNameCamelCase}Aspect } from './${componentName}.aspect';
+export function indexFile({ namePascalCase, name }: GeneratorContext) {
+  return `import { ${namePascalCase}Aspect } from './${name}.aspect';
 
-export type { ${componentNameCamelCase}Main } from './${componentName}.main.runtime';
-export default ${componentNameCamelCase}Aspect;
-export { ${componentNameCamelCase}Aspect };
+export type { ${namePascalCase}Main } from './${name}.main.runtime';
+export default ${namePascalCase}Aspect;
+export { ${namePascalCase}Aspect };
 `;
 }

--- a/scopes/harmony/aspect/templates/aspect/files/main-runtime.ts
+++ b/scopes/harmony/aspect/templates/aspect/files/main-runtime.ts
@@ -1,18 +1,18 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function mainRuntime({ componentName, componentNameCamelCase }: GeneratorContext) {
+export function mainRuntime({ name, namePascalCase }: GeneratorContext) {
   return `import { MainRuntime } from '@teambit/cli';
-import { ${componentNameCamelCase}Aspect } from './${componentName}.aspect';
+import { ${namePascalCase}Aspect } from './${name}.aspect';
 
-export class ${componentNameCamelCase}Main {
+export class ${namePascalCase}Main {
   static slots = [];
   static dependencies = [];
   static runtime = MainRuntime;
   static async provider() {
-    return new ${componentNameCamelCase}Main();
+    return new ${namePascalCase}Main();
   }
 }
 
-${componentNameCamelCase}Aspect.addRuntime(${componentNameCamelCase}Main);
+${namePascalCase}Aspect.addRuntime(${namePascalCase}Main);
 `;
 }

--- a/scopes/harmony/aspect/templates/aspect/index.ts
+++ b/scopes/harmony/aspect/templates/aspect/index.ts
@@ -13,11 +13,11 @@ export const aspectTemplate: ComponentTemplate = {
         isMain: true,
       },
       {
-        relativePath: `${context.componentName}.aspect.ts`,
+        relativePath: `${context.name}.aspect.ts`,
         content: aspectFile(context),
       },
       {
-        relativePath: `${context.componentName}.main.runtime.ts`,
+        relativePath: `${context.name}.main.runtime.ts`,
         content: mainRuntime(context),
       },
     ];

--- a/scopes/harmony/node/templates/node-env/files/extension.ts
+++ b/scopes/harmony/node/templates/node-env/files/extension.ts
@@ -1,6 +1,6 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function extensionFile({ componentNameCamelCase: Name }: GeneratorContext) {
+export function extensionFile({ namePascalCase: Name }: GeneratorContext) {
   return `import { EnvsMain, EnvsAspect } from '@teambit/envs'
 import { NodeAspect, NodeMain } from '@teambit/node'
 

--- a/scopes/harmony/node/templates/node-env/files/index.ts
+++ b/scopes/harmony/node/templates/node-env/files/index.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function indexFile({ componentNameCamelCase: Name, componentName }: GeneratorContext) {
-  return `import { ${Name}Extension } from './${componentName}.extension';
+export function indexFile({ namePascalCase: Name, name }: GeneratorContext) {
+  return `import { ${Name}Extension } from './${name}.extension';
 export { ${Name}Extension };
 export default ${Name}Extension;
 `;

--- a/scopes/harmony/node/templates/node-env/index.ts
+++ b/scopes/harmony/node/templates/node-env/index.ts
@@ -13,11 +13,11 @@ export const nodeEnvTemplate: ComponentTemplate = {
         isMain: true,
       },
       {
-        relativePath: `${context.componentName}.docs.mdx`,
+        relativePath: `${context.name}.docs.mdx`,
         content: docFile(),
       },
       {
-        relativePath: `${context.componentName}.extension.ts`,
+        relativePath: `${context.name}.extension.ts`,
         content: extensionFile(context),
       },
     ];

--- a/scopes/react/react-native/templates/react-native-env/files/extension.ts
+++ b/scopes/react/react-native/templates/react-native-env/files/extension.ts
@@ -1,6 +1,6 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function extensionFile({ componentNameCamelCase: Name }: GeneratorContext) {
+export function extensionFile({ namePascalCase: Name }: GeneratorContext) {
   return `import { EnvsMain, EnvsAspect } from '@teambit/envs'
 import { ReactNativeAspect, ReactNativeMain } from '@teambit/react-native'
 

--- a/scopes/react/react-native/templates/react-native-env/files/index.ts
+++ b/scopes/react/react-native/templates/react-native-env/files/index.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function indexFile({ componentNameCamelCase: Name, componentName }: GeneratorContext) {
-  return `import { ${Name}Extension } from './${componentName}.extension';
+export function indexFile({ namePascalCase: Name, name }: GeneratorContext) {
+  return `import { ${Name}Extension } from './${name}.extension';
 export { ${Name}Extension };
 export default ${Name}Extension;
 `;

--- a/scopes/react/react-native/templates/react-native-env/index.ts
+++ b/scopes/react/react-native/templates/react-native-env/index.ts
@@ -13,11 +13,11 @@ export const reactNativeTemplate: ComponentTemplate = {
         isMain: true,
       },
       {
-        relativePath: `${context.componentName}.docs.mdx`,
+        relativePath: `${context.name}.docs.mdx`,
         content: docFile(),
       },
       {
-        relativePath: `${context.componentName}.extension.ts`,
+        relativePath: `${context.name}.extension.ts`,
         content: extensionFile(context),
       },
     ];

--- a/scopes/react/react/templates/react-button/component.ts
+++ b/scopes/react/react/templates/react-button/component.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const componentFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
   return {
     relativePath: `${name}.tsx`,
     content: `import React from 'react';

--- a/scopes/react/react/templates/react-button/composition.ts
+++ b/scopes/react/react/templates/react-button/composition.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const compositionFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.composition.tsx`,

--- a/scopes/react/react/templates/react-button/docs.ts
+++ b/scopes/react/react/templates/react-button/docs.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const docsFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.docs.mdx`,

--- a/scopes/react/react/templates/react-button/index.ts
+++ b/scopes/react/react/templates/react-button/index.ts
@@ -8,7 +8,7 @@ export const reactButton: ComponentTemplate = {
   name: 'react-button',
 
   generateFiles: (context: GeneratorContext) => {
-    const { componentName: name, componentNameCamelCase: Name } = context;
+    const { name, namePascalCase: Name } = context;
     const indexFile = {
       relativePath: 'index.ts',
       content: `export { ${Name} } from './${name}';

--- a/scopes/react/react/templates/react-button/test.ts
+++ b/scopes/react/react/templates/react-button/test.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const testFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.spec.tsx`,

--- a/scopes/react/react/templates/react-component/component.ts
+++ b/scopes/react/react/templates/react-component/component.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const componentFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
   return {
     relativePath: `${name}.tsx`,
     content: `import React from 'react';

--- a/scopes/react/react/templates/react-component/composition.ts
+++ b/scopes/react/react/templates/react-component/composition.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const compositionFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.composition.tsx`,

--- a/scopes/react/react/templates/react-component/docs.ts
+++ b/scopes/react/react/templates/react-component/docs.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const docsFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.docs.mdx`,

--- a/scopes/react/react/templates/react-component/index.ts
+++ b/scopes/react/react/templates/react-component/index.ts
@@ -8,7 +8,7 @@ export const reactComponent: ComponentTemplate = {
   name: 'react-component',
 
   generateFiles: (context: GeneratorContext) => {
-    const { componentName: name, componentNameCamelCase: Name } = context;
+    const { name, namePascalCase: Name } = context;
     const indexFile = {
       relativePath: 'index.ts',
       content: `export { ${Name} } from './${name}';

--- a/scopes/react/react/templates/react-component/test.ts
+++ b/scopes/react/react/templates/react-component/test.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
 export const testFile = (context: GeneratorContext) => {
-  const { componentName: name, componentNameCamelCase: Name } = context;
+  const { name, namePascalCase: Name } = context;
 
   return {
     relativePath: `${name}.spec.tsx`,

--- a/scopes/react/react/templates/react-env/files/extension.ts
+++ b/scopes/react/react/templates/react-env/files/extension.ts
@@ -1,6 +1,6 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function extensionFile({ componentNameCamelCase: Name }: GeneratorContext) {
+export function extensionFile({ namePascalCase: Name }: GeneratorContext) {
   return `import { EnvsMain, EnvsAspect } from '@teambit/envs'
 import { ReactAspect, ReactMain } from '@teambit/react'
 

--- a/scopes/react/react/templates/react-env/files/index.ts
+++ b/scopes/react/react/templates/react-env/files/index.ts
@@ -1,7 +1,7 @@
 import { GeneratorContext } from '@teambit/generator';
 
-export function indexFile({ componentNameCamelCase: Name, componentName }: GeneratorContext) {
-  return `import { ${Name}Extension } from './${componentName}.extension';
+export function indexFile({ namePascalCase: Name, name }: GeneratorContext) {
+  return `import { ${Name}Extension } from './${name}.extension';
 export { ${Name}Extension };
 export default ${Name}Extension;
 `;

--- a/scopes/react/react/templates/react-env/index.ts
+++ b/scopes/react/react/templates/react-env/index.ts
@@ -13,11 +13,11 @@ export const reactEnvTemplate: ComponentTemplate = {
         isMain: true,
       },
       {
-        relativePath: `${context.componentName}.docs.mdx`,
+        relativePath: `${context.name}.docs.mdx`,
         content: docFile(),
       },
       {
-        relativePath: `${context.componentName}.extension.ts`,
+        relativePath: `${context.name}.extension.ts`,
         content: extensionFile(context),
       },
     ];


### PR DESCRIPTION
## Proposed Changes

- rename `componentName` to `name`.
- rename `componentNameCamelCase` to `namePascalCase`
- introduce `nameCamelCase` for lower camel case.
