### PR TITLE
update `bit lint` cmd to support component arg & `changed` option

### DIFF
--- a/scopes/defender/linter/lint.cmd.ts
+++ b/scopes/defender/linter/lint.cmd.ts
@@ -1,24 +1,35 @@
 import { Timer } from '@teambit/legacy/dist/toolbox/timer';
-import { Command } from '@teambit/cli';
-import { ComponentFactory } from '@teambit/component';
+import { Command, CommandOptions } from '@teambit/cli';
+import { ComponentFactory, ComponentID } from '@teambit/component';
 import { Logger } from '@teambit/logger';
+import { Workspace } from '@teambit/workspace';
 import { LinterMain } from './linter.main.runtime';
 
+export type LinterOptions = {
+  changed?: boolean;
+};
+
 export class LintCmd implements Command {
-  name = 'lint';
-  description = 'lint subset of components in your workspace.';
+  name = 'lint [component...]';
+  description = 'lint components in your workspace.';
   group = 'component';
-  options = [];
+  options = [['c', 'changed', 'lint only new and modified components']] as CommandOptions;
 
-  constructor(private linter: LinterMain, private componentHost: ComponentFactory, private logger: Logger) {}
+  constructor(
+    private linter: LinterMain,
+    private componentHost: ComponentFactory,
+    private logger: Logger,
+    private workspace: Workspace
+  ) {}
 
-  async report() {
+  async report([components]: [string[]], linterOptions: LinterOptions) {
     const timer = Timer.create();
     timer.start();
 
-    const components = await this.componentHost.list();
-    const linterResults = await this.linter.lint(components);
-    this.logger.consoleTitle(`linting total of ${components.length} in workspace '${this.componentHost.name}'`);
+    const componentsIds = await this.getIdsToLint(components, linterOptions.changed);
+    const componentsToLint = await this.workspace.getMany(componentsIds);
+    const linterResults = await this.linter.lint(componentsToLint);
+    this.logger.consoleTitle(`linting total of ${componentsToLint.length} in workspace '${this.componentHost.name}'`);
 
     linterResults.results.forEach((result) => {
       result.data?.results.forEach((lintRes) => {
@@ -28,6 +39,16 @@ export class LintCmd implements Command {
     });
 
     const { seconds } = timer.stop();
-    return `linted ${components.length} components in ${seconds}.`;
+    return `linted ${componentsToLint.length} components in ${seconds}.`;
+  }
+
+  private async getIdsToLint(components: string[], changed = false): Promise<ComponentID[]> {
+    if (components.length) {
+      return this.workspace.resolveMultipleComponentIds(components);
+    }
+    if (changed) {
+      return this.workspace.getNewAndModifiedIds();
+    }
+    return this.componentHost.listIds();
   }
 }

--- a/scopes/defender/linter/linter.main.runtime.ts
+++ b/scopes/defender/linter/linter.main.runtime.ts
@@ -2,6 +2,7 @@ import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { Component, ComponentAspect, ComponentMain } from '@teambit/component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { LoggerAspect, LoggerMain } from '@teambit/logger';
+import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { LinterAspect } from './linter.aspect';
 import { LinterService } from './linter.service';
 import { LintTask } from './lint.task';
@@ -17,11 +18,7 @@ export type LinterConfig = {
 export class LinterMain {
   static runtime = MainRuntime;
 
-  constructor(
-    private envs: EnvsMain,
-
-    private linterService: LinterService
-  ) {}
+  constructor(private envs: EnvsMain, private linterService: LinterService) {}
 
   /**
    * lint an array of components.
@@ -40,21 +37,21 @@ export class LinterMain {
     return new LintTask(LinterAspect.id, name);
   }
 
-  static dependencies = [EnvsAspect, CLIAspect, ComponentAspect, LoggerAspect];
+  static dependencies = [EnvsAspect, CLIAspect, ComponentAspect, LoggerAspect, WorkspaceAspect];
 
   static defaultConfig = {
     extensionFormats: ['.ts', 'tsx', '.js', '.jsx', 'js', 'mjs'],
   };
 
   static async provider(
-    [envs, cli, component, loggerAspect]: [EnvsMain, CLIMain, ComponentMain, LoggerMain],
+    [envs, cli, component, loggerAspect, workspace]: [EnvsMain, CLIMain, ComponentMain, LoggerMain, Workspace],
     config: LinterConfig
   ) {
     const logger = loggerAspect.createLogger(LinterAspect.id);
     const linterService = new LinterService(config);
     const linterAspect = new LinterMain(envs, linterService);
     envs.registerService(linterService);
-    cli.register(new LintCmd(linterAspect, component.getHost(), logger));
+    cli.register(new LintCmd(linterAspect, component.getHost(), logger, workspace));
 
     return linterAspect;
   }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1281,7 +1281,7 @@ export class Workspace implements ComponentFactory {
     return ComponentID.fromLegacy(legacyId, defaultScope);
   }
 
-  async resolveMultipleComponentIds(ids: Array<string | ComponentID | BitId>) {
+  async resolveMultipleComponentIds(ids: Array<string | ComponentID | BitId>): Promise<ComponentID[]> {
     return Promise.all(ids.map(async (id) => this.resolveComponentId(id)));
   }
 


### PR DESCRIPTION
## Proposed Changes

- Adding the option to pass a "component" argument to only lint this component
- Adding the `-c` option to only lint changed/new components in the current workspace