### PR TITLE
e2e-tests: remove "dereference" option from the copy on linux

### DIFF
--- a/e2e/commands/export.e2e.1.ts
+++ b/e2e/commands/export.e2e.1.ts
@@ -858,7 +858,7 @@ describe('bit export command', function () {
         forkScope = scopeName;
         forkScopePath = scopePath;
         helper.scopeHelper.addRemoteScope(forkScopePath);
-        localScope = helper.scopeHelper.cloneLocalScope();
+        localScope = helper.scopeHelper.cloneLocalScope(true);
       });
       describe('with id and --include-dependencies flag', () => {
         let forkScopeIds;

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "execa": "2.1.0",
     "find-up": "5.0.0",
     "firstline": "2.0.2",
-    "fs-extra": "9.1.0",
+    "fs-extra": "10.0.0",
     "gitconfig": "2.0.8",
     "glob": "7.1.6",
     "globby": "11.0.1",

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -2,8 +2,6 @@
 
 import fs from 'fs-extra';
 import * as path from 'path';
-import { IS_WINDOWS } from '../constants';
-
 import { InteractiveInputs } from '../interactive/utils/run-interactive-cmd';
 import { generateRandomStr } from '../utils';
 import createSymlinkOrCopy from '../utils/fs/create-symlink-or-copy';
@@ -213,7 +211,7 @@ export default class ScopeHelper {
    * To make it faster, use this method before all tests, and then use getClonedLocalScope method to restore from the
    * cloned scope.
    */
-  cloneLocalScope(dereferenceSymlinks = IS_WINDOWS) {
+  cloneLocalScope(dereferenceSymlinks = false) {
     const clonedScope = `${generateRandomStr()}-clone`;
     const clonedScopePath = path.join(this.scopes.e2eDir, clonedScope);
     if (this.debugMode) console.log(`cloning a scope from ${this.scopes.localPath} to ${clonedScopePath}`);

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -2,6 +2,7 @@
 
 import fs from 'fs-extra';
 import * as path from 'path';
+import { IS_WINDOWS } from '../constants';
 
 import { InteractiveInputs } from '../interactive/utils/run-interactive-cmd';
 import { generateRandomStr } from '../utils';
@@ -212,7 +213,7 @@ export default class ScopeHelper {
    * To make it faster, use this method before all tests, and then use getClonedLocalScope method to restore from the
    * cloned scope.
    */
-  cloneLocalScope(dereferenceSymlinks = true) {
+  cloneLocalScope(dereferenceSymlinks = IS_WINDOWS) {
     const clonedScope = `${generateRandomStr()}-clone`;
     const clonedScopePath = path.join(this.scopes.e2eDir, clonedScope);
     if (this.debugMode) console.log(`cloning a scope from ${this.scopes.localPath} to ${clonedScopePath}`);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7133,7 +7133,7 @@ __metadata:
     find-up: 5.0.0
     firstline: 2.0.2
     flatted: 3.1.0
-    fs-extra: 9.1.0
+    fs-extra: 10.0.0
     fuse.js: 6.4.6
     get-port: 5.1.1
     gh-release: 3.5.0
@@ -18363,6 +18363,17 @@ __metadata:
   version: 1.0.0
   resolution: "fs-constants@npm:1.0.0"
   checksum: 18f5b718371816155849475ac36c7d0b24d39a11d91348cfcb308b4494824413e03572c403c86d3a260e049465518c4f0d5bd00f0371cdfcad6d4f30a85b350d
+  languageName: node
+  linkType: hard
+
+"fs-extra@npm:10.0.0":
+  version: 10.0.0
+  resolution: "fs-extra@npm:10.0.0"
+  dependencies:
+    graceful-fs: ^4.2.0
+    jsonfile: ^6.0.1
+    universalify: ^2.0.0
+  checksum: 5285a3d8f34b917cf2b66af8c231a40c1623626e9d701a20051d3337be16c6d7cac94441c8b3732d47a92a2a027886ca93c69b6a4ae6aee3c89650d2a8880c0a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Also, upgrade fs-extra from 9.x to 10.x to fix coping dirs with broken symlinks (see https://github.com/jprichardson/node-fs-extra/pull/779). 
This makes the copy scopes during tests much faster and less error prone.