### PR TITLE
fix: alert card visual improvements

### DIFF
--- a/scopes/component/changelog/ui/change-log-page.module.scss
+++ b/scopes/component/changelog/ui/change-log-page.module.scss
@@ -2,7 +2,7 @@
   padding: 50px 40px 0 40px;
   max-width: 1440px;
   margin: 0 auto 48px;
-  width: 100%;
+  width: auto;
   overflow-y: scroll;
   @media screen and (max-width: 768px) {
     width: unset;

--- a/scopes/component/changelog/ui/change-log-page.tsx
+++ b/scopes/component/changelog/ui/change-log-page.tsx
@@ -23,7 +23,7 @@ export function ChangeLogPage({ className }: ChangeLogPageProps) {
     return (
       <div className={classNames(styles.changeLogPage, className)}>
         <H1 className={styles.title}>History</H1>
-        <Separator className={styles.separatorNoChangeLog} />
+        <Separator isPresentational className={styles.separatorNoChangeLog} />
         <AlertCard
           level="info"
           title="There is no change log as this component has not been exported yet.

--- a/scopes/compositions/compositions/compositions.module.scss
+++ b/scopes/compositions/compositions/compositions.module.scss
@@ -72,7 +72,7 @@ $panelBg: #fafafa;
 
 .noCompositionsPage {
   padding: 50px 40px 100px 40px;
-  width: 100%;
+  width: auto;
   max-width: 1440px;
   margin: 0 auto;
 

--- a/scopes/compositions/compositions/compositions.tsx
+++ b/scopes/compositions/compositions/compositions.tsx
@@ -133,7 +133,7 @@ function CompositionContent({ component, selected, queryParams, emptyState }: Co
       <div className={styles.noCompositionsPage}>
         <div>
           <H1 className={styles.title}>Compositions</H1>
-          <Separator className={styles.separator} />
+          <Separator isPresentational className={styles.separator} />
           <AlertCard
             level="info"
             title="There are no

--- a/scopes/defender/tester/ui/tests-page.module.scss
+++ b/scopes/defender/tester/ui/tests-page.module.scss
@@ -1,6 +1,6 @@
 .testsPage {
   padding: 50px 40px 100px 40px;
-  width: 100%;
+  width: auto;
   overflow-y: auto;
   max-width: 1440px;
   margin: 0 auto;

--- a/scopes/defender/tester/ui/tests-page.tsx
+++ b/scopes/defender/tester/ui/tests-page.tsx
@@ -97,7 +97,7 @@ export function TestsPage({ className, emptyState }: TestsPageProps) {
       <div className={classNames(styles.testsPage, className)}>
         <div>
           <H1 className={styles.title}>Tests</H1>
-          <Separator className={styles.separator} />
+          <Separator isPresentational className={styles.separator} />
           <AlertCard
             level="info"
             title="There are no

--- a/scopes/design/ui/alert-card/alert-card.module.scss
+++ b/scopes/design/ui/alert-card/alert-card.module.scss
@@ -1,5 +1,6 @@
 .card {
   padding: 24px;
+  margin-bottom: 2px;
 }
 
 .heading {


### PR DESCRIPTION
## Proposed Changes

- adds spacing at bottom of card to see shadow
- changes width to be seen properly as was cut off on larger acreens
- adds isPresentational for separator in changelog page
- 
From:
<img width="1888" alt="CleanShot 2021-05-18 at 19 13 27@2x" src="https://user-images.githubusercontent.com/13063165/118696948-17e78080-b80f-11eb-931b-daa5809fb169.png">

To:
<img width="1875" alt="CleanShot 2021-05-18 at 19 22 56@2x" src="https://user-images.githubusercontent.com/13063165/118696937-13bb6300-b80f-11eb-8e56-957d281734bd.png">
<img width="1898" alt="CleanShot 2021-05-18 at 19 18 56@2x" src="https://user-images.githubusercontent.com/13063165/118696944-161dbd00-b80f-11eb-81ed-6edcf9eeb8f3.png">

