### PR TITLE
expose routing components via the react-router aspect

### DIFF
--- a/scopes/ui-foundation/react-router/react-router/index.ts
+++ b/scopes/ui-foundation/react-router/react-router/index.ts
@@ -3,5 +3,10 @@ import { ReactRouterAspect } from './react-router.aspect';
 export { Routing } from './routing-method';
 export type { ReactRouterUI } from './react-router.ui.runtime';
 
+// TODO - replace with resolveFromHost / resolveFromApp when available
+// this exposes the Link components installed in bit bin, so they can use the same RoutingProvider file from node_modules
+export { Link, LinkProps } from '@teambit/ui.routing.link';
+export { NavLink, NavLinkProps } from '@teambit/ui.routing.nav-link';
+
 export { ReactRouterAspect };
 export default ReactRouterAspect;


### PR DESCRIPTION
## Proposed Changes

- expose routing components via the react-router aspect

this will allow bit extensions to use the Routing components as bit core, and control the location.