### PR TITLE
show previewNotFound when getting parse error in previews

### DIFF
--- a/scopes/component/component-id/component-id.ts
+++ b/scopes/component/component-id/component-id.ts
@@ -119,6 +119,17 @@ export class ComponentID {
   }
 
   /**
+   * generate a component ID from a string. Returns undefined if input is malformed
+   */
+  static tryFromString(idStr: string, scope?: string) {
+    try {
+      return ComponentID.fromString(idStr, scope);
+    } catch {
+      return undefined;
+    }
+  }
+
+  /**
    * generate a component ID from a string.
    */
   static fromString(idStr: string, scope?: string) {

--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -49,7 +49,7 @@ export class PreviewPreview {
     const name = previewName || this.getDefault();
 
     const preview = this.getPreview(name);
-    if (!preview) {
+    if (!preview || !componentId) {
       throw new PreviewNotFound(previewName);
     }
     const includes = (preview.include || [])
@@ -113,7 +113,7 @@ export class PreviewPreview {
 
     return {
       previewName: this.getParam(after, 'preview'),
-      componentId: ComponentID.fromString(before),
+      componentId: ComponentID.tryFromString(before),
     };
   }
 

--- a/scopes/react/component-highlighter/label/label.tsx
+++ b/scopes/react/component-highlighter/label/label.tsx
@@ -44,13 +44,7 @@ export interface LabelProps extends CardProps {
 }
 
 export function Label({ componentId, ...rest }: LabelProps) {
-  const parsedId = useMemo(() => {
-    try {
-      return ComponentID.fromString(componentId);
-    } catch {
-      return undefined;
-    }
-  }, [componentId]);
+  const parsedId = useMemo(() => ComponentID.tryFromString(componentId), [componentId]);
 
   if (!parsedId) return <DefaultLabel {...rest}>{componentId}</DefaultLabel>;
 


### PR DESCRIPTION
Fix this error:
```
Uncaught (in promise) Error: error: component ID "" is invalid, please use the following format: [scope]/<name>
```
(for example, here - https://k1lh7jpk.scopes.bit.dev/api/teambit.documenter/ui/table/td@3.0.6/~aspect/preview/)

## Proposed Changes

- add `.tryFromString()` to component id (returns undefined, instead of exception)
- in preview page, show PreviewNotFound when component id fails to parse
