### PR TITLE
bit-new - fix bit scope to be inside .git dir

### DIFF
--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -38,12 +38,13 @@ export class WorkspaceGenerator {
       throw new Error(`unable to create a workspace at "${this.workspaceName}", this path already exist`);
     }
     await fs.ensureDir(this.workspacePath);
+    process.chdir(this.workspacePath);
+    await this.initGit();
     await init(this.workspacePath, this.options.standalone, false, false, false, false, {});
     await this.writeWorkspaceFiles();
     await this.reloadBitInWorkspaceDir();
     await this.addComponentsFromRemote();
     await this.workspace.install();
-    await this.initGit();
 
     return this.workspacePath;
   }
@@ -76,7 +77,6 @@ export class WorkspaceGenerator {
   }
 
   private async reloadBitInWorkspaceDir() {
-    process.chdir(this.workspacePath);
     this.harmony = await loadBit(this.workspacePath);
     this.workspace = this.harmony.get<Workspace>(WorkspaceAspect.id);
   }


### PR DESCRIPTION
Currently, `.bit` directory is located in the workspace root.

See https://github.com/teambit/bit/issues/4056 for more info about `bit new`.