### PR TITLE
avoid crushing bit-start and bit-watch on errors

### DIFF
--- a/scopes/workspace/workspace/watch/watcher.ts
+++ b/scopes/workspace/workspace/watch/watcher.ts
@@ -60,20 +60,21 @@ export class Watcher {
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       watcher.on('change', async (filePath) => {
         const startTime = new Date().getTime();
-        const buildResults = (await this.handleChange(filePath).catch((err) => reject(err))) || [];
+        const buildResults = (await this.handleChange(filePath)) || [];
         const duration = new Date().getTime() - startTime;
         opts?.msgs?.onChange(filePath, buildResults, _verbose, duration);
       });
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
       watcher.on('add', async (filePath) => {
         const startTime = new Date().getTime();
-        const buildResults = (await this.handleChange(filePath).catch((err) => reject(err))) || [];
+        const buildResults = (await this.handleChange(filePath)) || [];
         const duration = new Date().getTime() - startTime;
         opts?.msgs?.onAdd(filePath, buildResults, _verbose, duration);
       });
-      watcher.on('unlink', (p) => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      watcher.on('unlink', async (p) => {
         opts?.msgs?.onUnlink(p);
-        this.handleChange(p).catch((err) => reject(err));
+        await this.handleChange(p);
       });
       watcher.on('error', (err) => {
         opts?.msgs?.onError(err);
@@ -83,20 +84,27 @@ export class Watcher {
   }
 
   private async handleChange(filePath: string): Promise<OnComponentEventResult[]> {
-    if (filePath.endsWith(BIT_MAP)) {
-      const buildResults = await this.handleBitmapChanges();
+    try {
+      if (filePath.endsWith(BIT_MAP)) {
+        const buildResults = await this.handleBitmapChanges();
+        this.completeWatch();
+        return buildResults;
+      }
+      const componentId = await this.getComponentIdAndClearItsCache(filePath);
+      if (!componentId) {
+        logger.debug(`file ${filePath} is not part of any component, ignoring it`);
+        return this.completeWatch();
+      }
+
+      const buildResults = await this.executeWatchOperationsOnComponent(componentId);
       this.completeWatch();
       return buildResults;
+    } catch (err) {
+      const msg = `watcher found an error while handling ${filePath}`;
+      logger.error(msg, err);
+      logger.console(`${msg}, ${err.message}`);
+      return [];
     }
-    const componentId = await this.getComponentIdAndClearItsCache(filePath);
-    if (!componentId) {
-      logger.debug(`file ${filePath} is not part of any component, ignoring it`);
-      return this.completeWatch();
-    }
-
-    const buildResults = await this.executeWatchOperationsOnComponent(componentId);
-    this.completeWatch();
-    return buildResults;
   }
 
   /**

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -13,7 +13,7 @@ import NoIdMatchWildcard from '../api/consumer/lib/exceptions/no-id-match-wildca
 import NothingToCompareTo from '../api/consumer/lib/exceptions/nothing-to-compare-to';
 import ObjectsWithoutConsumer from '../api/consumer/lib/exceptions/objects-without-consumer';
 import { BASE_DOCS_DOMAIN, DEBUG_LOG, IMPORT_PENDING_MSG } from '../constants';
-import { InvalidBitMap, MissingBitMapComponent, MissingMainFile } from '../consumer/bit-map/exceptions';
+import { InvalidBitMap, MissingMainFile } from '../consumer/bit-map/exceptions';
 import OutsideRootDir from '../consumer/bit-map/exceptions/outside-root-dir';
 import {
   DuplicateIds,
@@ -355,13 +355,6 @@ please use "bit remove" to delete the component or "bit add" with "--main" and "
     (err) => {
       return `component ${err.id} is invalid as part or all of the component files were deleted. please use 'bit remove' to resolve the issue`;
     },
-  ],
-  [
-    MissingBitMapComponent,
-    (err) =>
-      `error: component "${chalk.bold(
-        err.id
-      )}" was not found on your local workspace.\nplease specify a valid component ID or track the component using 'bit add' (see 'bit add --help' for more information)`,
   ],
   [PathsNotExist, (err) => `error: file or directory "${chalk.bold(err.paths.join(', '))}" was not found.`],
   [

--- a/src/consumer/bit-map/exceptions/missing-bit-map-component.ts
+++ b/src/consumer/bit-map/exceptions/missing-bit-map-component.ts
@@ -1,10 +1,11 @@
-import AbstractError from '../../../error/abstract-error';
+import { BitError } from '@teambit/bit-error';
+import chalk from 'chalk';
 
-export default class MissingBitMapComponent extends AbstractError {
+export default class MissingBitMapComponent extends BitError {
   id: string;
 
   constructor(id: string) {
-    super();
-    this.id = id;
+    super(`error: component "${chalk.bold(id)}" was not found on your local workspace.
+please specify a valid component ID or track the component using 'bit add' (see 'bit add --help' for more information)`);
   }
 }


### PR DESCRIPTION
These two commands `bit watch` and `bit start` use the `Watcher` service of the workspace.
In case error is happening during the handle-change process, the error is thrown, which introduces two issues:
1. these services shouldn't break, they should show the error and continue running.
2. the error is thrown inside an event-handler of `chokidar` and is not handled correctly. as a result we get unhandled promise.

This PR wrap the vulnerable code in try/catch to avoid it.