### PR TITLE
Webpack entry files dev server dist

### DIFF
--- a/scopes/compilation/babel/babel.compiler.ts
+++ b/scopes/compilation/babel/babel.compiler.ts
@@ -152,6 +152,7 @@ export class BabelCompiler implements Compiler {
   }
 
   private replaceFileExtToJs(filePath: string): string {
+    if (!this.isFileSupported(filePath)) return filePath;
     return replaceFileExtToJs(filePath);
   }
 }

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -197,7 +197,7 @@ export class ReactEnv implements Environment {
     const baseConfig = basePreviewConfigFactory(true);
     const baseProdConfig = basePreviewProdConfigFactory();
     // const componentProdConfig = componentPreviewProdConfigFactory(fileMapPath);
-    const componentProdConfig = componentPreviewProdConfigFactory(fileMapPath);
+    const componentProdConfig = componentPreviewProdConfigFactory();
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
       const merged = configMutator.merge([baseConfig, baseProdConfig, componentProdConfig]);

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -182,6 +182,7 @@ export class ReactEnv implements Environment {
     const envDevConfig = envPreviewDevConfigFactory(context.id);
     // const fileMapPath = this.writeFileMap(context.components, true);
     // const componentDevConfig = componentPreviewDevConfigFactory(fileMapPath, this.workspace.path);
+    // const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
     const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -180,8 +180,9 @@ export class ReactEnv implements Environment {
   getDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
     const baseConfig = basePreviewConfigFactory(false);
     const envDevConfig = envPreviewDevConfigFactory(context.id);
-    const fileMapPath = this.writeFileMap(context.components, true);
-    const componentDevConfig = componentPreviewDevConfigFactory(fileMapPath, this.workspace.path);
+    // const fileMapPath = this.writeFileMap(context.components, true);
+    // const componentDevConfig = componentPreviewDevConfigFactory(fileMapPath, this.workspace.path);
+    const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
       const merged = configMutator.merge([baseConfig, envDevConfig, componentDevConfig]);
@@ -192,9 +193,10 @@ export class ReactEnv implements Environment {
   }
 
   async getBundler(context: BundlerContext, transformers: WebpackConfigTransformer[] = []): Promise<Bundler> {
-    const fileMapPath = this.writeFileMap(context.components);
+    // const fileMapPath = this.writeFileMap(context.components);
     const baseConfig = basePreviewConfigFactory(true);
     const baseProdConfig = basePreviewProdConfigFactory();
+    // const componentProdConfig = componentPreviewProdConfigFactory(fileMapPath);
     const componentProdConfig = componentPreviewProdConfigFactory(fileMapPath);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -74,6 +74,27 @@ export default function (fileMapPath: string, workDir: string): Configuration {
             ],
           },
         },
+        // MDX support (move to the mdx aspect and extend from there)
+        {
+          test: /\.mdx?$/,
+          // to skip any files linked from other projects (like Bit itself)
+          include: path.join(workDir, 'node_modules'),
+          // only apply to packages with componentId in their package.json (ie. bit components)
+          descriptionData: { componentId: (value) => !!value },
+          use: [
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                babelrc: false,
+                configFile: false,
+                presets: [require.resolve('@babel/preset-react'), require.resolve('@babel/preset-env')],
+              },
+            },
+            {
+              loader: require.resolve('@teambit/mdx.modules.mdx-loader'),
+            },
+          ],
+        },
       ],
     },
   };

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -8,7 +8,7 @@ import '@teambit/react.babel.bit-react-transformer';
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 // eslint-disable-next-line complexity
-export default function (fileMapPath: string, workDir: string): Configuration {
+export default function (workDir: string): Configuration {
   return {
     module: {
       rules: [
@@ -45,34 +45,6 @@ export default function (fileMapPath: string, workDir: string): Configuration {
               },
             },
           ],
-        },
-        {
-          test: /\.(mjs|js|jsx|tsx|ts)$/,
-          // TODO: use a more specific exclude for our selfs
-          exclude: [/node_modules/, /dist/],
-          include: workDir,
-          resolve: {
-            fullySpecified: false,
-          },
-          loader: require.resolve('babel-loader'),
-          options: {
-            babelrc: false,
-            configFile: false,
-            presets: [
-              // Preset includes JSX, TypeScript, and some ESnext features
-              require.resolve('babel-preset-react-app'),
-            ],
-            plugins: [
-              // require.resolve('react-refresh/babel'),
-              // for component highlighting in preview.
-              [
-                require.resolve('@teambit/react.babel.bit-react-transformer'),
-                {
-                  componentFilesPath: fileMapPath,
-                },
-              ],
-            ],
-          },
         },
         // MDX support (move to the mdx aspect and extend from there)
         {

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -4,10 +4,12 @@ import { ComponentID } from '@teambit/component-id';
 // Make sure the bit-react-transformer is a dependency
 // TODO: remove it once we can set policy from component to component then set it via the component.json
 import '@teambit/react.babel.bit-react-transformer';
+// import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 // eslint-disable-next-line complexity
+// export default function (workDir: string, envId: string): Configuration {
 export default function (workDir: string): Configuration {
   return {
     module: {
@@ -38,6 +40,7 @@ export default function (workDir: string): Configuration {
                 plugins: [
                   // for component highlighting in preview.
                   [require.resolve('@teambit/react.babel.bit-react-transformer')],
+                  // [require.resolve('react-refresh/babel')],
                 ],
                 // turn off all optimizations (only slow down for node_modules)
                 compact: false,
@@ -69,5 +72,24 @@ export default function (workDir: string): Configuration {
         },
       ],
     },
+    // TODO: try to make it work. do not forget when enable this to -
+    // 1. enable/uncomment - react-refresh/babel above
+    // 2. make sure the react-refresh is a dependency of the react env via component.json
+    // 3. pass the envId to this function from react env
+    // plugins: [
+    //   new ReactRefreshWebpackPlugin({
+    //     overlay: {
+    //       sockPath: `_hmr/${envId}`,
+    //       // TODO: check why webpackHotDevClient and react-error-overlay are not responding for runtime
+    //       // errors
+    //       entry: require.resolve('./react-hot-dev-client'),
+    //       module: require.resolve('./refresh'),
+    //     },
+    //     // include: [/\.(js|jsx|tsx|ts|mdx|md)$/],
+    //     include: path.join(workDir, 'node_modules'),
+    //     // TODO: use a more specific exclude for our selfs
+    //     // exclude: [/dist/, /node_modules/],
+    //   }),
+    // ],
   };
 }

--- a/scopes/react/react/webpack/webpack.config.component.prod.ts
+++ b/scopes/react/react/webpack/webpack.config.component.prod.ts
@@ -7,7 +7,7 @@ import '@teambit/react.babel.bit-react-transformer';
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 // eslint-disable-next-line complexity
-export default function (fileMapPath: string): Configuration {
+export default function (): Configuration {
   return {
     module: {
       rules: [
@@ -32,36 +32,6 @@ export default function (fileMapPath: string): Configuration {
               },
             },
           ],
-        },
-        {
-          test: /\.(js|mjs|jsx|ts|tsx)$/,
-          exclude: [/node_modules/, /\/dist\//],
-          // consider: limit loader to files only in a capsule that has bitid in package.json
-          // descriptionData: { componentId: ComponentID.isValidObject },
-          // // or
-          // include: capsulePaths
-          loader: require.resolve('babel-loader'),
-          options: {
-            babelrc: false,
-            configFile: false,
-            // customize: require.resolve('babel-preset-react-app/webpack-overrides'),
-            // presets: [require.resolve('@babel/preset-react')],
-            plugins: [
-              [
-                require.resolve('@teambit/react.babel.bit-react-transformer'),
-                {
-                  componentFilesPath: fileMapPath,
-                },
-              ],
-            ],
-            // This is a feature of `babel-loader` for webpack (not Babel itself).
-            // It enables caching results in ./node_modules/.cache/babel-loader/
-            // directory for faster rebuilds.
-            cacheDirectory: true,
-            // See #6846 for context on why cacheCompression is disabled
-            cacheCompression: false,
-            compact: true,
-          },
         },
       ],
     },


### PR DESCRIPTION
## Proposed Changes

- improve babel replace file ext to js to only replace if the file is supported
- point webpack entry files for compositions and docs to the dist files instead of the source files
- remove webpack rules with bit-react-transformer by file map

Before this change the link modules in the entry file for the webpack looks like this:
Workspace (dev server)
```
linkModules("overview", defaultModule, {
  "my-comp": [
    require("workspace-path/my-comp/my-comp.composition.tsx"),
  ],
});
```

Capsule (build/tag):
```
linkModules('overview', defaultModule, {
  'my-comp': [require('capsules/8cf3a1e5b3f8b8d890c4e18a256129f06a3b00e1/my-comp@0.0.5/dist/my-comp.composition.tsx')],
});  
```

This means that we give webpack the source files for the dev server, but for build/tag, we give it the dist files (after compiled by the env compiler).
This creates diff between the dev server and remote scope which is incorrect.

This change, change the entry file for the dev server to look like this:
```
linkModules("overview", defaultModule, {
  "my-comp": [
    require("workspace-path/node_modules/my-comp/dist/my-comp.composition.js"),
  ],
});
```
This means, to point to the dist folder in the node_modules. 

