### PR TITLE
fix: ״module parse error" when adding composition file

### DIFF
--- a/scopes/react/bit-react-transformer/bit-react-transformer.ts
+++ b/scopes/react/bit-react-transformer/bit-react-transformer.ts
@@ -7,7 +7,7 @@ import { isClassComponent, isFunctionComponent } from './helpers';
 import { ComponentMeta, componentMetaField, fieldComponentId, fieldHomepageUrl, fieldIsExported } from './model';
 
 export type BitReactTransformerOptions = {
-  componentFilesPath: string;
+  componentFilesPath?: string;
 };
 
 const PLUGIN_NAME = 'bit-react-transformer';
@@ -20,7 +20,7 @@ type Api = { types: typeof Types };
  */
 export function createBitReactTransformer(api: Api, opts: BitReactTransformerOptions) {
   let componentMap: Record<string, ComponentMeta>;
-  const types = api.types as typeof Types;
+  const types = api.types;
 
   function setMap(mapPath: string) {
     try {
@@ -33,12 +33,9 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
   }
 
   const extractMeta = memoize(
-    (filePath: string) => {
-      return componentMap?.[filePath] || metaFromPackageJson(filePath);
-    },
-    {
-      primitive: true, // optimize for strings
-    }
+    (filePath: string) => componentMap?.[filePath] || metaFromPackageJson(filePath),
+    // optimize for string input:
+    { primitive: true }
   );
 
   function addComponentId(path: NodePath<any>, filePath: string, identifier: string) {
@@ -57,17 +54,12 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
   const visitor: Visitor<PluginPass> = {
     // visits the start of the file, right after `"use strict"`
     Program(path, state) {
+      // // Do not use .stop() or .skip(), it will stop all other babel plugins as well.
       const filename = state.file.opts.filename;
-      if (!filename) {
-        path.stop(); // stop traversal
-        return;
-      }
+      if (!filename) return;
 
       const meta = extractMeta(filename);
-      if (!meta) {
-        path.stop(); // stop traversal
-        return;
-      }
+      if (!meta) return;
 
       const deceleration = metaToDeceleration(meta, types);
 
@@ -79,14 +71,14 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
       // if (!isFunctionComponent(path.node.body)) return;
       const name = path.node.id?.name;
       const filename = state.file.opts.filename;
-      if (!name || !filename) return;
+      if (!name || !filename || !extractMeta(filename)) return;
 
       addComponentId(path, filename, name);
     },
 
     VariableDeclarator(path, state) {
       const filename = state.file.opts.filename;
-      if (!filename) return;
+      if (!filename || !extractMeta(filename)) return;
 
       const node = path.node;
       if (!node.init) return;
@@ -111,7 +103,7 @@ export function createBitReactTransformer(api: Api, opts: BitReactTransformerOpt
 
     ClassDeclaration(path, state) {
       const filename = state.file.opts.filename;
-      if (!filename) return;
+      if (!filename || !extractMeta(filename)) return;
       if (!isClassComponent(path.node)) return;
 
       const name = path.node.id.name;


### PR DESCRIPTION
## Proposed Changes

- remove `path.stop()`, which caused all babel plugins to stop.
- add guard to each visitor.
- perf should be ok, since webpack only runs the plugin for components (and not say, npm packages)

This fixes error "Module parse failed", that happens when adding a new composition file.

```
ERROR in ./src/components/react04.composition.tsx 8:9
Module parse failed: Unexpected token (8:9)
File was processed with these loaders:
 * ../../bit-bin/node_modules/@pmmmwh/react-refresh-webpack-plugin/loader/index.js
 * ../../bit-bin/node_modules/babel-loader/lib/index.js
You may need an additional loader to handle the result of these loaders.
| export function BasicReact01() {
|   // return null;
>   return <React01 text="hello from React02" />;
| }
| 
```

(I wonder how this ever worked before, it consistently fails in a standalone project. Perhaps `react-fast-refresh is using a different version of Babel)