### PR TITLE
add an API to convert ObjectList to IdGraph

### DIFF
--- a/e2e/harmony/graph-harmony.e2e.ts
+++ b/e2e/harmony/graph-harmony.e2e.ts
@@ -1,0 +1,43 @@
+import chai, { expect } from 'chai';
+import { ScopeMain, ScopeAspect } from '@teambit/scope';
+import { objectListToGraph, IdGraph } from '@teambit/graph';
+import { loadBit } from '@teambit/bit';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('graph aspect', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('tag a few components', () => {
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+    });
+    describe('ask the graph aspect for the graph ids', () => {
+      let graph: IdGraph;
+      before(async () => {
+        const harmony = await loadBit(helper.scopes.localPath);
+        const scope = harmony.get<ScopeMain>(ScopeAspect.id);
+        const objectList = await scope.toObjectList();
+        graph = await objectListToGraph(objectList);
+      });
+      it.only('should include the dependencies correctly', () => {
+        const jsonGraph = graph.toJson();
+        expect(jsonGraph.nodes).to.have.lengthOf(3);
+        expect(jsonGraph.edges).to.have.lengthOf(2);
+        expect(jsonGraph.edges[0]).to.deep.include({ sourceId: 'comp1@0.0.1', targetId: 'comp2@0.0.1' });
+        expect(jsonGraph.edges[1]).to.deep.include({ sourceId: 'comp2@0.0.1', targetId: 'comp3@0.0.1' });
+      });
+    });
+  });
+});

--- a/e2e/harmony/graph-harmony.e2e.ts
+++ b/e2e/harmony/graph-harmony.e2e.ts
@@ -31,7 +31,7 @@ describe('graph aspect', function () {
         const objectList = await scope.toObjectList();
         graph = await objectListToGraph(objectList);
       });
-      it.only('should include the dependencies correctly', () => {
+      it('should include the dependencies correctly', () => {
         const jsonGraph = graph.toJson();
         expect(jsonGraph.nodes).to.have.lengthOf(3);
         expect(jsonGraph.edges).to.have.lengthOf(2);

--- a/scopes/component/graph/index.ts
+++ b/scopes/component/graph/index.ts
@@ -8,3 +8,4 @@ export type { GraphMain } from './graph.main.runtime';
 export { EdgeType } from './edge-type';
 export type { GraphUI, ComponentWidget, ComponentWidgetSlot, ComponentWidgetProps } from './graph.ui.runtime';
 export { useGraph, useGraphQuery, GraphModel, EdgeModel, NodeModel } from './ui/query';
+export { objectListToGraph, IdGraph } from './object-list-to-graph';

--- a/scopes/component/graph/object-list-to-graph.ts
+++ b/scopes/component/graph/object-list-to-graph.ts
@@ -1,0 +1,52 @@
+import { Graph } from 'cleargraph';
+import { uniqBy } from 'lodash';
+import { BitId } from '@teambit/legacy-bit-id';
+import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';
+import { getAllVersionsInfo } from '@teambit/legacy/dist/scope/component-ops/traverse-versions';
+import { Dependency } from './model/dependency';
+
+type Node = { id: string; node: BitId };
+type Edge = { sourceId: string; targetId: string; edge: Dependency };
+
+export class IdGraph extends Graph<BitId, Dependency> {
+  constructor(nodes: Node[] = [], edges: Edge[] = []) {
+    super(nodes, edges);
+  }
+}
+
+export async function objectListToGraph(objectList: ObjectList): Promise<IdGraph> {
+  const bitObjectsList = await objectList.toBitObjects();
+  const components = bitObjectsList.getComponents();
+  const versions = bitObjectsList.getVersions();
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+  await Promise.all(
+    components.map(async (component) => {
+      const versionsInfo = await getAllVersionsInfo({
+        modelComponent: component,
+        versionObjects: versions,
+        throws: false,
+      });
+      versionsInfo.forEach((versionInfo) => {
+        const id = component.toBitId().changeVersion(versionInfo.tag || versionInfo.ref.toString());
+        const idStr = id.toString();
+        nodes.push({ id: idStr, node: id });
+        if (!versionInfo.version) {
+          return;
+        }
+        const { dependencies, devDependencies, extensionDependencies } = versionInfo.version.depsIdsGroupedByType;
+        const addDep = (depId: BitId, edge: Dependency) => {
+          edges.push({ sourceId: idStr, targetId: depId.toString(), edge });
+        };
+        const runTime = new Dependency('runtime');
+        const dev = new Dependency('dev');
+        dependencies.forEach((depId) => addDep(depId, runTime));
+        [...devDependencies, ...extensionDependencies].forEach((depId) => addDep(depId, dev));
+      });
+    })
+  );
+  const uniqNodes = uniqBy(nodes, 'id');
+  const idGraph = new IdGraph(uniqNodes, edges);
+
+  return idGraph;
+}

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -32,6 +32,7 @@ import { Remotes } from '@teambit/legacy/dist/remotes';
 import { isMatchNamespacePatternItem } from '@teambit/workspace.modules.match-pattern';
 import { Scope } from '@teambit/legacy/dist/scope';
 import { FETCH_OPTIONS } from '@teambit/legacy/dist/api/scope/lib/fetch';
+import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';
 import { Http, DEFAULT_AUTH_TYPE, AuthData, getAuthDataFromHeader } from '@teambit/legacy/dist/scope/network/http/http';
 import { buildOneGraphForComponentsUsingScope } from '@teambit/legacy/dist/scope/graph/components-graph';
 import { remove } from '@teambit/legacy/dist/api/scope';
@@ -304,6 +305,11 @@ export class ScopeMain implements ComponentFactory {
       }
     });
     return result;
+  }
+
+  async toObjectList(): Promise<ObjectList> {
+    const objects = await this.legacyScope.objects.list();
+    return ObjectList.fromBitObjects(objects);
   }
 
   // TODO: temporary compiler workaround - discuss this with david.

--- a/src/scope/component-ops/traverse-versions.ts
+++ b/src/scope/component-ops/traverse-versions.ts
@@ -41,7 +41,7 @@ export async function getAllVersionsInfo({
 }: {
   modelComponent: ModelComponent;
   repo?: Repository;
-  throws?: boolean;
+  throws?: boolean; // in case objects are missing
   versionObjects?: Version[];
   startFrom?: Ref | null; // by default, start from the head
   stopAt?: Ref | null; // by default, stop when the parents is empty


### PR DESCRIPTION
Add a new API to convert an array of bit objects to a graph when the nodes are component ids and the edges are the type of the dependency (either `runtime` or `dev`).