### PR TITLE
Fix bit-status to show missing scoped packages with tilda correctly

### DIFF
--- a/src/utils/packages/resolve-pkg-name-by-path.spec.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.spec.ts
@@ -1,0 +1,16 @@
+import { expect } from 'chai';
+import { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
+
+describe.only('resolvePackageNameByPath', () => {
+  it('should return the correct package for non-scoped package', () => {
+    expect(resolvePackageNameByPath('lodash/internal/file')).to.equal('lodash');
+  });
+  it('should return the correct package for scoped package', () => {
+    expect(resolvePackageNameByPath('@angular/core/src/utils.ts')).to.equal('@angular/core');
+  });
+  it('should return the correct package for webpack sass-loader path (with tilda) and scoped package', () => {
+    expect(resolvePackageNameByPath('~@teambit/base-ui.theme.colors/colors.module.scss')).to.equal(
+      '@teambit/base-ui.theme.colors'
+    );
+  });
+});

--- a/src/utils/packages/resolve-pkg-name-by-path.spec.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
 
-describe.only('resolvePackageNameByPath', () => {
+describe('resolvePackageNameByPath', () => {
   it('should return the correct package for non-scoped package', () => {
     expect(resolvePackageNameByPath('lodash/internal/file')).to.equal('lodash');
   });

--- a/src/utils/packages/resolve-pkg-name-by-path.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.ts
@@ -10,6 +10,8 @@ export function resolvePackageNameByPath(packagePath: string): string {
   const packagePathArr = packagePath.split(path.sep);
   // Regular package without path. example - import _ from 'lodash'
   if (packagePathArr.length === 1) return packagePath;
+  // sass-loader/webpack path. remove the tilda, it's not part of the package name
+  if (packagePathArr[0].startsWith('~')) packagePathArr[0] = packagePathArr[0].replace('~', '');
   // Scoped package. example - import getSymbolIterator from '@angular/core/src/util.d.ts';
   if (packagePathArr[0].startsWith('@')) return path.join(packagePathArr[0], packagePathArr[1]);
   // Regular package with internal path. example import something from 'mypackage/src/util/isString'


### PR DESCRIPTION
Resolve #3663.

Currently, if the import statement has something like this: `~@teambit/base-ui.theme.colors/colors.module.scss` and the package is not installed, it shows only `~@teambit`. 
This PR fixes it to show the full package-name `@teambit/base-ui.theme.colors`