### PR TITLE
support `*` and `**` in variants namespaces selectors

### DIFF
--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "@types/chai-string": "1.4.2",
     "@types/fs-extra": "9.0.7",
     "@types/graphlib": "2.1.7",
+    "@types/minimatch": "3.0.4",
     "@types/mocha": "5.2.7",
     "@types/node": "12.20.4",
     "@types/node-fetch": "2.5.8",

--- a/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
@@ -62,8 +62,13 @@ describe('isMatchNamespacePatternItem', () => {
     });
     it('pattern is part of name and ends with * and name has more parts', () => {
       const res = isMatchNamespacePatternItem('bar/foo/baz', '{bar/*}');
+      expect(res.match).to.be.false;
+      expect(res.specificity).to.equal(-1);
+    });
+    it('pattern is part of name and ends with ** and name has more parts', () => {
+      const res = isMatchNamespacePatternItem('bar/foo/baz', '{bar/**}');
       expect(res.match).to.be.true;
-      expect(res.specificity).to.equal(1.1);
+      expect(res.specificity).to.equal(1.05);
     });
     it('specificity is larger than 1', () => {
       const res = isMatchNamespacePatternItem('bar/foo/baz', '{bar/foo/*}');
@@ -74,6 +79,12 @@ describe('isMatchNamespacePatternItem', () => {
       const res = isMatchNamespacePatternItem('bar/foo/baz/goo', '{bar/*/baz/*}');
       expect(res.match).to.be.true;
       expect(res.specificity).to.equal(2.4);
+    });
+    it('using ** in the middle of the pattern', () => {
+      const res = isMatchNamespacePatternItem('bar/foo/moo/baz/goo', '{bar/**/baz/*}');
+      expect(res.match).to.be.true;
+      const specificity = Math.round(res.specificity * 100) / 100;
+      expect(specificity).to.equal(2.35);
     });
   });
   describe('item is not matched', () => {

--- a/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
@@ -200,6 +200,50 @@ describe('isMatchPattern', () => {
       expect(res.maxSpecificity).to.equal(4);
     });
   });
+  describe('special patterns', () => {
+    describe('only components without namespace', () => {
+      const pattern = '*,!{*/**}';
+      it('should match component without namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'comp-name', pattern);
+        expect(res.match).to.be.true;
+        expect(res.excluded).to.be.false;
+        expect(res.maxSpecificity).to.equal(0);
+      });
+      it('should exclude component with one namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'namespace1/comp-name', pattern);
+        expect(res.match).to.be.true;
+        expect(res.excluded).to.be.true;
+        expect(res.maxSpecificity).to.equal(0.05);
+      });
+      it('should exclude component with more than one namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'namespace1/namespace2/comp-name', pattern);
+        expect(res.match).to.be.true;
+        expect(res.excluded).to.be.true;
+        expect(res.maxSpecificity).to.equal(0.05);
+      });
+    });
+    describe('only components with at least namespace', () => {
+      const pattern = '{*/**}';
+      it('should not match component without namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'comp-name', pattern);
+        expect(res.match).to.be.false;
+        expect(res.excluded).to.be.false;
+        expect(res.maxSpecificity).to.equal(-1);
+      });
+      it('should match component with one namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'namespace1/comp-name', pattern);
+        expect(res.match).to.be.true;
+        expect(res.excluded).to.be.false;
+        expect(res.maxSpecificity).to.equal(0.05);
+      });
+      it('should match component with more than one namespace', () => {
+        const res = isMatchPattern('bar/foo/baz/goo', 'namespace1/namespace2/comp-name', pattern);
+        expect(res.match).to.be.true;
+        expect(res.excluded).to.be.false;
+        expect(res.maxSpecificity).to.equal(0.05);
+      });
+    });
+  });
 });
 
 describe('sortMatchesBySpecificity', () => {

--- a/scopes/workspace/modules/match-pattern/match-pattern.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.ts
@@ -1,6 +1,7 @@
 import { stripTrailingChar } from '@teambit/string.strip-trailing-char';
 import { isPathInside } from '@teambit/path.is-path-inside';
 import { sortBy, prop, any } from 'ramda';
+import minimatch from 'minimatch';
 import _ from 'lodash';
 
 export const PATTERNS_DELIMITER = ',';
@@ -109,14 +110,9 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
   const splittedComp = componentName.split('/');
   const splittedPattern = patternItemStriped.split('/');
 
-  if (splittedPattern.length > splittedComp.length) {
-    return {
-      match: false,
-      specificity: -1,
-    };
-  }
+  const minimatchMatch = minimatch(componentName, patternItemStriped);
 
-  if (splittedPattern.length < splittedComp.length && splittedPattern[splittedPattern.length - 1] !== '*') {
+  if (!minimatchMatch) {
     return {
       match: false,
       specificity: -1,
@@ -124,16 +120,16 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
   }
 
   splittedPattern.forEach((patternElement, index) => {
-    const componentElement = splittedComp[index];
+    if (patternElement === '**') {
+      specificity += index / 20;
+      return;
+    }
     if (patternElement === '*') {
       specificity += index / 10;
       return;
     }
-    if (patternElement === componentElement) {
-      specificity += 1;
-      return;
-    }
-    match = false;
+    // Matching an exact element
+    specificity += 1;
   });
 
   return {

--- a/scopes/workspace/modules/match-pattern/match-pattern.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.ts
@@ -54,7 +54,8 @@ export function isMatchPattern(rootDir: PathLinuxRelative, componentName: string
   };
 
   const maxMatch: MatchedPatternItemWithExclude = _.maxBy(matches, (match) => match.specificity) || defaultVal;
-  const excluded = any((match) => match.excluded, matches);
+  const excluded = any((match) => match.match && match.excluded, matches);
+
   return {
     match: maxMatch.match,
     maxSpecificity: maxMatch.specificity,

--- a/scopes/workspace/modules/match-pattern/match-pattern.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.ts
@@ -105,9 +105,7 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
   const withoutBrackets = patternItem.replace('{', '').replace('}', '').trim();
   const patternItemStriped = stripTrailingChar(withoutBrackets, '/').trim();
 
-  let match = true;
   let specificity = 0;
-  const splittedComp = componentName.split('/');
   const splittedPattern = patternItemStriped.split('/');
 
   const minimatchMatch = minimatch(componentName, patternItemStriped);
@@ -133,8 +131,8 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
   });
 
   return {
-    match,
-    specificity: match ? specificity : -1,
+    match: minimatchMatch,
+    specificity,
   };
 }
 

--- a/scopes/workspace/variants/variants.docs.md
+++ b/scopes/workspace/variants/variants.docs.md
@@ -12,23 +12,11 @@ Configurations set on a certain set of components can:
 1. Override conflicting configurations inherited from more general component selections
 1. Propagate configurations downwards to more specific sub-sets of components
 
-## Variants Examples
-
-### The Wildcard (\*) variant
-
-To select all components in the workspace use a wildcard (`*`). This is useful when wanting to apply a very general rules on all components. For example:
-
-```json
-"teambit.workspace/variants": {
-    "*": {
-        "teambit.harmony/node": {}
-    },
-}
-```
+## Variants Selector Examples
 
 ### Select a rule set by directory
 
-To select a set using a directory path, use the relative path to the components' parent directory. In the following example, all components under the `components/utility-functions` directory
+To select a set using a directory path, use the relative path to the components' parent directory from the workspace root. In the following example, all components under the `components/utility-functions` directory
 (and any sub-directories) will be included in this set:
 
 ```json
@@ -42,7 +30,9 @@ To select a set using a directory path, use the relative path to the components'
 ### Select a rule set via namespace
 
 This option is recommended as it decouples your components' configurations from the workspace's file structure. It handles components using fundamental definitions that pertain to function and purpose, via their namespace.
-The namespace selector behave like a glob pattern where the component name used as a file path matched against the pattern. This means that namespace selector for example support `*` to one part exactly where `**` match arbitrary parts of the component name.
+The namespace selector behaves like a glob pattern, with the component name (including its namespace) being the equivalent of a file path being matched against the pattern.  
+Specifically, this means that namespace selectors support the location-specific `*` matcher, and the 'anywhere' `**` matcher for matching the component name.
+
 In the following example, any component under the `utility-functions` namespace (and it's sub-namespaces) will be included in this rule set:
 
 ```json
@@ -53,7 +43,7 @@ In the following example, any component under the `utility-functions` namespace 
 }
 ```
 
-In the following example, any component **directly** under the `utility-functions` namespace will be included in this rule set:
+In the following example however, only components **directly** under the `utility-functions` namespace will be included in this rule set:
 
 ```json
 "teambit.workspace/variants": {
@@ -63,9 +53,9 @@ In the following example, any component **directly** under the `utility-function
 }
 ```
 
-### Several rule sets with the same variant configuration
+### Grouping selectors
 
-You can add several rule sets for the same variant configuration:
+You can add several sets for the same variant configuration by grouping selectors together:
 
 ```json title="Multiple directory paths"
 "teambit.workspace/variants": {
@@ -93,12 +83,12 @@ You can add several rule sets for the same variant configuration:
 
 ### Exclude directories/components from a rule
 
-Using the `!` you can exclude set of components from a specific rule.
-The `!` works both for directories and namespaces, for example:
+Using the `!` deselector you can exclude a set of components from a selector.
+The `!` deselector works both for directories and namespaces, for example:
 
-#### Exclude directory from a rule
+#### Exclude a sub-directory directory from a rule
 
-For example, apply the `teambit.harmony/node` environment on the `utility-functions` set, but exclude on `utility-functions/react-utils` from that set:
+For example, apply the `teambit.harmony/node` environment on the `utility-functions` set, but exclude the `utility-functions/react-utils` folder from that set:
 
 ```json title="workspace.json
 "teambit.workspace/variants": {
@@ -108,9 +98,9 @@ For example, apply the `teambit.harmony/node` environment on the `utility-functi
 }
 ```
 
-#### Exclude namespace from a rule
+#### Exclude namespaces from a rule
 
-For exapmle, apply the `teambit.harmony/node` environment on every component under the `utils` namespace but exclude the `utils/react` namespace and its children from this set:
+The following example applies the `teambit.harmony/node` environment on every component under the `utils` namespace, but excludes the `utils/react` namespace and its children from this set:
 
 ```json title="workspace.json
 "teambit.workspace/variants": {
@@ -120,9 +110,26 @@ For exapmle, apply the `teambit.harmony/node` environment on every component und
 }
 ```
 
+### Special Variants
+
+#### The Wildcard (\*) variant
+
+To select all components in your workspace use the wildcard variant `*`. This is useful when you want to apply very general configurations, especially default or backup configurations,
+on all components. Using this selector can produce unexpected consequences if the rules aren't general enough, so we recommend using this selector sparingly!  
+For example:
+
+```json
+"teambit.workspace/variants": {
+    "*": {
+        "teambit.harmony/node": {}
+    },
+}
+```
+
 ## Merging Configurations
 
-The same component may have several rules applied to it. This works very much like CSS rules where rules cascade but the more specific variant "wins" when there are rule 'conflicts'.
+The same component may have several rules applied to it, including several versions of the same configuration. This works very much like CSS rules where rules cascade
+but the more specific variant "wins" when there are rule 'conflicts'.
 
 The following example shows how Bit does not apply `aspect1-components-key` nor the `aspect1-root-key` for components under the `components/ui` directory, as the `my-aspect1` extension
 was re-set by a more specific variant.
@@ -178,13 +185,13 @@ was re-set by a more specific variant.
 }
 ```
 
-## Variants configurations
+## Variants Flags
 
-### propagate
+### Propagate
 
-Configurations set on one group of components are inherited by its sub-groups (in a CSS-like manner). For example, `components/react/ui` will inherit configurations from `components/react`.
-To prevent this from happening, set the `propogate` value of a group of components to `false`.
-Once bit see `"propagate": false` it takes the configuration for this group, and stop propagate.
+When using directory selectors, configurations set on one group of components are inherited by its sub-groups (in a CSS-like manner). For example, `components/react/ui` will inherit configurations from `components/react`.
+To prevent this from happening for specific set of inheritors, set the `propogate` value of an inheriting group of components to `false`.
+Once bit see `"propagate": false` it takes the configuration for this group and does not inherit.
 
 ```json title="workspace.json
 "teambit.workspace/variants": {
@@ -212,12 +219,12 @@ Once bit see `"propagate": false` it takes the configuration for this group, and
 
 ## Removing aspects
 
-> Note: Once a component has been tagged, any aspect configured for that component **can only** be removed from the component via the following `remove` method. (if you havent exported yet then `untag` would reset the effect of the tag)
+> Note: Once a component has been tagged, any aspect configured for that component **can only** be removed from the component via the following `remove` method. (if you haven't exported yet then `untag` would reset the effect of the tag)
 
 There are numerous scenarios where you would not want a specific aspect to be defined on a subgroup but you don't want to exclude the sub-group from upstream rules, or use the `propagate: false` flag, since you want to receive the
 other configurations from the parent group rule/s.
 
-In that case, removing a specific aspect can be achieved using `"-"` as the value for an aspect's configuration. This will remove this aspect from the current rule set.
+In that case, removing a specific aspect can be achieved using `"-"` as the value for an aspect's configuration. This will remove this aspect from the current component set.
 
 For instance, the following will remove `my-aspect2` from components in the `components/react/ui` set, while still inheriting other configs such as the `my-aspect3` aspect.
 

--- a/scopes/workspace/variants/variants.docs.md
+++ b/scopes/workspace/variants/variants.docs.md
@@ -30,7 +30,7 @@ To select a set using a directory path, use the relative path to the components'
 ### Select a rule set via namespace
 
 This option is recommended as it decouples your components' configurations from the workspace's file structure. It handles components using fundamental definitions that pertain to function and purpose, via their namespace.
-The namespace selector behaves like a glob pattern, with the component name (including its namespace) being the equivalent of a file path being matched against the pattern.  
+The namespace selector behaves like a glob pattern, with the component name (including its namespace) being the equivalent of a file path being matched against the pattern.
 Specifically, this means that namespace selectors support the location-specific `*` matcher, and the 'anywhere' `**` matcher for matching the component name.
 
 In the following example, any component under the `utility-functions` namespace (and it's sub-namespaces) will be included in this rule set:
@@ -115,7 +115,7 @@ The following example applies the `teambit.harmony/node` environment on every co
 #### The Wildcard (\*) variant
 
 To select all components in your workspace use the wildcard variant `*`. This is useful when you want to apply very general configurations, especially default or backup configurations,
-on all components. Using this selector can produce unexpected consequences if the rules aren't general enough, so we recommend using this selector sparingly!  
+on all components. Using this selector can produce unexpected consequences if the rules aren't general enough, so we recommend using this selector sparingly!
 For example:
 
 ```json
@@ -189,7 +189,7 @@ was re-set by a more specific variant.
 
 ### Propagate
 
-When using directory selectors, configurations set on one group of components are inherited by its sub-groups (in a CSS-like manner). For example, `components/react/ui` will inherit configurations from `components/react`.
+When using selectors, configurations set on one group of components are inherited by its sub-groups (in a CSS-like manner). For example, `components/react/ui` will inherit configurations from `components/react`.
 To prevent this from happening for specific set of inheritors, set the `propogate` value of an inheriting group of components to `false`.
 Once bit see `"propagate": false` it takes the configuration for this group and does not inherit.
 

--- a/scopes/workspace/variants/variants.docs.md
+++ b/scopes/workspace/variants/variants.docs.md
@@ -41,12 +41,23 @@ To select a set using a directory path, use the relative path to the components'
 
 ### Select a rule set via namespace
 
-This option is recommended as it decouples your components' configurations from the workspace's file structure. It handles components using fundamental definitions that pertain to function and purpose, via their namespace.  
+This option is recommended as it decouples your components' configurations from the workspace's file structure. It handles components using fundamental definitions that pertain to function and purpose, via their namespace.
+The namespace selector behave like a glob pattern where the component name used as a file path matched against the pattern. This means that namespace selector for example support `*` to one part exactly where `**` match arbitrary parts of the component name.
 In the following example, any component under the `utility-functions` namespace (and it's sub-namespaces) will be included in this rule set:
 
 ```json
 "teambit.workspace/variants": {
-    "{utility-functions/*}": {
+    "{utility-functions/**}": { // Match any component name starts with utility-functions
+        "teambit.harmony/node": {}
+    },
+}
+```
+
+In the following example, any component **directly** under the `utility-functions` namespace will be included in this rule set:
+
+```json
+"teambit.workspace/variants": {
+    "{utility-functions/*}": { // Match utility-functions/sort-array but not utility-functions/string/reverse
         "teambit.harmony/node": {}
     },
 }
@@ -66,7 +77,7 @@ You can add several rule sets for the same variant configuration:
 
 ```json title="Multiple namespaces"
 "teambit.workspace/variants": {
-    "{utility-functions/*}, {react-ui/*}": {
+    "{utility-functions/**}, {react-ui/**}": {
         "teambit.harmony/node": {}
     },
 }
@@ -74,7 +85,7 @@ You can add several rule sets for the same variant configuration:
 
 ```json title="Paths and namespaces"
 "teambit.workspace/variants": {
-    "{utility-functions/*}, {react-ui/*}, components/utils, components/react-ui": {
+    "{utility-functions/**}, {react-ui/**}, components/utils, components/react-ui": {
         "teambit.harmony/node": {}
     },
 }
@@ -103,7 +114,7 @@ For exapmle, apply the `teambit.harmony/node` environment on every component und
 
 ```json title="workspace.json
 "teambit.workspace/variants": {
-    "{utils/*}, !{utils/react/*}": {
+    "{utils/**}, !{utils/react/**}": {
         "teambit.harmony/node": {}
     },
 }

--- a/scopes/workspace/variants/variants.docs.md
+++ b/scopes/workspace/variants/variants.docs.md
@@ -189,9 +189,9 @@ was re-set by a more specific variant.
 
 ### Propagate
 
-When using selectors, configurations set on one group of components are inherited by its sub-groups (in a CSS-like manner). For example, `components/react/ui` will inherit configurations from `components/react`.
-To prevent this from happening for specific set of inheritors, set the `propogate` value of an inheriting group of components to `false`.
-Once bit see `"propagate": false` it takes the configuration for this group and does not inherit.
+When using selectors which can propagate down to sub-sets, such as with directory selectors (where all sub-directories are included) or {namespace/\*\*} type selectors,
+you can prevent this propagation for specific set of inheritors, by setting set the `propogate` value of an inheriting group of components to `false`.
+Once bit sees `"propagate": false` it uses only the configuration for this set and does not inherit.
 
 ```json title="workspace.json
 "teambit.workspace/variants": {
@@ -201,7 +201,7 @@ Once bit see `"propagate": false` it takes the configuration for this group and 
     }
   },
   "components/react/ui": {
-    "propagate": false, // take this config, and stop propagate
+    "propagate": false, // take this config, and don't propagate parent configs down to here
     "my-aspect1": {
       "aspect1-react-ui-key": "aspect1-react-ui-val"
     }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -379,24 +379,24 @@
       },
       "teambit.harmony/aspect": {}
     },
-    "{modules/*}": {
+    "{modules/**}": {
       "teambit.envs/envs": {
         "env": "teambit.harmony/node"
       },
       "teambit.harmony/node": {}
     },
-    "{cli/*}": {
+    "{cli/**}": {
       "teambit.envs/envs": {
         "env": "teambit.react/react"
       }
     },
-    "{babel/*}": {
+    "{babel/**}": {
       "teambit.envs/envs": {
         "env": "teambit.harmony/node"
       },
       "teambit.harmony/node": {}
     },
-    "{ui/*}": {
+    "{ui/**}": {
       "teambit.envs/envs": {
         "env": "teambit.react/react"
       },


### PR DESCRIPTION
## Proposed Changes

- this will break the previous `{namespace/*}` which will now won't match longer names like `{namespace/inner-ns/name}`

