### PR TITLE
enable basic autocomplete in the CLI

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -2,24 +2,24 @@ import didYouMean from 'didyoumean';
 import yargs, { CommandModule } from 'yargs';
 import { Command } from '@teambit/legacy/dist/cli/command';
 import { GroupsType } from '@teambit/legacy/dist/cli/command-groups';
+import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
 import loader from '@teambit/legacy/dist/cli/loader';
+import chalk from 'chalk';
 import { getCommandId } from './get-command-id';
 import { formatHelp } from './help';
 import { GLOBAL_GROUP, YargsAdapter } from './yargs-adapter';
+import { CommandNotFound } from './exceptions/command-not-found';
 
 export class CLIParser {
   constructor(private commands: Command[], private groups: GroupsType) {}
 
   async parse() {
     const args = process.argv.slice(2); // remove the first two arguments, they're not relevant
-    if (!args[0] || ['-h', '--help'].includes(args[0])) {
-      this.printHelp();
-      return;
-    }
 
     this.throwForNonExistsCommand(args[0]);
 
     yargs(args);
+    yargs.help(false);
     this.configureParser();
     this.commands.forEach((command: Command) => {
       if (command.commands && command.commands.length) {
@@ -30,8 +30,57 @@ export class CLIParser {
       }
     });
     this.configureGlobalFlags();
-    loader.off(); // stop the "loading bit..." before showing help if needed
-    await yargs.completion().recommendCommands().wrap(null).parse();
+    this.setHelpMiddleware();
+    this.configureCompletion();
+
+    yargs
+      // .recommendCommands() // don't use it, it brings the global help of yargs, we have a custom one
+      .wrap(null);
+
+    await yargs.parse();
+  }
+
+  private setHelpMiddleware() {
+    yargs.middleware((argv) => {
+      if (argv._.length === 0) {
+        // this is the main help page
+        this.printHelp();
+        process.exit(0);
+      }
+      if (argv.help) {
+        loader.off(); // stop the "loading bit..." before showing help if needed
+        // this is a command help page
+        yargs.showHelp(logCommandHelp);
+        process.exit(0);
+      }
+    }, true);
+  }
+
+  private configureCompletion() {
+    const commandsToShowComponentIdsForCompletion = [
+      'show',
+      'diff',
+      'tag',
+      'export',
+      'env',
+      'envs',
+      'compile',
+      'build',
+      'test',
+      'lint',
+      'log',
+      'dependents',
+      'dependencies',
+    ];
+    // @ts-ignore
+    yargs.completion('completion', async function (current, argv, completionFilter, done) {
+      if (!current.startsWith('-') && commandsToShowComponentIdsForCompletion.includes(argv._[1])) {
+        const consumer = await loadConsumerIfExist();
+        done(consumer?.bitmapIdsFromCurrentLane.map((id) => id.toStringWithoutVersion()));
+      } else {
+        completionFilter();
+      }
+    });
   }
 
   private printHelp() {
@@ -42,7 +91,7 @@ export class CLIParser {
 
   private configureParser() {
     yargs.parserConfiguration({
-      'strip-dashed': true,
+      // 'strip-dashed': true, // we can't enable it, otherwise, the completion doesn't work
       'strip-aliased': true,
       'boolean-negation': false,
       'populate--': true,
@@ -84,6 +133,9 @@ export class CLIParser {
   }
 
   private throwForNonExistsCommand(commandName: string) {
+    if (!commandName || commandName.startsWith('-')) {
+      return;
+    }
     const commandsNames = this.commands.map((c) => getCommandId(c.name));
     const aliases = this.commands.map((c) => c.alias).filter((a) => a);
     const existingGlobalFlags = ['-V', '--version'];
@@ -97,8 +149,29 @@ export class CLIParser {
         this.commands.filter((c) => !c.private).map((c) => getCommandId(c.name))
       );
       const suggestion = suggestions && Array.isArray(suggestions) ? suggestions[0] : suggestions;
-      // @ts-ignore
+
       throw new CommandNotFound(commandName, suggestion);
     }
   }
+}
+
+/**
+ * color the flags with green.
+ * there is no API to get the options, so it is done by regex.
+ * see https://github.com/yargs/yargs/issues/1956
+ */
+function logCommandHelp(help: string) {
+  const replacer = (_, p1, p2) => `${p1}${chalk.green(p2)}`;
+  const lines = help.split('\n');
+  let passedOptions = false;
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    if (line.startsWith('Options')) {
+      passedOptions = true;
+    } else if (passedOptions) {
+      lines[i] = line.replace(/(--)([\w-]+)/, replacer).replace(/(-)([\w-]+)/, replacer);
+    }
+  }
+  // eslint-disable-next-line no-console
+  console.log(lines.join('\n'));
 }

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -150,7 +150,7 @@ export class CLIParser {
       );
       const suggestion = suggestions && Array.isArray(suggestions) ? suggestions[0] : suggestions;
 
-      throw new CommandNotFound(commandName, suggestion);
+      throw new CommandNotFound(commandName, suggestion as string);
     }
   }
 }

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -105,7 +105,7 @@ export class CommandRunner {
    * for internals commands, such as, _put, _fetch, the command.loader = false.
    */
   private determineConsoleWritingDuringCommand() {
-    if (this.command.loader && !this.flags.json) {
+    if (this.command.loader && !this.flags.json && !this.flags['get-yargs-completions']) {
       loader.on();
       loader.start(`running command "${this.commandName}"...`);
       logger.shouldWriteToConsole = true;


### PR DESCRIPTION
## Proposed Changes

- enable Yargs completion for command-names and flags.
- customize the completion to auto-complete component names in some commands.
- color the flags in the help with green.
