### PR TITLE
fix bit-status to show the correct staged versions when snapping on a lane after exporting master

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -895,4 +895,23 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('tag on master, export, create lane and snap', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.exportAllComponents();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('bit status should show the correct staged versions', () => {
+      // before it was a bug that "versions" part of the staged-component was empty
+      // another bug was that it had all versions included exported.
+      const status = helper.command.status();
+      const hash = helper.command.getHeadOfLane('dev', 'comp1');
+      expect(status).to.have.string(`versions: ${hash} ...`);
+    });
+  });
 });

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_BINDINGS_PREFIX,
   DEFAULT_BIT_RELEASE_TYPE,
   DEFAULT_BIT_VERSION,
+  DEFAULT_LANE,
   DEFAULT_LANGUAGE,
   TESTER_ENV_TYPE,
 } from '../../constants';
@@ -243,6 +244,8 @@ export default class Component extends BitObject {
         RemoteLaneId.from(remoteLaneId.name, remoteScopeName),
         this.toBitId()
       );
+      // we need also the remote head of master, otherwise, the diverge-data assumes all versions are local
+      this.remoteHead = await repo.remoteLanes.getRef(RemoteLaneId.from(DEFAULT_LANE, remoteScopeName), this.toBitId());
     }
   }
 
@@ -809,9 +812,6 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
     const divergeData = this.getDivergeData();
     const localHashes = divergeData.snapsOnLocalOnly;
     if (!localHashes.length) return localVersions;
-    // @todo: this doesn't make sense when creating a new lane locally.
-    // the laneHeadRemote is not set. it needs to be compare to the head
-    if (!this.laneHeadRemote && this.scope) return localVersions; // backward compatibility of components tagged before v15
     return this.switchHashesWithTagsIfExist(localHashes).reverse(); // reverse to get the older first
   }
 


### PR DESCRIPTION
Currently, if all versions of master are exported and a new snap was created on a lane, bit-status shows no versions. 