### PR TITLE
lock version of sanitize.css (remove when postcss-normalize supports 13+)

### DIFF
--- a/scopes/react/react/component.json
+++ b/scopes/react/react/component.json
@@ -45,6 +45,7 @@
           "postcss-normalize": "10.0.0",
           "postcss-preset-env": "6.7.0",
           "postcss-flexbugs-fixes": "5.0.2",
+          "sanitize.css": "12.0.1",
           "sass-loader": "12.1.0",
           "less": "^4.1.1",
           "less-loader": "10.0.0",

--- a/scopes/ui-foundation/ui/component.json
+++ b/scopes/ui-foundation/ui/component.json
@@ -26,6 +26,7 @@
           "postcss-loader": "6.1.1",
           "postcss-normalize": "10.0.0",
           "postcss-flexbugs-fixes": "5.0.2",
+          "sanitize.css": "12.0.1",
           "sass-loader": "11.0.1",
           "less": "^4.1.1",
           "less-loader": "8.0.0",


### PR DESCRIPTION
## Proposed Changes

- lock version of sanitize.css to be 12.0.1 when postcss-normalize is used (it's an indirect dependency)

It was caused by https://github.com/csstools/sanitize.css/issues/225