### PR TITLE
enable calling loadBit multiple times in the same process

### DIFF
--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -51,7 +51,7 @@ describe('build command', function () {
   // @todo: fix!
   // here is the issue: if we enable this test, the next one fails.
   // for some reason `loadBit` doesn't work if we run it here once and in the next test again.
-  describe.skip('list tasks', () => {
+  describe.only('list tasks', () => {
     before(() => {
       helper = new Helper();
       helper.command.setFeatures(HARMONY_FEATURE);
@@ -60,17 +60,17 @@ describe('build command', function () {
     });
     it('should list the publish task in the tagPipeline but not in the snapPipeline', async () => {
       const harmony = await loadBit(helper.scopes.localPath);
-      const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
-      const compId = await workspace.resolveComponentId('comp1');
-      const component = await workspace.get(compId);
-      const builder = harmony.get<BuilderMain>(BuilderAspect.id);
-      const tasks = builder.listTasks(component);
-      expect(tasks.snapTasks).to.have.lengthOf(0);
-      expect(tasks.tagTasks).to.include('teambit.pkg/pkg:PublishComponents');
+      // const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+      // const compId = await workspace.resolveComponentId('comp1');
+      // const component = await workspace.get(compId);
+      // const builder = harmony.get<BuilderMain>(BuilderAspect.id);
+      // const tasks = builder.listTasks(component);
+      // expect(tasks.snapTasks).to.have.lengthOf(0);
+      // expect(tasks.tagTasks).to.include('teambit.pkg/pkg:PublishComponents');
     });
   });
 
-  describe('registering the publish task for the snap pipeline in a new-custom env', () => {
+  describe.only('registering the publish task for the snap pipeline in a new-custom env', () => {
     before(() => {
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.command.create('node-env', 'my-env');
@@ -86,9 +86,9 @@ describe('build command', function () {
       const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
       const compId = await workspace.resolveComponentId('comp1');
       const component = await workspace.get(compId);
-      const builder = harmony.get<BuilderMain>(BuilderAspect.id);
-      const tasks = builder.listTasks(component);
-      expect(tasks.snapTasks).to.include('teambit.pkg/pkg:PublishComponents');
+      // const builder = harmony.get<BuilderMain>(BuilderAspect.id);
+      // const tasks = builder.listTasks(component);
+      // expect(tasks.snapTasks).to.include('teambit.pkg/pkg:PublishComponents');
     });
   });
 });

--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -48,9 +48,6 @@ describe('build command', function () {
     });
   });
 
-  // @todo: fix!
-  // here is the issue: if we enable this test, the next one fails.
-  // for some reason `loadBit` doesn't work if we run it here once and in the next test again.
   describe.only('list tasks', () => {
     before(() => {
       helper = new Helper();
@@ -60,13 +57,13 @@ describe('build command', function () {
     });
     it('should list the publish task in the tagPipeline but not in the snapPipeline', async () => {
       const harmony = await loadBit(helper.scopes.localPath);
-      // const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
-      // const compId = await workspace.resolveComponentId('comp1');
-      // const component = await workspace.get(compId);
-      // const builder = harmony.get<BuilderMain>(BuilderAspect.id);
-      // const tasks = builder.listTasks(component);
-      // expect(tasks.snapTasks).to.have.lengthOf(0);
-      // expect(tasks.tagTasks).to.include('teambit.pkg/pkg:PublishComponents');
+      const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+      const compId = await workspace.resolveComponentId('comp1');
+      const component = await workspace.get(compId);
+      const builder = harmony.get<BuilderMain>(BuilderAspect.id);
+      const tasks = builder.listTasks(component);
+      expect(tasks.snapTasks).to.have.lengthOf(0);
+      expect(tasks.tagTasks).to.include('teambit.pkg/pkg:PublishComponents');
     });
   });
 
@@ -86,9 +83,9 @@ describe('build command', function () {
       const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
       const compId = await workspace.resolveComponentId('comp1');
       const component = await workspace.get(compId);
-      // const builder = harmony.get<BuilderMain>(BuilderAspect.id);
-      // const tasks = builder.listTasks(component);
-      // expect(tasks.snapTasks).to.include('teambit.pkg/pkg:PublishComponents');
+      const builder = harmony.get<BuilderMain>(BuilderAspect.id);
+      const tasks = builder.listTasks(component);
+      expect(tasks.snapTasks).to.include('teambit.pkg/pkg:PublishComponents');
     });
   });
 });

--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -48,7 +48,7 @@ describe('build command', function () {
     });
   });
 
-  describe.only('list tasks', () => {
+  describe('list tasks', () => {
     before(() => {
       helper = new Helper();
       helper.command.setFeatures(HARMONY_FEATURE);
@@ -67,7 +67,7 @@ describe('build command', function () {
     });
   });
 
-  describe.only('registering the publish task for the snap pipeline in a new-custom env', () => {
+  describe('registering the publish task for the snap pipeline in a new-custom env', () => {
     before(() => {
       helper.scopeHelper.reInitLocalScopeHarmony();
       helper.command.create('node-env', 'my-env');

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -237,11 +237,16 @@ function registerCoreAspectsToLegacyDepResolver(aspectLoader: AspectLoaderMain) 
   DependencyResolver.getCoreAspectsPackagesAndIds = () => coreAspectsPackagesAndIds;
 }
 
+/**
+ * loadBit may gets called multiple times (currently, it's happening during e2e-tests that call loadBit).
+ * when it happens, the static methods in this function still have the callbacks that were added in
+ * the previous loadBit call. this callbacks have the old data such as workspace/bitmap/consumer
+ * of the previous workspace, which leads to hard-to-debug issues.
+ */
 function clearGlobalsIfNeeded() {
   if (!loadConsumer.cache) {
     return;
   }
-
   delete loadConsumer.cache;
   ComponentLoader.onComponentLoadSubscribers = [];
   ComponentOverrides.componentOverridesLoadingRegistry = {};

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -27,9 +27,16 @@ import { Config } from '@teambit/harmony/dist/harmony-config';
 import { ConfigOptions } from '@teambit/harmony/dist/harmony-config/harmony-config';
 import { BitId, VERSION_DELIMITER } from '@teambit/legacy-bit-id';
 import { DependencyResolver } from '@teambit/legacy/dist/consumer/component/dependencies/dependency-resolver';
-import { getConsumerInfo } from '@teambit/legacy/dist/consumer';
+import { getConsumerInfo, loadConsumer } from '@teambit/legacy/dist/consumer';
 import { ConsumerInfo } from '@teambit/legacy/dist/consumer/consumer-locator';
 import BitMap from '@teambit/legacy/dist/consumer/bit-map';
+import ComponentLoader from '@teambit/legacy/dist/consumer/component/component-loader';
+import ComponentConfig from '@teambit/legacy/dist/consumer/config/component-config';
+import ComponentOverrides from '@teambit/legacy/dist/consumer/config/component-overrides';
+import { PackageJsonTransformer } from '@teambit/legacy/dist/consumer/component/package-json-transformer';
+import ManyComponentsWriter from '@teambit/legacy/dist/consumer/component-ops/many-components-writer';
+import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
+import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
 import { propogateUntil as propagateUntil } from '@teambit/legacy/dist/utils';
 import loader from '@teambit/legacy/dist/cli/loader';
@@ -179,6 +186,7 @@ function shouldLoadInSafeMode() {
 }
 
 export async function loadBit(path = process.cwd()) {
+  clearGlobalsIfNeeded();
   const loadCLIOnly = shouldLoadInSafeMode();
   const config = await getConfig(path);
   registerCoreExtensions();
@@ -227,4 +235,28 @@ function registerCoreAspectsToLegacyDepResolver(aspectLoader: AspectLoaderMain) 
   });
   // @ts-ignore
   DependencyResolver.getCoreAspectsPackagesAndIds = () => coreAspectsPackagesAndIds;
+}
+
+function clearGlobalsIfNeeded() {
+  if (!loadConsumer.cache) {
+    return;
+  }
+
+  delete loadConsumer.cache;
+  ComponentLoader.onComponentLoadSubscribers = [];
+  ComponentOverrides.componentOverridesLoadingRegistry = {};
+  ComponentConfig.componentConfigLegacyLoadingRegistry = {};
+  ComponentConfig.componentConfigLoadingRegistry = {};
+  PackageJsonTransformer.packageJsonTransformersRegistry = [];
+  // @ts-ignore
+  DependencyResolver.getWorkspacePolicy = undefined;
+  // @ts-ignore
+  ManyComponentsWriter.externalInstaller = {};
+  ExtensionDataList.coreExtensionsNames = new Map();
+  // @ts-ignore
+  WorkspaceConfig.workspaceConfigEnsuringRegistry = undefined;
+  // @ts-ignore
+  WorkspaceConfig.workspaceConfigIsExistRegistry = undefined;
+  // @ts-ignore
+  WorkspaceConfig.workspaceConfigLoadingRegistry = undefined;
 }

--- a/src/consumer/consumer-loader.ts
+++ b/src/consumer/consumer-loader.ts
@@ -3,29 +3,26 @@ import * as path from 'path';
 import Consumer from './consumer';
 import { ConsumerNotFound } from './exceptions';
 
-export async function loadConsumer(
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  currentPath?: string = process.cwd(),
-  newInstance? = false
+type LoadConsumerFunc = {
+  (currentPath?: string, newInstance?: boolean): Promise<Consumer>;
+  cache?: Record<string, Consumer>;
+};
+
+export const loadConsumer: LoadConsumerFunc = async function (
+  currentPath = process.cwd(),
+  newInstance = false
 ): Promise<Consumer> {
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (newInstance || !loadConsumer.cache || !loadConsumer.cache[currentPath]) {
     const consumer = await Consumer.load(path.resolve(currentPath));
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (!loadConsumer.cache) loadConsumer.cache = {};
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     loadConsumer.cache[currentPath] = consumer;
   }
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return loadConsumer.cache[currentPath];
-}
+};
 
 export async function loadConsumerIfExist(
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  currentPath?: string = process.cwd(),
-  newInstance? = false
+  currentPath = process.cwd(),
+  newInstance = false
 ): Promise<Consumer | undefined> {
   try {
     return await loadConsumer(currentPath, newInstance);


### PR DESCRIPTION
For now, It's needed for the e2e-tests. 
It wasn't working before because some state were left from the previous `loadBit` called. 