### PR TITLE
enable deleting files for new components, deprecate "bit untrack"

### DIFF
--- a/e2e/bit-hub/import-from-bit-hub.ts
+++ b/e2e/bit-hub/import-from-bit-hub.ts
@@ -285,9 +285,9 @@ module.exports = function isString() { return isType() +  ' and got is-string'; 
     before(() => {
       helper.scopeHelper.getClonedLocalScope(scopeAfterExport);
 
-      let removeOutput = helper.command.removeComponent('bar/foo', '--delete-files --silent');
+      let removeOutput = helper.command.removeComponent('bar/foo', '--delete-files');
       expect(removeOutput).to.have.string('successfully removed');
-      removeOutput = helper.command.removeComponent('utils/is-string', '--delete-files --silent');
+      removeOutput = helper.command.removeComponent('utils/is-string', '--delete-files');
       expect(removeOutput).to.have.string('successfully removed');
 
       output = helper.command.runCmd(`bit import ${scopeId}/utils/is-string`);

--- a/e2e/commands/import2.e2e.1.ts
+++ b/e2e/commands/import2.e2e.1.ts
@@ -513,7 +513,7 @@ console.log(barFoo.default());`;
       describe('removing is-string', () => {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScope);
-          helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string`, '-f -d -s');
+          helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string`, '-f -d');
         });
         it('should not delete is-type from the filesystem', () => {
           localConsumerFiles = helper.fs.getConsumerFiles();
@@ -1069,7 +1069,7 @@ console.log(barFoo.default());`;
       // intermediate step to make sure all are exported
       expect(exportOutput).to.have.string('exported 2 components');
 
-      const removeOutput = helper.command.removeComponent('utils/is-string', '--delete-files --silent');
+      const removeOutput = helper.command.removeComponent('utils/is-string', '--delete-files');
       expect(removeOutput).to.have.string('successfully removed');
 
       output = helper.command.importComponent('utils/is-string');

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -750,7 +750,7 @@ describe('bit lane command', function () {
     describe('removing a component that has dependents', () => {
       let output;
       before(() => {
-        output = helper.command.removeComponent('comp3 --silent');
+        output = helper.command.removeComponent('comp3');
       });
       it('should stop the process and indicate that a component has dependents', () => {
         expect(output).to.have.string('error: unable to delete');
@@ -759,7 +759,7 @@ describe('bit lane command', function () {
     describe('removing a component that has no dependents', () => {
       let output;
       before(() => {
-        output = helper.command.removeComponent('comp1 --silent');
+        output = helper.command.removeComponent('comp1');
       });
       it('should indicate that the component was removed from the lane', () => {
         expect(output).to.have.string('lane');

--- a/e2e/commands/remove.e2e.1.ts
+++ b/e2e/commands/remove.e2e.1.ts
@@ -41,7 +41,7 @@ describe('bit remove command', function () {
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFoo();
       helper.fixtures.tagComponentBarFoo();
-      output = helper.command.removeComponent('bar/foo -s');
+      output = helper.command.removeComponent('bar/foo');
     });
     it('should remove component', () => {
       expect(output).to.have.string('removed components');
@@ -73,7 +73,7 @@ describe('bit remove command', function () {
     });
     describe('removing the dependent', () => {
       before(() => {
-        output = helper.command.removeComponent('utils/is-string', '--delete-files --silent');
+        output = helper.command.removeComponent('utils/is-string', '--delete-files');
       });
       it('should remove local component', () => {
         expect(output).to.have.string('removed components');
@@ -112,7 +112,7 @@ describe('bit remove command', function () {
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFoo();
       helper.fixtures.tagComponentBarFoo();
-      helper.command.removeComponent('bar/foo', '-t -s');
+      helper.command.removeComponent('bar/foo', '-t');
     });
     it('should  show in bitmap', () => {
       const bitMap = helper.bitMap.read();
@@ -137,7 +137,7 @@ describe('bit remove command', function () {
     describe('without --remote flag', () => {
       let output;
       before(() => {
-        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo -s`);
+        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo`);
       });
       it('should show a successful message', () => {
         expect(output).to.have.string('removed components');
@@ -155,7 +155,7 @@ describe('bit remove command', function () {
     describe('with --remote flag', () => {
       let output;
       before(() => {
-        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo --remote -s`);
+        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo --remote`);
       });
       it('should show a successful message', () => {
         expect(output).to.have.string(`removed components from the remote scope: ${helper.scopes.remote}/bar/foo`);
@@ -178,13 +178,13 @@ describe('bit remove command', function () {
       helper.command.exportAllComponents();
     });
     it('should not remove component with dependencies when -f flag is false', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName} -s`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`);
       expect(output).to.have.string(
         `error: unable to delete ${helper.scopes.remote}/${componentName}, because the following components depend on it:`
       );
     });
     it('should  remove component with dependencies when -f flag is true', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`, '-f -s');
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`, '-f');
       expect(output).to.have.string('removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/${componentName}`);
     });
@@ -203,7 +203,7 @@ describe('bit remove command', function () {
       helper.command.importComponent('global/simple');
     });
     it('should remove components with no dependencies when -f flag is false', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/global/simple -s`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/global/simple`);
       expect(output).to.have.string('removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/global/simple`);
       const bitMap = helper.bitMap.read();
@@ -218,7 +218,7 @@ describe('bit remove command', function () {
       helper.fs.createFile('utils', 'is-type.js', fixtures.isTypeV2);
     });
     it('should not remove modified component ', () => {
-      const output = helper.command.removeComponent('utils/is-type@0.0.1 -s');
+      const output = helper.command.removeComponent('utils/is-type@0.0.1');
       expect(output).to.have.string('error: unable to remove modified components');
       expect(output).to.have.string('utils/is-type');
     });
@@ -257,23 +257,23 @@ describe('bit remove command', function () {
       helper.fixtures.addComponentUtilsIsString();
       helper.command.tagAllComponents();
       helper.fs.createFile('utils', 'is-string.js', fixtures.isStringV2);
-      const output = helper.command.removeComponent('utils/is-string@0.0.1 -s');
+      const output = helper.command.removeComponent('utils/is-string@0.0.1');
       expect(output).to.have.string('error: unable to remove modified components');
       expect(output).to.have.string('utils/is-string@0.0.1');
     });
     it('should not remove component when component is modified', () => {
-      const output = helper.command.removeComponent('utils/is-string -s');
+      const output = helper.command.removeComponent('utils/is-string');
       expect(output).to.have.string('error: unable to remove modified components');
       expect(output).to.have.string('utils/is-string');
     });
     it('should print error msg when trying to remove missing component', () => {
       helper.command.tagAllComponents();
-      const output = helper.command.removeComponent('utils/is-string@0.0.10 -s');
+      const output = helper.command.removeComponent('utils/is-string@0.0.10');
       expect(output).to.have.string('missing components: utils/is-string@0.0.10');
       helper.command.tagAllComponents();
     });
     it('should remove component version only', () => {
-      const output = helper.command.removeComponent('utils/is-string@0.0.2 -s');
+      const output = helper.command.removeComponent('utils/is-string@0.0.2');
       expect(output).to.have.string('successfully removed components');
       expect(output).to.have.string('utils/is-string@0.0.2');
     });
@@ -286,7 +286,7 @@ describe('bit remove command', function () {
       expect(bitMap).to.have.property('utils/is-string');
     });
     it('should remove entire component if specified version is the only one', () => {
-      const output = helper.command.removeComponent('utils/is-string@0.0.1', '-f -s');
+      const output = helper.command.removeComponent('utils/is-string@0.0.1', '-f');
       expect(output).to.have.string('successfully removed components');
       expect(output).to.have.string('utils/is-string');
       const bitMap = helper.bitMap.read();
@@ -309,7 +309,7 @@ describe('bit remove command', function () {
       helper.command.exportAllComponents();
     });
     it('should remove component version only', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string@0.0.2 -s`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string@0.0.2`);
       expect(output).to.have.string('successfully removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-string@0.0.2`);
     });
@@ -318,7 +318,7 @@ describe('bit remove command', function () {
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-string@0.0.1`);
     });
     it('should remove entire component if specified version is the only one', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string@0.0.1 -s`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/utils/is-string@0.0.1`);
       expect(output).to.have.string('successfully removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-string`);
       const listOutput = helper.command.listRemoteScope(true);
@@ -331,7 +331,7 @@ describe('bit remove command', function () {
       expect(output.includes('copy/is-type')).to.be.true;
     });
     it('2 components with same file hash should still work if one component is deleted', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/copy/is-type -s`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/copy/is-type`);
       expect(output).to.have.string('successfully removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/copy/is-type`);
       const listOutput = helper.command.listRemoteScope(true);
@@ -423,7 +423,7 @@ describe('bit remove command', function () {
       helper.fs.deletePath('bar/foo-main.js');
       const status = helper.command.status();
       expect(status).to.have.string('main-file was removed');
-      output = helper.command.removeComponent('bar/foo -s');
+      output = helper.command.removeComponent('bar/foo');
     });
     it('should remove the component successfully', () => {
       expect(output).to.have.string('successfully removed component');
@@ -457,7 +457,7 @@ describe('bit remove command', function () {
       // deleting utils/is-string, causes removal of its dependency utils/is-type as well.
       // a previous bug, deleted also the files associated with utils/is-type, leaving utils/is-type2
       // with missing files from the scope.
-      output = helper.command.removeComponent('utils/is-string -s');
+      output = helper.command.removeComponent('utils/is-string');
     });
     it('should successfully remove', () => {
       expect(output).to.have.string('removed components');

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -459,7 +459,7 @@ describe('bit snap command', function () {
         describe('removing the component', () => {
           before(() => {
             helper.scopeHelper.getClonedLocalScope(scopeWithConflicts);
-            helper.command.removeComponent('bar/foo --silent -f');
+            helper.command.removeComponent('bar/foo -f');
           });
           it('bit status should not show the component', () => {
             const status = helper.command.status();

--- a/e2e/flows/dist-outside-components.e2e.2.ts
+++ b/e2e/flows/dist-outside-components.e2e.2.ts
@@ -186,7 +186,7 @@ export default function foo() { return isString() + ' and got foo v2'; };`;
       describe('removing the component', () => {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(scopeAfterImport);
-          helper.command.removeComponent('bar/foo', '-s');
+          helper.command.removeComponent('bar/foo');
         });
         it('should remove the dist directory as well', () => {
           expect(path.join(helper.scopes.localPath, 'dist/components/bar')).to.not.be.a.path();

--- a/e2e/flows/id-with-wildcard.e2e.2.ts
+++ b/e2e/flows/id-with-wildcard.e2e.2.ts
@@ -83,7 +83,7 @@ describe('component id with wildcard', function () {
       });
       describe('when wildcard does not match any component', () => {
         it('should throw an error saying the wildcard does not match any id', () => {
-          const removeFunc = () => helper.command.removeComponent('none/* -s');
+          const removeFunc = () => helper.command.removeComponent('none/*');
           const error = new NoIdMatchWildcard(['none/*']);
           helper.general.expectToThrow(removeFunc, error);
         });
@@ -95,7 +95,7 @@ describe('component id with wildcard', function () {
           const status = helper.command.statusJson();
           expect(status.stagedComponents).to.have.lengthOf(5);
 
-          output = helper.command.removeComponent('"utils/fs/*" -s');
+          output = helper.command.removeComponent('"utils/fs/*"');
         });
         it('should indicate the removed components', () => {
           expect(output).to.have.string('utils/fs/read');
@@ -119,7 +119,7 @@ describe('component id with wildcard', function () {
       });
       describe('when wildcard does not match any component', () => {
         it('should throw an error saying the wildcard does not match any id', () => {
-          const removeFunc = () => helper.command.removeComponent(`${helper.scopes.remote}/none/* --silent --remote`);
+          const removeFunc = () => helper.command.removeComponent(`${helper.scopes.remote}/none/* --remote`);
           const error = new NoIdMatchWildcard([`${helper.scopes.remote}/none/*`]);
           helper.general.expectToThrow(removeFunc, error);
         });
@@ -127,7 +127,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard match some of the components', () => {
         let output;
         before(() => {
-          output = helper.command.removeComponent(`${helper.scopes.remote}/utils/fs/* --silent --remote`);
+          output = helper.command.removeComponent(`${helper.scopes.remote}/utils/fs/* --remote`);
         });
         it('should indicate the removed components', () => {
           expect(output).to.have.string('utils/fs/read');
@@ -145,7 +145,7 @@ describe('component id with wildcard', function () {
         helper.scopeHelper.reInitRemoteScope();
         helper.command.tagAllComponents();
         helper.command.exportAllComponents();
-        helper.command.removeComponent(`${helper.scopes.remote}/* -s`);
+        helper.command.removeComponent(`${helper.scopes.remote}/*`);
 
         // as an intermediate step, make sure the remote scope has all components
         const ls = helper.command.listRemoteScopeParsed();
@@ -158,7 +158,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard match some of the components', () => {
         let output;
         before(() => {
-          output = helper.command.removeComponent(`${helper.scopes.remote}/utils/fs/* --silent --remote`);
+          output = helper.command.removeComponent(`${helper.scopes.remote}/utils/fs/* --remote`);
         });
         it('should indicate the removed components', () => {
           expect(output).to.have.string('utils/fs/read');

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -404,7 +404,7 @@ describe('components that are not synced between the scope and the consumer', fu
         const bitMap = helper.bitMap.read();
         helper.scopeHelper.getClonedLocalScope(scopeAfterV1);
         helper.bitMap.write(bitMap);
-        helper.command.removeComponent(`${helper.scopes.remote}/bar/foo`, '-r -s');
+        helper.command.removeComponent(`${helper.scopes.remote}/bar/foo`, '-r');
         scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
       });
       describe('bit status', () => {

--- a/e2e/flows/remote-commands-outside-workspace.e2e.2.ts
+++ b/e2e/flows/remote-commands-outside-workspace.e2e.2.ts
@@ -74,7 +74,7 @@ describe('bit remote command', function () {
     describe('bit remove with --remote flag', () => {
       let output;
       before(() => {
-        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo`, '--silent --remote');
+        output = helper.command.removeComponent(`${helper.scopes.remote}/bar/foo`, '--remote');
       });
       it('should not throw an error', () => {
         expect(output).to.have.string('successfully removed');

--- a/e2e/functionalities/components-index.e2e.2.ts
+++ b/e2e/functionalities/components-index.e2e.2.ts
@@ -55,7 +55,7 @@ describe('scope components index mechanism', function () {
       });
       describe('removing the component', () => {
         before(() => {
-          helper.command.removeComponent('bar/foo', '-s');
+          helper.command.removeComponent('bar/foo');
         });
         it('should remove the record from index.json', () => {
           const indexJson = helper.general.getComponentsFromIndexJson();
@@ -78,7 +78,7 @@ describe('scope components index mechanism', function () {
         });
         describe('removing the component', () => {
           before(() => {
-            helper.command.removeComponent('bar/foo', '-s');
+            helper.command.removeComponent('bar/foo');
           });
           it('should remove the record from index.json', () => {
             const indexJson = helper.general.getComponentsFromIndexJson();

--- a/e2e/harmony/http.e2e.ts
+++ b/e2e/harmony/http.e2e.ts
@@ -66,12 +66,12 @@ import { HttpHelper } from '../http-helper';
         helper.scopeHelper.getClonedLocalScope(scopeAfterExport);
       });
       it('should show descriptive error when removing component that has dependents', () => {
-        const output = helper.command.removeComponent(`${helper.scopes.remote}/comp2`, '--remote --silent');
+        const output = helper.command.removeComponent(`${helper.scopes.remote}/comp2`, '--remote');
         expect(output).to.have.string(`error: unable to delete ${helper.scopes.remote}/comp2`);
         expect(output).to.have.string(`${helper.scopes.remote}/comp1`);
       });
       it('should remove successfully components that has no dependents', () => {
-        const output = helper.command.removeComponent(`${helper.scopes.remote}/comp1`, '--remote --silent');
+        const output = helper.command.removeComponent(`${helper.scopes.remote}/comp1`, '--remote');
         expect(output).to.have.string('successfully removed components');
         expect(output).to.have.string('comp1');
       });

--- a/e2e/harmony/remove-harmony.e2e.ts
+++ b/e2e/harmony/remove-harmony.e2e.ts
@@ -1,0 +1,54 @@
+import chai, { expect } from 'chai';
+import path from 'path';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('remove components on Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('remove new component without --delete-files flag', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.removeComponent('comp1');
+    });
+    it('should remove the component from .bitmap', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.not.have.property('comp1');
+    });
+    it('should not delete the directory from the filesystem', () => {
+      expect(path.join(helper.scopes.localPath, 'comp1')).to.be.a.directory();
+    });
+    it('should delete the directory from the node_modules', () => {
+      expect(path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}`, 'comp1')).to.not.be.a.path();
+    });
+  });
+  describe('remove new component with --delete-files flag', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.removeComponent('comp1', '--delete-files');
+    });
+    it('should remove the component from .bitmap', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.not.have.property('comp1');
+    });
+    it('should delete the directory from the filesystem', () => {
+      expect(path.join(helper.scopes.localPath, 'comp1')).to.not.be.a.path();
+    });
+    it('should delete the directory from the node_modules', () => {
+      expect(path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}`, 'comp1')).to.not.be.a.path();
+    });
+  });
+});

--- a/src/api/consumer/lib/untrack.ts
+++ b/src/api/consumer/lib/untrack.ts
@@ -3,7 +3,7 @@ import { Consumer, loadConsumer } from '../../../consumer';
 import ComponentsList from '../../../consumer/component/components-list';
 import hasWildcard from '../../../utils/string/has-wildcard';
 
-export default (async function untrack(
+export default async function untrack(
   componentIds: string[],
   all: boolean | null | undefined
 ): Promise<Record<string, any>> {
@@ -38,4 +38,4 @@ export default (async function untrack(
   });
   await consumer.onDestroy();
   return { untrackedComponents, unRemovableComponents, missingComponents: missing };
-});
+}

--- a/src/cli/commands/public-cmds/untrack-cmd.ts
+++ b/src/cli/commands/public-cmds/untrack-cmd.ts
@@ -8,7 +8,7 @@ import { CommandOptions, LegacyCommand } from '../../legacy-command';
 
 export default class Untrack implements LegacyCommand {
   name = 'untrack [ids...]';
-  description = `untrack a new component(s)
+  description = `DEPRECATED (use "bit remove" instead). untrack a new component(s)
   https://${BASE_DOCS_DOMAIN}/docs/add-and-isolate-components#untracking-components
   ${WILDCARD_HELP('untrack')}`;
   alias = 'u';
@@ -34,7 +34,7 @@ export default class Untrack implements LegacyCommand {
     unRemovableComponents: Array<string>;
     missingComponents: Array<string>;
   }): string {
-    const msg = [];
+    const msg = [chalk.yellow(`untrack has deprecated, please use "bit remove".`)];
     if (R.isEmpty(untrackedComponents) && R.isEmpty(unRemovableComponents) && R.isEmpty(missingComponents)) {
       return chalk.underline.red('no components untracked');
     }

--- a/src/cli/templates/all-help.ts
+++ b/src/cli/templates/all-help.ts
@@ -49,7 +49,7 @@ const allCommands = [
       },
       {
         name: 'untrack',
-        description: 'Untrack a new component(s).',
+        description: 'DEPRECATED (use "bit remove" instead). untrack a new component(s).',
       },
       {
         name: 'dependents',

--- a/src/cli/templates/remove-template.ts
+++ b/src/cli/templates/remove-template.ts
@@ -10,7 +10,7 @@ export default (
   const paintMissingComponents = () => {
     if (R.isEmpty(missingComponents)) return '';
     return (
-      chalk.red('missing components (try to `bit untrack` them instead):') +
+      chalk.red('missing components:') +
       chalk(
         ` ${missingComponents.map((id) => {
           if (!(id instanceof BitId)) id = new BitId(id); // when the id was received from a remote it's not an instance of BitId

--- a/src/consumer/component-ops/delete-component-files.ts
+++ b/src/consumer/component-ops/delete-component-files.ts
@@ -8,11 +8,11 @@ import Consumer from '../consumer';
 
 export default async function deleteComponentsFiles(consumer: Consumer, bitIds: BitIds, deleteFilesForAuthor: boolean) {
   logger.debug(`deleteComponentsFiles, ids: ${bitIds.toString()}`);
-  const filesToDelete = getFilesToDelete();
+  const filesToDelete = consumer.isLegacy ? getFilesToDeleteLegacy() : getFilesToDeleteHarmony();
   filesToDelete.addBasePath(consumer.getPath());
   return filesToDelete.persistAllToFS();
 
-  function getFilesToDelete(): DataToPersist {
+  function getFilesToDeleteLegacy(): DataToPersist {
     const dataToPersist = new DataToPersist();
     bitIds.forEach((id) => {
       const ignoreVersion = id.isLocal() || !id.hasVersion();
@@ -37,6 +37,25 @@ export default async function deleteComponentsFiles(consumer: Consumer, bitIds: 
         dataToPersist.removeManyPaths(filesToRemove);
       }
       return null;
+    });
+    return dataToPersist;
+  }
+
+  function getFilesToDeleteHarmony(): DataToPersist {
+    const dataToPersist = new DataToPersist();
+    bitIds.forEach((id) => {
+      if (!deleteFilesForAuthor) return;
+      const ignoreVersion = id.isLocal() || !id.hasVersion();
+      const componentMap = consumer.bitMap.getComponentIfExist(id, { ignoreVersion });
+      if (!componentMap) {
+        logger.warn(
+          `deleteComponentsFiles was unable to delete ${id.toString()} because the id is missing from bitmap`
+        );
+        return;
+      }
+      const rootDir = componentMap.rootDir;
+      if (!rootDir) throw new Error(`rootDir is missing from ${id.toString()}`);
+      dataToPersist.removePath(new RemovePath(rootDir, true));
     });
     return dataToPersist;
   }

--- a/src/consumer/component-ops/remove-components.ts
+++ b/src/consumer/component-ops/remove-components.ts
@@ -12,6 +12,7 @@ import { Remotes } from '../../remotes';
 import RemovedLocalObjects from '../../scope/removed-local-objects';
 import { getScopeRemotes } from '../../scope/scope-remotes';
 import deleteComponentsFiles from '../component-ops/delete-component-files';
+import ComponentsList from '../component/components-list';
 import Component from '../component/consumer-component';
 import * as packageJsonUtils from '../component/package-json-utils';
 
@@ -117,8 +118,14 @@ async function removeLocal(
     );
   }
   const idsToRemove = force ? bitIds : nonModifiedComponents;
-  const idsToRemoveFromScope = BitIds.fromArray(idsToRemove.filter((id) => id.hasScope()));
-  const idsToCleanFromWorkspace = BitIds.fromArray(idsToRemove.filter((id) => !id.hasScope()));
+  const componentsList = new ComponentsList(consumer);
+  const newComponents = (await componentsList.listNewComponents(false)) as BitIds;
+  const idsToRemoveFromScope = BitIds.fromArray(
+    idsToRemove.filter((id) => !newComponents.hasWithoutScopeAndVersion(id))
+  );
+  const idsToCleanFromWorkspace = BitIds.fromArray(
+    idsToRemove.filter((id) => newComponents.hasWithoutScopeAndVersion(id))
+  );
   const { components: componentsToRemove, invalidComponents } = await consumer.loadComponents(idsToRemove, false);
   const {
     removedComponentIds,

--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -208,9 +208,10 @@ async function _addDependenciesPackagesIntoPackageJson(dir: PathOsBasedAbsolute,
 
 export async function removeComponentsFromNodeModules(consumer: Consumer, components: Component[]) {
   logger.debug(`removeComponentsFromNodeModules: ${components.map((c) => c.id.toString()).join(', ')}`);
-  // paths without scope name, don't have a symlink in node-modules
   const pathsToRemoveWithNulls = components.map((c) => {
-    return c.id.scope ? getNodeModulesPathOfComponent(c) : null;
+    // for legacy, paths without scope name, don't have a symlink in node-modules
+    if (consumer.isLegacy) return c.id.scope ? getNodeModulesPathOfComponent(c) : null;
+    return getNodeModulesPathOfComponent({ ...c, id: c.id, allowNonScope: true });
   });
   const pathsToRemove = compact(pathsToRemoveWithNulls);
   logger.debug(`deleting the following paths: ${pathsToRemove.join('\n')}`);

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -136,7 +136,7 @@ export default class CommandHelper {
     return this.runCmd(`bit untrack ${id} ${all ? '--all' : ''}`, cwd);
   }
   removeComponent(id: string, flags = '') {
-    return this.runCmd(`bit remove ${id} ${flags}`);
+    return this.runCmd(`bit remove ${id} --silent ${flags}`);
   }
   deprecateComponent(id: string, flags = '') {
     return this.runCmd(`bit deprecate ${id} ${flags}`);


### PR DESCRIPTION
Resolves #4051 .

## Proposed Changes

- deprecate `bit untrack`.
- enable removing new components by `bit remove`, which opens the possibility to delete the component files.
- fix `bit remove` for Harmony to delete the component root-dir.
- fix deleting the directories from node-modules for new components.