### PR TITLE
symlink _src dir from node_modules to source files for Windows users only

### DIFF
--- a/e2e/harmony/set-default-owner-and-scope.e2e.4.ts
+++ b/e2e/harmony/set-default-owner-and-scope.e2e.4.ts
@@ -41,9 +41,10 @@ describe('set default owner and scope', function () {
       helper.command.tagAllComponents();
     });
     it('should create link with default owner as prefix', () => {
-      const linkFolderPath = path.normalize(`node_modules/${componentPackageName}/src`);
+      const linkFolderPath = path.normalize(`node_modules/${componentPackageName}`);
+      const linkFullPath = path.join(linkFolderPath, 'is-type.js');
       const outputLinkPath = parsedLinkOutput.legacyLinkResults[0].bound[0].to;
-      expect(outputLinkPath).to.equal(linkFolderPath);
+      expect(outputLinkPath).to.equal(linkFullPath);
       expect(path.join(helper.scopes.localPath, 'node_modules')).to.be.a.directory();
       expect(path.join(helper.scopes.localPath, linkFolderPath)).to.be.a.directory();
     });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -467,3 +467,5 @@ export enum BuildStatus {
 export const CENTRAL_BIT_HUB_URL = `https://${SYMPHONY_URL}/exporter`;
 
 export const CENTRAL_BIT_HUB_NAME = 'bit.dev';
+
+export const SOURCE_DIR_SYMLINK_TO_NM = '_src'; // symlink from node_modules to the workspace sources files

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -5,7 +5,13 @@ import * as path from 'path';
 import R from 'ramda';
 
 import { BitId } from '../bit-id';
-import { COMPONENT_ORIGINS, DEFAULT_BINDINGS_PREFIX, PACKAGE_JSON } from '../constants';
+import {
+  COMPONENT_ORIGINS,
+  DEFAULT_BINDINGS_PREFIX,
+  IS_WINDOWS,
+  PACKAGE_JSON,
+  SOURCE_DIR_SYMLINK_TO_NM,
+} from '../constants';
 import BitMap from '../consumer/bit-map/bit-map';
 import ComponentMap from '../consumer/bit-map/component-map';
 import ComponentsList from '../consumer/component/components-list';
@@ -274,21 +280,22 @@ export default class NodeModuleLinker {
   private symlinkDirAuthorHarmony(component: Component, linkPath: PathOsBasedRelative) {
     const componentMap = component.componentMap as ComponentMap;
 
-    this.dataToPersist.addSymlink(
-      Symlink.makeInstance(componentMap.rootDir as string, path.join(linkPath, 'src'), component.id)
-    );
-
-    // some files, such as .scss are imported with internal paths, not from the main index file.
-    // as such, the symlink of 'src' dir, won't help. bit-status shows missing packages.
     const filesToBind = componentMap.getAllFilesPaths();
-    const extToSymlink = ['.scss'];
     filesToBind.forEach((file) => {
-      if (extToSymlink.includes(path.extname(file))) {
-        const fileWithRootDir = path.join(componentMap.rootDir as string, file);
-        const dest = path.join(linkPath, file);
-        this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id, true));
-      }
+      const fileWithRootDir = path.join(componentMap.rootDir as string, file);
+      const dest = path.join(linkPath, file);
+      this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id));
     });
+
+    if (IS_WINDOWS) {
+      this.dataToPersist.addSymlink(
+        Symlink.makeInstance(
+          componentMap.rootDir as string,
+          path.join(linkPath, SOURCE_DIR_SYMLINK_TO_NM),
+          component.id
+        )
+      );
+    }
   }
 
   /**
@@ -459,9 +466,12 @@ export default class NodeModuleLinker {
     const packageJson = PackageJsonFile.createFromComponent(dest, component);
     if (!this.consumer?.isLegacy) {
       await this._applyTransformers(component, packageJson);
-      // in the workspace, override the "types" and add the "src" prefix.
-      // otherwise, the navigation and auto-complete won't work on the IDE.
-      packageJson.addOrUpdateProperty('types', `src/${component.mainFile}`);
+      if (IS_WINDOWS) {
+        // in the workspace, override the "types" and add the "src" prefix.
+        // otherwise, the navigation and auto-complete won't work on the IDE.
+        // this is for Windows only. For Linux, we use symlinks for the files.
+        packageJson.addOrUpdateProperty('types', `${SOURCE_DIR_SYMLINK_TO_NM}/${component.mainFile}`);
+      }
     }
     if (packageJson.packageJsonObject.version === 'latest') {
       packageJson.packageJsonObject.version = '0.0.1-new';


### PR DESCRIPTION
Practically, roll back #4135 changes for Linux users and apply them only for Windows users.
Also, change the dir of `src` to `_src`, to not conflict with a potential user's src dir.

To sum it up, with this change:
Linux users -> symlink each one of the files. No dir symlink.
Windows users -> symlink each one of the files if possible (admin), otherwise, hard-link. Also, symlink _src to the entire dir.

The reason for this rollback is that sometimes it is needed to import/require an internal file, e.g. for .scss files (see #4178 ) or for config files (webpack/babel).
Therefore, for all users we have to have a symlink/hardlink of each one of the files to the root of node_modules/component-dir. 
Doing so, leaves us with the IDE navigation issue on Windows when using hard-link, because it navigates to the node-modules dir. That's why the symlink of the `_src` dir is needed.