### PR TITLE
add more logs to better understand stream issues during fetch

### DIFF
--- a/scopes/scope/scope/routes/fetch.route.ts
+++ b/scopes/scope/scope/routes/fetch.route.ts
@@ -28,6 +28,7 @@ export class FetchRoute implements Route {
       const pipelinePromise = promisify(pipeline);
       try {
         await pipelinePromise(pack, res);
+        this.logger.info('fetch.router, the response has been sent successfully to the client', req.headers);
       } catch (err) {
         if (req.aborted) {
           this.logger.warn('FetchRoute, the client aborted the request', err);


### PR DESCRIPTION
This is an attempt to determine what's going on from the server side when the client gets `server terminated the stream unexpectedly` error. 
(here for example: https://app.circleci.com/pipelines/github/teambit/bit/11698/workflows/b85c09bd-9576-44ca-850b-d314fe75165a/jobs/149434).