### PR TITLE
quickfix - add react/dom/native-web as direct dependencies of env

### DIFF
--- a/scopes/react/react-native/component.json
+++ b/scopes/react/react-native/component.json
@@ -35,7 +35,10 @@
     "teambit.dependencies/dependency-resolver": {
       "policy": {
         "dependencies": {
-          "@teambit/legacy": "-"
+          "@teambit/legacy": "-",
+          "react": "^16.14.0",
+          "react-dom": "^16.14.0",
+          "react-native-web": "^0.14.0"
         },
         "devDependencies": {
           "@teambit/legacy": "-",
@@ -43,9 +46,6 @@
           "@types/react-dom": "^16.8.0"
         },
         "peerDependencies": {
-          "react": "^16.8.0",
-          "react-dom": "^16.8.0",
-          "react-native-web": "^0.14.0",
           "@teambit/legacy": "1.0.50"
         }
       }

--- a/scopes/react/react/component.json
+++ b/scopes/react/react/component.json
@@ -17,8 +17,8 @@
     "teambit.dependencies/dependency-resolver": {
       "policy": {
         "dependencies": {
-          "react": "-",
-          "react-dom": "-",
+          "react": "^16.14.0",
+          "react-dom": "^16.14.0",
           "@babel/preset-env": "7.12.17",
           "@babel/preset-react": "7.12.13",
           "@typescript-eslint/parser": "4.15.1",
@@ -57,8 +57,6 @@
           "@types/react-dom": "^16.8.0"
         },
         "peerDependencies": {
-          "react": "^16.8.0 || ^17.0.0",
-          "react-dom": "^16.8.0 || ^17.0.0",
           "@teambit/legacy": "1.0.50"
         }
       }


### PR DESCRIPTION
getting this error when running bbit v0.0.348

```
~/projects   
harmony-base-ui git/master*  
❯ bbit install
Cannot find module 'react-native-web'
Require stack:
- /Users/kutner/.bvm/versions/0.0.348/bit-0.0.348/node_modules/@teambit/react-native/dist/webpack/webpack.config.js
- /Users/kutner/.bvm/versions/0.0.348/bit-0.0.348/node_modules/@teambit/react-native/dist/react-native.main.runtime.js
- /Users/kutner/.bvm/versions/0.0.348/bit-0.0.348/node_modules/@teambit/bit/dist/load-bit.js
- /Users/kutner/.bvm/versions/0.0.348/bit-0.0.348/node_modules/@teambit/bit/dist/app.js
- /Users/kutner/.bvm/versions/0.0.348/bit-0.0.348/node_modules/@teambit/bit/bin/bit
```

## Proposed Changes

- move react, react-dom, react-native-web to be direct dependencies instead of peer. Should force bit to install them correctly
