### PR TITLE
add the ability to hide templates for `bit templates` cmd

### DIFF
--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -55,6 +55,11 @@ export interface ComponentTemplate {
   description?: string;
 
   /**
+   * hide this template so that it is not listed with `bit templates`
+   */
+  hidden?: boolean;
+
+  /**
    * template function for generating the file of a certain component.,
    */
   generateFiles(context: ComponentContext): ComponentFile[];

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -17,7 +17,7 @@ import { NewCmd, NewOptions } from './new.cmd';
 export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
 export type WorkspaceTemplateSlot = SlotRegistry<WorkspaceTemplate[]>;
 
-export type TemplateDescriptor = { aspectId: string; name: string; description?: string };
+export type TemplateDescriptor = { aspectId: string; name: string; description?: string; hidden?: boolean };
 
 export type GeneratorConfig = {
   /**
@@ -63,6 +63,7 @@ export class GeneratorMain {
         aspectId: id,
         name: template.name,
         description: template.description,
+        hidden: template.hidden,
       }));
     }
     const allTemplates = this.getAllWorkspaceTemplatesFlattened();
@@ -70,6 +71,7 @@ export class GeneratorMain {
       aspectId: id,
       name: template.name,
       description: template.description,
+      hidden: template.hidden,
     }));
   }
 

--- a/scopes/generator/generator/templates.cmd.ts
+++ b/scopes/generator/generator/templates.cmd.ts
@@ -3,10 +3,8 @@ import chalk from 'chalk';
 import { groupBy } from 'lodash';
 import { GeneratorMain, TemplateDescriptor } from './generator.main.runtime';
 
-export type GeneratorOptions = {
-  namespace?: string;
-  aspect?: string;
-  scope?: string;
+export type TemplatesOptions = {
+  showAll?: boolean;
 };
 
 export class TemplatesCmd implements Command {
@@ -17,12 +15,19 @@ export class TemplatesCmd implements Command {
   alias = '';
   loader = true;
   group = 'development';
-  options = [] as CommandOptions;
+  options = [['s', 'show-all', 'show hidden templates']] as CommandOptions;
 
   constructor(private generator: GeneratorMain) {}
 
-  async report() {
-    const results = await this.generator.listComponentTemplates();
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async report(args: [], templatesOptions: TemplatesOptions) {
+    let results = await this.generator.listComponentTemplates();
+
+    // Make sure that we don't list hidden templates
+    if (!templatesOptions.showAll) {
+      results = results.filter((template) => !template.hidden);
+    }
+
     const grouped = groupBy(results, 'aspectId');
     const title = chalk.green(`the following template(s) are available\n`);
     const templateOutput = (template: TemplateDescriptor) => {

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -30,6 +30,11 @@ export interface WorkspaceTemplate {
   description?: string;
 
   /**
+   * hide this template so that it is not listed with `bit templates`
+   */
+  hidden?: boolean;
+
+  /**
    * template function for generating the template files,
    */
   generateFiles(context: WorkspaceContext): WorkspaceFile[];


### PR DESCRIPTION
## Proposed Changes

I added a hidden property on templates so that they don't show up when you use `bit templates` (just to make sure that no one uses this for now).
You can use `bit templates --show-all` to show hidden templates.