### PR TITLE
remove components file-paths cache to improve performance

### DIFF
--- a/e2e/harmony/clear-cache.e2e.ts
+++ b/e2e/harmony/clear-cache.e2e.ts
@@ -13,7 +13,8 @@ describe('bit clear-cache', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('fs cache corrupted', () => {
+  // not relevant now that we disabled this feature. revisit again later if needed
+  describe.skip('fs cache corrupted', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "firstline": "2.0.2",
     "fs-extra": "9.1.0",
     "glob": "7.1.6",
+    "globby": "11.0.1",
     "graphlib": "2.1.8",
     "graphql-request": "3.4.0",
     "graphviz": "0.0.9",

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -379,7 +379,7 @@ export default class ComponentMap {
    * so then they'll be tracked by bitmap.
    * this doesn't get called on Harmony, it's for legacy only.
    */
-  async trackDirectoryChanges(consumer: Consumer, id: BitId): Promise<void> {
+  async trackDirectoryChangesLegacy(consumer: Consumer, id: BitId): Promise<void> {
     const trackDir = this.getTrackDir();
     if (!trackDir) {
       return;

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -953,7 +953,7 @@ export async function getFilesByDir(dir: string, consumerPath: string, gitIgnore
   if (!matches.length) throw new ComponentNotFoundInPath(dir);
   const filteredMatches = gitIgnore.filter(matches);
   if (!filteredMatches.length) throw new IgnoredDirectory(dir);
-  return matches.map((match: PathOsBased) => {
+  return filteredMatches.map((match: PathOsBased) => {
     const normalizedPath = pathNormalizeToLinux(match);
     // the path is relative to consumer. remove the rootDir.
     const relativePath = normalizedPath.replace(`${dir}/`, '');

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -1,4 +1,5 @@
 import arrayDiff from 'array-difference';
+import globby from 'globby';
 import fs from 'fs-extra';
 import ignore from 'ignore';
 import assignwith from 'lodash.assignwith';
@@ -945,14 +946,14 @@ function validateNoDuplicateIds(addComponents: Record<string, any>[]) {
 }
 
 export async function getFilesByDir(dir: string, consumerPath: string, gitIgnore: any): Promise<ComponentMapFile[]> {
-  const matches = await glob(path.join(dir, '**'), {
+  const matches = await globby(dir, {
     cwd: consumerPath,
-    nodir: true,
+    onlyFiles: true,
   });
   if (!matches.length) throw new ComponentNotFoundInPath(dir);
   const filteredMatches = gitIgnore.filter(matches);
   if (!filteredMatches.length) throw new IgnoredDirectory(dir);
-  return filteredMatches.map((match: PathOsBased) => {
+  return matches.map((match: PathOsBased) => {
     const normalizedPath = pathNormalizeToLinux(match);
     // the path is relative to consumer. remove the rootDir.
     const relativePath = normalizedPath.replace(`${dir}/`, '');

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -1171,7 +1171,7 @@ async function getLoadedFilesLegacy(
 ): Promise<SourceFile[]> {
   const bitMap: BitMap = consumer.bitMap;
   const sourceFiles = [];
-  await componentMap.trackDirectoryChanges(consumer, id);
+  await componentMap.trackDirectoryChangesLegacy(consumer, id);
   const filesToDelete = [];
   componentMap.files.forEach((file) => {
     const filePath = path.join(bitDir, file.relativePath);

--- a/src/utils/fs/last-modified.ts
+++ b/src/utils/fs/last-modified.ts
@@ -1,4 +1,4 @@
-import glob from 'glob';
+import globby from 'globby';
 import fs, { Stats } from 'fs-extra';
 import { compact } from 'lodash';
 
@@ -6,7 +6,12 @@ import { compact } from 'lodash';
  * check recursively all the sub-directories as well
  */
 export async function getLastModifiedDirTimestampMs(rootDir: string): Promise<number> {
-  const allDirs = glob.sync(`${rootDir}/**/`); // the trailing slash instructs glob to show only dirs
+  const allDirs = await globby(rootDir, {
+    onlyDirectories: true,
+    ignore: ['**/node_modules/**'],
+    // stats: true // todo: consider retrieving the stats from here.
+  });
+  allDirs.push(rootDir);
   return getLastModifiedPathsTimestampMs(allDirs);
 }
 

--- a/src/utils/fs/last-modified.ts
+++ b/src/utils/fs/last-modified.ts
@@ -8,7 +8,7 @@ import { compact } from 'lodash';
 export async function getLastModifiedDirTimestampMs(rootDir: string): Promise<number> {
   const allDirs = await globby(rootDir, {
     onlyDirectories: true,
-    ignore: ['**/node_modules/**'],
+    // ignore: ['**/node_modules/**'], // need to think about it more. sometimes we do want to invalidate cache upon node_modules changes inside component dir
     // stats: true // todo: consider retrieving the stats from here.
   });
   allDirs.push(rootDir);

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -213,7 +213,6 @@
         "flatted": "3.1.0",
         "fuse.js": "6.4.6",
         "get-port": "5.1.1",
-        "globby": "11.0.1",
         "graceful-fs": "4.2.4",
         "graphql-subscriptions": "1.2.0",
         "graphql-tag": "2.12.1",


### PR DESCRIPTION
The slowness of this cache was caused by a few factors:
1. calling `cacache` multiple times, one for each component.
2. globbing all components dirs to get their sub-dirs for checking the timestamp to potentially invalidate the cache.
3. accessing the stat for each one of the dirs and sub-dirs. 
4. the glob was sync.
5. the glob was fetching node_modules dir inside the components dir.

Even when fixing some of the points above, still, keeping the cache was a bit slower than not using it.
The big improvement after removing the cache was switching the `glob` package with `globby`. 