### PR TITLE
fix "Cannot read property 'find' of undefined" error during tag

### DIFF
--- a/src/cli/commands/public-cmds/checkout-cmd.ts
+++ b/src/cli/commands/public-cmds/checkout-cmd.ts
@@ -116,7 +116,7 @@ export default class Checkout implements LegacyCommand {
         return chalk.green(
           `checkout was not needed for ${chalk.bold(
             neutralComponents.length.toString()
-          )} components (use --verbose to get more details)`
+          )} components (use --verbose to get more details)\n`
         );
       }
 

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -405,7 +405,7 @@ export function updateComponentsByTagResult(components: Component[], tagResult: 
 export function getPublishedPackages(components: Component[]): string[] {
   const publishedPackages = components.map((comp) => {
     const builderExt = comp.extensions.findCoreExtension(Extensions.builder);
-    const pkgData = builderExt?.data?.aspectsData.find((a) => a.aspectId === Extensions.pkg);
+    const pkgData = builderExt?.data?.aspectsData?.find((a) => a.aspectId === Extensions.pkg);
     return pkgData?.data?.publishedPackage;
   });
   return compact(publishedPackages);


### PR DESCRIPTION
This is happening when the aspectData of the Builder is undefined. 
It was happening to a user, however, sadly, all the attempts to reproduce it were failed. Therefore, a test can't be written and the root cause remains unclear.