### PR TITLE
fix custom-env e2e-tests on Windows

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -24,6 +24,7 @@ describe('custom env', function () {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
+      helper.bitJsonc.setPackageManager();
       envName = helper.env.setCustomEnv();
       envId = `${helper.scopes.remote}/${envName}`;
       helper.fixtures.populateComponents(3);

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -64,8 +64,19 @@ export default class BitJsoncHelper {
     this.addKeyVal(bitJsoncDir, 'teambit.workspace/workspace', workspace);
   }
 
+  addKeyValToDependencyResolver(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
+    const bitJsonc = this.read(bitJsoncDir);
+    const depResolver = bitJsonc['teambit.dependencies/dependency-resolver'];
+    assign(depResolver, { [key]: val });
+    this.addKeyVal(bitJsoncDir, 'teambit.dependencies/dependency-resolver', depResolver);
+  }
+
   addDefaultScope(scope = this.scopes.remote) {
     this.addKeyValToWorkspace('defaultScope', scope);
+  }
+
+  setPackageManager(packageManager = 'teambit.dependencies/yarn') {
+    this.addKeyValToDependencyResolver('packageManager', packageManager);
   }
 
   addDefaultOwner(owner: string) {

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -32,6 +32,7 @@ export default class ScopeHelper {
     fsHelper: FsHelper,
     npmHelper: NpmHelper
   ) {
+    this.debugMode = debugMode;
     this.keepEnvs = !!process.env.npm_config_keep_envs; // default = false
     this.scopes = scopes;
     this.command = commandHelper;


### PR DESCRIPTION
These tests were failing due to `pnpm` hard-links. Switching to Yarn fixed the issue.