### PR TITLE
launch browser only in workspace (and not scopes)

### DIFF
--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -64,7 +64,13 @@ export class StartCmd implements Command {
     });
 
     if (!noBrowser) {
-      uiServer.then((server) => open(this.ui.publicUrl || server.fullUrl)).catch((error) => this.logger.error(error));
+      uiServer
+        .then((server) => {
+          if (!server.buildOptions?.launchBrowserOnStart) return undefined;
+
+          return open(this.ui.publicUrl || server.fullUrl);
+        })
+        .catch((error) => this.logger.error(error));
     }
 
     // DO NOT CHANGE THIS - this meant to be an async hook.

--- a/scopes/ui-foundation/ui/ui-root.tsx
+++ b/scopes/ui-foundation/ui/ui-root.tsx
@@ -23,6 +23,7 @@ export interface UIRoot extends ComponentDir {
 
   buildOptions?: {
     ssr?: boolean;
+    launchBrowserOnStart?: boolean;
   };
 
   /**

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -68,6 +68,10 @@ export class UIServer {
     const port = this.port !== 80 ? `:${this.port}` : '';
     return `http://${this.host}${port}`;
   }
+  
+  get buildOptions() {
+    return this.uiRoot.buildOptions;
+  }
 
   /**
    * get the webpack configuration of the UI server.
@@ -121,7 +125,7 @@ export class UIServer {
   }
 
   private async setupServerSideRendering({ root, port, app }: { root: string; port: number; app: Express }) {
-    if (!this.uiRoot.buildOptions?.ssr) return;
+    if (!this.buildOptions?.ssr) return;
 
     const ssrMiddleware = await createSsrMiddleware({
       root,

--- a/scopes/workspace/workspace/workspace.ui-root.ts
+++ b/scopes/workspace/workspace/workspace.ui-root.ts
@@ -35,6 +35,7 @@ export class WorkspaceUIRoot implements UIRoot {
 
   buildOptions = {
     ssr: false,
+    launchBrowserOnStart: true,
   };
 
   async resolveAspects(runtimeName: string) {


### PR DESCRIPTION
## Proposed Changes

- add new build option to UI Root - `launchBrowserOnStart`
- enable it only for workspace

This is so bit start in scopes won't try to open a browser in the server, and potentially cause errors.

I feels a little odd to pass `uiRoot.buildOptions` like that in the ui-server, but I wouldn't like to expose the whole uiRoot object.
