### PR TITLE
replace ramda with lodash in Harmony code wherever possible

### DIFF
--- a/scopes/component/component/aspect-list.ts
+++ b/scopes/component/component/aspect-list.ts
@@ -1,4 +1,4 @@
-import { isEmpty } from 'ramda';
+import { isEmpty } from 'lodash';
 import { ExtensionDataList, ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { ComponentID } from '@teambit/component-id';
 import { AspectEntry, SerializableMap } from './aspect-entry';

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -27,7 +27,7 @@ import { Scope } from '@teambit/legacy/dist/scope';
 import fs from 'fs-extra';
 import hash from 'object-hash';
 import path from 'path';
-import { equals, map } from 'ramda';
+import equals from 'ramda/src/equals';
 import BitMap from '@teambit/legacy/dist/consumer/bit-map';
 import ComponentWriter, { ComponentWriterProps } from '@teambit/legacy/dist/consumer/component-ops/component-writer';
 import { Capsule } from './capsule';
@@ -398,9 +398,9 @@ export class IsolatorMain {
     opts: IsolateComponentsOptions
   ): Promise<Capsule[]> {
     const capsules: Capsule[] = await Promise.all(
-      map((component: Component) => {
+      components.map((component: Component) => {
         return Capsule.createFromComponent(component, baseDir, opts);
-      }, components)
+      })
     );
     return capsules;
   }

--- a/scopes/component/legacy-bit-id/bit-id.ts
+++ b/scopes/component/legacy-bit-id/bit-id.ts
@@ -1,7 +1,7 @@
 import decamelize from 'decamelize';
 import * as path from 'path';
 import * as semver from 'semver';
-import { is, head, tail } from 'ramda';
+import { head, tail } from 'lodash';
 import { versionParser, isHash, LATEST_VERSION } from '@teambit/component-version';
 import isValidIdChunk from './utils/is-valid-id-chunk';
 import isValidScopeName from './utils/is-valid-scope-name';
@@ -153,7 +153,7 @@ export default class BitId {
   }
 
   static parse(id: BitIdStr, hasScope = true, version: string = LATEST_VERSION): BitId {
-    if (!is(String, id)) {
+    if (typeof id !== 'string') {
       throw new TypeError(`BitId.parse expects to get "id" as a string, instead, got ${typeof id}`);
     }
 

--- a/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
@@ -1,4 +1,4 @@
-import { uniqBy, prop } from 'ramda';
+import { uniqBy, property } from 'lodash';
 import { Dependency, DependencyLifecycleType, SerializedDependency, SemverVersion, PackageName } from './dependency';
 import { KEY_NAME_BY_LIFECYCLE_TYPE } from './constants';
 
@@ -92,6 +92,6 @@ export class DependencyList {
 }
 
 function uniqDeps(dependencies: Array<Dependency>): Array<Dependency> {
-  const uniq = uniqBy(prop('id'), dependencies);
+  const uniq = uniqBy(dependencies, property('id'));
   return uniq;
 }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -26,7 +26,6 @@ import { Version as VersionModel } from '@teambit/legacy/dist/scope/models';
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
 import fs from 'fs-extra';
 import { BitId } from '@teambit/legacy-bit-id';
-import { flatten } from 'ramda';
 import { SemVer } from 'semver';
 import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import GlobalConfigAspect, { GlobalConfigMain } from '@teambit/global-config';
@@ -276,7 +275,7 @@ export class DependencyResolverMain {
   }
 
   private getDependencyListFactory(): DependencyListFactory {
-    const factories = flatten(this.dependencyFactorySlot.values());
+    const factories = this.dependencyFactorySlot.values().flat();
     const factoriesMap = factories.reduce((acc, factory) => {
       acc[factory.type] = factory;
       return acc;
@@ -411,11 +410,11 @@ export class DependencyResolverMain {
   }
 
   private getPreInstallSubscribers(): PreInstallSubscriberList {
-    return flatten(this.preInstallSlot.values());
+    return this.preInstallSlot.values().flat();
   }
 
   private getPostInstallSubscribers(): PostInstallSubscriberList {
-    return flatten(this.postInstallSlot.values());
+    return this.postInstallSlot.values().flat();
   }
 
   /**

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -1,4 +1,5 @@
-import { countBy, forEachObjIndexed, prop, sortBy, uniq } from 'ramda';
+import forEachObjIndexed from 'ramda/src/forEachObjIndexed';
+import { countBy, property, sortBy, uniq } from 'lodash';
 import semver from 'semver';
 import { intersect, parseRange } from 'semver-intersect';
 
@@ -321,7 +322,7 @@ function findBestRange(ranges: SemverVersion[]): BestRange {
 // }
 
 function getSortedRangesCombination(ranges: SemverVersion[]): CombinationWithTotal[] {
-  const counts = countBy((item) => item)(ranges);
+  const counts = countBy(ranges, (item) => item);
   const uniqRanges = uniq(ranges);
   const rangesCombinations = arrayCombinations<SemverVersion>(uniqRanges);
   const countMultipleRanges = (items: SemverVersion[]): number => {
@@ -339,8 +340,7 @@ function getSortedRangesCombination(ranges: SemverVersion[]): CombinationWithTot
     };
   });
 
-  const sortByTotal = sortBy(prop('total'));
-  const sortedByTotal = sortByTotal(rangesCombinationsWithTotalCount).reverse();
+  const sortedByTotal = sortBy(rangesCombinationsWithTotalCount, property('total')).reverse();
   return sortedByTotal;
 }
 
@@ -367,7 +367,7 @@ function getLifecycleType(indexItems: PackageNameIndexComponentItem[]): Dependen
  * @returns {MostCommonVersion}
  */
 function findMostCommonVersion(versions: SemverVersion[]): MostCommonVersion {
-  const counts = countBy((item) => item)(versions);
+  const counts = countBy(versions, (item) => item);
   const result: MostCommonVersion = {
     version: '0.0.0',
     count: 0,

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/index-by-dep-id.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/index-by-dep-id.ts
@@ -1,5 +1,4 @@
-import { forEachObjIndexed } from 'ramda';
-
+import forEachObjIndexed from 'ramda/src/forEachObjIndexed';
 import { LIFECYCLE_TYPE_BY_KEY_NAME } from '../../dependencies/constants';
 import { ManifestDependenciesKeysNames, DepObjectValue } from '../manifest';
 import { DependencyLifecycleType, SemverVersion, PackageName } from '../../dependencies';

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/merge-with-root.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/merge-with-root.ts
@@ -1,4 +1,4 @@
-import { forEachObjIndexed } from 'ramda';
+import forEachObjIndexed from 'ramda/src/forEachObjIndexed';
 import { SemVer } from 'semver';
 
 import { PackageName } from '../../dependencies';

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
@@ -1,4 +1,4 @@
-import { uniqWith } from 'ramda';
+import { uniqWith } from 'lodash';
 import { DependenciesOverridesData } from '@teambit/legacy/dist/consumer/config/component-overrides';
 import { Policy, PolicyConfigKeys, PolicyEntry, SemverVersion } from '../policy';
 import { DependencyLifecycleType, KEY_NAME_BY_LIFECYCLE_TYPE } from '../../dependencies';
@@ -117,8 +117,8 @@ export class VariantPolicy implements Policy<VariantPolicyConfigObject> {
 }
 
 function uniqEntries(entries: Array<VariantPolicyEntry>): Array<VariantPolicyEntry> {
-  const uniq = uniqWith((entry1: VariantPolicyEntry, entry2: VariantPolicyEntry) => {
+  const uniq = uniqWith(entries, (entry1: VariantPolicyEntry, entry2: VariantPolicyEntry) => {
     return entry1.dependencyId === entry2.dependencyId && entry1.lifecycleType === entry2.lifecycleType;
-  }, entries);
+  });
   return uniq;
 }

--- a/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy.ts
@@ -1,4 +1,4 @@
-import { uniqWith } from 'ramda';
+import { uniqWith } from 'lodash';
 import { sortObject } from '@teambit/legacy/dist/utils';
 import { Policy, PolicyEntry, SemverVersion, GitUrlVersion, FileSystemPath, PolicyConfigKeys } from '../policy';
 import { KEY_NAME_BY_LIFECYCLE_TYPE, DependencyLifecycleType } from '../../dependencies';
@@ -154,8 +154,8 @@ export class WorkspacePolicy implements Policy<WorkspacePolicyConfigObject> {
 }
 
 function uniqEntries(entries: Array<WorkspacePolicyEntry>): Array<WorkspacePolicyEntry> {
-  const uniq = uniqWith((entry1: WorkspacePolicyEntry, entry2: WorkspacePolicyEntry) => {
+  const uniq = uniqWith(entries, (entry1: WorkspacePolicyEntry, entry2: WorkspacePolicyEntry) => {
     return entry1.dependencyId === entry2.dependencyId && entry1.lifecycleType === entry2.lifecycleType;
-  }, entries);
+  });
   return uniq;
 }

--- a/scopes/dependencies/pnpm/get-registries.ts
+++ b/scopes/dependencies/pnpm/get-registries.ts
@@ -1,7 +1,7 @@
 import getCredentialsByURI from 'credentials-by-uri';
 import { RegistriesMap } from '@teambit/dependency-resolver';
 import { stripTrailingChar } from '@teambit/legacy/dist/utils';
-import { isEmpty } from 'ramda';
+import { isEmpty } from 'lodash';
 import toNerfDart from 'nerf-dart';
 import { readConfig } from './read-config';
 

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -7,7 +7,7 @@ import { Logger, LoggerAspect } from '@teambit/logger';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import mapSeries from 'p-map-series';
-import { difference } from 'ramda';
+import { difference } from 'lodash';
 import { AspectDefinition, AspectDefinitionProps } from './aspect-definition';
 import { AspectLoaderAspect } from './aspect-loader.aspect';
 import { UNABLE_TO_LOAD_EXTENSION, UNABLE_TO_LOAD_EXTENSION_FROM_LIST } from './constants';

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -2,8 +2,6 @@ import { Slot, SlotRegistry } from '@teambit/harmony';
 import { buildRegistry } from '@teambit/legacy/dist/cli';
 import { Command } from '@teambit/legacy/dist/cli/command';
 import LegacyLoadExtensions from '@teambit/legacy/dist/legacy-extensions/extensions-loader';
-
-import { flatten } from 'ramda';
 import { groups, GroupsType } from '@teambit/legacy/dist/cli/command-groups';
 import { clone } from 'lodash';
 import { CLIAspect, MainRuntime } from './cli.aspect';
@@ -53,7 +51,7 @@ export class CLIMain {
    * list of all registered commands. (legacy and new).
    */
   get commands(): CommandList {
-    return flatten(this.commandsSlot.values());
+    return this.commandsSlot.values().flat();
   }
 
   /**
@@ -131,7 +129,7 @@ export class CLIMain {
     const legacyCommandsAdapters = legacyCommands.map((command) => new LegacyCommandAdapter(command, cliMain));
     const cliCmd = new CliCmd(cliMain);
     cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd);
-    
+
     return cliMain;
   }
 }

--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -20,7 +20,7 @@ import { PathOsBased, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/pat
 import { assign, parse, stringify } from 'comment-json';
 import * as fs from 'fs-extra';
 import * as path from 'path';
-import { isEmpty, omit } from 'ramda';
+import { isEmpty, omit } from 'lodash';
 
 import { SetExtensionOptions } from './config';
 import { ExtensionAlreadyConfigured } from './exceptions';
@@ -125,7 +125,7 @@ export class WorkspaceConfig implements HostConfig {
   }
 
   private loadExtensions() {
-    const withoutInternalConfig = omit(INTERNAL_CONFIG_PROPS, this.raw);
+    const withoutInternalConfig = omit(this.raw, INTERNAL_CONFIG_PROPS);
     this._extensions = ExtensionDataList.fromConfigObject(withoutInternalConfig);
   }
 

--- a/scopes/pipelines/builder/build-pipeline-result-list.ts
+++ b/scopes/pipelines/builder/build-pipeline-result-list.ts
@@ -1,5 +1,5 @@
 import { ComponentID, ComponentMap, Component } from '@teambit/component';
-import { isEmpty } from 'ramda';
+import { isEmpty } from 'lodash';
 import { compact } from 'lodash';
 import type { ArtifactObject } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { Artifact, ArtifactList } from './artifact';

--- a/scopes/pipelines/builder/build-pipeline-result-list.ts
+++ b/scopes/pipelines/builder/build-pipeline-result-list.ts
@@ -1,6 +1,5 @@
 import { ComponentID, ComponentMap, Component } from '@teambit/component';
-import { isEmpty } from 'lodash';
-import { compact } from 'lodash';
+import { isEmpty, compact } from 'lodash';
 import type { ArtifactObject } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { Artifact, ArtifactList } from './artifact';
 import { TaskResults } from './build-pipe';

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -1,5 +1,4 @@
-import R from 'ramda';
-import { compact } from 'lodash';
+import { compact, omit } from 'lodash';
 import { join } from 'path';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import ComponentAspect, { Component, ComponentMain, Snap } from '@teambit/component';
@@ -259,7 +258,7 @@ export class PkgMain {
     }
     // Keys not allowed to override
     const specialKeys = ['extensions', 'dependencies', 'devDependencies', 'peerDependencies'];
-    return R.omit(specialKeys, newProps);
+    return omit(newProps, specialKeys);
   }
 
   getPackageJsonModifications(component: Component): Record<string, any> {

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -1,4 +1,4 @@
-import { mergeDeepLeft } from 'ramda';
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { MainRuntime } from '@teambit/cli';
 import type { CompilerMain } from '@teambit/compiler';
 import { CompilerAspect, Compiler } from '@teambit/compiler';

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -5,7 +5,7 @@ import ejectTemplate from '@teambit/legacy/dist/cli/templates/eject-template';
 import { BASE_DOCS_DOMAIN, CURRENT_UPSTREAM, WILDCARD_HELP } from '@teambit/legacy/dist/constants';
 import GeneralError from '@teambit/legacy/dist/error/general-error';
 import chalk from 'chalk';
-import R from 'ramda';
+import { isEmpty } from 'lodash';
 
 export class ExportCmd implements Command {
   name = 'export [remote] [id...]';
@@ -98,11 +98,11 @@ export class ExportCmd implements Command {
       lanes,
       resumeExportId: resume,
     });
-    if (R.isEmpty(componentsIds) && R.isEmpty(nonExistOnBitMap) && R.isEmpty(missingScope)) {
+    if (isEmpty(componentsIds) && isEmpty(nonExistOnBitMap) && isEmpty(missingScope)) {
       return chalk.yellow('nothing to export');
     }
     const exportOutput = () => {
-      if (R.isEmpty(componentsIds)) return '';
+      if (isEmpty(componentsIds)) return '';
       if (remote) return chalk.green(`exported ${componentsIds.length} components to scope ${chalk.bold(remote)}`);
       return chalk.green(
         `exported the following ${componentsIds.length} component(s):\n${chalk.bold(componentsIds.join('\n'))}`
@@ -110,14 +110,14 @@ export class ExportCmd implements Command {
     };
     const nonExistOnBitMapOutput = () => {
       // if includeDependencies is true, the nonExistOnBitMap might be the dependencies
-      if (R.isEmpty(nonExistOnBitMap) || includeDependencies) return '';
+      if (isEmpty(nonExistOnBitMap) || includeDependencies) return '';
       const idsStr = nonExistOnBitMap.map((id) => id.toString()).join(', ');
       return chalk.yellow(
         `${idsStr}\nexported successfully. bit did not update the workspace as the component files are not tracked. this might happen when a component was tracked in a different git branch. to fix it check if they where tracked in a different git branch, checkout to that branch and resync by running 'bit import'. or stay on your branch and track the components again using 'bit add'.\n`
       );
     };
     const missingScopeOutput = () => {
-      if (R.isEmpty(missingScope)) return '';
+      if (isEmpty(missingScope)) return '';
       const idsStr = missingScope.map((id) => id.toString()).join(', ');
       return chalk.yellow(
         `the following component(s) were not exported: ${chalk.bold(

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1,7 +1,6 @@
 import mapSeries from 'p-map-series';
 import semver from 'semver';
 import type { AspectLoaderMain } from '@teambit/aspect-loader';
-import { difference } from 'ramda';
 import { TaskResultsList, BuilderData, BuilderAspect } from '@teambit/builder';
 import { readdirSync } from 'fs-extra';
 import { resolve, join } from 'path';
@@ -37,7 +36,7 @@ import { buildOneGraphForComponentsUsingScope } from '@teambit/legacy/dist/scope
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { resumeExport } from '@teambit/legacy/dist/scope/component-ops/export-scope-components';
 import { ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config';
-import { compact, slice, uniqBy } from 'lodash';
+import { compact, slice, uniqBy, difference } from 'lodash';
 import { ComponentNotFound } from './exceptions';
 import { ScopeAspect } from './scope.aspect';
 import { scopeSchema } from './scope.graphql';

--- a/scopes/workspace/modules/match-pattern/match-pattern.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.ts
@@ -1,8 +1,8 @@
 import { stripTrailingChar } from '@teambit/toolbox.string.strip-trailing-char';
 import { isPathInside } from '@teambit/toolbox.path.is-path-inside';
-import { sortBy, prop, any } from 'ramda';
+import any from 'ramda/src/any';
 import minimatch from 'minimatch';
-import _ from 'lodash';
+import { maxBy, property, sortBy } from 'lodash';
 
 export const PATTERNS_DELIMITER = ',';
 export const MATCH_ALL_ITEM = '*';
@@ -40,7 +40,7 @@ export type MatchedPatternItemWithExclude = MatchedPatternItem & {
 };
 
 export function sortMatchesBySpecificity(matches: MatchedPatternWithConfig[]) {
-  const sortedMatches: MatchedPatternWithConfig[] = sortBy(prop('specificity'), matches).reverse();
+  const sortedMatches: MatchedPatternWithConfig[] = sortBy(matches, property('specificity')).reverse();
   return sortedMatches;
 }
 
@@ -53,7 +53,7 @@ export function isMatchPattern(rootDir: PathLinuxRelative, componentName: string
     specificity: -1,
   };
 
-  const maxMatch: MatchedPatternItemWithExclude = _.maxBy(matches, (match) => match.specificity) || defaultVal;
+  const maxMatch: MatchedPatternItemWithExclude = maxBy(matches, (match) => match.specificity) || defaultVal;
   const excluded = any((match) => match.match && match.excluded, matches);
 
   return {

--- a/scopes/workspace/variants/variants.main.runtime.ts
+++ b/scopes/workspace/variants/variants.main.runtime.ts
@@ -2,7 +2,7 @@ import { MainRuntime } from '@teambit/cli';
 import ConsumerOverrides from '@teambit/legacy/dist/consumer/config/consumer-overrides';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { PathLinuxRelative } from '@teambit/legacy/dist/utils/path';
-import { forEachObjIndexed, omit } from 'ramda';
+import { omit, forEach } from 'lodash';
 import {
   MatchedPatternWithConfig,
   isMatchPattern,
@@ -35,11 +35,11 @@ export class VariantsMain {
   }
 
   private validateConfig() {
-    forEachObjIndexed((patternConfig: Record<string, any>, pattern: string) => {
+    forEach(this.patterns, (patternConfig: Record<string, any>, pattern: string) => {
       if (patternConfig.defaultScope && !isValidScopeName(patternConfig.defaultScope)) {
         throw new InvalidScopeName(patternConfig.defaultScope, undefined, pattern);
       }
-    }, this.patterns);
+    });
   }
 
   raw(): Patterns {
@@ -60,7 +60,7 @@ export class VariantsMain {
    */
   byRootDirAndName(rootDir: PathLinuxRelative, componentName: string): VariantsComponentConfig | undefined {
     const matches: MatchedPatternWithConfig[] = [];
-    forEachObjIndexed((patternConfig, pattern) => {
+    forEach(this.patterns, (patternConfig, pattern) => {
       const match = isMatchPattern(rootDir, componentName, pattern);
 
       // Ignore matches with exclude matches
@@ -70,7 +70,7 @@ export class VariantsMain {
           specificity: match.maxSpecificity,
         });
       }
-    }, this.patterns);
+    });
 
     const sortedMatches: MatchedPatternWithConfig[] = sortMatchesBySpecificity(matches);
 
@@ -103,7 +103,7 @@ export class VariantsMain {
 }
 
 function getExtensionFromPatternRawConfig(config: Record<string, any>) {
-  const rawExtensions = omit(INTERNAL_FIELDS, config);
+  const rawExtensions = omit(config, INTERNAL_FIELDS);
   const extensions = ExtensionDataList.fromConfigObject(rawExtensions);
   return extensions;
 }

--- a/scopes/workspace/workspace/watch/watcher.ts
+++ b/scopes/workspace/workspace/watch/watcher.ts
@@ -1,5 +1,6 @@
 import { PubsubMain } from '@teambit/pubsub';
 import { dirname } from 'path';
+import { difference } from 'lodash';
 import { ComponentID } from '@teambit/component';
 
 import { BitId } from '@teambit/legacy-bit-id';
@@ -13,7 +14,6 @@ import mapSeries from 'p-map-series';
 import chalk from 'chalk';
 import { ChildProcess } from 'child_process';
 import chokidar, { FSWatcher } from 'chokidar';
-import R from 'ramda';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 
 import { WorkspaceAspect } from '../';
@@ -114,15 +114,15 @@ export class Watcher {
     const previewsTrackDirs = { ...this.trackDirs };
     await this.workspace._reloadConsumer();
     await this.setTrackDirs();
-    const newDirs: string[] = R.difference(Object.keys(this.trackDirs), Object.keys(previewsTrackDirs));
-    const removedDirs: string[] = R.difference(Object.keys(previewsTrackDirs), Object.keys(this.trackDirs));
+    const newDirs: string[] = difference(Object.keys(this.trackDirs), Object.keys(previewsTrackDirs));
+    const removedDirs: string[] = difference(Object.keys(previewsTrackDirs), Object.keys(this.trackDirs));
     const results: OnComponentEventResult[] = [];
     if (newDirs.length) {
       this.fsWatcher.add(newDirs);
       const addResults = await mapSeries(newDirs, (dir) =>
         this.executeWatchOperationsOnComponent(this.trackDirs[dir], false)
       );
-      results.push(...R.flatten(addResults));
+      results.push(...addResults.flat());
     }
     if (removedDirs.length) {
       await this.fsWatcher.unwatch(removedDirs);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -59,9 +59,8 @@ import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-i
 import { PathOsBased, PathOsBasedRelative, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import findCacheDir from 'find-cache-dir';
 import fs from 'fs-extra';
-import { slice, uniqBy } from 'lodash';
+import { slice, uniqBy, difference } from 'lodash';
 import path, { join } from 'path';
-import { difference } from 'ramda';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import type { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
 import { ComponentConfigFile } from './component-config-file';


### PR DESCRIPTION
If not possible, or difficult, import specific files from Ramda lib. 
This helps to avoid bringing the entire Ramda lib into bit.