### PR TITLE
CircleCI - remove the bit.dev login configuration step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -90,7 +90,7 @@ commands: # reusable commands
       - run: 'bit config set error_reporting false'
       - run: 'bit config set user.name tester'
       - run: 'bit config set user.email ci@bit.dev'
-      - run: 'bit config set user.token <<parameters.token>>'
+      # - run: 'bit config set user.token <<parameters.token>>'
       - run: 'bit config set hub_domain <<parameters.env>>.bit.dev'
       - run: 'bit config set package-manager.cache /home/circleci/package-manager-cache'
 


### PR DESCRIPTION
It's not needed for a while now as the tests are isolated from bit.dev. 