### PR TITLE
Bit mdx lint fixes

### DIFF
--- a/scopes/defender/linter/linter.main.runtime.ts
+++ b/scopes/defender/linter/linter.main.runtime.ts
@@ -40,7 +40,7 @@ export class LinterMain {
   static dependencies = [EnvsAspect, CLIAspect, ComponentAspect, LoggerAspect, WorkspaceAspect];
 
   static defaultConfig = {
-    extensionFormats: ['.ts', 'tsx', '.js', '.jsx', 'js', 'mjs'],
+    extensionFormats: ['.ts', '.tsx', '.js', '.jsx', '.mjs'],
   };
 
   static async provider(

--- a/scopes/react/eslint-config-bit-react/bit-react-eslint.js
+++ b/scopes/react/eslint-config-bit-react/bit-react-eslint.js
@@ -1,7 +1,18 @@
 // As object
 module.exports = {
-  extends: [require.resolve('eslint-config-airbnb-typescript'), 'plugin:jest/recommended'],
+  extends: ['plugin:jest/recommended'],
   plugins: ['jest'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx', '*.js', '*.jsx', '*.mjs'],
+      extends: [require.resolve('eslint-config-airbnb-typescript')],
+      rules: {
+        '@typescript-eslint/camelcase': 'off',
+        'import/no-extraneous-dependencies': 'off',
+        'import/prefer-default-export': 'off',
+      },
+    },
+  ],
   parserOptions: {
     warnOnUnsupportedTypeScriptVersion: false,
     ecmaFeatures: {
@@ -17,11 +28,7 @@ module.exports = {
       version: 26,
     },
   },
-  rules: {
-    '@typescript-eslint/camelcase': 'off',
-    'import/no-extraneous-dependencies': 'off',
-    'import/prefer-default-export': 'off',
-  },
+
   env: {
     'jest/globals': true,
   },

--- a/scopes/react/react/component.json
+++ b/scopes/react/react/component.json
@@ -26,6 +26,7 @@
           "eslint-plugin-react-hooks": "4.2.0",
           "eslint-plugin-react": "7.22.0",
           "eslint-plugin-jsx-a11y": "6.4.1",
+          "eslint-plugin-mdx": "1.13.0",
           "react-app-polyfill": "1.0.6",
           "resolve-url-loader": "3.1.2",
           "@mdx-js/react": "1.6.22",

--- a/scopes/react/react/eslint/eslintrc.js
+++ b/scopes/react/react/eslint/eslintrc.js
@@ -4,15 +4,24 @@ import '@teambit/react.eslint-config-bit-react';
 module.exports = {
   extends: [require.resolve('@teambit/react.eslint-config-bit-react')],
   parserOptions: {
+    parser: require.resolve('@typescript-eslint/parser'),
     createDefaultProgram: true,
     // resolve the env tsconfig.
     project: require.resolve('../typescript/tsconfig.json'),
   },
+  overrides: [
+    {
+      files: ['*.md', '*.mdx'],
+      extends: ['plugin:mdx/recommended'],
+      parserOptions: {
+        // parser: '@typescript-eslint/parser',
+        ecmaVersion: 6,
+        sourceType: 'module',
+        ecmaFeatures: {
+          modules: true,
+        },
+        extensions: ['.md', '.mdx'],
+      },
+    },
+  ],
 };
-
-// module.exports = eslintConfig;
-
-// Using function
-// import generateEslint from '@teambit/react.eslint-config-bit-react';
-// const config = generateEslint(require.resolve('../typescript/tsconfig.json'));
-// module.exports = config;

--- a/scopes/react/react/eslint/eslintrc.js
+++ b/scopes/react/react/eslint/eslintrc.js
@@ -1,7 +1,7 @@
 // Using object
 import '@teambit/react.eslint-config-bit-react';
 
-export const eslintConfig = {
+module.exports = {
   extends: [require.resolve('@teambit/react.eslint-config-bit-react')],
   parserOptions: {
     createDefaultProgram: true,

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -25,9 +25,9 @@ import { Configuration } from 'webpack';
 // Makes sure the @teambit/react.ui.docs-app is a dependency
 // TODO: remove this import once we can set policy from component to component with workspace version. Then set it via the component.json
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import docs from '@teambit/react.ui.docs-app'; 
+import docs from '@teambit/react.ui.docs-app';
 import { ReactMainConfig } from './react.main.runtime';
-import { eslintConfig } from './eslint/eslintrc';
+import eslintConfig from './eslint/eslintrc';
 import { ReactAspect } from './react.aspect';
 
 // webpack configs for both components and envs

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -27,7 +27,6 @@ import { Configuration } from 'webpack';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import docs from '@teambit/react.ui.docs-app';
 import { ReactMainConfig } from './react.main.runtime';
-import eslintConfig from './eslint/eslintrc';
 import { ReactAspect } from './react.aspect';
 
 // webpack configs for both components and envs
@@ -46,6 +45,7 @@ export const AspectEnvType = 'react';
 const jestM = require('jest');
 const defaultTsConfig = require('./typescript/tsconfig.json');
 const buildTsConfig = require('./typescript/tsconfig.build.json');
+const eslintConfig = require('./eslint/eslintrc');
 
 /**
  * a component environment built for [React](https://reactjs.org) .

--- a/yarn.lock
+++ b/yarn.lock
@@ -7020,12 +7020,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@teambit/legacy@npm:1.0.109":
-  version: 1.0.109
-  resolution: "@teambit/legacy@npm:1.0.109"
+"@teambit/legacy@npm:1.0.110":
+  version: 1.0.110
+  resolution: "@teambit/legacy@npm:1.0.110"
   dependencies:
     "@babel/core": 7.12.17
     "@babel/runtime": 7.12.18
+    "@teambit/network.agent": 0.0.1
     "@teambit/toolbox.network.agent": 0.0.116
     "@vuedoc/parser": 2.4.0
     acorn: 6.4.2
@@ -7145,7 +7146,7 @@ __metadata:
     yn: 2.0.0
   bin:
     bit: bin/bit.js
-  checksum: cfde2fd07dc9fd00dc3381289eb74308823d538abeb10f337c94a95bd3ec69dc7e6424d6cd870cf794957cbf94db49d191b33d32fa78966ebf48d3b0276531b6
+  checksum: c61d4e2bed70f86d8aa855b99170bd2fc6721f420aebce66f36dc8d96eab94fa505044fbf926fb0d4dcb5a25954c0c32048dcb82d4ce9061039207b7ab45b415
   languageName: node
   linkType: hard
 
@@ -7283,12 +7284,9 @@ __metadata:
     "@teambit/evangelist.surfaces.dropdown": 1.0.2
     "@teambit/evangelist.surfaces.tooltip": 1.0.1
     "@teambit/harmony": 0.2.11
-    "@teambit/legacy": 1.0.109
-<<<<<<< Updated upstream
+    "@teambit/legacy": 1.0.110
     "@teambit/mdx.ui.mdx-scope-context": 0.0.368
     "@teambit/network.agent": 0.0.1
-=======
->>>>>>> Stashed changes
     "@teambit/react.instructions.react.adding-compositions": 0.0.5
     "@teambit/react.instructions.react.adding-tests": 0.0.5
     "@teambit/string.ellipsis": 0.0.7
@@ -7685,13 +7683,12 @@ __metadata:
     yargs: 17.0.1
     yn: 2.0.0
   peerDependencies:
-    "@teambit/legacy": 1.0.109
+    "@teambit/legacy": 1.0.110
   bin:
     bit: bin/bit.js
   languageName: unknown
   linkType: soft
 
-<<<<<<< Updated upstream
 "@teambit/mdx.ui.mdx-scope-context@npm:0.0.368":
   version: 0.0.368
   resolution: "@teambit/mdx.ui.mdx-scope-context@npm:0.0.368"
@@ -7705,8 +7702,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-=======
->>>>>>> Stashed changes
 "@teambit/model.composition-id@npm:0.0.259":
   version: 0.0.259
   resolution: "@teambit/model.composition-id@npm:0.0.259::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fmodel.composition-id%2F-%2Fmodel.composition-id-0.0.259.tgz"
@@ -7733,6 +7728,38 @@ __metadata:
     react: ^16.13.1
     react-dom: ^16.13.1
   checksum: 04a8e8a88cbbba7296705a0e8145d1e8f5cdd1e5264bfe0a9a9c87c5451b46d2a45bd879aa9986bafa65783036a489329e2f600db11603d9ce72c646a87cf828
+  languageName: node
+  linkType: hard
+
+"@teambit/network.agent@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@teambit/network.agent@npm:0.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fnetwork.agent%2F-%2Fnetwork.agent-0.0.1.tgz"
+  dependencies:
+    "@teambit/network.proxy-agent": 0.0.1
+    agentkeepalive: 4.1.4
+    core-js: 3.8.3
+  peerDependencies:
+    "@teambit/legacy": 1.0.38
+    react: 16.13.1
+    react-dom: 16.13.1
+  checksum: 5cea7497801060f00ad8cd090a8861383dd2d043b4df4a91c08369ebd18943b463c9fe9c06dbf4b3b1daf00b2281252cf84db5cd1a2b84e1fdcc6f08b81304b5
+  languageName: node
+  linkType: hard
+
+"@teambit/network.proxy-agent@npm:0.0.1":
+  version: 0.0.1
+  resolution: "@teambit/network.proxy-agent@npm:0.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fnetwork.proxy-agent%2F-%2Fnetwork.proxy-agent-0.0.1.tgz"
+  dependencies:
+    "@teambit/network.agent": 0.0.1
+    core-js: 3.8.3
+    http-proxy-agent: 4.0.1
+    https-proxy-agent: 5.0.0
+    socks-proxy-agent: 5.0.0
+  peerDependencies:
+    "@teambit/legacy": 1.0.38
+    react: 16.13.1
+    react-dom: 16.13.1
+  checksum: d9b2008ddbe2eb2043b50b44c75ca70ca44c9e6583674925915edfc23087d0fbd9e8bb5bd8475c06345a0c3b5661265d8a12c5d893e930508c4b6b284addfef9
   languageName: node
   linkType: hard
 
@@ -8851,15 +8878,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-<<<<<<< Updated upstream
-"@types/react@npm:^17.0.8":
-  version: 17.0.11
-  resolution: "@types/react@npm:17.0.11"
-=======
 "@types/react@npm:17.0.8":
   version: 17.0.8
   resolution: "@types/react@npm:17.0.8"
->>>>>>> Stashed changes
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"

--- a/yarn.lock
+++ b/yarn.lock
@@ -197,6 +197,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/code-frame@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/code-frame@npm:7.14.5"
+  dependencies:
+    "@babel/highlight": ^7.14.5
+  checksum: 0adbe4f8d91586f764f524e57631f582ab988b2ef504391a5d89db29bfaaf7c67c237798ed4a249b6a2d7135852cf94d3d07ce6b9739dd1df1f271d5ed069565
+  languageName: node
+  linkType: hard
+
 "@babel/compat-data@npm:^7.12.1, @babel/compat-data@npm:^7.13.12":
   version: 7.13.12
   resolution: "@babel/compat-data@npm:7.13.12::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcompat-data%2F-%2Fcompat-data-7.13.12.tgz"
@@ -282,6 +291,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/core@npm:7.12.9":
+  version: 7.12.9
+  resolution: "@babel/core@npm:7.12.9"
+  dependencies:
+    "@babel/code-frame": ^7.10.4
+    "@babel/generator": ^7.12.5
+    "@babel/helper-module-transforms": ^7.12.1
+    "@babel/helpers": ^7.12.5
+    "@babel/parser": ^7.12.7
+    "@babel/template": ^7.12.7
+    "@babel/traverse": ^7.12.9
+    "@babel/types": ^7.12.7
+    convert-source-map: ^1.7.0
+    debug: ^4.1.0
+    gensync: ^1.0.0-beta.1
+    json5: ^2.1.2
+    lodash: ^4.17.19
+    resolve: ^1.3.2
+    semver: ^5.4.1
+    source-map: ^0.5.0
+  checksum: 4d34eca4688214a4eb6bd5dde906b69a7824f17b931f52cd03628a8ac94d8fbe15565aebffdde106e974c8738cd64ac62c6a6060baa7139a06db1f18c4ff872d
+  languageName: node
+  linkType: hard
+
 "@babel/core@npm:7.13.10::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcore%2F-%2Fcore-7.13.10.tgz, @babel/core@npm:^7.11.1":
   version: 7.13.10
   resolution: "@babel/core@npm:7.13.10::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fcore%2F-%2Fcore-7.13.10.tgz"
@@ -338,6 +371,17 @@ __metadata:
     jsesc: ^2.5.1
     source-map: ^0.5.0
   checksum: 1b0e9fa1b5ea6656f0abeeedc99ff7bffa455d7bf118f4d17a75d80c439206b4ba3e1071c104b486b7447689512969286cbde505e6169ab38cf437e13ca54225
+  languageName: node
+  linkType: hard
+
+"@babel/generator@npm:^7.12.5, @babel/generator@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/generator@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+    jsesc: ^2.5.1
+    source-map: ^0.5.0
+  checksum: 7fcfeaf17e8e76ea91c66dc86c776d2112f52ce0315d3f4ca6a74b6eada0be1592d1ea6286d7241d3f634b63717ceef5d180d041a0b3dca9d071ba2e5fa7c77b
   languageName: node
   linkType: hard
 
@@ -468,12 +512,32 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-function-name@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-function-name@npm:7.14.5"
+  dependencies:
+    "@babel/helper-get-function-arity": ^7.14.5
+    "@babel/template": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: fd8ffa82f7622b6e9a6294fb3b98b42e743ab2a8e3c329367667a960b5b98b48bc5ebf8be7308981f1985b9f3c69e1a3b4a91c8944ae97c31803240da92fb3c8
+  languageName: node
+  linkType: hard
+
 "@babel/helper-get-function-arity@npm:^7.12.13":
   version: 7.12.13
   resolution: "@babel/helper-get-function-arity@npm:7.12.13::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-get-function-arity%2F-%2Fhelper-get-function-arity-7.12.13.tgz"
   dependencies:
     "@babel/types": ^7.12.13
   checksum: 847ef9f4d4b2dc38574db6b0732c3add1cd65d54bab94c24d319188f2066c9b9ab2b0dda539cae7281d12ec302e3335b11ca3dcfb555566138d213905d00f711
+  languageName: node
+  linkType: hard
+
+"@babel/helper-get-function-arity@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-get-function-arity@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: a60779918b677a35e177bb4f46babfd54e9790587b6a4f076092a9eff2a940cbeacdeb10c94331b26abfe838769554d72293d16df897246cfccd1444e5e27cb7
   languageName: node
   linkType: hard
 
@@ -484,6 +548,15 @@ __metadata:
     "@babel/traverse": ^7.13.0
     "@babel/types": ^7.13.0
   checksum: 14980ab95c9687f8df72d2ce4a074e2560d16b03de5c5e10382c06b779e1982c99da0625ec338a82fa2fd63048f97a25d46a692e83f5524cab5f9f1402743aff
+  languageName: node
+  linkType: hard
+
+"@babel/helper-hoist-variables@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-hoist-variables@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 35af58eebffca10988de7003e044ce2d27212aea72ac6d2c4604137da7f1e193cc694d8d60805d0d0beaf3d990f6f2dcc2622c52e3d3148e37017a29cacf2e56
   languageName: node
   linkType: hard
 
@@ -659,6 +732,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helper-split-export-declaration@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/helper-split-export-declaration@npm:7.14.5"
+  dependencies:
+    "@babel/types": ^7.14.5
+  checksum: 93437025a33747bfd37d6d5a9cdac8f4b6b3e5c0c53c0e24c5444575e731ea64fd5471a51a039fd74ff3378f916ea2d69d9f10274d253ed6f832952be2fd65f0
+  languageName: node
+  linkType: hard
+
 "@babel/helper-validator-identifier@npm:^7.12.11":
   version: 7.12.11
   resolution: "@babel/helper-validator-identifier@npm:7.12.11::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhelper-validator-identifier%2F-%2Fhelper-validator-identifier-7.12.11.tgz"
@@ -714,6 +796,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/helpers@npm:^7.12.5":
+  version: 7.14.6
+  resolution: "@babel/helpers@npm:7.14.6"
+  dependencies:
+    "@babel/template": ^7.14.5
+    "@babel/traverse": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: fe4e73975b062a8b8b95f499f4ac1064c9a53d4ee83cc273c2420250f6a46b59f1f5e35050d41ebe04efd7885a28ceea6f4f16d8eb091e24622f2a4a5eb20f23
+  languageName: node
+  linkType: hard
+
 "@babel/highlight@npm:^7.10.4, @babel/highlight@npm:^7.12.13, @babel/highlight@npm:^7.8.3":
   version: 7.13.8
   resolution: "@babel/highlight@npm:7.13.8::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Fhighlight%2F-%2Fhighlight-7.13.8.tgz"
@@ -722,6 +815,17 @@ __metadata:
     chalk: ^2.0.0
     js-tokens: ^4.0.0
   checksum: 1aa15ef0f8aa3c171e5eda442d77f9b845ff99da77aea797b52773b97b6854c5cbcffe3075dc68881408c2aee0dc2cb5f524b4f65eabe36b4239cd7c9f8a01a2
+  languageName: node
+  linkType: hard
+
+"@babel/highlight@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/highlight@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    chalk: ^2.0.0
+    js-tokens: ^4.0.0
+  checksum: 4e4b22fb886c939551d73307de16232c186fdb4d8ec8f514541b058feaecdba5234788a0740ca5bcd28777f4108596c39ac4b7463684c63b3812f6071e3fb88f
   languageName: node
   linkType: hard
 
@@ -749,6 +853,15 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: b1ac4b22f2ecca95170618c9b4a4adf6b342ebbc152181924be96a9ba59ef67c242b79b543a6a0f1d1749f370966b4362e6f0fe90e16c046be1759fd70544e4a
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.12.7, @babel/parser@npm:^7.14.5, @babel/parser@npm:^7.14.7":
+  version: 7.14.7
+  resolution: "@babel/parser@npm:7.14.7"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 0d7acc8cf9c19ccd0e80ab0608953f32f4375f3867c080211270e7bb4bb94c551fd1fc3f49b3cc92a4eec356cf507801f5c93c4c72996968bdc4c28815fe0550
   languageName: node
   linkType: hard
 
@@ -946,6 +1059,19 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 9449913e8724ef24cefef39886a6a8168015bef336de4c9b167aeeef6ceef03debc615dfbb8f657546bcd2bef611337e0fb4f7f10bce55e78c25010b7acef8e7
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-proposal-object-rest-spread@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@babel/plugin-proposal-object-rest-spread@npm:7.12.1"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+    "@babel/plugin-syntax-object-rest-spread": ^7.8.0
+    "@babel/plugin-transform-parameters": ^7.12.1
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: 221a41630c9a7162bf0416c71695b3f7f38482078a1d0d3af7abdc4f07ea1c9feed890399158d56c1d0278c971fe6f565ce822e9351e4481f7d98e9ff735dced
   languageName: node
   linkType: hard
 
@@ -1159,6 +1285,17 @@ __metadata:
   peerDependencies:
     "@babel/core": ^7.0.0-0
   checksum: 89dca777c5c203342506c27ac0770e0203c7af154800880739d62abb1b1b82de42a7de2eb63ba417f3a922d60a8bcaffc473a9f78ab76b68e9637127eb19afce
+  languageName: node
+  linkType: hard
+
+"@babel/plugin-syntax-jsx@npm:7.12.1":
+  version: 7.12.1
+  resolution: "@babel/plugin-syntax-jsx@npm:7.12.1"
+  dependencies:
+    "@babel/helper-plugin-utils": ^7.10.4
+  peerDependencies:
+    "@babel/core": ^7.0.0-0
+  checksum: d4b9b589c484b2e0856799770f060dff34c67b24d7f4526f66309a0e0e9cf388a5c1f2c0da329d1973cc87d1b2cede8f3dc8facfac59e785d6393a003bcdd0f9
   languageName: node
   linkType: hard
 
@@ -2305,6 +2442,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/template@npm:^7.12.7, @babel/template@npm:^7.14.5":
+  version: 7.14.5
+  resolution: "@babel/template@npm:7.14.5"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/parser": ^7.14.5
+    "@babel/types": ^7.14.5
+  checksum: 4939199c5b1ca8940e14c87f30f4fab5f35c909bef88447131075349027546927b4e3e08e50db5c2db2024f2c6585a4fe571c739c835ac980f7a4ada2dd8a623
+  languageName: node
+  linkType: hard
+
 "@babel/traverse@npm:7.12.13":
   version: 7.12.13
   resolution: "@babel/traverse@npm:7.12.13::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftraverse%2F-%2Ftraverse-7.12.13.tgz"
@@ -2339,6 +2487,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/traverse@npm:^7.12.9, @babel/traverse@npm:^7.14.5":
+  version: 7.14.7
+  resolution: "@babel/traverse@npm:7.14.7"
+  dependencies:
+    "@babel/code-frame": ^7.14.5
+    "@babel/generator": ^7.14.5
+    "@babel/helper-function-name": ^7.14.5
+    "@babel/helper-hoist-variables": ^7.14.5
+    "@babel/helper-split-export-declaration": ^7.14.5
+    "@babel/parser": ^7.14.7
+    "@babel/types": ^7.14.5
+    debug: ^4.1.0
+    globals: ^11.1.0
+  checksum: 11e9162e46bdd6daef8691facbf5c47838f6e312ac775be35c40353c77887338d1b9ce497211d2ae96628a9230551f03eb3df49b4ca53b6f668082f2c157d1a0
+  languageName: node
+  linkType: hard
+
 "@babel/types@npm:7.12.13":
   version: 7.12.13
   resolution: "@babel/types@npm:7.12.13::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40babel%2Ftypes%2F-%2Ftypes-7.12.13.tgz"
@@ -2358,6 +2523,16 @@ __metadata:
     lodash: ^4.17.19
     to-fast-properties: ^2.0.0
   checksum: 3dbb08add345325a49e1deebefa8d3774a8ab055c4be675c339a389358f4b3443652ded4bfdb230b342c6af12593a6fd3fb95156564e7ec84081018815896821
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.12.7":
+  version: 7.14.5
+  resolution: "@babel/types@npm:7.14.5"
+  dependencies:
+    "@babel/helper-validator-identifier": ^7.14.5
+    to-fast-properties: ^2.0.0
+  checksum: 7c1ab6e8bdf438d44236034cab10f7d0f1971179bc405dca26733a9b89dd87dd692dc49a238a7495075bc41a9a17fb6f08b4d1da45ea6ddcce1e5c8593574aea
   languageName: node
   linkType: hard
 
@@ -3232,6 +3407,13 @@ __metadata:
   version: 1.6.21
   resolution: "@mdx-js/util@npm:1.6.21::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40mdx-js%2Futil%2F-%2Futil-1.6.21.tgz"
   checksum: 1b4871fd65130ba9c3daa70b0db87784cbf16dfc25bbac040848f264c26029eeb4385bea7a605608b8d1f0f56395f8188088fc881135ec562165c25476ff61d0
+  languageName: node
+  linkType: hard
+
+"@mdx-js/util@npm:1.6.22":
+  version: 1.6.22
+  resolution: "@mdx-js/util@npm:1.6.22"
+  checksum: 4b393907e39a1a75214f0314bf72a0adfa5e5adffd050dd5efe9c055b8549481a3cfc9f308c16dfb33311daf3ff63added7d5fd1fe52db614c004f886e0e559a
   languageName: node
   linkType: hard
 
@@ -7102,8 +7284,11 @@ __metadata:
     "@teambit/evangelist.surfaces.tooltip": 1.0.1
     "@teambit/harmony": 0.2.11
     "@teambit/legacy": 1.0.109
+<<<<<<< Updated upstream
     "@teambit/mdx.ui.mdx-scope-context": 0.0.368
     "@teambit/network.agent": 0.0.1
+=======
+>>>>>>> Stashed changes
     "@teambit/react.instructions.react.adding-compositions": 0.0.5
     "@teambit/react.instructions.react.adding-tests": 0.0.5
     "@teambit/string.ellipsis": 0.0.7
@@ -7150,7 +7335,7 @@ __metadata:
     "@types/object-hash": 1.3.4
     "@types/pino": 6.3.6
     "@types/puppeteer": 3.0.5
-    "@types/react": ^17.0.8
+    "@types/react": 17.0.8
     "@types/react-dom": ^17.0.5
     "@types/react-router-dom": 5.1.7
     "@types/react-tabs": 2.3.2
@@ -7249,6 +7434,7 @@ __metadata:
     eslint-plugin-import: 2.22.1
     eslint-plugin-jest: 24.1.5
     eslint-plugin-jsx-a11y: 6.4.1
+    eslint-plugin-mdx: 1.13.0
     eslint-plugin-mocha: 6.3.0
     eslint-plugin-promise: 4.3.1
     eslint-plugin-react: 7.22.0
@@ -7505,6 +7691,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+<<<<<<< Updated upstream
 "@teambit/mdx.ui.mdx-scope-context@npm:0.0.368":
   version: 0.0.368
   resolution: "@teambit/mdx.ui.mdx-scope-context@npm:0.0.368"
@@ -7518,6 +7705,8 @@ __metadata:
   languageName: node
   linkType: hard
 
+=======
+>>>>>>> Stashed changes
 "@teambit/model.composition-id@npm:0.0.259":
   version: 0.0.259
   resolution: "@teambit/model.composition-id@npm:0.0.259::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fmodel.composition-id%2F-%2Fmodel.composition-id-0.0.259.tgz"
@@ -7544,38 +7733,6 @@ __metadata:
     react: ^16.13.1
     react-dom: ^16.13.1
   checksum: 04a8e8a88cbbba7296705a0e8145d1e8f5cdd1e5264bfe0a9a9c87c5451b46d2a45bd879aa9986bafa65783036a489329e2f600db11603d9ce72c646a87cf828
-  languageName: node
-  linkType: hard
-
-"@teambit/network.agent@npm:0.0.1":
-  version: 0.0.1
-  resolution: "@teambit/network.agent@npm:0.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fnetwork.agent%2F-%2Fnetwork.agent-0.0.1.tgz"
-  dependencies:
-    "@teambit/network.proxy-agent": 0.0.1
-    agentkeepalive: 4.1.4
-    core-js: 3.8.3
-  peerDependencies:
-    "@teambit/legacy": 1.0.38
-    react: 16.13.1
-    react-dom: 16.13.1
-  checksum: 5cea7497801060f00ad8cd090a8861383dd2d043b4df4a91c08369ebd18943b463c9fe9c06dbf4b3b1daf00b2281252cf84db5cd1a2b84e1fdcc6f08b81304b5
-  languageName: node
-  linkType: hard
-
-"@teambit/network.proxy-agent@npm:0.0.1":
-  version: 0.0.1
-  resolution: "@teambit/network.proxy-agent@npm:0.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2F%40teambit%2Fnetwork.proxy-agent%2F-%2Fnetwork.proxy-agent-0.0.1.tgz"
-  dependencies:
-    "@teambit/network.agent": 0.0.1
-    core-js: 3.8.3
-    http-proxy-agent: 4.0.1
-    https-proxy-agent: 5.0.0
-    socks-proxy-agent: 5.0.0
-  peerDependencies:
-    "@teambit/legacy": 1.0.38
-    react: 16.13.1
-    react-dom: 16.13.1
-  checksum: d9b2008ddbe2eb2043b50b44c75ca70ca44c9e6583674925915edfc23087d0fbd9e8bb5bd8475c06345a0c3b5661265d8a12c5d893e930508c4b6b284addfef9
   languageName: node
   linkType: hard
 
@@ -8694,14 +8851,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+<<<<<<< Updated upstream
 "@types/react@npm:^17.0.8":
   version: 17.0.11
   resolution: "@types/react@npm:17.0.11"
+=======
+"@types/react@npm:17.0.8":
+  version: 17.0.8
+  resolution: "@types/react@npm:17.0.8"
+>>>>>>> Stashed changes
   dependencies:
     "@types/prop-types": "*"
     "@types/scheduler": "*"
     csstype: ^3.0.2
-  checksum: 89e80ee8e08988abca0266e5e131f57b2e18f326bebfa0ed0a06b0bca29621a5a8202d617254a053f659b9c18090c52cae0aa475a6c6036b8858030f1d448e47
+  checksum: 6398dc200623dbf213747f3a1cf9f3c3bcac29b519e49c9fcb81d2665dadb21155c485381cddbb04b483a5bf3ddddefaff1a1a6ef4fa5080b1b9b144c789673e
   languageName: node
   linkType: hard
 
@@ -13245,6 +13408,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"character-entities-html4@npm:^1.0.0":
+  version: 1.1.4
+  resolution: "character-entities-html4@npm:1.1.4"
+  checksum: 22536aba07a378a2326420423ceadd65c0121032c527f80e84dfc648381992ed5aa666d7c2b267cd269864b3682d5b0315fc2f03a9e7c017d1a96d24ec292d5f
+  languageName: node
+  linkType: hard
+
 "character-entities-legacy@npm:^1.0.0":
   version: 1.1.4
   resolution: "character-entities-legacy@npm:1.1.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fcharacter-entities-legacy%2F-%2Fcharacter-entities-legacy-1.1.4.tgz"
@@ -15356,6 +15526,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.0.0":
+  version: 4.3.2
+  resolution: "debug@npm:4.3.2"
+  dependencies:
+    ms: 2.1.2
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 820ea160e267e23c953c9ed87e7ad93494d8cda2f7349af5e7e3bb236d23707ee3022f477d5a7d2ee86ef2bf7d60aa9ab22d1f58080d7deb9dccd073585e1e43
+  languageName: node
+  linkType: hard
+
 "debug@npm:~4.1.0":
   version: 4.1.1
   resolution: "debug@npm:4.1.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fdebug%2F-%2Fdebug-4.1.1.tgz"
@@ -16860,6 +17042,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-mdx@npm:^1.13.0":
+  version: 1.13.0
+  resolution: "eslint-mdx@npm:1.13.0"
+  dependencies:
+    remark-mdx: ^1.6.22
+    remark-parse: ^8.0.3
+    tslib: ^2.2.0
+    unified: ^9.2.1
+  peerDependencies:
+    eslint: ">=5.0.0"
+  checksum: 091cf47b8a375381c7776502e723befbe3382cea0493b3cbe927273cb4950a5deb10e7673a8c8a75a501f98bc9791f70090bc1caad035ffd0803e6ec870c1d5a
+  languageName: node
+  linkType: hard
+
 "eslint-module-utils@npm:^2.6.0":
   version: 2.6.0
   resolution: "eslint-module-utils@npm:2.6.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Feslint-module-utils%2F-%2Feslint-module-utils-2.6.0.tgz"
@@ -16922,6 +17118,37 @@ __metadata:
   peerDependencies:
     eslint: ^3 || ^4 || ^5 || ^6 || ^7
   checksum: 30326276385b6029754fbca0a25140be0f2f84d263b38f794651acf973399ea316ab1b9d69dffb9b9807d2b47592ba4bc271a242edbb15abfc05d07b08060a7e
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-markdown@npm:^2.1.0":
+  version: 2.2.0
+  resolution: "eslint-plugin-markdown@npm:2.2.0"
+  dependencies:
+    mdast-util-from-markdown: ^0.8.5
+  peerDependencies:
+    eslint: ">=6.0.0"
+  checksum: 004e77a269c406e94196c0df62ae20ace629370d6416f1d0a5d3cee30208efe3190be11ac902d8ffdc307573805f47d5af294eb47dd0d8ebe72ba94de60b19a6
+  languageName: node
+  linkType: hard
+
+"eslint-plugin-mdx@npm:1.13.0":
+  version: 1.13.0
+  resolution: "eslint-plugin-mdx@npm:1.13.0"
+  dependencies:
+    cosmiconfig: ^7.0.0
+    eslint-mdx: ^1.13.0
+    eslint-plugin-markdown: ^2.1.0
+    remark-mdx: ^1.6.22
+    remark-parse: ^8.0.3
+    remark-stringify: ^8.1.1
+    synckit: ^0.1.5
+    tslib: ^2.2.0
+    unified: ^9.2.1
+    vfile: ^4.2.1
+  peerDependencies:
+    eslint: ">=5.0.0"
+  checksum: 631d08b086e6e81c2ed0f8043273d3d52a558f715795e04bc2269e3fb60154922b48fbe021cf74f426d2c889375f67d2d6b7ff5fa91febcaa5f4c117049bbf8e
   languageName: node
   linkType: hard
 
@@ -20782,6 +21009,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"is-alphanumeric@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "is-alphanumeric@npm:1.0.0"
+  checksum: 2f4f4f227fe4cae977529f628021655edc172e1e5debfb3c30efd547f32e8d390c9bb7a71f3e9fea4187fe6598980072323d5a1b1abd3368379e33ba6504558c
+  languageName: node
+  linkType: hard
+
 "is-alphanumerical@npm:^1.0.0":
   version: 1.0.4
   resolution: "is-alphanumerical@npm:1.0.4::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fis-alphanumerical%2F-%2Fis-alphanumerical-1.0.4.tgz"
@@ -23471,6 +23705,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"longest-streak@npm:^2.0.1":
+  version: 2.0.4
+  resolution: "longest-streak@npm:2.0.4"
+  checksum: 28b8234a14963002c5c71035dee13a0a11e9e9d18ffa320fdc8796ed7437399204495702ed69cd2a7087b0af041a2a8b562829b7c1e2042e73a3374d1ecf6580
+  languageName: node
+  linkType: hard
+
 "loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Floose-envify%2F-%2Floose-envify-1.4.0.tgz"
@@ -23720,6 +23961,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"markdown-table@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "markdown-table@npm:2.0.0"
+  dependencies:
+    repeat-string: ^1.0.0
+  checksum: 9bb634a9300016cbb41216c1eab44c74b6b7083ac07872e296f900a29449cf0e260ece03fa10c3e9784ab94c61664d1d147da0315f95e1336e2bdcc025615c90
+  languageName: node
+  linkType: hard
+
 "marked@npm:1.1.1":
   version: 1.1.1
   resolution: "marked@npm:1.1.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmarked%2F-%2Fmarked-1.1.1.tgz"
@@ -23784,12 +24034,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"mdast-util-compact@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "mdast-util-compact@npm:2.0.1"
+  dependencies:
+    unist-util-visit: ^2.0.0
+  checksum: 750cc76e46223d2dadf86835d415d4954566572e6af5a8df5577065e5f863dda46c30767e12e29c4ec53cf2e7040863b0279d44af357e8b36f5983d78a73dceb
+  languageName: node
+  linkType: hard
+
 "mdast-util-definitions@npm:^3.0.0":
   version: 3.0.1
   resolution: "mdast-util-definitions@npm:3.0.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmdast-util-definitions%2F-%2Fmdast-util-definitions-3.0.1.tgz"
   dependencies:
     unist-util-visit: ^2.0.0
   checksum: 917112396b4d73a5b6f9310250caf26c54b351f9ab8a634919004cc8adf577ac681c314e6b7360237a65e6639c3b554fed3db3a303f0193e49bd756be682bcbb
+  languageName: node
+  linkType: hard
+
+"mdast-util-from-markdown@npm:^0.8.5":
+  version: 0.8.5
+  resolution: "mdast-util-from-markdown@npm:0.8.5"
+  dependencies:
+    "@types/mdast": ^3.0.0
+    mdast-util-to-string: ^2.0.0
+    micromark: ~2.11.0
+    parse-entities: ^2.0.0
+    unist-util-stringify-position: ^2.0.0
+  checksum: 5a9d0d753a42db763761e874c22365d0c7c9934a5a18b5ff76a0643610108a208a041ffdb2f3d3dd1863d3d915225a4020a0aade282af0facfd0df110601eee6
   languageName: node
   linkType: hard
 
@@ -23806,6 +24078,13 @@ __metadata:
     unist-util-position: ^3.0.0
     unist-util-visit: ^2.0.0
   checksum: 6eba44daefcc4cc7760018bbe2befd3ad212762ec489d1b05913aa43d645fe062e61cad8e3f15070a79c54ecf0960f47d1f35c5dbd1d4ea3f9ad1ae200bc8232
+  languageName: node
+  linkType: hard
+
+"mdast-util-to-string@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "mdast-util-to-string@npm:2.0.0"
+  checksum: 0b2113ada10e002fbccb014170506dabe2f2ddacaacbe4bc1045c33f986652c5a162732a2c057c5335cdb58419e2ad23e368e5be226855d4d4e280b81c4e9ec2
   languageName: node
   linkType: hard
 
@@ -24023,6 +24302,16 @@ __metadata:
   version: 0.1.1
   resolution: "microevent.ts@npm:0.1.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fmicroevent.ts%2F-%2Fmicroevent.ts-0.1.1.tgz"
   checksum: 7874fcdb3f0dfa4e996d3ea63b3b9882874ae7d22be28d51ae20da24c712e9e28e5011d988095c27dd2b32e37c0ad7425342a71b89adb8e808ec7194fadf4a7a
+  languageName: node
+  linkType: hard
+
+"micromark@npm:~2.11.0":
+  version: 2.11.4
+  resolution: "micromark@npm:2.11.4"
+  dependencies:
+    debug: ^4.0.0
+    parse-entities: ^2.0.0
+  checksum: f8a5477d394908a5d770227aea71657a76423d420227c67ea0699e659a5f62eb39d504c1f7d69ec525a6af5aaeb6a7bffcdba95614968c03d41d3851edecb0d6
   languageName: node
   linkType: hard
 
@@ -28971,9 +29260,49 @@ __metadata:
   languageName: node
   linkType: hard
 
+"remark-mdx@npm:^1.6.22":
+  version: 1.6.22
+  resolution: "remark-mdx@npm:1.6.22"
+  dependencies:
+    "@babel/core": 7.12.9
+    "@babel/helper-plugin-utils": 7.10.4
+    "@babel/plugin-proposal-object-rest-spread": 7.12.1
+    "@babel/plugin-syntax-jsx": 7.12.1
+    "@mdx-js/util": 1.6.22
+    is-alphabetical: 1.0.4
+    remark-parse: 8.0.3
+    unified: 9.2.0
+  checksum: 45e62f8a821c37261f94448d54f295de1c5c393f762ff96cd4d4b730715037fafeb6c89ef94adf6a10a09edfa72104afe1431b93b5ae5e40ce2a7677e133c3d9
+  languageName: node
+  linkType: hard
+
 "remark-parse@npm:8.0.3":
   version: 8.0.3
   resolution: "remark-parse@npm:8.0.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fremark-parse%2F-%2Fremark-parse-8.0.3.tgz"
+  dependencies:
+    ccount: ^1.0.0
+    collapse-white-space: ^1.0.2
+    is-alphabetical: ^1.0.0
+    is-decimal: ^1.0.0
+    is-whitespace-character: ^1.0.0
+    is-word-character: ^1.0.0
+    markdown-escapes: ^1.0.0
+    parse-entities: ^2.0.0
+    repeat-string: ^1.5.4
+    state-toggle: ^1.0.0
+    trim: 0.0.1
+    trim-trailing-lines: ^1.0.0
+    unherit: ^1.0.4
+    unist-util-remove-position: ^2.0.0
+    vfile-location: ^3.0.0
+    xtend: ^4.0.1
+  checksum: 2dfea250e7606ddfc9e223b9f41e0b115c5c701be4bd35181beaadd46ee59816bc00aadc6085a420f8df00b991ada73b590ea7fd34ace14557de4a0a41805be5
+  languageName: node
+  linkType: hard
+
+"remark-parse@npm:^8.0.3":
+  version: 8.0.3
+  resolution: "remark-parse@npm:8.0.3"
   dependencies:
     ccount: ^1.0.0
     collapse-white-space: ^1.0.2
@@ -29001,6 +29330,28 @@ __metadata:
   dependencies:
     mdast-squeeze-paragraphs: ^4.0.0
   checksum: 2071eb74d0ecfefb152c4932690a9fd950c3f9f798a676f1378a16db051da68fb20bf288688cc153ba5019dded35408ff45a31dfe9686eaa7a9f1df9edbb6c81
+  languageName: node
+  linkType: hard
+
+"remark-stringify@npm:^8.1.1":
+  version: 8.1.1
+  resolution: "remark-stringify@npm:8.1.1"
+  dependencies:
+    ccount: ^1.0.0
+    is-alphanumeric: ^1.0.0
+    is-decimal: ^1.0.0
+    is-whitespace-character: ^1.0.0
+    longest-streak: ^2.0.1
+    markdown-escapes: ^1.0.0
+    markdown-table: ^2.0.0
+    mdast-util-compact: ^2.0.0
+    parse-entities: ^2.0.0
+    repeat-string: ^1.5.4
+    state-toggle: ^1.0.0
+    stringify-entities: ^3.0.0
+    unherit: ^1.0.4
+    xtend: ^4.0.1
+  checksum: 9a556e5a0dc26db151694a5d0a1dcd0f21bd7e619b3934d677876a633ad01a03e38f5cf174ff5468ec755d5a9398f4fbccac4788e04f5bcab8bb2583eddbc1b3
   languageName: node
   linkType: hard
 
@@ -29050,6 +29401,13 @@ __metadata:
   version: 1.1.3
   resolution: "repeat-element@npm:1.1.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Frepeat-element%2F-%2Frepeat-element-1.1.3.tgz"
   checksum: 0743a136b484117016ad587577ede60a3ffe604b74e57bd5d7d0aa041fe2f1c956e6b2f3ff83c86f4db9fac022c3fa2da8e58b9d3618b8b4cb1c3d041bcc422f
+  languageName: node
+  linkType: hard
+
+"repeat-string@npm:^1.0.0":
+  version: 1.6.1
+  resolution: "repeat-string@npm:1.6.1"
+  checksum: 1b809fc6db97decdc68f5b12c4d1a671c8e3f65ec4a40c238bc5200e44e85bcc52a54f78268ab9c29fcf5fe4f1343e805420056d1f30fa9a9ee4c2d93e3cc6c0
   languageName: node
   linkType: hard
 
@@ -31271,6 +31629,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"stringify-entities@npm:^3.0.0":
+  version: 3.1.0
+  resolution: "stringify-entities@npm:3.1.0"
+  dependencies:
+    character-entities-html4: ^1.0.0
+    character-entities-legacy: ^1.0.0
+    xtend: ^4.0.0
+  checksum: 5b6212e2985101ddb8197d999a6c01abb610f2ba6efd6f8f7d7ec763b61cb08b55735b03febdf501c2091f484df16bc82412419ef35ee21135548f6a15881044
+  languageName: node
+  linkType: hard
+
 "stringify-object@npm:^3.2.1, stringify-object@npm:^3.3.0":
   version: 3.3.0
   resolution: "stringify-object@npm:3.3.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fstringify-object%2F-%2Fstringify-object-3.3.0.tgz"
@@ -31689,6 +32058,16 @@ __metadata:
     buffer: ^5.7.0
     node-fetch: ^2.6.1
   checksum: 42a9cca3b2ad22ab8baf33347fb43598a8d07783e6272bb9ad6de27d9913b8e5249effc4345c9911409e234fdef75e0ad29a7244995d7ad3e2b792f0f2597d01
+  languageName: node
+  linkType: hard
+
+"synckit@npm:^0.1.5":
+  version: 0.1.5
+  resolution: "synckit@npm:0.1.5"
+  dependencies:
+    tslib: ^2.2.0
+    uuid: ^8.3.2
+  checksum: 1437fc1a6d242a74c7d8d990bf770e49d19a6b85f2cc439997999d16edd7951a187037b3f430f0578d76309a14c328ef6a07b71c2f703e0690379bde1f2bebd4
   languageName: node
   linkType: hard
 
@@ -32409,6 +32788,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tslib@npm:^2.2.0":
+  version: 2.3.0
+  resolution: "tslib@npm:2.3.0"
+  checksum: 8869694c26e4a7b56d449662fd54a4f9ba872c889d991202c74462bd99f10e61d5bd63199566c4284c0f742277736292a969642cc7b590f98727a7cae9529122
+  languageName: node
+  linkType: hard
+
 "tslib@npm:~2.0.1":
   version: 2.0.3
   resolution: "tslib@npm:2.0.3::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Ftslib%2F-%2Ftslib-2.0.3.tgz"
@@ -32893,6 +33279,20 @@ typescript@^3.9.3:
     trough: ^1.0.0
     vfile: ^4.0.0
   checksum: 0cac4ae119893fbd49d309b4db48595e4d4e9f0a2dc1dde4d0074059f9a46012a2905f37c1346715e583f30c970bc8078db8462675411d39ff5036ae18b4fb8a
+  languageName: node
+  linkType: hard
+
+"unified@npm:^9.2.1":
+  version: 9.2.1
+  resolution: "unified@npm:9.2.1"
+  dependencies:
+    bail: ^1.0.0
+    extend: ^3.0.0
+    is-buffer: ^2.0.0
+    is-plain-obj: ^2.0.0
+    trough: ^1.0.0
+    vfile: ^4.0.0
+  checksum: 786b0e1847d358fef9d262eb68997ef39446682ecfccf659784b7d06952803c6ff642fc8fb9d9d738472a20b475b95294b5b03f45e70ca1e396d75d7ba9c5abc
   languageName: node
   linkType: hard
 
@@ -33480,6 +33880,15 @@ typescript@^3.9.3:
   languageName: node
   linkType: hard
 
+"uuid@npm:^8.3.2":
+  version: 8.3.2
+  resolution: "uuid@npm:8.3.2"
+  bin:
+    uuid: dist/bin/uuid
+  checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
+  languageName: node
+  linkType: hard
+
 "v8-compile-cache@npm:2.2.0, v8-compile-cache@npm:^2.0.3":
   version: 2.2.0
   resolution: "v8-compile-cache@npm:2.2.0::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fv8-compile-cache%2F-%2Fv8-compile-cache-2.2.0.tgz"
@@ -33694,6 +34103,18 @@ typescript@^3.9.3:
 "vfile@npm:^4.0.0":
   version: 4.2.1
   resolution: "vfile@npm:4.2.1::__archiveUrl=https%3A%2F%2Fregistry.npmjs.org%2Fvfile%2F-%2Fvfile-4.2.1.tgz"
+  dependencies:
+    "@types/unist": ^2.0.0
+    is-buffer: ^2.0.0
+    unist-util-stringify-position: ^2.0.0
+    vfile-message: ^2.0.0
+  checksum: ee5726e10d170472cde778fc22e0f7499caa096eb85babea5d0ce0941455b721037ee1c9e6ae506ca2803250acd313d0f464328ead0b55cfe7cb6315f1b462d6
+  languageName: node
+  linkType: hard
+
+"vfile@npm:^4.2.1":
+  version: 4.2.1
+  resolution: "vfile@npm:4.2.1"
   dependencies:
     "@types/unist": ^2.0.0
     is-buffer: ^2.0.0


### PR DESCRIPTION
## Proposed Changes

- change eslintrc.ts to eslintrc.js in react env
- fix linter extensions formats
- add eslint-plugin-mdx as dependency to react env
- use the `eslint-config-airbnb-typescript` only for ts/js files (including jsx/tsx/mjs)
- add md/mdx rules to react env linting config, using the plugin:mdx/recommended
