### PR TITLE
throw ConsumerNotFound when running bit-create outside a workspace

### DIFF
--- a/e2e/harmony/create.e2e.4.ts
+++ b/e2e/harmony/create.e2e.4.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import path from 'path';
-
+import os from 'os';
 import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
@@ -15,6 +15,11 @@ describe('create extension', function () {
   });
   after(() => {
     helper.scopeHelper.destroy();
+  });
+  describe('when running outside the workspace', () => {
+    it('should throw ConsumerNotFound error', () => {
+      expect(() => helper.command.runCmd('bit create aspect my-aspect', os.tmpdir())).to.throw('workspace not found');
+    });
   });
   describe('with --namespace flag', () => {
     before(() => {

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -2,6 +2,7 @@ import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
+import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import { ComponentID } from '@teambit/component-id';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import { ComponentTemplate } from './component-template';
@@ -111,6 +112,7 @@ export class GeneratorMain {
     templateName: string,
     options: CreateOptions
   ): Promise<GenerateResult[]> {
+    if (!this.workspace) throw new ConsumerNotFound();
     await this.loadAspects();
     const { namespace, aspect: aspectId } = options;
     const template = this.getComponentTemplate(templateName, aspectId);


### PR DESCRIPTION
Reported by @debs-obrien . 
Currently it shows an obscure error `Cannot read property 'loadAspects' of undefined`.