### PR TITLE
avoid caching objects during export to allow multiple bit-sign exporting to the same scope at the same time

### DIFF
--- a/src/hooks/hooks-manager.ts
+++ b/src/hooks/hooks-manager.ts
@@ -180,7 +180,7 @@ function _stripArgs(args) {
     res.componentObjects = res.componentObjects.length;
   }
   if (res.objectList) {
-    res.objectList = res.objectList.count ? res.objectList.count() : undefined;
+    res.objectList = args.objectList.count ? args.objectList.count() : undefined;
   }
   return res;
 }

--- a/src/scope/actions/export-persist.ts
+++ b/src/scope/actions/export-persist.ts
@@ -1,7 +1,7 @@
 import { Scope } from '..';
 import { BitIds } from '../../bit-id';
 import logger from '../../logger/logger';
-import { mergeObjects } from '../component-ops/export-scope-components';
+import { saveObjects } from '../component-ops/export-scope-components';
 import { Lane } from '../models';
 import { AuthData } from '../network/http/http';
 import { Action } from './action';
@@ -17,9 +17,7 @@ export class ExportPersist implements Action<Options, string[]> {
     const objectList = await scope.readObjectsFromPendingDir(options.clientId);
 
     logger.debugAndAddBreadCrumb('ExportPersist', `going to merge ${objectList.objects.length} objects`);
-    const bitIds: BitIds = await mergeObjects(scope, objectList);
-    await scope.objects.persist();
-    logger.debugAndAddBreadCrumb('ExportPersist', 'objects were written successfully to the filesystem');
+    const bitIds: BitIds = await saveObjects(scope, objectList);
 
     const componentsIds: string[] = bitIds.map((id) => id.toString());
     await scope.removePendingDir(options.clientId);

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -24,6 +24,8 @@ import loader from '../../cli/loader';
 import { getAllVersionHashes } from './traverse-versions';
 import { PersistFailed } from '../exceptions/persist-failed';
 import { Http } from '../network/http';
+import { MergeResult } from '../repositories/sources';
+import { mergeLanes } from '../../consumer/lanes/merge-lanes';
 
 type ModelComponentAndObjects = { component: ModelComponent; objects: BitObject[] };
 
@@ -36,7 +38,7 @@ export function registerUpdateDependenciesOnExport(func: UpdateDependenciesOnExp
 }
 
 /**
- * ** Legacy Only **
+ * ** Legacy and "bit sign" Only **
  *
  * @TODO there is no real difference between bare scope and a working directory scope - let's adjust terminology to avoid confusions in the future
  * saves a component into the objects directory of the remote scope, then, resolves its
@@ -45,13 +47,12 @@ export function registerUpdateDependenciesOnExport(func: UpdateDependenciesOnExp
  */
 export async function exportManyBareScope(scope: Scope, objectList: ObjectList): Promise<BitIds> {
   logger.debugAndAddBreadCrumb('exportManyBareScope', `started with ${objectList.objects.length} objects`);
-  const mergedIds: BitIds = await mergeObjects(scope, objectList);
+  const mergedIds: BitIds = await saveObjects(scope, objectList);
   logger.debugAndAddBreadCrumb('exportManyBareScope', 'will try to importMany in case there are missing dependencies');
   const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
   await scopeComponentsImporter.importManyFromOriginalScopes(mergedIds); // resolve dependencies
   logger.debugAndAddBreadCrumb('exportManyBareScope', 'successfully ran importMany');
-  await scope.objects.persist();
-  logger.debugAndAddBreadCrumb('exportManyBareScope', 'objects were written successfully to the filesystem');
+
   return mergedIds;
 }
 
@@ -472,13 +473,37 @@ export async function exportMany({
 }
 
 /**
+ * save objects into the scope.
+ */
+export async function saveObjects(scope: Scope, objectList: ObjectList): Promise<BitIds> {
+  const bitObjectList = await objectList.toBitObjects();
+  const objectsNotRequireMerge = bitObjectList.getObjectsNotRequireMerge();
+  // components and lanes can't be just added, they need to be carefully merged.
+  const { mergedIds, mergedComponentsResults, mergedLanes } = await mergeObjects(scope, objectList);
+
+  const mergedComponents = mergedComponentsResults.map((_) => _.mergedComponent);
+  const allObjects = [...mergedComponents, ...mergedLanes, ...objectsNotRequireMerge];
+  scope.objects.validateObjects(true, allObjects);
+  await scope.objects.writeObjectsToTheFS(allObjects);
+  logger.debugAndAddBreadCrumb('exportManyBareScope', 'objects were written successfully to the filesystem');
+
+  return mergedIds;
+}
+
+type MergeObjectsResult = { mergedIds: BitIds; mergedComponentsResults: MergeResult[]; mergedLanes: Lane[] };
+
+/**
  * merge components into the scope.
  *
  * a component might have multiple versions that some where merged and some were not.
  * the BitIds returned here includes the versions that were merged. so it could contain multiple
  * ids of the same component with different versions
  */
-export async function mergeObjects(scope: Scope, objectList: ObjectList, throwForMissingDeps = false): Promise<BitIds> {
+export async function mergeObjects(
+  scope: Scope,
+  objectList: ObjectList,
+  throwForMissingDeps = false
+): Promise<MergeObjectsResult> {
   const bitObjectList = await objectList.toBitObjects();
   const components = bitObjectList.getComponents();
   const lanesObjects = bitObjectList.getLanes();
@@ -487,35 +512,19 @@ export async function mergeObjects(scope: Scope, objectList: ObjectList, throwFo
     'export-scope-components.mergeObjects',
     `Going to merge ${components.length} components, ${lanesObjects.length} lanes`
   );
-  const mergeResults = await Promise.all(
-    components.map(async (component) => {
-      try {
-        const result = await scope.sources.merge(component, versions);
-        return result;
-      } catch (err) {
-        if (err instanceof MergeConflict || err instanceof ComponentNeedsUpdate) {
-          return err; // don't throw. instead, get all components with merge-conflicts
-        }
-        throw err;
-      }
-    })
+  const { mergeResults, errors } = await scope.sources.mergeComponents(components, versions);
+  const mergeAllLanesResults = await mapSeries(lanesObjects, (laneObject) =>
+    scope.sources.mergeLane(laneObject, false)
   );
-  // components and lanes can't be just added, they need to be carefully merged.
-  const objectsToAdd = bitObjectList.getAllExceptComponentsAndLanes();
-  scope.sources.putObjects(objectsToAdd);
-
-  const mergeLaneResultsP = lanesObjects.map((laneObject) => scope.sources.mergeLane(laneObject, false));
-  const mergeLaneResults = R.flatten(await Promise.all(mergeLaneResultsP));
-  const componentsWithConflicts = mergeResults.filter((result) => result instanceof MergeConflict);
+  const lanesErrors = mergeAllLanesResults.map((r) => r.mergeErrors).flat();
   const componentsNeedUpdate = [
-    ...mergeResults.filter((result) => result instanceof ComponentNeedsUpdate),
-    ...mergeLaneResults.filter((result) => result instanceof ComponentNeedsUpdate),
-  ];
+    ...errors.filter((result) => result instanceof ComponentNeedsUpdate),
+    ...lanesErrors,
+  ] as ComponentNeedsUpdate[];
+  const componentsWithConflicts = errors.filter((result) => result instanceof MergeConflict) as MergeConflict[];
   if (componentsWithConflicts.length || componentsNeedUpdate.length) {
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const idsAndVersions = componentsWithConflicts.map((c) => ({ id: c.id, versions: c.versions }));
     const idsAndVersionsWithConflicts = R.sortBy(R.prop('id'), idsAndVersions);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const idsOfNeedUpdateComps = R.sortBy(
       R.prop('id'),
       componentsNeedUpdate.map((c) => ({ id: c.id, lane: c.lane }))
@@ -524,12 +533,17 @@ export async function mergeObjects(scope: Scope, objectList: ObjectList, throwFo
     throw new MergeConflictOnRemote(idsAndVersionsWithConflicts, idsOfNeedUpdateComps);
   }
   if (throwForMissingDeps) await throwForMissingLocalDependencies(scope, versions);
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const mergedComponents = mergeResults.filter(({ mergedVersions }) => mergedVersions.length);
-  const mergedLanesComponents = mergeLaneResults.filter(({ mergedVersions }) => mergedVersions.length);
+  const mergedLanesComponents = mergeAllLanesResults
+    .map((r) => r.mergeResults)
+    .flat()
+    .filter(({ mergedVersions }) => mergedVersions.length);
+  const mergedComponentsResults = [...mergedComponents, ...mergedLanesComponents];
   const getMergedIds = ({ mergedComponent, mergedVersions }): BitId[] =>
     mergedVersions.map((version) => mergedComponent.toBitId().changeVersion(version));
-  return BitIds.uniqFromArray(R.flatten([...mergedComponents, ...mergedLanesComponents].map(getMergedIds)));
+  const mergedIds = BitIds.uniqFromArray(mergedComponentsResults.map(getMergedIds).flat());
+  const mergedLanes = mergeAllLanesResults.map((r) => r.mergeLane);
+  return { mergedIds, mergedComponentsResults, mergedLanes };
 }
 
 /**

--- a/src/scope/objects/bit-object-list.ts
+++ b/src/scope/objects/bit-object-list.ts
@@ -20,7 +20,24 @@ export class BitObjectList {
     return this.objects;
   }
 
-  getAllExceptComponentsAndLanes(): BitObject[] {
-    return this.objects.filter((object) => !(object instanceof ModelComponent) && !(object instanceof Lane));
+  /**
+   * object that needs merge operation before saving them into the scope, such as ModelComponent
+   */
+  getObjectsRequireMerge() {
+    const typeRequireMerge = this.objectTypesRequireMerge();
+    return this.objects.filter((object) => typeRequireMerge.some((ObjClass) => object instanceof ObjClass));
+  }
+
+  /**
+   * object that don't need merge operation and can be saved immediately into the scope.
+   * such as Source or Version
+   */
+  getObjectsNotRequireMerge() {
+    const typeRequireMerge = this.objectTypesRequireMerge();
+    return this.objects.filter((object) => typeRequireMerge.every((ObjClass) => !(object instanceof ObjClass)));
+  }
+
+  private objectTypesRequireMerge() {
+    return [ModelComponent, Lane];
   }
 }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -328,7 +328,7 @@ export default class Repository {
     await this.persistMutex.runExclusive(async () => {
       logger.debug(`Repository.persist, validate = ${validate.toString()}, a lock has been acquired`);
       await this.deleteObjectsFromFS(this.objectsToRemove);
-      this._validateObjects(validate);
+      this.validateObjects(validate, Object.values(this.objects));
       await this.writeObjectsToTheFS(Object.values(this.objects));
       await this.writeRemoteLanes();
       await this.unmergedComponents.write();
@@ -368,9 +368,8 @@ export default class Repository {
    * can easily revert it by changing `bitObject.validateBeforePersist = false` line run regardless
    * the `validate` argument.
    */
-  _validateObjects(validate: boolean) {
-    Object.keys(this.objects).forEach((hash) => {
-      const bitObject = this.objects[hash];
+  validateObjects(validate: boolean, objects: BitObject[]) {
+    objects.forEach((bitObject) => {
       // @ts-ignore some BitObject classes have validate() method
       if (validate && bitObject.validate) {
         // @ts-ignore


### PR DESCRIPTION
Currently, when this is happening, the cache is populated/deleted unpredictably. 
With this change, the cache is not used for persisting the data. Instead, the data is aggregated from different functions and then written at once.