### PR TITLE
improve error when "bit create" generates a component with an existing name

### DIFF
--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -5,6 +5,7 @@ import path from 'path';
 import { Workspace } from '@teambit/workspace';
 import { EnvsMain } from '@teambit/envs';
 import camelcase from 'camelcase';
+import { BitError } from '@teambit/bit-error';
 import { PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
 import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
 import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
@@ -30,7 +31,12 @@ export class ComponentGenerator {
       try {
         const componentPath = this.getComponentPath(componentId);
         if (fs.existsSync(path.join(this.workspace.path, componentPath))) {
-          throw new Error(`unable to create a component at "${componentPath}", this path already exist`);
+          throw new BitError(`unable to create a component at "${componentPath}", this path already exist`);
+        }
+        if (await this.workspace.hasName(componentId.fullName)) {
+          throw new BitError(
+            `unable to create a component "${componentId.fullName}", a component with the same name already exist`
+          );
         }
         dirsToDeleteIfFailed.push(componentPath);
         return await this.generateOneComponent(componentId, componentPath);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -321,6 +321,14 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
+   * whether or not a workspace has a component with the given name
+   */
+  async hasName(name: string): Promise<boolean> {
+    const ids = await this.listIds();
+    return Boolean(ids.find((id) => id.fullName === name));
+  }
+
+  /**
    * Check if a specific id exist in the workspace or in the scope
    * @param componentId
    */


### PR DESCRIPTION
Currently, it shows a confusing error message:
```
unable to add individual files outside the root dir (shoe/ui/button) of ui/button.
you can add the directory these files are located at and it'll change the root dir of the component accordingly
```
Now, it shows a better error
```
unable to create a component "ui/button", a component with the same name already exist
```