### PR TITLE
bit-doctor: fix validate-bit-version to work with Harmony version

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -119,8 +119,7 @@ function enableLoaderIfPossible() {
   }
 }
 
-// @todo: improve.
-export function getHarmonyVersion() {
+export function getHarmonyVersion(showValidSemver = false) {
   try {
     const teambitBit = require.resolve('@teambit/bit');
     // eslint-disable-next-line
@@ -128,10 +127,12 @@ export function getHarmonyVersion() {
     if (packageJson.version) return packageJson.version;
     // this is running locally
     if (packageJson.componentId && packageJson.componentId.version) {
-      return `last-tag ${packageJson.componentId.version}`;
+      return showValidSemver ? packageJson.componentId.version : `last-tag ${packageJson.componentId.version}`;
     }
+    if (showValidSemver) throw new Error(`unable to find Bit version`);
     return null;
   } catch (err: any) {
+    if (showValidSemver) throw err;
     return null;
   }
 }

--- a/src/doctor/core-diagnoses/validate-bit-version.ts
+++ b/src/doctor/core-diagnoses/validate-bit-version.ts
@@ -1,8 +1,5 @@
 import semver from 'semver';
-
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-import packageFile from '../../../package.json';
-import { BIT_VERSION } from '../../constants';
+import { getHarmonyVersion } from '../../bootstrap';
 import npmClient from '../../npm-client';
 import Diagnosis, { ExamineBareResult } from '../diagnosis';
 
@@ -18,9 +15,8 @@ export default class ValidateBitVersion extends Diagnosis {
       return 'could not fetch bit latest version';
     }
     return `bit is not up to date.
-    your version: ${BIT_VERSION}
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    latest version: ${bareResult.data.latestVersion}`;
+  your version: ${bareResult.data.currentVersion}
+  latest version: ${bareResult.data.latestVersion}`;
   }
 
   _formatManualTreat(bareResult: ExamineBareResult) {
@@ -29,18 +25,19 @@ export default class ValidateBitVersion extends Diagnosis {
     if (!bareResult.data.latestVersion) {
       return 'please make sure you have an internet connection';
     }
-    return 'please upgrade your bit version';
+    return 'please upgrade your bit version (bvm upgrade)';
   }
 
   async _runExamine(): Promise<ExamineBareResult> {
-    const bitLatestVersion = await npmClient.getPackageLatestVersion(packageFile.name);
-    const bitCurrentVersion = BIT_VERSION;
+    const bitLatestVersion = await npmClient.getPackageLatestVersion('@teambit/bit');
+    const bitCurrentVersion = getHarmonyVersion(true);
     if (bitLatestVersion) {
       if (semver.lt(bitCurrentVersion, bitLatestVersion)) {
         return {
           valid: false,
           data: {
             latestVersion: bitLatestVersion,
+            currentVersion: bitCurrentVersion,
           },
         };
       }


### PR DESCRIPTION
Currently, it works with the legacy version and shows "fails" incorrectly. 