### PR TITLE
show a descriptive error when adding a sub-dir of a tracked directory

### DIFF
--- a/e2e/harmony/add-harmony.e2e.ts
+++ b/e2e/harmony/add-harmony.e2e.ts
@@ -1,0 +1,31 @@
+import chai from 'chai';
+import path from 'path';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import { ParentDirTracked } from '../../src/consumer/component-ops/add-components/exceptions/parent-dir-tracked';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('add command on Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('add a directory inside an existing component', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/foo/foo.ts');
+    });
+    it('should throw a descriptive error about parent-dir is tracked', () => {
+      const cmd = () => helper.command.addComponent('comp1/foo');
+      const error = new ParentDirTracked('comp1', 'comp1', path.normalize('comp1/foo'));
+      helper.general.expectToThrow(cmd, error);
+    });
+  });
+});

--- a/src/consumer/component-ops/add-components/exceptions/parent-dir-tracked.ts
+++ b/src/consumer/component-ops/add-components/exceptions/parent-dir-tracked.ts
@@ -1,0 +1,8 @@
+import { BitError } from '@teambit/bit-error';
+
+export class ParentDirTracked extends BitError {
+  constructor(parentDir: string, componentName: string, currentDir: string) {
+    super(`unable to add "${currentDir}", an existing component "${componentName}" already has its parent-dir "${parentDir}" as the root-dir.
+if you would like "${currentDir}" as a separate component, please extract it outside "${parentDir}"`);
+  }
+}


### PR DESCRIPTION
E.g. .bitmap has an existing component located in `comp1`, and the user is running `bit add comp1/foo`.
Currently, it shows `ComponentNotFound` error, which is very confusing. 
This has been fixed to show the following error:
```
➜  bit add comp1/foo
unable to add "comp1/foo", an existing component "comp1" already has its parent-dir "comp1" as the root-dir.
if you would like "comp1/foo" as a separate component, please extract it outside "comp1"
```