### PR TITLE
support useWebpack in react-native API

### DIFF
--- a/scopes/react/react-native/webpack/webpack-transformers.ts
+++ b/scopes/react/react-native/webpack/webpack-transformers.ts
@@ -1,0 +1,42 @@
+import { WebpackConfigTransformer, WebpackConfigMutator, WebpackConfigTransformContext } from '@teambit/webpack';
+import webpackConfig from './webpack.config';
+
+/**
+ * Transformation to apply for both preview and dev server
+ * @param config
+ * @param _context
+ */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function commonTransformation(config: WebpackConfigMutator, _context: WebpackConfigTransformContext) {
+  // Merge config with the webpack.config.js file - adding handlebars support
+  config.merge([webpackConfig]);
+  return config;
+}
+
+/**
+ * Transformation for the preview only
+ * @param config
+ * @param context
+ * @returns
+ */
+export const previewConfigTransformer: WebpackConfigTransformer = (
+  config: WebpackConfigMutator,
+  context: WebpackConfigTransformContext
+) => {
+  const newConfig = commonTransformation(config, context);
+  return newConfig;
+};
+
+/**
+ * Transformation for the dev server only
+ * @param config
+ * @param context
+ * @returns
+ */
+export const devServerConfigTransformer: WebpackConfigTransformer = (
+  config: WebpackConfigMutator,
+  context: WebpackConfigTransformContext
+) => {
+  const newConfig = commonTransformation(config, context);
+  return newConfig;
+};


### PR DESCRIPTION
## Proposed Changes

- support useWebpack in react-native API
- use useWebpack in raect-native to mutate the react webpack config
- remove overridePreviewConfig and overrideDevServerConfig from react-native
