### PR TITLE
export current lane to its tracked remote-scope

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -90,7 +90,7 @@ describe('bit lane command', function () {
     });
     describe('exporting the lane by explicitly entering the lane to the cli', () => {
       before(() => {
-        helper.command.exportLane('dev');
+        helper.command.exportLane();
       });
       it('should export components on that lane', () => {
         const list = helper.command.listRemoteScopeParsed();
@@ -123,7 +123,7 @@ describe('bit lane command', function () {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(beforeExport);
         helper.scopeHelper.reInitRemoteScope();
-        helper.command.export(`${helper.command.scopes.remote} --lanes`);
+        helper.command.export();
       });
       it('should export components on that lane', () => {
         const list = helper.command.listRemoteScopeParsed();
@@ -152,7 +152,7 @@ describe('bit lane command', function () {
       appOutput = helper.fixtures.populateComponents();
       helper.command.createLane('dev');
       helper.command.snapAllComponents();
-      helper.command.exportLane('dev');
+      helper.command.exportLane();
     });
     describe('fetching lanes objects', () => {
       before(() => {
@@ -245,7 +245,7 @@ describe('bit lane command', function () {
         helper.command.createLane();
         helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
         helper.command.snapAllComponents();
-        helper.command.exportLane('dev');
+        helper.command.exportLane();
 
         helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();
@@ -333,7 +333,7 @@ describe('bit lane command', function () {
       appOutput = helper.fixtures.populateComponents();
       helper.command.createLane('dev');
       helper.command.snapAllComponents();
-      helper.command.exportLane('dev');
+      helper.command.exportLane();
       authorScope = helper.scopeHelper.cloneLocalScope();
     });
     describe('merging remote lane into main', () => {
@@ -396,7 +396,7 @@ describe('bit lane command', function () {
         helper.scopeHelper.getClonedLocalScope(authorScope);
         helper.fixtures.populateComponents(undefined, undefined, ' v2');
         helper.command.snapAllComponents();
-        helper.command.exportLane('dev');
+        helper.command.exportLane();
 
         helper.scopeHelper.getClonedLocalScope(importedScope);
         helper.command.fetchRemoteLane('dev');
@@ -723,7 +723,7 @@ describe('bit lane command', function () {
         helper.command.createLane();
         helper.fixtures.populateComponents();
         helper.command.snapAllComponents();
-        helper.command.export(`${helper.command.scopes.remote} --lanes`);
+        helper.command.export();
       });
       it('as an intermediate step, make sure the lane is on the remote', () => {
         const lanes = helper.command.showRemoteLanesParsed();
@@ -819,7 +819,7 @@ describe('bit lane command', function () {
       helper.command.createLane();
       helper.fixtures.populateComponents(1);
       helper.command.snapAllComponents();
-      helper.command.exportLane('dev');
+      helper.command.exportLane();
       helper.git.mimicGitCloneLocalProjectHarmony();
       helper.scopeHelper.addRemoteScope();
       helper.command.switchRemoteLane('dev');
@@ -828,7 +828,7 @@ describe('bit lane command', function () {
       helper.command.snapAllComponents();
     });
     it('should export with no errors about missing artifact files from the first snap', () => {
-      expect(() => helper.command.export(`${helper.command.scopes.remote} --lanes`)).to.not.throw();
+      expect(() => helper.command.export()).to.not.throw();
     });
   });
   describe('auto-snap when on a lane', () => {

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -34,7 +34,6 @@ describe('bit lane command', function () {
     });
   });
   describe('create a snap on main then on a new lane', () => {
-    let beforeExport;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
@@ -44,7 +43,6 @@ describe('bit lane command', function () {
       helper.command.createLane();
       helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
       helper.command.snapAllComponents();
-      beforeExport = helper.scopeHelper.cloneLocalScope();
     });
     it('bit status should show the component only once as staged', () => {
       const status = helper.command.statusJson();

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -88,7 +88,7 @@ describe('bit lane command', function () {
         expect(diffOutput).to.not.have.string('+++ Id');
       });
     });
-    describe('exporting the lane by explicitly entering the lane to the cli', () => {
+    describe('exporting the lane', () => {
       before(() => {
         helper.command.exportLane();
       });
@@ -99,6 +99,10 @@ describe('bit lane command', function () {
       it('bit status should show a clean state', () => {
         const output = helper.command.runCmd('bit status');
         expect(output).to.have.string(statusWorkspaceIsCleanMsg);
+      });
+      it('should change .bitmap to have the remote lane', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap[LANE_KEY]).to.deep.equal({ name: 'dev', scope: helper.scopes.remote });
       });
       it('bit lane --remote should show the exported lane', () => {
         const remoteLanes = helper.command.showRemoteLanesParsed();
@@ -117,30 +121,6 @@ describe('bit lane command', function () {
           expect(diffOutput).to.have.string(`-module.exports = function foo() { return 'got foo'; }`);
           expect(diffOutput).to.have.string(`+module.exports = function foo() { return 'got foo v2'; }`);
         });
-      });
-    });
-    describe('exporting the lane implicitly (no lane-name entered)', () => {
-      before(() => {
-        helper.scopeHelper.getClonedLocalScope(beforeExport);
-        helper.scopeHelper.reInitRemoteScope();
-        helper.command.export();
-      });
-      it('should export components on that lane', () => {
-        const list = helper.command.listRemoteScopeParsed();
-        expect(list).to.have.lengthOf(1);
-      });
-      it('bit status should show a clean state', () => {
-        const output = helper.command.runCmd('bit status');
-        expect(output).to.have.string(statusWorkspaceIsCleanMsg);
-      });
-      it('should change .bitmap to have the remote lane', () => {
-        const bitMap = helper.bitMap.read();
-        expect(bitMap[LANE_KEY]).to.deep.equal({ name: 'dev', scope: helper.scopes.remote });
-      });
-      it('bit lane --remote should show the exported lane', () => {
-        const remoteLanes = helper.command.showRemoteLanesParsed();
-        expect(remoteLanes.lanes).to.have.lengthOf(1);
-        expect(remoteLanes.lanes[0].name).to.equal('dev');
       });
     });
   });

--- a/scopes/lanes/lanes/lanes.docs.md
+++ b/scopes/lanes/lanes/lanes.docs.md
@@ -15,7 +15,6 @@ The following describes the final implementation, which differs from the specifi
 - remove a lane `bit lane remove <name>`.
 - fetch lane objects (without the components): `bit fetch --lanes`.
 - import a lane: `bit switch <name> --remote`.
-- export a lane: `bit export <name> --lanes`.
 - export current lane: `bit export`.
 - (internal) cat lane object: `bit cat-lane <name>`.
 

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -11,10 +11,8 @@ export class ExportCmd implements Command {
   name = 'export [remote] [id...]';
 
   description = `export components to a remote scope.
-bit export => export all staged components to their current scope
-\`bit export [id...]\` => export (optionally given ids) to their current scope
-\`bit export <remote> --lanes\` => export the current lane to the specified remote
-\`bit export <remote> <lane...> --lanes\` => export the specified lanes to the specified remote
+bit export => export all staged components to their current scope, if checked out to a lane, export the lane as well
+\`bit export [id...]\` => export the given ids to their current scope
 
 https://${BASE_DOCS_DOMAIN}/docs/export
 ${WILDCARD_HELP('export remote-scope')}`;
@@ -38,7 +36,6 @@ ${WILDCARD_HELP('export remote-scope')}`;
       'LEGACY ONLY. when exporting to a different or new scope, replace import/require statements in the source code to match the new scope',
     ],
     ['f', 'force', 'force changing a component remote without asking for a confirmation'],
-    ['l', 'lanes', 'HARMONY ONLY. export lanes'],
     ['', 'all-versions', 'export not only staged versions but all of them'],
     [
       '',
@@ -73,7 +70,6 @@ ${WILDCARD_HELP('export remote-scope')}`;
       originDirectly = false,
       force = false,
       rewire = false,
-      lanes = false,
       ignoreMissingArtifacts = false,
       resume,
     }: any
@@ -98,7 +94,6 @@ ${WILDCARD_HELP('export remote-scope')}`;
       originDirectly,
       codemod: rewire,
       force,
-      lanes,
       resumeExportId: resume,
       ignoreMissingArtifacts,
     });

--- a/src/consumer/lanes/export-lanes.ts
+++ b/src/consumer/lanes/export-lanes.ts
@@ -1,5 +1,3 @@
-import R from 'ramda';
-
 import { Consumer } from '..';
 import { BitIds } from '../../bit-id';
 import loader from '../../cli/loader';

--- a/src/consumer/lanes/export-lanes.ts
+++ b/src/consumer/lanes/export-lanes.ts
@@ -4,83 +4,51 @@ import { Consumer } from '..';
 import { BitIds } from '../../bit-id';
 import loader from '../../cli/loader';
 import { BEFORE_LOADING_COMPONENTS } from '../../cli/loader/loader-messages';
-import GeneralError from '../../error/general-error';
-import LaneId, { RemoteLaneId } from '../../lane-id/lane-id';
+import { RemoteLaneId } from '../../lane-id/lane-id';
 import { Lane } from '../../scope/models';
 import WorkspaceLane from '../bit-map/workspace-lane';
 import ComponentsList from '../component/components-list';
 
-export async function updateLanesAfterExport(consumer: Consumer, lanes: Lane[]) {
-  const lanesToUpdate = lanes.filter((l) => l.remoteLaneId);
+export async function updateLanesAfterExport(consumer: Consumer, lane: Lane) {
   // lanes that don't have remoteLaneId should not be updated. it happens when updating to a
   // different remote with no intention to save the remote.
-  if (!lanesToUpdate.length) return;
+  if (!lane.remoteLaneId) return;
   const currentLane = consumer.getCurrentLaneId();
+  const isCurrentLane = lane.name === currentLane.name;
+  if (!isCurrentLane) {
+    throw new Error(
+      `updateLanesAfterExport should get called only with current lane, got ${lane.name}, current ${currentLane.name}`
+    );
+  }
   const workspaceLanesToUpdate: WorkspaceLane[] = [];
-  lanesToUpdate.forEach((lane) => {
-    const remoteLaneId = lane.remoteLaneId as RemoteLaneId;
-    consumer.scope.lanes.trackLane({
-      localLane: lane.name,
-      remoteLane: remoteLaneId.name,
-      remoteScope: remoteLaneId.scope,
-    });
-    const isCurrentLane = lane.name === currentLane.name;
-    if (isCurrentLane) {
-      consumer.bitMap.setRemoteLane(remoteLaneId);
-    }
-    const workspaceLane = isCurrentLane
-      ? (consumer.bitMap.workspaceLane as WorkspaceLane) // bitMap.workspaceLane is empty only when is on main
-      : WorkspaceLane.load(lane.name, consumer.scope.path);
-    if (!isCurrentLane) workspaceLanesToUpdate.push(workspaceLane);
-    consumer.bitMap.updateLanesProperty(workspaceLane, remoteLaneId);
-    workspaceLane.reset();
-  });
+  const remoteLaneId = lane.remoteLaneId as RemoteLaneId;
+  consumer.bitMap.setRemoteLane(remoteLaneId);
+  const workspaceLane = consumer.bitMap.workspaceLane as WorkspaceLane; // bitMap.workspaceLane is empty only when is on main
+  consumer.bitMap.updateLanesProperty(workspaceLane, remoteLaneId);
+  workspaceLane.reset();
   await Promise.all(workspaceLanesToUpdate.map((l) => l.write()));
 }
 
 export async function getLaneCompIdsToExport(
   consumer: Consumer,
-  ids: string[],
   includeNonStaged: boolean
-): Promise<{ componentsToExport: BitIds; lanesObjects: Lane[] }> {
+): Promise<{ componentsToExport: BitIds; laneObject: Lane }> {
   const currentLaneId = consumer.getCurrentLaneId();
-  const laneIds = ids.length ? ids.map((laneName) => new LaneId({ name: laneName })) : [currentLaneId];
-  const nonExistingLanes: string[] = [];
-  const lanesObjects: Lane[] = [];
-  await Promise.all(
-    laneIds.map(async (laneId) => {
-      const laneObject = await consumer.scope.loadLane(laneId);
-      if (laneObject) {
-        lanesObjects.push(laneObject);
-      } else if (!laneId.isDefault()) {
-        nonExistingLanes.push(laneId.name);
-      }
-    })
-  );
-  if (nonExistingLanes.length) {
-    throw new GeneralError(
-      `unable to export the following lanes ${nonExistingLanes.join(', ')}. they don't exist or are empty`
-    );
+  const laneObject = await consumer.scope.loadLane(currentLaneId);
+  if (!laneObject) {
+    throw new Error(`fatal: unable to load the current lane object (${currentLaneId.toString()})`);
   }
   loader.start(BEFORE_LOADING_COMPONENTS);
   const componentsList = new ComponentsList(consumer);
-  const compsToExportP = lanesObjects.map(async (laneObject: Lane | null) => {
-    // null in case of default-lane
-    return includeNonStaged
-      ? componentsList.listNonNewComponentsIds()
-      : componentsList.listExportPendingComponentsIds(laneObject);
-  });
-  const componentsToExport = BitIds.fromArray(R.flatten(await Promise.all(compsToExportP)));
-  return { componentsToExport, lanesObjects };
+  const componentsToExport = includeNonStaged
+    ? await componentsList.listNonNewComponentsIds()
+    : await componentsList.listExportPendingComponentsIds(laneObject);
+  return { componentsToExport, laneObject };
 }
 
-export function isUserTryingToExportLanes(consumer: Consumer, ids: string[], lanes: boolean) {
-  if (!ids.length) {
-    const currentLaneId = consumer.getCurrentLaneId();
-    // if no ids entered, when a user checked out to a lane, we should export the lane
-    return !currentLaneId.isDefault();
-  }
-  return lanes;
+export function isUserTryingToExportLanes(consumer: Consumer) {
+  const currentLaneId = consumer.getCurrentLaneId();
+  return !currentLaneId.isDefault();
 }
 
 // leave this here in case we do want to guess whether a user wants to export a lane.

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -280,8 +280,8 @@ export default class CommandHelper {
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }
-  exportLane(laneName = '', scope: string = this.scopes.remote, assert = true) {
-    const result = this.runCmd(`bit export ${scope} ${laneName} --force --lanes`);
+  exportLane(assert = true) {
+    const result = this.export();
     if (assert) expect(result).to.not.have.string('nothing to export');
     return result;
   }

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -106,9 +106,9 @@ export async function exportMany({
 }): Promise<{ exported: BitIds; updatedLocally: BitIds; newIdsOnRemote: BitId[] }> {
   logger.debugAndAddBreadCrumb('scope.exportMany', 'ids: {ids}', { ids: ids.toString() });
   if (laneObject) {
-    const trackingData = scope.lanes.getRemoteTrackedDataByLocalLane(laneObject.id.name);
+    const trackingData = scope.lanes.getRemoteTrackedDataByLocalLane(laneObject.name);
     if (!trackingData) {
-      throw new Error(`error: unable to find tracking data for lane "${laneObject.id.name}".
+      throw new Error(`error: unable to find tracking data for lane "${laneObject.name}".
 please run "bit lane track" command to specify a remote-scope for this lane`);
     }
     remoteName = trackingData.remoteScope;

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -82,7 +82,7 @@ export async function exportMany({
   includeDependencies = false, // kind of fork. by default dependencies only cached, with this, their scope-name is changed
   changeLocallyAlthoughRemoteIsDifferent = false, // by default only if remote stays the same the component is changed from staged to exported
   codemod = false,
-  lanesObjects = [],
+  laneObject,
   allVersions,
   originDirectly,
   idsWithFutureScope,
@@ -97,7 +97,7 @@ export async function exportMany({
   includeDependencies: boolean;
   changeLocallyAlthoughRemoteIsDifferent: boolean;
   codemod: boolean;
-  lanesObjects?: Lane[];
+  laneObject?: Lane;
   allVersions: boolean;
   originDirectly?: boolean;
   idsWithFutureScope: BitIds;
@@ -105,8 +105,13 @@ export async function exportMany({
   ignoreMissingArtifacts?: boolean;
 }): Promise<{ exported: BitIds; updatedLocally: BitIds; newIdsOnRemote: BitId[] }> {
   logger.debugAndAddBreadCrumb('scope.exportMany', 'ids: {ids}', { ids: ids.toString() });
-  if (lanesObjects.length && !remoteName) {
-    throw new Error('todo: implement export lanes to default scopes after tracking lanes local:remote is implemented');
+  if (laneObject) {
+    const trackingData = scope.lanes.getRemoteTrackedDataByLocalLane(laneObject.id.name);
+    if (!trackingData) {
+      throw new Error(`error: unable to find tracking data for lane "${laneObject.id.name}".
+please run "bit lane track" command to specify a remote-scope for this lane`);
+    }
+    remoteName = trackingData.remoteScope;
   }
   if (includeDependencies) {
     const dependenciesIds = await getDependenciesImportIfNeeded();
@@ -122,15 +127,15 @@ export async function exportMany({
   let manyObjectsPerRemote: ObjectsPerRemote[];
   if (isLegacy) {
     manyObjectsPerRemote = remoteName
-      ? [await getUpdatedObjectsToExportLegacy(remoteName, ids, lanesObjects)]
+      ? [await getUpdatedObjectsToExportLegacy(remoteName, ids)]
       : await mapSeries(Object.keys(idsGroupedByScope), (scopeName) =>
-          getUpdatedObjectsToExportLegacy(scopeName, idsGroupedByScope[scopeName], lanesObjects)
+          getUpdatedObjectsToExportLegacy(scopeName, idsGroupedByScope[scopeName])
         );
   } else {
     manyObjectsPerRemote = remoteName
-      ? [await getUpdatedObjectsToExport(remoteName, ids, lanesObjects)]
+      ? [await getUpdatedObjectsToExport(remoteName, ids, laneObject)]
       : await mapSeries(Object.keys(idsGroupedByScope), (scopeName) =>
-          getUpdatedObjectsToExport(scopeName, idsGroupedByScope[scopeName], lanesObjects)
+          getUpdatedObjectsToExport(scopeName, idsGroupedByScope[scopeName], laneObject)
         );
   }
 
@@ -146,7 +151,7 @@ export async function exportMany({
   }
 
   loader.start('updating data locally...');
-  const results = await updateLocalObjects(lanesObjects);
+  const results = await updateLocalObjects(laneObject);
   return {
     newIdsOnRemote: R.flatten(results.map((r) => r.newIdsOnRemote)),
     exported: BitIds.uniqFromArray(R.flatten(results.map((r) => r.exported))),
@@ -288,7 +293,7 @@ export async function exportMany({
   async function getUpdatedObjectsToExport(
     remoteNameStr: string,
     bitIds: BitIds,
-    lanes: Lane[] = []
+    lane?: Lane
   ): Promise<ObjectsPerRemote> {
     bitIds.throwForDuplicationIgnoreVersion();
     const remote: Remote = await scopeRemotes.resolve(remoteNameStr, scope);
@@ -331,15 +336,13 @@ export async function exportMany({
     scope.objects.clearCache();
     // don't use Promise.all, otherwise, it'll throw "JavaScript heap out of memory" on a large set of data
     await mapSeries(modelComponents, processModelComponent);
-    const lanesData = await Promise.all(
-      lanes.map(async (lane) => {
-        lane.components.forEach((c) => {
-          c.id = c.id.changeScope(remoteName);
-        });
-        return { ref: lane.hash(), buffer: await lane.compress() };
-      })
-    );
-    objectList.addIfNotExist(lanesData);
+    if (lane) {
+      lane.components.forEach((c) => {
+        c.id = c.id.changeScope(remoteName);
+      });
+      const laneData = { ref: lane.hash(), buffer: await lane.compress() };
+      objectList.addIfNotExist([laneData]);
+    }
 
     return { remote, objectList, objectListPerName, idsToChangeLocally, componentsAndObjects };
   }
@@ -409,7 +412,7 @@ export async function exportMany({
   }
 
   async function updateLocalObjects(
-    lanes: Lane[]
+    lane?: Lane
   ): Promise<Array<{ exported: BitIds; updatedLocally: BitIds; newIdsOnRemote: BitId[] }>> {
     return mapSeries(manyObjectsPerRemote, async (objectsPerRemote: ObjectsPerRemote) => {
       const { remote, idsToChangeLocally, componentsAndObjects, exportedIds } = objectsPerRemote;
@@ -427,20 +430,19 @@ export async function exportMany({
       componentsAndObjects.forEach((componentObject) => scope.sources.put(componentObject));
 
       // update lanes
-      await Promise.all(
-        lanes.map(async (lane) => {
-          if (idsToChangeLocally.length) {
-            // otherwise, we don't want to update scope-name of components in the lane object
-            scope.objects.add(lane);
-            // this is needed so later on we can add the tracking data and update .bitmap
-            // @todo: support having a different name on the remote by a flag
-            lane.remoteLaneId = RemoteLaneId.from(lane.name, remoteNameStr);
-          }
-          await scope.objects.remoteLanes.syncWithLaneObject(remoteNameStr, lane);
-        })
-      );
+      if (lane) {
+        if (idsToChangeLocally.length) {
+          // otherwise, we don't want to update scope-name of components in the lane object
+          scope.objects.add(lane);
+          // this is needed so later on we can add the tracking data and update .bitmap
+          // @todo: support having a different name on the remote by a flag
+          lane.remoteLaneId = RemoteLaneId.from(lane.name, remoteNameStr);
+        }
+        await scope.objects.remoteLanes.syncWithLaneObject(remoteNameStr, lane);
+      }
+
       const currentLane = scope.lanes.getCurrentLaneName();
-      if (currentLane === DEFAULT_LANE && !lanes.length) {
+      if (currentLane === DEFAULT_LANE && !lane) {
         // all exported from main
         const remoteLaneId = RemoteLaneId.from(DEFAULT_LANE, remoteNameStr);
         await scope.objects.remoteLanes.loadRemoteLane(remoteLaneId);


### PR DESCRIPTION
Currently, it's required to specify a remote when exporting lanes. 
With this change, Bit uses the tracking data from scope.json to get the remote-scope of the current lane.
Also, the options to export multiple lanes is disabled. Only the current lane is allowed to be exported. 
The `--lanes` flag is removed, as it's not needed anymore.