### PR TITLE
remove url limitations

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -98,6 +98,9 @@ function createWebpackConfig(workspaceDir, entryFiles, title, aspectPaths): Webp
     stats: 'errors-only',
 
     devServer: {
+      // @ts-ignore - temp until types of webpack-dev-server v4
+      firewall: false,
+
       // @ts-ignore - remove this once there is types package for webpack-dev-server v4
       static: [
         {

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -79,6 +79,9 @@ export function configFactory(
     stats: 'errors-only',
 
     devServer: {
+      // @ts-ignore - temp until types of webpack-dev-server v4
+      firewall: false,
+
       // @ts-ignore until types are updated with new options from webpack-dev-server v4
       static: [
         {


### PR DESCRIPTION
## Proposed Changes

- disable `firewall` (previously `disableHostCheck` in v3) in webpack dev server

This will allow using the local dev server with a different url so companies like Dell can access their API without Cross-Origin Resource Sharing errors. We already use it internally to work on symphony and a dev version of `bit.dev`.

Reference to the config can be found [here](https://sourcegraph.com/github.com/webpack/webpack-dev-server/-/blob/CHANGELOG.md):
> the disableHostCheck and allowedHosts options were removed in favor of the firewall option

```js
// Previously disableHostCheck and allowedHosts

module.exports = {
  // ...
  devServer: {
    // Can be
    // firewall: ['192.168.0.1', 'domain.com']
    firewall: false,
  },
};
```