### PR TITLE
fix ENOENT error upon loading components when it has orphaned versions

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -80,9 +80,10 @@ export class ScopeComponentLoader {
   async getSnap(id: ComponentID, hash: string): Promise<Snap> {
     const getVersionObject = async (): Promise<Version> => {
       try {
-        return (await this.scope.legacyScope.objects.load(new Ref(hash), true)) as Version;
+        const snap = await this.scope.legacyScope.objects.load(new Ref(hash), true);
+        return snap as Version;
       } catch (err) {
-        if (err === 'ENOENT') {
+        if (err.code === 'ENOENT') {
           const errMsg = `fatal: snap "${hash}" file for component "${id.toString()}" was not found in the filesystem`;
           this.logger.error(errMsg, err);
           throw new Error(errMsg);
@@ -117,8 +118,8 @@ export class ScopeComponentLoader {
 
   private async getTagMap(modelComponent: ModelComponent): Promise<TagMap> {
     const tagMap = new TagMap();
-    Object.keys(modelComponent.versions).forEach((versionStr: string) => {
-      const tag = new Tag(modelComponent.versions[versionStr].toString(), new SemVer(versionStr));
+    Object.keys(modelComponent.versionsIncludeOrphaned).forEach((versionStr: string) => {
+      const tag = new Tag(modelComponent.versionsIncludeOrphaned[versionStr].toString(), new SemVer(versionStr));
       tagMap.set(tag.version, tag);
     });
     return tagMap;

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -124,9 +124,8 @@ export default class Repository {
       if (throws) {
         // if we just `throw err` we loose the stack trace.
         // see https://stackoverflow.com/questions/68022123/no-stack-in-fs-promises-readfile-enoent-error
-        throw new Error(
-          `fatal: failed finding an object file ${this.objectPath(ref)} in the filesystem at ${err.path}`
-        );
+        const msg = `fatal: failed finding an object file ${this.objectPath(ref)} in the filesystem at ${err.path}`;
+        throw Object.assign(err, { stack: new Error(msg).stack });
       }
       // @ts-ignore @todo: fix! it should return BitObject | null.
       return null;


### PR DESCRIPTION
This is happening because the `TagMap` on Harmony wasn't aware of the orphaned-versions (tags that are coming from a non-origin scope). This is fixed by including these versions in the TagMap.