### PR TITLE
fix aspects loading order for custom envs

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -924,12 +924,13 @@ export class Workspace implements ComponentFactory {
     // no need to filter core aspects as they are not included in the graph
     // here we are trying to load extensions from the workspace.
     const { workspaceComps, scopeComps } = await this.groupComponentsByWorkspaceAndScope(aspects);
+    // load the scope first because we might need it for custom envs that extend external aspects
+    if (scopeComps.length) {
+      await this.scope.loadAspects(scopeComps.map((aspect) => aspect.id.toString()));
+    }
     if (workspaceComps.length) {
       const requireableExtensions: any = await this.requireComponents(workspaceComps);
       await this.aspectLoader.loadRequireableExtensions(requireableExtensions, throwOnError);
-    }
-    if (scopeComps.length) {
-      await this.scope.loadAspects(scopeComps.map((aspect) => aspect.id.toString()));
     }
   }
 


### PR DESCRIPTION
When using an external aspect and creating a custom env that extends this external aspects, we need to load the external aspect first otherwise it cannot be injected into the local custom env