### PR TITLE
POC - introduce bit prompt to speed up commands 

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -3,6 +3,7 @@ import yargs, { CommandModule } from 'yargs';
 import { Command } from '@teambit/legacy/dist/cli/command';
 import { GroupsType } from '@teambit/legacy/dist/cli/command-groups';
 import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
+import logger from '@teambit/legacy/dist/logger/logger';
 import loader from '@teambit/legacy/dist/cli/loader';
 import chalk from 'chalk';
 import { getCommandId } from './get-command-id';
@@ -11,11 +12,9 @@ import { GLOBAL_GROUP, STANDARD_GROUP, YargsAdapter } from './yargs-adapter';
 import { CommandNotFound } from './exceptions/command-not-found';
 
 export class CLIParser {
-  constructor(private commands: Command[], private groups: GroupsType) {}
+  constructor(private commands: Command[], private groups: GroupsType, public parser = yargs) {}
 
-  async parse() {
-    const args = process.argv.slice(2); // remove the first two arguments, they're not relevant
-
+  async parse(args = process.argv.slice(2)) {
     this.throwForNonExistsCommand(args[0]);
 
     yargs(args);
@@ -31,6 +30,7 @@ export class CLIParser {
     });
     this.configureGlobalFlags();
     this.setHelpMiddleware();
+    this.handleCommandFailure();
     this.configureCompletion();
 
     yargs
@@ -42,7 +42,7 @@ export class CLIParser {
 
   private setHelpMiddleware() {
     yargs.middleware((argv) => {
-      if (argv._.length === 0) {
+      if (argv._.length === 0 && argv.help) {
         // this is the main help page
         this.printHelp();
         process.exit(0);
@@ -51,9 +51,22 @@ export class CLIParser {
         loader.off(); // stop the "loading bit..." before showing help if needed
         // this is a command help page
         yargs.showHelp(logCommandHelp);
-        process.exit(0);
+        if (!logger.isDaemon) process.exit(0);
       }
     }, true);
+  }
+
+  private handleCommandFailure() {
+    yargs.fail((msg, err) => {
+      loader.stop();
+      if (err) {
+        throw err;
+      }
+      yargs.showHelp(logCommandHelp);
+      // eslint-disable-next-line no-console
+      console.log(`\n${chalk.yellow(msg)}`);
+      if (!logger.isDaemon) process.exit(1);
+    });
   }
 
   private configureCompletion() {

--- a/scopes/harmony/cli/cli.cmd.ts
+++ b/scopes/harmony/cli/cli.cmd.ts
@@ -1,22 +1,75 @@
 import { Command, CommandOptions } from '@teambit/cli';
+import logger from '@teambit/legacy/dist/logger/logger';
+import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
+import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
+import readline from 'readline';
+import { CLIParser } from './cli-parser';
 import { CLIMain } from './cli.main.runtime';
 import { GenerateCommandsDoc } from './generate-doc-md';
 
 export class CliCmd implements Command {
   name = 'cli';
-  description = 'shows all available commands';
+  description = 'EXPERIMENTAL. enters bit cli program';
   alias = '';
   loader = false;
   group = 'general';
-  options = [['', 'generate', 'generate an .md file']] as CommandOptions;
+  options = [['', 'generate', 'generate an .md file with all commands details']] as CommandOptions;
 
   constructor(private cliMain: CLIMain) {}
 
-  async report(args, { generate }: { generate: boolean }) {
+  async report(args, { generate }: { generate: boolean }): Promise<string> {
     if (generate) return new GenerateCommandsDoc(this.cliMain.commands).generate();
-    return this.cliMain.commands
-      .filter((cmd) => !cmd.private)
-      .map((cmd) => `${cmd.name}`)
-      .join('\n');
+
+    logger.isDaemon = true;
+    const rl = readline.createInterface({
+      input: process.stdin,
+      output: process.stdout,
+      prompt: 'bit > ',
+      completer: (line, cb) => completer(line, cb, this.cliMain),
+    });
+
+    const cliParser = new CLIParser(this.cliMain.commands, this.cliMain.groups);
+
+    rl.prompt();
+
+    return new Promise((resolve) => {
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      rl.on('line', async (line) => {
+        const cmd = line.trim().split(' ');
+        try {
+          await cliParser.parse(cmd);
+        } catch (err) {
+          await handleErrorAndExit(err, cmd[0]);
+        }
+        rl.prompt();
+      }).on('close', () => {
+        resolve('Have a great day!');
+      });
+    });
   }
+}
+
+function completer(line: string, cb: Function, cliMain: CLIMain) {
+  const lineSplit = line.split(' ');
+  let values: string[] = [];
+  if (lineSplit.length <= 1) {
+    values = completeCommand(line, cliMain);
+    cb(null, [values, line]);
+  }
+  loadConsumerIfExist()
+    .then((consumer) => {
+      const comps = consumer?.bitmapIdsFromCurrentLane.map((id) => id.toStringWithoutVersion()) || [];
+      values = comps.filter((c) => c.includes(lineSplit[1]));
+      // eslint-disable-next-line promise/no-callback-in-promise
+      cb(null, [values, line]);
+    })
+    .catch((err) => {
+      // eslint-disable-next-line promise/no-callback-in-promise
+      cb(err, [[], line]);
+    });
+}
+
+function completeCommand(line: string, cliMain: CLIMain): string[] {
+  const commands = cliMain.commands.filter((cmd) => cmd.name.startsWith(line));
+  return commands.map((c) => c.name).map((name) => name.split(' ')[0]);
 }

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -13,6 +13,7 @@ import { LegacyCommandAdapter } from './legacy-command-adapter';
 import { CLIParser } from './cli-parser';
 import { CompletionCmd } from './completion.cmd';
 import { CliCmd } from './cli.cmd';
+import { HelpCmd } from './help.cmd';
 
 export type CommandList = Array<Command>;
 export type OnStart = (hasWorkspace: boolean) => Promise<void>;
@@ -21,7 +22,7 @@ export type OnStartSlot = SlotRegistry<OnStart>;
 export type CommandsSlot = SlotRegistry<CommandList>;
 
 export class CLIMain {
-  private groups: GroupsType = clone(groups); // if it's not cloned, it is cached across loadBit() instances
+  public groups: GroupsType = clone(groups); // if it's not cloned, it is cached across loadBit() instances
 
   constructor(private commandsSlot: CommandsSlot, private onStartSlot: OnStartSlot) {}
 
@@ -57,10 +58,10 @@ export class CLIMain {
   }
 
   /**
-   * when running `bit --help`, commands are grouped by categories.
+   * when running `bit help`, commands are grouped by categories.
    * this method helps registering a new group by providing its name and a description.
    * the name is what needs to be assigned to the `group` property of the Command interface.
-   * the description is what shown in the `bit --help` output.
+   * the description is what shown in the `bit help` output.
    */
   registerGroup(name: string, description: string) {
     if (this.groups[name]) {
@@ -130,8 +131,8 @@ export class CLIMain {
     const legacyCommands = legacyRegistry.commands.concat(legacyRegistry.extensionsCommands || []);
     const legacyCommandsAdapters = legacyCommands.map((command) => new LegacyCommandAdapter(command, cliMain));
     const cliCmd = new CliCmd(cliMain);
-    cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd);
-    
+    const helpCmd = new HelpCmd(cliMain);
+    cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd, helpCmd);
     return cliMain;
   }
 }

--- a/scopes/harmony/cli/exceptions/command-not-found.ts
+++ b/scopes/harmony/cli/exceptions/command-not-found.ts
@@ -12,7 +12,7 @@ export class CommandNotFound extends BitError {
   report() {
     let output = chalk.yellow(
       `warning: '${chalk.bold(this.commandName)}' is not a valid command.
-see 'bit --help' for additional information`
+see 'bit help' for additional information`
     );
     if (this.suggestion) {
       output += `\nDid you mean ${chalk.bold(this.suggestion)}?`;

--- a/scopes/harmony/cli/help.cmd.ts
+++ b/scopes/harmony/cli/help.cmd.ts
@@ -1,0 +1,18 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import { CLIMain } from './cli.main.runtime';
+import { formatHelp } from './help';
+
+export class HelpCmd implements Command {
+  name = 'help';
+  description = 'shows help';
+  alias = '$0'; // default command (meaning, if no args are provided, this will be used), see https://github.com/yargs/yargs/blob/master/docs/advanced.md#default-commands
+  loader = false;
+  group = 'general';
+  options = [] as CommandOptions;
+
+  constructor(private cliMain: CLIMain) {}
+
+  async report() {
+    return formatHelp(this.cliMain.commands, this.cliMain.groups);
+  }
+}

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -35,7 +35,7 @@ export interface Command {
   group?: Group | string;
 
   /**
-   * should a command be exposed to the user (by bit --help).
+   * should a command be exposed to the user (by bit help).
    * e.g. experimental commands or commands created for the ssh communication should not be exposed
    */
   private?: boolean;

--- a/src/cli/legacy-command.ts
+++ b/src/cli/legacy-command.ts
@@ -15,8 +15,8 @@ export interface LegacyCommand {
   migration?: boolean;
   internal?: boolean; // used for serialize the error it returns
   remoteOp?: boolean; // Used for adding the token option globally
-  group?: Group; // for grouping in the "bit --help" page
-  shortDescription?: string; // for the "bit --help" page.
+  group?: Group; // for grouping in the "bit help" page
+  shortDescription?: string; // for the "bit help" page.
 
   action(params: any, opts: { [key: string]: any }, packageManagerArgs?: string[]): Promise<any>;
 

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -60,7 +60,8 @@ export interface IBitLogger {
  */
 class BitLogger implements IBitLogger {
   logger: PinoLogger;
-  profiler: Profiler;
+  private profiler: Profiler;
+  isDaemon = false; // 'bit cli' is a daemon as it should never exit the process, unless the user kills it
   /**
    * being set on command-registrar, once the flags are parsed. here, it's a workaround to have
    * it set before the command-registrar is loaded. at this stage we don't know for sure the "-j"
@@ -175,7 +176,7 @@ class BitLogger implements IBitLogger {
     // const finalLogger = pino.final(pinoLogger);
     // finalLogger[level](msg);
     this.logger[level](msg);
-    process.exit(code);
+    if (!this.isDaemon) process.exit(code);
   }
 
   debugAndAddBreadCrumb(


### PR DESCRIPTION
This is an experimental feature. 
The idea is to have a command line tool, similar to typing `node` in the cli, you can type `bit cli` and get `bit >` prompt, from there, you can type commands directly without `bit` prefix. 
The big plus is that bit is loaded into the memory once and doesn't need the bootstrap process for every command.
It feels faster especially when using the auto-complete, where users expect to get feedback immediately.