### PR TITLE
add "completion" as a command

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -7,7 +7,7 @@ import loader from '@teambit/legacy/dist/cli/loader';
 import chalk from 'chalk';
 import { getCommandId } from './get-command-id';
 import { formatHelp } from './help';
-import { GLOBAL_GROUP, YargsAdapter } from './yargs-adapter';
+import { GLOBAL_GROUP, STANDARD_GROUP, YargsAdapter } from './yargs-adapter';
 import { CommandNotFound } from './exceptions/command-not-found';
 
 export class CLIParser {
@@ -166,7 +166,7 @@ function logCommandHelp(help: string) {
   let passedOptions = false;
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i];
-    if (line.startsWith('Options')) {
+    if (line.startsWith(STANDARD_GROUP)) {
       passedOptions = true;
     } else if (passedOptions) {
       lines[i] = line.replace(/(--)([\w-]+)/, replacer).replace(/(-)([\w-]+)/, replacer);

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -11,6 +11,7 @@ import { AlreadyExistsError } from './exceptions/already-exists';
 import { getCommandId } from './get-command-id';
 import { LegacyCommandAdapter } from './legacy-command-adapter';
 import { CLIParser } from './cli-parser';
+import { CompletionCmd } from './completion.cmd';
 
 export type CommandList = Array<Command>;
 export type OnStart = (hasWorkspace: boolean) => Promise<void>;
@@ -125,10 +126,10 @@ export class CLIMain {
     }, []);
 
     const legacyRegistry = buildRegistry(extensionsCommands);
-    const allCommands = legacyRegistry.commands.concat(legacyRegistry.extensionsCommands || []);
-    const allCommandsAdapters = allCommands.map((command) => new LegacyCommandAdapter(command, cliMain));
+    const legacyCommands = legacyRegistry.commands.concat(legacyRegistry.extensionsCommands || []);
+    const legacyCommandsAdapters = legacyCommands.map((command) => new LegacyCommandAdapter(command, cliMain));
     // @ts-ignore
-    cliMain.register(...allCommandsAdapters);
+    cliMain.register(...legacyCommandsAdapters, new CompletionCmd());
     return cliMain;
   }
 }

--- a/scopes/harmony/cli/completion.cmd.ts
+++ b/scopes/harmony/cli/completion.cmd.ts
@@ -1,0 +1,9 @@
+import { Command } from '@teambit/cli';
+
+export class CompletionCmd implements Command {
+  name = 'completion';
+  description = 'enable bash/zsh-completion shortcuts for commands and options';
+  alias = '';
+  group = 'general';
+  options = [];
+}

--- a/scopes/harmony/cli/completion.cmd.ts
+++ b/scopes/harmony/cli/completion.cmd.ts
@@ -1,4 +1,4 @@
-import { Command } from '@teambit/cli';
+import { Command } from '@teambit/legacy/dist/cli/command';
 
 export class CompletionCmd implements Command {
   name = 'completion';


### PR DESCRIPTION
So it'll be shown in the main help and also users won't get errors when running it.
This command shows the script to add to the bash/zsh to enable the auto-complete.