### PR TITLE
enable tree shaking for Ramda to avoid loading the entire lib

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -16,6 +16,7 @@ module.exports = function (api) {
     ],
   ];
   const plugins = [
+    'ramda',
     [
       '@babel/plugin-transform-modules-commonjs',
       {

--- a/package.json
+++ b/package.json
@@ -273,6 +273,7 @@
     "@typescript-eslint/parser": "4.15.1",
     "@typescript-eslint/typescript-estree": "4.15.1",
     "babel-eslint": "9.0.0",
+    "babel-plugin-ramda": "2.0.0",
     "babel-plugin-transform-typescript-metadata": "0.3.1",
     "chai": "4.3.0",
     "chai-arrays": "1.1.0",

--- a/scopes/pipelines/builder/build-pipeline-order.ts
+++ b/scopes/pipelines/builder/build-pipeline-order.ts
@@ -1,4 +1,3 @@
-import R from 'ramda';
 import { Graph } from 'cleargraph';
 import TesterAspect from '@teambit/tester';
 import { EnvDefinition, Environment } from '@teambit/envs';
@@ -66,7 +65,7 @@ export function calculatePipelineOrder(
     pipelineEnvs.push({ env: envDefinition, pipeline });
   });
 
-  const flattenedPipeline: BuildTask[] = R.flatten(pipelineEnvs.map((pipelineEnv) => pipelineEnv.pipeline));
+  const flattenedPipeline: BuildTask[] = pipelineEnvs.map((pipelineEnv) => pipelineEnv.pipeline).flat();
   flattenedPipeline.forEach((task) => addDependenciesToGraph(graphs, flattenedPipeline, task));
 
   const dataPerLocation: DataPerLocation[] = graphs.map(({ location, graph }) => {
@@ -176,7 +175,7 @@ which is invalid. the dependency must be located earlier or in the same location
 
 function getPipelineForEnv(taskSlot: TaskSlot, env: Environment, pipeNameOnEnv: string): BuildTask[] {
   const buildTasks: BuildTask[] = env[pipeNameOnEnv] ? env[pipeNameOnEnv]() : [];
-  const slotsTasks = R.flatten(taskSlot.values());
+  const slotsTasks = taskSlot.values().flat();
   const tasksAtStart: BuildTask[] = [];
   const tasksAtEnd: BuildTask[] = [];
   slotsTasks.forEach((task) => {

--- a/scopes/pkg/pkg/publisher.ts
+++ b/scopes/pkg/pkg/publisher.ts
@@ -10,7 +10,6 @@ import { BitError } from '@teambit/bit-error';
 import { Scope } from '@teambit/legacy/dist/scope';
 import mapSeries from 'p-map-series';
 import execa from 'execa';
-import R from 'ramda';
 import { PkgAspect } from './pkg.aspect';
 
 export type PublisherOptions = {
@@ -57,8 +56,8 @@ export class Publisher {
     if (this.options.dryRun) publishParams.push('--dry-run');
     const extraArgs = this.getExtraArgsFromConfig(capsule.component);
     if (extraArgs && Array.isArray(extraArgs) && extraArgs?.length) {
-      const extraArgsSplit = extraArgs.map((arg) => arg.split(' '));
-      publishParams.push(...R.flatten(extraArgsSplit));
+      const extraArgsSplit = extraArgs.map((arg) => arg.split(' ')).flat();
+      publishParams.push(...extraArgsSplit);
     }
     const publishParamsStr = publishParams.join(' ');
     const cwd = capsule.path;

--- a/scopes/workspace/eject/components-ejector.ts
+++ b/scopes/workspace/eject/components-ejector.ts
@@ -8,7 +8,6 @@
  * removing the component files, so then it's easier to rollback.
  */
 import { Workspace } from '@teambit/workspace';
-import R from 'ramda';
 import { Consumer } from '@teambit/legacy/dist/consumer';
 import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
 import defaultErrorHandler from '@teambit/legacy/dist/cli/default-error-handler';
@@ -86,7 +85,7 @@ export class ComponentsEjector {
 
   async decideWhichComponentsToEject(): Promise<void> {
     this.logger.setStatusLine('Eject: getting the components status');
-    if (R.isEmpty(this.componentsIds)) return;
+    if (!this.componentsIds.length) return;
     const remotes = await getScopeRemotes(this.consumer.scope);
     const hubExportedComponents = new BitIds();
     this.componentsIds.forEach((bitId) => {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1,4 +1,5 @@
-import { clone, equals, forEachObjIndexed, isEmpty } from 'ramda';
+import { clone, equals, forEachObjIndexed } from 'ramda';
+import { isEmpty } from 'lodash';
 import * as semver from 'semver';
 import { versionParser, isHash, isTag } from '@teambit/component-version';
 import { v4 } from 'uuid';


### PR DESCRIPTION
This is done by adding [babel-plugin-ramda](https://github.com/megawac/babel-plugin-ramda) to the babel config. 
It knows to convert `import R, {map} from 'ramda';` into:
```
import add from 'ramda/src/add';
import map from 'ramda/src/map';
```