### PR TITLE
block running bit-new inside a workspace

### DIFF
--- a/e2e/harmony/new.e2e.ts
+++ b/e2e/harmony/new.e2e.ts
@@ -56,4 +56,12 @@ describe('new command', function () {
       expect(dependencies).to.not.have.property('@types/node');
     });
   });
+  describe('running inside workspace', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+    });
+    it('should throw an error', () => {
+      expect(() => helper.command.new('react')).to.throw();
+    });
+  });
 });

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -187,6 +187,9 @@ export class GeneratorMain {
   }
 
   async generateWorkspaceTemplate(workspaceName: string, templateName: string, options: NewOptions) {
+    if (this.workspace) {
+      throw new BitError("error: unable generating a new workspace, you're in a workspace already");
+    }
     const { aspect: aspectId, loadFrom } = options;
     const template = loadFrom
       ? await this.findTemplateInOtherWorkspace(loadFrom, templateName, aspectId)


### PR DESCRIPTION
Currently, it's allowed and it ends up in an invalid state of a workspace inside another workspace.