### PR TITLE
bit-new: import the latest component if --aspect component has no version

### DIFF
--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -336,9 +336,11 @@ export class AspectLoaderMain {
     const globalScopeHarmony = await loadBit(globalScope.path);
     const scope = globalScopeHarmony.get<ScopeMain>(ScopeAspect.id);
     const ids = aspectIds.map((id) => ComponentID.fromLegacy(BitId.parse(id, true)));
+    const hasVersions = ids.every((id) => id.hasVersion());
+    const useCache = hasVersions; // if all components has versions, try to use the cached aspects
     // @todo: Gilad make this work
     // const ids = await scope.resolveMultipleComponentIds(aspectIds);
-    const components = await scope.import(ids, undefined, true);
+    const components = await scope.import(ids, useCache, true);
     const resolvedAspects = await scope.getResolvedAspects(components);
     await this.loadRequireableExtensions(resolvedAspects, true);
     return components;


### PR DESCRIPTION
currently, when `bit new --aspect <component-id>` has no version, it load the latest version from the cache. If a new version was published, it doesn't check for it and just reload the last one. 
This PR re-imports the aspect in this case to make sure it always has the lastest.