### PR TITLE
throw an error when an invalid-scope was entered to bit-create command

### DIFF
--- a/e2e/harmony/create.e2e.4.ts
+++ b/e2e/harmony/create.e2e.4.ts
@@ -97,4 +97,13 @@ describe('create extension', function () {
       expect(compRootDir).to.not.be.a.path();
     });
   });
+  describe('with an invalid scope-name', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+    });
+    it('should throw InvalidScopeName error', () => {
+      expect(() => helper.command.create('aspect', 'my-aspect', '--scope ui/')).to.throw('"ui/" is invalid');
+    });
+  });
 });

--- a/scopes/component/legacy-bit-id/exceptions/invalid-scope-name.ts
+++ b/scopes/component/legacy-bit-id/exceptions/invalid-scope-name.ts
@@ -4,7 +4,7 @@ export default class InvalidScopeName extends BitError {
   scopeName: string;
   id: string;
 
-  constructor(scopeName: string, id: string) {
+  constructor(scopeName: string, id?: string) {
     super(
       `error: "${
         id || scopeName

--- a/scopes/component/legacy-bit-id/index.ts
+++ b/scopes/component/legacy-bit-id/index.ts
@@ -1,4 +1,5 @@
 import BitId, { VERSION_DELIMITER, BitIdStr } from './bit-id';
-import { InvalidName } from './exceptions';
+import { InvalidName, InvalidScopeName } from './exceptions';
+import isValidScopeName from './utils/is-valid-scope-name';
 
-export { BitId, BitIdStr, VERSION_DELIMITER, InvalidName };
+export { BitId, BitIdStr, VERSION_DELIMITER, isValidScopeName, InvalidName, InvalidScopeName };

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -4,6 +4,7 @@ import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { ComponentID } from '@teambit/component-id';
 import { Slot, SlotRegistry } from '@teambit/harmony';
+import { InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
 import { ComponentTemplate } from './component-template';
 import { GeneratorAspect } from './generator.aspect';
 import { CreateCmd, CreateOptions } from './create.cmd';
@@ -13,7 +14,6 @@ import { ComponentGenerator, GenerateResult } from './component-generator';
 import { WorkspaceGenerator } from './workspace-generator';
 import { WorkspaceTemplate } from './workspace-template';
 import { NewCmd, NewOptions } from './new.cmd';
-import { InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
 
 export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
 export type WorkspaceTemplateSlot = SlotRegistry<WorkspaceTemplate[]>;

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -13,6 +13,7 @@ import { ComponentGenerator, GenerateResult } from './component-generator';
 import { WorkspaceGenerator } from './workspace-generator';
 import { WorkspaceTemplate } from './workspace-template';
 import { NewCmd, NewOptions } from './new.cmd';
+import { InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
 
 export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
 export type WorkspaceTemplateSlot = SlotRegistry<WorkspaceTemplate[]>;
@@ -116,6 +117,9 @@ export class GeneratorMain {
     const template = this.getComponentTemplate(templateName, aspectId);
     if (!template) throw new Error(`template "${templateName}" was not found`);
     const scope = options.scope || this.workspace.defaultScope;
+    if (!isValidScopeName(scope)) {
+      throw new InvalidScopeName(scope);
+    }
     if (!scope) throw new Error(`failed finding defaultScope`);
 
     const componentIds = componentNames.map((componentName) => {


### PR DESCRIPTION
Reported by @debs-obrien . 
This is happening when `--scope` flag of `bit create` gets an invalid scope. 