### PR TITLE
 implement "graph" method in http

### DIFF
--- a/e2e/harmony/http.e2e.ts
+++ b/e2e/harmony/http.e2e.ts
@@ -59,6 +59,17 @@ import { HttpHelper } from '../http-helper';
         expect(importOutput).to.have.string('successfully imported one component');
       });
     });
+    describe('bit import --dependents', () => {
+      let importOutput;
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteHttpScope();
+        importOutput = helper.command.importComponent('comp3', '--dependents');
+      });
+      it('should import all dependents successfully', () => {
+        expect(importOutput).to.have.string('successfully imported 3 components');
+      });
+    });
     describe('bit remove --remote', () => {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(scopeAfterExport);

--- a/e2e/http-helper.ts
+++ b/e2e/http-helper.ts
@@ -36,6 +36,7 @@ export class HttpHelper {
       });
       this.httpProcess.on('close', (code) => {
         if (this.helper.debugMode) console.log(`child process exited with code ${code}`);
+        reject(new Error(`http exited with code ${code}`));
       });
     });
   }

--- a/e2e/http-helper.ts
+++ b/e2e/http-helper.ts
@@ -7,18 +7,18 @@ import Helper from '../src/e2e-helper/e2e-helper';
 
 const HTTP_TIMEOUT_FOR_MSG = 120000; // 2 min
 
-const HTTP_SERVER_READY_MSG = 'Bit server is running on';
+const HTTP_SERVER_READY_MSG = 'UI server of teambit.scope/scope is listening to port';
 
 export class HttpHelper {
   httpProcess: ChildProcess;
   constructor(private helper: Helper) {}
   start(): Promise<void> {
     return new Promise((resolve, reject) => {
-      const cmd = `${this.helper.command.bitBin} start --verbose`;
+      const cmd = `${this.helper.command.bitBin} start --verbose --log`;
       const cwd = this.helper.scopes.remotePath;
       if (this.helper.debugMode) console.log(rightpad(chalk.green('cwd: '), 20, ' '), cwd); // eslint-disable-line no-console
       if (this.helper.debugMode) console.log(rightpad(chalk.green('command: '), 20, ' '), cmd); // eslint-disable-line
-      this.httpProcess = childProcess.spawn(this.helper.command.bitBin, ['start', '--verbose'], { cwd });
+      this.httpProcess = childProcess.spawn(this.helper.command.bitBin, ['start', '--verbose', '--log'], { cwd });
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       this.httpProcess.stdout.on('data', (data) => {
         if (this.helper.debugMode) console.log(`stdout: ${data}`);

--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -105,6 +105,10 @@ export function scopeSchema(scopeMain: ScopeMain) {
           return listData;
         },
 
+        getLogs: async (scope: ScopeMain, { id }: { id: string }) => {
+          return scope.getLogs(ComponentID.fromString(id));
+        },
+
         getMany: async (scope: ScopeMain, { ids }: { ids: string[] }) => {
           return scope.getMany(ids.map((str) => ComponentID.fromString(str)));
         },

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -39,21 +39,21 @@ export class StartCmd implements Command {
     private logger: Logger
   ) {}
 
-  async report([uiRootName, userPattern]: StartArgs, { dev, port, rebuild, verbose }: StartFlags): Promise<string> {
-    this.logger.off();
-    const pattern = userPattern && userPattern.toString();
+  // async report([uiRootName, userPattern]: StartArgs, { dev, port, rebuild, verbose }: StartFlags): Promise<string> {
+  //   this.logger.off();
+  //   const pattern = userPattern && userPattern.toString();
 
-    const uiServer = await this.ui.createRuntime({
-      uiRootName,
-      pattern,
-      dev,
-      port: port ? parseInt(port) : undefined,
-      rebuild,
-      verbose,
-    });
+  //   const uiServer = await this.ui.createRuntime({
+  //     uiRootName,
+  //     pattern,
+  //     dev,
+  //     port: port ? parseInt(port) : undefined,
+  //     rebuild,
+  //     verbose,
+  //   });
 
-    return `Bit server has started on port ${uiServer.port}`;
-  }
+  //   return `Bit server has started on port ${uiServer.port}`;
+  // }
 
   async render(
     [uiRootName, userPattern]: StartArgs,

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -115,6 +115,8 @@ export class UIServer {
     server.listen(port);
     this._port = port;
 
+    // important: we use the string of the following message for the http.e2e.ts. if you change the message,
+    // please make sure you change the `HTTP_SERVER_READY_MSG` const.
     this.logger.info(`UI server of ${this.uiRootExtension} is listening to port ${port}`);
   }
 

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -313,8 +313,8 @@ export default class CommandHelper {
     const jsonResult = result.substring(jsonStart);
     return JSON.parse(jsonResult);
   }
-  importComponent(id: string) {
-    return this.runCmd(`bit import ${this.scopes.remote}/${id}`);
+  importComponent(id: string, flags = '') {
+    return this.runCmd(`bit import ${this.scopes.remote}/${id} ${flags}`);
   }
   import(value = '') {
     return this.runCmd(`bit import ${value}`);

--- a/src/scope/graph/scope-graph.ts
+++ b/src/scope/graph/scope-graph.ts
@@ -173,6 +173,17 @@ export default class DependencyGraph {
     });
   }
 
+  static buildFromNodesAndEdges(
+    nodes: Array<{ idStr: string; bitId: BitId }>,
+    edges: Array<{ src: string; target: string; depType: string }>
+  ): Graph {
+    const graph = new Graph();
+    nodes.forEach((node) => graph.setNode(node.idStr, node.bitId));
+    edges.forEach((edge) => graph.setEdge(edge.src, edge.target, edge.depType));
+
+    return graph;
+  }
+
   /**
    * returns a new Graph that has only nodes that are related to the given id.
    * (meaning, they're either dependents or dependencies)


### PR DESCRIPTION
## Proposed Changes

- resolve #4601, fix "bit import --dependents` in Harmony.
- fix `bit log --remote`. it stopped working since https://github.com/teambit/bit/pull/3673.
- fix http e2e-tests to start working again. 
- remove `report` method from `bit start` command, seems like it's not needed (and it makes issues to the e2e-tests).