### PR TITLE
bit-new: rename --standalone flag to --skip-git

### DIFF
--- a/scopes/generator/generator/new.cmd.ts
+++ b/scopes/generator/generator/new.cmd.ts
@@ -5,7 +5,7 @@ import { GeneratorMain } from './generator.main.runtime';
 export type NewOptions = {
   aspect?: string;
   defaultScope?: string;
-  standalone?: boolean;
+  skipGit?: boolean;
   loadFrom?: string;
   empty?: boolean;
 };
@@ -24,7 +24,8 @@ export class NewCmd implements Command {
       'aspect-id of the template. mandatory for non-core aspects. helpful for core aspects in case of a name collision',
     ],
     ['d', 'default-scope <string>', `set defaultScope in the new workspace.jsonc`],
-    ['s', 'standalone', 'skip generation of Git repository'],
+    ['', 'standalone', 'DEPRECATED. use --skip-git instead'],
+    ['s', 'skip-git', 'skip generation of Git repository'],
     ['e', 'empty', 'empty workspace with no components (relevant for templates that add components by default)'],
     [
       '',
@@ -35,7 +36,8 @@ export class NewCmd implements Command {
 
   constructor(private generator: GeneratorMain) {}
 
-  async report([templateName, workspaceName]: [string, string], options: NewOptions) {
+  async report([templateName, workspaceName]: [string, string], options: NewOptions & { standalone: boolean }) {
+    options.skipGit = options.skipGit ?? options.standalone;
     const results = await this.generator.generateWorkspaceTemplate(workspaceName, templateName, options);
     return chalk.white(
       `${chalk.green(`

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -48,7 +48,7 @@ export class WorkspaceGenerator {
     try {
       process.chdir(this.workspacePath);
       await this.initGit();
-      await init(this.workspacePath, this.options.standalone, false, false, false, false, {});
+      await init(this.workspacePath, this.options.skipGit, false, false, false, false, {});
       await this.writeWorkspaceFiles();
       await this.reloadBitInWorkspaceDir();
       await this.addComponentsFromRemote();
@@ -68,7 +68,7 @@ export class WorkspaceGenerator {
   }
 
   private async initGit() {
-    if (this.options.standalone) return;
+    if (this.options.skipGit) return;
     const gitExecutablePath = getGitExecutablePath();
     const params = ['init'];
     try {


### PR DESCRIPTION
Asked by @ranm8 , to make the flag clearer. 