### PR TITLE
Bit start open browser + publicUrl

### DIFF
--- a/scopes/ui-foundation/cli/ui-server-console/ui-server-console.tsx
+++ b/scopes/ui-foundation/cli/ui-server-console/ui-server-console.tsx
@@ -13,9 +13,12 @@ export type UIServerConsoleProps = {
    * name of the app.
    */
   appName: string;
+
+  /** explicity server url */
+  url?: string;
 };
 
-export function UIServerConsole({ appName, futureUiServer }: UIServerConsoleProps) {
+export function UIServerConsole({ appName, futureUiServer, url }: UIServerConsoleProps) {
   const [uiServer, setUiServer] = useState<UIServer>();
 
   useEffect(() => {
@@ -40,7 +43,7 @@ export function UIServerConsole({ appName, futureUiServer }: UIServerConsoleProp
       <Text>
         You can now view '<Text color="cyan">{appName}</Text>' components in the browser.
       </Text>
-      <Text>Bit server is running on http://localhost:{uiServer.port}</Text>
+      <Text>Bit server is running on {url || uiServer.fullUrl}</Text>
     </>
   );
 }

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -83,13 +83,13 @@ export class StartCmd implements Command {
       verbose,
     });
 
-    uiServer.then((server) => open(server.publicUrl)).catch((error) => this.logger.error(error));
+    uiServer.then((server) => open(this.ui.publicUrl || server.fullUrl)).catch((error) => this.logger.error(error));
 
     // DO NOT CHANGE THIS - this meant to be an async hook.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises
     this.ui.invokeOnStart();
     this.ui.clearConsole();
 
-    return <UIServerConsole appName={appName} futureUiServer={uiServer} />;
+    return <UIServerConsole appName={appName} futureUiServer={uiServer} url={this.ui.publicUrl} />;
   }
 }

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import open from 'open';
 import { Command, CommandOptions } from '@teambit/cli';
 import { Logger } from '@teambit/logger';
 import { UIServerConsole } from '@teambit/ui-foundation.cli.ui-server-console';
@@ -81,6 +82,8 @@ export class StartCmd implements Command {
       rebuild,
       verbose,
     });
+
+    uiServer.then((server) => open(`http://localhost:${server.port}`)).catch((error) => this.logger.error(error));
 
     // DO NOT CHANGE THIS - this meant to be an async hook.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -83,7 +83,7 @@ export class StartCmd implements Command {
       verbose,
     });
 
-    uiServer.then((server) => open(`http://localhost:${server.port}`)).catch((error) => this.logger.error(error));
+    uiServer.then((server) => open(server.publicUrl)).catch((error) => this.logger.error(error));
 
     // DO NOT CHANGE THIS - this meant to be an async hook.
     // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -58,6 +58,17 @@ export class UIServer {
     return this._port;
   }
 
+  /** the hostname for the server to listen at. Currently statically 'localhost' */
+  get host() {
+    return 'localhost';
+  }
+
+  /** the url to display when server is listening. Note that bit does not provide proxying to this url */
+  get publicUrl() {
+    const port = this.port !== 80 ? `:${this.port}` : '';
+    return `http://localhost${port}`;
+  }
+
   /**
    * get the webpack configuration of the UI server.
    */
@@ -111,7 +122,7 @@ export class UIServer {
     // No any other endpoints past this will execute
     app.use(fallback('index.html', { root }));
 
-    server.listen(port);
+    server.listen(port, this.host);
     this._port = port;
 
     this.logger.info(`UI server of ${this.uiRootExtension} is listening to port ${port}`);
@@ -178,12 +189,12 @@ export class UIServer {
     const gqlProxies: ProxyEntry[] = [
       {
         context: ['/graphql', '/api'],
-        target: `http://localhost:${port}`,
+        target: `http://${this.host}:${port}`,
         changeOrigin: true,
       },
       {
         context: ['/subscriptions'],
-        target: `ws://localhost:${port}`,
+        target: `ws://${this.host}:${port}`,
         ws: true,
       },
     ];

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -63,10 +63,10 @@ export class UIServer {
     return 'localhost';
   }
 
-  /** the url to display when server is listening. Note that bit does not provide proxying to this url */
-  get publicUrl() {
+  /** the server listens at this url */
+  get fullUrl() {
     const port = this.port !== 80 ? `:${this.port}` : '';
-    return `http://localhost${port}`;
+    return `http://${this.host}${port}`;
   }
 
   /**

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -70,6 +70,9 @@ export type UIConfig = {
    * always relative to the workspace root directory.
    */
   publicDir: string;
+
+  /** the url to display when server is listening. Note that bit does not provide proxying to this url */
+  publicUrl?: string;
 };
 
 export type RuntimeOptions = {
@@ -452,6 +455,10 @@ export class UiMain {
     const hash = await this.buildUiHash(uiRoot);
     await this.build(name);
     await this.cache.set(uiRoot.path, hash);
+  }
+
+  get publicUrl() {
+    return this.config.publicUrl;
   }
 
   private async openBrowser(url: string) {


### PR DESCRIPTION
## Proposed Changes

- open browser on `bit start`
- allow setting a custom `publicUrl` to open instead of local host (@itaymendel  FYI)

example configuration:
```json
"teambit.ui-foundation/ui": {
  "publicUrl": "https://sym.bit.dev"
},
```
