### PR TITLE
replace the hard-links from node-modules to source files with soft-links

### DIFF
--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -176,7 +176,7 @@ export default class NodeModuleLinker {
       const fileWithRootDir = componentMap.hasRootDir() ? path.join(componentMap.rootDir as string, file) : file;
       const dest = path.join(componentNodeModulesPath, file);
 
-      this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId));
+      this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId, true));
     });
     this._deleteExistingLinksRootIfSymlink(componentNodeModulesPath);
     // remove this for now, it should be handled by dependency-linker.addSymlinkFromComponentDirNMToWorkspaceDirNM
@@ -252,7 +252,7 @@ export default class NodeModuleLinker {
         this.dataToPersist.addFile(linkFile);
       } else {
         // it's an un-supported file, or it's Harmony version and above, create a symlink instead
-        this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId, component.isLegacy));
+        this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId, true));
       }
     });
     this._deleteExistingLinksRootIfSymlink(linkPath);


### PR DESCRIPTION
Due to the recent change of replacing all soft-link to hard-link, the IDE navigates form one component to the node-modules of the other component, instead of going to the component source files.
Another issue is that we get errors such:
```
Type 'import("/Users/davidfirst/teambit/bit/scopes/pipelines/builder/task-results-list").TaskResultsList[]' is not assignable to type 'import("/Users/davidfirst/teambit/bit/node_modules/@teambit/builder/task-results-list").TaskResultsList[]'.
```
It's happening because typescript fails to see that these two files are linked via hard-link. (same inode).