### PR TITLE
recreate capsules in case they errored with MODULE_NOT_FOUND

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -1,9 +1,12 @@
+import fs from 'fs-extra';
+import path from 'path';
 import chai, { expect } from 'chai';
 import { IssuesClasses } from '../../scopes/component/component-issues';
 
 import { IS_WINDOWS } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+import { UNABLE_TO_LOAD_EXTENSION } from '../../scopes/harmony/aspect-loader/constants';
 
 chai.use(require('chai-fs'));
 chai.use(require('chai-string'));
@@ -129,6 +132,24 @@ describe('custom env', function () {
       describe('running any other command', () => {
         // @Gilad TODO
         it.skip('should warn or error about the misconfigured env and suggest to enter the version', () => {});
+      });
+    });
+    describe('missing modules in the env capsule', () => {
+      before(() => {
+        helper.fixtures.populateComponents(1);
+        helper.extensions.addExtensionToVariant('*', `${envId}@0.0.1`);
+        const capsules = helper.command.capsuleListParsed();
+        const scopeAspectCapsulesPath = capsules.scopeAspectsCapsulesRootDir;
+        fs.removeSync(path.join(scopeAspectCapsulesPath, 'node_modules'));
+      });
+      it('should re-create the capsule dir and should not show any warning/error about loading the env', () => {
+        const status = helper.command.status();
+        const errMsg = UNABLE_TO_LOAD_EXTENSION(`${envId}@0.0.1`);
+        expect(status).to.not.include(errMsg);
+      });
+      it('bit show should show the correct env', () => {
+        const env = helper.env.getComponentEnv('comp1');
+        expect(env).to.equal(`${envId}@0.0.1`);
       });
     });
     after(() => {

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -136,6 +136,9 @@ describe('custom env', function () {
     });
     describe('missing modules in the env capsule', () => {
       before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.bitJsonc.setupDefault();
         helper.fixtures.populateComponents(1);
         helper.extensions.addExtensionToVariant('*', `${envId}@0.0.1`);
         const capsules = helper.command.capsuleListParsed();

--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -204,7 +204,7 @@ export class WorkspaceCompiler {
   }
 
   async onAspectLoadFail(err: Error & { code?: string }, id: ComponentID): Promise<boolean> {
-    if (err.code && err.code === 'MODULE_NOT_FOUND') {
+    if (err.code && err.code === 'MODULE_NOT_FOUND' && this.workspace) {
       await this.compileComponents([id.toString()], {}, true);
       return true;
     }

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -423,6 +423,9 @@ export class ScopeMain implements ComponentFactory {
       await this.aspectLoader.loadRequireableExtensions(resolvedAspects, true);
     } catch (err) {
       if (err?.error.code === 'MODULE_NOT_FOUND') {
+        this.logger.warn(
+          'failed loading aspects from capsules due to MODULE_NOT_FOUND error, re-creating the capsules and trying again'
+        );
         const resolvedAspectsAgain = await this.getResolvedAspects(components, { skipIfExists: false });
         await this.aspectLoader.loadRequireableExtensions(resolvedAspectsAgain, throwOnError);
       } else {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -363,9 +363,8 @@ export class ScopeMain implements ComponentFactory {
     await this.loadAspectFromPath(localAspects);
     const componentIds = await this.resolveMultipleComponentIds(aspectIds);
     if (!componentIds || !componentIds.length) return;
-    const resolvedAspects = await this.getResolvedAspects(await this.import(componentIds));
-    // Always throw an error when can't load scope extension
-    await this.aspectLoader.loadRequireableExtensions(resolvedAspects, throwOnError);
+    const components = await this.import(componentIds);
+    await this.loadAspectsFromCapsules(components, throwOnError);
   }
 
   private async resolveLocalAspects(ids: string[], runtime?: string) {
@@ -383,14 +382,14 @@ export class ScopeMain implements ComponentFactory {
     });
   }
 
-  async getResolvedAspects(components: Component[]) {
+  async getResolvedAspects(components: Component[], { skipIfExists = true } = {}): Promise<RequireableComponent[]> {
     if (!components.length) return [];
     const network = await this.isolator.isolateComponents(
       components.map((c) => c.id),
       // includeFromNestedHosts - to support case when you are in a workspace, trying to load aspect defined in the workspace.jsonc but not part of the workspace
       {
         baseDir: this.getAspectCapsulePath(),
-        skipIfExists: true,
+        skipIfExists,
         includeFromNestedHosts: true,
         installOptions: { copyPeerToRuntimeOnRoot: true },
       },
@@ -412,6 +411,31 @@ export class ScopeMain implements ComponentFactory {
         return aspect;
       });
     });
+  }
+
+  /**
+   * if capsules already exist for these aspects, use them. otherwise, isolate them first.
+   * in case of module-not-found error, give it another try by re-creating the capsules and re-loading.
+   */
+  async loadAspectsFromCapsules(components: Component[], throwOnError: boolean) {
+    const resolvedAspects = await this.getResolvedAspects(components);
+    try {
+      await this.aspectLoader.loadRequireableExtensions(resolvedAspects, true);
+    } catch (err) {
+      if (err?.error.code === 'MODULE_NOT_FOUND') {
+        const resolvedAspectsAgain = await this.getResolvedAspects(components, { skipIfExists: false });
+        await this.aspectLoader.loadRequireableExtensions(resolvedAspectsAgain, throwOnError);
+      } else {
+        if (throwOnError) {
+          throw err;
+        }
+        // throwOnError is false, it's not ideal, but we call loadRequireableExtensions again.
+        // otherwise, because it was throwing before, it didn't have the chance to log into the console
+        // as we caught that error. also, if the first aspect failed, it didn't load the second aspect
+        // but threw immediately.
+        await this.aspectLoader.loadRequireableExtensions(resolvedAspects, false);
+      }
+    }
   }
 
   getAspectCapsulePath() {

--- a/scopes/workspace/workspace/capsule.cmd.ts
+++ b/scopes/workspace/workspace/capsule.cmd.ts
@@ -82,22 +82,29 @@ export class CapsuleListCmd implements Command {
 
   async report() {
     const list = await this.isolator.list(this.workspace.path);
-    const workspaceRootDir = this.isolator.getCapsulesRootDir(this.workspace.path);
-    const scopeRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.path);
-    const scopeAspectsRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.getAspectCapsulePath());
+    const { workspaceCapsulesRootDir, scopeCapsulesRootDir, scopeAspectsCapsulesRootDir } = this.getCapsulesRootDirs();
     // TODO: improve output
     return chalk.green(`found ${chalk.cyan(list.capsules.length.toString())} capsule(s) for workspace:  ${chalk.cyan(
       list.workspace
     )}
-workspace capsules root-dir:       ${chalk.cyan(workspaceRootDir)}
-scope capsules root-dir:           ${chalk.cyan(scopeRootDir)}
-scope's aspects capsules root-dir: ${chalk.cyan(scopeAspectsRootDir)}
+workspace capsules root-dir:       ${chalk.cyan(workspaceCapsulesRootDir)}
+scope capsules root-dir:           ${chalk.cyan(scopeCapsulesRootDir)}
+scope's aspects capsules root-dir: ${chalk.cyan(scopeAspectsCapsulesRootDir)}
 use --json to get the list of all workspace capsules`);
   }
 
   async json() {
     const list = await this.isolator.list(this.workspace.path);
-    return list;
+    const rootDirs = this.getCapsulesRootDirs();
+    return { ...list, ...rootDirs };
+  }
+
+  private getCapsulesRootDirs() {
+    const workspaceCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.path);
+    const scopeCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.path);
+    const scopeAspectsCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.getAspectCapsulePath());
+
+    return { workspaceCapsulesRootDir, scopeCapsulesRootDir, scopeAspectsCapsulesRootDir };
   }
 }
 

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -372,9 +372,13 @@ export default class CommandHelper {
     return output;
   }
 
-  getCapsuleOfComponent(id: string) {
+  capsuleListParsed() {
     const capsulesJson = this.runCmd('bit capsule list -j');
-    const capsules = JSON.parse(capsulesJson);
+    return JSON.parse(capsulesJson);
+  }
+
+  getCapsuleOfComponent(id: string) {
+    const capsules = this.capsuleListParsed();
     const idWithUnderScore = id.replace(/\//, '_');
     const capsulePath = capsules.capsules.find((c) => c.endsWith(idWithUnderScore));
     if (!capsulePath) throw new Error(`unable to find the capsule for ${id}`);
@@ -462,6 +466,11 @@ export default class CommandHelper {
 
   showComponentParsed(id = 'bar/foo') {
     const output = this.runCmd(`bit show ${id} --json --legacy`);
+    return JSON.parse(output);
+  }
+
+  showComponentParsedHarmony(id = 'bar/foo') {
+    const output = this.runCmd(`bit show ${id} --json`);
     return JSON.parse(output);
   }
 

--- a/src/e2e-helper/e2e-env-helper.ts
+++ b/src/e2e-helper/e2e-env-helper.ts
@@ -235,4 +235,10 @@ export default class EnvHelper {
     this.command.compile();
     return EXTENSIONS_BASE_FOLDER;
   }
+
+  getComponentEnv(id: string): string {
+    const show = this.command.showComponentParsedHarmony(id);
+    const env = show.find((fragment) => fragment.title === 'env');
+    return env.json;
+  }
 }


### PR DESCRIPTION
When loading aspects from isolated capsules, they may throw MODULE_NOT_FOUND error due to missing/corrupted packages or maybe the previous capsule installation never completed.
With this fix, in this case, the capsule is recreated and the aspect is re-loaded. 