### PR TITLE
bit-status: don't show new components in the auto-tag-pending section

### DIFF
--- a/e2e/harmony/status-harmony.e2e.ts
+++ b/e2e/harmony/status-harmony.e2e.ts
@@ -1,4 +1,5 @@
 import { IssuesClasses } from '@teambit/component-issues';
+import { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
 describe('status command on Harmony', function () {
@@ -49,6 +50,19 @@ describe('status command on Harmony', function () {
     });
     it('should show an issue of missing-links-from-node-modules-to-src', () => {
       helper.command.expectStatusToHaveIssue(IssuesClasses.MissingLinksFromNodeModulesToSrc.name);
+    });
+  });
+  describe('components that are both: new and auto-tag-pending', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagWithoutBuild('comp3');
+      helper.fixtures.populateComponents(3, undefined, 'v2');
+    });
+    it('should be shown in the newComponents section only and not in the autoTagPendingComponents', () => {
+      const status = helper.command.statusJson();
+      expect(status.autoTagPendingComponents).to.have.lengthOf(0);
+      expect(status.newComponents).to.have.lengthOf(2);
     });
   });
 });

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -321,8 +321,10 @@ export default class ComponentsList {
 
   async listAutoTagPendingComponents(): Promise<Component[]> {
     const modifiedComponents = (await this.listModifiedComponents()) as BitId[];
+    const newComponents = (await this.listNewComponents()) as BitIds;
     if (!modifiedComponents || !modifiedComponents.length) return [];
-    return this.consumer.listComponentsForAutoTagging(BitIds.fromArray(modifiedComponents));
+    const autoTagPending = await this.consumer.listComponentsForAutoTagging(BitIds.fromArray(modifiedComponents));
+    return autoTagPending.filter((autoTagComp) => !newComponents.has(autoTagComp.id));
   }
 
   idsFromBitMap(origin?: ComponentOrigin): BitIds {


### PR DESCRIPTION
If the component is new, it's a candidate for tagging, so no need to show it in the auto-tag-pending section. 
Reported by @ranm8 . 