### PR TITLE
bit-export: introduce a new flag "--ignore-missing-artifacts"

### DIFF
--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -50,6 +50,11 @@ ${WILDCARD_HELP('export remote-scope')}`;
       'resume <string>',
       'in case the previous export failed and suggested to resume with an export-id, enter the id',
     ],
+    [
+      '',
+      'ignore-missing-artifacts',
+      "EXPERIMENTAL. don't throw an error when artifact files are missing. not recommended, unless you're sure the artifacts are in the remote",
+    ],
   ] as CommandOptions;
   loader = true;
   migration = true;
@@ -69,6 +74,7 @@ ${WILDCARD_HELP('export remote-scope')}`;
       force = false,
       rewire = false,
       lanes = false,
+      ignoreMissingArtifacts = false,
       resume,
     }: any
   ): Promise<string> {
@@ -94,6 +100,7 @@ ${WILDCARD_HELP('export remote-scope')}`;
       force,
       lanes,
       resumeExportId: resume,
+      ignoreMissingArtifacts,
     });
     if (isEmpty(componentsIds) && isEmpty(nonExistOnBitMap) && isEmpty(missingScope)) {
       return chalk.yellow('nothing to export');

--- a/src/api/consumer/lib/export.ts
+++ b/src/api/consumer/lib/export.ts
@@ -55,6 +55,7 @@ type ExportParams = {
   force: boolean;
   lanes: boolean;
   resumeExportId: string | undefined;
+  ignoreMissingArtifacts: boolean;
 };
 
 export default async function exportAction(params: ExportParams) {
@@ -81,15 +82,13 @@ export default async function exportAction(params: ExportParams) {
 async function exportComponents({
   ids,
   remote,
-  includeDependencies,
   setCurrentScope,
   includeNonStaged,
   codemod,
   force,
   lanes,
-  allVersions,
   originDirectly,
-  resumeExportId,
+  ...params
 }: ExportParams): Promise<{
   updatedIds: BitId[];
   nonExistOnBitMap: BitId[];
@@ -125,18 +124,16 @@ async function exportComponents({
   }
 
   const { exported, updatedLocally, newIdsOnRemote } = await exportMany({
+    ...params,
     scope: consumer.scope,
     isLegacy: consumer.isLegacy,
     ids: idsToExport,
     remoteName: remote,
-    includeDependencies,
     changeLocallyAlthoughRemoteIsDifferent: setCurrentScope,
     codemod,
     lanesObjects,
-    allVersions,
     originDirectly,
     idsWithFutureScope,
-    resumeExportId,
   });
   if (lanesObjects) await updateLanesAfterExport(consumer, lanesObjects);
   const { updatedIds, nonExistOnBitMap } = _updateIdsOnBitMap(consumer.bitMap, updatedLocally);

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -87,6 +87,7 @@ export async function exportMany({
   originDirectly,
   idsWithFutureScope,
   resumeExportId,
+  ignoreMissingArtifacts,
 }: {
   scope: Scope;
   isLegacy: boolean;
@@ -101,6 +102,7 @@ export async function exportMany({
   originDirectly?: boolean;
   idsWithFutureScope: BitIds;
   resumeExportId?: string | undefined;
+  ignoreMissingArtifacts?: boolean;
 }): Promise<{ exported: BitIds; updatedLocally: BitIds; newIdsOnRemote: BitId[] }> {
   logger.debugAndAddBreadCrumb('scope.exportMany', 'ids: {ids}', { ids: ids.toString() });
   if (lanesObjects.length && !remoteName) {
@@ -299,7 +301,11 @@ export async function exportMany({
     const processModelComponent = async (modelComponent: ModelComponent) => {
       const versionToExport = await getVersionsToExport(modelComponent);
       modelComponent.clearStateData();
-      const objectItems = await modelComponent.collectVersionsObjects(scope.objects, versionToExport);
+      const objectItems = await modelComponent.collectVersionsObjects(
+        scope.objects,
+        versionToExport,
+        ignoreMissingArtifacts
+      );
       const objectsList = await new ObjectList(objectItems).toBitObjects();
       const componentAndObject = { component: modelComponent, objects: objectsList.getAll() };
       await convertToCorrectScopeHarmony(scope, componentAndObject, remoteNameStr, bitIds, idsWithFutureScope);


### PR DESCRIPTION
Mostly useful when running `bit export --all` to export all versions, not only staged. In which case, the artifacts of old versions are in the remote but probably not exist locally.