### PR TITLE
bit-new: improve the error when --load-from was entered with an invalid workspace

### DIFF
--- a/e2e/harmony/new.e2e.ts
+++ b/e2e/harmony/new.e2e.ts
@@ -11,6 +11,13 @@ describe('new command', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
+  it('entering a non-exist workspace, should throw a descriptive error', () => {
+    helper.scopeHelper.setNewLocalAndRemoteScopes();
+    helper.scopeHelper.cleanLocalScope(); // it deletes all content without bit-init
+    expect(() =>
+      helper.command.new('non-exist', '--aspect non.exist/aspect --load-from /non/exist/workspace')
+    ).to.throw(`fatal: "/non/exist/workspace" is not a valid Bit workspace, make sure the path is correct`);
+  });
   describe('export a workspace-template aspect', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -125,7 +125,12 @@ export class GeneratorMain {
   async findTemplateInOtherWorkspace(workspacePath: string, name: string, aspectId?: string) {
     if (!aspectId) throw new BitError(`to load template from a different workspace, please provide the aspect-id`);
     const harmony = await loadBit(workspacePath);
-    const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+    let workspace: Workspace;
+    try {
+      workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+    } catch (err) {
+      throw new Error(`fatal: "${workspacePath}" is not a valid Bit workspace, make sure the path is correct`);
+    }
     const aspectComponentId = await workspace.resolveComponentId(aspectId);
     await workspace.loadAspects([aspectId], true);
     const aspectFullId = aspectComponentId.toString();


### PR DESCRIPTION
Currently, it shows an unhelpful error: `failed loading extension teambit.workspace/workspace`.
With this PR it shows a descriptive error:
```
fatal: "/non/exist/workspace" is not a valid Bit workspace, make sure the path is correct
```
Reported by @debs-obrien .