### PR TITLE
make the concurrency limit configurable

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -255,6 +255,10 @@ export const CFG_PROXY_CERT = 'proxy.cert';
 export const CFG_PROXY_KEY = 'proxy.key';
 export const CFG_PROXY_NO_PROXY = 'proxy.no_proxy';
 
+export const CFG_CONCURRENCY_IO = 'concurrency.io';
+export const CFG_CONCURRENCY_COMPONENTS = 'concurrency.components';
+export const CFG_CONCURRENCY_FETCH = 'concurrency.fetch';
+
 /**
  * git hooks
  */
@@ -438,10 +442,6 @@ export const DEFAULT_LANE = 'master';
 const MISSING_DEPS_SPACE_COUNT = 10;
 export const MISSING_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT);
 export const MISSING_NESTED_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT + 2);
-
-export const CONCURRENT_IO_LIMIT = 100; // limit number of files to read/write/delete/symlink at the same time
-export const CONCURRENT_COMPONENTS_LIMIT = 50; // limit number of components to load at the same time
-export const CONCURRENT_FETCH_LIMIT = 15; // limit number of scopes to fetch from at the same time
 
 // todo: move the following two lines to the watch extension once its e2e moved to the extension dir
 export const STARTED_WATCHING_MSG = 'started watching for component changes to rebuild';

--- a/src/consumer/component/sources/data-to-persist.ts
+++ b/src/consumer/component/sources/data-to-persist.ts
@@ -1,11 +1,10 @@
 import Bluebird from 'bluebird';
 import fs from 'fs-extra';
 import * as path from 'path';
-
 import Capsule from '../../../../legacy-capsule/core/capsule';
-import { CONCURRENT_IO_LIMIT as concurrency } from '../../../constants';
 import Symlink from '../../../links/symlink';
 import logger from '../../../logger/logger';
+import { concurrentIOLimit } from '../../../utils/concurrency';
 import removeFilesAndEmptyDirsRecursively from '../../../utils/fs/remove-files-and-empty-dirs-recursively';
 import AbstractVinyl from './abstract-vinyl';
 import RemovePath from './remove-path';
@@ -164,9 +163,11 @@ export default class DataToPersist {
     return dataToPersist;
   }
   async _persistFilesToFS() {
+    const concurrency = concurrentIOLimit();
     return Bluebird.map(this.files, (file) => file.write(), { concurrency });
   }
   async _persistSymlinksToFS() {
+    const concurrency = concurrentIOLimit();
     return Bluebird.map(this.symlinks, (symlink) => symlink.write(), { concurrency });
   }
   async _deletePathsFromFS() {
@@ -175,6 +176,7 @@ export default class DataToPersist {
     if (pathWithRemoveItsDirIfEmptyEnabled.length) {
       await removeFilesAndEmptyDirsRecursively(pathWithRemoveItsDirIfEmptyEnabled);
     }
+    const concurrency = concurrentIOLimit();
     return Bluebird.map(restPaths, (removePath) => removePath.persistToFS(), { concurrency });
   }
   _validateAbsolute() {

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -25,9 +25,10 @@ import { ObjectItemsStream, ObjectList } from '../objects/object-list';
 import SourcesRepository, { ComponentDef } from '../repositories/sources';
 import { getScopeRemotes } from '../scope-remotes';
 import VersionDependencies from '../version-dependencies';
-import { CONCURRENT_COMPONENTS_LIMIT, DEFAULT_LANE } from '../../constants';
+import { DEFAULT_LANE } from '../../constants';
 import { BitObjectList } from '../objects/bit-object-list';
 import { ObjectFetcher } from '../objects-fetcher/objects-fetcher';
+import { concurrentComponentsLimit } from '../../utils/concurrency';
 
 const removeNils = R.reject(R.isNil);
 
@@ -405,6 +406,7 @@ export default class ScopeComponentsImporter {
   }
 
   private async multipleCompsDefsToVersionDeps(compsDefs: ComponentDef[]): Promise<VersionDependencies[]> {
+    const concurrency = concurrentComponentsLimit();
     const componentsWithVersionsWithNulls = await pMap(
       compsDefs,
       async ({ component, id }) => {
@@ -423,7 +425,7 @@ export default class ScopeComponentsImporter {
 
         return { componentVersion: versionComp, versionObj: version };
       },
-      { concurrency: CONCURRENT_COMPONENTS_LIMIT }
+      { concurrency }
     );
     const componentsWithVersion = compact(componentsWithVersionsWithNulls);
 

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -5,7 +5,6 @@ import pMap from 'p-map';
 import { Scope } from '..';
 import { FETCH_OPTIONS } from '../../api/scope/lib/fetch';
 import loader from '../../cli/loader';
-import { CONCURRENT_FETCH_LIMIT } from '../../constants';
 import logger from '../../logger/logger';
 import { Remotes } from '../../remotes';
 import { ScopeNotFound } from '../exceptions';
@@ -17,6 +16,7 @@ import { ObjectsWritable } from './objects-writable-stream';
 import { WriteComponentsQueue } from './write-components-queue';
 import { WriteObjectsQueue } from './write-objects-queue';
 import { groupByScopeName } from '../component-ops/scope-components-importer';
+import { concurrentFetchLimit } from '../../utils/concurrency';
 
 /**
  * due to the use of streams, this is memory efficient and can handle easily GBs of objects.
@@ -59,7 +59,7 @@ export class ObjectFetcher {
         if (!readableStream) return;
         await this.writeFromSingleRemote(readableStream, scopeName, objectsQueue, componentsQueue);
       },
-      { concurrency: CONCURRENT_FETCH_LIMIT }
+      { concurrency: concurrentFetchLimit() }
     );
     if (Object.keys(this.failedScopes).length) {
       const failedScopesErr = Object.keys(this.failedScopes).map(

--- a/src/scope/objects-fetcher/write-objects-queue.ts
+++ b/src/scope/objects-fetcher/write-objects-queue.ts
@@ -1,10 +1,10 @@
 import PQueue from 'p-queue';
-import { CONCURRENT_IO_LIMIT } from '../../constants';
+import { concurrentIOLimit } from '../../utils/concurrency';
 
 export class WriteObjectsQueue {
   private queue: PQueue;
   private addedHashes: string[] = [];
-  constructor(concurrency = CONCURRENT_IO_LIMIT) {
+  constructor(concurrency = concurrentIOLimit()) {
     this.queue = new PQueue({ concurrency, autoStart: true });
   }
   addImmutableObject<T>(hash: string, fn: () => Promise<T | null>) {

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -2,7 +2,7 @@ import R from 'ramda';
 import pMap from 'p-map';
 import { isHash } from '@teambit/component-version';
 import { BitId, BitIds } from '../../bit-id';
-import { BuildStatus, COMPONENT_ORIGINS, CONCURRENT_COMPONENTS_LIMIT, Extensions } from '../../constants';
+import { BuildStatus, COMPONENT_ORIGINS, Extensions } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { revertDirManipulationForPath } from '../../consumer/component-ops/manipulate-dir';
 import AbstractVinyl from '../../consumer/component/sources/abstract-vinyl';
@@ -24,6 +24,7 @@ import Repository from '../objects/repository';
 import Scope from '../scope';
 import { ExportMissingVersions } from '../exceptions/export-missing-versions';
 import { ModelComponentMerger } from '../component-ops/model-components-merger';
+import { concurrentComponentsLimit } from '../../utils/concurrency';
 
 export type ComponentTree = {
   component: ModelComponent;
@@ -53,6 +54,7 @@ export default class SourceRepository {
 
   async getMany(ids: BitId[] | BitIds, versionShouldBeBuilt = false): Promise<ComponentDef[]> {
     if (!ids.length) return [];
+    const concurrency = concurrentComponentsLimit();
     logger.debug(`sources.getMany, Ids: ${ids.join(', ')}`);
     return pMap(
       ids,
@@ -63,7 +65,7 @@ export default class SourceRepository {
           component,
         };
       },
-      { concurrency: CONCURRENT_COMPONENTS_LIMIT }
+      { concurrency }
     );
   }
 

--- a/src/utils/concurrency.ts
+++ b/src/utils/concurrency.ts
@@ -1,0 +1,37 @@
+import { getSync } from '../api/consumer/lib/global-config';
+import { CFG_CONCURRENCY_COMPONENTS, CFG_CONCURRENCY_FETCH, CFG_CONCURRENCY_IO } from '../constants';
+
+const CONCURRENT_IO_LIMIT = 100;
+const CONCURRENT_COMPONENTS_LIMIT = 50;
+const CONCURRENT_FETCH_LIMIT = 15;
+
+/**
+ * limit number of files to read/write/delete/symlink at the same time
+ */
+export function concurrentIOLimit(): number {
+  return getFromConfig(CFG_CONCURRENCY_IO) || CONCURRENT_IO_LIMIT;
+}
+
+/**
+ * limit number of components to load at the same time
+ */
+export function concurrentComponentsLimit(): number {
+  return getFromConfig(CFG_CONCURRENCY_COMPONENTS) || CONCURRENT_COMPONENTS_LIMIT;
+}
+
+/**
+ * limit number of scopes to fetch from at the same time
+ */
+export function concurrentFetchLimit(): number {
+  return getFromConfig(CFG_CONCURRENCY_FETCH) || CONCURRENT_FETCH_LIMIT;
+}
+
+function getFromConfig(name: string): number | null {
+  const fromConfig = getSync(name);
+  if (!fromConfig) return null;
+  const num = Number(fromConfig);
+  if (Number.isNaN(num)) {
+    throw new Error(`config of "${name}" is invalid. Expected number, got "${fromConfig}"`);
+  }
+  return num;
+}

--- a/src/utils/fs/remove-files-and-empty-dirs-recursively.ts
+++ b/src/utils/fs/remove-files-and-empty-dirs-recursively.ts
@@ -2,9 +2,8 @@ import fs from 'fs-extra';
 import pMap from 'p-map';
 import mapSeries from 'p-map-series';
 import * as path from 'path';
-import { CONCURRENT_IO_LIMIT } from '../../constants';
-
 import logger from '../../logger/logger';
+import { concurrentIOLimit } from '../concurrency';
 import removeEmptyDir from './remove-empty-dir';
 
 /**
@@ -14,7 +13,8 @@ import removeEmptyDir from './remove-empty-dir';
 export default async function removeFilesAndEmptyDirsRecursively(filesPaths: string[]): Promise<boolean> {
   const dirs = filesPaths.map((filePath) => path.dirname(filePath));
   logger.info(`remove-files-and-empty-dirs-recursively deleting the following paths: ${filesPaths.join(', ')}`);
-  await pMap(filesPaths, (filePath) => fs.remove(filePath), { concurrency: CONCURRENT_IO_LIMIT });
+  const concurrency = concurrentIOLimit();
+  await pMap(filesPaths, (filePath) => fs.remove(filePath), { concurrency });
   // Sorting it to make sure we will delete the inner dirs first
   const sortedDirs = dirs.sort().reverse();
   await mapSeries(sortedDirs, (dir) => removeEmptyDir(dir));


### PR DESCRIPTION
Currently the concurrency limit for IO/Component/Fetch are hard-coded. 
This PR enables setting them to a non-default number by changing the global Bit configuration as following:
```
bit config set concurrency.io 100
bit config set concurrency.components 50
bit config set concurrency.fetch 15
```