### PR TITLE
fix tsconfig exclude

### DIFF
--- a/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.spec.ts
+++ b/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.spec.ts
@@ -37,7 +37,14 @@ describe('ts config mutator test', () => {
   it('add exclude', () => {
     const config = new TypescriptConfigMutator(baseTypescriptConfig);
     config.addExclude(['dist']);
-    expect(config.raw.tsconfig.exclude[0]).toContain('dist');
+    expect(config.raw.tsconfig.exclude).toContain('dist');
+  });
+  
+  it('add multiple excludes', () => {
+    const config = new TypescriptConfigMutator(baseTypescriptConfig);
+    config.addExclude(['dist', 'public']);
+    expect(config.raw.tsconfig.exclude).toContain('dist');
+    expect(config.raw.tsconfig.exclude).toContain('public');
   });
 });
 

--- a/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.ts
+++ b/scopes/typescript/modules/ts-config-mutator/ts-config-mutator.ts
@@ -96,7 +96,7 @@ export class TypescriptConfigMutator {
   }
 
   addExclude(exclusions: string[]): TypescriptConfigMutator {
-    this.raw.tsconfig.exclude.push(exclusions);
+    this.raw.tsconfig.exclude.push(...exclusions);
     return this;
   }
 


### PR DESCRIPTION
## Proposed Changes

using `typescript.addExclude(['one', two'])` ends up creating a tsconfig like this:
```ts
{
  // ...
  exclude: [
    ["one", "two"]
  ]
}
```

this PR simply fix it to be:
```ts
{
  // ...
  exclude: [
    "one",
    "two"
  ]
}
```