### PR TITLE
introduce "bit link --target" to link components to another project

### DIFF
--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -55,6 +55,7 @@ export {
   LinkingOptions,
   DepsLinkedToEnvResult,
   NestedNMDepsLinksResult,
+  LinkToDirResult,
 } from './dependency-linker';
 export { InstallOptions } from './dependency-installer';
 export { DependencyDetector, FileContext } from './dependency-detector';

--- a/scopes/workspace/workspace/link/link-to-dir.ts
+++ b/scopes/workspace/workspace/link/link-to-dir.ts
@@ -1,4 +1,4 @@
-import { LinkToDirResult } from '@teambit/dependency-resolver/dependency-linker';
+import { LinkToDirResult } from '@teambit/dependency-resolver';
 import chalk from 'chalk';
 import { LinkRow } from './link-row';
 

--- a/scopes/workspace/workspace/link/link-to-dir.ts
+++ b/scopes/workspace/workspace/link/link-to-dir.ts
@@ -1,0 +1,13 @@
+import { LinkToDirResult } from '@teambit/dependency-resolver/dependency-linker';
+import chalk from 'chalk';
+import { LinkRow } from './link-row';
+
+export function linkToDir(links?: LinkToDirResult[]) {
+  if (!links || !links.length) return '';
+  const title = chalk.bold.cyan('Target Links');
+  const linksOutput = links
+    .map(({ componentId, linksDetail }) => LinkRow({ title: componentId, target: linksDetail.to }))
+    .join('\n');
+
+  return `${title}\n${linksOutput}\n`;
+}

--- a/scopes/workspace/workspace/link/link.cmd.ts
+++ b/scopes/workspace/workspace/link/link.cmd.ts
@@ -9,10 +9,12 @@ import { ComponentListLinks } from './component-list-links';
 import { CoreAspectsLinks } from './core-aspects-links';
 import { NestedComponentLinksLinks } from './nested-deps-in-nm-links';
 import { RewireRow } from './rewire-row';
+import { linkToDir } from './link-to-dir';
 
 type LinkCommandOpts = {
   rewire: boolean;
   verbose: boolean;
+  target: string;
 };
 export class LinkCommand implements Command {
   name = 'link [ids...]';
@@ -24,7 +26,12 @@ export class LinkCommand implements Command {
   options = [
     ['j', 'json', 'return the output as JSON'],
     ['', 'verbose', 'verbose output'],
-    ['r', 'rewire', 'EXPERIMENTAL. Replace relative paths with module paths in code (e.g. "../foo" => "@bit/foo")'],
+    ['r', 'rewire', 'Replace relative paths with module paths in code (e.g. "../foo" => "@bit/foo")'],
+    [
+      '',
+      'target <dir>',
+      'EXPERIMENTAL. link to an external directory (similar to npm-link) so other projects could use these components',
+    ],
   ] as CommandOptions;
 
   constructor(
@@ -62,8 +69,9 @@ export class LinkCommand implements Command {
       nestedDepsInNmLinks: linkResults.nestedDepsInNmLinks,
       verbose: opts.verbose,
     });
+    const targetLinks = linkToDir(linkResults.linkToDirResults);
     const footer = `Finished. ${timeDiff}`;
-    return `${title}\n${coreLinks}\n${compsLinks}\n${rewireRow}${nestedLinks}${footer}`;
+    return `${title}\n${coreLinks}\n${compsLinks}\n${rewireRow}${nestedLinks}${targetLinks}${footer}`;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -77,6 +85,7 @@ export class LinkCommand implements Command {
       rewire: opts.rewire,
       linkCoreAspects: true,
       linkTeambitBit: true,
+      linkToDir: opts.target,
     };
     const linkResults = await this.workspace.link(linkOpts);
     return linkResults;


### PR DESCRIPTION
The functionality is similar to `npm link` or `yarn link`.  It is helpful when other projects depend on the this workspace. 
From the current workspace run `bit link --target <external-dir>`, it'll create symlinks from the node_modules of the current workspace to the target-dir/node_modules directory.


