### PR TITLE
Skip bit dev registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -217,7 +217,7 @@ jobs:
       # -
       # run: 'echo "//node-stg.bit.dev/:_authToken=$registryStgToken" >> ~/.npmrc'
       - save_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
           # key: bitsrc-registry-stg-v2
           paths:
             - ~/.npmrc
@@ -500,7 +500,7 @@ jobs:
       - attach_workspace:
           at: ./
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
       - run:
           name: 'install husky globally'
           command: 'sudo npm i -g husky'
@@ -561,7 +561,7 @@ jobs:
       - restore_cache:
           key: bitsrc-ssh-key3
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
       # - update_ssh_agent
       - run:
           name: 'bit status'
@@ -595,7 +595,7 @@ jobs:
       - restore_cache:
           key: bitsrc-ssh-key3
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
       - update_ssh_agent
       - set_git_credentials
       - run:
@@ -841,7 +841,7 @@ jobs:
       - restore_cache:
           key: bitsrc-ssh-key3
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
       - update_ssh_agent
       - set_git_credentials
       - run: bit config set user.token ${BIT_DEV_PROD_TOKEN}
@@ -891,7 +891,7 @@ jobs:
       - restore_cache:
           key: bitsrc-ssh-key3
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
       # add the id_rsa to ssh_agent to make sure we authenticate with the correct user
       # - run: 'chmod 400 ~/.ssh/id_rsa'
       # - run: 'ssh-add ~/.ssh/id_rsa'
@@ -966,7 +966,7 @@ jobs:
       - restore_cache:
           key: bitsrc-ssh-key3
       - restore_cache:
-          key: bitsrc-registry8
+          key: bitsrc-registry9
           # key: bitsrc-registry-stg-v2
       - # add the id_rsa to ssh_agent to make sure we authenticate with the correct user
         run: 'chmod 400 ~/.ssh/id_rsa'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,7 +210,7 @@ jobs:
       # prod registry
       - run: npm config set @bit:registry https://node.bit.dev
       - run: echo "//node.bit.dev/:_authToken=$registryProdToken" >> ~/.npmrc
-      - run: echo "always-auth=true" >> ~/.npmrc
+      # - run: echo "always-auth=true" >> ~/.npmrc
       # stage registry
       # -
       # run: 'npm config set @bit:registry https://node-stg.bit.dev'

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -144,6 +144,16 @@ export interface DependencyResolverWorkspaceConfig {
    * regex to determine whether a file is a file meant for development purposes.
    */
   devFilePatterns: string[];
+
+  /**
+   * By default when bit see your default registry in your npmrc is set to 'https://registry.npmjs.org/'
+   * bit will replace it with the bit.dev npm registry (node.bit.dev) during bit install
+   * bit does this in order to save you the need to configure many scoped registries for components from different owners
+   * bit.dev registry will then proxy the request to npmjs registry for non found packages in the bit.dev registry.
+   * in case you want to disable this proxy set this config to false
+   *
+   */
+  installFromBitDevRegistry: boolean;
 }
 
 export interface DependencyResolverVariantConfig {
@@ -571,9 +581,10 @@ export class DependencyResolverMain {
     // Override default registry to use bit registry in case npmjs is the default - bit registry will proxy it
     // We check also NPM_REGISTRY.startsWith because the uri might not have the trailing / we have in NPM_REGISTRY
     if (
-      !registries.defaultRegistry.uri ||
-      registries.defaultRegistry.uri === NPM_REGISTRY ||
-      NPM_REGISTRY.startsWith(registries.defaultRegistry.uri)
+      this.config.installFromBitDevRegistry &&
+      (!registries.defaultRegistry.uri ||
+        registries.defaultRegistry.uri === NPM_REGISTRY ||
+        NPM_REGISTRY.startsWith(registries.defaultRegistry.uri))
     ) {
       // TODO: this will not handle cases where you have token for private npm registries stored on npmjs
       // it should be handled by somehow in such case (default is npmjs and there is token for default) by sending the token of npmjs to the registry
@@ -743,6 +754,7 @@ export class DependencyResolverMain {
     packageManagerArgs: [],
     devFilePatterns: ['**/*.spec.ts'],
     strictPeerDependencies: true,
+    installFromBitDevRegistry: true,
   };
 
   static async provider(

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -8,6 +8,8 @@
   },
   "teambit.dependencies/dependency-resolver": {
     "packageManager": "teambit.dependencies/yarn",
+    // Setting this to false, to make sure we are not consuming anything that exists only on the bit.dev registry
+    "installFromBitDevRegistry": false,
     "policy": {
       "dependencies": {
         "@babel/core": "7.11.6",


### PR DESCRIPTION
## Proposed Changes

- new config for dependency resolver workspace config - installFromBitDevRegistry - let you decide if you want to be proxied by the bit.dev registry
- set the installFromBitDevRegistry config to false on bit repo to make sure we are not consuming packages from bit.dev registry
