### PR TITLE
disallow non-exist options and commands

### DIFF
--- a/scopes/component/component/show/show.cmd.ts
+++ b/scopes/component/component/show/show.cmd.ts
@@ -18,7 +18,7 @@ export class ShowCmd implements Command {
     ['r', 'remote', 'show a remote component'],
     [
       'c',
-      'compare [boolean]',
+      'compare',
       'compare current file system component to latest tagged component [default=latest]. only works in legacy.',
     ],
   ] as CommandOptions;

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -32,6 +32,7 @@ export class CLIParser {
     this.setHelpMiddleware();
     this.handleCommandFailure();
     this.configureCompletion();
+    yargs.strict(); // don't allow non-exist flags and non-exist commands
 
     yargs
       // .recommendCommands() // don't use it, it brings the global help of yargs, we have a custom one

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -38,11 +38,13 @@ export class YargsAdapter implements CommandModule {
 
   private optionsToBuilder(command: Command) {
     const option = command.options.reduce((acc, [alias, opt, desc]) => {
-      acc[opt] = {
+      const optName = opt.split(' ')[0];
+      acc[optName] = {
         alias,
         describe: desc,
         group: STANDARD_GROUP,
-        type: opt.includes(' ') ? undefined : 'boolean',
+        type: opt.includes(' ') ? 'string' : 'boolean',
+        requiresArg: opt.includes('<'),
       };
       return acc;
     }, {});

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -26,8 +26,9 @@ export class YargsAdapter implements CommandModule {
     // a workaround to get a flag syntax such as "--all [version]" work with yargs.
     const flags = Object.keys(argv).reduce((acc, current) => {
       if (current === '_' || current === '$0' || current === '--') return acc;
-      const flagName = current.split(' ')[0];
-      acc[flagName] = argv[current];
+      // const flagName = current.split(' ')[0];
+      const val = typeof argv[current] === 'string' && !argv[current] ? true : argv[current];
+      acc[current] = val;
       return acc;
     }, {});
     this.commanderCommand._packageManagerArgs = (argv['--'] || []) as string[];

--- a/scopes/pkg/pkg/pack.cmd.tsx
+++ b/scopes/pkg/pkg/pack.cmd.tsx
@@ -18,11 +18,11 @@ export class PackCmd implements Command {
   description = 'create tar for npm publish';
   options = [
     ['d', 'out-dir <out-dir>', 'directory to put the result tar file'],
-    ['o', 'override [boolean]', 'override existing pack file'],
-    ['k', 'keep [boolean]', 'should keep isolated environment [default = false]'],
-    ['p', 'prefix [boolean]', 'keep custom (binding) prefix'],
-    // ['c', 'use-capsule [boolean]', 'isolate using the capsule and pack on the capsule'],
-    ['j', 'json [boolean]', 'return the output as JSON'],
+    ['o', 'override', 'override existing pack file'],
+    ['k', 'keep', 'should keep isolated environment [default = false]'],
+    ['p', 'prefix', 'keep custom (binding) prefix'],
+    // ['c', 'use-capsule', 'isolate using the capsule and pack on the capsule'],
+    ['j', 'json', 'return the output as JSON'],
   ] as CommandOptions;
   shortDescription = '';
   alias = '';

--- a/scopes/pkg/pkg/publish.cmd.tsx
+++ b/scopes/pkg/pkg/publish.cmd.tsx
@@ -10,9 +10,9 @@ export class PublishCmd implements Command {
   name = 'publish <componentId>';
   description = 'publish components to npm (npm publish)';
   options = [
-    ['d', 'dry-run [boolean]', 'npm publish --dry-run'],
+    ['d', 'dry-run', 'npm publish --dry-run'],
     ['', 'allow-staged', 'allow publish components that were not exported yet (not recommended)'],
-    ['j', 'json [boolean]', 'return the output as JSON'],
+    ['j', 'json', 'return the output as JSON'],
   ] as CommandOptions;
   shortDescription = '';
   alias = '';

--- a/scopes/workspace/workspace/eject-conf.cmd.tsx
+++ b/scopes/workspace/workspace/eject-conf.cmd.tsx
@@ -19,8 +19,8 @@ export default class EjectConfCmd implements Command {
   group = 'development';
   shortDescription = 'eject the target component configuration file (e.g. create a `component.json` file)';
   options = [
-    ['p', 'propagate [boolean]', 'mark propagate true in the config file'],
-    ['o', 'override [boolean]', 'override file if exist'],
+    ['p', 'propagate', 'mark propagate true in the config file'],
+    ['o', 'override', 'override file if exist'],
   ] as CommandOptions;
 
   constructor(private workspace: Workspace) {}

--- a/src/cli/commands/private-cmds/ci-update-cmd.ts
+++ b/src/cli/commands/private-cmds/ci-update-cmd.ts
@@ -12,7 +12,7 @@ export default class CiUpdate implements LegacyCommand {
   alias = '';
   loader = true;
   opts = [
-    // ['v', 'verbose [boolean]', 'showing npm verbose output for inspection'],
+    // ['v', 'verbose', 'showing npm verbose output for inspection'],
     ['d', 'directory [file]', 'directory to run ci-update'],
     ['k', 'keep', 'keep test environment after run (default false)'],
     ['c', 'no-cache', 'ignore component cache when creating dist file'],

--- a/src/cli/commands/public-cmds/build-cmd.ts
+++ b/src/cli/commands/public-cmds/build-cmd.ts
@@ -14,7 +14,7 @@ export default class Build implements LegacyCommand {
   description = `build any set of components with a configured compiler (as defined in bit.json)\n  https://${BASE_DOCS_DOMAIN}/docs/building-components`;
   alias = '';
   opts = [
-    ['v', 'verbose [boolean]', 'showing npm verbose output for inspection'],
+    ['v', 'verbose', 'showing npm verbose output for inspection'],
     ['c', 'no-cache', 'ignore component cache when creating dist file'],
   ] as CommandOptions;
   loader = true;

--- a/src/cli/commands/public-cmds/deprecate-cmd.ts
+++ b/src/cli/commands/public-cmds/deprecate-cmd.ts
@@ -13,7 +13,7 @@ export default class Deprecate implements LegacyCommand {
   skipWorkspace = true;
   alias = 'd';
 
-  opts = [['r', 'remote [boolean]', 'deprecate a component from a remote scope']] as CommandOptions;
+  opts = [['r', 'remote', 'deprecate a component from a remote scope']] as CommandOptions;
   loader = true;
   migration = true;
   remoteOp = true;

--- a/src/cli/commands/public-cmds/init-cmd.ts
+++ b/src/cli/commands/public-cmds/init-cmd.ts
@@ -26,7 +26,7 @@ export default class Init implements LegacyCommand {
     ['s', 'shared <groupname>', 'add group write permissions to a scope properly'],
     [
       'T',
-      'standalone [boolean]',
+      'standalone',
       'do not nest component store within .git directory and do not write config data inside package.json',
     ],
     ['r', 'reset', 'write missing or damaged Bit files'],

--- a/src/cli/commands/public-cmds/isolate-cmd.ts
+++ b/src/cli/commands/public-cmds/isolate-cmd.ts
@@ -8,27 +8,19 @@ export default class Isolate implements LegacyCommand {
   alias = '';
   opts = [
     ['d', 'directory [directory] ', 'path to store isolated component'],
-    ['w', 'write-bit-dependencies [boolean] ', 'write bit components dependencies to package.json file'],
-    ['l', 'npm-links [boolean]', 'point dependencies link files to npm package'],
-    ['s', 'skip-npm-install [boolean]', 'do not install npm package dependencies'],
-    ['', 'install-peer-dependencies [boolean]', 'install peer npm package dependencies'],
+    ['w', 'write-bit-dependencies ', 'write bit components dependencies to package.json file'],
+    ['l', 'npm-links', 'point dependencies link files to npm package'],
+    ['s', 'skip-npm-install', 'do not install npm package dependencies'],
+    ['', 'install-peer-dependencies', 'install peer npm package dependencies'],
     ['', 'dist', 'write dist files (when exist) to the configured directory'],
     ['', 'conf', 'write the configuration file (bit.json)'],
-    ['', 'no-package-json [boolean]', 'do not generate package.json for the isolated component'],
-    ['o', 'override [boolean]', 'override existing isolated component'],
-    [
-      '',
-      'save-dependencies-as-components [boolean]',
-      'import the dependencies as bit components instead of as npm packages',
-    ],
-    [
-      '',
-      'exclude-registry-prefix [boolean]',
-      "exclude the registry prefix from the component's name in the package.json",
-    ],
-    ['v', 'verbose [boolean]', 'print more logs'],
-    ['', 'silent-client-result [boolean]', 'print environment install result'],
-    ['', 'use-capsule [boolean]', 'use capsule with fs-container'],
+    ['', 'no-package-json', 'do not generate package.json for the isolated component'],
+    ['o', 'override', 'override existing isolated component'],
+    ['', 'save-dependencies-as-components', 'import the dependencies as bit components instead of as npm packages'],
+    ['', 'exclude-registry-prefix', "exclude the registry prefix from the component's name in the package.json"],
+    ['v', 'verbose', 'print more logs'],
+    ['', 'silent-client-result', 'print environment install result'],
+    ['', 'use-capsule', 'use capsule with fs-container'],
   ] as CommandOptions;
   loader = true;
   remoteOp = true;

--- a/src/cli/commands/public-cmds/login-cmd.ts
+++ b/src/cli/commands/public-cmds/login-cmd.ts
@@ -15,7 +15,7 @@ export default class Login implements LegacyCommand {
     ['p', 'port <port>', 'port number to open for localhost server (default 8085)'],
     ['', 'suppress-browser-launch', 'do not open a browser for authentication'],
     ['', 'npmrc-path <path>', `path to npmrc file to configure ${BASE_WEB_DOMAIN} registry`],
-    ['', 'skip-registry-config [boolean]', `don't configure ${BASE_WEB_DOMAIN} registry`],
+    ['', 'skip-registry-config', `don't configure ${BASE_WEB_DOMAIN} registry`],
     [
       '',
       'machine-name <string>',

--- a/src/cli/commands/public-cmds/remove-cmd.ts
+++ b/src/cli/commands/public-cmds/remove-cmd.ts
@@ -21,19 +21,19 @@ export default class Remove implements LegacyCommand {
   alias = 'rm';
   opts = [
     ['r', 'remote', 'remove a component from a remote scope'],
-    ['t', 'track [boolean]', 'keep tracking component (default = false)'],
+    ['t', 'track', 'keep tracking component (default = false)'],
     [
       'd',
-      'delete-files [boolean]',
+      'delete-files',
       'delete local component files (authored components only. for imported components the files are always deleted)',
     ],
     [
       'f',
-      'force [boolean]',
+      'force',
       'removes the component from the scope, even if used as a dependency. WARNING: components that depend on this component will corrupt',
     ],
-    ['s', 'silent [boolean]', 'skip confirmation'],
-    ['', 'lane [boolean]', 'EXPERIMENTAL. remove a lane'],
+    ['s', 'silent', 'skip confirmation'],
+    ['', 'lane', 'EXPERIMENTAL. remove a lane'],
   ] as CommandOptions;
   loader = true;
   migration = true;

--- a/src/cli/commands/public-cmds/show-cmd.ts
+++ b/src/cli/commands/public-cmds/show-cmd.ts
@@ -18,7 +18,7 @@ export default class Show implements LegacyCommand {
     ['r', 'remote', 'show a remote component'],
     ['v', 'versions', 'return a json of all the versions of the component'],
     ['o', 'outdated', 'show latest version from the remote scope (if exists)'],
-    ['c', 'compare [boolean]', 'compare current file system component to latest tagged component [default=latest]'],
+    ['c', 'compare', 'compare current file system component to latest tagged component [default=latest]'],
     ['d', 'detailed', 'show more details'],
     ['', 'dependents', 'EXPERIMENTAL. show all dependents recursively'],
     ['', 'dependencies', 'EXPERIMENTAL. show all dependencies recursively'],

--- a/src/cli/commands/public-cmds/undeprecate-cmd.ts
+++ b/src/cli/commands/public-cmds/undeprecate-cmd.ts
@@ -11,7 +11,7 @@ export default class Undeprecate implements LegacyCommand {
   group: Group = 'collaborate';
   description = 'undeprecate a deprecated component (local/remote)';
   alias = '';
-  opts = [['r', 'remote [boolean]', 'undeprecate a component from a remote scope']] as CommandOptions;
+  opts = [['r', 'remote', 'undeprecate a component from a remote scope']] as CommandOptions;
   loader = true;
   migration = true;
   skipWorkspace = true;


### PR DESCRIPTION
currently, if a flag had a typo, it continues without indicating the issue, which is confusing.
With this change, it stops the process and shows the help page.