### PR TITLE
instruct users to build bit-bin using full-setup:bit in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,19 +9,18 @@ the setup process is more involving than expected because we write bit using bit
 
 ### installation
 
-- one script to rule them all
+- make sure you have `bit` installed via `bvm` (see [instructions](https://harmony-docs.bit.dev/getting-started/installing-bit/)), then run:
 
 ```bash
-  $ npm run full-setup
+  $ npm run full-setup:bit
 ```
 
 the script does the following:
 
-1. installs a previous version of bit inside `build-harmony` directory.
-2. runs `bit install` to install all dependencies
-3. runs `bit compile` to compile all components in the workspace (Harmony code).
-4. compiles bit-legacy code (by `npm run build`).
-5. generates the d.ts files for the bit-legacy code (by `npm run build:types`).
+1. runs `bit install` to install all dependencies
+2. runs `bit compile` to compile all components in the workspace (Harmony code).
+3. compiles bit-legacy code (by `npm run build`).
+4. generates the d.ts files for the bit-legacy code (by `npm run build:types`).
 
 install command globally and link (in order to use the "bit-dev" command globally and always use the
 latest development build)
@@ -39,7 +38,7 @@ if you want your command to be different then the default (bit-dev) just add you
 for example:
 
 ```bash
-  npm run dev-link bit-dev
+  npm run dev-link bd
 ```
 
 bit will install these commands in `/usr/local/bin/` directory, so in order to remove them just use the bash `rm` command.

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "full-setup": "npm run install-harmony && npm run build-harmony && npm run build && npm run build:types",
     "full-setup:windows": "npm run install-harmony && npm run build-harmony:windows && npm run build && npm run build:types:windows",
     "full-setup:bbit": "rm -rf node_modules/@teambit/legacy && bbit install && npm run link-bit-legacy && bbit compile && npm run build && npm run build:types",
+    "full-setup:bit": "rm -rf node_modules/@teambit/legacy && bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types",
     "build-centos-image": "docker build ./scripts/linux/centos -t centos-rpm",
     "build-debian-image": "docker build ./scripts/linux/debian -t debian-deb",
     "doc-gen": "node ./scripts/doc-generator.js",


### PR DESCRIPTION
and add `full-setup:bit` script to use `bit` from `bvm` to build bit-bin.