### PR TITLE
optimize artifacts fetching during capsule creation to be grouped by scope

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -22,6 +22,7 @@ import LegacyScope from '@teambit/legacy/dist/scope/scope';
 import { CACHE_ROOT, DEPENDENCIES_FIELDS, PACKAGE_JSON } from '@teambit/legacy/dist/constants';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import PackageJsonFile from '@teambit/legacy/dist/consumer/component/package-json-file';
+import { importMultipleDistsArtifacts } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import { Scope } from '@teambit/legacy/dist/scope';
 import fs from 'fs-extra';
@@ -322,6 +323,7 @@ export class IsolatorMain {
 
   private async writeComponentsInCapsules(components: Component[], capsuleList: CapsuleList, legacyScope?: Scope) {
     const legacyComponents = components.map((component) => component.state._consumer.clone());
+    if (legacyScope) await importMultipleDistsArtifacts(legacyScope, legacyComponents);
     const allIds = BitIds.fromArray(legacyComponents.map((c) => c.id));
     await Promise.all(
       components.map(async (component) => {

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -240,6 +240,8 @@ export default class ComponentWriter {
         if (!(artifactFiles instanceof ArtifactFiles)) {
           artifactFiles = deserializeArtifactFiles(artifactFiles);
         }
+        // fyi, if this is coming from the isolator aspect, it is optimized to import all at once.
+        // see artifact-files.importMultipleDistsArtifacts().
         const vinylFiles = await artifactFiles.getVinylsAndImportIfMissing(this.component.scope as string, scope);
         artifactsVinylFlattened.push(...vinylFiles);
       })


### PR DESCRIPTION
Currently, if multiple components are isolated, it fetches missing artifacts for each one individually. With this fix, it starts the import only once all artifacts are grouped per scope.