### PR TITLE
show a loader when compositions are having a hard time loading

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1075,6 +1075,12 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/ui/load-preview"
     },
+    "ui/loader-fallback": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/react/ui/loader-fallback"
+    },
     "ui/main-dropdown": {
         "scope": "teambit.ui-foundation",
         "version": "0.0.397",

--- a/scopes/react/react/compositions-app.tsx
+++ b/scopes/react/react/compositions-app.tsx
@@ -3,6 +3,7 @@ import { Composer } from '@teambit/base-ui.utils.composer';
 import { StandaloneNotFoundPage } from '@teambit/design.ui.pages.standalone-not-found-page';
 import { RenderingContext } from '@teambit/preview';
 import { ErrorFallback } from '@teambit/react.ui.error-fallback';
+import { LoaderFallback } from '@teambit/react.ui.loader-fallback';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ReactAspect } from './react.aspect';
 
@@ -10,7 +11,7 @@ import { ReactAspect } from './react.aspect';
 const hideScrollbars = 'body::-webkit-scrollbar {display: none;}';
 
 export function CompositionsApp({
-  Composition = StandaloneNotFoundPage,
+  Composition,
   previewContext,
 }: {
   Composition?: React.ComponentType;
@@ -23,7 +24,7 @@ export function CompositionsApp({
     <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[Composition]}>
       <Composer components={providers}>
         <style>{hideScrollbars}</style>
-        <Composition />
+        <LoaderFallback Target={Composition} DefaultComponent={StandaloneNotFoundPage} />
       </Composer>
     </ErrorBoundary>
   );

--- a/scopes/react/ui/loader-fallback/index.ts
+++ b/scopes/react/ui/loader-fallback/index.ts
@@ -1,0 +1,2 @@
+export { LoaderFallback } from './loader-fallback';
+export type { LoaderProps } from './loader-fallback';

--- a/scopes/react/ui/loader-fallback/loader-fallback.compositions.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.compositions.tsx
@@ -14,7 +14,6 @@ export const ChangingComponent = () => {
 
   useEffect(() => {
     const intervalId = setInterval(() => {
-      console.log('tick');
       setCurrent((x?: ComponentType) => (x ? undefined : Component));
     }, 2000);
 

--- a/scopes/react/ui/loader-fallback/loader-fallback.compositions.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.compositions.tsx
@@ -1,0 +1,57 @@
+import React, { useEffect, useState, ComponentType } from 'react';
+import { LoaderFallback } from './loader-fallback';
+
+export const RegularComponent = () => {
+  return <LoaderFallback Target={Component} DefaultComponent={Fallback} />;
+};
+
+export const UndefinedComponent = () => {
+  return <LoaderFallback Target={undefined} DefaultComponent={Fallback} />;
+};
+
+export const ChangingComponent = () => {
+  const [current, setCurrent] = useState<ComponentType | undefined>(() => Component);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      console.log('tick');
+      setCurrent((x?: ComponentType) => (x ? undefined : Component));
+    }, 2000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <div style={{ width: 200, height: '3em' }}>
+      <div style={{ fontSize: '0.8em' }}>(this will not timeout, and show only the loader)</div>
+      <LoaderFallback Target={current} DefaultComponent={Fallback} />
+    </div>
+  );
+};
+
+export const LongChangingComponent = () => {
+  const [current, setCurrent] = useState<ComponentType | undefined>(() => Component);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      setCurrent((x?: ComponentType) => (x ? undefined : Component));
+    }, 6000);
+
+    return () => clearInterval(intervalId);
+  }, []);
+
+  return (
+    <div style={{ width: 200, height: '3em' }}>
+      <div style={{ fontSize: '0.8em' }}>(this will timeout, showing the fallback component)</div>
+      <LoaderFallback Target={current} DefaultComponent={Fallback} timeout={2000} />
+    </div>
+  );
+};
+
+function Component() {
+  return <div style={{ color: '#2e945a' }}>✓ actual component</div>;
+}
+
+function Fallback() {
+  return <div>target is (undefined)</div>;
+}

--- a/scopes/react/ui/loader-fallback/loader-fallback.docs.mdx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.docs.mdx
@@ -1,0 +1,33 @@
+import { LoaderFallback } from './loader-fallback';
+
+Renders a component, and show a placeholder when it is undefined.
+
+Logic is as follows:
+
+1. when component is defined -> render it
+1. when the initial value of the component is undefined -> show the default immediately
+1. when the component had just changed to be undefined -> show Loader for _x_ seconds
+   1. then, after _x_ seconds - show NotFound
+
+<!-- live playground doesn't keep state when editing :( -->
+<!-- Try it out:
+
+```tsx live
+function Example() {
+  return (
+    <LoaderFallback
+      Target={RegularComponent} // comment this out
+      DefaultComponent={Fallback}
+      timeout={2000}
+    />
+  );
+
+  function RegularComponent() {
+    return <div>regular component</div>;
+  }
+
+  function Fallback() {
+    return <div>this shows when component is undefined</div>;
+  }
+}
+``` -->

--- a/scopes/react/ui/loader-fallback/loader-fallback.spec.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.spec.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react';
+import { LoaderFallback } from './loader-fallback';
+
+describe('loader-fallback', () => {
+  it('should render target, when defined', () => {
+    const { getByText } = render(
+      <LoaderFallback Target={Component} DefaultComponent={Default} Loader={Loader} timeout={10} />
+    );
+
+    const result = getByText('test target');
+
+    expect(result).toBeInTheDocument();
+  });
+
+  it('should render default, when target is undefined', () => {
+    const { getByText } = render(
+      <LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />
+    );
+
+    const result = getByText('Target is undefined');
+
+    expect(result).toBeInTheDocument();
+  });
+
+  it('should render loader, when target becomes undefined', () => {
+    const { rerender, getByText } = render(
+      <LoaderFallback Target={Component} DefaultComponent={Default} Loader={Loader} timeout={10} />
+    );
+
+    rerender(<LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />);
+
+    const result = getByText('loading...');
+
+    expect(result).toBeInTheDocument();
+  });
+
+  it('should render DefaultComponent, after timeout, when target becomes undefined', async () => {
+    const { rerender, getByText } = render(
+      <LoaderFallback Target={Component} DefaultComponent={Default} Loader={Loader} timeout={10} />
+    );
+
+    rerender(<LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />);
+
+    await waitFor(() => {
+      expect(getByText('Target is undefined')).toBeInTheDocument();
+    });
+  });
+});
+
+function Component() {
+  return <div>test target</div>;
+}
+
+function Default() {
+  return <div>Target is undefined</div>;
+}
+
+function Loader() {
+  return <div>loading...</div>;
+}

--- a/scopes/react/ui/loader-fallback/loader-fallback.spec.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.spec.tsx
@@ -8,9 +8,8 @@ describe('loader-fallback', () => {
       <LoaderFallback Target={Component} DefaultComponent={Default} Loader={Loader} timeout={10} />
     );
 
-    const result = getByText('test target');
-
-    expect(result).toBeInTheDocument();
+    // throws if not found, same as expect
+    getByText('test target');
   });
 
   it('should render default, when target is undefined', () => {
@@ -18,9 +17,8 @@ describe('loader-fallback', () => {
       <LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />
     );
 
-    const result = getByText('Target is undefined');
-
-    expect(result).toBeInTheDocument();
+    // throws if not found, same as expect
+    getByText('Target is undefined');
   });
 
   it('should render loader, when target becomes undefined', () => {
@@ -30,9 +28,8 @@ describe('loader-fallback', () => {
 
     rerender(<LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />);
 
-    const result = getByText('loading...');
-
-    expect(result).toBeInTheDocument();
+    // throws if not found, same as expect
+    getByText('loading...');
   });
 
   it('should render DefaultComponent, after timeout, when target becomes undefined', async () => {
@@ -42,9 +39,7 @@ describe('loader-fallback', () => {
 
     rerender(<LoaderFallback Target={undefined} DefaultComponent={Default} Loader={Loader} timeout={10} />);
 
-    await waitFor(() => {
-      expect(getByText('Target is undefined')).toBeInTheDocument();
-    });
+    await waitFor(() => getByText('Target is undefined'));
   });
 });
 

--- a/scopes/react/ui/loader-fallback/loader-fallback.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.tsx
@@ -1,0 +1,67 @@
+import React, { ComponentType, useRef, useEffect, useState } from 'react';
+import { LoaderRibbon } from '@teambit/base-ui.loaders.loader-ribbon';
+
+export type LoaderProps = {
+  /** component to render */
+  Target: ComponentType | undefined;
+  /** component to render when target is missing, for a grace period, until rendering the default */
+  Loader?: ComponentType;
+  /** cool-down period (in ms) to show Loader, before showing the default */
+  timeout?: number;
+  /** component to render when Target is undefined */
+  DefaultComponent: ComponentType;
+};
+
+export function LoaderFallback({ Target, Loader = LoaderComponent, DefaultComponent, timeout = 15000 }: LoaderProps) {
+  const [ToRender, setRenderTarget] = useState<JSX.Element | null>(Target ? <Target /> : <DefaultComponent />);
+  const prevValue = useRef<ComponentType | undefined>(undefined);
+
+  // could re-implement with a state machine or a reducer
+  useEffect(() => {
+    const prev = prevValue.current;
+    prevValue.current = Target;
+
+    if (Target) {
+      setRenderTarget(<Target />);
+      return () => {};
+    }
+    // else -> Target === undefined
+
+    // Target has changed from a value to undefined.
+    // show loader and hope webpack will supply a component
+    if (prev) {
+      setRenderTarget(<Loader />);
+
+      const tmId = setTimeout(() => setRenderTarget(<DefaultComponent />), timeout);
+      return () => clearTimeout(tmId);
+    }
+    // else -> Target === undefined, prev === undefined
+
+    // comp changed from undefined to undefined
+    // could happen on first render, or when one of the other values change.
+
+    return () => {}; // nothing to do here
+  }, [Target, DefaultComponent, Loader, timeout]);
+
+  return ToRender;
+}
+
+/*
+ * TIP:
+ * useState() and setState() can receive a function as value.
+ * So, be careful when using a react Function Component, like:
+ * ```
+ * useState(ButtonComponent) // will try to run ButtonComponent as a function
+ * setState(ButtonComponent)
+ *
+ * // instead, do:
+ * useState(() => ButtonComponent)
+ * setState(() => ButtonComponent)
+ * ```
+ *
+ * or don't set components as state to begin with.
+ */
+
+function LoaderComponent() {
+  return <LoaderRibbon active style={{ position: 'fixed', top: 0, left: 0, right: 0 }} />;
+}


### PR DESCRIPTION
## Proposed Changes

- fixes bug where we'd get an error message "not found" when changing composition name
- shows a loader when composition turns to undefined
- shows "not found" error after timeout (15 seconds!) or when component starts undefined.