### PR TITLE
added "@types/testing-library__jest-dom" as dev dependency for react components

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -259,6 +259,7 @@ export class ReactEnv implements Environment {
         // '@types/react-router-dom': '^5.0.0', // TODO - should not be here (!)
         // This is added as dev dep since our jest file transformer uses babel plugins that require this to be installed
         '@babel/runtime': '7.12.18',
+        '@types/testing-library__jest-dom': '5.9.5',
       },
       // TODO: take version from config
       peerDependencies: {


### PR DESCRIPTION
## Proposed Changes

- fixing 
```
or TS2339: Property 'toHaveValue' does not exist on type 'JestMatchersShape<Matchers<void, HTMLElement>, Matchers<Promise<void>, HTMLElement>>'.

9     expect(input).toHaveValue("test value");
``` 
during bit build
- resolves #4004 

