### PR TITLE
remove lazy-loading exclusion from ui and preview files

### DIFF
--- a/scopes/harmony/aspect/babel/babel-config.ts
+++ b/scopes/harmony/aspect/babel/babel-config.ts
@@ -17,7 +17,8 @@ const plugins = [
     require.resolve('@babel/plugin-transform-modules-commonjs'),
     {
       lazy: (requirePath) => {
-        return !requirePath.includes('.ui') && !requirePath.includes('.preview');
+        return true;
+        // return !requirePath.includes('.ui') && !requirePath.includes('.preview');
       },
     },
   ],

--- a/scopes/harmony/aspect/babel/babel-config.ts
+++ b/scopes/harmony/aspect/babel/babel-config.ts
@@ -16,10 +16,7 @@ const plugins = [
   [
     require.resolve('@babel/plugin-transform-modules-commonjs'),
     {
-      lazy: (requirePath) => {
-        return true;
-        // return !requirePath.includes('.ui') && !requirePath.includes('.preview');
-      },
+      lazy: () => true,
     },
   ],
   require.resolve('babel-plugin-transform-typescript-metadata'),


### PR DESCRIPTION
Currently, if the path includes `.ui` or `.preview` it doesn't apply the lazy-loading improvements. 