### PR TITLE
comment out ink-spinner

### DIFF
--- a/scopes/ui-foundation/cli/ui-server-loader/ui-server-loader.tsx
+++ b/scopes/ui-foundation/cli/ui-server-loader/ui-server-loader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Box, Text } from 'ink';
-import Spinner from 'ink-spinner';
+// import Spinner from 'ink-spinner';
 
 export type UIServerLoaderProps = {
   /**
@@ -13,9 +13,9 @@ export function UIServerLoader({ name }: UIServerLoaderProps) {
   return (
     <Box paddingTop={1}>
       <Text>
-        <Text color="green">
+        {/* <Text color="green">
           <Spinner type="dots" />
-        </Text>{' '}
+        </Text>{' '} */}
         Starting UI servers{' '}
         {name && (
           <>


### PR DESCRIPTION
## Proposed Changes

- comment out `ink-spinner`  from `UIServerLoader`
- this avoids this bug - https://github.com/vadimdemedes/ink-spinner/issues/12

⚠️ Note we still use the problematic `cli-spinners` at `src/constants.ts`  
(though it may be safely locked to a specific version)

Before:
<img width="385" alt="Screen Shot 2021-10-04 at 18 59 42" src="https://user-images.githubusercontent.com/5400361/135885305-0b2b9048-b29f-4c3d-af7b-e97356b69621.png">

After:
<img width="403" alt="Screen Shot 2021-10-04 at 18 57 38" src="https://user-images.githubusercontent.com/5400361/135885279-adba7daa-595b-4794-a955-25370b2839d2.png">