### PR TITLE
throw a descriptive error during tag when an external env is configured without a version in workspace.jsonc

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -3,7 +3,6 @@ import chai, { expect } from 'chai';
 import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
 import { IS_WINDOWS } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { DEFAULT_OWNER } from '../../src/e2e-helper/e2e-scopes';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 
 chai.use(require('chai-fs'));


### PR DESCRIPTION
Currently it shows a cryptic error `scope.getVersionInstance - id <component-id> is missing the version`.
This is happening when an environment is configured in the workspace.jsonc but is not part of the workspace (it's in the `.bitmap` file). In which case, the env-id must include a version.
