### PR TITLE
support pre-release tagging

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -26,6 +26,7 @@ describe('publish functionality', function () {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
+      helper.bitJsonc.setPackageManager();
       scopeWithoutOwner = helper.scopes.remoteWithoutOwner;
       appOutput = helper.fixtures.populateComponentsTS(3);
       npmCiRegistry = new NpmCiRegistry(helper);
@@ -47,7 +48,7 @@ describe('publish functionality', function () {
       after(() => {
         npmCiRegistry.destroy();
       });
-      describe('automatically by onPostPersistTag hook', () => {
+      describe('automatically by deploy pipeline', () => {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
           helper.command.tagAllComponents();
@@ -77,6 +78,23 @@ describe('publish functionality', function () {
           helper.scopeHelper.reInitLocalScopeHarmony();
           helper.npm.initNpm();
           helper.npm.installNpmPackage(`@${DEFAULT_OWNER}/${scopeWithoutOwner}.comp1`, '2.0.0');
+          helper.fs.outputFile(
+            'app.js',
+            `const comp1 = require('@${DEFAULT_OWNER}/${scopeWithoutOwner}.comp1').default;\nconsole.log(comp1())`
+          );
+          const output = helper.command.runCmd('node app.js');
+          expect(output.trim()).to.be.equal(appOutput.trim());
+        });
+      });
+      describe('with pre-release', () => {
+        before(async () => {
+          helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
+          helper.command.tagScope('3.0.0-dev.1');
+        });
+        it('should publish with the tag flag and be able to npm install them by the tag name', () => {
+          helper.scopeHelper.reInitLocalScopeHarmony();
+          helper.npm.initNpm();
+          helper.npm.installNpmPackage(`@${DEFAULT_OWNER}/${scopeWithoutOwner}.comp1`, 'dev');
           helper.fs.outputFile(
             'app.js',
             `const comp1 = require('@${DEFAULT_OWNER}/${scopeWithoutOwner}.comp1').default;\nconsole.log(comp1())`

--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -319,4 +319,26 @@ describe('tag components on Harmony', function () {
       });
     });
   });
+  describe('tag pre-release', () => {
+    let tagOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.bitJsonc.setPackageManager();
+      helper.fixtures.populateComponents(3);
+      tagOutput = helper.command.tagAllWithoutBuild('--pre-release dev');
+    });
+    it('should tag all components according to the pre-release version', () => {
+      expect(tagOutput).to.have.string('comp1@0.0.1-dev.0');
+    });
+    describe('increment pre-release', () => {
+      before(() => {
+        helper.fixtures.populateComponents(3, undefined, 'v2');
+        tagOutput = helper.command.tagAllWithoutBuild('--pre-release');
+      });
+      it('should use the last pre-release identifier and increment it', () => {
+        expect(tagOutput).to.have.string('comp1@0.0.1-dev.1');
+      });
+    });
+  });
 });

--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -341,4 +341,28 @@ describe('tag components on Harmony', function () {
       });
     });
   });
+  describe('soft-tag pre-release', () => {
+    let tagOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.bitJsonc.setPackageManager();
+      helper.fixtures.populateComponents(3);
+      tagOutput = helper.command.softTag('--all --pre-release dev');
+    });
+    it('should save the pre-release name in the .bitmap file', () => {
+      const bitMap = helper.bitMap.read();
+      const nextVersion = bitMap.comp1.nextVersion;
+      expect(nextVersion.version).to.equal('prerelease');
+      expect(nextVersion.preRelease).to.equal('dev');
+    });
+    describe('persist the soft-tag', () => {
+      before(() => {
+        tagOutput = helper.command.persistTagWithoutBuild();
+      });
+      it('should use the data in the .bitmap file and tag as a pre-release version', () => {
+        expect(tagOutput).to.have.string('comp1@0.0.1-dev.0');
+      });
+    });
+  });
 });

--- a/scopes/component/component-id/component-id.ts
+++ b/scopes/component/component-id/component-id.ts
@@ -87,6 +87,17 @@ export class ComponentID {
   }
 
   /**
+   * examples:
+   * 1.0.0 => null
+   * 1.0.0-dev.1 => ['dev', 1]
+   * 1.0.0-dev.1.alpha.2 => ['dev', 1, 'alpha', 2]
+   * 1.0.0-0 => [0]
+   */
+  getVersionPreReleaseData(): null | readonly string[] {
+    return this._legacy.getVersionPreReleaseData();
+  }
+
+  /**
    * serialize a component ID without its version.
    */
   toStringWithoutVersion() {

--- a/scopes/component/component-version/version.ts
+++ b/scopes/component/component-version/version.ts
@@ -13,7 +13,7 @@ export class Version {
   }
 
   resolve(availableVersion: string[]) {
-    const getLatest = () => semver.maxSatisfying(availableVersion, '*');
+    const getLatest = () => semver.maxSatisfying(availableVersion, '*', { includePrerelease: true });
 
     if (this.latest) return getLatest();
     return this.versionNum;

--- a/scopes/component/component/tag-map.ts
+++ b/scopes/component/component/tag-map.ts
@@ -1,5 +1,5 @@
 import { getLatestVersion } from '@teambit/legacy/dist/utils/semver-helper';
-import { SemVer } from 'semver';
+import { SemVer, maxSatisfying } from 'semver';
 
 import { CouldNotFindLatest } from './exceptions';
 import { Hash } from './hash';
@@ -12,6 +12,32 @@ export class TagMap extends Map<SemVer, Tag> {
   byHash(hash: Hash) {
     const tag = Array.from(this.values()).find((currTag) => currTag.hash === hash);
     return tag;
+  }
+
+  /**
+   * e.g.
+   * {
+   *   alpha: '1.0.0-alpha.5',
+   *   dev: '2.2.4-dev.37
+   * }
+   */
+  getPreReleaseLatestTags(): { [preRelease: string]: string } {
+    const preReleaseTagsWithAllVersions = this.toArray().reduce((acc, current) => {
+      const preReleases = current.version.prerelease;
+      if (!preReleases.length) return acc;
+      if (preReleases.length !== 2) {
+        // it could be length 1, e.g. 1.0.0-0, we ignore it.
+        // it could also be length > 2, e.g. 1.0.0-dev.1.alpha.1, we don't support it for now.
+        return acc;
+      }
+      if (typeof preReleases[0] !== 'string') return acc;
+      (acc[preReleases[0]] ||= []).push(current.version.raw);
+      return acc;
+    }, {});
+    return Object.keys(preReleaseTagsWithAllVersions).reduce((acc, current) => {
+      acc[current] = maxSatisfying<string>(preReleaseTagsWithAllVersions[current], '*', { includePrerelease: true });
+      return acc;
+    }, {});
   }
 
   /**
@@ -41,7 +67,7 @@ export class TagMap extends Map<SemVer, Tag> {
   /**
    * get an array of all tags.
    */
-  toArray() {
+  toArray(): Tag[] {
     return Array.from(this.values());
   }
 

--- a/scopes/component/legacy-bit-id/bit-id.ts
+++ b/scopes/component/legacy-bit-id/bit-id.ts
@@ -132,6 +132,18 @@ export default class BitId {
   }
 
   /**
+   * examples:
+   * 1.0.0 => null
+   * 1.0.0-dev.1 => ['dev', 1]
+   * 1.0.0-dev.1.alpha.2 => ['dev', 1, 'alpha', 2]
+   * 1.0.0-0 => [0]
+   */
+  getVersionPreReleaseData(): null | readonly string[] {
+    if (!this.version) return null;
+    return semver.prerelease(this.version);
+  }
+
+  /**
    * Get a string id and return a string without the version part
    * @param {string} id
    * @return {string} id - id without version

--- a/scopes/pipelines/builder/build.cmd.ts
+++ b/scopes/pipelines/builder/build.cmd.ts
@@ -26,7 +26,7 @@ export class BuilderCmd implements Command {
       '',
       'tasks <string>',
       `build the specified task(s) only. for multiple tasks, separate by a comma and wrap with quotes.
-                            specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. teambit.compilation/compiler)`,
+specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. teambit.compilation/compiler)`,
     ],
     ['', 'cache-packages-on-capsule-root', 'set the package-manager cache on the capsule root'],
   ] as CommandOptions;

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -280,9 +280,10 @@ export class PkgMain {
     if (!latestVersion) {
       throw new BitError('can not get manifest for component without versions');
     }
+    const preReleaseLatestTags = component.tags.getPreReleaseLatestTags();
     const distTags = {
-      // dev: 1.0.0-dev.3
       latest: latestVersion,
+      ...preReleaseLatestTags,
     };
 
     const versions = await this.getAllSnapsManifests(component);

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -281,6 +281,7 @@ export class PkgMain {
       throw new BitError('can not get manifest for component without versions');
     }
     const distTags = {
+      // dev: 1.0.0-dev.3
       latest: latestVersion,
     };
 

--- a/scopes/pkg/pkg/publisher.ts
+++ b/scopes/pkg/pkg/publisher.ts
@@ -1,5 +1,5 @@
 import { ComponentResult, TaskMetadata } from '@teambit/builder';
-import { Component } from '@teambit/component';
+import { Component, ComponentID } from '@teambit/component';
 import { Capsule, IsolatorMain } from '@teambit/isolator';
 import { Logger } from '@teambit/logger';
 import { Workspace } from '@teambit/workspace';
@@ -54,6 +54,7 @@ export class Publisher {
     const startTime = Date.now();
     const publishParams = ['publish'];
     if (this.options.dryRun) publishParams.push('--dry-run');
+    publishParams.push(...this.getTagFlagForPreRelease(capsule.component.id));
     const extraArgs = this.getExtraArgsFromConfig(capsule.component);
     if (extraArgs && Array.isArray(extraArgs) && extraArgs?.length) {
       const extraArgsSplit = extraArgs.map((arg) => arg.split(' ')).flat();
@@ -80,6 +81,14 @@ export class Publisher {
     }
     const component = capsule.component;
     return { component, metadata, errors, startTime, endTime: Date.now() };
+  }
+
+  private getTagFlagForPreRelease(id: ComponentID): string[] {
+    const preReleaseData = id.getVersionPreReleaseData();
+    if (!preReleaseData) return [];
+    const maybeIdentifier = preReleaseData[0]; // it can be numeric as in 1.0.0-0.
+    if (typeof maybeIdentifier !== 'string') return [];
+    return ['--tag', maybeIdentifier];
   }
 
   private async getComponentCapsules(componentIds: string[]): Promise<Capsule[]> {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -599,7 +599,9 @@ export class ScopeMain implements ComponentFactory {
   async getExactVersionBySemverRange(id: ComponentID, range: string): Promise<string | undefined> {
     const modelComponent = await this.legacyScope.getModelComponent(id._legacy);
     const versions = modelComponent.listVersions();
-    return semver.maxSatisfying<string>(versions, range)?.toString();
+    return semver
+      .maxSatisfying<string>(versions, range, { includePrerelease: true })
+      ?.toString();
   }
 
   async resumeExport(exportId: string, remotes: string[]): Promise<string[]> {

--- a/src/api/consumer/lib/tag.ts
+++ b/src/api/consumer/lib/tag.ts
@@ -38,6 +38,7 @@ export type BasicTagParams = {
   persist: boolean;
   disableDeployPipeline: boolean;
   forceDeploy: boolean;
+  preRelease?: string;
 };
 
 type TagParams = {

--- a/src/cli/commands/public-cmds/tag-cmd.ts
+++ b/src/cli/commands/public-cmds/tag-cmd.ts
@@ -26,6 +26,7 @@ export default class Tag implements LegacyCommand {
     ['p', 'patch', 'increment the patch version number'],
     ['', 'minor', 'increment the minor version number'],
     ['', 'major', 'increment the major version number'],
+    ['', 'pre-release [identifier]', 'EXPERIMENTAL. increment a pre-release version (e.g. 1.0.0-dev.1)'],
     ['f', 'force', 'force-tag even if tests are failing and even when component has not changed'],
     ['v', 'verbose', 'show specs output on failure'],
     ['', 'ignore-missing-dependencies', 'DEPRECATED. use --ignore-unresolved-dependencies instead'],
@@ -55,6 +56,7 @@ export default class Tag implements LegacyCommand {
       patch,
       minor,
       major,
+      preRelease,
       force = false,
       verbose = false,
       ignoreMissingDependencies = false,
@@ -100,9 +102,9 @@ export default class Tag implements LegacyCommand {
       throw new GeneralError('you can use either force-deploy or disable-deploy-pipeline, but not both');
     }
 
-    const releaseFlags = [patch, minor, major].filter((x) => x);
+    const releaseFlags = [patch, minor, major, preRelease].filter((x) => x);
     if (releaseFlags.length > 1) {
-      throw new GeneralError('you can use only one of the following - patch, minor, major');
+      throw new GeneralError('you can use only one of the following - patch, minor, major, pre-release');
     }
 
     let releaseType: ReleaseType = DEFAULT_BIT_RELEASE_TYPE;
@@ -111,6 +113,7 @@ export default class Tag implements LegacyCommand {
     if (major) releaseType = 'major';
     else if (minor) releaseType = 'minor';
     else if (patch) releaseType = 'patch';
+    else if (preRelease) releaseType = 'prerelease';
 
     if (ignoreMissingDependencies) ignoreUnresolvedDependencies = true;
 
@@ -120,6 +123,7 @@ export default class Tag implements LegacyCommand {
       message,
       exactVersion: getVersion(),
       releaseType,
+      preRelease: typeof preRelease === 'string' ? preRelease : '',
       force,
       verbose,
       ignoreUnresolvedDependencies,

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -27,7 +27,8 @@ export type ComponentMapFile = {
 };
 
 export type NextVersion = {
-  version: 'patch' | 'minor' | 'major' | string;
+  version: 'patch' | 'minor' | 'major' | 'prerelease' | string;
+  preRelease?: string;
   message?: string;
   username?: string;
   email?: string;

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import mapSeries from 'p-map-series';
 import * as path from 'path';
 import R from 'ramda';
-import semver from 'semver';
+import semver, { ReleaseType } from 'semver';
 import { IssuesClasses } from '@teambit/component-issues';
 import { Analytics } from '../analytics/analytics';
 import { BitId, BitIds } from '../bit-id';
@@ -45,7 +45,7 @@ import { composeComponentPath, composeDependencyPath } from '../utils/bit/compos
 import { packageNameToComponentId } from '../utils/bit/package-name-to-component-id';
 import { PathAbsolute, PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative, PathRelative } from '../utils/path';
 import BitMap, { CURRENT_BITMAP_SCHEMA } from './bit-map/bit-map';
-import ComponentMap from './bit-map/component-map';
+import ComponentMap, { NextVersion } from './bit-map/component-map';
 import Component from './component';
 import { ComponentStatus, ComponentStatusLoader, ComponentStatusResult } from './component-ops/component-status-loader';
 import ComponentsPendingImport from './component-ops/exceptions/components-pending-import';
@@ -589,16 +589,22 @@ export default class Consumer {
     }
   }
 
-  updateNextVersionOnBitmap(taggedComponents: Component[], exactVersion, releaseType) {
+  updateNextVersionOnBitmap(
+    taggedComponents: Component[],
+    exactVersion?: string | null,
+    releaseType?: ReleaseType,
+    preRelease?: string
+  ) {
     taggedComponents.forEach((taggedComponent) => {
       const log = taggedComponent.log;
       if (!log) throw new Error('updateNextVersionOnBitmap, unable to get log');
-      const nextVersion = {
-        version: exactVersion || releaseType,
+      const nextVersion: NextVersion = {
+        version: exactVersion || (releaseType as string), // one of them is set for sure
         message: log.message,
         username: log.username,
         email: log.email,
       };
+      if (preRelease) nextVersion.preRelease = preRelease;
       if (!taggedComponent.componentMap) throw new Error('updateNextVersionOnBitmap componentMap is missing');
       taggedComponent.componentMap.updateNextVersion(nextVersion);
     });

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -181,6 +181,9 @@ export default class CommandHelper {
   persistTag(options = '') {
     return this.runCmd(`bit tag --persist ${options}`);
   }
+  persistTagWithoutBuild(options = '') {
+    return this.runCmd(`bit tag --persist ${options}`, undefined, undefined, BUILD_ON_CI);
+  }
   snapComponent(id: string, tagMsg = 'snap-message', options = '') {
     return this.runCmd(`bit snap ${id} -m ${tagMsg} ${options}`);
   }

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -88,7 +88,9 @@ async function setFutureVersions(
         const exactVersionOrReleaseType = getValidVersionOrReleaseType(nextVersion);
         componentToTag.version = modelComponent.getVersionToAdd(
           exactVersionOrReleaseType.releaseType,
-          exactVersionOrReleaseType.exactVersion
+          exactVersionOrReleaseType.exactVersion,
+          undefined,
+          componentToTag.componentMap?.nextVersion?.preRelease
         );
       } else {
         componentToTag.version = isAutoTag
@@ -297,7 +299,7 @@ export default async function tagModelComponent({
   await addLogToComponents(componentsToTag, autoTagComponents, persist, message);
 
   if (soft) {
-    consumer.updateNextVersionOnBitmap(allComponentsToTag, exactVersion, releaseType);
+    consumer.updateNextVersionOnBitmap(allComponentsToTag, exactVersion, releaseType, preRelease);
   } else {
     if (!skipTests) addSpecsResultsToComponents(allComponentsToTag, testsResults);
     await addFlattenedDependenciesToComponents(consumer.scope, allComponentsToTag);

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -2,7 +2,7 @@ import mapSeries from 'p-map-series';
 import R from 'ramda';
 import { isNilOrEmpty, compact } from 'ramda-adjunct';
 import pMap from 'p-map';
-import { prerelease, ReleaseType } from 'semver';
+import { ReleaseType } from 'semver';
 import { v4 } from 'uuid';
 import * as globalConfig from '../../api/consumer/lib/global-config';
 import { Scope } from '..';

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -302,7 +302,7 @@ export default class Component extends BitObject {
     }
     // backward compatibility. components created before v15 have master without head
     // @ts-ignore
-    return semver.maxSatisfying(this.listVersions(), '*');
+    return semver.maxSatisfying(this.listVersions(), '*', { includePrerelease: true });
   }
 
   /**
@@ -415,12 +415,13 @@ export default class Component extends BitObject {
   getVersionToAdd(
     releaseType: semver.ReleaseType = DEFAULT_BIT_RELEASE_TYPE,
     exactVersion?: string | null,
-    incrementBy?: number
+    incrementBy?: number,
+    preRelease?: string
   ): string {
     if (exactVersion && this.versions[exactVersion]) {
       throw new VersionAlreadyExists(exactVersion, this.id());
     }
-    return exactVersion || this.version(releaseType, incrementBy);
+    return exactVersion || this.version(releaseType, incrementBy, preRelease);
   }
 
   isEqual(component: Component, considerOrphanedVersions = true): boolean {
@@ -497,15 +498,19 @@ export default class Component extends BitObject {
     return versionToAdd;
   }
 
-  version(releaseType: semver.ReleaseType = DEFAULT_BIT_RELEASE_TYPE, incrementBy = 1): string {
-    const latest = this.latestVersion();
-    if (!latest) return DEFAULT_BIT_VERSION;
+  version(releaseType: semver.ReleaseType = DEFAULT_BIT_RELEASE_TYPE, incrementBy = 1, preRelease?: string): string {
+    if (preRelease) releaseType = 'prerelease';
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    let result = semver.inc(latest, releaseType)!;
+    const increment = (ver: string) => semver.inc(ver, releaseType, undefined, preRelease)!;
+
+    const latest = this.latestVersion();
+    if (!latest) {
+      return preRelease ? increment(DEFAULT_BIT_VERSION) : DEFAULT_BIT_VERSION;
+    }
+    let result = increment(latest);
     if (incrementBy === 1) return result;
     for (let i = 1; i < incrementBy; i += 1) {
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      result = semver.inc(result, releaseType)!;
+      result = increment(result);
     }
     return result;
   }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -206,7 +206,7 @@ export default class Scope {
     const componentFullPath = pathLib.join(scopePath, Scope.getComponentsRelativePath(), relativePath);
     if (!fs.existsSync(componentFullPath)) return '';
     const versions = readDirSyncIgnoreDsStore(componentFullPath);
-    const latestVersion = semver.maxSatisfying(versions, '*');
+    const latestVersion = semver.maxSatisfying(versions, '*', { includePrerelease: true });
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return pathLib.join(relativePath, latestVersion!);
   }

--- a/src/utils/resolveLatestVersion.spec.ts
+++ b/src/utils/resolveLatestVersion.spec.ts
@@ -24,12 +24,12 @@ describe('getLatestVersionNumber', () => {
     const result = resolveLatestVersion(bitIds, idWithNoVersion);
     expect(result).to.deep.equal(idWithNoVersion);
   });
-  it('should throw when using a pre-release tag', () => {
+  it('should work with a pre-release tag', () => {
     const anotherId = new BitId({ scope: 'foo', name: 'is-type' });
     const idWithPreRelease = new BitId({ scope: 'foo', name: 'is-type', version: '3.0.0-dev.1' });
     const bitIds = new BitIds(idWithPreRelease);
-    const func = () => resolveLatestVersion(bitIds, anotherId);
-    expect(func).to.throw('semver was not able to find the highest version among the following: 3.0.0-dev.1');
+    const result = resolveLatestVersion(bitIds, anotherId);
+    expect(result).to.deep.equal(idWithPreRelease);
   });
   it('should return the id from the bitIds array if it is there with a version', () => {
     const bitIds = new BitIds(idWithVersion1);

--- a/src/utils/resolveLatestVersion.ts
+++ b/src/utils/resolveLatestVersion.ts
@@ -30,7 +30,7 @@ export default function getLatestVersionNumber(bitIds: BitIds, bitId: BitId): Bi
   }
   const allVersionsWithoutNullForId = compact(allVersionsForId);
 
-  const maxVersion = semver.maxSatisfying<string>(allVersionsWithoutNullForId, '*');
+  const maxVersion = semver.maxSatisfying<string>(allVersionsWithoutNullForId, '*', { includePrerelease: true });
   if (!maxVersion) {
     throw new Error(
       `semver was not able to find the highest version among the following: ${allVersionsWithoutNullForId.join(', ')}`

--- a/src/utils/semver-helper.ts
+++ b/src/utils/semver-helper.ts
@@ -8,7 +8,7 @@ export function isStrReleaseType(str: string): boolean {
 }
 
 export function isReleaseTypeSupported(str: string): boolean {
-  const supportedReleaseTypes = ['patch', 'minor', 'major'];
+  const supportedReleaseTypes = ['patch', 'minor', 'major', 'prerelease'];
   return supportedReleaseTypes.includes(str);
 }
 

--- a/src/utils/semver-helper.ts
+++ b/src/utils/semver-helper.ts
@@ -40,7 +40,7 @@ export function getValidVersionOrReleaseType(str: string): { releaseType?: Relea
 }
 
 export function getLatestVersion(versions: string[]): string {
-  const max = maxSatisfying(versions, '*');
+  const max = maxSatisfying(versions, '*', { includePrerelease: true });
   if (!max) throw new Error(`unable to find the latest version from ${versions.join(', ')}`);
   return max;
 }

--- a/src/utils/semver-helper.ts
+++ b/src/utils/semver-helper.ts
@@ -1,6 +1,5 @@
-import { ReleaseType, valid, prerelease, maxSatisfying } from 'semver';
+import { ReleaseType, valid, maxSatisfying } from 'semver';
 import { InvalidVersion } from '@teambit/component-version';
-import GeneralError from '../error/general-error';
 
 export function isStrReleaseType(str: string): boolean {
   const releaseTypes = ['major', 'premajor', 'minor', 'preminor', 'patch', 'prepatch', 'prerelease'];

--- a/src/utils/semver-helper.ts
+++ b/src/utils/semver-helper.ts
@@ -23,7 +23,6 @@ export function validateVersion(version: string | undefined): string | undefined
     // it also changes to a valid string (e.g. from v1.0.0 to 1.0.0)
     const validVersion = valid(version);
     if (!validVersion) throw new InvalidVersion(version);
-    if (prerelease(version)) throw new GeneralError(`error: a prerelease version "${version}" is not supported`);
     return validVersion;
   }
   return undefined;


### PR DESCRIPTION
Currently it's impossible.
With this PR, you can `bit tag --pre-release dev` to get a pre-release version with "dev" identifier. 
Then, on the following tags, you can omit the identifier and just `bit tag --pre-release` to increment it. 
Alternatively, you can use an exact version, e.g. `bit tag --all 1.0.0-alpha.2`.

<img width="498" alt="Screen Shot 2021-06-14 at 1 41 39 PM" src="https://user-images.githubusercontent.com/1963573/121935286-44ab8c80-cd16-11eb-8c9a-1dfd05cfe3d5.png">

Added support in the GrpahQL query of Component at packageManifest.distTag, see screenshot.

<img width="672" alt="Screen Shot 2021-06-15 at 4 30 25 PM" src="https://user-images.githubusercontent.com/1963573/122119594-63358480-cdf7-11eb-8239-aba7bddf8e91.png">


Todo:
- [x] upon `npm publish`, check if the tag is pre-release, and then add `--tag <pre-release>` to the exec params. (publisher.ts line 70).
- [x] pkg.main.runtime.ts, the `distTags` should have keys/values of the pre-releases and their latest.
- [x] `bit tag --soft` should save in the `nextTag` prop a new field of `preRelease` with the identifier. 