### PR TITLE
bit-update-dependencies, validate that this command is running from a new bare scope

### DIFF
--- a/scopes/scope/update-dependencies/update-dependencies.cmd.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.cmd.ts
@@ -31,6 +31,7 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","dependencies
     ['', 'message <string>', 'message to be saved as part of the version log'],
     ['', 'username <string>', 'username to be saved as part of the version log'],
     ['', 'email <string>', 'email to be saved as part of the version log'],
+    ['', 'skip-new-scope-validation', 'avoid throwing an error when running on a non-new scope'],
   ] as CommandOptions;
 
   constructor(


### PR DESCRIPTION
Otherwise, it could save local data in the ModelComponent into the original remote-scope unexpectedly.  For example:
```
"state": {
      "versions": {
            "3.0.13": {
                "local": true
            }
    }
}
```