### PR TITLE
preserve workspace.jsonc comments when creating workspaces via bit-new

### DIFF
--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -68,7 +68,7 @@ export class WorkspaceGenerator {
    */
   private async writeWorkspaceFiles(): Promise<void> {
     const workspaceContext = { name: this.workspaceName, defaultScope: this.options.defaultScope };
-    const templateFiles = this.template.generateFiles(workspaceContext);
+    const templateFiles = await this.template.generateFiles(workspaceContext);
     await Promise.all(
       templateFiles.map(async (templateFile) => {
         await fs.outputFile(path.join(this.workspacePath, templateFile.relativePath), templateFile.content);

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -48,7 +48,7 @@ export interface WorkspaceTemplate {
   /**
    * template function for generating the template files,
    */
-  generateFiles(context: WorkspaceContext): WorkspaceFile[];
+  generateFiles(context: WorkspaceContext): Promise<WorkspaceFile[]>;
 
   importComponents?: () => ComponentToImport[];
 }

--- a/scopes/harmony/config/index.ts
+++ b/scopes/harmony/config/index.ts
@@ -1,4 +1,4 @@
 export { Config } from './config';
 export type { ConfigMain } from './config.main.runtime';
 export { ConfigAspect, ConfigRuntime } from './config.aspect';
-export { ComponentScopeDirMap } from './workspace-config';
+export { ComponentScopeDirMap, getWorkspaceConfigTemplateFile } from './workspace-config';

--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -192,18 +192,8 @@ export class WorkspaceConfig implements HostConfig {
       const instance = WorkspaceConfig.fromLegacyConfig(legacyConfig);
       return instance;
     }
-    const getTemplateFile = async () => {
-      try {
-        return await fs.readFile(path.join(__dirname, 'workspace-template.jsonc'));
-      } catch (err) {
-        if (err.code !== 'ENOENT') throw err;
-        // when the extension is compiled by tsc, it doesn't copy .jsonc files into the dists, grab it from src
-        return fs.readFile(path.join(__dirname, '..', 'workspace-template.jsonc'));
-      }
-    };
-    const templateFile = await getTemplateFile();
-    const templateStr = templateFile.toString();
 
+    const templateStr = await getWorkspaceConfigTemplateFile();
     const template = parse(templateStr);
     // TODO: replace this assign with some kind of deepAssign that keeps the comments
     // right now the comments above the internal props are overrides after the assign
@@ -478,4 +468,14 @@ export function transformLegacyPropsToExtensions(
   }
   // @ts-ignore
   return data;
+}
+
+export async function getWorkspaceConfigTemplateFile(): Promise<string> {
+  try {
+    return await fs.readFile(path.join(__dirname, 'workspace-template.jsonc'), 'utf-8');
+  } catch (err) {
+    if (err.code !== 'ENOENT') throw err;
+    // when the extension is compiled by tsc, it doesn't copy .jsonc files into the dists, grab it from src
+    return fs.readFile(path.join(__dirname, '..', 'workspace-template.jsonc'), 'utf-8');
+  }
 }

--- a/scopes/react/react/templates/react-workspace-learn-bit/index.ts
+++ b/scopes/react/react/templates/react-workspace-learn-bit/index.ts
@@ -9,7 +9,7 @@ export const reactWorkspaceLearnBitTemplate: WorkspaceTemplate = {
   name: 'react-learn-bit',
   description: 'EXPERIMENTAL. react workspace with learn-bit components',
   hidden: true,
-  generateFiles: (context: WorkspaceContext) => {
+  generateFiles: async (context: WorkspaceContext) => {
     return [
       {
         relativePath: 'workspace.jsonc',

--- a/scopes/react/react/templates/react-workspace/files/workspace-config.ts
+++ b/scopes/react/react/templates/react-workspace/files/workspace-config.ts
@@ -1,29 +1,17 @@
 import { WorkspaceContext } from '@teambit/generator';
+import { getWorkspaceConfigTemplateFile } from '@teambit/config';
+import { parse, stringify } from 'comment-json';
 
-export function workspaceConfig({ name, defaultScope }: WorkspaceContext) {
-  const data = {
-    $schema: 'https://static.bit.dev/teambit/schemas/schema.json',
-    'teambit.workspace/workspace': {
-      name,
-      icon: 'https://static.bit.dev/bit-logo.svg',
-      defaultDirectory: '{scope}/{name}',
-      defaultScope: defaultScope || 'my-scope',
-    },
-    'teambit.dependencies/dependency-resolver': {
-      packageManager: 'teambit.dependencies/pnpm',
-      policy: {
-        dependencies: {},
-        peerDependencies: {
-          react: '16.13.1',
-          'react-dom': '16.13.1',
-        },
-      },
-    },
-    'teambit.workspace/variants': {
-      '*': {
-        'teambit.react/react': {},
-      },
+export async function workspaceConfig({ name, defaultScope }: WorkspaceContext) {
+  const workspaceConfigTemplate = await getWorkspaceConfigTemplateFile();
+  const configParsed = parse(workspaceConfigTemplate);
+  configParsed['teambit.workspace/workspace'].name = name;
+  configParsed['teambit.workspace/workspace'].defaultScope = defaultScope || 'my-scope';
+  configParsed['teambit.workspace/variants'] = {
+    '*': {
+      'teambit.react/react': {},
     },
   };
-  return JSON.stringify(data, undefined, 2);
+
+  return stringify(configParsed, undefined, 2);
 }

--- a/scopes/react/react/templates/react-workspace/index.ts
+++ b/scopes/react/react/templates/react-workspace/index.ts
@@ -6,11 +6,11 @@ import { gitIgnore } from './files/git-ignore';
 export const reactWorkspaceTemplate: WorkspaceTemplate = {
   name: 'react-workspace',
   description: 'create a new React project',
-  generateFiles: (context: WorkspaceContext) => {
+  generateFiles: async (context: WorkspaceContext) => {
     return [
       {
         relativePath: 'workspace.jsonc',
-        content: workspaceConfig(context),
+        content: await workspaceConfig(context),
       },
       {
         relativePath: `.gitignore`,


### PR DESCRIPTION
## Proposed Changes

- change "react-workspace" template to re-use the default workspace.jsonc template.
- change the `generateFiles` API to return a promise.
