### PR TITLE
improve the error when an object file is missing from the filesystem

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -78,7 +78,20 @@ export class ScopeComponentLoader {
   }
 
   async getSnap(id: ComponentID, hash: string): Promise<Snap> {
-    const version = (await this.scope.legacyScope.objects.load(new Ref(hash), true)) as Version;
+    const getVersionObject = async (): Promise<Version> => {
+      try {
+        return (await this.scope.legacyScope.objects.load(new Ref(hash), true)) as Version;
+      } catch (err) {
+        if (err === 'ENOENT') {
+          const errMsg = `fatal: snap "${hash}" file for component "${id.toString()}" was not found in the filesystem`;
+          this.logger.error(errMsg, err);
+          throw new Error(errMsg);
+        } else {
+          throw err;
+        }
+      }
+    };
+    const version = await getVersionObject();
     return this.createSnapFromVersion(version);
   }
 

--- a/src/api/scope/lib/cat-object.ts
+++ b/src/api/scope/lib/cat-object.ts
@@ -1,15 +1,12 @@
 import { loadScope } from '../../../scope';
 
-export default function catObject(hash: string, pretty: boolean, stringify: boolean, headers: boolean) {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  return loadScope().then((scope) => {
-    return scope.getRawObject(hash).then((object) => {
-      if (headers) {
-        return object.headers;
-      }
-      if (!object) return 'object not found';
-      if (stringify) return JSON.stringify(object.content.toString());
-      return object.getString(pretty);
-    });
-  });
+export default async function catObject(hash: string, pretty: boolean, stringify: boolean, headers: boolean) {
+  const scope = await loadScope();
+  const object = await scope.getRawObject(hash);
+  if (headers) {
+    return object.headers;
+  }
+  if (!object) return 'object not found';
+  if (stringify) return JSON.stringify(object.content.toString());
+  return object.getString(pretty);
 }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -121,7 +121,13 @@ export default class Repository {
         throw err;
       }
       logger.trace(`Failed finding a ref file ${this.objectPath(ref)}.`);
-      if (throws) throw err;
+      if (throws) {
+        // if we just `throw err` we loose the stack trace.
+        // see https://stackoverflow.com/questions/68022123/no-stack-in-fs-promises-readfile-enoent-error
+        throw new Error(
+          `fatal: failed finding an object file ${this.objectPath(ref)} in the filesystem at ${err.path}`
+        );
+      }
       // @ts-ignore @todo: fix! it should return BitObject | null.
       return null;
     }


### PR DESCRIPTION
Currently, it only shows the ENOENT error with no stack. It is fixed to show the stack in the log and also, if the error is coming from the ScopeComponentLoader, it shows the component whose this object belongs to.