### PR TITLE
bit-lane-diff:make the newComponents section more visible

### DIFF
--- a/scopes/lanes/diff/lane-diff.cmd.ts
+++ b/scopes/lanes/diff/lane-diff.cmd.ts
@@ -29,7 +29,7 @@ bit lane diff from to => diff between "from" lane and "to" lane.
     const diffResultsStr = outputDiffResults(compsWithDiff);
     const newCompsIdsStr = newComps.map((id) => chalk.bold(id)).join('\n');
     const newCompsTitle = `The following components were introduced in ${chalk.bold(toLaneName)} lane`;
-    const newCompsStr = newComps.length ? `${chalk.green(newCompsTitle)}\n${newCompsIdsStr}` : '';
+    const newCompsStr = newComps.length ? `${chalk.inverse(newCompsTitle)}\n${newCompsIdsStr}` : '';
     return `${diffResultsStr}\n${newCompsStr}`;
   }
 }


### PR DESCRIPTION
Before it looked like part of the "diff" section and was easily overlooked. 
Now the new section is more prominent. 

<img width="409" alt="Screen Shot 2021-09-02 at 12 21 35 PM" src="https://user-images.githubusercontent.com/1963573/131880917-48f83d18-823a-4797-8791-53eb6fc6b119.png">
