### PR TITLE
support class compositions for typescript

### DIFF
--- a/scopes/typescript/typescript/typescript.parser.ts
+++ b/scopes/typescript/typescript/typescript.parser.ts
@@ -1,6 +1,12 @@
 import { Export, Module, Parser } from '@teambit/schema';
 import { readFileSync } from 'fs-extra';
-import ts, { isFunctionDeclaration, isVariableStatement, SourceFile, VariableStatement } from 'typescript';
+import ts, {
+  isClassDeclaration,
+  isFunctionDeclaration,
+  isVariableStatement,
+  SourceFile,
+  VariableStatement,
+} from 'typescript';
 
 export class TypeScriptParser implements Parser {
   public extension = /^.*\.(js|jsx|ts|tsx)$/;
@@ -22,6 +28,11 @@ export class TypeScriptParser implements Parser {
       }
 
       if (isFunctionDeclaration(statement)) {
+        if (!statement.name) return undefined;
+        return new Export(statement.name.text);
+      }
+
+      if (isClassDeclaration(statement)) {
         if (!statement.name) return undefined;
         return new Export(statement.name.text);
       }


### PR DESCRIPTION
## Proposed Changes

Add class compositions support for the typescript parser: users can now export a class and it will be detected as a valid composition (which is important for Angular since it uses classes for almost everything)