### PR TITLE
fix untag to work on lane snaps

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1020,4 +1020,21 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('untag on a lane', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      output = helper.command.untagAll();
+    });
+    it('should untag successfully', () => {
+      expect(output).to.have.string('1 component(s) were untagged');
+    });
+    it('should change the component to be new', () => {
+      const status = helper.command.statusJson();
+      expect(status.newComponents).to.have.lengthOf(1);
+    });
+  });
 });

--- a/src/api/consumer/lib/untag.ts
+++ b/src/api/consumer/lib/untag.ts
@@ -20,7 +20,7 @@ export default async function unTagAction(
   const idHasWildcard = hasWildcard(id);
   const untag = async (): Promise<untagResult[]> => {
     if (idHasWildcard) {
-      return removeLocalVersionsForComponentsMatchedByWildcard(consumer.scope, version, force, id);
+      return removeLocalVersionsForComponentsMatchedByWildcard(consumer, version, force, id);
     }
     if (id) {
       const bitId = consumer.getParsedId(id);
@@ -31,7 +31,7 @@ export default async function unTagAction(
       return [result];
     }
     // untag all
-    return removeLocalVersionsForAllComponents(consumer.scope, version, force);
+    return removeLocalVersionsForAllComponents(consumer, version, force);
   };
   const softUntag = () => {
     const getIds = (): BitId[] => {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -838,7 +838,8 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
   }
 
   /**
-   * local versions that are not exported. to get also local snaps, use `getLocalTagsOrHashes()`.
+   * local versions that are not exported on the main lane.
+   * @see `this.getLocalTagsOrHashes()`, to get local snaps on the current lane
    */
   getLocalVersions(): string[] {
     if (isEmpty(this.state) || isEmpty(this.state.versions)) return [];


### PR DESCRIPTION
Currently, when creating a lane, snapping and then running `bit untag -a` it says "no components found with version to untag on your workspace" incorrectly.
This PR fixes it by changing the way of fetching staged-components to be the same as `bit status`.