### PR TITLE
warn for multiple envs

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -1,4 +1,5 @@
 import chai, { expect } from 'chai';
+import { IssuesClasses } from '../../scopes/component/component-issues';
 
 import { IS_WINDOWS } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
@@ -81,9 +82,8 @@ describe('custom env', function () {
         const newEnvId = 'teambit.react/react';
         helper.extensions.addExtensionToVariant('*', newEnvId, undefined, true);
       });
-      it.only('should not show the previous env as an extension', () => {
-        const comp3 = helper.command.showComponent('comp3');
-        expect(comp3).to.not.include(envId);
+      it('bit status should show it as an issue because the previous env was not removed', () => {
+        helper.command.expectStatusToHaveIssue(IssuesClasses.MultipleEnvs.name);
       });
     });
   });

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -74,6 +74,17 @@ describe('custom env', function () {
         expect(() => helper.command.status()).not.to.throw();
       });
     });
+    describe('change an env', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(wsAllNew);
+        envId = 'teambit.react/react';
+        helper.extensions.addExtensionToVariant('*', envId, undefined, true);
+      });
+      it.only('should not show the previous env as an extension', () => {
+        const comp3 = helper.command.showComponent('comp3');
+        expect(comp3).to.not.include(envId);
+      });
+    });
   });
   (supportNpmCiRegistryTesting ? describe : describe.skip)('custom env installed as a package', () => {
     let envId;

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -74,11 +74,12 @@ describe('custom env', function () {
         expect(() => helper.command.status()).not.to.throw();
       });
     });
-    describe('change an env', () => {
+    describe('change an env after tag', () => {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(wsAllNew);
-        envId = 'teambit.react/react';
-        helper.extensions.addExtensionToVariant('*', envId, undefined, true);
+        helper.command.tagAllWithoutBuild();
+        const newEnvId = 'teambit.react/react';
+        helper.extensions.addExtensionToVariant('*', newEnvId, undefined, true);
       });
       it.only('should not show the previous env as an extension', () => {
         const comp3 = helper.command.showComponent('comp3');

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -13,6 +13,7 @@ import { relativeComponentsAuthored } from './relative-components-authored';
 import { ResolveErrors } from './resolve-errors';
 import { UntrackedDependencies } from './untracked-dependencies';
 import { LegacyInsideHarmony } from './legacy-inside-harmony';
+import { MultipleEnvs } from './multiple-envs';
 
 export const IssuesClasses = {
   MissingPackagesDependenciesOnFs,
@@ -29,6 +30,7 @@ export const IssuesClasses = {
   MissingCustomModuleResolutionLinks,
   ImportNonMainFiles,
   CustomModuleResolutionUsed,
+  MultipleEnvs,
 };
 export type IssuesNames = keyof typeof IssuesClasses;
 

--- a/scopes/component/component-issues/multiple-envs.ts
+++ b/scopes/component/component-issues/multiple-envs.ts
@@ -1,0 +1,12 @@
+import { ComponentIssue, ISSUE_FORMAT_SPACE } from './component-issue';
+
+export class MultipleEnvs extends ComponentIssue {
+  description = 'multiple envs';
+  solution =
+    'remove the old envs by setting them with "-" sign in the variants. see https://harmony-docs.bit.dev/aspects/variants#removing-aspects ';
+  data: string[]; // env ids
+  isTagBlocker = true;
+  dataToString() {
+    return ISSUE_FORMAT_SPACE + this.data.join(', ');
+  }
+}

--- a/scopes/component/component/state.ts
+++ b/scopes/component/component/state.ts
@@ -1,3 +1,4 @@
+import { IssuesList } from '@teambit/component-issues';
 import ComponentFS from './component-fs';
 import Config from './config';
 import { AspectList } from './aspect-list';
@@ -37,6 +38,10 @@ export class State {
    */
   get hash() {
     return '';
+  }
+
+  get issues(): IssuesList {
+    return (this._consumer.issues ||= new IssuesList());
   }
 
   /**

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -288,6 +288,14 @@ export class EnvsMain {
     return this.getDefaultEnv();
   }
 
+  getAllEnvsConfiguredOnComponent(component: Component): EnvDefinition[] {
+    return component.state.aspects.entries.reduce((acc: EnvDefinition[], aspectEntry) => {
+      const envDef = this.getEnvDefinitionById(aspectEntry.id);
+      if (envDef) acc.push(envDef);
+      return acc;
+    }, []);
+  }
+
   /**
    * @deprecated DO NOT USE THIS METHOD ANYMORE!!! (PLEASE USE .calculateEnv() instead!)
    */

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -6,10 +6,11 @@ import { compact } from 'lodash';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { MissingBitMapComponent } from '@teambit/legacy/dist/consumer/bit-map/exceptions';
 import { getLatestVersionNumber } from '@teambit/legacy/dist/utils';
+import { IssuesClasses } from '@teambit/component-issues';
 import { ComponentNotFound } from '@teambit/legacy/dist/scope/exceptions';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import { Logger } from '@teambit/logger';
-import { EnvsAspect } from '@teambit/envs';
+import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config';
 import { getMaxSizeForComponents, InMemoryCache } from '@teambit/legacy/dist/cache/in-memory-cache';
 import { createInMemoryCache } from '@teambit/legacy/dist/cache/cache-factory';
@@ -23,7 +24,8 @@ export class WorkspaceComponentLoader {
   constructor(
     private workspace: Workspace,
     private logger: Logger,
-    private dependencyResolver: DependencyResolverMain
+    private dependencyResolver: DependencyResolverMain,
+    private envs: EnvsMain
   ) {
     this.componentsCache = createInMemoryCache({ maxSize: getMaxSizeForComponents() });
     this.componentsCacheForCapsule = createInMemoryCache({ maxSize: getMaxSizeForComponents() });
@@ -102,9 +104,18 @@ export class WorkspaceComponentLoader {
     const updatedId = consumerComponent ? ComponentID.fromLegacy(consumerComponent.id, id.scope) : id;
     const component = await this.loadOne(updatedId, consumerComponent);
     if (storeInCache) {
+      this.addMultipleEnvsIssueIfNeeded(component); // it's in storeInCache block, otherwise, it wasn't fully loaded
       this.saveInCache(component, forCapsule);
     }
     return component;
+  }
+
+  private addMultipleEnvsIssueIfNeeded(component: Component) {
+    const envs = this.envs.getAllEnvsConfiguredOnComponent(component);
+    if (envs.length < 2) {
+      return;
+    }
+    component.state.issues.getOrCreate(IssuesClasses.MultipleEnvs).data = envs.map((e) => e.id);
   }
 
   clearCache() {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -191,7 +191,7 @@ export class Workspace implements ComponentFactory {
   ) {
     // TODO: refactor - prefer to avoid code inside the constructor.
     this.owner = this.config?.defaultOwner;
-    this.componentLoader = new WorkspaceComponentLoader(this, logger, dependencyResolver);
+    this.componentLoader = new WorkspaceComponentLoader(this, logger, dependencyResolver, envs);
     this.validateConfig();
   }
 

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -34,10 +34,16 @@ export default class BitJsoncHelper {
     this.write(updated, bitJsoncDir);
   }
 
-  addToVariant(variant: string, key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
+  addToVariant(
+    variant: string,
+    key: string,
+    val: any,
+    replaceExisting = false,
+    bitJsoncDir: string = this.scopes.localPath
+  ) {
     const bitJsonc = this.read(bitJsoncDir);
     const variants = bitJsonc['teambit.workspace/variants'];
-    const newVariant = variants[variant] ?? {};
+    const newVariant = replaceExisting ? {} : variants[variant] ?? {};
     assign(newVariant, { [key]: val });
     this.setVariant(bitJsoncDir, variant, newVariant);
   }

--- a/src/e2e-helper/e2e-extensions-helper.ts
+++ b/src/e2e-helper/e2e-extensions-helper.ts
@@ -32,8 +32,8 @@ export default class ExtensionsHelper {
     this.bitJsonc.addKeyVal(this.scopes.localPath, extName, extConfig);
   }
 
-  addExtensionToVariant(variant: string, extName: string, extConfig = {}) {
-    this.bitJsonc.addToVariant(variant, extName, extConfig);
+  addExtensionToVariant(variant: string, extName: string, extConfig = {}, replaceExisting = false) {
+    this.bitJsonc.addToVariant(variant, extName, extConfig, replaceExisting);
   }
 
   removeAllExtensionsFromVariant(variant: string) {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -470,6 +470,7 @@
       "teambit.envs/envs": {
         "env": "teambit.harmony/node"
       },
+      "teambit.harmony/aspect": "-",
       "defaultScope": "teambit.toolbox"
     },
     "scopes/workspace": {


### PR DESCRIPTION
When a component has multiple envs, it's probably due to replacing the env and not removing the old env via the variants. 
This PR shows a warning in `bit status` in such case and blocks `bit tag` from tagging until it's fixed.
See https://github.com/teambit/bit/issues/4753 for more context. 