### PR TITLE
Add auth headers to scoped registries point to bit.dev registry

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -628,6 +628,7 @@ export class DependencyResolverMain {
         );
         updatedRegistries = updatedRegistries.updateScopedRegistry(name, registryWithAuth);
       }
+      return updatedRegistries;
     });
     return updatedRegistries;
   }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -570,20 +570,9 @@ export class DependencyResolverMain {
     const bitScope = registries.scopes.bit;
 
     const getDefaultBitRegistry = (): Registry => {
-      const bitGlobalConfigToken = this.globalConfig.getSync(CFG_USER_TOKEN_KEY);
-
       const bitRegistry = bitScope?.uri || BIT_DEV_REGISTRY;
 
-      let bitAuthHeaderValue = bitScope?.authHeaderValue;
-      let bitOriginalAuthType = bitScope?.originalAuthType;
-      let bitOriginalAuthValue = bitScope?.originalAuthValue;
-
-      // In case there is no auth configuration in the npmrc, but there is token in bit config, take it from the config
-      if ((!bitScope || !bitScope.authHeaderValue) && bitGlobalConfigToken) {
-        bitOriginalAuthType = 'authToken';
-        bitAuthHeaderValue = `Bearer ${bitGlobalConfigToken}`;
-        bitOriginalAuthValue = bitGlobalConfigToken;
-      }
+      const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig(bitScope);
 
       const alwaysAuth = bitAuthHeaderValue !== undefined;
       const bitDefaultRegistry = new Registry(
@@ -617,7 +606,52 @@ export class DependencyResolverMain {
       registries = registries.updateScopedRegistry('bit', bitDefaultRegistry);
     }
 
+    registries = this.addAuthToScopedBitRegistries(registries, bitScope);
     return registries;
+  }
+
+  /**
+   * This will mutate any registry which point to BIT_DEV_REGISTRY to have the auth config from the @bit scoped registry or from the user.token in bit's config
+   */
+  private addAuthToScopedBitRegistries(registries: Registries, bitScopeRegistry: Registry): Registries {
+    const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig(bitScopeRegistry);
+    const alwaysAuth = bitAuthHeaderValue !== undefined;
+    let updatedRegistries = registries;
+    Object.entries(registries.scopes).map(([name, registry]) => {
+      if (!registry.authHeaderValue && BIT_DEV_REGISTRY.includes(registry.uri)) {
+        const registryWithAuth = new Registry(
+          registry.uri,
+          alwaysAuth,
+          bitAuthHeaderValue,
+          bitOriginalAuthType,
+          bitOriginalAuthValue
+        );
+        updatedRegistries = updatedRegistries.updateScopedRegistry(name, registryWithAuth);
+      }
+    });
+    return updatedRegistries;
+  }
+
+  private getBitAuthConfig(
+    bitScopeRegistry: Registry
+  ): Partial<{ bitOriginalAuthType: string; bitAuthHeaderValue: string; bitOriginalAuthValue: string }> {
+    const bitGlobalConfigToken = this.globalConfig.getSync(CFG_USER_TOKEN_KEY);
+    let bitAuthHeaderValue = bitScopeRegistry?.authHeaderValue;
+    let bitOriginalAuthType = bitScopeRegistry?.originalAuthType;
+    let bitOriginalAuthValue = bitScopeRegistry?.originalAuthValue;
+
+    // In case there is no auth configuration in the npmrc, but there is token in bit config, take it from the config
+    if ((!bitScopeRegistry || !bitScopeRegistry.authHeaderValue) && bitGlobalConfigToken) {
+      bitOriginalAuthType = 'authToken';
+      bitAuthHeaderValue = `Bearer ${bitGlobalConfigToken}`;
+      bitOriginalAuthValue = bitGlobalConfigToken;
+    }
+
+    return {
+      bitOriginalAuthType,
+      bitAuthHeaderValue,
+      bitOriginalAuthValue,
+    };
   }
 
   get packageManagerName(): string {


### PR DESCRIPTION
With this PR if you have a scoped registry that points to bit.dev registry configured in your npmrc file, bit will know automatically to send it with bit's token without you need to configure it manually.
for example, let's say you have this entry in your .npmrc file
`@my-org-bit:registry=https://node.bit.dev`

Bit will take its auth token from (ordered)
A token defined for the `@bit` scoped registry, or bit's `user.token` as defined in your bit global config