### PR TITLE
bit-status: introduce a new flag --strict to exit with code 1 when issues found

### DIFF
--- a/e2e/harmony/status-harmony.e2e.ts
+++ b/e2e/harmony/status-harmony.e2e.ts
@@ -37,6 +37,15 @@ describe('status command on Harmony', function () {
     it('should show an issue of missing-dists', () => {
       helper.command.expectStatusToHaveIssue(IssuesClasses.MissingDists.name);
     });
+    it('should exit with non zero exit-code if --strict flag is used', () => {
+      let error;
+      try {
+        helper.command.runCmd('bit status --strict');
+      } catch (err: any) {
+        error = err;
+      }
+      expect(error.status).to.equal(1);
+    });
   });
   describe('package dir is deleted from node-modules', () => {
     before(() => {

--- a/src/cli/commands/public-cmds/status-cmd.ts
+++ b/src/cli/commands/public-cmds/status-cmd.ts
@@ -32,16 +32,25 @@ export default class Status implements LegacyCommand {
   group: Group = 'development';
   description = `show the working area component(s) status.\n  https://${BASE_DOCS_DOMAIN}/docs/view#status`;
   alias = 's';
-  opts = [['j', 'json', 'return a json version of the component']] as CommandOptions;
+  opts = [
+    ['j', 'json', 'return a json version of the component'],
+    ['', 'strict', 'in case issues found, exit with code 1'],
+  ] as CommandOptions;
   loader = true;
   migration = true;
   json = false;
 
   // eslint-disable-next-line no-empty-pattern
-  action([], { json }: { json?: boolean }): Promise<Record<string, any>> {
+  async action([], { json, strict }: { json?: boolean; strict?: boolean }): Promise<any> {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.json = json;
-    return status();
+    const results = await status();
+    const exitCode = results.componentsWithIssues.length && strict ? 1 : 0;
+
+    return {
+      data: results,
+      __code: exitCode,
+    };
   }
 
   report({


### PR DESCRIPTION
This is helpful for automation tools such as a CI to make sure the status is fine.