### PR TITLE
fix bit-import to recreate dists directories

### DIFF
--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -121,7 +121,7 @@ export default class ManyComponentsWriter {
   }
 
   static externalInstaller: ExternalPackageInstaller;
-  static externalCompiler: (ids: BitId[]) => Promise<any>;
+  static externalCompiler: (ids?: BitId[]) => Promise<any>;
   static registerExternalInstaller(installer: ExternalPackageInstaller) {
     this.externalInstaller = installer;
   }
@@ -404,7 +404,10 @@ to move all component files to a different directory, run bit remove and then bi
       });
     } else {
       await ManyComponentsWriter.externalInstaller?.install();
-      await ManyComponentsWriter.externalCompiler?.(this.componentsWithDependencies.map((c) => c.component.id));
+      // this compiles all components on the workspace, not only the imported ones.
+      // reason being is that a component has deps or indirect deps in the workspace, which the installed above deletes
+      // their dist directory.
+      await ManyComponentsWriter.externalCompiler?.();
     }
   }
   async _getAllLinks(): Promise<DataToPersist> {

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -405,8 +405,8 @@ to move all component files to a different directory, run bit remove and then bi
     } else {
       await ManyComponentsWriter.externalInstaller?.install();
       // this compiles all components on the workspace, not only the imported ones.
-      // reason being is that a component has deps or indirect deps in the workspace, which the installed above deletes
-      // their dist directory.
+      // reason being is that the installed above deletes all dists dir of components that are somehow part of the
+      // dependency graph. not only the imported components.
       await ManyComponentsWriter.externalCompiler?.();
     }
   }


### PR DESCRIPTION
Currently, since package installation takes place during import, the dists directories are deleted.
The "compile" process that happens after the installation was only compiling the imported component.
In this PR it has been fixed to compile all components on the workspace.