### PR TITLE
Add GraphQL queries for list-lanes, show-lane and lane-diffs

### DIFF
--- a/scopes/lanes/diff/index.ts
+++ b/scopes/lanes/diff/index.ts
@@ -1,1 +1,2 @@
 export { LaneDiffCmd } from './lane-diff.cmd';
+export { LaneDiffGenerator } from './lane-diff-generator';

--- a/scopes/lanes/diff/lane-diff-generator.ts
+++ b/scopes/lanes/diff/lane-diff-generator.ts
@@ -5,18 +5,34 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { Ref } from '@teambit/legacy/dist/scope/objects';
 import { DEFAULT_LANE } from '@teambit/legacy/dist/constants';
 import { diffBetweenVersionsObjects, DiffResults } from '@teambit/legacy/dist/consumer/component-ops/components-diff';
+import LaneId from '@teambit/legacy/dist/lane-id/lane-id';
 
 export class LaneDiffGenerator {
   private newComps: BitId[] = [];
   private compsWithDiff: DiffResults[] = [];
   private compsWithNoChanges: BitId[] = [];
-  constructor(
-    private workspace: Workspace,
-    private scope: ScopeMain,
-    private fromLane: Lane | null,
-    private toLane: Lane
-  ) {}
-  async generate() {
+  private fromLane: Lane | null;
+  private toLane: Lane;
+  constructor(private workspace: Workspace | undefined, private scope: ScopeMain) {}
+
+  /**
+   * the values array may include zero to two values and will be processed as following:
+   * [] => diff between the current lane and default lane. (only inside workspace).
+   * [to] => diff between the current lane (or default-lane when in scope) and "to" lane.
+   * [from, to] => diff between "from" lane and "to" lane.
+   */
+  async generate(values: string[]) {
+    const { fromLaneName, toLaneName } = this.getLaneNames(values);
+    if (fromLaneName === toLaneName) {
+      throw new Error(`unable to run diff between "${fromLaneName}" and "${toLaneName}", they're the same lane`);
+    }
+    const legacyScope = this.scope.legacyScope;
+    this.fromLane = fromLaneName ? await legacyScope.lanes.loadLane(new LaneId({ name: fromLaneName })) : null;
+    const toLane = await legacyScope.lanes.loadLane(new LaneId({ name: toLaneName }));
+    if (!toLane) {
+      throw new Error(`unable to find a lane "${toLaneName}" in the scope`);
+    }
+    this.toLane = toLane;
     await Promise.all(
       this.toLane.components.map(async ({ id, head }) => {
         await this.componentDiff(id, head);
@@ -26,8 +42,10 @@ export class LaneDiffGenerator {
       newComps: this.newComps.map((id) => id.toString()),
       compsWithDiff: this.compsWithDiff,
       compsWithNoChanges: this.compsWithNoChanges.map((id) => id.toString()),
+      toLaneName: toLane.name,
     };
   }
+
   private async componentDiff(id: BitId, toLaneHead: Ref) {
     const modelComponent = await this.scope.legacyScope.getModelComponent(id);
     const compFromLane = this.fromLane?.getComponentByName(id);
@@ -53,5 +71,32 @@ export class LaneDiffGenerator {
       { formatDepsAsTable: false }
     );
     this.compsWithDiff.push(diff);
+  }
+
+  private getLaneNames(values: string[]): { fromLaneName?: string; toLaneName: string } {
+    if (values.length > 2) {
+      throw new Error(`expect "values" to include no more than two args, got ${values.length}`);
+    }
+    if (this.workspace) {
+      const currentLane = this.workspace.getCurrentLaneId();
+      if (!values.length) {
+        if (currentLane.isDefault()) {
+          throw new Error(`you are currently on the default branch, to run diff between lanes, please specify them`);
+        }
+        return { toLaneName: currentLane.name };
+      }
+      if (values.length === 1) {
+        const fromLaneName = currentLane.isDefault() ? undefined : currentLane.name;
+        return { fromLaneName, toLaneName: values[0] };
+      }
+      return { fromLaneName: values[0], toLaneName: values[1] };
+    }
+    // running from the scope
+    if (values.length < 1) {
+      throw new Error(`expect "values" to include at least one arg - the lane name`);
+    }
+    const fromLaneName = values.length === 2 ? values[0] : undefined;
+    const toLaneName = values.length === 2 ? values[1] : values[0];
+    return { fromLaneName, toLaneName };
   }
 }

--- a/scopes/lanes/diff/lane-diff.cmd.ts
+++ b/scopes/lanes/diff/lane-diff.cmd.ts
@@ -3,7 +3,6 @@ import { ScopeMain } from '@teambit/scope';
 import { Workspace } from '@teambit/workspace';
 import chalk from 'chalk';
 import { outputDiffResults } from '@teambit/legacy/dist/consumer/component-ops/components-diff';
-import LaneId from '@teambit/legacy/dist/lane-id/lane-id';
 import { LaneDiffGenerator } from './lane-diff-generator';
 
 export class LaneDiffCmd implements Command {
@@ -25,49 +24,12 @@ bit lane diff from to => diff between "from" lane and "to" lane.
   constructor(private workspace: Workspace, private scope: ScopeMain) {}
 
   async report([values = []]: [string[]]) {
-    const { fromLaneName, toLaneName } = this.getLaneNames(values);
-    if (fromLaneName === toLaneName) {
-      throw new Error(`unable to run diff between "${fromLaneName}" and "${toLaneName}", they're the same lane`);
-    }
-    const legacyScope = this.scope.legacyScope;
-    const fromLane = fromLaneName ? await legacyScope.lanes.loadLane(new LaneId({ name: fromLaneName })) : null;
-    const toLane = await legacyScope.lanes.loadLane(new LaneId({ name: toLaneName }));
-    if (!toLane) {
-      throw new Error(`unable to find a lane "${toLaneName}" in the scope`);
-    }
-    const laneDiffGenerator = new LaneDiffGenerator(this.workspace, this.scope, fromLane, toLane);
-    const { compsWithDiff, newComps } = await laneDiffGenerator.generate();
+    const laneDiffGenerator = new LaneDiffGenerator(this.workspace, this.scope);
+    const { compsWithDiff, newComps, toLaneName } = await laneDiffGenerator.generate(values);
     const diffResultsStr = outputDiffResults(compsWithDiff);
     const newCompsIdsStr = newComps.map((id) => chalk.bold(id)).join('\n');
     const newCompsTitle = `The following components were introduced in ${chalk.bold(toLaneName)} lane`;
     const newCompsStr = newComps.length ? `${chalk.green(newCompsTitle)}\n${newCompsIdsStr}` : '';
     return `${diffResultsStr}\n${newCompsStr}`;
-  }
-
-  private getLaneNames(values: string[]): { fromLaneName?: string; toLaneName: string } {
-    if (values.length > 2) {
-      throw new Error(`expect "values" to include no more than two args, got ${values.length}`);
-    }
-    if (this.workspace) {
-      const currentLane = this.workspace.getCurrentLaneId();
-      if (!values.length) {
-        if (currentLane.isDefault()) {
-          throw new Error(`you are currently on the default branch, to run diff between lanes, please specify them`);
-        }
-        return { toLaneName: currentLane.name };
-      }
-      if (values.length === 1) {
-        const fromLaneName = currentLane.isDefault() ? undefined : currentLane.name;
-        return { fromLaneName, toLaneName: values[0] };
-      }
-      return { fromLaneName: values[0], toLaneName: values[1] };
-    }
-    // running from the scope
-    if (values.length < 1) {
-      throw new Error(`expect "values" to include at least one arg - the lane name`);
-    }
-    const fromLaneName = values.length === 2 ? values[0] : undefined;
-    const toLaneName = values.length === 2 ? values[1] : values[0];
-    return { fromLaneName, toLaneName };
   }
 }

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -119,7 +119,7 @@ export class LaneShowCmd implements Command {
   description = `show lane details`;
   alias = '';
   options = [
-    ['j', 'json', 'show lanes details in json format'],
+    ['j', 'json', 'show the lane details in json format'],
     ['r', 'remote <string>', 'show remote lanes'],
   ] as CommandOptions;
   loader = true;
@@ -149,9 +149,8 @@ export class LaneShowCmd implements Command {
     const lanes = await this.lanes.getLanes({
       name,
       remote,
-      showDefaultLane: true,
     });
-    return lanes;
+    return lanes[0];
   }
 }
 

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -37,33 +37,34 @@ export class LaneListCmd implements Command {
   async report(args, laneOptions: LaneOptions): Promise<string> {
     const { details, remote, merged, notMerged } = laneOptions;
 
-    const results = await this.lanes.getLanes({
+    const lanes = await this.lanes.getLanes({
       remote,
       merged,
       notMerged,
     });
     if (merged) {
-      const mergedLanes = results.lanes.filter((l) => l.isMerged);
+      const mergedLanes = lanes.filter((l) => l.isMerged);
       if (!mergedLanes.length) return chalk.green('None of the lanes is merged');
       return chalk.green(mergedLanes.map((m) => m.name).join('\n'));
     }
     if (notMerged) {
-      const unmergedLanes = results.lanes.filter((l) => !l.isMerged);
+      const unmergedLanes = lanes.filter((l) => !l.isMerged);
       if (!unmergedLanes.length) return chalk.green('All lanes are merged');
       return chalk.green(unmergedLanes.map((m) => m.name).join('\n'));
     }
-    let currentLane = results.currentLane ? `current lane - ${chalk.bold(results.currentLane as string)}` : '';
+    const currentLane = this.lanes.getCurrentLane();
+    let currentLaneStr = currentLane ? `current lane - ${chalk.bold(currentLane as string)}` : '';
     if (details) {
-      const laneDataOfCurrentLane = results.lanes.find((l) => l.name === results.currentLane);
+      const laneDataOfCurrentLane = lanes.find((l) => l.name === currentLane);
       const remoteOfCurrentLane = laneDataOfCurrentLane ? laneDataOfCurrentLane.remote : null;
       const currentLaneComponents = laneDataOfCurrentLane ? outputComponents(laneDataOfCurrentLane.components) : '';
-      if (currentLane) {
-        currentLane += `${outputRemoteLane(remoteOfCurrentLane)}\n${currentLaneComponents}`;
+      if (currentLaneStr) {
+        currentLaneStr += `${outputRemoteLane(remoteOfCurrentLane)}\n${currentLaneComponents}`;
       }
     }
 
-    const availableLanes = results.lanes
-      .filter((l) => l.name !== results.currentLane)
+    const availableLanes = lanes
+      .filter((l) => l.name !== currentLane)
       // @ts-ignore
       .map((laneData) => {
         if (details) {
@@ -91,7 +92,7 @@ export class LaneListCmd implements Command {
     return outputCurrentLane() + outputAvailableLanes() + outputFooter();
 
     function outputCurrentLane() {
-      return currentLane ? `${currentLane}\n` : '';
+      return currentLaneStr ? `${currentLaneStr}\n` : '';
     }
 
     function outputAvailableLanes() {
@@ -102,13 +103,14 @@ export class LaneListCmd implements Command {
   async json(args, laneOptions: LaneOptions) {
     const { remote, merged = false, notMerged = false } = laneOptions;
 
-    const results = await this.lanes.getLanes({
+    const lanes = await this.lanes.getLanes({
       remote,
       showDefaultLane: true,
       merged,
       notMerged,
     });
-    return results;
+    const currentLane = this.lanes.getCurrentLane();
+    return { lanes, currentLane };
   }
 }
 
@@ -129,41 +131,27 @@ export class LaneShowCmd implements Command {
   constructor(private lanes: LanesMain, private workspace: Workspace, private scope: ScopeMain) {}
 
   async report([name]: [string], laneOptions: LaneOptions): Promise<string> {
-    const { remote, json = false } = laneOptions;
+    const { remote } = laneOptions;
 
-    if (!this.workspace) {
-      if (!this.scope) throw new Error(`lane command needs to be run within a workspace or a scope`);
-      const scopeLanes = await this.scope.legacyScope.listLanes();
-      return scopeLanes.map((l) => l.name).join('\n');
-    }
-
-    const results = await this.lanes.getLanes({
+    const lanes = await this.lanes.getLanes({
       name,
       remote,
-      showDefaultLane: json,
     });
-    if (json) return JSON.stringify(results, null, 2);
 
-    const onlyLane = results.lanes[0];
+    const onlyLane = lanes[0];
     const title = `showing information for ${chalk.bold(name)}${outputRemoteLane(onlyLane.remote)}\n`;
     return title + outputComponents(onlyLane.components);
   }
 
   async json([name]: [string], laneOptions: LaneOptions) {
-    const { remote, json = false } = laneOptions;
+    const { remote } = laneOptions;
 
-    if (!this.workspace) {
-      if (!this.scope) throw new Error(`lane command needs to be run within a workspace or a scope`);
-      const scopeLanes = await this.scope.legacyScope.listLanes();
-      return scopeLanes;
-    }
-
-    const results = await this.lanes.getLanes({
+    const lanes = await this.lanes.getLanes({
       name,
       remote,
-      showDefaultLane: json,
+      showDefaultLane: true,
     });
-    return results;
+    return lanes;
   }
 }
 

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -2,7 +2,7 @@ import { Schema } from '@teambit/graphql';
 import gql from 'graphql-tag';
 import { LanesMain } from './lanes.main.runtime';
 
-export function lanesSchema(lanes: LanesMain): Schema {
+export function lanesSchema(lanesMain: LanesMain): Schema {
   return {
     typeDefs: gql`
       type CompLaneData {
@@ -16,9 +16,34 @@ export function lanesSchema(lanes: LanesMain): Schema {
         isMerged: Boolean
       }
 
+      type FileDiff {
+        filePath: String!
+        diffOutput: String
+      }
+
+      type FieldsDiff {
+        fieldName: String!
+        diffOutput: String
+      }
+
+      type DiffResults {
+        id: String
+        hasDiff: Boolean
+        filesDiff: [FileDiff]
+        fieldsDiff: [FieldsDiff]
+      }
+
+      type GetDiffResult {
+        newComps: [String]
+        compsWithNoChanges: [String]
+        toLaneName: String
+        compsWithDiff: [DiffResults]
+      }
+
       type Lanes {
         getLanes: [LanesData]
         getCurrentLane: String
+        getDiff(values: [String]): GetDiffResult
       }
 
       type Query {
@@ -27,7 +52,7 @@ export function lanesSchema(lanes: LanesMain): Schema {
     `,
     resolvers: {
       Lanes: {
-        getLanes: async () => {
+        getLanes: async (lanes: LanesMain) => {
           const lanesResults = await lanes.getLanes({});
           return lanesResults.map((lane) => ({
             name: lane.name,
@@ -35,12 +60,19 @@ export function lanesSchema(lanes: LanesMain): Schema {
             isMerged: Boolean(lane.isMerged),
           }));
         },
-        getCurrentLane: () => {
+        getCurrentLane: (lanes: LanesMain) => {
           return lanes.getCurrentLane();
+        },
+        getDiff: async (lanes: LanesMain, { values }: { values: string[] }) => {
+          const getDiffResults = await lanes.getDiff(values);
+          return {
+            ...getDiffResults,
+            compsWithDiff: getDiffResults.compsWithDiff.map((item) => ({ ...item, id: item.id.toString() })),
+          };
         },
       },
       Query: {
-        lanes: () => lanes,
+        lanes: () => lanesMain,
       },
     },
   };

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -1,0 +1,47 @@
+import { Schema } from '@teambit/graphql';
+import gql from 'graphql-tag';
+import { LanesMain } from './lanes.main.runtime';
+
+export function lanesSchema(lanes: LanesMain): Schema {
+  return {
+    typeDefs: gql`
+      type CompLaneData {
+        id: String!
+        head: String!
+      }
+
+      type LanesData {
+        name: String!
+        components: [CompLaneData]
+        isMerged: Boolean
+      }
+
+      type Lanes {
+        getLanes: [LanesData]
+        getCurrentLane: String
+      }
+
+      type Query {
+        lanes: Lanes
+      }
+    `,
+    resolvers: {
+      Lanes: {
+        getLanes: async () => {
+          const lanesResults = await lanes.getLanes({});
+          return lanesResults.map((lane) => ({
+            name: lane.name,
+            components: lane.components.map((c) => ({ id: c.id.toString(), head: c.head.toString() })),
+            isMerged: Boolean(lane.isMerged),
+          }));
+        },
+        getCurrentLane: () => {
+          return lanes.getCurrentLane();
+        },
+      },
+      Query: {
+        lanes: () => lanes,
+      },
+    },
+  };
+}

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -42,7 +42,8 @@ export function lanesSchema(lanesMain: LanesMain): Schema {
 
       type Lanes {
         getLanes: [LanesData]
-        getCurrentLane: String
+        getLaneByName(name: String): LanesData
+        getCurrentLaneName: String
         getDiff(values: [String]): GetDiffResult
       }
 
@@ -60,7 +61,16 @@ export function lanesSchema(lanesMain: LanesMain): Schema {
             isMerged: Boolean(lane.isMerged),
           }));
         },
-        getCurrentLane: (lanes: LanesMain) => {
+        getLaneByName: async (lanes: LanesMain, { name }: { name: string }) => {
+          const lanesResults = await lanes.getLanes({ name });
+          const laneResult = lanesResults[0];
+          return {
+            name: laneResult.name,
+            components: laneResult.components.map((c) => ({ id: c.id.toString(), head: c.head.toString() })),
+            isMerged: Boolean(laneResult.isMerged),
+          };
+        },
+        getCurrentLaneName: (lanes: LanesMain) => {
           return lanes.getCurrentLane();
         },
         getDiff: async (lanes: LanesMain, { values }: { values: string[] }) => {

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -3,7 +3,7 @@ import { ScopeMain, ScopeAspect } from '@teambit/scope';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import getRemoteByName from '@teambit/legacy/dist/remotes/get-remote-by-name';
-import { LaneDiffCmd } from '@teambit/lanes.modules.diff';
+import { LaneDiffCmd, LaneDiffGenerator } from '@teambit/lanes.modules.diff';
 import { LaneData } from '@teambit/legacy/dist/scope/lanes/lanes';
 import { DEFAULT_LANE } from '@teambit/legacy/dist/constants';
 import { LanesAspect } from './lanes.aspect';
@@ -51,6 +51,17 @@ export class LanesMain {
   getCurrentLane(): string | null {
     if (!this.workspace?.consumer) return null;
     return this.scope.legacyScope.lanes.getCurrentLaneName();
+  }
+
+  /**
+   * the values array may include zero to two values and will be processed as following:
+   * [] => diff between the current lane and default lane. (only inside workspace).
+   * [to] => diff between the current lane (or default-lane when in scope) and "to" lane.
+   * [from, to] => diff between "from" lane and "to" lane.
+   */
+  public getDiff(values: string[]) {
+    const laneDiffGenerator = new LaneDiffGenerator(this.workspace, this.scope);
+    return laneDiffGenerator.generate(values);
   }
 
   private getLaneDataOfDefaultLane(): LaneData | null {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -230,7 +230,7 @@ export default class CommandHelper {
   showOneLaneParsed(name: string) {
     const results = this.runCmd(`bit lane show ${name} --json`);
     const parsed = JSON.parse(results);
-    return parsed.lanes[0];
+    return parsed;
   }
   diffLane(args = '', onScope = false) {
     const cwd = onScope ? this.scopes.remotePath : this.scopes.localPath;


### PR DESCRIPTION
## Proposed Changes

- introduce `getLanes()` query to list all lanes.
- introduce `getLaneByName(name)` to show one lane.
- introduce `getCurrentLaneName()` to get the current lane name when on the workspace.
- introduce `getDiff(values)` to get diff between lanes.


<img width="414" alt="Screen Shot 2021-06-23 at 4 19 51 PM" src="https://user-images.githubusercontent.com/1963573/123270558-03fa0300-d4ce-11eb-82d0-d066f909355d.png">
<img width="730" alt="Screen Shot 2021-06-23 at 4 14 44 PM" src="https://user-images.githubusercontent.com/1963573/123270560-04929980-d4ce-11eb-8c9b-22206c11faa4.png">
<img width="1271" alt="Screen Shot 2021-06-24 at 9 11 53 AM" src="https://user-images.githubusercontent.com/1963573/123270552-02303f80-d4ce-11eb-8880-ee6ec6ba9e16.png">