### PR TITLE
fix large headers in docs

### DIFF
--- a/scopes/react/react/docs/docs-app.tsx
+++ b/scopes/react/react/docs/docs-app.tsx
@@ -5,6 +5,8 @@ import { ThemeContext } from '@teambit/documenter.theme.theme-context';
 import { IconFont } from '@teambit/design.theme.icons-font';
 import { RenderingContext } from '@teambit/preview';
 import { Base } from './base';
+// @TODO - delete this once using @teambit/documenter.theme.theme-context > v40.0.0
+import tempStyles from './docs.headers.module.scss';
 
 export type DocsAppProps = {
   Provider?: React.ComponentType;
@@ -17,7 +19,7 @@ export type DocsAppProps = {
 export function DocsApp({ Provider = Noop, docs, componentId, compositions, renderingContext }: DocsAppProps) {
   return (
     <Provider>
-      <ThemeContext>
+      <ThemeContext className={tempStyles.headingOverrides}>
         <IconFont query="jyyv17" />
         <Base docs={docs} componentId={componentId} compositions={compositions} renderingContext={renderingContext} />
       </ThemeContext>

--- a/scopes/react/react/docs/docs-app.tsx
+++ b/scopes/react/react/docs/docs-app.tsx
@@ -5,7 +5,7 @@ import { ThemeContext } from '@teambit/documenter.theme.theme-context';
 import { IconFont } from '@teambit/design.theme.icons-font';
 import { RenderingContext } from '@teambit/preview';
 import { Base } from './base';
-// @TODO - delete this once using @teambit/documenter.theme.theme-context > v40.0.0
+// @TODO - delete this once using @teambit/documenter.theme.theme-context > v4.0.0
 import tempStyles from './docs.headers.module.scss';
 
 export type DocsAppProps = {

--- a/scopes/react/react/docs/docs.headers.module.scss
+++ b/scopes/react/react/docs/docs.headers.module.scss
@@ -1,0 +1,20 @@
+// @TODO - delete this file once using documenter theme > v4.0.0
+
+.headingOverrides {
+  --bit-h-xxs: 16px;
+  --bit-h-xs: 18px;
+  --bit-h-sm: 24px;
+  --bit-h-md: 26px;
+  --bit-h-lg: 36px;
+  --bit-h-xl: 40px;
+  --bit-h-xxl: 50px;
+
+  // legacy values:
+  --h-xxs: 16px;
+  --h-xs: 18px;
+  --h-sm: 24px;
+  --h-md: 26px;
+  --h-lg: 36px;
+  --h-xl: 40px;
+  --h-xxl: 50px;
+}


### PR DESCRIPTION
## Proposed Changes

- introduce the css variables overrides used by Documenter.
- these will be included in `@teambit/documenter.theme.theme-context` `v4.0.1`, and replaced once all usages are updated.

(left is too big, right is the correct one)
![Screen Shot 2021-06-21 at 4 17 18 PM](https://user-images.githubusercontent.com/5400361/122771960-96708b80-d2af-11eb-98d1-d1f8470237f1.png)

![ok gif](https://media.giphy.com/media/3o7abKhOpu0NwenH3O/giphy.gif)