### PR TITLE
fix bit-import performance by caching the concurrency-limit value

### DIFF
--- a/src/api/consumer/lib/global-config.ts
+++ b/src/api/consumer/lib/global-config.ts
@@ -70,13 +70,19 @@ export function getSync(key: string): string | undefined {
   const config = getConfigObject();
   const val = config ? config.get(key) : undefined;
   if (!R.isNil(val)) return val;
+  const gitConfigCache = gitCache().get() || {};
+  if (key in gitConfigCache) {
+    return gitConfigCache[val];
+  }
   try {
     const gitVal = gitconfig.get.sync(key);
-    return gitVal;
-    // Ignore error from git config get
+    gitConfigCache[key] = gitVal;
   } catch (err) {
-    return undefined;
+    // Ignore error from git config get
+    gitConfigCache[key] = undefined;
   }
+  gitCache().set(gitConfigCache);
+  return gitConfigCache[key];
 }
 
 export function list(): Promise<any> {
@@ -97,6 +103,19 @@ function cache() {
     set: (config) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       cache.config = config;
+    },
+  };
+}
+
+function gitCache() {
+  return {
+    get: () => {
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      return gitCache.config;
+    },
+    set: (config) => {
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      gitCache.config = config;
     },
   };
 }


### PR DESCRIPTION
Currently, if a config value is not in bit-config, it goes to Git and if not found, it doesn't cache the result. It causes the fetch operation on the remote to be very slow.