### PR TITLE
improve build webpack loaders

### DIFF
--- a/scopes/react/bit-react-transformer/meta-from-pkg-json.ts
+++ b/scopes/react/bit-react-transformer/meta-from-pkg-json.ts
@@ -56,9 +56,7 @@ function safeFindRoot(filepath: string) {
   try {
     return findRoot(filepath);
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.debug(`bit-react-transformer: could not find package.json for ${filepath}`);
-    // might happen when the component is new, etc
+    // might happen for "scaffolding" files outside the project.
     return undefined;
   }
 }

--- a/scopes/react/react/webpack/webpack.config.preview.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.ts
@@ -6,6 +6,7 @@ import webpack, { Configuration } from 'webpack';
 import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 import WorkboxWebpackPlugin from 'workbox-webpack-plugin';
 import * as stylesRegexps from '@teambit/webpack.modules.style-regexps';
+import { ComponentID } from '@teambit/component-id';
 import { postCssConfig } from './postcss.config';
 // Make sure the bit-react-transformer is a dependency
 // TODO: remove it once we can set policy from component to component then set it via the component.json
@@ -215,10 +216,35 @@ export default function (fileMapPath: string): Configuration {
               // See https://github.com/webpack/webpack/issues/6571
               sideEffects: true,
             },
+
+            {
+              test: /\.js$/,
+              include: [/node_modules/, /\/dist\//],
+              exclude: /@teambit\/legacy/,
+              descriptionData: { componentId: ComponentID.isValidObject },
+              use: [
+                {
+                  loader: require.resolve('babel-loader'),
+                  options: {
+                    babelrc: false,
+                    configFile: false,
+                    plugins: [
+                      // for component highlighting in preview.
+                      [require.resolve('@teambit/react.babel.bit-react-transformer')],
+                    ],
+                    // turn off all optimizations (only slow down for node_modules)
+                    compact: false,
+                    minified: false,
+                  },
+                },
+              ],
+            },
+
             // Process application JS with Babel.
             // The preset includes JSX, Flow, TypeScript, and some ESnext features.
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
+              exclude: [/node_modules/, /\/dist\//],
               loader: require.resolve('babel-loader'),
               options: {
                 babelrc: false,

--- a/scopes/react/react/webpack/webpack.config.preview.ts
+++ b/scopes/react/react/webpack/webpack.config.preview.ts
@@ -245,6 +245,10 @@ export default function (fileMapPath: string): Configuration {
             {
               test: /\.(js|mjs|jsx|ts|tsx)$/,
               exclude: [/node_modules/, /\/dist\//],
+              // consider: limit loader to files only in a capsule that has bitid in package.json
+              // descriptionData: { componentId: ComponentID.isValidObject },
+              // // or
+              // include: capsulePaths
               loader: require.resolve('babel-loader'),
               options: {
                 babelrc: false,


### PR DESCRIPTION
## Proposed Changes

- build preview: limit webpack loaders to source files only 
- build preview: apply highlighter transformer to bit's node_modules packages only

This improved the build time on Evangelist from 6min to 4min (~30%!)

# Important
- [x] Needs to be verified on Dell's scopes