### PR TITLE
fix dep - cannot find module workbox-build

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -593,7 +593,7 @@
     },
     "network/agent": {
         "scope": "teambit.toolbox",
-        "version": "0.0.175",
+        "version": "0.0.176",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/network/agent"
     },
@@ -605,7 +605,7 @@
     },
     "network/proxy-agent": {
         "scope": "teambit.toolbox",
-        "version": "0.0.175",
+        "version": "0.0.176",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/network/proxy-agent"
     },

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -312,7 +312,7 @@
         "webpack-hot-middleware": "2.25.0",
         "webpack-manifest-plugin": "3.1.1",
         "webpack-merge": "5.7.3",
-        "workbox-webpack-plugin": "6.1.5",
+        "workbox-webpack-plugin": "6.2.2",
         "ws": "7.4.2",
         "yaml": "1.10.2"
       },


### PR DESCRIPTION
## Proposed Changes

- update `workbox-webpack-plugin` from `6.1.5` to `6.2.2`
- should fix #4706 
