### PR TITLE
fix source-map on capsules, replace absolute paths with relative

### DIFF
--- a/scopes/compilation/babel/babel.compiler.ts
+++ b/scopes/compilation/babel/babel.compiler.ts
@@ -92,12 +92,13 @@ export class BabelCompiler implements Compiler {
     await Promise.all(
       sourceFiles.map(async (filePath) => {
         const absoluteFilePath = path.join(capsule.path, filePath);
+        this.options.babelTransformOptions ||= {};
+        this.options.babelTransformOptions.sourceFileName = path.basename(filePath);
+        this.options.babelTransformOptions.filename = path.basename(filePath);
         try {
           const result = await transpileFilePathAsync(
             absoluteFilePath,
-
             this.options.babelTransformOptions || {},
-
             this.babelModule
           );
           if (!result || !result.length) {

--- a/scopes/compilation/modules/babel-compiler/babel-compiler.ts
+++ b/scopes/compilation/modules/babel-compiler/babel-compiler.ts
@@ -66,7 +66,7 @@ export async function transpileFilePathAsync(
   if (!result || !result.code) {
     return null;
   }
-  const outputPath = replaceFileExtToJs(filePath);
+  const outputPath = replaceFileExtToJs(path.basename(filePath));
   const mapFilePath = `${outputPath}.map`;
   const code = result.code || '';
   const outputText = result.map ? `${code}\n\n//# sourceMappingURL=${mapFilePath}` : code;


### PR DESCRIPTION
Currently, when using Babel compiler, the source maps include absolute paths to the capsules. This PR fixes it to have the source-map always relative to the source file.