### PR TITLE
fix bit-new tests

### DIFF
--- a/e2e/harmony/new.e2e.ts
+++ b/e2e/harmony/new.e2e.ts
@@ -28,7 +28,7 @@ describe('new command', function () {
 
       const indexPath = path.join(helper.scopes.remote, 'workspace-example/template/index.ts');
       const indexContent = helper.fs.readFile(indexPath);
-      const updatedIndex = indexContent.replace('teambit.react/templates/ui/title', `${helper.scopes.remote}/comp1`);
+      const updatedIndex = indexContent.replace('teambit.react/templates/ui/text', `${helper.scopes.remote}/comp1`);
       helper.fs.outputFile(indexPath, updatedIndex);
 
       helper.command.tagAllComponents();


### PR DESCRIPTION
They're not failing on CircleCI with a strange error, after trying to install a non-exist package: `@teambit/react.templates.env.templates`.