### PR TITLE
bit-import: introduce a new flag "--all-history" to skip optimizations and bring all history objects

### DIFF
--- a/src/cli/commands/public-cmds/import-cmd.ts
+++ b/src/cli/commands/public-cmds/import-cmd.ts
@@ -60,6 +60,11 @@ export default class Import implements LegacyCommand {
       'skip-lane',
       'EXPERIMENTAL. when checked out to a lane, do not import the component into the lane, save it on main',
     ],
+    [
+      '',
+      'all-history',
+      'relevant for fetching all components objects. avoid optimizations, fetch all history versions, always',
+    ],
   ] as CommandOptions;
   loader = true;
   migration = true;
@@ -85,6 +90,7 @@ export default class Import implements LegacyCommand {
       skipLane = false,
       dependencies = false,
       dependents = false,
+      allHistory = false,
     }: {
       tester?: boolean;
       compiler?: boolean;
@@ -103,6 +109,7 @@ export default class Import implements LegacyCommand {
       skipLane?: boolean;
       dependencies?: boolean;
       dependents?: boolean;
+      allHistory?: boolean;
     },
     packageManagerArgs: string[]
   ): Promise<any> {
@@ -144,6 +151,7 @@ export default class Import implements LegacyCommand {
       skipLane,
       importDependenciesDirectly: dependencies,
       importDependents: dependents,
+      allHistory,
     };
     return importAction(environmentOptions, importOptions, packageManagerArgs).then((importResults) => ({
       displayDependencies,

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -48,6 +48,7 @@ export type ImportOptions = {
   fromOriginalScope?: boolean; // default: false, otherwise, it fetches flattened dependencies from their dependents
   skipLane?: boolean; // save on main instead of current lane
   lanes?: { laneIds: RemoteLaneId[]; lanes?: Lane[] };
+  allHistory?: boolean;
 };
 type ComponentMergeStatus = {
   componentWithDependencies: ComponentWithDependencies;
@@ -261,7 +262,11 @@ export default class ImportComponents {
       const idsWithLatestVersion = componentsIdsToImport.toVersionLatest();
       componentsAndDependencies =
         !this.consumer.isLegacy && this.options.objectsOnly
-          ? await this.consumer.importComponentsObjectsHarmony(componentsIdsToImport, this.options.fromOriginalScope)
+          ? await this.consumer.importComponentsObjectsHarmony(
+              componentsIdsToImport,
+              this.options.fromOriginalScope,
+              this.options.allHistory
+            )
           : await this.consumer.importComponents(BitIds.fromArray(idsWithLatestVersion), true);
       await this._throwForModifiedOrNewDependencies(componentsAndDependencies);
       await this._writeToFileSystem(componentsAndDependencies);

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -400,18 +400,13 @@ export default class Consumer {
     return componentWithDependencies;
   }
 
-  async importComponentsObjectsHarmony(ids: BitIds, fromOriginalScope = false): Promise<ComponentWithDependencies[]> {
+  async importComponentsObjectsHarmony(
+    ids: BitIds,
+    fromOriginalScope = false,
+    allHistory = false
+  ): Promise<ComponentWithDependencies[]> {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
-    try {
-      await scopeComponentsImporter.importManyDeltaWithoutDeps(ids);
-    } catch (err) {
-      loader.stop();
-      // @todo: remove once the server is deployed with this new "component-delta" type
-      if (err && err.message && err.message.includes('type component-delta was not implemented')) {
-        return this.importComponents(ids.toVersionLatest(), true);
-      }
-      throw err;
-    }
+    await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory);
     loader.start(`import ${ids.length} components with their dependencies (if missing)`);
     const versionDependenciesArr: VersionDependencies[] = fromOriginalScope
       ? await scopeComponentsImporter.importManyFromOriginalScopes(ids)

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -205,14 +205,14 @@ export default class ScopeComponentsImporter {
    * delta between the local head and the remote head. mainly to improve performance
    * not applicable and won't work for legacy. for legacy, refer to importManyWithAllVersions
    */
-  async importManyDeltaWithoutDeps(ids: BitIds): Promise<void> {
+  async importManyDeltaWithoutDeps(ids: BitIds, allHistory = false): Promise<void> {
     logger.debugAndAddBreadCrumb('importManyDeltaWithoutDeps', `Ids: {ids}`, { ids: ids.toString() });
     const idsWithoutNils = BitIds.uniqFromArray(compact(ids));
     if (R.isEmpty(idsWithoutNils)) return;
 
     const compDef = await this.sources.getMany(idsWithoutNils.toVersionLatest(), true);
     const idsToFetch = await mapSeries(compDef, async ({ id, component }) => {
-      if (!component) {
+      if (!component || allHistory) {
         // remove the version to fetch it with all versions.
         return id.changeVersion(undefined);
       }


### PR DESCRIPTION
Currently, `bit import` with no ids brings only the delta between the local and the remote. In some rare cases, objects are still missing. This flag fetches all objects.