### PR TITLE
prevent using legacy components in Harmony workspace

### DIFF
--- a/e2e/flows/dependencies-as-packages.e2e.2.ts
+++ b/e2e/flows/dependencies-as-packages.e2e.2.ts
@@ -309,6 +309,20 @@ chai.use(require('chai-fs'));
           });
         });
       });
+      describe('installing in Harmony', () => {
+        before(() => {
+          helper.scopeHelper.reInitLocalScopeHarmony();
+          helper.scopeHelper.addRemoteScope();
+          helper.command.runCmd('npm init -y');
+          helper.command.runCmd(`npm install @ci/${helper.scopes.remote}.utils.is-type`);
+          helper.fs.outputFile('bar/index.js', `require('@ci/${helper.scopes.remote}.utils.is-type');`);
+          helper.command.addComponent('bar');
+          helper.command.compile();
+        });
+        it('should throw an error and prevent tagging the component', () => {
+          expect(() => helper.command.tagAllComponents()).to.throw('unable tagging');
+        });
+      });
     });
     describe('components with nested dependencies and compiler', () => {
       before(async () => {

--- a/e2e/functionalities/custom-module-resolutions.e2e.2.ts
+++ b/e2e/functionalities/custom-module-resolutions.e2e.2.ts
@@ -152,8 +152,8 @@ describe('custom module resolutions', function () {
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.scopeHelper.addRemoteScope();
         });
-        it('should not throw an error on import', () => {
-          expect(() => helper.command.importComponent('bar/foo')).to.not.throw();
+        it('should throw an error on import', () => {
+          expect(() => helper.command.importComponent('bar/foo')).to.throw();
         });
       });
     });

--- a/e2e/harmony/mix-harmony-legacy.e2e.ts
+++ b/e2e/harmony/mix-harmony-legacy.e2e.ts
@@ -1,8 +1,5 @@
 import { IssuesClasses } from '@teambit/component-issues';
 import chai, { expect } from 'chai';
-import path from 'path';
-
-import { WORKSPACE_JSONC } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
 chai.use(require('chai-fs'));

--- a/e2e/harmony/mix-harmony-legacy.e2e.ts
+++ b/e2e/harmony/mix-harmony-legacy.e2e.ts
@@ -1,0 +1,48 @@
+import { IssuesClasses } from '@teambit/component-issues';
+import chai, { expect } from 'chai';
+import path from 'path';
+
+import { WORKSPACE_JSONC } from '../../src/constants';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('mix use of Legacy and Harmony', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('legacy component into Harmony workspace', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFooAsDir();
+      helper.command.tagAllComponents();
+      helper.command.exportAllComponents();
+
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('should block importing the component', () => {
+      expect(() => helper.command.importComponent(`${helper.scopes.remote}/*`)).to.throw('unable to write component');
+    });
+    describe('re-creating the component in Harmony using the legacy objects', () => {
+      before(() => {
+        helper.command.importComponent('bar/foo --objects');
+        helper.fixtures.createComponentBarFoo();
+        helper.fixtures.addComponentBarFooAsDir();
+        helper.command.addComponent('bar', { i: 'bar/foo' });
+      });
+      it('bit status should show an issue of ', () => {
+        helper.command.expectStatusToHaveIssue(IssuesClasses.LegacyInsideHarmony.name);
+      });
+      it('bit tag should throw an error', () => {
+        expect(() => helper.command.tagAllComponents()).to.throw('error: issues found');
+      });
+    });
+  });
+});

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -12,6 +12,7 @@ import { relativeComponents } from './relative-components';
 import { relativeComponentsAuthored } from './relative-components-authored';
 import { ResolveErrors } from './resolve-errors';
 import { UntrackedDependencies } from './untracked-dependencies';
+import { LegacyInsideHarmony } from './legacy-inside-harmony';
 
 export const IssuesClasses = {
   MissingPackagesDependenciesOnFs,
@@ -23,6 +24,7 @@ export const IssuesClasses = {
   ParseErrors,
   MissingLinks,
   MissingDists,
+  LegacyInsideHarmony,
   MissingDependenciesOnFs,
   MissingCustomModuleResolutionLinks,
   ImportNonMainFiles,

--- a/scopes/component/component-issues/legacy-inside-harmony.ts
+++ b/scopes/component/component-issues/legacy-inside-harmony.ts
@@ -1,0 +1,11 @@
+import { ComponentIssue, formatTitle } from './component-issue';
+
+export class LegacyInsideHarmony extends ComponentIssue {
+  description = 'legacy component inside Harmony workspace';
+  solution = 'remove the component and re-create it via Harmony';
+  data: boolean;
+  isTagBlocker = true;
+  outputForCLI() {
+    return formatTitle(this.descriptionWithSolution, false);
+  }
+}

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -116,7 +116,6 @@ export default class ComponentWriter {
   async write(): Promise<Component> {
     if (!this.consumer) throw new Error('ComponentWriter.write expect to have a consumer');
     await this.populateComponentsFilesToWrite();
-    // $FlowFixMe consumer is set
     this.component.dataToPersist.addBasePath(this.consumer.getPath());
     await this.component.dataToPersist.persistAllToFS();
     return this.component;
@@ -126,6 +125,7 @@ export default class ComponentWriter {
     if (!this.component.files || !this.component.files.length) {
       throw new ShowDoctorError(`Component ${this.component.id.toString()} is invalid as it has no files`);
     }
+    this.throwForImportingLegacyIntoHarmony();
     this.component.dataToPersist = new DataToPersist();
     this._updateFilesBasePaths();
     this.component.componentMap = this.existingComponentMap || this.addComponentToBitMap(this.writeToPath);
@@ -140,6 +140,14 @@ export default class ComponentWriter {
     await this.populateFilesToWriteToComponentDir(packageManager);
     if (this.isolated) await this.populateArtifacts();
     return this.component;
+  }
+
+  private throwForImportingLegacyIntoHarmony() {
+    if (this.component.isLegacy && this.consumer && !this.consumer.isLegacy) {
+      throw new Error(
+        `unable to write component "${this.component.id.toString()}", it is a legacy component and this workspace is Harmony`
+      );
+    }
   }
 
   async populateFilesToWriteToComponentDir(packageManager?: string) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -119,6 +119,7 @@ export default class DependencyResolver {
     this.processedFiles = [];
     this.issues = new IssuesList();
     this.setMissingDistsIssue();
+    this.setLegacyInsideHarmonyIssue();
     this.overridesDependencies = new OverridesDependencies(component, consumer);
     this.debugDependenciesData = { components: [] };
   }
@@ -1192,6 +1193,13 @@ either, use the ignore file syntax or change the require statement to have a mod
     const isMissing = !this.isDistDirExists(pkgName);
     if (isMissing) {
       this.issues.getOrCreate(IssuesClasses.MissingDists).data = true;
+    }
+  }
+
+  private setLegacyInsideHarmonyIssue() {
+    if (this.consumer.isLegacy) return;
+    if (this.componentFromModel && this.componentFromModel.isLegacy) {
+      this.issues.getOrCreate(IssuesClasses.LegacyInsideHarmony).data = true;
     }
   }
 

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -1,6 +1,7 @@
 import mapSeries from 'p-map-series';
 import R from 'ramda';
 import { isNilOrEmpty, compact } from 'ramda-adjunct';
+import pMap from 'p-map';
 import { ReleaseType } from 'semver';
 import { v4 } from 'uuid';
 import * as globalConfig from '../../api/consumer/lib/global-config';
@@ -23,6 +24,7 @@ import { getValidVersionOrReleaseType } from '../../utils/semver-helper';
 import { LegacyOnTagResult } from '../scope';
 import { Log } from '../models/version';
 import { BasicTagParams } from '../../api/consumer/lib/tag';
+import { concurrentComponentsLimit } from '../../utils/concurrency';
 
 export type onTagIdTransformer = (id: BitId) => BitId | null;
 type UpdateDependenciesOnTagFunc = (component: Component, idTransformer: onTagIdTransformer) => Component;
@@ -288,10 +290,11 @@ export default async function tagModelComponent({
   } else {
     if (!skipTests) addSpecsResultsToComponents(allComponentsToTag, testsResults);
     await addFlattenedDependenciesToComponents(consumer.scope, allComponentsToTag);
+    await throwForLegacyDependenciesInsideHarmony(consumer, allComponentsToTag);
     emptyBuilderData(allComponentsToTag);
     addBuildStatus(consumer, allComponentsToTag, BuildStatus.Pending);
     await addComponentsToScope(consumer, allComponentsToTag, Boolean(resolveUnmerged));
-    validateDirManipulation(allComponentsToTag);
+    if (consumer.isLegacy) validateDirManipulation(allComponentsToTag);
     await consumer.updateComponentsVersions(allComponentsToTag);
   }
 
@@ -338,6 +341,29 @@ export async function addFlattenedDependenciesToComponents(scope: Scope, compone
   const flattenedDependenciesGetter = new FlattenedDependenciesGetter(scope, components);
   await flattenedDependenciesGetter.populateFlattenedDependencies();
   loader.stop();
+}
+
+async function throwForLegacyDependenciesInsideHarmony(consumer: Consumer, components: Component[]) {
+  if (consumer.isLegacy) {
+    return;
+  }
+  const throwForComponent = async (component: Component) => {
+    const dependenciesIds = component.getAllDependenciesIds();
+    await Promise.all(
+      dependenciesIds.map(async (depId) => {
+        if (!depId.hasVersion()) return;
+        const modelComp = await consumer.scope.getModelComponentIfExist(depId);
+        if (!modelComp) return;
+        const version = await modelComp.loadVersion(depId.version as string, consumer.scope.objects);
+        if (version.isLegacy) {
+          throw new Error(
+            `unable tagging "${component.id.toString()}", its dependency "${depId.toString()}" is legacy`
+          );
+        }
+      })
+    );
+  };
+  await pMap(components, (component) => throwForComponent(component), { concurrency: concurrentComponentsLimit() });
 }
 
 function addSpecsResultsToComponents(components: Component[], testsResults): void {


### PR DESCRIPTION
## Proposed Changes

- prevent importing legacy components inside Harmony workspace
- prevent tagging components that have legacy dependencies installed as packages
- `bit status` shows warning when a component is legacy inside Harmony
