### PR TITLE
make tsconfig optional in overrideTsConfig function

### DIFF
--- a/scopes/react/react-native/react-native.main.runtime.ts
+++ b/scopes/react/react-native/react-native.main.runtime.ts
@@ -51,7 +51,7 @@ export class ReactNativeMain {
    * override the build ts config.
    */
   overrideBuildTsConfig: (
-    tsconfig: any,
+    tsconfig?: TsConfigSourceFile,
     compilerOptions?: Partial<TsCompilerOptionsWithoutTsConfig>
   ) => EnvTransformer = this.react.overrideBuildTsConfig.bind(this.react);
 

--- a/scopes/react/react-native/react-native.main.runtime.ts
+++ b/scopes/react/react-native/react-native.main.runtime.ts
@@ -32,7 +32,7 @@ export class ReactNativeMain {
    * override the TS config of the environment.
    */
   overrideTsConfig: (
-    tsconfig: TsConfigSourceFile,
+    tsconfig?: TsConfigSourceFile,
     compilerOptions?: Partial<TsCompilerOptionsWithoutTsConfig>,
     tsModule?: any
   ) => EnvTransformer = this.react.overrideTsConfig.bind(this.react);

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -94,7 +94,7 @@ export class ReactMain {
    * @param tsModule typeof `ts` module instance.
    */
   overrideTsConfig(
-    tsconfig: TsConfigSourceFile,
+    tsconfig?: TsConfigSourceFile,
     compilerOptions: Partial<TsCompilerOptionsWithoutTsConfig> = {},
     tsModule: any = ts
   ) {

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -110,7 +110,10 @@ export class ReactMain {
   /**
    * override the build tsconfig.
    */
-  overrideBuildTsConfig(tsconfig, compilerOptions: Partial<TsCompilerOptionsWithoutTsConfig> = {}) {
+  overrideBuildTsConfig(
+    tsconfig?: TsConfigSourceFile,
+    compilerOptions: Partial<TsCompilerOptionsWithoutTsConfig> = {}
+  ) {
     return this.envs.override({
       getBuildPipe: () => {
         return this.reactEnv.getBuildPipe(tsconfig, compilerOptions);


### PR DESCRIPTION
## Proposed Changes

Sometimes we want to pass only the second param, the object with the types option, but without the requirements of passing also a tsconfig file because we don't need it.
So I changed tsconfig to be optional. 

For example I can use the function like that:
```
reactNative.overrideTsConfig(undefined, {types: [dtsPath]}),
reactNative.overrideBuildTsConfig(undefined, {types: [dtsPath]}),
```
And send "undefined" without getting a TS error.