### PR TITLE
replace "bit app-list" with "bit app list" to support app subcommands

### DIFF
--- a/scopes/harmony/application/app.cmd.ts
+++ b/scopes/harmony/application/app.cmd.ts
@@ -1,15 +1,13 @@
+// eslint-disable-next-line max-classes-per-file
 import { Command, CommandOptions } from '@teambit/cli';
 // import { Logger } from '@teambit/logger';
 import chalk from 'chalk';
 import { CLITable } from '@teambit/cli-table';
 import { ApplicationMain } from './application.main.runtime';
 
-/**
- * @deprecated use AppListCmd class
- */
-export class AppListCmdDeprecated implements Command {
-  name = 'app-list';
-  description = 'DEPRECATED. use "bit app list"';
+export class AppListCmd implements Command {
+  name = 'list';
+  description = 'list all registered applications';
   alias = '';
   group = 'apps';
   options = [['j', 'json', 'return the component data in json format']] as CommandOptions;
@@ -19,16 +17,28 @@ export class AppListCmdDeprecated implements Command {
   async report(args: [string], { json }: { json: boolean }) {
     const apps = this.applicationAspect.listApps();
     if (json) return JSON.stringify(apps, null, 2);
-    const deprecationStr = `this command is deprecated. please use "bit app list" instead\n`;
-    // eslint-disable-next-line no-console
-    console.log(chalk.red());
-    if (!apps.length) return chalk.yellow(`${deprecationStr}no apps found`);
+    if (!apps.length) return chalk.yellow('no apps found');
 
     const rows = apps.map((app) => {
       return [app.name];
     });
 
     const table = new CLITable([], rows);
-    return deprecationStr + table.render();
+    return table.render();
+  }
+}
+
+export class AppCmd implements Command {
+  name = 'app <sub-command>';
+  description = 'manage applications';
+  alias = '';
+  group = 'apps';
+  commands: Command[] = [];
+  options = [] as CommandOptions;
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async report(args: [string]) {
+    // it should never be here. Yargs throws an error before reaching this method.
+    return `Please specify a sub-command`;
   }
 }

--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -10,10 +10,11 @@ import { Application } from './application';
 import { DeploymentProvider } from './deployment-provider';
 import { AppNotFound } from './exceptions';
 import { ApplicationAspect } from './application.aspect';
-import { AppListCmd } from './app-list.cmd';
+import { AppListCmdDeprecated } from './app-list.cmd';
 import { DeployTask } from './deploy.task';
 import { RunCmd } from './run.cmd';
 import { AppService } from './application.service';
+import { AppCmd, AppListCmd } from './app.cmd';
 
 export type ApplicationTypeSlot = SlotRegistry<ApplicationType[]>;
 export type ApplicationSlot = SlotRegistry<Application[]>;
@@ -167,9 +168,11 @@ export class ApplicationMain {
     const logger = loggerAspect.createLogger(ApplicationAspect.id);
     const appService = new AppService();
     const application = new ApplicationMain(appSlot, appTypeSlot, deploymentProviderSlot, envs, component, appService);
-    builder.registerDeployTasks([new DeployTask(application)]);
+    const appCmd = new AppCmd();
+    appCmd.commands = [new AppListCmd(application)];
+    builder.registerTagTasks([new DeployTask(application)]);
     cli.registerGroup('apps', 'Applications');
-    cli.register(new RunCmd(application, logger), new AppListCmd(application));
+    cli.register(new RunCmd(application, logger), new AppListCmdDeprecated(application), appCmd);
 
     return application;
   }


### PR DESCRIPTION
Deprecate `bit app-list` in favor of `bit app list`. 

Asked by @ranm8 .