### PR TITLE
Replace "bit export <scope>" with "bit export" for Harmony

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -39,7 +39,7 @@ describe('bit lane command', function () {
     let beforeExport;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.disablePreview();
+      helper.bitJsonc.setupDefault();
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       helper.command.snapAllComponents();
@@ -95,7 +95,7 @@ describe('bit lane command', function () {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(beforeExport);
         helper.scopeHelper.reInitRemoteScope();
-        helper.command.export(helper.command.scopes.remote);
+        helper.command.export(`${helper.command.scopes.remote} --lanes`);
       });
       it('should export components on that lane', () => {
         const list = helper.command.listRemoteScopeParsed();
@@ -541,7 +541,7 @@ describe('bit lane command', function () {
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.scopeHelper.addRemoteScope();
       helper.command.createLane();
@@ -594,7 +594,7 @@ describe('bit lane command', function () {
       helper.command.tagAllComponents();
       helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
 
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.bitJsonc.setupDefault();
@@ -627,7 +627,7 @@ describe('bit lane command', function () {
         helper.bitJsonc.setupDefault();
         helper.fixtures.populateComponents();
         helper.command.snapAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
 
         helper.command.createLane();
         helper.command.snapComponent('comp1 -f');
@@ -692,7 +692,7 @@ describe('bit lane command', function () {
         helper.command.createLane();
         helper.fixtures.populateComponents();
         helper.command.snapAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
       });
       it('as an intermediate step, make sure the lane is on the remote', () => {
         const lanes = helper.command.showRemoteLanesParsed();
@@ -737,7 +737,7 @@ describe('bit lane command', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents();
       helper.command.snapAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
 
       helper.command.createLane();
       helper.fixtures.populateComponents(undefined, undefined, ' v2');
@@ -799,7 +799,7 @@ describe('bit lane command', function () {
       helper.command.snapAllComponents();
     });
     it('should export with no errors about missing artifact files from the first snap', () => {
-      expect(() => helper.command.exportAllComponents()).to.not.throw();
+      expect(() => helper.command.export()).to.not.throw();
     });
   });
   describe('auto-snap when on a lane', () => {
@@ -852,7 +852,7 @@ describe('bit lane command', function () {
     // @todo
     describe.skip('importing the component to another scope', () => {
       before(() => {
-        helper.command.exportAllComponents();
+        helper.command.export();
 
         helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();
@@ -878,7 +878,7 @@ describe('bit lane command', function () {
       npmCiRegistry.configureCiInPackageJsonHarmony();
       await npmCiRegistry.init();
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.reInitLocalScopeHarmony();
       npmCiRegistry.setResolver();
       helper.command.importComponent('comp1');
@@ -901,7 +901,7 @@ describe('bit lane command', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.command.createLane();
       helper.fixtures.populateComponents(1, undefined, 'v2');
       helper.command.snapAllComponentsWithoutBuild();

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -692,7 +692,7 @@ describe('bit lane command', function () {
         helper.command.createLane();
         helper.fixtures.populateComponents();
         helper.command.snapAllComponents();
-        helper.command.export();
+        helper.command.export(`${helper.command.scopes.remote} --lanes`);
       });
       it('as an intermediate step, make sure the lane is on the remote', () => {
         const lanes = helper.command.showRemoteLanesParsed();
@@ -799,7 +799,7 @@ describe('bit lane command', function () {
       helper.command.snapAllComponents();
     });
     it('should export with no errors about missing artifact files from the first snap', () => {
-      expect(() => helper.command.export()).to.not.throw();
+      expect(() => helper.command.export(`${helper.command.scopes.remote} --lanes`)).to.not.throw();
     });
   });
   describe('auto-snap when on a lane', () => {

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -153,17 +153,17 @@ describe('bit snap command', function () {
     let secondSnap: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.disablePreview();
+      helper.bitJsonc.setupDefault();
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       helper.command.snapComponent('bar/foo');
       firstSnap = helper.command.getHead('bar/foo');
-      helper.command.exportAllComponents();
+      helper.command.export();
       scopeAfterFirstSnap = helper.scopeHelper.cloneLocalScope();
       helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
       helper.command.snapComponent('bar/foo');
       secondSnap = helper.command.getHead('bar/foo');
-      helper.command.exportAllComponents();
+      helper.command.export();
     });
     describe('when the local is behind the remote', () => {
       describe('import only objects', () => {
@@ -225,7 +225,7 @@ describe('bit snap command', function () {
         localScope = helper.scopeHelper.cloneLocalScope();
       });
       it('should prevent exporting the component', () => {
-        const exportFunc = () => helper.command.exportAllComponents(); // v2 is exported again
+        const exportFunc = () => helper.command.export(); // v2 is exported again
         const ids = [{ id: `${helper.scopes.remote}/bar/foo` }];
         const error = new MergeConflictOnRemote([], ids);
         helper.general.expectToThrow(exportFunc, error);
@@ -651,7 +651,7 @@ describe('bit snap command', function () {
     });
     describe('importing the component to another scope', () => {
       before(() => {
-        helper.command.exportAllComponents();
+        helper.command.export();
 
         helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();
@@ -673,12 +673,12 @@ describe('bit snap command', function () {
   describe('tag after tag', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.disablePreview();
+      helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllComponents();
       helper.fixtures.populateComponents(1, undefined, ' v2');
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.scopeHelper.addRemoteScope();
       helper.command.importComponent('comp1');
@@ -696,18 +696,18 @@ describe('bit snap command', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       authorFirstTag = helper.scopeHelper.cloneLocalScope();
       helper.fixtures.populateComponents(1, undefined, ' v2');
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.getClonedLocalScope(authorFirstTag);
       helper.fixtures.populateComponents(1, undefined, ' v3');
       helper.command.tagAllWithoutBuild('-s 0.0.3');
       helper.command.importAllComponents();
     });
     it('should prevent exporting the component', () => {
-      const exportFunc = () => helper.command.exportAllComponents();
+      const exportFunc = () => helper.command.export();
       const ids = [{ id: `${helper.scopes.remote}/comp1` }];
       const error = new MergeConflictOnRemote([], ids);
       helper.general.expectToThrow(exportFunc, error);

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -112,7 +112,7 @@ describe('components that are not synced between the scope and the consumer', fu
       helper.fixtures.addComponentBarFooAsDir();
       const bitMap = helper.bitMap.read();
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       // the mimic and import here is to make sure the local doesn't have the symlink object
       helper.git.mimicGitCloneLocalProjectHarmony();
       helper.scopeHelper.addRemoteScope();

--- a/e2e/functionalities/reduce-path.e2e.3.ts
+++ b/e2e/functionalities/reduce-path.e2e.3.ts
@@ -65,10 +65,11 @@ describe('reduce-path functionality (eliminate the original shared-dir among com
     describe('when rootDir is not the same as the sharedDir', () => {
       before(() => {
         helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
         helper.fs.outputFile('src/bar/foo.js');
         helper.command.addComponent('src', { i: 'comp' });
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
         helper.scopeHelper.reInitLocalScope();
         helper.scopeHelper.addRemoteScope();
         helper.command.importComponent('comp');

--- a/e2e/functionalities/track-directories.e2e.3.ts
+++ b/e2e/functionalities/track-directories.e2e.3.ts
@@ -155,8 +155,9 @@ describe('track directories functionality', function () {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
         helper.scopeHelper.addRemoteScope();
+        helper.bitJsonc.setupDefault();
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
         helper.command.importComponent('utils/bar');
       });
       it('should not change the rootDir', () => {

--- a/e2e/harmony/compile.e2e.4.ts
+++ b/e2e/harmony/compile.e2e.4.ts
@@ -80,7 +80,7 @@ describe('compile extension', function () {
       });
       describe('export and import to another scope', () => {
         before(() => {
-          helper.command.exportAllComponents();
+          helper.command.export();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope();
           helper.command.importComponent('comp1');

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -159,7 +159,7 @@ describe('dependency-resolver extension', function () {
     });
     describe('exporting the component', () => {
       before(() => {
-        helper.command.exportAllComponents();
+        helper.command.export();
       });
       it('should change the component id to include the scope name', () => {
         const comp2 = helper.command.catComponent('comp2@latest');

--- a/e2e/harmony/eject-harmony.e2e.ts
+++ b/e2e/harmony/eject-harmony.e2e.ts
@@ -34,7 +34,7 @@ describe('eject command on Harmony', function () {
       npmCiRegistry.configureCiInPackageJsonHarmony();
       await npmCiRegistry.init();
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.removeRemoteScope();
       npmCiRegistry.setResolver();
       scopeBeforeEject = helper.scopeHelper.cloneLocalScope(false);

--- a/e2e/harmony/extensions-config.e2e.3.ts
+++ b/e2e/harmony/extensions-config.e2e.3.ts
@@ -132,12 +132,12 @@ describe('harmony extension config', function () {
             remoteBeforeExport = helper.scopeHelper.cloneRemoteScope();
           });
           it('should block exporting component without exporting the extension', () => {
-            output = helper.general.runWithTryCatch(`bit export ${helper.scopes.remote} bar/foo`);
+            output = helper.general.runWithTryCatch(`bit export bar/foo`);
             expect(output).to.have.string(`"${helper.scopes.remote}/dummy-extension@0.0.1" was not found`);
           });
           describe('exporting extension and component together', () => {
             before(() => {
-              helper.command.exportAllComponents();
+              helper.command.export();
               const componentModelStr = helper.command.catComponent('bar/foo@0.0.1', undefined, false);
               const componentModelStrWithoutExtString = componentModelStr.substring(componentModelStr.indexOf('{'));
               componentModel = JSON.parse(componentModelStrWithoutExtString);
@@ -150,8 +150,8 @@ describe('harmony extension config', function () {
             before(() => {
               helper.scopeHelper.getClonedLocalScope(localBeforeExport);
               helper.scopeHelper.getClonedRemoteScope(remoteBeforeExport);
-              helper.command.exportComponent('dummy-extension');
-              helper.command.exportComponent('bar/foo');
+              helper.command.export('dummy-extension');
+              helper.command.export('bar/foo');
               const componentModelStr = helper.command.catComponent('bar/foo@0.0.1', undefined, false);
               const componentModelStrWithoutExtString = componentModelStr.substring(componentModelStr.indexOf('{'));
               componentModel = JSON.parse(componentModelStrWithoutExtString);
@@ -170,10 +170,10 @@ describe('harmony extension config', function () {
           helper.scopeHelper.reInitRemoteScope();
           helper.scopeHelper.addRemoteScope();
           helper.command.tagComponent('dummy-extension');
-          helper.command.exportComponent('dummy-extension');
+          helper.command.export('dummy-extension');
           helper.extensions.addExtensionToVariant('*', `${helper.scopes.remote}/dummy-extension`, config);
           helper.command.tagAllComponents();
-          helper.command.exportAllComponents();
+          helper.command.export();
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope();
           helper.command.importComponent('bar/foo');

--- a/e2e/harmony/flows.e2e.4.ts
+++ b/e2e/harmony/flows.e2e.4.ts
@@ -50,7 +50,7 @@ describe.skip('flows functionality', function () {
     describe('imported component', () => {
       before(() => {
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
         helper.scopeHelper.reInitLocalScope();
         helper.scopeHelper.addRemoteScope();
         helper.command.importComponent('comp1');

--- a/e2e/harmony/http.e2e.ts
+++ b/e2e/harmony/http.e2e.ts
@@ -28,14 +28,14 @@ describe('http protocol', function () {
       helper.scopeHelper.addRemoteHttpScope();
       helper.fixtures.populateComponents();
       helper.command.tagAllComponents();
-      exportOutput = helper.command.exportAllComponents();
+      exportOutput = helper.command.export();
       scopeAfterExport = helper.scopeHelper.cloneLocalScope();
     });
     after(() => {
       httpHelper.killHttp();
     });
     it('should export successfully', () => {
-      expect(exportOutput).to.have.string('exported 3 components');
+      expect(exportOutput).to.have.string('exported the following 3 component');
     });
     describe('bit log', () => {
       let logOutput: string;

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -32,7 +32,7 @@ describe('import functionality on Harmony', function () {
       before(async () => {
         await npmCiRegistry.init();
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
       });
       after(() => {
         npmCiRegistry.destroy();
@@ -98,10 +98,10 @@ describe('import functionality on Harmony', function () {
   describe('tag, export, clean scope objects, tag and export', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.disablePreview();
+      helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.git.mimicGitCloneLocalProjectHarmony();
       helper.scopeHelper.addRemoteScope();
       helper.command.importAllComponents();
@@ -109,7 +109,7 @@ describe('import functionality on Harmony', function () {
       helper.command.tagAllComponents();
     });
     it('should export with no errors about missing artifacts (pkg file) from the first tag', () => {
-      expect(() => helper.command.exportAllComponents()).to.not.throw();
+      expect(() => helper.command.export()).to.not.throw();
     });
   });
   describe('import delta (bit import without ids) when local is behind', () => {
@@ -121,12 +121,12 @@ describe('import functionality on Harmony', function () {
       helper.command.tagAllWithoutBuild();
       helper.fixtures.populateComponents(1, undefined, ' v2');
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.command.importAllComponents(); // to save all refs.
       afterFirstExport = helper.scopeHelper.cloneLocalScope();
       helper.fixtures.populateComponents(1, undefined, ' v3');
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       const bitMap = helper.bitMap.read();
       helper.scopeHelper.getClonedLocalScope(afterFirstExport);
       helper.bitMap.write(bitMap);

--- a/e2e/harmony/pkg.e2e.ts
+++ b/e2e/harmony/pkg.e2e.ts
@@ -27,6 +27,7 @@ describe('pkg extension', function () {
 
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       helper.fixtures.createComponentUtilsIsType();
@@ -55,7 +56,7 @@ describe('pkg extension', function () {
     describe('after import', () => {
       before(() => {
         helper.command.tagAllComponents();
-        helper.command.exportAllComponents();
+        helper.command.export();
         helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();
         helper.command.importComponent('bar/foo');

--- a/e2e/harmony/relative-paths.e2e.3.ts
+++ b/e2e/harmony/relative-paths.e2e.3.ts
@@ -64,7 +64,7 @@ describe('relative paths flow (components requiring each other by relative paths
         });
         describe('should work after importing to another workspace', () => {
           before(() => {
-            helper.command.exportAllComponentsAndRewire();
+            helper.command.exportToDefaultAndRewire();
             helper.scopeHelper.reInitLocalScope();
             helper.scopeHelper.addRemoteScope();
             helper.command.importComponent('comp1');

--- a/e2e/harmony/set-default-owner-and-scope.e2e.4.ts
+++ b/e2e/harmony/set-default-owner-and-scope.e2e.4.ts
@@ -51,10 +51,10 @@ describe('set default owner and scope', function () {
     describe('after export', () => {
       let exportOutput;
       before(() => {
-        exportOutput = helper.command.exportAllComponents();
+        exportOutput = helper.command.export();
       });
       it('should export the component to correct scope', () => {
-        expect(exportOutput).to.have.string('exported 1 components');
+        expect(exportOutput).to.have.string('exported the following 1 component');
         expect(exportOutput).to.have.string(defaultScope);
       });
       describe('validate models data', () => {

--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -21,7 +21,7 @@ describe('sign command', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(2);
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       // yes, this is strange, it adds the remote-scope to itself as a remote. we need it because
       // we run "action" command from the remote to itself to clear the cache. (needed because
       // normally bit-sign is running from the fs but a different http service is running as well)
@@ -60,7 +60,7 @@ describe('sign command', function () {
       helper.fs.outputFile('bar/foo.spec.js'); // it will fail as it doesn't have any test
       helper.command.addComponent('bar');
       helper.command.tagAllWithoutBuild();
-      helper.command.exportAllComponents();
+      helper.command.export();
       // yes, this is strange, it adds the remote-scope to itself as a remote. we need it because
       // we run "action" command from the remote to itself to clear the cache. (needed because
       // normally bit-sign is running from the fs but a different http service is running as well)

--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -23,7 +23,7 @@ describe('tag components on Harmony', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents();
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.scopeHelper.addRemoteScope();
       helper.command.importComponent('comp1');
@@ -58,7 +58,7 @@ describe('tag components on Harmony', function () {
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents();
       helper.command.tagAllComponents();
-      helper.command.exportAllComponents();
+      helper.command.export();
       helper.command.tagScope('0.0.2');
     });
     it('should not show the component as modified', () => {

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -10,10 +10,14 @@ import R from 'ramda';
 export class ExportCmd implements Command {
   name = 'export [remote] [id...]';
   description = `export components to a remote scope.
-  bit export <remote> [id...] => export (optionally given ids) to the specified remote
-  bit export <remote> <lane...> => export the specified lanes to the specified remote
-  bit export ${CURRENT_UPSTREAM} [id...] => export (optionally given ids) to their current scope
   bit export => export all staged components to their current scope
+  Legacy:
+  bit export <remote> [id...] => export (optionally given ids) to the specified remote
+  bit export ${CURRENT_UPSTREAM} [id...] => export (optionally given ids) to their current scope
+  Harmony:
+  bit export [id...] => export (optionally given ids) to their current scope
+  bit export <remote> <lane...> => export the specified lanes to the specified remote
+
   https://${BASE_DOCS_DOMAIN}/docs/export
   ${WILDCARD_HELP('export remote-scope')}`;
   alias = 'e';

--- a/src/api/consumer/lib/export.ts
+++ b/src/api/consumer/lib/export.ts
@@ -100,6 +100,11 @@ async function exportComponents({
 }> {
   const consumer: Consumer = await loadConsumer();
   if (consumer.isLegacy && lanes) throw new LanesIsDisabled();
+  if (!consumer.isLegacy && !lanes && remote) {
+    // on Harmony, we don't allow to specify a remote (except lanes), it exports to the default-scope
+    ids.push(remote);
+    remote = null;
+  }
   const { idsToExport, missingScope, idsWithFutureScope, lanesObjects } = await getComponentsToExport(
     ids,
     consumer,

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -268,13 +268,15 @@ export default class CommandHelper {
   exportAllComponentsAndRewire(scope: string = this.scopes.remote) {
     return this.runCmd(`bit export ${scope} --rewire --force`);
   }
+  exportToDefaultAndRewire() {
+    return this.runCmd(`bit export --rewire --force`);
+  }
   exportToCurrentScope(ids?: string) {
     return this.runCmd(`bit export ${CURRENT_UPSTREAM} ${ids || ''}`);
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  export(options? = '') {
+  export(options = '') {
     // --force just silents the prompt, which obviously needed for CIs
-    return this.runCmd(`bit export --force ${options}`);
+    return this.runCmd(`bit export ${options} --force`);
   }
   resumeExport(exportId: string, remotes: string[]) {
     return this.runCmd(`bit resume-export ${exportId} ${remotes.join(' ')}`);


### PR DESCRIPTION
Since the introduction of `defaultScope` no need to enter the scope-name. The components are exported to their current scope or `defaultScope` if they're new.
The way to "fork" a component is to change the default-scope (for now at least) and then `bit export`. 

Implements #4098.