### PR TITLE
add @mdx-js/react package as a dependency of react env

### DIFF
--- a/scopes/react/react/component.json
+++ b/scopes/react/react/component.json
@@ -29,6 +29,7 @@
           "react-app-polyfill": "1.0.6",
           "resolve-url-loader": "3.1.2",
           "file-loader": "6.2.0",
+          "@mdx-js/react": "1.6.22",
           "jest-environment-jsdom": "26.6.2",
           "identity-obj-proxy": "3.0.0",
           "url-loader": "4.1.1",


### PR DESCRIPTION
Reported by @debs-obrien . When using CRA it shows an error about missing `@mdx-js/react`. 
@GiladShoham , please review. It is used in the webpack configuration of react-env, but when running `bit show react`, it's not a dependency. In this PR I added it to the component.json of react as a package dependency.