### PR TITLE
provide better error when yaml fails to parse front-matter in mdx files

### DIFF
--- a/scopes/mdx/modules/compiler/mdx-compiler.ts
+++ b/scopes/mdx/modules/compiler/mdx-compiler.ts
@@ -127,7 +127,11 @@ function createCompiler(options: Partial<MDXCompileOptions>) {
 function extractMetadata() {
   return function transformer(tree, file) {
     visit(tree, 'yaml', (node: any) => {
-      file.data.frontmatter = yaml.parse(node.value);
+      try {
+        file.data.frontmatter = yaml.parse(node.value);
+      } catch (err) {
+        throw new Error(`failed extracting metadata/front-matter using Yaml lib, due to an error: ${err.message}`);
+      }
     });
   };
 }


### PR DESCRIPTION
For example, a component has an .mdx file with the following content:
```
---
label: ['a', 'b'];
---
```
Which is an invalid syntax because of the `;`.

`bit status` gives:
```
> bar ...  issues found
       error found while parsing the file (edit the file and fix the parsing error):
          test.mdx -> All collection items must start at the same column
```

It's improved to show a better error:
```
     > bar ...  issues found
       error found while parsing the file (edit the file and fix the parsing error):
          test.mdx -> failed extracting metadata/front-matter using Yaml lib, due to an error: All collection items must start at the same column
```