### PR TITLE
component-issues: split the description field to description and solution

### DIFF
--- a/e2e/commands/import2.e2e.1.ts
+++ b/e2e/commands/import2.e2e.1.ts
@@ -340,7 +340,7 @@ console.log(barFoo.default());`;
       const RelativeCompClass = IssuesClasses.relativeComponents;
       expect(output).to.have.string('error: issues found with the following component dependencies');
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-string@0.0.1`);
-      expect(output).to.have.string(new RelativeCompClass().description);
+      expect(output).to.have.string(new RelativeCompClass().descriptionWithSolution);
       expect(output).to.have.string('is-string.js -> utils/is-type');
     });
   });
@@ -372,7 +372,7 @@ console.log(barFoo.default());`;
     });
     it('should not allow tagging the component', () => {
       const RelativeCompClass = IssuesClasses.relativeComponents;
-      expect(output).to.have.string(new RelativeCompClass().description);
+      expect(output).to.have.string(new RelativeCompClass().descriptionWithSolution);
     });
   });
 

--- a/scopes/component/component-issues/component-issue.ts
+++ b/scopes/component/component-issues/component-issue.ts
@@ -7,13 +7,18 @@ export const ISSUE_FORMAT_SPACE_COUNT = 10;
 export const ISSUE_FORMAT_SPACE = ' '.repeat(ISSUE_FORMAT_SPACE_COUNT);
 
 export class ComponentIssue {
-  description: string;
+  description: string; // issue description
+  solution: string; // suggest how to fix the issue
   data: any;
   isTagBlocker = true; // if true, it stops the tag process and shows the issue
   isCacheBlocker = true; // if true, it doesn't cache the component in the filesystem
   formatDataFunction: FormatIssueFunc = componentIssueToString;
+  get descriptionWithSolution() {
+    const solution = this.solution ? ` (${this.solution})` : '';
+    return `${this.description}${solution}`;
+  }
   outputForCLI(): string {
-    return formatTitle(this.description) + chalk.white(this.dataToString());
+    return formatTitle(this.descriptionWithSolution) + chalk.white(this.dataToString());
   }
   dataToString(): string {
     return Object.keys(this.data)
@@ -26,6 +31,7 @@ export class ComponentIssue {
     return {
       type: this.constructor.name,
       description: this.description,
+      solution: this.solution,
       data: this.data,
     };
   }

--- a/scopes/component/component-issues/custom-module-resolution-used.ts
+++ b/scopes/component/component-issues/custom-module-resolution-used.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class CustomModuleResolutionUsed extends ComponentIssue {
-  description = 'component is using an unsupported resolve-modules (aka aliases) feature, replace to module paths';
+  description = 'component is using an unsupported resolve-modules (aka aliases) feature';
+  solution = 'replace to module paths';
   data: StringsPerFilePath = {};
 }

--- a/scopes/component/component-issues/import-non-main-files.ts
+++ b/scopes/component/component-issues/import-non-main-files.ts
@@ -1,7 +1,8 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class ImportNonMainFiles extends ComponentIssue {
-  description = 'importing non-main files (the dependency should expose its API from the main file)';
+  description = 'importing non-main files';
+  solution = 'the dependency should expose its API from the main file';
   data: StringsPerFilePath = {};
   isCacheBlocker = false;
 }

--- a/scopes/component/component-issues/missing-components.ts
+++ b/scopes/component/component-issues/missing-components.ts
@@ -2,7 +2,8 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { ComponentIssue, deserializeWithBitId } from './component-issue';
 
 export class MissingComponents extends ComponentIssue {
-  description = 'missing components (use "bit import" or `bit install` to make sure all components exist)';
+  description = 'missing components';
+  solution = 'use "bit import" or `bit install` to make sure all components exist';
   data: { [filePath: string]: BitId[] } = {};
   deserialize(data: string) {
     return deserializeWithBitId(data);

--- a/scopes/component/component-issues/missing-custom-module-resolution-links.ts
+++ b/scopes/component/component-issues/missing-custom-module-resolution-links.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class MissingCustomModuleResolutionLinks extends ComponentIssue {
-  description = 'missing links (use "bit link" to build missing component links)';
+  description = 'missing links';
+  solution = 'use "bit link" to build missing component links';
   data: StringsPerFilePath = {};
 }

--- a/scopes/component/component-issues/missing-dependencies-on-fs.ts
+++ b/scopes/component/component-issues/missing-dependencies-on-fs.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class MissingDependenciesOnFs extends ComponentIssue {
-  description = 'non-existing dependency files (make sure all files exists on your workspace)';
+  description = 'non-existing dependency files';
+  solution = 'make sure all files exists on your workspace';
   data: StringsPerFilePath = {};
 }

--- a/scopes/component/component-issues/missing-dists.ts
+++ b/scopes/component/component-issues/missing-dists.ts
@@ -1,10 +1,11 @@
 import { ComponentIssue, formatTitle } from './component-issue';
 
 export class MissingDists extends ComponentIssue {
-  description = 'missing dists (run "bit compile")';
+  description = 'missing dists';
+  solution = 'run "bit compile"';
   data: boolean;
   isTagBlocker = false;
   outputForCLI() {
-    return formatTitle(this.description, false);
+    return formatTitle(this.descriptionWithSolution, false);
   }
 }

--- a/scopes/component/component-issues/missing-links.ts
+++ b/scopes/component/component-issues/missing-links.ts
@@ -2,7 +2,8 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { ComponentIssue, deserializeWithBitId } from './component-issue';
 
 export class MissingLinks extends ComponentIssue {
-  description = 'missing links between components(use "bit link" to build missing component links)';
+  description = 'missing links between components';
+  solution = 'use "bit link" to build missing component links';
   data: { [filePath: string]: BitId[] } = {};
   deserialize(data: string) {
     return deserializeWithBitId(data);

--- a/scopes/component/component-issues/missing-packages-dependencies-on-fs.ts
+++ b/scopes/component/component-issues/missing-packages-dependencies-on-fs.ts
@@ -1,7 +1,7 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class MissingPackagesDependenciesOnFs extends ComponentIssue {
-  description = `missing packages or links from node_modules to the source (run "bit install" to fix both issues. if it's an external package, make sure it's added as a package dependency)`;
-
+  description = `missing packages or links from node_modules to the source`;
+  solution = `run "bit install" to fix both issues. if it's an external package, make sure it's added as a package dependency`;
   data: StringsPerFilePath = {};
 }

--- a/scopes/component/component-issues/parse-errors.ts
+++ b/scopes/component/component-issues/parse-errors.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue } from './component-issue';
 
 export class ParseErrors extends ComponentIssue {
-  description = 'error found while parsing the file (edit the file and fix the parsing error)';
+  description = 'error found while parsing the file';
+  solution = 'edit the file and fix the parsing error';
   data: { [filePath: string]: string } = {};
 }

--- a/scopes/component/component-issues/relative-components-authored.ts
+++ b/scopes/component/component-issues/relative-components-authored.ts
@@ -11,8 +11,8 @@ export type RelativeComponentsAuthoredEntry = {
 };
 
 export class relativeComponentsAuthored extends ComponentIssue {
-  description =
-    'components with relative import statements found (replace to module paths or use "bit link --rewire" to replace)';
+  description = 'components with relative import statements found';
+  solution = 'replace to module paths or use "bit link --rewire" to replace';
   data: { [fileName: string]: RelativeComponentsAuthoredEntry[] } = {};
   isCacheBlocker = false;
   formatDataFunction = relativeComponentsAuthoredIssuesToString;

--- a/scopes/component/component-issues/relative-components.ts
+++ b/scopes/component/component-issues/relative-components.ts
@@ -2,7 +2,8 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { ComponentIssue, deserializeWithBitId } from './component-issue';
 
 export class relativeComponents extends ComponentIssue {
-  description = 'components with relative import statements found (use module paths for imported components)';
+  description = 'components with relative import statements found';
+  solution = 'use module paths for imported components';
   data: { [filePath: string]: BitId[] } = {};
   isCacheBlocker = false;
   deserialize(data: string) {

--- a/scopes/component/component-issues/resolve-errors.ts
+++ b/scopes/component/component-issues/resolve-errors.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue } from './component-issue';
 
 export class ResolveErrors extends ComponentIssue {
-  description = 'error found while resolving the file dependencies (see the log for the full error)';
+  description = 'error found while resolving the file dependencies';
+  solution = 'see the log for the full error';
   data: { [filePath: string]: string } = {};
 }

--- a/scopes/component/component-issues/untracked-dependencies.ts
+++ b/scopes/component/component-issues/untracked-dependencies.ts
@@ -14,7 +14,8 @@ export interface UntrackedFileDependencyEntry {
 }
 
 export class UntrackedDependencies extends ComponentIssue {
-  description = 'untracked file dependencies (use "bit add <file>" to track untracked files as components)';
+  description = 'untracked file dependencies';
+  solution = 'use "bit add <file>" to track untracked files as components';
   data: { [filePath: string]: UntrackedFileDependencyEntry } = {};
   dataToString() {
     return Object.keys(this.data)

--- a/scopes/workspace/workspace/workspace.graphql.ts
+++ b/scopes/workspace/workspace/workspace.graphql.ts
@@ -45,6 +45,7 @@ export default (workspace: Workspace, graphql: GraphqlMain) => {
       type Issue {
         type: String!
         description: String!
+        solution: String
         data: String
       }
 


### PR DESCRIPTION
This way it's easier to show only the issues in the UI, without mixing the suggested solutions inside the issue description.
