### PR TITLE
fix copy-non-supported-files during build to happen in the pre-build phase

### DIFF
--- a/scopes/compilation/compiler/compiler.task.ts
+++ b/scopes/compilation/compiler/compiler.task.ts
@@ -17,17 +17,17 @@ export class CompilerTask implements BuildTask {
   }
 
   async preBuild(context: BuildContext) {
+    await Promise.all(
+      context.capsuleNetwork.seedersCapsules.map((capsule) =>
+        this.copyNonSupportedFiles(capsule, this.compilerInstance)
+      )
+    );
     if (!this.compilerInstance.preBuild) return;
     await this.compilerInstance.preBuild(context);
   }
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const buildResults = await this.compilerInstance.build(context);
-
-    await Promise.all(
-      context.capsuleNetwork.graphCapsules.map((capsule) => this.copyNonSupportedFiles(capsule, this.compilerInstance))
-    );
-
     return buildResults;
   }
 


### PR DESCRIPTION
and only for the seeders.

Currently, for Babel compiler, which compiles only seeders and not the entire graph, the copy-files mechanism runs on the entire graph. 
In cases where a component has one env and a dependency has another env and one of them configured to copy-non-supported-files and the other does not, the file is always copied. 
This PR fixes it by running the copy process on the seeders only. 
Also, it runs it on the pre-build phase to avoid cases when TS finds other components by their dists and fails with an error about missing scss files. (it basically fixes the issue caused #4300 to fail).