### PR TITLE
fix getting old versions of components from the workspace

### DIFF
--- a/e2e/harmony/harmony-workspace.e2e.ts
+++ b/e2e/harmony/harmony-workspace.e2e.ts
@@ -1,0 +1,47 @@
+import chai, { expect } from 'chai';
+import { loadBit } from '@teambit/bit';
+import { Workspace, WorkspaceAspect } from '@teambit/workspace';
+import { Component } from '@teambit/component';
+import { HARMONY_FEATURE } from '../../src/api/consumer/lib/feature-toggle';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('workspace aspect', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+    helper.command.setFeatures(HARMONY_FEATURE);
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('tag a component twice', () => {
+    before(() => {
+      helper = new Helper();
+      helper.command.setFeatures(HARMONY_FEATURE);
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild(); // 0.0.1
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.tagAllWithoutBuild(); // 0.0.2
+    });
+    describe('ask the workspace for the first tag', () => {
+      let component: Component;
+      before(async () => {
+        const harmony = await loadBit(helper.scopes.localPath);
+        const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+        const compId = await workspace.resolveComponentId('comp1@0.0.1');
+        component = await workspace.get(compId);
+      });
+      // a previous bug, assigned the `component.state` of 0.0.2 to this 0.0.1 version
+      it('should contain the files of the first tag not the second', () => {
+        const content = component.state.filesystem.files[0].contents.toString();
+        expect(content).not.to.contain('v2');
+      });
+    });
+  });
+});

--- a/e2e/harmony/mix-harmony-legacy.e2e.ts
+++ b/e2e/harmony/mix-harmony-legacy.e2e.ts
@@ -34,7 +34,7 @@ describe('mix use of Legacy and Harmony', function () {
         helper.fixtures.addComponentBarFooAsDir();
         helper.command.addComponent('bar', { i: 'bar/foo' });
       });
-      it('bit status should show an issue of ', () => {
+      it('bit status should show an issue of LegacyInsideHarmony', () => {
         helper.command.expectStatusToHaveIssue(IssuesClasses.LegacyInsideHarmony.name);
       });
       it('bit tag should throw an error', () => {

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -57,7 +57,7 @@ export default class BitMap {
   markAsChangedBinded: Function;
   _cacheIds: { [origin: string]: BitIds | undefined };
   allTrackDirs: { [trackDir: string]: BitId } | null | undefined;
-
+  private updatedIds: { [oldIdStr: string]: ComponentMap } = {}; // needed for out-of-sync where the id is changed during the process
   constructor(
     public projectRoot: string,
     private mapPath: string,
@@ -390,6 +390,9 @@ export default class BitMap {
     if (ignoreScopeAndVersion) {
       const matchWithoutScopeAndVersion = allIds.searchWithoutScopeAndVersion(bitId);
       if (matchWithoutScopeAndVersion) return matchWithoutScopeAndVersion;
+    }
+    if (this.updatedIds[bitId.toString()]) {
+      return this.updatedIds[bitId.toString()].id;
     }
     throw new MissingBitMapComponent(bitId.toString());
   }
@@ -746,6 +749,7 @@ export default class BitMap {
     this._removeFromComponentsArray(oldId);
     this.setComponent(newId, componentMap);
     this.markAsChanged();
+    this.updatedIds[oldIdStr] = componentMap;
     return newId;
   }
 

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -144,8 +144,7 @@ export default class ComponentLoader {
   }
 
   private async loadOne(id: BitId, throwOnFailure: boolean, invalidComponents: InvalidComponent[]) {
-    // ignoreScopeAndVersion because out-of-sync might changed it before
-    const componentMap = this.consumer.bitMap.getComponent(id, { ignoreScopeAndVersion: true });
+    const componentMap = this.consumer.bitMap.getComponent(id);
     let bitDir = this.consumer.getPath();
     if (componentMap.rootDir) {
       bitDir = path.join(bitDir, componentMap.rootDir);
@@ -177,8 +176,7 @@ export default class ComponentLoader {
     component.originallySharedDir = componentMap.originallySharedDir || undefined;
     component.wrapDir = componentMap.wrapDir || undefined;
     // reload component map as it may be changed after calling Component.loadFromFileSystem()
-    // ignoreScopeAndVersion because out-of-sync might changed it before
-    component.componentMap = this.consumer.bitMap.getComponent(id, { ignoreScopeAndVersion: true });
+    component.componentMap = this.consumer.bitMap.getComponent(id);
     await this._handleOutOfSyncScenarios(component);
 
     const loadDependencies = async () => {


### PR DESCRIPTION
Currently, when asking the Workspace aspect for an older version of a component, we get a mix of the current version with the old version data, which later on, result in ComponentNotFound error. 
This is a regression started since https://github.com/teambit/bit/pull/4414, which we ignored the scope/version when loading a component.
In this PR, a different approach was taken for the out-of-sync issue. Instead of ignoring the scope/version, we save the old-id and the new-id in case of out-of-sync, so later on, we could retrieve the updated data of that id.