### PR TITLE
fix running bit-build when components are out-of-sync

### DIFF
--- a/e2e/harmony/out-of-sync-components-harmony.e2e.ts
+++ b/e2e/harmony/out-of-sync-components-harmony.e2e.ts
@@ -46,4 +46,43 @@ describe('components that are not synced between the scope and the consumer', fu
       });
     });
   });
+  describe('consumer with a tagged component and scope with no components', () => {
+    let scopeOutOfSync;
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFooAsDir();
+      helper.command.tagAllWithoutBuild();
+      helper.fs.deletePath('.bit');
+      scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
+    });
+    describe('bit build', () => {
+      it('should build the component successfully', () => {
+        expect(() => helper.command.build()).to.not.throw();
+      });
+    });
+    describe('bit status', () => {
+      let output;
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(scopeOutOfSync);
+        output = helper.command.status();
+      });
+      it('should show the component as new', () => {
+        expect(output).to.have.string('new components');
+        const bitMap = helper.bitMap.read();
+        const newId = 'bar/foo';
+        expect(bitMap).to.have.property(newId);
+        const oldId = 'bar/foo@0.0.1';
+        expect(bitMap).to.not.have.property(oldId);
+      });
+    });
+    describe('bit show', () => {
+      it('should not show the component with the version', () => {
+        helper.scopeHelper.getClonedLocalScope(scopeOutOfSync);
+        const show = helper.command.showComponent('bar/foo');
+        expect(show).to.not.have.string('0.0.1');
+      });
+    });
+  });
 });

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -99,7 +99,7 @@ export class WorkspaceComponentLoader {
     }
     const consumerComponent = legacyComponent || (await this.getConsumerComponent(id, forCapsule));
     // in case of out-of-sync, the id may changed during the load process
-    const updatedId = ComponentID.fromLegacy(consumerComponent.id, id.scope);
+    const updatedId = consumerComponent ? ComponentID.fromLegacy(consumerComponent.id, id.scope) : id;
     const component = await this.loadOne(updatedId, consumerComponent);
     if (storeInCache) {
       this.saveInCache(component, forCapsule);

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -98,7 +98,9 @@ export class WorkspaceComponentLoader {
       return fromCache;
     }
     const consumerComponent = legacyComponent || (await this.getConsumerComponent(id, forCapsule));
-    const component = await this.loadOne(id, consumerComponent);
+    // in case of out-of-sync, the id may changed during the load process
+    const updatedId = ComponentID.fromLegacy(consumerComponent.id, id.scope);
+    const component = await this.loadOne(updatedId, consumerComponent);
     if (storeInCache) {
       this.saveInCache(component, forCapsule);
     }


### PR DESCRIPTION
In case userA has locally tagged a new version, but not exported. He then pushes his changes to the repo. Someone else (or a CI process) tries to load the repo, some commands such as bit build fail because the new version only exists on the local scope of the author, and nowhere else.
These scenarios were fixed in the legacy by a process called 'out-of-sync'. It would change the .bitmap and remove the local version.
This PR fixes the issue on Harmony by synchronizing the component-id between the legacy and Harmony. 