### PR TITLE
fix removing new components when on a lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -786,6 +786,18 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('remove a new component when on a lane', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.removeComponent('comp1');
+    });
+    it('should remove the component from the .bitmap file', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.not.have.property('comp1');
+    });
+  });
   // this makes sure that when exporting lanes, it only exports the local snaps.
   // in this test, the second snap is done on a clean scope without the objects of the first snap.
   describe('snap on lane, export, clear project, snap and export', () => {

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -743,12 +743,12 @@ describe('bit lane command', function () {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents();
-      helper.command.snapAllComponents();
+      helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
 
       helper.command.createLane();
       helper.fixtures.populateComponents(undefined, undefined, ' v2');
-      helper.command.snapAllComponents();
+      helper.command.snapAllComponentsWithoutBuild();
     });
     it('as an intermediate step, make sure the snapped components are part of the lane', () => {
       const lane = helper.command.showOneLaneParsed('dev');

--- a/src/consumer/component-ops/remove-components.ts
+++ b/src/consumer/component-ops/remove-components.ts
@@ -129,12 +129,11 @@ async function removeLocal(
   const { components: componentsToRemove, invalidComponents } = await consumer.loadComponents(idsToRemove, false);
   const { removedComponentIds, missingComponents, dependentBits, removedFromLane, removedDependencies } =
     await consumer.scope.removeMany(idsToRemoveFromScope, force, true, consumer);
-
   if (!removedFromLane) {
     // otherwise, components should still be in .bitmap file
     idsToCleanFromWorkspace.push(...removedComponentIds);
   }
-  if (!R.isEmpty(idsToCleanFromWorkspace)) {
+  if (idsToCleanFromWorkspace.length) {
     await deleteComponentsFiles(consumer, idsToCleanFromWorkspace, deleteFiles);
     await deleteComponentsFiles(consumer, removedDependencies, false);
     if (!track) {
@@ -149,7 +148,7 @@ async function removeLocal(
     }
   }
   return new RemovedLocalObjects(
-    idsToCleanFromWorkspace,
+    BitIds.uniqFromArray([...idsToCleanFromWorkspace, ...removedComponentIds]),
     missingComponents,
     modifiedComponents,
     removedDependencies,

--- a/src/consumer/component-ops/remove-components.ts
+++ b/src/consumer/component-ops/remove-components.ts
@@ -127,16 +127,14 @@ async function removeLocal(
     idsToRemove.filter((id) => newComponents.hasWithoutScopeAndVersion(id))
   );
   const { components: componentsToRemove, invalidComponents } = await consumer.loadComponents(idsToRemove, false);
-  const {
-    removedComponentIds,
-    missingComponents,
-    dependentBits,
-    removedFromLane,
-    removedDependencies,
-  } = await consumer.scope.removeMany(idsToRemoveFromScope, force, true, consumer);
-  idsToCleanFromWorkspace.push(...removedComponentIds);
+  const { removedComponentIds, missingComponents, dependentBits, removedFromLane, removedDependencies } =
+    await consumer.scope.removeMany(idsToRemoveFromScope, force, true, consumer);
 
-  if (!R.isEmpty(idsToCleanFromWorkspace) && !removedFromLane) {
+  if (!removedFromLane) {
+    // otherwise, components should still be in .bitmap file
+    idsToCleanFromWorkspace.push(...removedComponentIds);
+  }
+  if (!R.isEmpty(idsToCleanFromWorkspace)) {
     await deleteComponentsFiles(consumer, idsToCleanFromWorkspace, deleteFiles);
     await deleteComponentsFiles(consumer, removedDependencies, false);
     if (!track) {

--- a/src/scope/component-ops/remove-model-components.ts
+++ b/src/scope/component-ops/remove-model-components.ts
@@ -50,7 +50,7 @@ export default class RemoveModelComponents {
       await this.scope.objects.deleteObjectsFromFS(refsToRemoveAll);
       await this.scope.objects.deleteRecordsFromUnmergedComponents(allIds.map((id) => id.name));
 
-      const removedFromLane = Boolean(this.currentLane);
+      const removedFromLane = Boolean(this.currentLane && foundComponents.length);
       return new RemovedObjects({
         removedComponentIds: compIds,
         missingComponents,


### PR DESCRIPTION
Currently, when removing a new components when checked out to a lane, it shows a message that the component was removed from the lane, but it's still in the .bitmap file.
With this fix, it removes the component from the .bitmap file as expected.

Reported by @ranm8 .