### PR TITLE
allow customizing the metadata/front-matter of the .md file generated by bit cli generate

### DIFF
--- a/scopes/harmony/cli/cli.cmd.ts
+++ b/scopes/harmony/cli/cli.cmd.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line max-classes-per-file
 import { Command, CommandOptions } from '@teambit/cli';
 import logger from '@teambit/legacy/dist/logger/logger';
 import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
@@ -5,21 +6,41 @@ import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
 import readline from 'readline';
 import { CLIParser } from './cli-parser';
 import { CLIMain } from './cli.main.runtime';
-import { GenerateCommandsDoc } from './generate-doc-md';
+import { GenerateCommandsDoc, GenerateOpts } from './generate-doc-md';
 
-export class CliCmd implements Command {
-  name = 'cli';
-  description = 'EXPERIMENTAL. enters bit cli program';
+export class CliGenerateCmd implements Command {
+  name = 'generate';
+  description = 'EXPERIMENTAL. generate an .md file with all commands details';
   alias = '';
   loader = false;
   group = 'general';
-  options = [['', 'generate', 'generate an .md file with all commands details']] as CommandOptions;
+  options = [
+    [
+      '',
+      'metadata',
+      'metadata/front-matter to place at the top of the .md file, enter as an object e.g. --metadata.id=cli --metadata.title=commands',
+    ],
+  ] as CommandOptions;
 
   constructor(private cliMain: CLIMain) {}
 
-  async report(args, { generate }: { generate: boolean }): Promise<string> {
-    if (generate) return new GenerateCommandsDoc(this.cliMain.commands).generate();
+  async report(args, { metadata }: GenerateOpts): Promise<string> {
+    return new GenerateCommandsDoc(this.cliMain.commands, { metadata }).generate();
+  }
+}
 
+export class CliCmd implements Command {
+  name = 'cli';
+  description = 'EXPERIMENTAL. enters bit cli program and generate commands list';
+  alias = '';
+  commands: Command[] = [];
+  loader = false;
+  group = 'general';
+  options = [] as CommandOptions;
+
+  constructor(private cliMain: CLIMain) {}
+
+  async report(): Promise<string> {
     logger.isDaemon = true;
     const rl = readline.createInterface({
       input: process.stdin,

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -10,7 +10,7 @@ import { getCommandId } from './get-command-id';
 import { LegacyCommandAdapter } from './legacy-command-adapter';
 import { CLIParser } from './cli-parser';
 import { CompletionCmd } from './completion.cmd';
-import { CliCmd } from './cli.cmd';
+import { CliCmd, CliGenerateCmd } from './cli.cmd';
 import { HelpCmd } from './help.cmd';
 
 export type CommandList = Array<Command>;
@@ -128,8 +128,10 @@ export class CLIMain {
     const legacyRegistry = buildRegistry(extensionsCommands);
     const legacyCommands = legacyRegistry.commands.concat(legacyRegistry.extensionsCommands || []);
     const legacyCommandsAdapters = legacyCommands.map((command) => new LegacyCommandAdapter(command, cliMain));
+    const cliGenerateCmd = new CliGenerateCmd(cliMain);
     const cliCmd = new CliCmd(cliMain);
     const helpCmd = new HelpCmd(cliMain);
+    cliCmd.commands.push(cliGenerateCmd);
     cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd, helpCmd);
     return cliMain;
   }

--- a/scopes/harmony/cli/generate-doc-md.ts
+++ b/scopes/harmony/cli/generate-doc-md.ts
@@ -2,14 +2,24 @@ import { Command } from '@teambit/legacy/dist/cli/command';
 import { CommandOptions } from '@teambit/legacy/dist/cli/legacy-command';
 import { getCommandId } from './get-command-id';
 
+export type GenerateOpts = {
+  metadata?: Record<string, string>;
+};
 export class GenerateCommandsDoc {
-  constructor(private commands: Command[]) {}
+  constructor(private commands: Command[], private options: GenerateOpts) {}
 
   generate(): string {
     const commands = this.getAllPublicCommands();
+    const metadata = {
+      id: 'cli-all',
+      title: 'CLI Commands',
+      ...this.options.metadata,
+    };
+    const metadataStr = Object.keys(metadata)
+      .map((key) => `${key}: ${metadata[key]}`)
+      .join('\n');
     let output = `---
-id: cli-all
-title: CLI Commands
+${metadataStr}
 ---
 
 Commands that are marked as workspace only must be executed inside a workspace. Commands that are marked as not workspace only, can be executed from anywhere and will run on a remote server.


### PR DESCRIPTION
Also, change `generate` to be a sub-command of `bit cli`, rather than a flag.
