### PR TITLE
fix missing-packages warning when dists are missing, refactor the DependenciesResults

### DIFF
--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -717,17 +717,6 @@ describe('bit tag command', function () {
         expect(output).to.have.string('2 component(s) tagged');
       });
     });
-    // We throw this error because we don't know the packege version in this case
-    it.skip('should throw error if there is missing package dependency', () => {});
-
-    it.skip('should index all components', () => {});
-
-    it.skip('should tag the components in the correct order', () => {});
-
-    it.skip('should add the correct dependencies to each component', () => {
-      // Make sure the use case contain dependenceis from all types -
-      // Packages, files and bits
-    });
 
     it('should add dependencies for files which are not the main files', () => {
       helper.scopeHelper.reInitLocalScope();

--- a/e2e/harmony/status-harmony.e2e.ts
+++ b/e2e/harmony/status-harmony.e2e.ts
@@ -1,0 +1,28 @@
+import { IssuesClasses } from '@teambit/component-issues';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+describe('status command on Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('main filename is not index and dists are missing', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fs.outputFile('comp1/comp1.ts', "require('@my-scope/comp2');");
+      helper.fs.outputFile('comp2/comp2.ts');
+      helper.command.addComponent('comp1');
+      helper.command.addComponent('comp2');
+      helper.command.link();
+    });
+    it('should not show an issue of missing-packages', () => {
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingPackagesDependenciesOnFs.name);
+    });
+  });
+});

--- a/scopes/component/component-url/scope-url.spec.ts
+++ b/scopes/component/component-url/scope-url.spec.ts
@@ -19,3 +19,21 @@ describe('scope url', () => {
     expect(result).to.equal(`${baseUrl}/ioncannon`);
   });
 });
+
+describe('scope url', () => {
+  it('should convert to toPathname', () => {
+    const id = 'teambit.base-ui';
+
+    const result = ScopeUrl.toPathname(id);
+
+    expect(result).to.equal(`teambit/base-ui`);
+  });
+
+  it('should convert to url', () => {
+    const id = 'ioncannon';
+
+    const result = ScopeUrl.toPathname(id);
+
+    expect(result).to.equal(`ioncannon`);
+  });
+});

--- a/src/cli/commands/private-cmds/cat-object-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-object-cmd.ts
@@ -17,7 +17,6 @@ export default class CatObject implements LegacyCommand {
     [hash]: [string],
     { pretty, stringify, headers }: { pretty: boolean; stringify: boolean; headers: boolean }
   ): Promise<any> {
-    // @TODO - import should support multiple bits
     return catObject(hash, pretty, stringify, headers);
   }
 

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.spec.ts
@@ -27,7 +27,7 @@ describe('buildTree', () => {
     it('when unsupported files are passed should return them with no dependencies', async () => {
       dependencyTreeParams.filePaths = [`${fixtures}/unsupported-file.pdf`];
       const results = await buildTree.getDependencyTree(dependencyTreeParams);
-      expect(results.tree).to.deep.equal({ 'fixtures/unsupported-file.pdf': {} });
+      expect(results.tree['fixtures/unsupported-file.pdf'].isEmpty()).to.be.true;
     });
     it('when supported and unsupported files are passed should return them all', async () => {
       dependencyTreeParams.filePaths = [`${fixtures}/unsupported-file.pdf`, `${precinctFixtures}/es6.js`];
@@ -78,8 +78,8 @@ describe('buildTree', () => {
         expect(results.tree).to.have.property('fixtures/build-tree/unparsed.js');
       });
       it('should not add the error to the files without parsing error', () => {
-        expect(results.tree['fixtures/build-tree/a.js']).to.not.have.property('error');
-        expect(results.tree['fixtures/build-tree/b.js']).to.not.have.property('error');
+        expect(results.tree['fixtures/build-tree/a.js'].error).to.be.undefined;
+        expect(results.tree['fixtures/build-tree/b.js'].error).to.be.undefined;
       });
       it('should add the parsing error to the un-parsed file', () => {
         expect(results.tree['fixtures/build-tree/unparsed.js']).to.have.property('error');

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
@@ -22,7 +22,7 @@ export type LinkFile = {
 };
 
 /**
- * Gets a list of dependencies and group them by types (files, bits, packages)
+ * Gets a list of dependencies and group them by types (files, components, packages)
  * It's also transform the node package dependencies from array of paths to object in this format:
  * {dependencyName: version} (like in package.json)
  *
@@ -51,7 +51,7 @@ function groupDependencyList(
       return;
     }
 
-    // If the package is a component add it to the components (bits) list
+    // If the package is a component add it to the components list
     // @todo: currently, for author, the package.json doesn't have any version.
     // we might change this decision later. see https://github.com/teambit/bit/pull/2924
     if (resolvedPackage.componentId) {
@@ -164,7 +164,7 @@ function mergeManuallyFoundPackagesToTree(
   missingGroups: MissingGroupItem[],
   tree: DependenciesTree
 ) {
-  if (R.isEmpty(foundPackages.bits) && R.isEmpty(foundPackages.packages)) return;
+  if (R.isEmpty(foundPackages.components) && R.isEmpty(foundPackages.packages)) return;
   // Merge manually found packages (by groupMissing()) with the packages found by Madge (generate-tree-madge)
   Object.keys(foundPackages.packages).forEach((pkg) => {
     // locate package in groups(contains missing)
@@ -175,13 +175,14 @@ function mergeManuallyFoundPackagesToTree(
       }
     });
   });
-  foundPackages.bits.forEach((component) => {
+  foundPackages.components.forEach((component) => {
     missingGroups.forEach((fileDep: MissingGroupItem) => {
       if (
-        fileDep.bits &&
-        ((component.fullPath && fileDep.bits.includes(component.fullPath)) || fileDep.bits.includes(component.name))
+        fileDep.components &&
+        ((component.fullPath && fileDep.components.includes(component.fullPath)) ||
+          fileDep.components.includes(component.name))
       ) {
-        fileDep.bits = fileDep.bits.filter((existComponent) => {
+        fileDep.components = fileDep.components.filter((existComponent) => {
           return existComponent !== component.fullPath && existComponent !== component.name;
         });
         (tree[fileDep.originFile] ||= new DependenciesTreeItem()).components.push(component);

--- a/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/build-tree.ts
@@ -246,7 +246,6 @@ export async function getDependencyTree({
     }
     return path.resolve(componentDir, filePath);
   });
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const { madgeTree, skipped, pathMap, errors } = generateTree(fullPaths, config);
   const tree: DependenciesTree = MadgeTreeToDependenciesTree(madgeTree, componentDir, bindingPrefix, isLegacyProject);
   const { missingGroups, foundPackages } = new MissingHandler(

--- a/src/consumer/component/dependencies/files-dependency-builder/generate-tree-madge.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/generate-tree-madge.ts
@@ -118,7 +118,7 @@ type GenerateTreeResults = {
  * @param config
  * @return {Object}
  */
-export default function generateTree(files = [], config): GenerateTreeResults {
+export default function generateTree(files: string[] = [], config): GenerateTreeResults {
   const depTree = {};
   const nonExistent = {};
   const npmPaths = {};
@@ -162,7 +162,6 @@ export default function generateTree(files = [], config): GenerateTreeResults {
       });
       Object.assign(depTree, dependencyTreeResult);
     } catch (err) {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       errors[file] = err;
     }
   });

--- a/src/consumer/component/dependencies/files-dependency-builder/missing-handler.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/missing-handler.ts
@@ -9,10 +9,10 @@ import {
 } from '../../../../utils/packages';
 import { processPath, Missing } from './generate-tree-madge';
 
-export type MissingGroupItem = { originFile: string; packages?: string[]; bits?: string[]; files?: string[] };
+export type MissingGroupItem = { originFile: string; packages?: string[]; components?: string[]; files?: string[] };
 export type FoundPackages = {
   packages: { [packageName: string]: string };
-  bits: ResolvedPackageData[];
+  components: ResolvedPackageData[];
 };
 
 export class MissingHandler {
@@ -32,13 +32,13 @@ export class MissingHandler {
     const missingGroups: MissingGroupItem[] = this.groupMissingByType();
     missingGroups.forEach((group: MissingGroupItem) => {
       if (group.packages) group.packages = group.packages.map(resolvePackageNameByPath);
-      if (group.bits) group.bits = group.bits.map(resolvePackageNameByPath);
+      if (group.components) group.components = group.components.map(resolvePackageNameByPath);
     });
     // This is a hack to solve problems that madge has with packages for type script files
     // It see them as missing even if they are exists
     const foundPackages: FoundPackages = {
       packages: {},
-      bits: [],
+      components: [],
     };
     missingGroups.forEach((group) => this.processMissingGroup(group, foundPackages));
 
@@ -61,9 +61,9 @@ export class MissingHandler {
         missingPackages.push(packageName);
         return;
       }
-      // if the package is actually a component add it to the components (bits) list
+      // if the package is actually a component add it to the components list
       if (resolvedPackageData.componentId) {
-        foundPackages.bits.push(resolvedPackageData);
+        foundPackages.components.push(resolvedPackageData);
       } else {
         const version = resolvedPackageData.versionUsedByDependent || resolvedPackageData.concreteVersion;
         if (!version) throw new Error(`unable to find the version for a package ${packageName}`);
@@ -76,7 +76,7 @@ export class MissingHandler {
   }
 
   /**
-   * Group missing dependencies by types (files, bits, packages)
+   * Group missing dependencies by types (files, components, packages)
    * @param {Array} missing list of missing paths to group
    * @returns {Function} function which group the dependencies
    */
@@ -86,7 +86,7 @@ export class MissingHandler {
         this.isLegacyProject &&
         (item.startsWith(`${this.bindingPrefix}/`) || item.startsWith(`${DEFAULT_BINDINGS_PREFIX}/`))
       ) {
-        return 'bits';
+        return 'components';
       }
       return item.startsWith('.') ? 'files' : 'packages';
     });

--- a/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -24,7 +24,7 @@ export type ImportSpecifier = {
 export type FileObject = {
   file: string;
   importSpecifiers?: ImportSpecifier[];
-  importSource: string;
+  importSource?: string;
   isCustomResolveUsed?: boolean;
   isLink?: boolean;
   linkDependencies?: Record<string, any>[];
@@ -37,17 +37,17 @@ export type LinkFile = {
 
 type MissingType = 'files' | 'packages' | 'bits';
 
-export type DependenciesResults = {
-  files?: FileObject[];
-  packages?: { [packageName: string]: string }; // pkgName: pkgVersion
-  unidentifiedPackages?: string[];
-  bits?: ResolvedPackageData[];
+export class DependenciesTreeItem {
+  files: FileObject[] = [];
+  packages: { [packageName: string]: string } = {}; // pkgName: pkgVersion
+  unidentifiedPackages: string[] = [];
+  components: ResolvedPackageData[] = [];
   error?: Error; // error.code is either PARSING_ERROR or RESOLVE_ERROR
   missing?: { [key in MissingType]: string[] };
-};
+}
 
-export type Tree = {
-  [filePath: string]: DependenciesResults;
+export type DependenciesTree = {
+  [filePath: string]: DependenciesTreeItem;
 };
 
 export type ResolveModulesConfig = {

--- a/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -1,3 +1,4 @@
+import R from 'ramda';
 import { ResolvedPackageData } from '../../../../../utils/packages';
 
 /**
@@ -44,6 +45,17 @@ export class DependenciesTreeItem {
   components: ResolvedPackageData[] = [];
   error?: Error; // error.code is either PARSING_ERROR or RESOLVE_ERROR
   missing?: { [key in MissingType]: string[] };
+
+  isEmpty() {
+    return (
+      !this.files.length &&
+      R.isEmpty(this.packages) &&
+      !this.unidentifiedPackages.length &&
+      !this.components.length &&
+      !this.error &&
+      !this.missing
+    );
+  }
 }
 
 export type DependenciesTree = {

--- a/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -36,7 +36,7 @@ export type LinkFile = {
   importSpecifiers: ImportSpecifier[];
 };
 
-type MissingType = 'files' | 'packages' | 'bits';
+type MissingType = 'files' | 'packages' | 'components';
 
 export class DependenciesTreeItem {
   files: FileObject[] = [];

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -405,6 +405,11 @@ export default class CommandHelper {
     expect(allIssues).to.include(issueName);
   }
 
+  expectStatusToNotHaveIssue(issueName: string) {
+    const allIssues = this.getAllIssuesFromStatus();
+    expect(allIssues).to.not.include(issueName);
+  }
+
   getAllIssuesFromStatus(): string[] {
     const statusJson = this.statusJson();
     return statusJson.componentsWithIssues.map((comp) => comp.issues.map((issue) => issue.type)).flat();

--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -15,7 +15,7 @@ export interface ResolvedPackageData {
   name: string; // package name
   concreteVersion?: string; // version from the package.json of the package itself
   versionUsedByDependent?: string; // version from the dependent package.json
-  componentId?: BitId; // add the component id in case it's a bit component
+  componentId?: BitId; // component id in case it's a bit component
 }
 
 /**


### PR DESCRIPTION
## Proposed Changes

- fix `missing packages` on bit-status when dists are missing and the main file is not an index.js/ts file.
- refactor the dependencies resolution results to be a class.
- change the old name `bits` in these dependency-resolution files to `components`.
