### PR TITLE
add the defaultScope to the componentId prop of package.json of a new component

### DIFF
--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -133,6 +133,7 @@ export default class PackageJsonFile {
       // TODO: replace by better way to identify that something is a component for sure
       // TODO: Maybe need to add the binding prefix here
       componentId: componentIdWithDefaultScope.serialize(),
+      exported: component.id.hasScope(),
       dependencies: {
         ...component.packageDependencies,
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -115,7 +115,8 @@ export default class PackageJsonFile {
     component: Component,
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     excludeRegistryPrefix? = false,
-    addDefaultScopeToCompId? = false // for the capsule, we want the default-scope because it gets published
+    addDefaultScopeToCompId? = false, // for the capsule, we want the default-scope because it gets published
+    addExportProperty? = false
   ): PackageJsonFile {
     const filePath = composePath(componentDir);
     const name = componentIdToPackageName({ withPrefix: !excludeRegistryPrefix, ...component, id: component.id });
@@ -133,7 +134,6 @@ export default class PackageJsonFile {
       // TODO: replace by better way to identify that something is a component for sure
       // TODO: Maybe need to add the binding prefix here
       componentId: componentIdWithDefaultScope.serialize(),
-      exported: component.id.hasScope(),
       dependencies: {
         ...component.packageDependencies,
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -157,6 +157,8 @@ export default class PackageJsonFile {
       },
       license: `SEE LICENSE IN ${!R.isEmpty(component.license) ? 'LICENSE' : 'UNLICENSED'}`,
     };
+    // @ts-ignore
+    if (addExportProperty) packageJsonObject.exported = component.id.hasScope();
     if (!packageJsonObject.homepage) delete packageJsonObject.homepage;
     return new PackageJsonFile({ filePath, packageJsonObject, fileExist: false });
   }

--- a/src/consumer/component/package-json.ts
+++ b/src/consumer/component/package-json.ts
@@ -25,6 +25,7 @@ export type PackageJsonProps = {
   workspaces?: string[];
   private?: boolean;
   componentId?: BitId;
+  exported?: boolean;
 };
 
 export default class PackageJson {
@@ -40,6 +41,7 @@ export default class PackageJson {
   scripts?: Record<string, any>;
   workspaces?: string[];
   componentId?: BitId;
+  exported?: boolean;
 
   constructor(
     componentRootFolder: string,
@@ -55,6 +57,7 @@ export default class PackageJson {
       scripts,
       workspaces,
       componentId,
+      exported,
     }: PackageJsonProps
   ) {
     this.name = name;
@@ -69,6 +72,7 @@ export default class PackageJson {
     this.scripts = scripts;
     this.workspaces = workspaces;
     this.componentId = componentId;
+    this.exported = exported;
   }
 
   static loadSync(componentRootFolder: string): PackageJson | null {

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -463,7 +463,7 @@ export default class NodeModuleLinker {
         allowNonScope: true,
       })
     );
-    const packageJson = PackageJsonFile.createFromComponent(dest, component);
+    const packageJson = PackageJsonFile.createFromComponent(dest, component, undefined, true);
     if (!this.consumer?.isLegacy) {
       await this._applyTransformers(component, packageJson);
       if (IS_WINDOWS) {

--- a/src/links/node-modules-linker.ts
+++ b/src/links/node-modules-linker.ts
@@ -463,7 +463,7 @@ export default class NodeModuleLinker {
         allowNonScope: true,
       })
     );
-    const packageJson = PackageJsonFile.createFromComponent(dest, component, undefined, true);
+    const packageJson = PackageJsonFile.createFromComponent(dest, component, undefined, true, true);
     if (!this.consumer?.isLegacy) {
       await this._applyTransformers(component, packageJson);
       if (IS_WINDOWS) {

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -96,6 +96,10 @@ function enrichDataFromDependency(packageData: ResolvedPackageData) {
   packageData.name = packageInfo.name;
   packageData.concreteVersion = packageInfo.version;
   if (packageInfo.componentId) {
+    if (packageInfo.exported === false) {
+      // @ts-ignore
+      delete packageInfo.componentId.scope;
+    }
     packageData.componentId = new BitId(packageInfo.componentId);
   }
 }


### PR DESCRIPTION
currently, the generated package.json inside node_modules, looks like the following:
```
{
  "name": "@my-scope/bar",
  "main": "dist/foo.js",
  "componentId": {
    "name": "bar"
  },
...
```
The "scope" is missing from the componentId prop.
