### PR TITLE
Warn (bit-status) when a component imports a non-main file from another bit-component

### DIFF
--- a/e2e/harmony/import-non-main-files.e2e.ts
+++ b/e2e/harmony/import-non-main-files.e2e.ts
@@ -1,0 +1,36 @@
+import chai, { expect } from 'chai';
+import { componentIssuesLabels } from '../../src/cli/templates/component-issues-template';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('importing internal files flow (component imports from a non-index file of another component)', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('importing of a non-main .js file', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2, false);
+      helper.fs.outputFile('comp2/non-main.js', 'export function nonMain(){}');
+      helper.fs.outputFile('comp1/index.js', `import { nonMain } from '@${helper.scopes.remote}/comp2/non-main';`);
+      helper.command.link();
+    });
+    it('bit status should show it as an invalid component', () => {
+      const status = helper.command.statusJson();
+      expect(status.componentsWithMissingDeps).to.have.lengthOf(1);
+      expect(status.componentsWithMissingDeps[0]).to.equal('comp1');
+    });
+    it('bit status should print the path for the non-main file', () => {
+      const status = helper.command.status();
+      expect(status).to.have.string(`index.js -> @${helper.scopes.remote}/comp2/non-main.js`);
+      expect(status).to.have.string(componentIssuesLabels.importNonMainFiles);
+    });
+  });
+});

--- a/src/api/consumer/lib/status.ts
+++ b/src/api/consumer/lib/status.ts
@@ -51,6 +51,7 @@ export default (async function status(): Promise<StatusResult> {
   const componentsWithMissingDeps = newAndModified.filter((component: Component) => {
     if (consumer.isLegacy && component.issues) {
       delete component.issues.relativeComponentsAuthored;
+      delete component.issues.importNonMainFiles;
     }
     return Boolean(component.issues) && !R.isEmpty(component.issues);
   });

--- a/src/cli/templates/component-issues-template.ts
+++ b/src/cli/templates/component-issues-template.ts
@@ -24,6 +24,7 @@ export const componentIssuesLabels = {
     'component is using an unsupported resolve-modules (aka aliases) feature, replace to module paths',
   parseErrors: 'error found while parsing the file (edit the file and fix the parsing error)',
   resolveErrors: 'error found while resolving the file dependencies (see the log for the full error)',
+  importNonMainFiles: 'importing non-main files (the dependency should expose its API from the main file)',
 };
 
 export const MISSING_PACKAGES_FROM_OVERRIDES_LABEL = 'from overrides configuration';

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -10,6 +10,7 @@ import { resolvePackageNameByPath } from './resolve-pkg-name-by-path';
 export interface ResolvedPackageData {
   fullPath: PathLinuxAbsolute; // package path
   packageJsonPath?: PathOsBased;
+  packageJsonContent?: Record<string, any>;
   dependentPackageJsonPath?: PathOsBased;
   name: string; // package name
   concreteVersion?: string; // version from the package.json of the package itself
@@ -93,6 +94,7 @@ function enrichDataFromDependency(packageData: ResolvedPackageData) {
     return;
   }
   packageData.packageJsonPath = path.join(packageDir, PACKAGE_JSON);
+  packageData.packageJsonContent = packageInfo;
   packageData.name = packageInfo.name;
   packageData.concreteVersion = packageInfo.version;
   if (packageInfo.componentId) {


### PR DESCRIPTION
Resolve #4157

e.g. `import { compB } from '@owner.scope/ui.button/an-internal-file.ts'`;
It's suggested to expose whatever needed from the component main-file, so then other component can always import by using the component-package without internal files.
Otherwise, issues happening during `bit build` and other commands.

This new warning is enabled for the following extensions only: `['.ts', '.tsx', '.js', '.jsx']`.