### PR TITLE
fix bit-status when switching lanes back and forth

### DIFF
--- a/e2e/commands/import2.e2e.1.ts
+++ b/e2e/commands/import2.e2e.1.ts
@@ -436,8 +436,7 @@ console.log(barFoo.default());`;
       helper.scopeHelper.reInitLocalScope();
       helper.scopeHelper.addRemoteScope();
 
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      helper.command.importManyComponents(['utils/is-string@0.0.1', ['utils/is-type@0.0.2']]);
+      helper.command.importManyComponents(['utils/is-string@0.0.1', 'utils/is-type@0.0.2']);
     });
     it('should successfully print results of is-type@0.0.1 when requiring it indirectly by is-string', () => {
       const requirePath = helper.general.getRequireBitPath('utils', 'is-string');

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -944,5 +944,32 @@ describe('bit lane command', function () {
       const hash = helper.command.getHeadOfLane('dev', 'comp1');
       expect(status).to.have.string(`versions: ${hash} ...`);
     });
+    describe('export the lane, then switch back to main', () => {
+      before(() => {
+        helper.command.exportLane();
+        helper.command.switchLocalLane('main');
+      });
+      it('status should not show the components as pending updates', () => {
+        helper.command.expectStatusToBeClean();
+      });
+      describe('switch the lane back to dev', () => {
+        before(() => {
+          helper.command.switchLocalLane('dev');
+        });
+        // before, it was changing the version to the head of the lane
+        it('should not change the version prop in .bitmap', () => {
+          const bitMap = helper.bitMap.read();
+          expect(bitMap.comp1.version).to.equal('0.0.1');
+        });
+        describe('switch back to main', () => {
+          before(() => {
+            helper.command.switchLocalLane('main');
+          });
+          it('status should not show the components as pending updates', () => {
+            helper.command.expectStatusToBeClean();
+          });
+        });
+      });
+    });
   });
 });

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -643,7 +643,8 @@ export default class BitMap {
     logger.debug(`adding to bit.map ${componentIdStr}`);
 
     const getOrCreateComponentMap = (): ComponentMap => {
-      const componentMap = this.getComponentIfExist(componentId, { ignoreVersion: true });
+      const ignoreVersion = !this.isLegacy; // legacy can have two components on .bitmap with different versions
+      const componentMap = this.getComponentIfExist(componentId, { ignoreVersion });
       if (componentMap) {
         logger.info(`bit.map: updating an exiting component ${componentIdStr}`);
         componentMap.files = files;

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -64,7 +64,7 @@ export default class BitMap {
     private mapPath: string,
     public schema: string,
     private isLegacy: boolean,
-    public workspaceLane: WorkspaceLane | null,
+    public workspaceLane: WorkspaceLane | null, // null if not checked out to a lane
     private remoteLaneName?: RemoteLaneId
   ) {
     this.components = [];
@@ -398,13 +398,7 @@ export default class BitMap {
    */
   getBitId(
     bitId: BitId,
-    {
-      ignoreVersion = false,
-      ignoreScopeAndVersion = false,
-    }: {
-      ignoreVersion?: boolean;
-      ignoreScopeAndVersion?: boolean;
-    } = {}
+    { ignoreVersion = false, ignoreScopeAndVersion = false }: GetBitMapComponentOptions = {}
   ): BitId {
     if (!(bitId instanceof BitId)) {
       throw new TypeError(`BitMap.getBitId expects bitId to be an instance of BitId, instead, got ${bitId}`);
@@ -423,6 +417,7 @@ export default class BitMap {
     if (this.updatedIds[bitId.toString()]) {
       return this.updatedIds[bitId.toString()].id;
     }
+
     throw new MissingBitMapComponent(bitId.toString());
   }
 
@@ -459,7 +454,10 @@ export default class BitMap {
     bitId: BitId,
     { ignoreVersion = false, ignoreScopeAndVersion = false }: GetBitMapComponentOptions = {}
   ): ComponentMap {
-    const existingBitId: BitId = this.getBitId(bitId, { ignoreVersion, ignoreScopeAndVersion });
+    const existingBitId: BitId = this.getBitId(bitId, {
+      ignoreVersion,
+      ignoreScopeAndVersion,
+    });
     return this.components.find((c) => c.id.isEqual(existingBitId)) as ComponentMap;
   }
 
@@ -470,13 +468,7 @@ export default class BitMap {
    */
   getComponentIfExist(
     bitId: BitId,
-    {
-      ignoreVersion = false,
-      ignoreScopeAndVersion = false,
-    }: {
-      ignoreVersion?: boolean;
-      ignoreScopeAndVersion?: boolean;
-    } = {}
+    { ignoreVersion = false, ignoreScopeAndVersion = false }: GetBitMapComponentOptions = {}
   ): ComponentMap | undefined {
     try {
       const componentMap = this.getComponent(bitId, { ignoreVersion, ignoreScopeAndVersion });
@@ -651,10 +643,11 @@ export default class BitMap {
     logger.debug(`adding to bit.map ${componentIdStr}`);
 
     const getOrCreateComponentMap = (): ComponentMap => {
-      const componentMap = this.getComponentIfExist(componentId);
+      const componentMap = this.getComponentIfExist(componentId, { ignoreVersion: true });
       if (componentMap) {
         logger.info(`bit.map: updating an exiting component ${componentIdStr}`);
         componentMap.files = files;
+        componentMap.id = componentId;
         return componentMap;
       }
       if (origin === COMPONENT_ORIGINS.IMPORTED || origin === COMPONENT_ORIGINS.AUTHORED) {
@@ -704,6 +697,7 @@ export default class BitMap {
 
   reLoadAfterSwitchingLane(workspaceLane: null | WorkspaceLane) {
     this.workspaceLane = workspaceLane;
+    if (!workspaceLane) this.remoteLaneName = undefined;
     this._invalidateCache();
     this.components.forEach((componentMap) =>
       componentMap.updatePerLane(this.remoteLaneName, this.workspaceLane ? this.workspaceLane.ids : null)
@@ -724,6 +718,7 @@ export default class BitMap {
   };
 
   _removeFromComponentsArray(componentId: BitId) {
+    logger.debug(`bit-map: _removeFromComponentsArray ${componentId.toString()}`);
     this.components = this.components.filter((componentMap) => !componentMap.id.isEqual(componentId));
     this.markAsChanged();
   }

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -355,18 +355,23 @@ export default class ComponentWriter {
    */
   _updateBitMapIfNeeded() {
     if (this.isolated) return;
-    const componentMapExistWithSameVersion = this.bitMap.isExistWithSameVersion(this.component.id);
-    if (componentMapExistWithSameVersion) {
-      if (
-        this.existingComponentMap &&
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        this.existingComponentMap !== COMPONENT_ORIGINS.NESTED &&
-        this.origin === COMPONENT_ORIGINS.NESTED
-      ) {
-        return;
+    if (this.consumer?.isLegacy) {
+      // this logic is not needed in Harmony, and we can't just remove the component as it may have
+      // lanes data
+      const componentMapExistWithSameVersion = this.bitMap.isExistWithSameVersion(this.component.id);
+      if (componentMapExistWithSameVersion) {
+        if (
+          this.existingComponentMap &&
+          // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+          this.existingComponentMap !== COMPONENT_ORIGINS.NESTED &&
+          this.origin === COMPONENT_ORIGINS.NESTED
+        ) {
+          return;
+        }
+        this.bitMap.removeComponent(this.component.id);
       }
-      // this.bitMap.removeComponent(this.component.id);
     }
+
     // @ts-ignore this.component.componentMap is set
     this.component.componentMap = this.addComponentToBitMap(this.component.componentMap.rootDir);
   }

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -365,10 +365,9 @@ export default class ComponentWriter {
       ) {
         return;
       }
-      this.bitMap.removeComponent(this.component.id);
+      // this.bitMap.removeComponent(this.component.id);
     }
-    // $FlowFixMe this.component.componentMap is set
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-ignore this.component.componentMap is set
     this.component.componentMap = this.addComponentToBitMap(this.component.componentMap.rootDir);
   }
 

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -266,7 +266,7 @@ export default class CommandHelper {
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }
-  exportLane(laneName: string, scope: string = this.scopes.remote, assert = true) {
+  exportLane(laneName = '', scope: string = this.scopes.remote, assert = true) {
     const result = this.runCmd(`bit export ${scope} ${laneName} --force --lanes`);
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;


### PR DESCRIPTION
Currently, when switching lanes from main to an existing remote-lane dev, and then back to main, and then again to dev, the .bitmap has the wrong version, which result in the wrong bit-status when switching again to main.  (yes, lots of switching are needed to see the issue).