### PR TITLE
fix bit-status when importing scss files (regression due to #4135)

### DIFF
--- a/build-harmony/package.json
+++ b/build-harmony/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@teambit/bit": "*"
+    "@teambit/bit": "0.0.371"
   },
   "resolutions": {
     "@teambit/bit/core-js": "3.8.3"

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -218,54 +218,77 @@ export default class NodeModuleLinker {
       defaultScope: this._getDefaultScope(component),
       extensions: component.extensions,
     });
-    const componentMap = component.componentMap as ComponentMap;
-    if (component.isLegacy) {
-      const filesToBind = componentMap.getAllFilesPaths();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      component.dists.updateDistsPerWorkspaceConfig(component.id, this.consumer, component.componentMap);
-      filesToBind.forEach((file) => {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        const isMain = file === componentMap.mainFile;
-        const fileWithRootDir = componentMap.hasRootDir() ? path.join(componentMap.rootDir as string, file) : file;
-        const possiblyDist = component.dists.calculateDistFileForAuthored(
-          path.normalize(fileWithRootDir),
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          this.consumer,
-          isMain
-        );
-        const dest = path.join(linkPath, file);
-        const destRelative = getPathRelativeRegardlessCWD(path.dirname(dest), possiblyDist);
-        const fileContent = getLinkToFileContent(destRelative);
-        // if component.compiler is set, this component is working with the old compiler (< v15)
-        // and not with compile extension. as such, the dists for author are in the root, not in the
-        // component directory. Having symlinks here instead of links causes import of module-paths to
-        // break. try e2e-test: 'as author, move individual component files to dedicated directory with bit move --component'
-        if (fileContent && component.compiler) {
-          const linkFile = LinkFile.load({
-            filePath: dest,
-            content: fileContent,
-            srcPath: file,
-            componentId,
-            override: true,
-            ignorePreviousSymlink: true, // in case the component didn't have a compiler before, this file was a symlink
-          });
-          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-          this.dataToPersist.addFile(linkFile);
-        } else {
-          // it's an un-supported file, or it's Harmony version and above, create a symlink instead
-          this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, componentId, true));
-        }
-      });
-    } else {
-      // on Harmony, just symlink the entire source directory into "src" in node-modules.
-      this.dataToPersist.addSymlink(
-        Symlink.makeInstance(componentMap.rootDir as string, path.join(linkPath, 'src'), componentId)
-      );
-    }
+
+    component.isLegacy
+      ? this.symlinkFilesAuthorLegacy(component, linkPath)
+      : this.symlinkDirAuthorHarmony(component, linkPath);
 
     this._deleteExistingLinksRootIfSymlink(linkPath);
     this._deleteOldLinksOfIdWithoutScope(component);
     await this._createPackageJsonForAuthor(component);
+  }
+
+  private symlinkFilesAuthorLegacy(component: Component, linkPath: PathOsBasedRelative) {
+    const componentMap = component.componentMap as ComponentMap;
+    const filesToBind = componentMap.getAllFilesPaths();
+    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    component.dists.updateDistsPerWorkspaceConfig(component.id, this.consumer, component.componentMap);
+    filesToBind.forEach((file) => {
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      const isMain = file === componentMap.mainFile;
+      const fileWithRootDir = componentMap.hasRootDir() ? path.join(componentMap.rootDir as string, file) : file;
+      const possiblyDist = component.dists.calculateDistFileForAuthored(
+        path.normalize(fileWithRootDir),
+        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        this.consumer,
+        isMain
+      );
+      const dest = path.join(linkPath, file);
+      const destRelative = getPathRelativeRegardlessCWD(path.dirname(dest), possiblyDist);
+      const fileContent = getLinkToFileContent(destRelative);
+      // if component.compiler is set, this component is working with the old compiler (< v15)
+      // and not with compile extension. as such, the dists for author are in the root, not in the
+      // component directory. Having symlinks here instead of links causes import of module-paths to
+      // break. try e2e-test: 'as author, move individual component files to dedicated directory with bit move --component'
+      if (fileContent && component.compiler) {
+        const linkFile = LinkFile.load({
+          filePath: dest,
+          content: fileContent,
+          srcPath: file,
+          componentId: component.id,
+          override: true,
+          ignorePreviousSymlink: true, // in case the component didn't have a compiler before, this file was a symlink
+        });
+        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        this.dataToPersist.addFile(linkFile);
+      } else {
+        // it's an un-supported file, or it's Harmony version and above, create a symlink instead
+        this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id, true));
+      }
+    });
+  }
+
+  /**
+   * on Harmony, just symlink the entire source directory into "src" in node-modules.
+   */
+  private symlinkDirAuthorHarmony(component: Component, linkPath: PathOsBasedRelative) {
+    const componentMap = component.componentMap as ComponentMap;
+
+    this.dataToPersist.addSymlink(
+      Symlink.makeInstance(componentMap.rootDir as string, path.join(linkPath, 'src'), component.id)
+    );
+
+    // some files, such as .scss are imported with internal paths, not from the main index file.
+    // as such, the symlink of 'src' dir, won't help. bit-status shows missing packages.
+    const filesToBind = componentMap.getAllFilesPaths();
+    const extToSymlink = ['.scss'];
+    filesToBind.forEach((file) => {
+      if (extToSymlink.includes(path.extname(file))) {
+        const fileWithRootDir = path.join(componentMap.rootDir as string, file);
+        const dest = path.join(linkPath, file);
+        this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id, true));
+      }
+    });
   }
 
   /**


### PR DESCRIPTION
As a result of not symlinking all files in the workspace one by one, but symlinking the entire dir to 'src' folder (see #4135 ), `bit status` showed errors when importing scss files.
The reason is that scss files are imported using the entire file-path inside the component and not from the main index file. This path didn't exist anymore.
This PR takes care of these files and symlink only them. The rest are handled with the `src` dir symlink.