### PR TITLE
improve error when the workspace.jsonc has a non-component key

### DIFF
--- a/e2e/harmony/workspace-config.e2e.ts
+++ b/e2e/harmony/workspace-config.e2e.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+describe('workspace config (workspace.jsonc)', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('adding a non-component key', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.addKeyVal(undefined, 'non-comp', {});
+    });
+    it('any command should throw a descriptive error', () => {
+      expect(() => helper.command.status()).to.throw(
+        `unable to parse the component-id "non-comp" from the workspace.jsonc file`
+      );
+    });
+  });
+});

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -114,7 +114,14 @@ function attachVersionsFromBitmap(config: Config, consumerInfo: ConsumerInfo): C
 }
 
 function getVersionFromBitMapIds(allBitmapIds: BitIds, aspectId: string): string | undefined {
-  const aspectBitId = BitId.parse(aspectId, true);
+  let aspectBitId: BitId;
+  try {
+    aspectBitId = BitId.parse(aspectId, true);
+  } catch (err) {
+    throw new Error(
+      `unable to parse the component-id "${aspectId}" from the workspace.jsonc file, make sure this is a component id`
+    );
+  }
   // start by searching id in the bitmap with exact match (including scope name)
   // in case the aspect is not exported yet, it will be in the bitmap without a scope,
   // while in the aspect id it will have the default scope


### PR DESCRIPTION
Currently, the error only says that the string is not a component-id but it doesn't say where it was taken from.
The new error shows this:
```
unable to parse the component-id "non-comp" from the workspace.jsonc file, make sure this is a component id
```
Reported by @ranm8 .