### PR TITLE
fixes #4040, fix writing files on Windows to not multiply the EOL

### DIFF
--- a/src/utils/eol.ts
+++ b/src/utils/eol.ts
@@ -1,20 +1,15 @@
 import { isBinaryFileSync } from 'isbinaryfile';
 
-import replaceBuffer from './buffer/replace-buffer-non-recursive';
-
 const isWindows = typeof process !== 'undefined' && process.platform === 'win32';
 const lineBreak = isWindows ? '\r\n' : '\n';
-const newLines = ['\r\n', '\r', '\n'];
 const newline = /\r\n|\r|\n/g;
 
 function converts(text: string | Buffer, to: string) {
   if (Buffer.isBuffer(text)) {
     if (isBinaryFileSync(text)) return text; // don't touch binary files
-    newLines.forEach((newLine) => {
-      // $FlowFixMe text is Buffer here
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      if (newLine !== to) text = replaceBuffer(text, newLine, to);
-    });
+    const str = text.toString();
+    const strReplaced = str.replace(newline, to);
+    if (str !== strReplaced) return Buffer.from(strReplaced);
     return text;
   }
   return text.toString().replace(newline, to);


### PR DESCRIPTION
In some scenarios, when files were saved on Linux and then opened and written on Windows, the new lines characters were duplicated.

The reason for this duplication is that we looped through `['\r\n', '\r', '\n']` inside the buffer and replace this with `\r\n` on Windows. So, `\r` was replaced by `\r\n` and then `\n` was replaced with `\r\n`, hence the double EOL.

In this PR, the algorithm of changing the EOL in buffers has changed to convert it to string and then use regex to replace them all. (instead of the loop).