### PR TITLE
throw a descriptive error when getSnap cannot find the snap

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -59,7 +59,7 @@ export class ScopeComponentLoader {
   }
 
   async getSnap(id: ComponentID, hash: string): Promise<Snap> {
-    const version = (await this.scope.legacyScope.objects.load(new Ref(hash))) as Version;
+    const version = (await this.scope.legacyScope.objects.load(new Ref(hash), true)) as Version;
     return this.createSnapFromVersion(version);
   }
 


### PR DESCRIPTION
Currently, it shows a cryptic error.