### PR TITLE
use jest instance from env for jest worker

### DIFF
--- a/scopes/defender/jest/jest.main.runtime.ts
+++ b/scopes/defender/jest/jest.main.runtime.ts
@@ -5,15 +5,13 @@ import { JestAspect } from './jest.aspect';
 import { JestTester } from './jest.tester';
 import type { JestWorker } from './jest.worker';
 
-const jestM = require('jest');
-
 export const WORKER_NAME = 'jest';
 
 export class JestMain {
   constructor(private jestWorker: HarmonyWorker<JestWorker>, private logger: Logger) {}
 
-  createTester(jestConfig: any, jestModule = jestM) {
-    return new JestTester(JestAspect.id, jestConfig, jestModule, this.jestWorker, this.logger);
+  createTester(jestConfig: any, jestModulePath = require.resolve('jest')) {
+    return new JestTester(JestAspect.id, jestConfig, jestModulePath, this.jestWorker, this.logger);
   }
 
   static runtime = MainRuntime;

--- a/scopes/defender/jest/jest.tester.ts
+++ b/scopes/defender/jest/jest.tester.ts
@@ -10,19 +10,23 @@ import { TestResult as JestTestResult, AggregatedResult } from '@jest/test-resul
 import { formatResultsErrors } from 'jest-message-util';
 import { ComponentMap, ComponentID } from '@teambit/component';
 import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
+import type jest from 'jest';
 import { JestError } from './error';
 import type { JestWorker } from './jest.worker';
 
-const jest = require('jest');
-
 export class JestTester implements Tester {
+  private readonly jestModule: typeof jest;
+
   constructor(
     readonly id: string,
     readonly jestConfig: any,
-    private jestModule: typeof jest,
+    private jestModulePath: string,
     private jestWorker: HarmonyWorker<JestWorker>,
     private logger: Logger
-  ) {}
+  ) {
+    // eslint-disable-next-line global-require,import/no-dynamic-require
+    this.jestModule = require(jestModulePath);
+  }
 
   configPath = this.jestConfig;
 
@@ -139,7 +143,7 @@ export class JestTester implements Tester {
       config.watchAll = true;
       config.noCache = true;
     }
-    // eslint-disable-next-line
+    // eslint-disable-next-line global-require,import/no-dynamic-require
     const jestConfig = require(this.jestConfig);
 
     const jestConfigWithSpecs = Object.assign(jestConfig, {
@@ -193,8 +197,12 @@ export class JestTester implements Tester {
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         await workerApi.onTestComplete(cbFn);
 
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        await workerApi.watch(this.jestConfig, this.patternsToArray(context.patterns), context.rootPath);
+        await workerApi.watch(
+          this.jestConfig,
+          this.patternsToArray(context.patterns),
+          context.rootPath,
+          this.jestModulePath
+        );
       } catch (err) {
         this.logger.error('jest.tester.watch() caught an error', err);
       }

--- a/scopes/defender/jest/jest.worker.ts
+++ b/scopes/defender/jest/jest.worker.ts
@@ -1,6 +1,6 @@
 import { stringify, parse } from 'flatted';
 import { expose } from '@teambit/worker';
-import { runCLI } from 'jest';
+import type jest from 'jest';
 
 export class JestWorker {
   private onTestCompleteCb;
@@ -10,13 +10,15 @@ export class JestWorker {
     // return this;
   }
 
-  watch(jestConfigPath: string, testFiles: string[], rootPath: string): Promise<void> {
+  watch(jestConfigPath: string, testFiles: string[], rootPath: string, jestModulePath: string): Promise<void> {
     return new Promise((resolve) => {
       // TODO: remove this after jest publish new version to npm: https://github.com/facebook/jest/pull/10804
       // eslint-disable-next-line
       console.warn = function () {};
-      // eslint-disable-next-line
+      // eslint-disable-next-line import/no-dynamic-require,global-require
       const jestConfig = require(jestConfigPath);
+      // eslint-disable-next-line import/no-dynamic-require,global-require
+      const jestModule: typeof jest = require(jestModulePath);
 
       const jestConfigWithSpecs = Object.assign(jestConfig, {
         testMatch: testFiles,
@@ -51,7 +53,7 @@ export class JestWorker {
 
       const withEnv = Object.assign(jestConfigWithSpecs, config);
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
-      const res = runCLI(withEnv, [jestConfigPath]);
+      const res = jestModule.runCLI(withEnv, [jestConfigPath]);
       // eslint-disable-next-line no-console
       res.catch((err) => console.error(err));
       resolve();

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -25,7 +25,6 @@ import { Configuration } from 'webpack';
 // Makes sure the @teambit/react.ui.docs-app is a dependency
 // TODO: remove this import once we can set policy from component to component with workspace version. Then set it via the component.json
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import docs from '@teambit/react.ui.docs-app';
 import { ReactMainConfig } from './react.main.runtime';
 import { ReactAspect } from './react.aspect';
 
@@ -42,7 +41,6 @@ import componentPreviewProdConfigFactory from './webpack/webpack.config.componen
 import componentPreviewDevConfigFactory from './webpack/webpack.config.component.dev';
 
 export const AspectEnvType = 'react';
-const jestM = require('jest');
 const defaultTsConfig = require('./typescript/tsconfig.json');
 const buildTsConfig = require('./typescript/tsconfig.build.json');
 const eslintConfig = require('./eslint/eslintrc');
@@ -103,9 +101,9 @@ export class ReactEnv implements TesterEnv, LinterEnv, DevEnv, BuilderEnv, Depen
   /**
    * returns a component tester.
    */
-  getTester(jestConfigPath: string, jestModule = jestM): Tester {
+  getTester(jestConfigPath: string, jestModulePath?: string): Tester {
     const config = jestConfigPath || require.resolve('./jest/jest.config');
-    return this.jestAspect.createTester(config, jestModule);
+    return this.jestAspect.createTester(config, jestModulePath || require.resolve('jest'));
   }
 
   createTsCompiler(

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -24,7 +24,6 @@ import { VariantPolicyConfigObject } from '@teambit/dependency-resolver';
 import ts, { TsConfigSourceFile } from 'typescript';
 import { ApplicationAspect, ApplicationMain } from '@teambit/application';
 import { ESLintMain, ESLintAspect } from '@teambit/eslint';
-import jest from 'jest';
 import { ReactAspect } from './react.aspect';
 import { ReactEnv } from './react.env';
 import { reactSchema } from './react.graphql';
@@ -200,10 +199,11 @@ export class ReactMain {
   /**
    * override the jest configuration.
    * @param jestConfigPath {typeof jest} absolute path to jest.config.json.
+   * @param jestModulePath absolute path to jest
    */
-  overrideJestConfig(jestConfigPath: string, jestModule: any = jest) {
+  overrideJestConfig(jestConfigPath: string, jestModulePath?: string) {
     return this.envs.override({
-      getTester: () => this.reactEnv.getTester(jestConfigPath, jestModule),
+      getTester: () => this.reactEnv.getTester(jestConfigPath, jestModulePath),
     });
   }
 


### PR DESCRIPTION
## Proposed Changes

- We use the jest instance from the env for regular tests, but the tests displayed in the "tests" tab of the preview are using a worker that was using jest from bit instead. Since we cannot pass the jest module directly to the worker, we pass the path to require it instead
