### PR TITLE
fix watch mode on Windows & EPERM / EBUSY errors

### DIFF
--- a/scopes/compilation/bundler/dev-server.service.ts
+++ b/scopes/compilation/bundler/dev-server.service.ts
@@ -94,7 +94,8 @@ export class DevServerService implements EnvService<ComponentServer> {
 
     return Object.assign(context, {
       entry: await getEntry(context, this.runtimeSlot),
-      rootPath: `/preview/${context.envRuntime.id}`,
+      // don't start with a leading "/" because it generates errors on Windows
+      rootPath: `preview/${context.envRuntime.id}`,
       publicPath: `/public`,
     });
   }

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -131,7 +131,7 @@ export function configFactory(devServerID, workspaceDir, entryFiles, publicRoot,
 
       dev: {
         // Public path is root of content base
-        publicPath: publicRoot,
+        publicPath: path.join('/', publicRoot),
       },
     },
 


### PR DESCRIPTION
## Proposed Changes

We were using the wrong output path in the webpack config (on windows AND linux/mac), it was only causing an error on windows because of the way ntfs absolute paths work.

The root cause is in this function:
```
const resolveWorkspacePath = (relativePath) => path.resolve(workspaceDir, relativePath);
```

Our relative path was actually absolute (it was starting with a leading `/`), which was generating a wrong resolve (see: https://github.com/nodejs/node/issues/14719#issuecomment-321370167).