### PR TITLE
add jestconfig export in react-env, and use new transform regex for jest

### DIFF
--- a/scopes/react/react-native/index.ts
+++ b/scopes/react/react-native/index.ts
@@ -1,5 +1,3 @@
-import jestConfig from './jest/jest.config';
-
 export type { ReactNativeMain } from './react-native.main.runtime';
 export { ReactNativeAspect, ReactNativeAspect as default } from './react-native.aspect';
-export { jestConfig };
+export { default as jestConfig } from './jest/jest.config';

--- a/scopes/react/react-native/jest/jest.config.js
+++ b/scopes/react/react-native/jest/jest.config.js
@@ -1,6 +1,10 @@
+const { generateNodeModulesPattern } = require('@teambit/dependencies.modules.packages-excluder');
+
+const packagesToExclude = ['@react-native', 'react-native', 'react-native-button'];
+
 module.exports = {
   preset: 'react-native',
-  transformIgnorePatterns: ['<rootDir>/node_modules/(?!(@react-native|react-native|react-native-button)/).*/'],
+  transformIgnorePatterns: [`<rootDir>/${generateNodeModulesPattern({ packages: packagesToExclude })}`],
   transform: { '^.+\\.(js|jsx|ts|tsx)$': '<rootDir>/node_modules/react-native/jest/preprocessor.js' },
   setupFilesAfterEnv: [require.resolve('./setupTests.js')],
   moduleNameMapper: {

--- a/scopes/react/react-native/templates/react-native-env/files/extension.ts
+++ b/scopes/react/react-native/templates/react-native-env/files/extension.ts
@@ -1,8 +1,9 @@
 import { ComponentContext } from '@teambit/generator';
 
 export function extensionFile({ namePascalCase: Name }: ComponentContext) {
-  return `import { EnvsMain, EnvsAspect } from '@teambit/envs'
-import { ReactNativeAspect, ReactNativeMain } from '@teambit/react-native'
+  return `import { EnvsMain, EnvsAspect } from '@teambit/envs';
+import { ReactNativeAspect, ReactNativeMain } from '@teambit/react-native';
+// import { previewConfigTransformer, devServerConfigTransformer } from './webpack/webpack-transformers';
 
 export class ${Name}Extension {
   constructor(private reactNative: ReactNativeMain) {}
@@ -14,6 +15,11 @@ export class ${Name}Extension {
       /*
         Use any of the "reactNative.override..." transformers to
       */
+      // reactNative.useWebpack({
+      //   previewConfig: [previewConfigTransformer],
+      //   devServerConfig: [devServerConfigTransformer],
+      // }),
+      // reactNative.overrideJestConfig(require.resolve('./jest/jest.config')),
     ])
 
     envs.registerEnv(${Name}Env)

--- a/scopes/react/react-native/templates/react-native-env/files/jest.config.ts
+++ b/scopes/react/react-native/templates/react-native-env/files/jest.config.ts
@@ -1,9 +1,9 @@
 export function jestConfigFile() {
   return `
   // Override the Jest config to ignore transpiling from specific folders
-  // See the base Jest config: https://bit.dev/teambit/react/react/~code/jest/jest.config.js
+  // See the base Jest config: https://bit.dev/teambit/react/react-native/~code/jest/jest.config.js
 
-  // const reactJestConfig = require('@teambit/react').jestConfig;
+  // const reactNativeJestConfig = require('@teambit/react-native').jestConfig;
   // uncomment the line below and install the package if you want to use this function
   // const {
   //   generateNodeModulesPattern,
@@ -11,10 +11,10 @@ export function jestConfigFile() {
   // const packagesToExclude = ['prop-types', '@teambit'];
 
   // module.exports = {
-  //   ...reactJestConfig,
+  //   ...reactNativeJestConfig,
   //   transformIgnorePatterns: [
-  //     ...reactJestConfig.transformIgnorePatterns,
-  //     '/' + generateNodeModulesPattern({ packages: packagesToExclude }),
+  //     ...reactNativeJestConfig.transformIgnorePatterns,
+  //     '<rootDir>/' + generateNodeModulesPattern({packages: packagesToExclude}),
   //   ],
   // };
   `;

--- a/scopes/react/react-native/templates/react-native-env/files/webpack.config.ts
+++ b/scopes/react/react-native/templates/react-native-env/files/webpack.config.ts
@@ -1,0 +1,48 @@
+export function webpackConfigFile() {
+  return `
+  import { WebpackConfigTransformer, WebpackConfigMutator, WebpackConfigTransformContext } from '@teambit/webpack';
+
+  /**
+   * Transformation to apply for both preview and dev server
+   * @param config
+   * @param _context
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function commonTransformation(config: WebpackConfigMutator, _context: WebpackConfigTransformContext) {
+    // Merge config with the webpack.config.js file if you choose to import a module export format config.
+    // config.merge([webpackConfig]);
+    // config.addAliases({});
+    // config.addModuleRule(youRuleHere);
+    return config;
+  }
+
+  /**
+   * Transformation for the preview only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const previewConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+
+  /**
+   * Transformation for the dev server only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const devServerConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+
+`;
+}

--- a/scopes/react/react-native/templates/react-native-env/index.ts
+++ b/scopes/react/react-native/templates/react-native-env/index.ts
@@ -2,6 +2,8 @@ import { ComponentContext, ComponentTemplate } from '@teambit/generator';
 import { indexFile } from './files/index';
 import { docFile } from './files/doc';
 import { extensionFile } from './files/extension';
+import { webpackConfigFile } from './files/webpack.config';
+import { jestConfigFile } from './files/jest.config';
 
 export const reactNativeTemplate: ComponentTemplate = {
   name: 'react-native-env',
@@ -20,6 +22,14 @@ export const reactNativeTemplate: ComponentTemplate = {
       {
         relativePath: `${context.name}.extension.ts`,
         content: extensionFile(context),
+      },
+      {
+        relativePath: `webpack/webpack-transformers.ts`,
+        content: webpackConfigFile(),
+      },
+      {
+        relativePath: `jest/jest.config.js`,
+        content: jestConfigFile(),
       },
     ];
   },

--- a/scopes/react/react/index.ts
+++ b/scopes/react/react/index.ts
@@ -6,3 +6,4 @@ export type { ReactEnv } from './react.env';
 // export * as styleRegexps from '@teambit/modules.style-regexps';
 
 export { ReactAspect, ReactAspect as default } from './react.aspect';
+export { default as jestConfig } from './jest/jest.config';


### PR DESCRIPTION
## Proposed Changes

- Jest was not working on custom React/React native extension because jestConfig was not exported - fixed.
- Use the new function from [packages excluder](https://bit.dev/teambit/dependencies/modules/packages-excluder) to generate node_modules regex for Jest in React template and for React native env and template.

