### PR TITLE
avoid showing the multiple-envs issue when it has "envs" set

### DIFF
--- a/scopes/component/component-id/component-id.ts
+++ b/scopes/component/component-id/component-id.ts
@@ -151,7 +151,7 @@ export class ComponentID {
   /**
    * generate a component ID from a string.
    */
-  static fromString(idStr: string, scope?: string) {
+  static fromString(idStr: string, scope?: string): ComponentID {
     const legacyId = BitId.parse(idStr, true);
     if (!scope && !legacyId.scope) throw new MissingScope(idStr);
     return new ComponentID(legacyId, scope);

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -466,7 +466,6 @@
       "teambit.envs/envs": {
         "env": "teambit.react/react"
       },
-      "teambit.harmony/node": "-",
       "teambit.react/react": {}
     },
     "scopes/toolbox": {
@@ -567,7 +566,6 @@
       "teambit.envs/envs": {
         "env": "teambit.react/react"
       },
-      "teambit.harmony/node": "-",
       "teambit.dependencies/dependency-resolver": {
         "policy": {
           "devDependencies": {
@@ -584,7 +582,6 @@
       "teambit.envs/envs": {
         "env": "teambit.mdx/mdx"
       },
-      "teambit.harmony/node": "-",
       "teambit.mdx/mdx": {}
     },
     "scopes/semantics": {


### PR DESCRIPTION
When a component has an env set up via `"teambit.envs/envs"`, then this is the only env. 