### PR TITLE
add tests for external aspects loading order

### DIFF
--- a/e2e/harmony/custom-aspects.e2e.ts
+++ b/e2e/harmony/custom-aspects.e2e.ts
@@ -30,7 +30,10 @@ describe('custom aspects', function () {
       npmCiRegistry.configureCiInPackageJsonHarmony();
       helper.command.create('aspect', 'dep-aspect');
       helper.command.create('aspect', 'main-aspect');
-      helper.fs.outputFile(`${helper.scopes.remoteWithoutOwner}/main-aspect/main-aspect.main.runtime.ts`, getMainAspect(helper.scopes.remoteWithoutOwner));
+      helper.fs.outputFile(
+        `${helper.scopes.remoteWithoutOwner}/main-aspect/main-aspect.main.runtime.ts`,
+        getMainAspect(helper.scopes.remoteWithoutOwner)
+      );
       helper.extensions.addExtensionToVariant('*', 'teambit.harmony/aspect');
       helper.command.compile();
       helper.command.install();
@@ -56,10 +59,19 @@ describe('custom aspects', function () {
     after(() => {
       npmCiRegistry.destroy();
     });
-
     it('should load the env correctly and use it for the consuming component', async () => {
       const envId = helper.env.getComponentEnv('comp1');
-      expect(envId).to.equal(`ci.${helper.scopes.remoteWithoutOwner}/my-env`);
+      expect(envId).to.equal(`${helper.scopes.remote}/my-env`);
+    });
+    // @todo: FIX!
+    describe.skip('when the aspect dependency is loaded from the workspace but the main dependency is loaded from the scope', () => {
+      before(() => {
+        helper.command.importComponent('dep-aspect');
+      });
+      it('should load the env correctly and use it for the consuming component', async () => {
+        const envId = helper.env.getComponentEnv('comp1');
+        expect(envId).to.equal(`${helper.scopes.remote}/my-env`);
+      });
     });
   });
 });
@@ -98,7 +110,7 @@ function getMainAspect(remoteScope: string) {
     static slots = [];
     static dependencies = [DepAspectAspect];
     static runtime = MainRuntime;
-    static async provider(depAspect: [DepAspectMain]) {
+    static async provider([depAspect]: [DepAspectMain]) {
       if (!depAspect) {
         throw new Error('unable to load the depAspect');
       }

--- a/e2e/harmony/custom-aspects.e2e.ts
+++ b/e2e/harmony/custom-aspects.e2e.ts
@@ -1,6 +1,4 @@
 import chai, { expect } from 'chai';
-import path from 'path';
-import os from 'os';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
 chai.use(require('chai-fs'));
@@ -17,11 +15,78 @@ describe('custom aspects', function () {
   describe('create custom aspect', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.command.create('aspect', 'custom-aspect');
-      helper.bitJsonc.setVariant(undefined, 'my-scope/custom-aspect', { 'teambit.harmony/aspect': {} });
-      helper.command.compile();
-      helper.command.install();
+
+      // Create first aspect that will be used as a dependency
+      helper.command.create('aspect', 'dep');
+
+      // Create second env aspect that will depend upon "aspect-dep"
+      helper.command.create('aspect', 'env');
+      helper.extensions.addExtensionToWorkspace('my-scope/env', {
+        'teambit.dependencies/dependency-resolver': {
+          policy: {
+            dependencies: {
+              dep: '^0.0.0',
+            },
+          },
+        },
+      });
+      helper.fs.outputFile('my-scope/env/env.main.runtime.ts', getEnvRuntime());
+
+      // Set all scope aspects as aspects
+      helper.extensions.addExtensionToVariant('my-scope/env', 'teambit.harmony/aspect');
+      helper.extensions.addExtensionToVariant('my-scope/dep', 'teambit.harmony/aspect');
+
+      // Create test component using the env
+      helper.fixtures.populateComponents(1);
+      helper.extensions.addExtensionToVariant('comp1', 'my-scope/env');
+
+      // helper.command.tagAllWithoutBuild();
+      // helper.command.export();
     });
-    it.only('should', () => {});
+
+    it.only('should compile without error', async () => {
+      expect(() => {
+        helper.command.link();
+        helper.command.compile();
+        helper.command.install();
+      }).to.not.throw();
+
+      helper.command.list();
+
+      const comp1 = helper.command.catComponent('comp1');
+      const compEnv = getEnvIdFromModel(comp1);
+      console.log(compEnv);
+      // const builder = harmony.get<BuilderMain>(BuilderAspect.id);
+      // const tasks = builder.listTasks(component);
+      // expect(tasks.snapTasks).to.include('teambit.pkg/pkg:PublishComponents');
+    });
   });
 });
+
+function getEnvRuntime() {
+  return `import { MainRuntime } from '@teambit/cli';
+import { EnvAspect } from './env.aspect';
+import { DepAspect, DepMain } from '@my-scope/dep';
+
+export class EnvMain {
+  static slots = [];
+  static dependencies = [
+    DepAspect
+  ];
+  static runtime = MainRuntime;
+  static async provider([dep]: [DepMain]) {
+    if(!dep) {
+      throw new Error('Dep dependency is missing');
+    }
+    return new EnvMain();
+  }
+}
+
+EnvAspect.addRuntime(EnvMain);`;
+}
+
+function getEnvIdFromModel(compModel: any): string {
+  const envEntry = compModel.extensions.find((ext) => ext.name === 'teambit.envs/envs');
+  const envId = envEntry.data.id;
+  return envId;
+}

--- a/e2e/harmony/custom-aspects.e2e.ts
+++ b/e2e/harmony/custom-aspects.e2e.ts
@@ -1,0 +1,27 @@
+import chai, { expect } from 'chai';
+import path from 'path';
+import os from 'os';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('custom aspects', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('create custom aspect', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.command.create('aspect', 'custom-aspect');
+      helper.bitJsonc.setVariant(undefined, 'my-scope/custom-aspect', { 'teambit.harmony/aspect': {} });
+      helper.command.compile();
+      helper.command.install();
+    });
+    it.only('should', () => {});
+  });
+});

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -422,7 +422,7 @@ export class ScopeMain implements ComponentFactory {
     try {
       await this.aspectLoader.loadRequireableExtensions(resolvedAspects, true);
     } catch (err: any) {
-      if (err?.error.code === 'MODULE_NOT_FOUND') {
+      if (err?.error?.code === 'MODULE_NOT_FOUND') {
         this.logger.warn(
           'failed loading aspects from capsules due to MODULE_NOT_FOUND error, re-creating the capsules and trying again'
         );


### PR DESCRIPTION
The added e2e-test makes sure that when the aspects in the current workspace depend on external aspects, the loading order is correct.