### PR TITLE
resolve manually added component dependency package name

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -285,7 +285,13 @@ export default class DependencyResolver {
     const { components, packages } = dependencies;
     DEPENDENCIES_FIELDS.forEach((depField) => {
       if (components[depField] && components[depField].length) {
-        components[depField].forEach((id) => this.allDependencies[depField].push({ id, relativePaths: [] }));
+        components[depField].forEach((depData) =>
+          this.allDependencies[depField].push({
+            id: depData.componentId,
+            relativePaths: [],
+            packageName: depData.packageName,
+          })
+        );
       }
       if (packages[depField] && !R.isEmpty(packages[depField])) {
         Object.assign(this.allPackagesDependencies[this._pkgFieldMapping(depField)], packages[depField]);

--- a/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
@@ -120,20 +120,20 @@ export default class OverridesDependencies {
       Object.keys(overrides[depField]).forEach((dependency) => {
         const dependencyValue = overrides[depField][dependency];
         if (dependencyValue === MANUALLY_REMOVE_DEPENDENCY) return;
-        const componentId = this._getComponentIdToAdd(
+        const componentData = this._getComponentIdToAdd(
           depField,
           dependency,
           dependencyValue,
           idsFromBitmap,
           idsFromModel
         );
-        if (componentId) {
+        if (componentData && componentData.componentId) {
           const dependencyExist = existingDependencies[depField].find((d) =>
-            d.id.isEqualWithoutScopeAndVersion(componentId)
+            d.id.isEqualWithoutScopeAndVersion(componentData.componentId)
           );
           if (!dependencyExist) {
-            this._addManuallyAddedDep(depField, componentId.toString());
-            components[depField] ? components[depField].push(componentId) : (components[depField] = [componentId]);
+            this._addManuallyAddedDep(depField, componentData.componentId.toString());
+            components[depField] ? components[depField].push(componentData) : (components[depField] = [componentData]);
           }
           return;
         }
@@ -165,13 +165,26 @@ export default class OverridesDependencies {
     dependencyValue: string,
     idsFromBitmap: BitIds,
     idsFromModel: BitIds
-  ): BitId | undefined {
+  ): { componentId?: BitId; packageName?: string } | undefined {
     if (field === 'peerDependencies') return undefined;
     if (this.consumer.isLegacy && dependency.startsWith(OVERRIDE_COMPONENT_PREFIX)) {
-      return this._getComponentIdToAddForLegacyWs(field, dependency, dependencyValue, idsFromBitmap, idsFromModel);
+      const componentId = this._getComponentIdToAddForLegacyWs(
+        field,
+
+        dependency,
+
+        dependencyValue,
+
+        idsFromBitmap,
+
+        idsFromModel
+      );
+      return {
+        componentId,
+      };
     }
     const packageData = this._resolvePackageData(dependency);
-    return packageData?.componentId;
+    return { componentId: packageData?.componentId, packageName: packageData?.name };
   }
 
   _getComponentIdFromPackage(packageName: string, idsFromBitmap: BitIds, idsFromModel: BitIds): BitId | undefined {


### PR DESCRIPTION
## Proposed Changes

- Make sure that when we added a component dependency by its package name (for example from env's get dependencies function) we resolve the package name correctly
