### PR TITLE
bit-create: change --path flag to include the whole path and not only the root-dir

### DIFF
--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -113,7 +113,7 @@ export class ComponentGenerator {
   }
 
   private getComponentPath(componentId: ComponentID) {
-    if (this.options.path) return path.join(this.options.path, componentId.fullName);
+    if (this.options.path) return this.options.path;
     return composeComponentPath(componentId._legacy.changeScope(componentId.scope), this.workspace.defaultDirectory);
   }
 }


### PR DESCRIPTION
Currently, the path where to place the component consists of the entered `--path` flag and the component full-name. With this PR, in case `--path` was entered, it will be used for the whole path. 
For example:
```
bit create react-component-js ui/button --path my-button
```
path before: `my-button/ui/button`.
path now:      `my-button`.

Asked by @ranm8 .

Also resolve https://github.com/teambit/bit/issues/4813.