### PR TITLE
Fix svgr + svg types

### DIFF
--- a/scopes/react/react/templates/react-workspace-learn-bit/files/types/asset.ts
+++ b/scopes/react/react/templates/react-workspace-learn-bit/files/types/asset.ts
@@ -3,8 +3,11 @@ export const assetTypes = `declare module '*.png' {
   export = value;
 }
 declare module '*.svg' {
-  const value: any;
-  export = value;
+  import type { FunctionComponent, SVGProps } from 'react';
+
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement> & { title?: string }>;
+  const src: string;
+  export default src;
 }
 declare module '*.jpg' {
   const value: any;

--- a/scopes/react/react/typescript/asset.d.ts
+++ b/scopes/react/react/typescript/asset.d.ts
@@ -3,9 +3,13 @@ declare module '*.png' {
   export = value;
 }
 declare module '*.svg' {
-  const value: any;
-  export = value;
+  import type { FunctionComponent, SVGProps } from 'react';
+
+  export const ReactComponent: FunctionComponent<SVGProps<SVGSVGElement> & { title?: string }>;
+  const src: string;
+  export default src;
 }
+
 // @TODO Gilad
 declare module '*.jpg' {
   const value: any;

--- a/scopes/react/react/webpack/webpack.config.base.ts
+++ b/scopes/react/react/webpack/webpack.config.base.ts
@@ -304,7 +304,13 @@ export default function (isEnvProduction = false): Configuration {
               oneOf: [
                 {
                   dependency: { not: ['url'] }, // exclude new URL calls
-                  use: [require.resolve('@svgr/webpack'), require.resolve('new-url-loader')],
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options: { titleProp: true, ref: true },
+                    },
+                    require.resolve('new-url-loader'),
+                  ],
                 },
                 {
                   type: 'asset', // export a data URI or emit a separate file


### PR DESCRIPTION
## Proposed Changes

- add the svgr props included in the previous setup, as per @marella's comment [here](https://github.com/teambit/bit/pull/4595#pullrequestreview-709393730):
  - pass titleProp
  - pass ref
  - (do not disable `svgo` svg optimizer.)
- add the types needed to tag svg-as-react. (`ReactComponent`)
- add the same types to the `react-workspace-learn-bit` template. (not sure how to check it, but `bit new` isn't user facing yet)