### PR TITLE
add option to configure savePrefix for bit install

### DIFF
--- a/scopes/dependencies/dependency-resolver/exceptions/index.ts
+++ b/scopes/dependencies/dependency-resolver/exceptions/index.ts
@@ -4,3 +4,4 @@ export { MainAspectNotInstallable } from './main-aspect-not-installable';
 export { MainAspectNotLinkable } from './main-aspect-not-linkable';
 export { CoreAspectLinkError } from './core-aspect-link-error';
 export { HarmonyLinkError } from './harmony-link-error';
+export { InvalidVersionWithPrefix } from './invalid-version-with-prefix';

--- a/scopes/dependencies/dependency-resolver/exceptions/invalid-version-with-prefix.ts
+++ b/scopes/dependencies/dependency-resolver/exceptions/invalid-version-with-prefix.ts
@@ -1,0 +1,7 @@
+import { BitError } from '@teambit/bit-error';
+
+export class InvalidVersionWithPrefix extends BitError {
+  constructor(version: string) {
+    super(`the version ${version} is invalid. your prefix might be invalid`);
+  }
+}

--- a/scopes/workspace/workspace/install.cmd.tsx
+++ b/scopes/workspace/workspace/install.cmd.tsx
@@ -11,6 +11,7 @@ type InstallCmdOptions = {
   skipDedupe: boolean;
   skipImport: boolean;
   updateExisting: boolean;
+  savePrefix: string;
 };
 
 export default class InstallCmd implements Command {
@@ -23,6 +24,7 @@ export default class InstallCmd implements Command {
     ['v', 'variants <variants>', 'add packages to specific variants'],
     ['t', 'type [lifecycleType]', 'runtime (default), dev or peer dependency'],
     ['u', 'update-existing [updateExisting]', 'update existing dependencies version and types'],
+    ['', 'save-prefix [savePrefix]', 'set the prefix to use when adding dependency to workspace.jsonc'],
     ['', 'skip-dedupe [skipDedupe]', 'do not dedupe dependencies on installation'],
     ['', 'skip-import [skipImport]', 'do not import bit objects post installation'],
   ] as CommandOptions;
@@ -48,6 +50,7 @@ export default class InstallCmd implements Command {
       dedupe: !options.skipDedupe,
       import: !options.skipImport,
       updateExisting: options.updateExisting,
+      savePrefix: options.savePrefix,
     };
     const components = await this.workspace.install(packages, installOpts);
     const endTime = Date.now();

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -106,6 +106,7 @@ export type WorkspaceInstallOptions = {
   copyPeerToRuntimeOnRoot?: boolean;
   copyPeerToRuntimeOnComponents?: boolean;
   updateExisting: boolean;
+  savePrefix?: string;
 };
 
 export type WorkspaceLinkOptions = LinkingOptions;
@@ -1085,10 +1086,14 @@ export class Workspace implements ComponentFactory {
       const newWorkspacePolicyEntries: WorkspacePolicyEntry[] = [];
       resolvedPackages.forEach((resolvedPackage) => {
         if (resolvedPackage.version) {
+          const versionWithPrefix = this.dependencyResolver.getVersionWithSavePrefix(
+            resolvedPackage.version,
+            options?.savePrefix
+          );
           newWorkspacePolicyEntries.push({
             dependencyId: resolvedPackage.packageName,
             value: {
-              version: resolvedPackage.version,
+              version: versionWithPrefix,
             },
             lifecycleType: options?.lifecycleType || 'runtime',
           });


### PR DESCRIPTION
## Proposed Changes

- add an option to configure savePrefix via dependency-resolver config
- add an option to configure savePrefix via bit install --save-prefix
- resolves #4175 

With this PR you can now:
1. configure `"savePrefix"` in the workspace.jsonc under `teambit.dependencies/dependency-resolver`
for example `"savePrefix": "~"`
2. pass `--save-prefix` flag to `bit install command. for example `bit install lodash.get --save-prefix="^"`
3. In case of conflicts between the install flag and the dep resolver config in workspace.jsonc, the install flag is stronger.
4. default is just empty string which behave as save exact version 
