### PR TITLE
override typescript outDir configuration with CompilerOption.distDir

### DIFF
--- a/scopes/typescript/aspect-docs/typescript/typescript.mdx
+++ b/scopes/typescript/aspect-docs/typescript/typescript.mdx
@@ -7,10 +7,19 @@ An env that uses typescript compiler can have two tsconfig.json files, one for t
 On the workspace, the following two configurations are overridden:
 
 ```
-compilerOptions.sourceRoot = componentDir;
+compilerOptions.sourceRoot = <componentDir>;
 compilerOptions.rootDir = '.';
 ```
 
 The reason to override them is to make the source-map working on the workspace.
+
+On the capsules, the following configurion is overridden:
+
+```
+compilerOptions.outDir = <CompilerOptions.distDir>
+```
+
+This is done to avoid confusion when the distDir is `x` and ts-config outDir is `y`,
+in which case, the dists in the capsule are written into `y`, but other bit processes expect to find them in `x`.
 
 As a reminder, the `dists` are written into the node_modules and not in the component-dir, without the configuration above, the source-map won't have the correct `sourceRoot` and `sources` values, and as a result, the debugger won't work.

--- a/scopes/typescript/aspect-docs/typescript/typescript.mdx
+++ b/scopes/typescript/aspect-docs/typescript/typescript.mdx
@@ -13,6 +13,8 @@ compilerOptions.rootDir = '.';
 
 The reason to override them is to make the source-map working on the workspace.
 
+As a reminder, the `dists` are written into the node_modules and not in the component-dir, without the configuration above, the source-map won't have the correct `sourceRoot` and `sources` values, and as a result, the debugger won't work.
+
 On the capsules, the following configurion is overridden:
 
 ```
@@ -21,5 +23,3 @@ compilerOptions.outDir = <CompilerOptions.distDir>
 
 This is done to avoid confusion when the distDir is `x` and ts-config outDir is `y`,
 in which case, the dists in the capsule are written into `y`, but other bit processes expect to find them in `x`.
-
-As a reminder, the `dists` are written into the node_modules and not in the component-dir, without the configuration above, the source-map won't have the correct `sourceRoot` and `sources` values, and as a result, the debugger won't work.

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -25,6 +25,10 @@ export class TypescriptCompiler implements Compiler {
     this.shouldCopyNonSupportedFiles =
       typeof options.shouldCopyNonSupportedFiles === 'boolean' ? options.shouldCopyNonSupportedFiles : true;
     this.artifactName = options.artifactName || 'dist';
+    this.options.tsconfig ||= {};
+    this.options.tsconfig.compilerOptions ||= {};
+    // mutate the outDir, otherwise, on capsules, the dists might be written to a different directory and make confusion
+    this.options.tsconfig.compilerOptions.outDir = this.distDir;
   }
 
   displayName = 'TypeScript';


### PR DESCRIPTION
This is done to avoid confusion when the distDir is `x` and ts-config outDir is `y`, in which case, the dists in the capsule are written into `y`, but other bit processes expect to find them in `x`.

