### PR TITLE
fix tagging mdx components

### DIFF
--- a/scopes/docs/docs/docs.main.runtime.ts
+++ b/scopes/docs/docs/docs.main.runtime.ts
@@ -42,6 +42,7 @@ export type DocsConfig = {
  */
 export class DocsMain {
   constructor(
+    private patterns: string[],
     /**
      * envs extension.
      */
@@ -127,6 +128,10 @@ export class DocsMain {
     return new Doc(docData.filePath, new DocPropList(docData.props));
   }
 
+  getPatterns() {
+    return this.patterns;
+  }
+
   /**
    * register a new doc reader. this allows to support further
    * documentation file formats.
@@ -168,7 +173,25 @@ export class DocsMain {
     [docPropSlot, docReaderSlot]: [DocPropSlot, DocReaderSlot]
   ) {
     const logger = loggerAspect.createLogger(DocsAspect.id);
-    const docs = new DocsMain(preview, pkg, compiler, workspace, logger, devFiles, docPropSlot, docReaderSlot);
+    const docs = new DocsMain(
+      config.patterns,
+
+      preview,
+
+      pkg,
+
+      compiler,
+
+      workspace,
+
+      logger,
+
+      devFiles,
+
+      docPropSlot,
+
+      docReaderSlot
+    );
     docs.registerDocReader(new DefaultDocReader(pkg, compiler, workspace));
     devFiles.registerDevPattern(config.patterns);
 

--- a/scopes/mdx/mdx/index.ts
+++ b/scopes/mdx/mdx/index.ts
@@ -1,5 +1,6 @@
 import { MDXAspect } from './mdx.aspect';
 
 export default MDXAspect;
-export type { MDXMain, MDXCompilerOpts } from './mdx.main.runtime';
+export type { MDXMain } from './mdx.main.runtime';
+export type { MDXCompilerOpts } from './mdx.compiler';
 export { MDXAspect };

--- a/scopes/mdx/mdx/mdx.compiler.ts
+++ b/scopes/mdx/mdx/mdx.compiler.ts
@@ -3,7 +3,12 @@ import { outputFileSync } from 'fs-extra';
 import { Compiler, TranspileOutput, TranspileOpts } from '@teambit/compiler';
 import { BuiltTaskResult, BuildContext } from '@teambit/builder';
 import { compileSync } from '@teambit/modules.mdx-compiler';
+import minimatch from 'minimatch';
 
+export type MDXCompilerOpts = {
+  ignoredExtensions?: string[];
+  ignoredPatterns?: string[];
+};
 export class MDXCompiler implements Compiler {
   displayName = 'MDX';
 
@@ -11,7 +16,7 @@ export class MDXCompiler implements Compiler {
 
   distDir = 'dist';
 
-  constructor(readonly id: string, readonly config: any) {}
+  constructor(readonly id: string, readonly config: MDXCompilerOpts) {}
 
   displayConfig() {
     return JSON.stringify(this.config, null, 2);
@@ -46,7 +51,7 @@ export class MDXCompiler implements Compiler {
       const errors = srcFiles.map((srcFile) => {
         try {
           const output = compileSync(srcFile.contents.toString('utf-8'));
-          outputFileSync(join(capsule.path, 'dist', this.getDistPathBySrcPath(srcFile.path)), output.contents);
+          outputFileSync(join(capsule.path, this.getDistPathBySrcPath(srcFile.path)), output.contents);
           return undefined;
         } catch (err) {
           return err;
@@ -75,14 +80,23 @@ export class MDXCompiler implements Compiler {
    * both, the return path and the given path are relative paths.
    */
   getDistPathBySrcPath(srcPath: string): string {
-    return join(srcPath.replace('.mdx', '.mdx.js'));
+    let fileWithNewExt = srcPath;
+    if (this.isFileSupported(srcPath)) {
+      fileWithNewExt = srcPath.replace('.mdx', '.mdx.js');
+    }
+
+    return join(this.distDir, fileWithNewExt);
   }
 
   /**
    * only supported files matching get compiled. others, are copied to the dist dir.
    */
   isFileSupported(filePath: string): boolean {
-    return filePath.endsWith('.mdx') || filePath.endsWith('.md');
+    const ignoredExtensions = this.config.ignoredExtensions ?? [];
+    const ignoredExt = ignoredExtensions.find((ext) => filePath.endsWith(ext));
+    const ignoredPatterns = this.config.ignoredPatterns ?? [];
+    const ignoredPattern = ignoredPatterns.find((pattern) => minimatch(filePath, pattern));
+    return !ignoredExt && !ignoredPattern && (filePath.endsWith('.mdx') || filePath.endsWith('.md'));
   }
 
   /**

--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -7,13 +7,11 @@ import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import MultiCompilerAspect, { MultiCompilerMain } from '@teambit/multi-compiler';
 import ReactAspect, { ReactMain } from '@teambit/react';
 import { MDXAspect } from './mdx.aspect';
-import { MDXCompiler } from './mdx.compiler';
+import { MDXCompiler, MDXCompilerOpts } from './mdx.compiler';
 import { MDXDependencyDetector } from './mdx.detector';
 import { MDXDocReader } from './mdx.doc-reader';
 
 const babelConfig = require('./babel/babel.config');
-
-export type MDXCompilerOpts = {};
 
 export type MDXConfig = {
   /**
@@ -64,7 +62,11 @@ export class MDXMain {
   ) {
     const mdx = new MDXMain();
     const mdxCompiler = multiCompiler.createCompiler(
-      [mdx.createCompiler(), babel.createCompiler(babelConfig), react.reactEnv.getCompiler()],
+      [
+        mdx.createCompiler({ ignoredPatterns: docs.getPatterns() }),
+        babel.createCompiler(babelConfig),
+        react.reactEnv.getCompiler(),
+      ],
       {}
     );
     const mdxEnv = envs.compose(react.reactEnv, [


### PR DESCRIPTION
## Proposed Changes

- add new API for docs aspect to get the patterns
- do not compile mdx files that matches the docs pattern by the mdx compiler
- fix should copy non supported files for multi compiler
- get the dist path for src file by the multi compiler by the first matching compiler
