### PR TITLE
fix ctrl+k not working in windows

### DIFF
--- a/scopes/explorer/command-bar/command-bar.preview.runtime.tsx
+++ b/scopes/explorer/command-bar/command-bar.preview.runtime.tsx
@@ -1,5 +1,6 @@
 import { PreviewRuntime } from '@teambit/preview';
 import { PubsubAspect, PubsubPreview } from '@teambit/pubsub';
+import { isOpenCommandBarKeybinding } from './keybinding';
 import { CommandBarAspect } from './command-bar.aspect';
 import { KeyEvent } from './model/key-event';
 
@@ -13,6 +14,7 @@ export class CommandBarPreview {
   handleKeyEvent = (e: KeyboardEvent) => {
     const { target } = e;
     if (!target || isEditable(target as HTMLElement)) return;
+    if (isDenyListed(e)) e.preventDefault();
 
     this.pubSub.pub(CommandBarAspect.id, new KeyEvent(e));
   };
@@ -31,3 +33,8 @@ function isEditable(element: HTMLElement) {
 }
 
 CommandBarAspect.addRuntime(CommandBarPreview);
+
+// block default browser behavior that would override our keybinding.
+function isDenyListed(e: KeyboardEvent) {
+  return isOpenCommandBarKeybinding(e);
+}

--- a/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
+++ b/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
@@ -14,6 +14,7 @@ import { DuplicateCommandError } from './duplicate-command-error';
 import { KeyEvent } from './model/key-event';
 import { CommandBarContext } from './ui/command-bar-context';
 import { MousetrapStub } from './mousetrap-stub';
+import { openCommandBarKeybinding } from './keybinding';
 
 const RESULT_LIMIT = 5;
 type SearcherSlot = SlotRegistry<SearchProvider>;
@@ -34,6 +35,7 @@ export class CommandBarUI {
   /** Opens the command bar */
   open = () => {
     this.setVisibility?.(true);
+    return false; // aka prevent default
   };
 
   /** Closes the command bar */
@@ -160,11 +162,13 @@ export class CommandBarUI {
       id: commandBarCommands.open,
       handler: commandBar.open,
       displayName: 'Open command bar',
-      keybinding: 'mod+k',
+      keybinding: openCommandBarKeybinding,
     });
 
     uiUi.registerHudItem(commandBar.getCommandBar());
-    uiUi.registerContext(commandBar.renderContext);
+    uiUi.registerRenderHooks({
+      reactContext: commandBar.renderContext,
+    });
 
     return commandBar;
   }

--- a/scopes/explorer/command-bar/keybinding.ts
+++ b/scopes/explorer/command-bar/keybinding.ts
@@ -1,0 +1,5 @@
+export const openCommandBarKeybinding = 'mod+k';
+export const isOpenCommandBarKeybinding = (e: KeyboardEvent) => {
+  // TODO - use a keybinding matcher.
+  return (e.ctrlKey || e.metaKey) && e.key === 'k';
+};


### PR DESCRIPTION
## Proposed Changes

- add prevent default for `ctrl+k` (also applies to `⌘ + k`)
- same prevents default also in Preview (requires re-tagging)

@itaymendel FYI