### PR TITLE
shorten template names

### DIFF
--- a/scopes/generator/generator/templates.cmd.ts
+++ b/scopes/generator/generator/templates.cmd.ts
@@ -30,8 +30,8 @@ export class TemplatesCmd implements Command {
 
     const grouped = groupBy(results, 'aspectId');
     const titleStr = this.generator.isRunningInsideWorkspace()
-      ? `The following template(s) are available with the command bit create: \nbit create react-component ui/button`
-      : `The following template(s) are available with the command bit new: \nbit new react-workspace my-workspace`;
+      ? `The following template(s) are available with the command bit create:  \nExample - bit create react my-component`
+      : `The following template(s) are available with the command bit new: \nExample - bit new react-workspace my-workspace`;
     const title = chalk.green(`\n${titleStr}\n`);
     const templateOutput = (template: TemplateDescriptor) => {
       const desc = template.description ? ` (${template.description})` : '';

--- a/scopes/generator/generator/templates/component-generator/index.ts
+++ b/scopes/generator/generator/templates/component-generator/index.ts
@@ -6,7 +6,8 @@ import { mainRuntime } from './files/main-runtime';
 
 export const componentGeneratorTemplate: ComponentTemplate = {
   name: 'component-generator',
-  description: 'create your own component generator',
+  description:
+    'create your own component generator \nDocs: https://harmony-docs.bit.dev/extending-bit/creating-a-custom-generator',
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/generator/generator/templates/workspace-generator/index.ts
+++ b/scopes/generator/generator/templates/workspace-generator/index.ts
@@ -9,7 +9,8 @@ import { workspaceConfigTemplate } from './files/workspace-config-tpl';
 
 export const workspaceGeneratorTemplate: ComponentTemplate = {
   name: 'workspace-generator',
-  description: 'create your own workspace generator',
+  description:
+    'create your own workspace generator - \nDocs: https://harmony-docs.bit.dev/extending-bit/creating-a-custom-workspace-generator',
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/html/html/html.main.runtime.ts
+++ b/scopes/html/html/html.main.runtime.ts
@@ -10,7 +10,7 @@ import { EnvsAspect, EnvsMain, EnvTransformer } from '@teambit/envs';
 import { ReactAspect, ReactMain } from '@teambit/react';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 import { htmlEnvTemplate } from './templates/html-env';
-import { htmlComponentTemplate } from './templates/html-component';
+import { htmlComponentTemplate, deprecatedHtmlComponentTemplate } from './templates/html-component';
 import { HtmlAspect } from './html.aspect';
 import { HtmlEnv } from './html.env';
 
@@ -98,7 +98,7 @@ export class HtmlMain {
   static async provider([envs, react, generator]: [EnvsMain, ReactMain, GeneratorMain]) {
     const htmlEnv: HtmlEnv = envs.merge(new HtmlEnv(), react.reactEnv);
     envs.registerEnv(htmlEnv);
-    generator.registerComponentTemplate([htmlEnvTemplate, htmlComponentTemplate]);
+    generator.registerComponentTemplate([htmlEnvTemplate, htmlComponentTemplate, deprecatedHtmlComponentTemplate]);
     return new HtmlMain(react, htmlEnv, envs);
   }
 }

--- a/scopes/html/html/templates/html-component/index.ts
+++ b/scopes/html/html/templates/html-component/index.ts
@@ -5,8 +5,26 @@ import { docsFile } from './files/docs';
 import { testFile } from './files/test';
 
 export const htmlComponentTemplate: ComponentTemplate = {
+  name: 'html',
+  description: 'a basic html component',
+
+  generateFiles: (context: ComponentContext) => {
+    const { name, namePascalCase: Name } = context;
+    const indexFile = {
+      relativePath: 'index.ts',
+      content: `export { ${Name} } from './${name}';
+export type { ${Name}Props } from './${name}';
+`,
+    };
+
+    return [indexFile, componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
+  },
+};
+
+export const deprecatedHtmlComponentTemplate: ComponentTemplate = {
   name: 'html-component',
   description: 'a basic html component',
+  hidden: true,
 
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;

--- a/scopes/mdx/mdx/mdx.templates.ts
+++ b/scopes/mdx/mdx/mdx.templates.ts
@@ -1,4 +1,4 @@
 import { ComponentTemplate } from '@teambit/generator';
-import { MDXComponent } from './templates/mdx-component';
+import { MDXComponent, deprecatedMDXComponent } from './templates/mdx-component';
 
-export const componentTemplates: ComponentTemplate[] = [MDXComponent];
+export const componentTemplates: ComponentTemplate[] = [MDXComponent, deprecatedMDXComponent];

--- a/scopes/mdx/mdx/templates/mdx-component/index.ts
+++ b/scopes/mdx/mdx/templates/mdx-component/index.ts
@@ -6,8 +6,25 @@ import { docsFile } from './files/docs';
 // import { testFile } from './files/test';
 
 export const MDXComponent: ComponentTemplate = {
+  name: 'mdx',
+  description: 'MDX-file compiled by Bit to a reuseable component',
+
+  generateFiles: (context: ComponentContext) => {
+    const { name, namePascalCase: Name } = context;
+    const indexFile = {
+      relativePath: 'index.ts',
+      content: `export { default as ${Name} } from './${name}.mdx';
+`,
+    };
+
+    return [indexFile, componentFile(context), compositionFile(context), docsFile(context)];
+  },
+};
+
+export const deprecatedMDXComponent: ComponentTemplate = {
   name: 'mdx-component',
   description: 'MDX-file compiled by Bit to a reuseable component',
+  hidden: true,
 
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;

--- a/scopes/react/react/react.templates.ts
+++ b/scopes/react/react/react.templates.ts
@@ -1,6 +1,6 @@
 import { ComponentTemplate, WorkspaceTemplate } from '@teambit/generator';
-import { reactComponent } from './templates/react-component';
-import { reactComponentJS } from './templates/react-component-js';
+import { reactComponent, deprecatedReactComponent } from './templates/react-component';
+import { reactComponentJS, deprecatedReactComponentJS } from './templates/react-component-js';
 import { reactEnvTemplate } from './templates/react-env';
 import { reactWorkspaceEmptyTemplate } from './templates/react-workspace-empty';
 import { reactHook } from './templates/react-hook';
@@ -13,6 +13,8 @@ export const componentTemplates: ComponentTemplate[] = [
   reactHook,
   reactComponentJS,
   reactEnvTemplate,
+  deprecatedReactComponent,
+  deprecatedReactComponentJS,
 ];
 
 export const workspaceTemplates: WorkspaceTemplate[] = [reactWorkspaceTemplate, reactWorkspaceEmptyTemplate];

--- a/scopes/react/react/templates/react-component-js/index.ts
+++ b/scopes/react/react/templates/react-component-js/index.ts
@@ -5,8 +5,25 @@ import { docsFile } from './files/docs';
 import { testFile } from './files/test';
 
 export const reactComponentJS: ComponentTemplate = {
+  name: 'react-js',
+  description: 'a basic react component in js',
+
+  generateFiles: (context: ComponentContext) => {
+    const { name, namePascalCase: Name } = context;
+    const indexFile = {
+      relativePath: 'index.js',
+      content: `export { ${Name} } from './${name}';
+`,
+    };
+
+    return [indexFile, componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
+  },
+};
+
+export const deprecatedReactComponentJS: ComponentTemplate = {
   name: 'react-component-js',
   description: 'a basic react component in js',
+  hidden: true,
 
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;

--- a/scopes/react/react/templates/react-component/index.ts
+++ b/scopes/react/react/templates/react-component/index.ts
@@ -5,8 +5,26 @@ import { docsFile } from './files/docs';
 import { testFile } from './files/test';
 
 export const reactComponent: ComponentTemplate = {
+  name: 'react',
+  description: 'a basic react component',
+
+  generateFiles: (context: ComponentContext) => {
+    const { name, namePascalCase: Name } = context;
+    const indexFile = {
+      relativePath: 'index.ts',
+      content: `export { ${Name} } from './${name}';
+export type { ${Name}Props } from './${name}';
+`,
+    };
+
+    return [indexFile, componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
+  },
+};
+
+export const deprecatedReactComponent: ComponentTemplate = {
   name: 'react-component',
   description: 'a basic react component',
+  hidden: true,
 
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;


### PR DESCRIPTION

## Proposed Changes

- shorten names for bit create but keep others as hidden so no breaking changes. both bit create react-component and bit create react will work
- add links to docs for workspace and component generators

