### PR TITLE
fix avatar default bg color

### DIFF
--- a/scopes/design/ui/Avatar/styles.module.scss
+++ b/scopes/design/ui/Avatar/styles.module.scss
@@ -53,5 +53,5 @@
 
 :export {
   //text without hash
-  defaultAvatarBgColor: str-slice(inspect(var(--bit-border-color-lightest, #ededed)), 2);
+  defaultAvatarBgColor: 'ededed';
 }

--- a/scopes/design/ui/Avatar/styles.module.scss
+++ b/scopes/design/ui/Avatar/styles.module.scss
@@ -53,5 +53,5 @@
 
 :export {
   //text without hash
-  defaultAvatarBgColor: 'ededed';
+  defaultAvatarBgColor: ededed;
 }


### PR DESCRIPTION
## Proposed Changes

- replace css var with correct string as the background parameter for imgix

Example of the problem:
<img width="164" alt="Screen Shot 2021-08-02 at 10 59 54" src="https://user-images.githubusercontent.com/5400361/127838292-1ee244bc-5c94-4802-80ef-58f1fd855731.png">

Should look like this:
<img width="164" alt="Screen Shot 2021-08-02 at 16 10 32" src="https://user-images.githubusercontent.com/5400361/127867269-836e57b1-1100-407b-9e3c-443a3682f69b.png">
