### PR TITLE
fix merging lanes when a dependency is local

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -930,11 +930,11 @@ describe('bit lane command', function () {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
-      helper.fixtures.populateComponents(1);
+      helper.fixtures.populateComponents(2);
       helper.command.tagAllWithoutBuild();
       helper.command.export();
       helper.command.createLane();
-      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.fixtures.populateComponents(2, undefined, 'v2');
       helper.command.snapAllComponentsWithoutBuild();
     });
     it('bit status should show the correct staged versions', () => {
@@ -945,9 +945,11 @@ describe('bit lane command', function () {
       expect(status).to.have.string(`versions: ${hash} ...`);
     });
     describe('export the lane, then switch back to main', () => {
+      let afterSwitching;
       before(() => {
         helper.command.exportLane();
         helper.command.switchLocalLane('main');
+        afterSwitching = helper.scopeHelper.cloneLocalScope();
       });
       it('status should not show the components as pending updates', () => {
         helper.command.expectStatusToBeClean();
@@ -968,6 +970,16 @@ describe('bit lane command', function () {
           it('status should not show the components as pending updates', () => {
             helper.command.expectStatusToBeClean();
           });
+        });
+      });
+      describe('merging the dev lane when the lane is ahead (no diverge)', () => {
+        before(() => {
+          helper.scopeHelper.getClonedLocalScope(afterSwitching);
+          helper.command.mergeLane('dev');
+        });
+        it('should merge the lane', () => {
+          const mergedLanes = helper.command.showLanes('--merged');
+          expect(mergedLanes).to.include('dev');
         });
       });
     });

--- a/src/links/linker.ts
+++ b/src/links/linker.ts
@@ -98,6 +98,8 @@ export async function reLinkDependents(consumer: Consumer, components: Component
 }
 
 /**
+ * Not needed for Harmony.
+ *
  * needed for the following cases:
  * 1) user is importing a component directly which was a dependency before. (before: NESTED, now: IMPORTED).
  * 2) user used bit-move to move a dependency to another directory.
@@ -110,8 +112,11 @@ export async function getReLinkDependentsData(
   linkedComponents: BitIds
 ): Promise<DataToPersist> {
   logger.debug('linker: check whether there are direct dependents for re-linking');
-  const directDependentComponents = await consumer.getAuthoredAndImportedDependentsComponentsOf(components);
   const dataToPersist = new DataToPersist();
+  if (!consumer.isLegacy) {
+    return dataToPersist;
+  }
+  const directDependentComponents = await consumer.getAuthoredAndImportedDependentsComponentsOf(components);
   if (directDependentComponents.length) {
     if (directDependentComponents.every((c) => linkedComponents.has(c.id))) {
       // all components already linked


### PR DESCRIPTION
Currently, when the dependent is import, during the link process, it re-imports the dependency and override its head. 