### PR TITLE
add mdx-js/react as dependency for mdx components

### DIFF
--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -83,6 +83,7 @@ export class MDXMain {
       react.overrideDependencies({
         dependencies: {
           '@teambit/mdx.ui.mdx-scope-context': '0.0.368',
+          '@mdx-js/react': '1.6.22',
         },
       }),
       react.overrideCompilerTasks([compiler.createTask('MDXCompiler', mdxCompiler)]),


### PR DESCRIPTION
## Proposed Changes

- The mdx components need this as runtime dependency (added by the mdx compiler)
