### PR TITLE
fix out-of-sync id changes to work well on Harmony

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -64,6 +64,20 @@ describe('custom env', function () {
         expect(() => helper.command.untag('--all')).to.not.throw();
       });
     });
+    describe('out-of-sync scenario where the id is changed during the process', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(wsAllNew);
+        helper.command.tagAllWithoutBuild();
+        const bitMapBeforeExport = helper.bitMap.read();
+        helper.command.export();
+        helper.bitMap.write(bitMapBeforeExport);
+      });
+      it('bit status should not throw ComponentNotFound error', () => {
+        expect(() => helper.command.status()).not.to.throw();
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(4);
+      });
+    });
   });
   (supportNpmCiRegistryTesting ? describe : describe.skip)('custom env installed as a package', () => {
     let envId;

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -74,8 +74,6 @@ describe('custom env', function () {
       });
       it('bit status should not throw ComponentNotFound error', () => {
         expect(() => helper.command.status()).not.to.throw();
-        const status = helper.command.statusJson();
-        expect(status.newComponents).to.have.lengthOf(4);
       });
     });
   });

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -165,8 +165,21 @@ export class WorkspaceComponentLoader {
     }
   }
 
-  private getFromCache(id: ComponentID, forCapsule: boolean) {
-    return forCapsule ? this.componentsCacheForCapsule.get(id.toString()) : this.componentsCache.get(id.toString());
+  /**
+   * make sure that not only the id-str match, but also the legacy-id.
+   * this is needed because the ComponentID.toString() is the same whether or not the legacy-id has
+   * scope-name, as it includes the defaultScope if the scope is empty.
+   * as a result, when out-of-sync is happening and the id is changed to include scope-name in the
+   * legacy-id, the component is the cache has the old id.
+   */
+  private getFromCache(id: ComponentID, forCapsule: boolean): Component | undefined {
+    const fromCache = forCapsule
+      ? this.componentsCacheForCapsule.get(id.toString())
+      : this.componentsCache.get(id.toString());
+    if (fromCache && fromCache.id._legacy.isEqual(id._legacy)) {
+      return fromCache;
+    }
+    return undefined;
   }
 
   private async getConsumerComponent(id: ComponentID, forCapsule = false) {

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -144,7 +144,8 @@ export default class ComponentLoader {
   }
 
   private async loadOne(id: BitId, throwOnFailure: boolean, invalidComponents: InvalidComponent[]) {
-    const componentMap = this.consumer.bitMap.getComponent(id);
+    // ignoreScopeAndVersion because out-of-sync might changed it before
+    const componentMap = this.consumer.bitMap.getComponent(id, { ignoreScopeAndVersion: true });
     let bitDir = this.consumer.getPath();
     if (componentMap.rootDir) {
       bitDir = path.join(bitDir, componentMap.rootDir);
@@ -176,7 +177,8 @@ export default class ComponentLoader {
     component.originallySharedDir = componentMap.originallySharedDir || undefined;
     component.wrapDir = componentMap.wrapDir || undefined;
     // reload component map as it may be changed after calling Component.loadFromFileSystem()
-    component.componentMap = this.consumer.bitMap.getComponent(id);
+    // ignoreScopeAndVersion because out-of-sync might changed it before
+    component.componentMap = this.consumer.bitMap.getComponent(id, { ignoreScopeAndVersion: true });
     await this._handleOutOfSyncScenarios(component);
 
     const loadDependencies = async () => {


### PR DESCRIPTION
Currently, if the out-of-sync mechanism adds a scope-name to a component, a user might get ComponentNotFound in some scenarios. 