### PR TITLE
fix installation during bit-new to have the general node_modules with common packages

### DIFF
--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -52,7 +52,13 @@ export class WorkspaceGenerator {
       await this.writeWorkspaceFiles();
       await this.reloadBitInWorkspaceDir();
       await this.addComponentsFromRemote();
-      await this.workspace.install();
+      await this.workspace.install(undefined, {
+        dedupe: true,
+        import: false,
+        copyPeerToRuntimeOnRoot: true,
+        copyPeerToRuntimeOnComponents: false,
+        updateExisting: false,
+      });
     } catch (err) {
       await fs.remove(this.workspacePath);
       throw err;


### PR DESCRIPTION
Currently, it installs some of the packages inside the node_modules of the components. 
This PR fixes it by passing the correct parameters to `workspace.install()` method.
Reported by @ranm8 .