### PR TITLE
Webpack improvements

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -331,6 +331,12 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/model/composition-type"
     },
+    "modules/config-mutator": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/webpack/config-mutator"
+    },
     "modules/dom-to-react": {
         "scope": "teambit.react",
         "version": "0.0.351",
@@ -372,6 +378,12 @@
         "version": "0.0.350",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/modules/resolved-component"
+    },
+    "modules/style-regexps": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/webpack/style-regexps"
     },
     "multi-compiler": {
         "scope": "teambit.compilation",
@@ -1230,12 +1242,6 @@
         "version": "0.0.63",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent"
-    },
-    "modules/config-mutator": {
-        "scope": "",
-        "version": "",
-        "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/config-mutator"
     },
     "variants": {
         "scope": "teambit.workspace",

--- a/scopes/react/react/index.ts
+++ b/scopes/react/react/index.ts
@@ -3,5 +3,8 @@ import { ReactAspect } from './react.aspect';
 export type { ReactMain, UseWebpackModifiers } from './react.main.runtime';
 export type { ReactPreview } from './react.preview.runtime';
 export type { ReactEnv } from './react.env';
+// Re-export it to indicate for people that extends the react env that we are using it
+export * as styleRegexps from '@teambit/modules.style-regexps';
+
 export { ReactAspect };
 export default ReactAspect;

--- a/scopes/react/react/webpack/postcss.config.ts
+++ b/scopes/react/react/webpack/postcss.config.ts
@@ -1,7 +1,7 @@
 import postcssNormalize from 'postcss-normalize';
 // import postcssFlexbugsFixes from 'postcss-flexbugs-fixes';
 
-const config = {
+export const postCssConfig = {
   // Necessary for external CSS imports to work
   // https://github.com/facebook/create-react-app/issues/2677
   ident: 'postcss',
@@ -21,4 +21,3 @@ const config = {
     postcssNormalize(),
   ],
 };
-module.exports = config;

--- a/scopes/react/react/webpack/webpack.config.preview.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.dev.ts
@@ -4,6 +4,7 @@ import { ComponentID } from '@teambit/component-id';
 import path from 'path';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import webpack from 'webpack';
+import * as stylesRegexps from '@teambit/modules.style-regexps';
 
 import type { WebpackConfigWithDevServer } from '@teambit/webpack';
 
@@ -135,7 +136,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.module\.s(a|c)ss$/,
+          test: stylesRegexps.sassModuleRegex,
           use: [
             require.resolve('style-loader'),
             {
@@ -156,8 +157,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.s(a|c)ss$/,
-          exclude: /\.module\.s(a|c)ss$/,
+          test: stylesRegexps.sassNoModuleRegex,
           use: [
             require.resolve('style-loader'),
             require.resolve('css-loader'),
@@ -170,7 +170,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.module\.less$/,
+          test: stylesRegexps.lessModuleRegex,
           use: [
             require.resolve('style-loader'),
             {
@@ -191,8 +191,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.less$/,
-          exclude: /\.module\.less$/,
+          test: stylesRegexps.lessNoModuleRegex,
           use: [
             require.resolve('style-loader'),
             require.resolve('css-loader'),
@@ -205,7 +204,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.module.css$/,
+          test: stylesRegexps.cssModuleRegex,
           use: [
             require.resolve('style-loader'),
             {
@@ -220,8 +219,7 @@ export default function ({ envId, fileMapPath, workDir }: Options): WebpackConfi
           ],
         },
         {
-          test: /\.css$/,
-          exclude: /\.module\.css$/,
+          test: stylesRegexps.cssNoModulesRegex,
           use: [require.resolve('style-loader'), require.resolve('css-loader')],
         },
       ],

--- a/scopes/react/react/webpack/webpack.config.preview.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.ts
@@ -1,4 +1,3 @@
-import path from 'path';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import getCSSModuleLocalIdent from 'react-dev-utils/getCSSModuleLocalIdent';
@@ -6,6 +5,8 @@ import TerserPlugin from 'terser-webpack-plugin';
 import webpack, { Configuration } from 'webpack';
 import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 import WorkboxWebpackPlugin from 'workbox-webpack-plugin';
+import * as stylesRegexps from '@teambit/modules.style-regexps';
+import { postCssConfig } from './postcss.config';
 // Make sure the bit-react-transformer is a dependency
 // TODO: remove it once we can set policy from component to component then set it via the component.json
 import '@teambit/babel.bit-react-transformer';
@@ -30,16 +31,6 @@ const moduleFileExtensions = [
 const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 
 const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '10000');
-
-// style files regexes
-
-// css regex - will catch .css but not .module.css
-const cssRegex = /(?<!\.module)\.css$/;
-const cssModuleRegex = /\.module\.css$/;
-const sassRegex = /\.(scss|sass)$/;
-const sassModuleRegex = /\.module\.(scss|sass)$/;
-const lessRegex = /\.less$/;
-const lessModuleRegex = /\.module\.less$/;
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
@@ -73,9 +64,8 @@ export default function (fileMapPath: string): Configuration {
         // package.json
         loader: require.resolve('postcss-loader'),
         options: {
-          postcssOptions: {
-            config: path.resolve(__dirname, 'postcss.config.js'),
-          },
+          // We don't use the config file way to make it easier to mutate it by other envs
+          postcssOptions: postCssConfig,
           sourceMap: isEnvProduction && shouldUseSourceMap,
         },
       },
@@ -214,7 +204,7 @@ export default function (fileMapPath: string): Configuration {
             // of CSS.
             // By default we support CSS Modules with the extension .module.css
             {
-              test: cssRegex,
+              test: stylesRegexps.cssNoModulesRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
                 sourceMap: isEnvProduction && shouldUseSourceMap,
@@ -317,7 +307,7 @@ export default function (fileMapPath: string): Configuration {
             // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
             // using the extension .module.css
             {
-              test: cssModuleRegex,
+              test: stylesRegexps.cssModuleRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
                 sourceMap: isEnvProduction && shouldUseSourceMap,
@@ -330,8 +320,7 @@ export default function (fileMapPath: string): Configuration {
             // By default we support SASS Modules with the
             // extensions .module.scss or .module.sass
             {
-              test: sassRegex,
-              exclude: sassModuleRegex,
+              test: stylesRegexps.sassNoModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
@@ -348,7 +337,7 @@ export default function (fileMapPath: string): Configuration {
             // Adds support for CSS Modules, but using SASS
             // using the extension .module.scss or .module.sass
             {
-              test: sassModuleRegex,
+              test: stylesRegexps.sassModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
@@ -361,8 +350,7 @@ export default function (fileMapPath: string): Configuration {
               ),
             },
             {
-              test: lessRegex,
-              exclude: lessModuleRegex,
+              test: stylesRegexps.lessNoModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 1,
@@ -377,7 +365,7 @@ export default function (fileMapPath: string): Configuration {
               sideEffects: true,
             },
             {
-              test: lessModuleRegex,
+              test: stylesRegexps.lessModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 1,

--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -4,6 +4,7 @@ import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 import WorkboxWebpackPlugin from 'workbox-webpack-plugin';
 import getCSSModuleLocalIdent from 'react-dev-utils/getCSSModuleLocalIdent';
 import path from 'path';
+import * as stylesRegexps from '@teambit/modules.style-regexps';
 
 const moduleFileExtensions = [
   'web.mjs',
@@ -24,15 +25,6 @@ const shouldUseSourceMap = process.env.GENERATE_SOURCEMAP !== 'false';
 
 const imageInlineSizeLimit = parseInt(process.env.IMAGE_INLINE_SIZE_LIMIT || '10000');
 
-// style files regexes
-
-// css regex - will catch .css but not .module.css
-const cssRegex = /(?<!\.module)\.css$/;
-const cssModuleRegex = /\.module\.css$/;
-const sassRegex = /\.(scss|sass)$/;
-const sassModuleRegex = /\.module\.(scss|sass)$/;
-const lessRegex = /\.less$/;
-const lessModuleRegex = /\.module\.less$/;
 const isEnvProduction = true;
 
 // common function to get style loaders
@@ -176,7 +168,7 @@ export default function createWebpackConfig(
             // of CSS.
             // By default we support CSS Modules with the extension .module.css
             {
-              test: cssRegex,
+              test: stylesRegexps.cssNoModulesRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
                 sourceMap: isEnvProduction && shouldUseSourceMap,
@@ -259,7 +251,7 @@ export default function createWebpackConfig(
             // Adds support for CSS Modules (https://github.com/css-modules/css-modules)
             // using the extension .module.css
             {
-              test: cssModuleRegex,
+              test: stylesRegexps.cssModuleRegex,
               use: getStyleLoaders({
                 importLoaders: 1,
                 sourceMap: isEnvProduction && shouldUseSourceMap,
@@ -272,8 +264,7 @@ export default function createWebpackConfig(
             // By default we support SASS Modules with the
             // extensions .module.scss or .module.sass
             {
-              test: sassRegex,
-              exclude: sassModuleRegex,
+              test: stylesRegexps.sassNoModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
@@ -290,7 +281,7 @@ export default function createWebpackConfig(
             // Adds support for CSS Modules, but using SASS
             // using the extension .module.scss or .module.sass
             {
-              test: sassModuleRegex,
+              test: stylesRegexps.sassModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 3,
@@ -303,8 +294,7 @@ export default function createWebpackConfig(
               ),
             },
             {
-              test: lessRegex,
-              exclude: lessModuleRegex,
+              test: stylesRegexps.lessNoModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 1,
@@ -319,7 +309,7 @@ export default function createWebpackConfig(
               sideEffects: true,
             },
             {
-              test: lessModuleRegex,
+              test: stylesRegexps.lessModuleRegex,
               use: getStyleLoaders(
                 {
                   importLoaders: 1,

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -1,4 +1,5 @@
 import { Configuration } from 'webpack';
+import * as stylesRegexps from '@teambit/modules.style-regexps';
 
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ReactRefreshWebpackPlugin = require('@pmmmwh/react-refresh-webpack-plugin');
@@ -223,7 +224,7 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
           },
         },
         {
-          test: /\.module\.s(a|c)ss$/,
+          test: stylesRegexps.sassModuleRegex,
           use: [
             require.resolve('style-loader'),
             {
@@ -244,8 +245,7 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
           ],
         },
         {
-          test: /\.s(a|c)ss$/,
-          exclude: /\.module.(s(a|c)ss)$/,
+          test: stylesRegexps.sassNoModuleRegex,
           use: [
             require.resolve('style-loader'),
             require.resolve('css-loader'),
@@ -258,7 +258,7 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
           ],
         },
         {
-          test: /\.module\.less$/,
+          test: stylesRegexps.lessModuleRegex,
           use: [
             require.resolve('style-loader'),
             {
@@ -279,8 +279,7 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
           ],
         },
         {
-          test: /\.less$/,
-          exclude: /\.module\.less$/,
+          test: stylesRegexps.lessNoModuleRegex,
           use: [
             require.resolve('style-loader'),
             require.resolve('css-loader'),
@@ -293,8 +292,22 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Conf
           ],
         },
         {
-          test: /\.css$/,
-          exclude: /\.(s(a|c)ss)$/,
+          test: stylesRegexps.cssModuleRegex,
+          use: [
+            require.resolve('style-loader'),
+            {
+              loader: require.resolve('css-loader'),
+              options: {
+                modules: {
+                  localIdentName: '[name]__[local]--[hash:base64:5]',
+                },
+                sourceMap: true,
+              },
+            },
+          ],
+        },
+        {
+          test: stylesRegexps.cssNoModulesRegex,
           use: [require.resolve('style-loader'), require.resolve('css-loader')],
         },
       ],

--- a/scopes/webpack/style-regexps/index.ts
+++ b/scopes/webpack/style-regexps/index.ts
@@ -1,0 +1,1 @@
+export * from './style-regexps';

--- a/scopes/webpack/style-regexps/style-regexps.docs.md
+++ b/scopes/webpack/style-regexps/style-regexps.docs.md
@@ -1,11 +1,11 @@
 ---
-labels: ['typescript', 'utils', 'webpack']
-description: 'A set of style regexps to use in loaders's test field.'
+labels: ['typescript', 'utils', 'webpack', 'regex']
+description: 'A set of style regexps to use in loaders test field'
 ---
 
-A set of style regexps to use in loaders's test field
+A set of style regexps to use in loaders' test field
 
-Available regexps
+## Available regexps
 
 ```js
 // css

--- a/scopes/webpack/style-regexps/style-regexps.docs.md
+++ b/scopes/webpack/style-regexps/style-regexps.docs.md
@@ -1,0 +1,28 @@
+---
+labels: ['typescript', 'utils', 'webpack']
+description: 'A set of style regexps to use in loaders's test field.'
+---
+
+A set of style regexps to use in loaders's test field
+
+Available regexps
+
+```js
+// css
+export const cssRegex = /\.css$/;
+// css regex - will catch .css but not .module.css
+export const cssNoModulesRegex = /(?<!\.module)\.css$/;
+export const cssModuleRegex = /\.module\.css$/;
+
+// sass | scss
+export const sassRegex = /\.(scss|sass)$/;
+// scss|sass regex - will catch .scss|sass but not .module.scss|sass
+export const sassNoModuleRegex = /(?<!\.module)\.(scss|sass)$/;
+export const sassModuleRegex = /\.module\.(scss|sass)$/;
+
+// less
+export const lessRegex = /\.less$/;
+// less regex - will catch .less but not .module.less
+export const lessNoModuleRegex = /(?<!\.module)\.less$/;
+export const lessModuleRegex = /\.module\.less$/;
+```

--- a/scopes/webpack/style-regexps/style-regexps.ts
+++ b/scopes/webpack/style-regexps/style-regexps.ts
@@ -1,0 +1,19 @@
+// style files regexps
+
+// css
+export const cssRegex = /\.css$/;
+// css regex - will catch .css but not .module.css
+export const cssNoModulesRegex = /(?<!\.module)\.css$/;
+export const cssModuleRegex = /\.module\.css$/;
+
+// sass | scss
+export const sassRegex = /\.(scss|sass)$/;
+// scss|sass regex - will catch .scss|sass but not .module.scss|sass
+export const sassNoModuleRegex = /(?<!\.module)\.(scss|sass)$/;
+export const sassModuleRegex = /\.module\.(scss|sass)$/;
+
+// less
+export const lessRegex = /\.less$/;
+// less regex - will catch .less but not .module.less
+export const lessNoModuleRegex = /(?<!\.module)\.less$/;
+export const lessModuleRegex = /\.module\.less$/;


### PR DESCRIPTION
## Proposed Changes

- webpack styles regexps component
- add style regexp to bit
- use style regexp component in ui foundation webpack configs
- use postcss inline instead of passing a config path (to improve extendability)
- export postcss config as regular object
- use style regexps component in react webpack configs 
- add css modules rule for ui foundation webpack dev config
- re-export styles regexps from react aspe
