### PR TITLE
Use the new JSX transform in React environment.

### DIFF
--- a/scopes/react/react/jest/jest.config.js
+++ b/scopes/react/react/jest/jest.config.js
@@ -18,7 +18,8 @@ module.exports = {
     '^.+\\.css$': require.resolve('./css-transform.js'),
     '^(?!.*\\.(js|jsx|ts|tsx|css|json)$)': require.resolve('./file-transform.js'),
   },
-  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|jsx|ts|tsx)$', '^.+\\.module\\.(css|sass|scss)$'],
+  // We need to transform JSX and TSX files inside node_modules because Bit components are located there.
+  transformIgnorePatterns: ['[/\\\\]node_modules[/\\\\].+\\.(js|ts)$', '^.+\\.module\\.(css|sass|scss)$'],
   modulePaths: [],
   moduleNameMapper: {
     '^react-native$': require.resolve('react-native-web'),

--- a/scopes/react/react/jest/transformer.js
+++ b/scopes/react/react/jest/transformer.js
@@ -2,7 +2,12 @@
 const { transform } = require('@babel/core');
 
 const presets = [
-  require('@babel/preset-react'),
+  [
+    require('@babel/preset-react'),
+    {
+      runtime: 'automatic',
+    },
+  ],
   require('@babel/preset-typescript'),
   require('babel-preset-jest'),
   [

--- a/scopes/react/react/typescript/tsconfig.build.json
+++ b/scopes/react/react/typescript/tsconfig.build.json
@@ -5,7 +5,7 @@
     ],
     "target": "es2015",
     "module": "commonjs",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "allowJs": true,
     "composite": true,
     "declaration": true,

--- a/scopes/react/react/typescript/tsconfig.json
+++ b/scopes/react/react/typescript/tsconfig.json
@@ -5,7 +5,7 @@
     ],
     "target": "es2015",
     "module": "commonjs",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "declaration": true,
     "sourceMap": true,
     "skipLibCheck": true,

--- a/scopes/react/react/webpack/webpack.config.base.ts
+++ b/scopes/react/react/webpack/webpack.config.base.ts
@@ -134,7 +134,14 @@ export default function (isEnvProduction = false): Configuration {
                 babelrc: false,
                 configFile: false,
                 customize: require.resolve('babel-preset-react-app/webpack-overrides'),
-                presets: [require.resolve('@babel/preset-react')],
+                presets: [
+                  [
+                    require.resolve('@babel/preset-react'),
+                    {
+                      runtime: 'automatic',
+                    },
+                  ],
+                ],
                 plugins: [
                   [
                     require.resolve('babel-plugin-named-asset-import'),

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -60,7 +60,12 @@ export default function (fileMapPath: string, workDir: string): Configuration {
             configFile: false,
             presets: [
               // Preset includes JSX, TypeScript, and some ESnext features
-              require.resolve('babel-preset-react-app'),
+              [
+                require.resolve('babel-preset-react-app'),
+                {
+                  runtime: 'automatic',
+                },
+              ],
             ],
             plugins: [
               // require.resolve('react-refresh/babel'),


### PR DESCRIPTION
## Proposed Changes

New JSX transform was introduced in React about 8 months ago: https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html

Currently Create React App and Next.js supports it out of the box.

Thanks to the new JSX transform you don't have to write:
```
import React from "react"
```
at the top of every JSX/TSX file.

After merging this PR, React environment in Bit will use the new JSX transform for compatible React version.

The code in this PR is heavily inspired by ejected Create React App project.