### PR TITLE
re-enable source map loader for main UI dev

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -6,7 +6,7 @@ import { BuildTask } from '@teambit/builder';
 import { merge, omit } from 'lodash';
 import { Bundler, BundlerContext, DevServer, DevServerContext } from '@teambit/bundler';
 import { CompilerMain } from '@teambit/compiler';
-import { Environment, ExecutionContext } from '@teambit/envs';
+import { Environment } from '@teambit/envs';
 import { JestMain } from '@teambit/jest';
 import { PkgMain } from '@teambit/pkg';
 import { Tester, TesterMain } from '@teambit/tester';

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -152,27 +152,13 @@ export class ReactEnv implements Environment {
     return path;
   }
 
-  private calcDistPaths(context: ExecutionContext, rootDir: string) {
-    const components = context.components;
-    const distDir = this.getCompiler().distDir;
-
-    const distPaths = components.map((comp) => {
-      const modulePath = this.pkg.getModulePath(comp);
-      const dist = join(rootDir, modulePath, distDir);
-      return dist;
-    });
-
-    return distPaths;
-  }
-
   /**
    * get the default react webpack config.
    */
   private getDevWebpackConfig(context: DevServerContext): Configuration {
     const fileMapPath = this.writeFileMap(context.components, true);
-    const distPaths = this.calcDistPaths(context, this.workspace.path);
 
-    return devPreviewConfigFactory({ envId: context.id, fileMapPath, distPaths, workDir: this.workspace.path });
+    return devPreviewConfigFactory({ envId: context.id, fileMapPath, workDir: this.workspace.path });
   }
 
   getDevEnvId(id?: string) {

--- a/scopes/react/react/webpack/webpack.config.preview.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.dev.ts
@@ -34,9 +34,9 @@ const moduleFileExtensions = [
   'md',
 ];
 
-type Options = { envId: string; fileMapPath: string; distPaths: string[]; workDir: string };
+type Options = { envId: string; fileMapPath: string; workDir: string };
 
-export default function ({ envId, fileMapPath, distPaths, workDir }: Options): WebpackConfigWithDevServer {
+export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfigWithDevServer {
   return {
     devServer: {
       // @ts-ignore - remove this once there is types package for webpack-dev-server v4
@@ -55,17 +55,20 @@ export default function ({ envId, fileMapPath, distPaths, workDir }: Options): W
         {
           test: /\.js$/,
           enforce: 'pre',
-          include: distPaths,
+          // limit loader to files in the current project,
+          // to skip any files linked from other projects (like Bit itself)
+          include: path.join(workDir, 'node_modules'),
+          // only apply to packages with componentId in their package.json (ie. bit components)
+          descriptionData: { componentId: (value) => !!value },
           use: [require.resolve('source-map-loader')],
         },
         {
           test: /\.js$/,
-          descriptionData: {
-            componentId: ComponentID.isValidObject,
-          },
           // limit loader to files in the current project,
           // to skip any files linked from other projects (like Bit itself)
           include: path.join(workDir, 'node_modules'),
+          // only apply to packages with componentId in their package.json (ie. bit components)
+          descriptionData: { componentId: ComponentID.isValidObject },
           use: [
             {
               loader: require.resolve('babel-loader'),

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -199,12 +199,14 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
             fullySpecified: false,
           },
         },
-        // {
-        //   test: /\.js$/,
-        //   enforce: 'pre',
-        //   include: /node_modules/,
-        //   use: [require.resolve('source-map-loader')],
-        // },
+        {
+          test: /\.js$/,
+          enforce: 'pre',
+          include: /node_modules/,
+          // only apply to packages with componentId in their package.json (ie. bit components)
+          descriptionData: { componentId: (value) => !!value },
+          use: [require.resolve('source-map-loader')],
+        },
         {
           test: /\.(js|jsx|tsx|ts)$/,
           exclude: /node_modules/,


### PR DESCRIPTION
## Proposed Changes

- uncomment source-map-loader for `bit start --dev`
- limit loader to apply only to bit components, filtering by `componentId` field in package.json
- also use the same filter for Preview, instead of pre-calculating dists.

I tried this out on Symphony, bit-bin, and Evangelist.
- [x] Working in preview (composition, docs), and from another component
- [x] Working in the main UI
- [x] Time to `bit start --dev` is similar in local bit and the published version from BVM.