### PR TITLE
hard link source-files from node_modules on Windows only, for Linux, symlink them

### DIFF
--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -284,7 +284,7 @@ export default class NodeModuleLinker {
     filesToBind.forEach((file) => {
       const fileWithRootDir = path.join(componentMap.rootDir as string, file);
       const dest = path.join(linkPath, file);
-      this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id));
+      this.dataToPersist.addSymlink(Symlink.makeInstance(fileWithRootDir, dest, component.id, true));
     });
 
     if (IS_WINDOWS) {

--- a/src/utils/fs/create-symlink-or-copy.ts
+++ b/src/utils/fs/create-symlink-or-copy.ts
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import fsNative from 'fs';
 import * as path from 'path';
-import symlinkOrCopy from 'symlink-or-copy';
 import { IS_WINDOWS } from '../../constants';
 import ShowDoctorError from '../../error/show-doctor-error';
 import logger from '../../logger/logger';
@@ -34,7 +33,19 @@ export default function createSymlinkOrCopy(
   }
 
   function symlink() {
-    IS_WINDOWS ? symlinkOrCopy.sync(srcPath, destPath) : fs.symlinkSync(srcPath, destPath);
+    IS_WINDOWS ? symlinkOrHardLink() : fs.symlinkSync(srcPath, destPath);
+  }
+
+  /**
+   * for Windows. try to symlink, if fails (probably not-admin user), try to link.
+   */
+  function symlinkOrHardLink() {
+    try {
+      fs.symlinkSync(srcPath, destPath);
+    } catch (err) {
+      // it can be a file or directory, we don't know. just run link(), it will junction for dirs and hard-link for files.
+      link();
+    }
   }
 
   function link() {


### PR DESCRIPTION
This was the purpose in https://github.com/teambit/bit/pull/4182. However, in that PR, by mistake it hard-linked for Linux as well.