### PR TITLE
New webpack api

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1225,6 +1225,12 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent"
     },
+    "utils/config-mutator": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/webpack/config-mutator"
+    },
     "variants": {
         "scope": "teambit.workspace",
         "version": "0.0.351",

--- a/scopes/compilation/bundler/bundler.ts
+++ b/scopes/compilation/bundler/bundler.ts
@@ -13,3 +13,5 @@ export type BundlerResult = {
 export interface Bundler {
   run(): Promise<BundlerResult[]>;
 }
+
+export type BundlerMode = 'dev' | 'prod';

--- a/scopes/compilation/bundler/index.ts
+++ b/scopes/compilation/bundler/index.ts
@@ -1,6 +1,6 @@
 export { DevServer } from './dev-server';
 export { BundlerContext, Target, DevServerContext } from './dev-server-context';
-export { Bundler, BundlerResult } from './bundler';
+export { Bundler, BundlerResult, BundlerMode } from './bundler';
 export type { BundlerMain } from './bundler.main.runtime';
 export { BundlerAspect } from './bundler.aspect';
 export { ComponentDir } from './get-entry';

--- a/scopes/compilation/webpack/config/webpack.config.ts
+++ b/scopes/compilation/webpack/config/webpack.config.ts
@@ -1,10 +1,10 @@
-import webpack from 'webpack';
+import webpack, { Configuration } from 'webpack';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { fallbacks } from './webpack-fallbacks';
 
 const html = require('./html');
 
-export function configFactory(entries, rootPath) {
+export function configFactory(entries, rootPath): Configuration {
   return {
     mode: 'production',
     // Stop compilation early in production
@@ -36,6 +36,7 @@ export function configFactory(entries, rootPath) {
         buffer: require.resolve('buffer/'),
       },
 
+      // @ts-ignore
       fallback: fallbacks,
     },
 

--- a/scopes/compilation/webpack/index.ts
+++ b/scopes/compilation/webpack/index.ts
@@ -1,4 +1,4 @@
-export type { WebpackMain, WebpackConfigTransform } from './webpack.main.runtime';
+export type { WebpackMain, WebpackConfigTransformer } from './webpack.main.runtime';
 export { WebpackAspect } from './webpack.aspect';
 export type { WebpackConfigWithDevServer } from './webpack.dev-server';
 export * from './events';

--- a/scopes/compilation/webpack/index.ts
+++ b/scopes/compilation/webpack/index.ts
@@ -1,4 +1,5 @@
-export type { WebpackMain } from './webpack.main.runtime';
+export type { WebpackMain, WebpackConfigTransform } from './webpack.main.runtime';
 export { WebpackAspect } from './webpack.aspect';
 export type { WebpackConfigWithDevServer } from './webpack.dev-server';
 export * from './events';
+export { Configuration } from 'webpack';

--- a/scopes/compilation/webpack/webpack.main.runtime.ts
+++ b/scopes/compilation/webpack/webpack.main.runtime.ts
@@ -1,15 +1,24 @@
 import PubsubAspect, { PubsubMain } from '@teambit/pubsub';
-import { BundlerAspect, BundlerContext, BundlerMain, DevServer, DevServerContext } from '@teambit/bundler';
+import { BundlerAspect, BundlerContext, BundlerMain, DevServer, DevServerContext, BundlerMode } from '@teambit/bundler';
 import { MainRuntime } from '@teambit/cli';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
+import { WebpackConfigMutator } from '@teambit/utils.config-mutator';
 
 import { configFactory as devServerConfigFactory } from './config/webpack.dev.config';
 import { WebpackAspect } from './webpack.aspect';
 import { WebpackBundler } from './webpack.bundler';
 import { WebpackDevServer } from './webpack.dev-server';
+
+export type WebpackConfigTransformContext = {
+  mode: BundlerMode;
+};
+export type WebpackConfigTransform = (
+  config: WebpackConfigMutator,
+  context: WebpackConfigTransformContext
+) => WebpackConfigMutator | Configuration;
 
 export class WebpackMain {
   constructor(
@@ -44,7 +53,7 @@ export class WebpackMain {
     return new WebpackDevServer(mergedConfig);
   }
 
-  getWebpackDevServerConfig(context: DevServerContext, config: any): any {
+  private getWebpackDevServerConfig(context: DevServerContext, config: any): any {
     return merge(
       // TODO: create the type for the webpack config
       this.createDevServerConfig(

--- a/scopes/compilation/webpack/webpack.main.runtime.ts
+++ b/scopes/compilation/webpack/webpack.main.runtime.ts
@@ -1,13 +1,24 @@
 import PubsubAspect, { PubsubMain } from '@teambit/pubsub';
-import { BundlerAspect, BundlerContext, BundlerMain, DevServer, DevServerContext, BundlerMode } from '@teambit/bundler';
+import {
+  BundlerAspect,
+  BundlerContext,
+  BundlerMain,
+  DevServer,
+  DevServerContext,
+  BundlerMode,
+  Target,
+} from '@teambit/bundler';
 import { MainRuntime } from '@teambit/cli';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { Configuration } from 'webpack';
 import { merge } from 'webpack-merge';
 import { WebpackConfigMutator } from '@teambit/utils.config-mutator';
+import { flow } from 'lodash';
 
 import { configFactory as devServerConfigFactory } from './config/webpack.dev.config';
+import { configFactory as previewConfigFactory } from './config/webpack.config';
+
 import { WebpackAspect } from './webpack.aspect';
 import { WebpackBundler } from './webpack.bundler';
 import { WebpackDevServer } from './webpack.dev-server';
@@ -15,7 +26,7 @@ import { WebpackDevServer } from './webpack.dev-server';
 export type WebpackConfigTransformContext = {
   mode: BundlerMode;
 };
-export type WebpackConfigTransform = (
+export type WebpackConfigTransformer = (
   config: WebpackConfigMutator,
   context: WebpackConfigTransformContext
 ) => WebpackConfigMutator | Configuration;
@@ -48,32 +59,38 @@ export class WebpackMain {
    * @param components array of components to launch.
    * @param config webpack config. will be merged to the base webpack config as seen at './config'
    */
-  createDevServer(context: DevServerContext, config: any): DevServer {
-    const mergedConfig = this.getWebpackDevServerConfig(context, config);
-    return new WebpackDevServer(mergedConfig);
-  }
-
-  private getWebpackDevServerConfig(context: DevServerContext, config: any): any {
-    return merge(
-      // TODO: create the type for the webpack config
-      this.createDevServerConfig(
-        context.entry,
-        this.workspace.path,
-        context.id,
-        context.rootPath,
-        context.publicPath,
-        context.title
-      ) as any,
-      config
-    );
+  createDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
+    const config = this.createDevServerConfig(
+      context.entry,
+      this.workspace.path,
+      context.id,
+      context.rootPath,
+      context.publicPath,
+      context.title
+    ) as any;
+    const configMutator = new WebpackConfigMutator(config);
+    const afterMutation = flow(transformers)(configMutator);
+    return new WebpackDevServer(afterMutation.raw);
   }
 
   mergeConfig(target: any, source: any): any {
     return merge(target, source);
   }
 
-  createBundler(context: BundlerContext, envConfig: Configuration) {
-    return new WebpackBundler(context.targets, envConfig, this.logger);
+  createBundler(context: BundlerContext, transformers: WebpackConfigTransformer[] = []) {
+    const configs = this.createPreviewConfig(context.targets);
+    const mutatedConfigs = configs.map((config) => {
+      const configMutator = new WebpackConfigMutator(config);
+      const afterMutation = flow(transformers)(configMutator);
+      return afterMutation.raw;
+    });
+    return new WebpackBundler(context.targets, mutatedConfigs, this.logger);
+  }
+
+  private createPreviewConfig(targets: Target[]) {
+    return targets.map((target) => {
+      return previewConfigFactory(target.entries, target.outputPath);
+    });
   }
 
   private createDevServerConfig(

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -11,7 +11,7 @@ import { PkgMain } from '@teambit/pkg';
 import { Tester, TesterMain } from '@teambit/tester';
 import { TypescriptMain } from '@teambit/typescript';
 import type { TsCompilerOptionsWithoutTsConfig } from '@teambit/typescript';
-import { WebpackMain } from '@teambit/webpack';
+import { WebpackConfigTransformer, WebpackMain } from '@teambit/webpack';
 import { Workspace } from '@teambit/workspace';
 import { ESLintMain } from '@teambit/eslint';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
@@ -186,32 +186,23 @@ export class ReactEnv implements Environment {
   /**
    * returns and configures the React component dev server.
    */
-  getDevServer(context: DevServerContext, targetConfig?: Configuration): DevServer {
+  getDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
     const defaultConfig = this.getDevWebpackConfig(context);
-    const config = targetConfig ? webpackMerge(targetConfig as any, defaultConfig as any) : defaultConfig;
+    const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
+      return configMutator.merge([defaultConfig]);
+    };
 
-    return this.webpack.createDevServer(context, config);
+    return this.webpack.createDevServer(context, [defaultTransformer, ...transformers]);
   }
 
-  async getBundler(context: BundlerContext, targetConfig?: Configuration): Promise<Bundler> {
+  async getBundler(context: BundlerContext, transformers: WebpackConfigTransformer[] = []): Promise<Bundler> {
     const path = this.writeFileMap(context.components);
     const defaultConfig = previewConfigFactory(path);
+    const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
+      return configMutator.merge([defaultConfig]);
+    };
 
-    if (targetConfig?.entry) {
-      const additionalEntries = this.getEntriesFromWebpackConfig(targetConfig);
-
-      const targetsWithGlobalEntries = context.targets.map((target) => {
-        // Putting the additionalEntries first to support globals defined there (like regenerator-runtime)
-        target.entries = additionalEntries.concat(target.entries);
-        return target;
-      });
-      context.targets = targetsWithGlobalEntries;
-    }
-
-    delete targetConfig?.entry;
-
-    const config = targetConfig ? webpackMerge(targetConfig as any, defaultConfig as any) : defaultConfig;
-    return this.webpack.createBundler(context, config as any);
+    return this.webpack.createBundler(context, [defaultTransformer, ...transformers]);
   }
 
   private getEntriesFromWebpackConfig(config?: Configuration): string[] {

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -1,4 +1,3 @@
-import { Configuration } from 'webpack';
 import { mergeDeepLeft } from 'ramda';
 import { MainRuntime } from '@teambit/cli';
 import type { CompilerMain } from '@teambit/compiler';
@@ -16,7 +15,7 @@ import type { TesterMain } from '@teambit/tester';
 import { TesterAspect } from '@teambit/tester';
 import type { TypescriptMain, TsCompilerOptionsWithoutTsConfig } from '@teambit/typescript';
 import { TypescriptAspect } from '@teambit/typescript';
-import type { WebpackMain } from '@teambit/webpack';
+import type { WebpackMain, Configuration, WebpackConfigTransform } from '@teambit/webpack';
 import { WebpackAspect } from '@teambit/webpack';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
@@ -65,6 +64,11 @@ export type ReactMainConfig = {
    * version of React to configure.
    */
   reactVersion: string;
+};
+
+export type UseWebpackModifiers = {
+  previewConfig?: WebpackConfigTransform;
+  devServerConfig?: WebpackConfigTransform;
 };
 
 export class ReactMain {
@@ -235,6 +239,18 @@ export class ReactMain {
         };
       },
     });
+  }
+
+  useWebpack(modifiers?: UseWebpackModifiers) {
+    const overrides: any = {};
+    if (modifiers?.devServerConfig) {
+      overrides.getDevServer = (context: DevServerContext) => this.reactEnv.getDevServer(context, config);
+      overrides.getDevEnvId = (context: DevServerContext) => this.reactEnv.getDevEnvId(context.envDefinition.id);
+    }
+    if (modifiers?.previewConfig) {
+      overrides.getBundler = (context: BundlerContext) => this.reactEnv.getBundler(context, config);
+    }
+    return this.envs.override(overrides);
   }
 
   /**

--- a/scopes/webpack/config-mutator/config-mutator.ts
+++ b/scopes/webpack/config-mutator/config-mutator.ts
@@ -1,0 +1,171 @@
+import { Configuration } from 'webpack';
+import { merge, mergeWithCustomize, mergeWithRules, CustomizeRule } from 'webpack-merge';
+import { ICustomizeOptions } from 'webpack-merge/dist/types';
+
+export * from 'webpack-merge';
+
+type ConflictPolicy = 'override' | 'error' | 'ignore';
+type ArrayPosition = 'append' | 'prepend';
+
+type AddKeyOpts = {
+  conflictPolicy?: ConflictPolicy;
+};
+
+type AddToArrayOpts = {
+  position?: ArrayPosition;
+};
+
+type MergeOpts = {
+  rawConfigPosition: ArrayPosition;
+};
+
+type Rules = {
+  [s: string]: CustomizeRule | Rules;
+};
+
+const defaultAddToArrayOpts: AddToArrayOpts = {
+  position: 'prepend',
+};
+
+const defaultAddKeyOpts: AddKeyOpts = {
+  conflictPolicy: 'override',
+};
+
+const defaultMergeOpts: MergeOpts = {
+  rawConfigPosition: 'prepend',
+};
+
+export class WebpackConfigMutator {
+  constructor(public raw: Configuration) {}
+
+  /**
+   * Add a key value to the top level config
+   * @param key
+   * @param value
+   */
+  addTopLevel(key: string, value: any, opts: AddKeyOpts = {}): WebpackConfigMutator {
+    const concreteOpts = Object.assign({}, defaultAddKeyOpts, opts);
+    // eslint-disable-next-line no-prototype-builtins
+    const exist = this.raw.hasOwnProperty(key);
+    if (concreteOpts.conflictPolicy === 'override') {
+      this.raw[key] = value;
+    } else if (exist) {
+      if (concreteOpts.conflictPolicy === 'error') {
+        throw new Error(`key with name ${key} already exist in config`);
+      }
+    } else {
+      this.raw[key] = value;
+    }
+    return this;
+  }
+
+  /**
+   * Remove a key from the top level
+   * @param key
+   * @returns
+   */
+  removeTopLevel(key: string): WebpackConfigMutator {
+    delete this.raw[key];
+    return this;
+  }
+
+  /**
+   * Add new entry to the config
+   * @param entry
+   * @param opts
+   * @returns
+   */
+  addEntry(entry: string, opts: AddToArrayOpts = {}): WebpackConfigMutator {
+    if (!this.raw.entry) {
+      this.raw.entry = [];
+    }
+    if (!Array.isArray(this.raw.entry)) {
+      throw new Error(`can't add an entry to a function type raw entry`);
+    }
+    addToArray(this.raw.entry, entry, opts);
+    return this;
+  }
+
+  /**
+   * Add a new plugin
+   * @param plugin
+   * @param opts
+   * @returns
+   */
+  addPlugin(plugin: any, opts: AddToArrayOpts = {}): WebpackConfigMutator {
+    if (!this.raw.plugins) {
+      this.raw.plugins = [];
+    }
+    addToArray(this.raw.plugins, plugin, opts);
+    return this;
+  }
+
+  /**
+   * Merge external configs with the current config (utilize webpack-merge)
+   * @param configs
+   * @param opts
+   */
+  merge(configs: Configuration[], opts: MergeOpts): WebpackConfigMutator {
+    const concreteOpts = Object.assign({}, defaultMergeOpts, opts);
+    const { firstConfig, configs: otherConfigs } = getConfigsToMerge(this.raw, configs, concreteOpts.rawConfigPosition);
+    const merged = merge(firstConfig, ...otherConfigs);
+    this.raw = merged;
+    return this;
+  }
+
+  /**
+   * Merge external configs with the current config uses customize (array/object) function (utilize webpack-merge)
+   * @param configs
+   * @param customizes
+   * @param opts
+   * @returns
+   */
+  mergeWithCustomize(configs: Configuration[], customizes: ICustomizeOptions, opts: MergeOpts): WebpackConfigMutator {
+    const concreteOpts = Object.assign({}, defaultMergeOpts, opts);
+    const { firstConfig, configs: otherConfigs } = getConfigsToMerge(this.raw, configs, concreteOpts.rawConfigPosition);
+    const merged = mergeWithCustomize(customizes)(firstConfig, ...otherConfigs);
+    this.raw = merged;
+    return this;
+  }
+
+  /**
+   * Merge external configs with the current config uses rules (utilize webpack-merge)
+   * @param configs
+   * @param rules
+   * @param opts
+   * @returns
+   */
+  mergeWithRules(configs: Configuration[], rules: Rules, opts: MergeOpts): WebpackConfigMutator {
+    const concreteOpts = Object.assign({}, defaultMergeOpts, opts);
+    const { firstConfig, configs: otherConfigs } = getConfigsToMerge(this.raw, configs, concreteOpts.rawConfigPosition);
+    const merged = mergeWithRules(rules)(firstConfig, ...otherConfigs);
+    this.raw = merged;
+    return this;
+  }
+}
+
+function getConfigsToMerge(
+  originalConfig: Configuration,
+  configs: Configuration[],
+  originalPosition: ArrayPosition
+): { firstConfig: Configuration; configs: Configuration[] } {
+  let firstConfig = originalConfig;
+  if (originalPosition === 'append') {
+    firstConfig = configs.shift() || {};
+    configs.push(originalConfig);
+  }
+  return {
+    firstConfig,
+    configs,
+  };
+}
+
+function addToArray(array: Array<any>, val: any, opts: AddToArrayOpts = {}): Array<any> {
+  const concreteOpts = Object.assign({}, defaultAddToArrayOpts, opts);
+  if (concreteOpts.position === 'append') {
+    array?.unshift(val);
+  } else {
+    array?.push(val);
+  }
+  return array;
+}

--- a/scopes/webpack/config-mutator/index.ts
+++ b/scopes/webpack/config-mutator/index.ts
@@ -1,0 +1,1 @@
+export { WebpackConfigMutator } from './config-mutator';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -410,6 +410,9 @@
     "scopes/workspace": {
       "defaultScope": "teambit.workspace"
     },
+    "scopes/webpack": {
+      "defaultScope": "teambit.webpack"
+    },
     "scopes/scope": {
       "defaultScope": "teambit.scope"
     },


### PR DESCRIPTION
## Proposed Changes

- new WebpackConfigMutator class
- new `useWebpack` API for react aspect - this API enables you to pass webpack config transformers down the chain to be able to mutate webpack config for preview and for dev server
- depreacate both `overrideDevServerConfig` and `overridePreviewConfig` (use the `useWebpack` instead)
- get transformers in webpack aspects for dev server and for bundler
