### PR TITLE
Fix deprecation commands to be shown on the UI 

### DIFF
--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -25,11 +25,15 @@ export class DeprecationMain {
   }
 
   async deprecate(ids: string[]) {
-    return deprecate({ path: this.scope.path, ids }, null);
+    const results = await deprecate({ path: this.scope.path, ids }, null);
+    this.scope.clearCache();
+    return results;
   }
 
   async unDeprecate(ids: string[]) {
-    return undeprecate({ path: this.scope.path, ids }, null);
+    const results = undeprecate({ path: this.scope.path, ids }, null);
+    this.scope.clearCache();
+    return results;
   }
 
   static async provider([graphql, scope, componentAspect]: [GraphqlMain, ScopeMain, ComponentMain]) {


### PR DESCRIPTION
Resolve #4215.

Currently, they're shown only after re-running `bit start`. It is fixed by clearing the scope cache once the http executes the deprecation logic.

