### PR TITLE
bit-lane-diff: fix git EPERM error and remove the redundant id field

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -83,6 +83,10 @@ describe('bit lane command', function () {
         expect(diffOutput).to.have.string(`-module.exports = function foo() { return 'got foo'; }`);
         expect(diffOutput).to.have.string(`+module.exports = function foo() { return 'got foo v2'; }`);
       });
+      it('should not show the id field as it is redundant', () => {
+        expect(diffOutput).to.not.have.string('--- Id');
+        expect(diffOutput).to.not.have.string('+++ Id');
+      });
     });
     describe('exporting the lane by explicitly entering the lane to the cli', () => {
       before(() => {

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -11,16 +11,13 @@ export class ExportCmd implements Command {
   name = 'export [remote] [id...]';
 
   description = `export components to a remote scope.
-  bit export => export all staged components to their current scope
-  Legacy:
-  \`bit export <remote> [id...]\` => export (optionally given ids) to the specified remote
-  \`bit export ${CURRENT_UPSTREAM} [id...]\` => export (optionally given ids) to their current scope
-  Harmony:
-  \`bit export [id...]\` => export (optionally given ids) to their current scope
-  \`bit export <remote> <lane...>\` => export the specified lanes to the specified remote
+bit export => export all staged components to their current scope
+\`bit export [id...]\` => export (optionally given ids) to their current scope
+\`bit export <remote> --lanes\` => export the current lane to the specified remote
+\`bit export <remote> <lane...> --lanes\` => export the specified lanes to the specified remote
 
-  https://${BASE_DOCS_DOMAIN}/docs/export
-  ${WILDCARD_HELP('export remote-scope')}`;
+https://${BASE_DOCS_DOMAIN}/docs/export
+${WILDCARD_HELP('export remote-scope')}`;
   alias = 'e';
   options = [
     ['e', 'eject', 'replaces the exported components from the local scope with the corresponding packages'],

--- a/src/cli/commands/public-cmds/fetch-cmd.ts
+++ b/src/cli/commands/public-cmds/fetch-cmd.ts
@@ -13,7 +13,11 @@ export default class Fetch implements LegacyCommand {
   alias = '';
   private = true;
   opts = [
-    ['l', 'lanes', 'EXPERIMENTAL. fetch lanes'],
+    [
+      'l',
+      'lanes',
+      'EXPERIMENTAL. fetch lanes, use "/" as a separator between the remote and the lane name, e.g. teambit.ui/fix-button',
+    ],
     ['c', 'components', 'fetch components'],
     ['j', 'json', 'return the output as JSON'],
     [

--- a/src/consumer/component-ops/components-diff.ts
+++ b/src/consumer/component-ops/components-diff.ts
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import R from 'ramda';
-
 import { Consumer } from '..';
 import { BitId } from '../../bit-id';
 import GeneralError from '../../error/general-error';
@@ -9,6 +8,7 @@ import { Scope } from '../../scope';
 import { ModelComponent, Version } from '../../scope/models';
 import { Tmp } from '../../scope/repositories';
 import diffFiles from '../../utils/diff-files';
+import { saveIntoOsTmp } from '../../utils/fs/save-into-os-tmp';
 import { PathLinux, PathOsBased } from '../../utils/path';
 import Component from '../component/consumer-component';
 import { SourceFile } from '../component/sources';
@@ -38,7 +38,6 @@ export default async function componentsDiff(
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const { components } = await consumer.loadComponents(ids);
   if (!components) throw new ShowDoctorError('failed loading the components');
-  const tmp = new Tmp(consumer.scope);
 
   // try to resolve ids scope of by components array
   const idsWithScope = ids.map((id) => {
@@ -49,23 +48,17 @@ export default async function componentsDiff(
     return id;
   });
 
-  try {
-    const getResults = (): Promise<DiffResults[]> => {
-      if (version && toVersion) {
-        return Promise.all(idsWithScope.map((id) => getComponentDiffBetweenVersions(id)));
-      }
-      if (version) {
-        return Promise.all(components.map((component) => getComponentDiffOfVersion(component)));
-      }
-      return Promise.all(components.map((component) => getComponentDiff(component)));
-    };
-    const componentsDiffResults = await getResults();
-    await tmp.clear();
-    return componentsDiffResults;
-  } catch (err) {
-    await tmp.clear();
-    throw err;
-  }
+  const getResults = (): Promise<DiffResults[]> => {
+    if (version && toVersion) {
+      return Promise.all(idsWithScope.map((id) => getComponentDiffBetweenVersions(id)));
+    }
+    if (version) {
+      return Promise.all(components.map((component) => getComponentDiffOfVersion(component)));
+    }
+    return Promise.all(components.map((component) => getComponentDiff(component)));
+  };
+  const componentsDiffResults = await getResults();
+  return componentsDiffResults;
 
   async function getComponentDiffOfVersion(component: Component): Promise<DiffResults> {
     const diffResult: DiffResults = { id: component.id, hasDiff: false };
@@ -81,9 +74,8 @@ export default async function componentsDiff(
     // $FlowFixMe version must be defined as the component.componentFromModel do exist
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const versionB: string = component.id.version;
-    // $FlowFixMe this function gets called only when version is set
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    diffResult.filesDiff = await getFilesDiff(tmp, versionFiles, fsFiles, version, versionB);
+    // this function gets called only when version is set
+    diffResult.filesDiff = await getFilesDiff(versionFiles, fsFiles, version as string, versionB);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const fromVersionComponent = await modelComponent.toConsumerComponent(version, consumer.scope.name, repository);
     await updateFieldsDiff(fromVersionComponent, component, diffResult, diffOpts);
@@ -106,7 +98,7 @@ export default async function componentsDiff(
     const toVersionFiles = await toVersionObject.modelFilesToSourceFiles(repository);
     // $FlowFixMe version and toVersion are set when calling this function
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    diffResult.filesDiff = await getFilesDiff(tmp, fromVersionFiles, toVersionFiles, version, toVersion);
+    diffResult.filesDiff = await getFilesDiff(fromVersionFiles, toVersionFiles, version, toVersion);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const fromVersionComponent = await modelComponent.toConsumerComponent(version, consumer.scope.name, repository);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -126,7 +118,7 @@ export default async function componentsDiff(
     const fsFiles = component.files;
     // $FlowFixMe version must be defined as the component.componentFromModel do exist
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    diffResult.filesDiff = await getFilesDiff(tmp, modelFiles, fsFiles, component.id.version, component.id.version);
+    diffResult.filesDiff = await getFilesDiff(modelFiles, fsFiles, component.id.version, component.id.version);
     // $FlowFixMe we made sure already that component.componentFromModel is defined
     await updateFieldsDiff(component.componentFromModel, component, diffResult, diffOpts);
 
@@ -147,14 +139,7 @@ export async function diffBetweenVersionsObjects(
   const repository = scope.objects;
   const fromVersionFiles = await fromVersionObject.modelFilesToSourceFiles(repository);
   const toVersionFiles = await toVersionObject.modelFilesToSourceFiles(repository);
-  const tmp = new Tmp(scope);
-  try {
-    diffResult.filesDiff = await getFilesDiff(tmp, fromVersionFiles, toVersionFiles, fromVersion, toVersion);
-  } catch (err) {
-    await tmp.clear();
-    throw err;
-  }
-  await tmp.clear();
+  diffResult.filesDiff = await getFilesDiff(fromVersionFiles, toVersionFiles, fromVersion, toVersion);
   const fromVersionComponent = await modelComponent.toConsumerComponent(
     fromVersionObject.hash().toString(),
     scope.name,
@@ -207,7 +192,6 @@ async function getOneFileDiff(
 }
 
 async function getFilesDiff(
-  tmp: Tmp,
   filesA: SourceFile[],
   filesB: SourceFile[],
   filesAVersion: string,
@@ -224,7 +208,7 @@ async function getFilesDiff(
     const getFilePath = async (files): Promise<PathOsBased> => {
       const file = files.find((f) => f[fileNameAttribute] === relativePath);
       const fileContent = file ? file.contents : '';
-      return tmp.save(fileContent);
+      return saveIntoOsTmp(fileContent);
     };
     const [fileAPath, fileBPath] = await Promise.all([getFilePath(filesA), getFilePath(filesB)]);
     const diffOutput = await getOneFileDiff(fileAPath, fileBPath, fileALabel, fileBLabel, relativePath);

--- a/src/consumer/component-ops/components-diff.ts
+++ b/src/consumer/component-ops/components-diff.ts
@@ -6,7 +6,6 @@ import GeneralError from '../../error/general-error';
 import ShowDoctorError from '../../error/show-doctor-error';
 import { Scope } from '../../scope';
 import { ModelComponent, Version } from '../../scope/models';
-import { Tmp } from '../../scope/repositories';
 import diffFiles from '../../utils/diff-files';
 import { saveIntoOsTmp } from '../../utils/fs/save-into-os-tmp';
 import { PathLinux, PathOsBased } from '../../utils/path';

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -136,6 +136,7 @@ function componentToPrintableForDiffCommand(component: Component, verbose = fals
   delete comp.dependencies;
   delete comp.devDependencies;
   delete comp.peerDependencies;
+  delete comp.id;
   if (!verbose) {
     delete comp.overridesDependencies;
     delete comp.overridesDevDependencies;

--- a/src/scope/lanes/README.md
+++ b/src/scope/lanes/README.md
@@ -9,10 +9,11 @@ The following describes the final implementation, which differs from the specifi
 
 - create a snap: `bit snap` (synopsis similar to the `bit tag`).
 - create a new lane: `bit switch <name> --create`
-- list lanes: `bit lane`.
+- list lanes: `bit lane list`.
 - switch between lanes: `bit switch <name>`
 - merge lanes: `bit merge --lane`.
-- show lane details: `bit lane <name>`
+- show lane details: `bit lane show <name>`
+- diff between lanes: `bit lane diff <values>`
 - track local lane to a remote lane: `bit switch --as`
 - rename a lane `bit switch --rename`
 - remove a lane `bit remove --lane`.

--- a/src/utils/fs/save-into-os-tmp.ts
+++ b/src/utils/fs/save-into-os-tmp.ts
@@ -1,0 +1,13 @@
+import os from 'os';
+import path from 'path';
+import fs from 'fs-extra';
+import { v4 } from 'uuid';
+import { PathOsBased } from '../path';
+
+const BASE_PATH = path.join(os.tmpdir(), 'bit', 'tmp');
+
+export async function saveIntoOsTmp(data: string, filename = v4(), ext = '.js'): Promise<PathOsBased> {
+  const filePath = path.join(BASE_PATH, `${filename}${ext}`);
+  await fs.outputFile(filePath, data);
+  return filePath;
+}


### PR DESCRIPTION
## Proposed Changes

- fix `bit lane diff` to not throw `git EPERM` errors. It happened because the tmp dir containing the files to diff were deleted prematurely. 
- remove the `id` field when running diff, it is not needed and confusing.
