### PR TITLE
do not error when pubsub fails connecting to parent

### DIFF
--- a/scopes/harmony/pubsub/no-parent-error.ts
+++ b/scopes/harmony/pubsub/no-parent-error.ts
@@ -1,0 +1,6 @@
+export class PubSubNoParentError extends Error {
+  constructor() {
+    super('could not connect to parent window');
+    this.name = 'PubSubNoParentError';
+  }
+}


### PR DESCRIPTION
parent doesn't always listen for child, for example, in search results page.

<img width="1385" alt="Screen Shot 2021-04-11 at 14 43 19" src="https://user-images.githubusercontent.com/5400361/114302974-49648200-9ad4-11eb-8a5c-1d012ef6f73c.png">
