### PR TITLE
validate that a component object has the "head" prop

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -935,5 +935,8 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
         );
       }
     });
+    if (!this.head) {
+      throw new ValidationError(`${message}, the "head" prop is missing`);
+    }
   }
 }


### PR DESCRIPTION
A rare case was reported by a user in Slack where the "head" was missing for some reason. This makes sure to throw as soon as it's happening. 