### PR TITLE
add GrpahQL query to get component issues

### DIFF
--- a/scopes/component/component-issues/component-issue.ts
+++ b/scopes/component/component-issues/component-issue.ts
@@ -3,25 +3,24 @@ import { BitId } from '@teambit/legacy-bit-id';
 
 export type StringsPerFilePath = { [filePath: string]: string[] };
 
-export const MISSING_DEPS_SPACE_COUNT = 10;
-export const MISSING_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT);
+export const ISSUE_FORMAT_SPACE_COUNT = 10;
+export const ISSUE_FORMAT_SPACE = ' '.repeat(ISSUE_FORMAT_SPACE_COUNT);
 
 export class ComponentIssue {
   description: string;
   data: any;
   isTagBlocker = true; // if true, it stops the tag process and shows the issue
   isCacheBlocker = true; // if true, it doesn't cache the component in the filesystem
-  format(formatIssueFunc: FormatIssueFunc = componentIssueToString): string {
-    return (
-      formatTitle(this.description) +
-      chalk.white(
-        Object.keys(this.data)
-          .map((k) => {
-            return `${MISSING_DEPS_SPACE}${k} -> ${formatIssueFunc(this.data[k])}`;
-          })
-          .join('\n')
-      )
-    );
+  formatDataFunction: FormatIssueFunc = componentIssueToString;
+  outputForCLI(): string {
+    return formatTitle(this.description) + chalk.white(this.dataToString());
+  }
+  dataToString(): string {
+    return Object.keys(this.data)
+      .map((k) => {
+        return `${ISSUE_FORMAT_SPACE}${k} -> ${this.formatDataFunction(this.data[k])}`;
+      })
+      .join('\n');
   }
   toObject() {
     return {

--- a/scopes/component/component-issues/custom-module-resolution-used.ts
+++ b/scopes/component/component-issues/custom-module-resolution-used.ts
@@ -3,5 +3,4 @@ import { ComponentIssue, StringsPerFilePath } from './component-issue';
 export class CustomModuleResolutionUsed extends ComponentIssue {
   description = 'component is using an unsupported resolve-modules (aka aliases) feature, replace to module paths';
   data: StringsPerFilePath = {};
-  isCacheBlocker: false;
 }

--- a/scopes/component/component-issues/import-non-main-files.ts
+++ b/scopes/component/component-issues/import-non-main-files.ts
@@ -3,5 +3,5 @@ import { ComponentIssue, StringsPerFilePath } from './component-issue';
 export class ImportNonMainFiles extends ComponentIssue {
   description = 'importing non-main files (the dependency should expose its API from the main file)';
   data: StringsPerFilePath = {};
-  isCacheBlocker: false;
+  isCacheBlocker = false;
 }

--- a/scopes/component/component-issues/index.ts
+++ b/scopes/component/component-issues/index.ts
@@ -1,4 +1,4 @@
 export { IssuesList, IssuesClasses, IssuesNames } from './issues-list';
-export { MISSING_DEPS_SPACE } from './component-issue';
+export { ISSUE_FORMAT_SPACE as MISSING_DEPS_SPACE } from './component-issue';
 export { UntrackedFileDependencyEntry, MISSING_NESTED_DEPS_SPACE } from './untracked-dependencies';
 export { RelativeComponentsAuthoredEntry } from './relative-components-authored';

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -41,12 +41,19 @@ export class IssuesList {
     return this.issues.length === 0;
   }
 
-  toString() {
-    return this.issues.map((issue) => issue.format()).join('');
+  outputForCLI() {
+    return this.issues.map((issue) => issue.outputForCLI()).join('');
   }
 
-  toObject() {
+  toObject(): { type: string; description: string; data: any }[] {
     return this.issues.map((issue) => issue.toObject());
+  }
+
+  toObjectWithDataAsString(): { type: string; description: string; data: string }[] {
+    return this.issues.map((issue) => ({
+      ...issue.toObject(),
+      data: issue.dataToString().trim(),
+    }));
   }
 
   add(issue: ComponentIssue) {
@@ -63,6 +70,10 @@ export class IssuesList {
 
   getIssueByName<T extends ComponentIssue>(issueType: IssuesNames): T | undefined {
     return this.issues.find((issue) => issue.constructor.name === issueType) as T | undefined;
+  }
+
+  getAllIssues(): ComponentIssue[] {
+    return this.issues;
   }
 
   createIssue<T extends ComponentIssue>(IssueClass: { new (): T }): T {

--- a/scopes/component/component-issues/missing-dists.ts
+++ b/scopes/component/component-issues/missing-dists.ts
@@ -4,7 +4,7 @@ export class MissingDists extends ComponentIssue {
   description = 'missing dists (run "bit compile")';
   data: boolean;
   isTagBlocker = false;
-  format() {
+  outputForCLI() {
     return formatTitle(this.description, false);
   }
 }

--- a/scopes/component/component-issues/parse-errors.ts
+++ b/scopes/component/component-issues/parse-errors.ts
@@ -3,5 +3,4 @@ import { ComponentIssue } from './component-issue';
 export class ParseErrors extends ComponentIssue {
   description = 'error found while parsing the file (edit the file and fix the parsing error)';
   data: { [filePath: string]: string } = {};
-  isCacheBlocker: false;
 }

--- a/scopes/component/component-issues/relative-components-authored.ts
+++ b/scopes/component/component-issues/relative-components-authored.ts
@@ -14,10 +14,9 @@ export class relativeComponentsAuthored extends ComponentIssue {
   description =
     'components with relative import statements found (replace to module paths or use "bit link --rewire" to replace)';
   data: { [fileName: string]: RelativeComponentsAuthoredEntry[] } = {};
-  isCacheBlocker: false;
-  format() {
-    return super.format(relativeComponentsAuthoredIssuesToString);
-  }
+  isCacheBlocker = false;
+  formatDataFunction = relativeComponentsAuthoredIssuesToString;
+
   deserialize(dataStr: string) {
     const data = JSON.parse(dataStr);
     Object.keys(data).forEach((fileName) => {

--- a/scopes/component/component-issues/relative-components.ts
+++ b/scopes/component/component-issues/relative-components.ts
@@ -4,7 +4,7 @@ import { ComponentIssue, deserializeWithBitId } from './component-issue';
 export class relativeComponents extends ComponentIssue {
   description = 'components with relative import statements found (use module paths for imported components)';
   data: { [filePath: string]: BitId[] } = {};
-  isCacheBlocker: false;
+  isCacheBlocker = false;
   deserialize(data: string) {
     return deserializeWithBitId(data);
   }

--- a/scopes/component/component-issues/untracked-dependencies.ts
+++ b/scopes/component/component-issues/untracked-dependencies.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
-import { ComponentIssue, formatTitle, MISSING_DEPS_SPACE, MISSING_DEPS_SPACE_COUNT } from './component-issue';
+import { ComponentIssue, ISSUE_FORMAT_SPACE, ISSUE_FORMAT_SPACE_COUNT } from './component-issue';
 
-export const MISSING_NESTED_DEPS_SPACE = ' '.repeat(MISSING_DEPS_SPACE_COUNT + 2);
+export const MISSING_NESTED_DEPS_SPACE = ' '.repeat(ISSUE_FORMAT_SPACE_COUNT + 2);
 
 interface UntrackedFileEntry {
   relativePath: string;
@@ -16,21 +16,16 @@ export interface UntrackedFileDependencyEntry {
 export class UntrackedDependencies extends ComponentIssue {
   description = 'untracked file dependencies (use "bit add <file>" to track untracked files as components)';
   data: { [filePath: string]: UntrackedFileDependencyEntry } = {};
-  format(): string {
-    return (
-      formatTitle(this.description) +
-      chalk.white(
-        Object.keys(this.data)
-          .map((k) => {
-            let space = MISSING_DEPS_SPACE;
-            if (this.data[k].nested) {
-              space = MISSING_NESTED_DEPS_SPACE;
-            }
-            return `${space}${k} -> ${untrackedFilesComponentIssueToString(this.data[k])}`;
-          })
-          .join('\n')
-      )
-    );
+  dataToString() {
+    return Object.keys(this.data)
+      .map((k) => {
+        let space = ISSUE_FORMAT_SPACE;
+        if (this.data[k].nested) {
+          space = MISSING_NESTED_DEPS_SPACE;
+        }
+        return `${space}${k} -> ${untrackedFilesComponentIssueToString(this.data[k])}`;
+      })
+      .join('\n');
   }
 }
 

--- a/scopes/workspace/workspace/workspace-component/workspace-component.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component.ts
@@ -41,7 +41,7 @@ export class WorkspaceComponent extends Component {
   /**
    * get all issues reported on the component.
    */
-  async getIssues(): Promise<IssuesList | null> {
+  getIssues(): IssuesList | null {
     return this.workspace.getComponentIssues(this);
   }
 

--- a/scopes/workspace/workspace/workspace.graphql.ts
+++ b/scopes/workspace/workspace/workspace.graphql.ts
@@ -42,9 +42,16 @@ export default (workspace: Workspace, graphql: GraphqlMain) => {
         status: ComponentStatus
       }
 
+      type Issue {
+        type: String!
+        description: String!
+        data: String
+      }
+
       extend type Component {
         # the count of errors in component in workspace
         issuesCount: Int
+        issues: [Issue]
       }
 
       type Workspace {
@@ -85,8 +92,11 @@ export default (workspace: Workspace, graphql: GraphqlMain) => {
         status: async (wsComponent: WorkspaceComponent) => {
           return wsComponent.getStatus();
         },
-        issuesCount: async (wsComponent: WorkspaceComponent): Promise<number> => {
-          return (await wsComponent.getIssues())?.count || 0;
+        issuesCount: (wsComponent: WorkspaceComponent): number => {
+          return wsComponent.getIssues()?.count || 0;
+        },
+        issues: (wsComponent: WorkspaceComponent) => {
+          return wsComponent.getIssues()?.toObjectWithDataAsString();
         },
       },
       Workspace: {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -264,7 +264,7 @@ export class Workspace implements ComponentFactory {
   /**
    * get Component issues
    */
-  async getComponentIssues(component: Component): Promise<IssuesList | null> {
+  getComponentIssues(component: Component): IssuesList | null {
     return component.state._consumer.issues || null;
   }
 

--- a/src/cli/templates/component-issues-template.ts
+++ b/src/cli/templates/component-issues-template.ts
@@ -38,5 +38,5 @@ export default function componentIssuesTemplate(components: ConsumerComponent[])
 }
 
 export function formatIssues(compWithIssues: ConsumerComponent) {
-  return `       ${compWithIssues.issues?.toString()}\n`;
+  return `       ${compWithIssues.issues?.outputForCLI()}\n`;
 }


### PR DESCRIPTION
This will be helpful to show the issues (normally shown in `bit status`) in the web UI.

<img width="1510" alt="Screen Shot 2021-05-25 at 5 04 51 PM" src="https://user-images.githubusercontent.com/1963573/119569474-c85c0400-bd7c-11eb-922c-4038e5b233ff.png">

Query for example:
```
query {
  workspace {
    components {
      id {
        scope,
        name
      }
      issuesCount,
      issues {
        type,
        description
        data
      }
    }
  }
}
```