### PR TITLE
Add option to compile from source

### DIFF
--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -6,6 +6,7 @@ import prettyTime from 'pretty-time';
 import type ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { formatCompileResults } from './output-formatter';
 import { CompileError, WorkspaceCompiler, CompileOptions } from './workspace-compiler';
+import { CompileOrigin } from './types';
 
 // IDs & events
 import { CompilerAspect } from './compiler.aspect';
@@ -38,7 +39,7 @@ export class CompileCmd implements Command {
 
     let outputString = '';
     compilerOptions.deleteDistDir = true;
-    await this.compile.compileComponents(components, compilerOptions);
+    await this.compile.compileComponents(components, { ...compilerOptions, origin: CompileOrigin.CmdReport });
     const compileTimeLength = process.hrtime(startTimestamp);
 
     outputString += '\n';
@@ -59,7 +60,10 @@ export class CompileCmd implements Command {
   async json([components]: [string[]], compilerOptions: CompileOptions) {
     compilerOptions.deleteDistDir = true;
     // @ts-ignore
-    const compileResults = await this.compile.compileComponents(components, compilerOptions);
+    const compileResults = await this.compile.compileComponents(components, {
+      ...compilerOptions,
+      origin: CompileOrigin.CmdJson,
+    });
     return {
       data: compileResults,
       // @todo: fix the code once compile is ready.

--- a/scopes/compilation/compiler/index.ts
+++ b/scopes/compilation/compiler/index.ts
@@ -1,4 +1,11 @@
 export type { CompilerMain } from './compiler.main.runtime';
 export { CompilerAspect } from './compiler.aspect';
-export { Compiler, CompilerOptions, TranspileFileOutput, TranspileFileParams, TranspileComponentParams } from './types';
+export {
+  Compiler,
+  CompilerOptions,
+  CompileOrigin,
+  TranspileFileOutput,
+  TranspileFileParams,
+  TranspileComponentParams,
+} from './types';
 export * from './events';

--- a/scopes/compilation/compiler/types.ts
+++ b/scopes/compilation/compiler/types.ts
@@ -1,5 +1,6 @@
 import { BuildContext, BuildTask, BuiltTaskResult, TaskResultsList } from '@teambit/builder';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
+import type { Component } from '@teambit/component';
 
 export type TranspileFileParams = {
   componentDir: string; // absolute path of the component's root directory
@@ -93,6 +94,12 @@ export interface Compiler extends CompilerOptions {
    * both, the return path and the given path are relative paths.
    */
   getDistPathBySrcPath(srcPath: string): string;
+
+  /**
+   * given a component, returns the path to source folder to use for the preview, uses the one
+   * in node_modules by default
+   */
+  getPreviewComponentPath?(component: Component): string;
 
   /**
    * only supported files matching get compiled. others, are copied to the dist dir.

--- a/scopes/compilation/compiler/types.ts
+++ b/scopes/compilation/compiler/types.ts
@@ -6,10 +6,19 @@ export type TranspileFileParams = {
   filePath: string; // relative path of the file inside the component directory
 };
 
+export enum CompileOrigin {
+  CmdReport,
+  CmdJson,
+  PreStart,
+  ComponentChanged,
+  AspectLoadFail,
+}
+
 export type TranspileComponentParams = {
   component: ConsumerComponent;
   componentDir: string; // absolute path of the component's root directory
   outputDir: string; // absolute path of the component's output directory
+  origin: CompileOrigin; // origin of the compilation's request
 };
 
 export type TranspileFileOutput =

--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -21,7 +21,7 @@ import type { PreStartOpts } from '@teambit/ui';
 import { PathOsBasedAbsolute, PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
 import { CompilerAspect } from './compiler.aspect';
 import { CompilerErrorEvent, ComponentCompilationOnDoneEvent } from './events';
-import { Compiler } from './types';
+import { Compiler, CompileOrigin } from './types';
 
 export type BuildResult = { component: string; buildResults: string[] | null | undefined };
 
@@ -34,6 +34,7 @@ export type CompileOptions = {
    * start` to avoid webpack "EINTR" error.
    */
   deleteDistDir?: boolean;
+  origin: CompileOrigin;
 };
 
 export type CompileError = { path: string; error: Error };
@@ -60,9 +61,11 @@ export class ComponentCompiler {
     }
 
     if (this.compilerInstance.transpileFile) {
-      await Promise.all(this.component.files.map((file: SourceFile) => this.compileOneFileWithNewCompiler(file)));
+      await Promise.all(
+        this.component.files.map((file: SourceFile) => this.compileOneFileWithNewCompiler(file, options.origin))
+      );
     } else if (this.compilerInstance.transpileComponent) {
-      await this.compileAllFilesWithNewCompiler(this.component);
+      await this.compileAllFilesWithNewCompiler(this.component, options.origin);
     } else {
       throw new Error(
         `compiler ${this.compilerId.toString()} doesn't implement either "transpileFile" or "transpileComponent" methods`
@@ -115,8 +118,8 @@ ${this.compileErrors.map(formatError).join('\n')}`);
     return this.workspace.componentDir(new ComponentID(this.component.id));
   }
 
-  private async compileOneFileWithNewCompiler(file: SourceFile): Promise<void> {
-    const options = { componentDir: this.componentDir, filePath: file.relative };
+  private async compileOneFileWithNewCompiler(file: SourceFile, origin: CompileOrigin): Promise<void> {
+    const options = { componentDir: this.componentDir, filePath: file.relative, origin };
     const isFileSupported = this.compilerInstance.isFileSupported(file.path);
     let compileResults;
     if (isFileSupported) {
@@ -145,7 +148,7 @@ ${this.compileErrors.map(formatError).join('\n')}`);
     }
   }
 
-  private async compileAllFilesWithNewCompiler(component: ConsumerComponent): Promise<void> {
+  private async compileAllFilesWithNewCompiler(component: ConsumerComponent, origin: CompileOrigin): Promise<void> {
     const base = this.distDir;
     const filesToCompile: SourceFile[] = [];
     component.files.forEach((file: SourceFile) => {
@@ -170,6 +173,7 @@ ${this.compileErrors.map(formatError).join('\n')}`);
           component,
           componentDir: this.componentDir,
           outputDir: this.workspace.getComponentPackagePath(component),
+          origin,
         });
       } catch (error: any) {
         this.compileErrors.push({ path: this.componentDir, error });
@@ -200,19 +204,28 @@ export class WorkspaceCompiler {
     if (preStartOpts.skipCompilation) {
       return;
     }
-    await this.compileComponents([], { changed: true, verbose: false, deleteDistDir: false });
+    await this.compileComponents([], {
+      changed: true,
+      verbose: false,
+      deleteDistDir: false,
+      origin: CompileOrigin.PreStart,
+    });
   }
 
   async onAspectLoadFail(err: Error & { code?: string }, id: ComponentID): Promise<boolean> {
     if (err.code && err.code === 'MODULE_NOT_FOUND' && this.workspace) {
-      await this.compileComponents([id.toString()], {}, true);
+      await this.compileComponents([id.toString()], { origin: CompileOrigin.AspectLoadFail }, true);
       return true;
     }
     return false;
   }
 
   async onComponentChange(component: Component): Promise<SerializableResults> {
-    const buildResults = await this.compileComponents([component.id.toString()], {}, true);
+    const buildResults = await this.compileComponents(
+      [component.id.toString()],
+      { origin: CompileOrigin.ComponentChanged },
+      true
+    );
     return {
       results: buildResults,
       toString() {

--- a/scopes/harmony/worker/harmony-worker.ts
+++ b/scopes/harmony/worker/harmony-worker.ts
@@ -5,17 +5,21 @@ import nodeEndpoint from './node-endpoint';
 
 export type InitOptions = {
   /**
-   * determine whether stdout should be piped into the parent process.
+   * Determines whether stdout should be piped into the parent process.
+   * If this is set to true, then worker.stdout is NOT automatically piped through to process.stdout in the parent.
    */
   stdout: boolean;
 
   /**
-   * determine whether stderr should be piped into the parent process.
+   * Determines whether stderr should be piped into the parent process.
+   * If this is set to true, then worker.stderr is NOT automatically piped through to process.stderr in the parent.
    */
   stderr: boolean;
 
   /**
-   * determine whether stdin should be piped into the parent process.
+   * Determines whether stdin should be piped into the parent process.
+   * If this is set to true, then worker.stdin provides a writable stream whose contents appear as process.stdin inside
+   * the Worker. By default, no data is provided.
    */
   stdin: boolean;
 };

--- a/scopes/harmony/worker/worker.main.runtime.ts
+++ b/scopes/harmony/worker/worker.main.runtime.ts
@@ -20,14 +20,14 @@ export class WorkerMain {
 
   static runtime = MainRuntime;
 
-  listWorkers() {
+  listWorkers(): HarmonyWorker<any>[] {
     return this.workerSlot.values();
   }
 
   /**
    * create a new worker.
    */
-  async declareWorker<T>(name: string, path: string) {
+  async declareWorker<T>(name: string, path: string): Promise<HarmonyWorker<T>> {
     this.workerNameSlot.register(name);
 
     const maybeAspectId = this.workerNameSlot.toArray().find(([, workerName]) => {
@@ -43,7 +43,7 @@ export class WorkerMain {
     return systemWorker;
   }
 
-  private async resolveWorkerScript(name: string, aspectId: string) {
+  private async resolveWorkerScript(name: string, aspectId: string): Promise<string> {
     const host = this.componentAspect.getHost();
     const id = await host.resolveComponentId(aspectId);
     const component = await host.get(id);
@@ -54,7 +54,7 @@ export class WorkerMain {
     return require.resolve(join(packageName, 'dist', `${name}.worker.js`));
   }
 
-  getWorker<T>(id: string) {
+  getWorker<T>(id: string): HarmonyWorker<T> {
     return this.workerSlot.get(id) as HarmonyWorker<T>;
   }
 

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -138,10 +138,9 @@ export class PreviewMain {
 
       const map = await previewDef.getModuleMap(components);
       const environment = context.envRuntime.env;
-
-      const compilerInstance = hasCompiler(environment) && environment.getCompiler();
+      const compilerInstance = environment.getCompiler?.();
       const withPaths = map.map<string[]>((files, component) => {
-        const modulePath = this.pkg.getModulePath(component);
+        const modulePath = compilerInstance?.getPreviewComponentPath?.(component) || this.pkg.getModulePath(component);
         return files.map((file) => {
           if (!this.workspace || !compilerInstance) {
             return file.path;

--- a/scopes/workspace/workspace/watch/watcher.ts
+++ b/scopes/workspace/workspace/watch/watcher.ts
@@ -106,7 +106,7 @@ export class Watcher {
   }
 
   /**
-   * if .bitmap has change, it's possible that a new component has added. trigger onComponentAdd.
+   * if .bitmap changed, it's possible that a new component has been added. trigger onComponentAdd.
    */
   private async handleBitmapChanges(): Promise<OnComponentEventResult[]> {
     const previewsTrackDirs = { ...this.trackDirs };


### PR DESCRIPTION
## Proposed Changes

- add `CompileOrigin` information: allows to ignore compilation on bit start (or do it in the background), since we're only using source files, we don't really need compiled files for the preview
- add `getPreviewComponentPath` on compiler: gives the option to change the path of the preview files that will be used to source instead of compiled files

With these two changes, we are able to use the source files for the preview so that we avoid lenghty compilations. It also fixes issues with watchers that don't need to / cannot watch node modules (e.g. Angular typescript watcher)
