### PR TITLE
avoid deleting the dist directory during watch

### DIFF
--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -37,7 +37,7 @@ export class CompileCmd implements Command {
     this.pubsub.sub(CompilerAspect.id, this.onComponentCompilationDone.bind(this));
 
     let outputString = '';
-
+    compilerOptions.deleteDistDir = true;
     await this.compile.compileComponents(components, compilerOptions);
     const compileTimeLength = process.hrtime(startTimestamp);
 
@@ -57,6 +57,7 @@ export class CompileCmd implements Command {
   }
 
   async json([components]: [string[]], compilerOptions: CompileOptions) {
+    compilerOptions.deleteDistDir = true;
     // @ts-ignore
     const compileResults = await this.compile.compileComponents(components, compilerOptions);
     return {

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -14,7 +14,7 @@ import { CompilerAspect } from './compiler.aspect';
 import { CompileCmd } from './compiler.cmd';
 import { CompilerTask } from './compiler.task';
 import { Compiler } from './types';
-import { WorkspaceCompiler } from './workspace-compiler';
+import { CompileOptions, WorkspaceCompiler } from './workspace-compiler';
 import { DistArtifact } from './dist-artifact';
 import { DistArtifactNotFound } from './exceptions';
 
@@ -28,10 +28,7 @@ export class CompilerMain {
 
   compileOnWorkspace(
     componentsIds: string[] | BitId[], // when empty, it compiles all
-    options: {
-      noCache?: boolean;
-      verbose?: boolean;
-    } = {}
+    options: CompileOptions = {}
   ) {
     return this.workspaceCompiler.compileComponents(componentsIds, options);
   }


### PR DESCRIPTION
Due to a recent change of #4177 , the dist directory is deleted before compilation. 
This causes an issue with watch processes, such as Webpack that expect the dist dir to be there.  (reported by @odedre ).
Here is an example error from Webpack:
```
watchpack Error (watcher): Error: EINTR: interrupted system call, watch '/Users/davidfirst/teambit/bit/node_modules/@teambit/panels/dist
```
This PR changes the default to not delete the dist dir unless it's `bit compile`.