### PR TITLE
add tests to scope-url

### DIFF
--- a/scopes/component/component-url/scope-url.spec.ts
+++ b/scopes/component/component-url/scope-url.spec.ts
@@ -19,3 +19,21 @@ describe('scope url', () => {
     expect(result).to.equal(`${baseUrl}/ioncannon`);
   });
 });
+
+describe('scope url', () => {
+  it('should convert to toPathname', () => {
+    const id = 'teambit.base-ui';
+
+    const result = ScopeUrl.toPathname(id);
+
+    expect(result).to.equal(`teambit/base-ui`);
+  });
+
+  it('should convert to url', () => {
+    const id = 'ioncannon';
+
+    const result = ScopeUrl.toPathname(id);
+
+    expect(result).to.equal(`ioncannon`);
+  });
+});


### PR DESCRIPTION
## Proposed Changes

component `teambit.component/modules/component-url` was incorrectly tagged as `@teambit/.modules.component-url`.
According to @GiladShoham, this only happened because it was tagged for the first time.

So, this should be fixed by a tag to be:
`@teambit/component.modules.component-url`