### PR TITLE
Capsules filter components upcoming version + do not mutate scope component

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ It unlocks the development and composition of modern applications from independe
 
 The [component cloud platform](https://bit.dev/) is a component marketplace as-a-service, where teams can smoothly scale collaboration on components to many developers and applications. Developers can host, discover, and share components while continuously releasing small updates to everyone in the organization. Everything is free for open-source developers.
 
-Modularity benefits almost every part of the development process, from [accelerating releases](https://www.youtube.com/watch?v=yDjTcBKXKDE) to making debugging or refactoring much simpler. For teams, Bit is often used as a solution for a verity of ]use-cases](https://blog.bitsrc.io/4-bit-use-cases-build-like-the-best-teams-1c36560c7c6e) such as Micro Frontends, Design Systems, Delivery Speed, and Collaboration on components.
+Modularity benefits almost every part of the development process, from [accelerating releases](https://www.youtube.com/watch?v=yDjTcBKXKDE) to making debugging or refactoring much simpler. For teams, Bit is often used as a solution for a verity of [use-cases](https://blog.bitsrc.io/4-bit-use-cases-build-like-the-best-teams-1c36560c7c6e) such as Micro Frontends, Design Systems, Delivery Speed, and Collaboration on components.
 
 [![Bit](https://storage.googleapis.com/static.bit.dev/harmony-docs/homepage-components-micro-frontends.png)](https://bit.dev/)
 

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -6,6 +6,8 @@ import { PubsubAspect, PubsubMain } from '@teambit/pubsub';
 import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import { Component } from '@teambit/component';
 import { BitId } from '@teambit/legacy-bit-id';
+import { BuilderMain } from '@teambit/builder';
+
 import ManyComponentsWriter from '@teambit/legacy/dist/consumer/component-ops/many-components-writer';
 import { CompilerService } from './compiler.service';
 import { CompilerAspect } from './compiler.aspect';
@@ -15,7 +17,6 @@ import { Compiler } from './types';
 import { WorkspaceCompiler } from './workspace-compiler';
 import { DistArtifact } from './dist-artifact';
 import { DistArtifactNotFound } from './exceptions';
-import { BuilderMain } from '@teambit/builder';
 
 export class CompilerMain {
   constructor(
@@ -63,7 +64,7 @@ export class CompilerMain {
 
   static dependencies = [CLIAspect, WorkspaceAspect, EnvsAspect, LoggerAspect, PubsubAspect, AspectLoaderAspect];
 
-  static async provider([cli, workspace, envs, loggerMain, pubsub, aspectLoader]: [
+  static async provider([cli, workspace, envs, loggerMain, pubsub, aspectLoader, builder]: [
     CLIMain,
     Workspace,
     EnvsMain,

--- a/scopes/compilation/compiler/dist-artifact.ts
+++ b/scopes/compilation/compiler/dist-artifact.ts
@@ -1,0 +1,11 @@
+import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
+
+export class DistArtifact {
+  constructor(private artifacts: AbstractVinyl[]) {}
+
+  getFile(path: string) {
+    return this.artifacts.find((file) => {
+      return file.relative === path;
+    });
+  }
+}

--- a/scopes/compilation/compiler/exceptions/dist-artifact-not-found.ts
+++ b/scopes/compilation/compiler/exceptions/dist-artifact-not-found.ts
@@ -1,0 +1,8 @@
+import { ComponentID } from '@teambit/component';
+import { BitError } from '@teambit/bit-error';
+
+export class DistArtifactNotFound extends BitError {
+  constructor(readonly componentId: ComponentID) {
+    super(`dist artifact for component ${componentId.toString()} was not found`);
+  }
+}

--- a/scopes/compilation/compiler/exceptions/index.ts
+++ b/scopes/compilation/compiler/exceptions/index.ts
@@ -1,0 +1,1 @@
+export { DistArtifactNotFound } from './dist-artifact-not-found';

--- a/scopes/component/graph/graph-builder.ts
+++ b/scopes/component/graph/graph-builder.ts
@@ -1,26 +1,36 @@
-import { ComponentID, ComponentMain } from '@teambit/component';
+import { ComponentFactory, ComponentID, ComponentMain } from '@teambit/component';
 import type LegacyGraph from '@teambit/legacy/dist/scope/graph/graph';
 import { ComponentGraph } from './component-graph';
 import { Dependency } from './model/dependency';
 
+type GetGraphOpts = {
+  host?: ComponentFactory;
+};
+
+type BuildFromLegacyGraphOpts = {
+  host?: ComponentFactory;
+};
 export class GraphBuilder {
   _graph?: ComponentGraph;
   _initialized = false;
   constructor(private componentAspect: ComponentMain) {}
 
-  async getGraph(ids?: ComponentID[]): Promise<ComponentGraph> {
-    const componentHost = this.componentAspect.getHost();
-    const legacyGraph = await componentHost.getLegacyGraph(ids);
-    const graph = await this.buildFromLegacy(legacyGraph);
+  async getGraph(ids?: ComponentID[], opts: GetGraphOpts = {}): Promise<ComponentGraph> {
+    const componentHost = opts.host || this.componentAspect.getHost();
 
+    const legacyGraph = await componentHost.getLegacyGraph(ids);
+    const graph = await this.buildFromLegacy(legacyGraph, { host: opts.host });
     this._graph = graph;
     this._initialized = true;
     return this._graph;
   }
 
-  private async buildFromLegacy(legacyGraph: LegacyGraph): Promise<ComponentGraph> {
+  private async buildFromLegacy(
+    legacyGraph: LegacyGraph,
+    opts: BuildFromLegacyGraphOpts = {}
+  ): Promise<ComponentGraph> {
     const newGraph = new ComponentGraph();
-    const componentHost = this.componentAspect.getHost();
+    const componentHost = opts.host || this.componentAspect.getHost();
 
     const setNodeP = legacyGraph.nodes().map(async (nodeId) => {
       const componentId = await componentHost.resolveComponentId(nodeId);

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1,7 +1,7 @@
 import { MainRuntime } from '@teambit/cli';
 import { compact, pick } from 'lodash';
 import { Component, ComponentMap, ComponentAspect, ComponentID } from '@teambit/component';
-import type { ComponentMain } from '@teambit/component';
+import type { ComponentMain, ComponentFactory } from '@teambit/component';
 import { getComponentPackageVersion } from '@teambit/component-package-version';
 import { GraphAspect } from '@teambit/graph';
 import type { GraphBuilder } from '@teambit/graph';
@@ -59,6 +59,11 @@ type CreateGraphOptions = {
    * include components that exists in nested hosts. for example include components that exist in scope but not in the workspace
    */
   includeFromNestedHosts?: boolean;
+
+  /**
+   * Force specific host to get the component from.
+   */
+  host?: ComponentFactory;
 };
 
 export type IsolateComponentsOptions = CreateGraphOptions & {
@@ -105,6 +110,11 @@ export type IsolateComponentsOptions = CreateGraphOptions & {
    * do not build graph with all dependencies. isolate the seeders only.
    */
   seedersOnly?: boolean;
+
+  /**
+   * Force specific host to get the component from.
+   */
+  host?: ComponentFactory;
 };
 
 type CapsulePackageJsonData = {
@@ -152,8 +162,15 @@ export class IsolatorMain {
   ): Promise<Network> {
     const host = this.componentAspect.getHost();
     const longProcessLogger = this.logger.createLongProcessLogger('create capsules network');
-    legacyLogger.debug(`isolatorExt, createNetwork ${seeders.join(', ')}. opts: ${JSON.stringify(opts)}`);
-    const createGraphOpts = pick(opts, 'includeFromNestedHosts');
+    if (opts.host) {
+      console.log('i have host');
+    }
+    legacyLogger.debug(
+      `isolatorExt, createNetwork ${seeders.join(', ')}. opts: ${JSON.stringify(
+        Object.assign({}, opts, { host: opts.host?.name })
+      )}`
+    );
+    const createGraphOpts = pick(opts, ['includeFromNestedHosts', 'host']);
     const componentsToIsolate = opts.seedersOnly
       ? await host.getMany(seeders)
       : await this.createGraph(seeders, createGraphOpts);
@@ -166,7 +183,8 @@ export class IsolatorMain {
 
   private async createGraph(seeders: ComponentID[], opts: CreateGraphOptions = {}): Promise<Component[]> {
     const host = this.componentAspect.getHost();
-    const graph = await this.graphBuilder.getGraph(seeders);
+    const getGraphOpts = pick(opts, ['host']);
+    const graph = await this.graphBuilder.getGraph(seeders, getGraphOpts);
     const successorsSubgraph = graph.successorsSubgraph(seeders.map((id) => id.toString()));
     const compsAndDeps = successorsSubgraph.nodes.map((node) => node.attr);
     // do not ignore the version here. a component might be in .bitmap with one version and

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -162,9 +162,6 @@ export class IsolatorMain {
   ): Promise<Network> {
     const host = this.componentAspect.getHost();
     const longProcessLogger = this.logger.createLongProcessLogger('create capsules network');
-    if (opts.host) {
-      console.log('i have host');
-    }
     legacyLogger.debug(
       `isolatorExt, createNetwork ${seeders.join(', ')}. opts: ${JSON.stringify(
         Object.assign({}, opts, { host: opts.host?.name })

--- a/scopes/component/isolator/symlink-dependencies-to-capsules.ts
+++ b/scopes/component/isolator/symlink-dependencies-to-capsules.ts
@@ -36,6 +36,7 @@ async function symlinkComponent(component: ConsumerComponent, capsuleList: Capsu
   if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
   const allDeps = component.getAllDependenciesIds();
   const symlinks = allDeps.map((depId: BitId) => {
+    // TODO: this is dangerous - we might have 2 capsules for the same component with different version, then we might link to the wrong place
     const devCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(new ComponentID(depId));
     if (!devCapsule) {
       // happens when a dependency is not in the workspace. (it gets installed via the package manager)

--- a/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
@@ -139,7 +139,14 @@ function filterComponents(dependencyList: DependencyList, componentsToFilterOut:
       if (!component.id.hasVersion()) {
         return component.id.toString() === dep.componentId.toString({ ignoreVersion: true });
       }
-      return component.id._legacy.isEqual(dep.componentId._legacy);
+      // We are checking against both component.id._legacy and component.state._consumer.id
+      // Because during tag operation, the component.id._legacy has the current version (before the tag)
+      // while the component.state._consumer.id has the upcoming version (the version that will be after the tag)
+      // The dependency in some cases is already updated to the upcoming version
+      return (
+        component.id._legacy.isEqual(dep.componentId._legacy) ||
+        component.state._consumer.id.isEqual(dep.componentId._legacy)
+      );
     });
     if (existingComponent) return false;
     return true;

--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -12,8 +12,9 @@ export class ScopeComponentLoader {
 
   async get(id: ComponentID): Promise<Component | undefined> {
     const idStr = id.toString();
-    if (this.componentsCache[idStr]) {
-      return this.componentsCache[idStr];
+    const fromCache = this.componentsCache[idStr];
+    if (fromCache) {
+      return fromCache;
     }
     this.logger.debug(`ScopeComponentLoader.get, loading ${idStr}`);
     const legacyId = id._legacy;

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -369,6 +369,7 @@ export class ScopeMain implements ComponentFactory {
         skipIfExists: true,
         includeFromNestedHosts: true,
         installOptions: { copyPeerToRuntimeOnRoot: true },
+        host: this,
       },
       this.legacyScope
     );

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -113,8 +113,16 @@ export class WorkspaceComponentLoader {
       consumerComponent
     );
     if (componentFromScope) {
-      componentFromScope.state = state;
-      const workspaceComponent = WorkspaceComponent.fromComponent(componentFromScope, this.workspace);
+      // Removed by @gilad. do not mutate the component from the scope
+      // componentFromScope.state = state;
+      // const workspaceComponent = WorkspaceComponent.fromComponent(componentFromScope, this.workspace);
+      const workspaceComponent = new WorkspaceComponent(
+        componentFromScope.id,
+        componentFromScope.head,
+        state,
+        componentFromScope.tags,
+        this.workspace
+      );
       return this.executeLoadSlot(workspaceComponent);
     }
     return this.executeLoadSlot(this.newComponentFromState(id, state));


### PR DESCRIPTION
## Proposed Changes

- do not mutate scope component by workspace component
- filter components with the upcoming version (by tag) from workspace manifest
- provide an option to pass host to isolator and pass it when loading aspects from the scope
- get dists files api for compiler
