### PR TITLE
fix bit-artifacts command when a component was not exported yet

### DIFF
--- a/e2e/harmony/artifacts.e2e.ts
+++ b/e2e/harmony/artifacts.e2e.ts
@@ -1,0 +1,27 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('bit artifacts command', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('staged component that was never exported', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllComponents();
+    });
+    it('should not throw an error about missing scope', () => {
+      expect(() => helper.command.artifacts('comp1')).to.not.throw();
+    });
+  });
+});

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -568,18 +568,16 @@ export class ScopeMain implements ComponentFactory {
    * @param includeCache whether or not include components that their scope-name is different than the current scope-name
    */
   async listIds(includeCache = false): Promise<ComponentID[]> {
-    let modelComponents = await this.legacyScope.list();
-    const ids = modelComponents.map((component) => ComponentID.fromLegacy(component.toBitIdWithLatestVersion()));
-    this.logger.debug(`scope listIds: modelComponents ids: ${JSON.stringify(ids)}`);
-    if (!includeCache) {
-      modelComponents = modelComponents.filter((modelComponent) => this.exists(modelComponent));
-    }
+    const allModelComponents = await this.legacyScope.list();
+    const modelComponentsToList = includeCache
+      ? allModelComponents
+      : allModelComponents.filter((modelComponent) => this.exists(modelComponent));
 
-    const componentsIds = modelComponents.map((component) =>
-      ComponentID.fromLegacy(component.toBitIdWithLatestVersion())
+    const ids = modelComponentsToList.map((component) =>
+      ComponentID.fromLegacy(component.toBitIdWithLatestVersion(), component.scope || this.name)
     );
-    this.logger.debug(`scope listIds: componentsIds after filter scope: ${JSON.stringify(componentsIds)}`);
-    return componentsIds;
+    this.logger.debug(`scope listIds: componentsIds after filter scope: ${JSON.stringify(ids, undefined, 2)}`);
+    return ids;
   }
 
   /**

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -127,6 +127,9 @@ export default class CommandHelper {
   sign(ids: string[], flags = '', cwd = this.scopes.localPath) {
     return this.runCmd(`bit sign ${ids.join(' ')} ${flags}`, cwd);
   }
+  artifacts(id = '', flags = '') {
+    return this.runCmd(`bit artifacts ${id} ${flags}`);
+  }
   updateDependencies(data: Record<string, any>, flags = '', cwd = this.scopes.localPath) {
     return this.runCmd(`bit update-dependencies '${JSON.stringify(data)}' ${flags}`, cwd);
   }


### PR DESCRIPTION
Currently, it shows an error:
```
scope was not defined directly or by "envs/my-react@0.0.1"
```
Reported by @giteden . 