### PR TITLE
fix copy-non-supported-files during compile to operate only on the compiled capsules

### DIFF
--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -37,7 +37,7 @@ export class CompilerMain {
    * with this method you can create any number of compilers and add them to the buildPipeline.
    */
   createTask(name: string, compiler: Compiler): CompilerTask {
-    return new CompilerTask(CompilerAspect.id, name, compiler);
+    return new CompilerTask(CompilerAspect.id, name, compiler, this.envs);
   }
 
   /**

--- a/scopes/compilation/compiler/compiler.task.ts
+++ b/scopes/compilation/compiler/compiler.task.ts
@@ -1,10 +1,10 @@
 import { BuildContext, BuiltTaskResult, BuildTask, TaskResultsList } from '@teambit/builder';
 import { EnvsMain } from '@teambit/envs';
 import { Capsule } from '@teambit/isolator';
-import { CompilerAspect } from './compiler.aspect';
 import fs from 'fs-extra';
 import path from 'path';
 
+import { CompilerAspect } from './compiler.aspect';
 import { Compiler } from './types';
 
 /**

--- a/scopes/compilation/compiler/compiler.task.ts
+++ b/scopes/compilation/compiler/compiler.task.ts
@@ -23,10 +23,10 @@ export class CompilerTask implements BuildTask {
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const buildResults = await this.compilerInstance.build(context);
+    const compiledIds = buildResults.componentsResults.map((result) => result.component.id);
+    const compiledCapsules = context.capsuleNetwork.getCapsulesByIds(compiledIds);
 
-    await Promise.all(
-      context.capsuleNetwork.graphCapsules.map((capsule) => this.copyNonSupportedFiles(capsule, this.compilerInstance))
-    );
+    await Promise.all(compiledCapsules.map((capsule) => this.copyNonSupportedFiles(capsule, this.compilerInstance)));
 
     return buildResults;
   }

--- a/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
+++ b/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
@@ -6,23 +6,24 @@ import { mergeComponentResults } from '@teambit/modules.merge-component-results'
 
 export type MultiCompilerOptions = {
   targetExtension?: string;
-};
+} & Partial<CompilerOptions>;
 
 export class MultiCompiler implements Compiler {
   displayName = 'Multi compiler';
 
-  shouldCopyNonSupportedFiles =
-    typeof this.compilerOptions.shouldCopyNonSupportedFiles === 'boolean'
-      ? this.compilerOptions.shouldCopyNonSupportedFiles
-      : true;
-  distDir = 'dist';
+  shouldCopyNonSupportedFiles: boolean;
+  distDir: string;
 
   constructor(
     readonly id: string,
     readonly compilers: Compiler[],
     readonly compilerOptions: Partial<CompilerOptions> = {},
     readonly options: MultiCompilerOptions = {}
-  ) {}
+  ) {
+    this.distDir = options.distDir || 'dist';
+    this.shouldCopyNonSupportedFiles =
+      typeof options.shouldCopyNonSupportedFiles === 'boolean' ? options.shouldCopyNonSupportedFiles : true;
+  }
 
   getArtifactDefinition() {
     return [

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -1,5 +1,6 @@
 import { ComponentID } from '@teambit/component';
 import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
+import { Capsule } from './capsule';
 import CapsuleList from './capsule-list';
 
 export class Network {
@@ -31,5 +32,9 @@ export class Network {
 
   get capsulesRootDir(): PathOsBasedAbsolute {
     return this._capsulesRootDir;
+  }
+
+  getCapsulesByIds(ids: ComponentID[]): Capsule[] {
+    return this.graphCapsules.filter((capsule) => ids.find((id) => id.isEqual(capsule.component.id)));
   }
 }


### PR DESCRIPTION
Currently, for Babel compiler, which compiles only seeders and not the entire graph, the copy-files mechanism runs on the entire graph. 
In cases where a component has one env and a dependency has another env and one of them configured to copy-non-supported-files and the other does not, the file is always copied. 
This PR fixes it by checking what was compiled and running the copy process only on them.