### PR TITLE
apply env 'node' for components using namespace

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -434,9 +434,9 @@
         }
       },
       "teambit.envs/envs": {
-        "env": "teambit.harmony/aspect"
+        "env": "teambit.harmony/node"
       },
-      "teambit.harmony/aspect": {}
+      "teambit.harmony/node": {}
     },
     "{modules/**}": {
       "teambit.envs/envs": {


### PR DESCRIPTION
## Proposed Changes

- change the (default) env of components having a namespace - from 'aspect' to be 'node'
- this should change the following components:
  - `teambit.compositions/model/composition-type`
  - `teambit.compositions/model/composition-id`

TODO
- [ ] verify no other components are effected, by the results of `bit status` in the CI
