### PR TITLE
resolve custom aspects versions when they are aspect deps of another custom aspect

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
@@ -9,6 +9,10 @@ export interface DependenciesManifest {
   devDependencies?: LifecycleDependenciesManifest;
   peerDependencies?: LifecycleDependenciesManifest;
 }
+
+export type FindDependencyOptions = {
+  ignoreVersion?: boolean;
+};
 export class DependencyList {
   constructor(private _dependencies: Array<Dependency>) {
     this._dependencies = uniqDeps(_dependencies);
@@ -22,8 +26,13 @@ export class DependencyList {
   /**
    * @param componentIdStr complete string include the scope and the version
    */
-  findDependency(componentIdStr: string): Dependency | undefined {
-    return this.dependencies.find((dep) => dep.id === componentIdStr);
+  findDependency(componentIdStr: string, opts: FindDependencyOptions = {}): Dependency | undefined {
+    const ignoreVersion = opts.ignoreVersion;
+    if (!ignoreVersion) {
+      return this.dependencies.find((dep) => dep.id === componentIdStr);
+    }
+    const componentIdStrWithoutVersion = removeVersion(componentIdStr);
+    return this.dependencies.find((dep) => removeVersion(dep.id) === componentIdStrWithoutVersion);
   }
 
   forEach(predicate: (dep: Dependency, index?: number) => void): void {
@@ -94,4 +103,8 @@ export class DependencyList {
 function uniqDeps(dependencies: Array<Dependency>): Array<Dependency> {
   const uniq = uniqBy(dependencies, property('id'));
   return uniq;
+}
+
+function removeVersion(id: string): string {
+  return id.split('@')[0];
 }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -1,10 +1,12 @@
+import mapSeries from 'p-map-series';
 import { MainRuntime } from '@teambit/cli';
 import ComponentAspect, { Component, ComponentMain } from '@teambit/component';
 import type { Config } from '@teambit/config';
 import { get } from 'lodash';
 import { ConfigAspect } from '@teambit/config';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
-import { Slot, SlotRegistry } from '@teambit/harmony';
+import { Slot, SlotRegistry, ExtensionManifest, Aspect, RuntimeManifest } from '@teambit/harmony';
+import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
 import type { LoggerMain } from '@teambit/logger';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { Logger, LoggerAspect } from '@teambit/logger';
@@ -778,6 +780,83 @@ export class DependencyResolverMain {
     return this;
   }
 
+  /**
+   * This function registered to the onLoadRequireableExtensionSlot of the aspect-loader
+   * Update the aspect / manifest deps versions in the runtimes (recursively)
+   * This function mutate the manifest directly as otherwise it becomes very complicated
+   * TODO: think if this funciton should be here as it about dependencies, or on the aspect loader
+   * (as it's aware of the internal structure of aspects)
+   * Maybe only register the dep resolution part to the aspect loader
+   * at the moment it here for simplify the process
+   * @param requireableExtension
+   * @param manifest
+   * @returns
+   */
+  async onLoadRequireableExtensionSubscriber(
+    requireableExtension: RequireableComponent,
+    manifest: ExtensionManifest | Aspect
+  ): Promise<ExtensionManifest | Aspect> {
+    const parentComponent = requireableExtension.component;
+    return this.resolveRequireableExtensionManifestDepsVersionsRecursively(parentComponent, manifest);
+  }
+
+  /**
+   * Update the aspect / manifest deps versions in the runtimes (recursively)
+   * @param parentComponent
+   * @param manifest
+   */
+  private async resolveRequireableExtensionManifestDepsVersionsRecursively(
+    // Allow getting here string for lazy load the component
+    // we only want to load the component in case there are deps to resolve
+    parentComponent: Component | string,
+    manifest: ExtensionManifest | Aspect
+    // TODO: add visited = new Map() for performence improve
+  ): Promise<ExtensionManifest | Aspect> {
+    // Not resolve it immediately for performance sake
+    let resolvedParentComponent: Component | undefined;
+    let resolvedParentDeps: DependencyList;
+    const updateDirectDepsVersions = (deps: Array<ExtensionManifest | Aspect>): Promise<void[]> => {
+      return mapSeries(deps, async (dep) => {
+        // Nothing to update (this shouldn't happen ever)
+        if (!dep.id) return;
+        // In case of core aspect, do not update the version, as it's loaded to harmony without version
+        if (this.aspectLoader.isCoreAspect(dep.id)) return;
+        // Lazily get the parent component
+        resolvedParentComponent =
+          typeof parentComponent === 'string'
+            ? await this.componentAspect.getHost().get(parentComponent)
+            : parentComponent;
+        if (!resolvedParentComponent) {
+          this.logger.error(
+            `could not resolve the component ${parentComponent} during manifest deps resolution. it shouldn't happen`
+          );
+          return;
+        }
+        // Lazily get the dependencies
+        resolvedParentDeps = resolvedParentDeps || (await this.getDependencies(resolvedParentComponent));
+        const resolvedDep = resolvedParentDeps.findDependency(dep.id, { ignoreVersion: true });
+        // TODO: add a way to update id in harmony
+        // @ts-ignore
+        dep.id = resolvedDep?.id ?? dep.id;
+        await this.resolveRequireableExtensionManifestDepsVersionsRecursively(dep.id, dep);
+      });
+    };
+    if (manifest.dependencies) {
+      await updateDirectDepsVersions(manifest.dependencies);
+    }
+    // TODO: add a function to get all runtimes and not access private member
+    // @ts-ignore
+    if (manifest._runtimes) {
+      // @ts-ignore
+      await mapSeries(manifest._runtimes, async (runtime: RuntimeManifest) => {
+        if (runtime.dependencies) {
+          await updateDirectDepsVersions(runtime.dependencies);
+        }
+      });
+    }
+    return manifest;
+  }
+
   static runtime = MainRuntime;
   static dependencies = [
     EnvsAspect,
@@ -882,6 +961,9 @@ export class DependencyResolverMain {
     });
     registerUpdateDependenciesOnTag(dependencyResolver.updateDepsOnLegacyTag.bind(dependencyResolver));
     registerUpdateDependenciesOnExport(dependencyResolver.updateDepsOnLegacyExport.bind(dependencyResolver));
+    aspectLoader.registerOnLoadRequireableExtensionSlot(
+      dependencyResolver.onLoadRequireableExtensionSubscriber.bind(dependencyResolver)
+    );
 
     graphql.register(dependencyResolverSchema(dependencyResolver));
 

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -7,7 +7,7 @@ import { Logger, LoggerAspect } from '@teambit/logger';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import mapSeries from 'p-map-series';
-import { difference } from 'lodash';
+import { difference, compact } from 'lodash';
 import { AspectDefinition, AspectDefinitionProps } from './aspect-definition';
 import { AspectLoaderAspect } from './aspect-loader.aspect';
 import { UNABLE_TO_LOAD_EXTENSION, UNABLE_TO_LOAD_EXTENSION_FROM_LIST } from './constants';
@@ -35,6 +35,15 @@ export type ResolvedAspect = {
 
 type OnAspectLoadError = (err: Error, id: ComponentID) => Promise<boolean>;
 export type OnAspectLoadErrorSlot = SlotRegistry<OnAspectLoadError>;
+
+export type OnLoadRequireableExtension = (
+  requireableExtension: RequireableComponent,
+  manifest: ExtensionManifest | Aspect
+) => Promise<ExtensionManifest | Aspect>;
+/**
+ * A slot which run during loading the requirable extension (after first manifest calculation)
+ */
+export type OnLoadRequireableExtensionSlot = SlotRegistry<OnLoadRequireableExtension>;
 
 export type MainAspect = {
   /**
@@ -73,7 +82,8 @@ export class AspectLoaderMain {
     private logger: Logger,
     private envs: EnvsMain,
     private harmony: Harmony,
-    private onAspectLoadErrorSlot: OnAspectLoadErrorSlot
+    private onAspectLoadErrorSlot: OnAspectLoadErrorSlot,
+    private onLoadRequireableExtensionSlot: OnLoadRequireableExtensionSlot
   ) {}
 
   private getCompiler(component: Component) {
@@ -83,6 +93,10 @@ export class AspectLoaderMain {
 
   registerOnAspectLoadErrorSlot(onAspectLoadError: OnAspectLoadError) {
     this.onAspectLoadErrorSlot.register(onAspectLoadError);
+  }
+
+  registerOnLoadRequireableExtensionSlot(onLoadRequireableExtension: OnLoadRequireableExtension) {
+    this.onLoadRequireableExtensionSlot.register(onLoadRequireableExtension);
   }
 
   /**
@@ -247,9 +261,10 @@ export class AspectLoaderMain {
       const aspect = await requireableExtension.require();
       const manifest = aspect.default || aspect;
       manifest.id = idStr;
-      return manifest;
+      const newManifest = await this.runOnLoadRequireableExtensionSubscribers(requireableExtension, manifest);
+      return newManifest;
     };
-    const manifestsP = requireableExtensions.map(async (requireableExtension) => {
+    const manifestsP = mapSeries(requireableExtensions, async (requireableExtension) => {
       if (!requireableExtensions) return undefined;
       const idStr = requireableExtension.component.id.toString();
       try {
@@ -283,20 +298,32 @@ export class AspectLoaderMain {
       }
       return undefined;
     });
-    const manifests = await Promise.all(manifestsP);
+    const manifests = await manifestsP;
 
     // Remove empty manifests as a result of loading issue
-    const filteredManifests = manifests.filter((manifest) => manifest);
+    const filteredManifests = compact(manifests);
     return this.loadExtensionsByManifests(filteredManifests, throwOnError);
   }
 
-  isAspect(manifest: any) {
-    return manifest.addRuntime && manifest.getRuntime;
+  async runOnLoadRequireableExtensionSubscribers(
+    requireableExtension: RequireableComponent,
+    manifest: ExtensionManifest | Aspect
+  ): Promise<ExtensionManifest | Aspect> {
+    let updatedManifest = manifest;
+    const entries = this.onLoadRequireableExtensionSlot.toArray();
+    await mapSeries(entries, async ([, onLoadRequireableExtensionFunc]) => {
+      updatedManifest = await onLoadRequireableExtensionFunc(requireableExtension, updatedManifest);
+    });
+    return updatedManifest;
   }
 
-  private prepareManifests(manifests: ExtensionManifest[]) {
+  isAspect(manifest: any) {
+    return !!(manifest.addRuntime && manifest.getRuntime);
+  }
+
+  private prepareManifests(manifests: Array<ExtensionManifest | Aspect>): Aspect[] {
     return manifests.map((manifest: any) => {
-      if (this.isAspect(manifest)) return manifest;
+      if (this.isAspect(manifest)) return manifest as Aspect;
       manifest.runtime = MainRuntime;
       if (!manifest.id) throw new Error('manifest must have static id');
       const aspect = Aspect.create({
@@ -308,14 +335,16 @@ export class AspectLoaderMain {
   }
 
   // TODO: change to use the new logger, see more info at loadExtensions function in the workspace
-  async loadExtensionsByManifests(extensionsManifests: ExtensionManifest[], throwOnError = true) {
+  async loadExtensionsByManifests(extensionsManifests: Array<ExtensionManifest | Aspect>, throwOnError = true) {
     try {
       const manifests = extensionsManifests.filter((manifest) => {
+        // @ts-ignore TODO: fix this
         const isValid = this.isAspect(manifest) || manifest.provider;
         if (!isValid) this.logger.warn(`${manifest.id} is invalid. please make sure the extension is valid.`);
         return isValid;
       });
       const preparedManifests = this.prepareManifests(manifests);
+      // @ts-ignore TODO: fix this
       await this.harmony.load(preparedManifests);
     } catch (e) {
       const ids = extensionsManifests.map((manifest) => manifest.id || 'unknown');
@@ -336,16 +365,22 @@ export class AspectLoaderMain {
 
   static runtime = MainRuntime;
   static dependencies = [LoggerAspect, EnvsAspect];
-  static slots = [Slot.withType<OnAspectLoadError>()];
+  static slots = [Slot.withType<OnAspectLoadError>(), Slot.withType<OnLoadRequireableExtension>()];
 
   static async provider(
     [loggerExt, envs]: [LoggerMain, EnvsMain],
     config,
-    [onAspectLoadErrorSlot]: [OnAspectLoadErrorSlot],
+    [onAspectLoadErrorSlot, onLoadRequireableExtensionSlot]: [OnAspectLoadErrorSlot, OnLoadRequireableExtensionSlot],
     harmony: Harmony
   ) {
     const logger = loggerExt.createLogger(AspectLoaderAspect.id);
-    const aspectLoader = new AspectLoaderMain(logger, envs, harmony, onAspectLoadErrorSlot);
+    const aspectLoader = new AspectLoaderMain(
+      logger,
+      envs,
+      harmony,
+      onAspectLoadErrorSlot,
+      onLoadRequireableExtensionSlot
+    );
     return aspectLoader;
   }
 }

--- a/scopes/harmony/aspect-loader/index.ts
+++ b/scopes/harmony/aspect-loader/index.ts
@@ -1,6 +1,11 @@
 import { AspectLoaderAspect } from './aspect-loader.aspect';
 
-export type { AspectLoaderMain, AspectDescriptor, MainAspect } from './aspect-loader.main.runtime';
+export type {
+  AspectLoaderMain,
+  AspectDescriptor,
+  MainAspect,
+  OnLoadRequireableExtension,
+} from './aspect-loader.main.runtime';
 export {
   getAspectDef,
   getAspectDir,


### PR DESCRIPTION
## Proposed Changes

Before this pr if you had a custom aspect imported into your workspace, and this custom aspect uses another custom aspect is an aspect dependency (via the static dependencies prop) it will fail to find this custom aspect dependency in harmony engine because it was resolved without the correct version.
This PR fixes it by updating the manifest dependencies recursively before send them to harmony.