### PR TITLE
introduce a new flag "--push" for bit-sign and bit-update-dependencies to export

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -14,7 +14,7 @@ describe('sign command', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('simple case with one scope', () => {
+  describe('simple case with one scope with --push flag', () => {
     let signOutput: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
@@ -28,7 +28,7 @@ describe('sign command', function () {
       helper.scopeHelper.addRemoteScope(undefined, helper.scopes.remotePath);
       const ids = [`${helper.scopes.remote}/comp1`, `${helper.scopes.remote}/comp2`];
       // console.log('sign-command', `bit sign ${ids.join(' ')}`);
-      signOutput = helper.command.sign(ids, '', helper.scopes.remotePath);
+      signOutput = helper.command.sign(ids, '--push', helper.scopes.remotePath);
     });
     it('on the workspace, the build status should be pending', () => {
       const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
@@ -49,6 +49,26 @@ describe('sign command', function () {
         const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
         expect(comp1.buildStatus).to.equal('succeed');
       });
+    });
+  });
+  describe('simple case with one scope without --push flag', () => {
+    let signOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      const ids = [`${helper.scopes.remote}/comp1`, `${helper.scopes.remote}/comp2`];
+      // console.log('sign-command', `bit sign ${ids.join(' ')}`);
+      signOutput = helper.command.sign(ids, '', helper.scopes.remotePath);
+    });
+    it('on the workspace, the build status should be pending', () => {
+      const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
+      expect(comp1.buildStatus).to.equal('pending');
+    });
+    it('should sign successfully', () => {
+      expect(signOutput).to.include('the following 2 component(s) were signed with build-status "succeed"');
     });
   });
   describe('failure case', () => {

--- a/e2e/harmony/update-dependencies.e2e.ts
+++ b/e2e/harmony/update-dependencies.e2e.ts
@@ -53,7 +53,7 @@ describe('update-dependencies command', function () {
     after(() => {
       npmCiRegistry.destroy();
     });
-    describe('running from a new bare scope', () => {
+    describe('running from a new bare scope without flags', () => {
       let updateDepsOutput: string;
       let headBefore: string;
       let updateRemotePath: string;
@@ -83,7 +83,7 @@ describe('update-dependencies command', function () {
         expect(headBefore).to.equal(currentHeadOnRemote);
       });
     });
-    describe('running from a new bare scope using --tag flag', () => {
+    describe('running from a new bare scope using --tag and --push flags', () => {
       let updateDepsOutput: string;
       before(() => {
         helper.scopeHelper.getClonedScope(secondScopeBeforeUpdate, secondRemotePath);
@@ -96,7 +96,7 @@ describe('update-dependencies command', function () {
             versionToTag: '3.0.0',
           },
         ];
-        updateDepsOutput = helper.command.updateDependencies(data, '--tag', updateRemote.scopePath);
+        updateDepsOutput = helper.command.updateDependencies(data, '--tag --push', updateRemote.scopePath);
       });
       it('should succeed', () => {
         expect(updateDepsOutput).to.have.string('the following 1 component(s) were updated');
@@ -106,7 +106,7 @@ describe('update-dependencies command', function () {
         expect(compB.dependencies[0].id.version).to.equal('1.1.0');
       });
     });
-    describe('running from a new bare scope using --snap flag', () => {
+    describe('running from a new bare scope using --push flag', () => {
       let updateDepsOutput: string;
       before(() => {
         helper.scopeHelper.getClonedScope(secondScopeBeforeUpdate, secondRemotePath);
@@ -118,7 +118,7 @@ describe('update-dependencies command', function () {
             dependencies: [`${DEFAULT_OWNER}.${scopeWithoutOwner}/comp1@^1.0.0`],
           },
         ];
-        updateDepsOutput = helper.command.updateDependencies(data, '--snap', updateRemote.scopePath);
+        updateDepsOutput = helper.command.updateDependencies(data, '--push', updateRemote.scopePath);
       });
       it('should succeed', () => {
         expect(updateDepsOutput).to.have.string('the following 1 component(s) were updated');

--- a/scopes/scope/sign/sign.cmd.ts
+++ b/scopes/scope/sign/sign.cmd.ts
@@ -6,6 +6,7 @@ import { BuildStatus } from '@teambit/legacy/dist/constants';
 import { Logger } from '@teambit/logger';
 import { SignMain } from './sign.main.runtime';
 
+type SignOptions = { multiple: boolean; alwaysSucceed: boolean; push: boolean };
 export class SignCmd implements Command {
   name = 'sign <component...>';
   private = true;
@@ -15,13 +16,14 @@ export class SignCmd implements Command {
   options = [
     ['', 'multiple', 'sign components from multiple scopes'],
     ['', 'always-succeed', 'exit with code 0 even though the build failed'],
+    ['', 'push', 'export the updated objects to the original scopes once done'],
   ] as CommandOptions;
 
   constructor(private signMain: SignMain, private scope: ScopeMain, private logger: Logger) {}
 
-  async report([components]: [string[]], { multiple, alwaysSucceed }: { multiple: boolean; alwaysSucceed: boolean }) {
+  async report([components]: [string[]], { multiple, alwaysSucceed, push }: SignOptions) {
     const componentIds = components.map((c) => ComponentID.fromString(c));
-    const results = await this.signMain.sign(componentIds, multiple);
+    const results = await this.signMain.sign(componentIds, multiple, push);
     if (!results) {
       return chalk.bold('no more components left to sign');
     }

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -36,7 +36,7 @@ export class SignMain {
     private onPostSignSlot: OnPostSignSlot
   ) {}
 
-  async sign(ids: ComponentID[], isMultiple?: boolean): Promise<SignResult | null> {
+  async sign(ids: ComponentID[], isMultiple?: boolean, push?: boolean): Promise<SignResult | null> {
     if (isMultiple) await this.scope.import(ids);
     const { componentsToSkip, componentsToSign } = await this.getComponentIdsToSign(ids);
     if (componentsToSkip.length) {
@@ -60,12 +60,14 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     const publishedPackages = getPublishedPackages(legacyComponents);
     const pipeWithError = pipeResults.find((pipe) => pipe.hasErrors());
     const buildStatus = pipeWithError ? BuildStatus.Failed : BuildStatus.Succeed;
-    if (isMultiple) {
-      await this.exportExtensionsDataIntoScopes(legacyComponents, buildStatus);
-    } else {
-      await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+    if (push) {
+      if (isMultiple) {
+        await this.exportExtensionsDataIntoScopes(legacyComponents, buildStatus);
+      } else {
+        await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+      }
+      await this.clearScopesCaches(legacyComponents);
     }
-    await this.clearScopesCaches(legacyComponents);
     await this.triggerOnPostSign(components);
 
     return {

--- a/scopes/scope/update-dependencies/update-dependencies.cmd.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.cmd.ts
@@ -13,7 +13,7 @@ export class UpdateDependenciesCmd implements Command {
   name = 'update-dependencies <data>';
   private = true;
   shortDescription = 'update dependencies for components and tag/snap the results';
-  description = `update versions dependencies for components and optionally tag/snap the results.
+  description = `update versions dependencies for components and tag/snap the results.
 this command should be running from a new bare scope, it first imports the components it needs and then processes the update.
 the input data is a stringified JSON of an array of the following object.
 {
@@ -26,8 +26,8 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","dependencies
   alias = '';
   group = 'development';
   options = [
-    ['', 'tag', 'tag once the build is completed and export to the remote scopes'],
-    ['', 'snap', 'snap once the build is completed and export to the remote scopes'],
+    ['', 'tag', 'tag once the build is completed (by default it snaps)'],
+    ['', 'push', 'export the updated objects to the original scopes once tagged/snapped'],
     ['', 'message <string>', 'message to be saved as part of the version log'],
     ['', 'username <string>', 'username to be saved as part of the version log'],
     ['', 'email <string>', 'email to be saved as part of the version log'],

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -24,11 +24,11 @@ import { UpdateDependenciesAspect } from './update-dependencies.aspect';
 
 export type UpdateDepsOptions = {
   tag?: boolean;
-  snap?: boolean;
   output?: string;
   message?: string;
   username?: string;
   email?: string;
+  push?: boolean;
 };
 
 export type DepUpdateItemRaw = {
@@ -208,7 +208,7 @@ export class UpdateDependenciesMain {
         const { releaseType, exactVersion } = getValidVersionOrReleaseType(depUpdateItem.versionToTag || 'patch');
         legacyComp.version = modelComponent.getVersionToAdd(releaseType, exactVersion);
       } else {
-        // snap is the default. When the "--snap" flag wasn't used it still should snap but not export.
+        // snap is the default
         legacyComp.version = modelComponent.getSnapToAdd();
       }
     });
@@ -275,7 +275,7 @@ export class UpdateDependenciesMain {
   }
 
   private async export() {
-    const shouldExport = this.updateDepsOptions.tag || this.updateDepsOptions.snap;
+    const shouldExport = this.updateDepsOptions.push;
     if (!shouldExport) return;
     const ids = BitIds.fromArray(this.legacyComponents.map((c) => c.id));
     await exportMany({


### PR DESCRIPTION
Currently it exports by default. Instead, use `--push` flag to instruct Bit to export the objects after updating them.