### PR TITLE
improve errors when importing/installing legacy components/packages inside Harmony

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -12,7 +12,7 @@ import GeneralError from '../../../../error/general-error';
 import ShowDoctorError from '../../../../error/show-doctor-error';
 import { isSupportedExtension } from '../../../../links/link-content';
 import logger from '../../../../logger/logger';
-import { getExt, isDirEmptySync, pathNormalizeToLinux, pathRelativeLinux } from '../../../../utils';
+import { getExt, pathNormalizeToLinux, pathRelativeLinux } from '../../../../utils';
 import { packageNameToComponentId } from '../../../../utils/bit/package-name-to-component-id';
 import { PathLinux, PathLinuxRelative, PathOsBased } from '../../../../utils/path';
 import ComponentMap from '../../../bit-map/component-map';
@@ -1200,11 +1200,6 @@ either, use the ignore file syntax or change the require statement to have a mod
     if (this.componentFromModel && this.componentFromModel.isLegacy) {
       this.issues.getOrCreate(IssuesClasses.LegacyInsideHarmony).data = true;
     }
-  }
-
-  private areDistsMissing(pkgName: string) {
-    const distDir = path.join(this.consumerPath, 'node_modules', pkgName, DEFAULT_DIST_DIRNAME);
-    return !fs.existsSync(distDir) || isDirEmptySync(distDir);
   }
 
   /**


### PR DESCRIPTION
Currently, Bit allows installing legacy component packages inside Harmony workspace, and then when running `bit build`, it shows a cryptic error from the TSCompiler: `error TS2307: Cannot find module '@bit/legacy-package-name' or its corresponding type declarations`.
Now, when loading the component, it shows the following error:
```
error: legacy dependency "legacy-package-name" was imported to one of the files in "/component/dir".
this workspace is Harmony and therefore legacy components/packages are unsupported.
remove the import statement to fix this error
```

Also, when importing a legacy component into Harmony, it used to show the following inaccurate error:
```
unexpected network error has occurred during fetching scopes: bit.envs
server responded with the following error messages:
bit.envs - Please update your Bit client.
For additional information: https://docs.bit.dev/docs/installation#latest-version
```
Now, it shows a better error:
```
fatal: unable to connect to a remote legacy SSH server from Harmony client
```