### PR TITLE
avoid too many trips to the remotes when build was not succeed

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -90,6 +90,7 @@ function printBitVersionIfAsked() {
 function enableLoaderIfPossible() {
   const safeCommandsForLoader = [
     'status',
+    's', // status alias
     'compile',
     'start',
     'add',

--- a/src/cache/in-memory-cache.ts
+++ b/src/cache/in-memory-cache.ts
@@ -7,10 +7,12 @@ export interface InMemoryCache<T> {
   delete(key: string): void;
   has(key: string): boolean;
   deleteAll(): void;
+  keys(): string[];
 }
 
 export type CacheOptions = {
   maxSize?: number;
+  maxAge?: number; // in milliseconds
 };
 
 export function getMaxSizeForComponents(): number {

--- a/src/cache/lru-cache-adapter.ts
+++ b/src/cache/lru-cache-adapter.ts
@@ -4,7 +4,9 @@ import { InMemoryCache, CacheOptions } from './in-memory-cache';
 export class LRUCacheAdapter<T> implements InMemoryCache<T> {
   private cache: LRU;
   constructor(options: CacheOptions) {
-    this.cache = new LRU({ max: options.maxSize || Infinity });
+    const lruOptions: Record<string, any> = { max: options.maxSize || Infinity };
+    if (options.maxAge) lruOptions.maxAge = options.maxAge;
+    this.cache = new LRU(lruOptions);
   }
   set(key: string, value: T) {
     this.cache.set(key, value);
@@ -20,5 +22,8 @@ export class LRUCacheAdapter<T> implements InMemoryCache<T> {
   }
   deleteAll() {
     this.cache.reset();
+  }
+  keys() {
+    return this.cache.keys();
   }
 }


### PR DESCRIPTION
If a component Version has build-status of "pending" or "failed", it goes to the remote to ask for the component again, in case it was re-built. 
To avoid too many trips to the remotes with the same components, we cache the results for a small period of time (currently, 1 min).