### PR TITLE
extract pack-task from the publish-task

### DIFF
--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -59,7 +59,7 @@ describe('build command', function () {
       const component = await workspace.get(compId);
       const builder = harmony.get<BuilderMain>(BuilderAspect.id);
       const tasks = builder.listTasks(component);
-      expect(tasks.snapTasks).to.have.lengthOf(0);
+      expect(tasks.snapTasks).to.not.include('teambit.pkg/pkg:PublishComponents');
       expect(tasks.tagTasks).to.include('teambit.pkg/pkg:PublishComponents');
     });
   });

--- a/scopes/pkg/pkg/pack.task.ts
+++ b/scopes/pkg/pkg/pack.task.ts
@@ -1,0 +1,24 @@
+import { BuildContext, BuiltTaskResult, BuildTask, TaskLocation } from '@teambit/builder';
+import { Logger } from '@teambit/logger';
+import { Packer } from './packer';
+
+/**
+ * pack components to a .tgz file
+ */
+export class PackTask implements BuildTask {
+  readonly name = 'PackComponents';
+  readonly location: TaskLocation = 'end';
+  constructor(readonly aspectId: string, private packer: Packer, private logger: Logger) {}
+
+  async execute(context: BuildContext): Promise<BuiltTaskResult> {
+    const capsules = context.capsuleNetwork.seedersCapsules;
+    this.logger.info(`going to run pack on ${capsules.length} capsules`);
+    const packResults = await this.packer.packMultipleCapsules(capsules, { override: true }, false, true);
+    const packArtifactsDefs = this.packer.getArtifactDefInCapsule();
+
+    return {
+      componentsResults: packResults,
+      artifacts: [packArtifactsDefs],
+    };
+  }
+}

--- a/scopes/pkg/pkg/publish.task.ts
+++ b/scopes/pkg/pkg/publish.task.ts
@@ -2,7 +2,6 @@ import { BuildContext, BuiltTaskResult, BuildTask, TaskLocation } from '@teambit
 import { Logger } from '@teambit/logger';
 import { Capsule } from '@teambit/isolator';
 import { Publisher } from './publisher';
-import { Packer } from './packer';
 
 /**
  * publish components by running "npm publish"
@@ -10,12 +9,7 @@ import { Packer } from './packer';
 export class PublishTask implements BuildTask {
   readonly name = 'PublishComponents';
   readonly location: TaskLocation = 'end';
-  constructor(
-    readonly aspectId: string,
-    private publisher: Publisher,
-    private packer: Packer,
-    private logger: Logger
-  ) {}
+  constructor(readonly aspectId: string, private publisher: Publisher, private logger: Logger) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     this.publisher.options.dryRun = false;
@@ -29,16 +23,11 @@ export class PublishTask implements BuildTask {
       }
     });
     this.logger.info(`going to run publish on ${capsulesToPublish.length} out of ${capsules.length}`);
-
     const publishResults = await this.publisher.publishMultipleCapsules(capsulesToPublish);
-    this.logger.info(`going to run pack dry-run on ${capsules.length} out of ${capsules.length}`);
-
-    const packResults = await this.packer.packMultipleCapsules(capsules, { override: true }, false, true);
-    const packArtifactsDefs = this.packer.getArtifactDefInCapsule();
 
     return {
-      componentsResults: publishResults.concat(packResults),
-      artifacts: [packArtifactsDefs],
+      componentsResults: publishResults,
+      artifacts: [],
     };
   }
 }


### PR DESCRIPTION
Currently, the pack is done during the publish-task. As a result, the snap-pipeline, doesn't generate the .tgz file, as it doesn't run the publish-task by default.
This PR makes them two separate tasks and register the pack-task to the snap-pipeline.