### PR TITLE
fix webpack manifest

### DIFF
--- a/scopes/react/react/webpack/webpack.config.base.prod.ts
+++ b/scopes/react/react/webpack/webpack.config.base.prod.ts
@@ -91,10 +91,11 @@ export default function (): Configuration {
           }, seed);
           const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
 
+          // @ts-ignore - https://github.com/shellscape/webpack-manifest-plugin/issues/276
           return {
-            files: JSON.stringify(manifestFiles),
-            entrypoints: JSON.stringify(entrypointFiles),
-          };
+            files: manifestFiles,
+            entrypoints: entrypointFiles,
+          } as Record<string, string>;
         },
       }),
       // Generate a service worker script that will precache, and keep up to date,

--- a/scopes/ui-foundation/ui/ssr/render-middleware.ts
+++ b/scopes/ui-foundation/ui/ssr/render-middleware.ts
@@ -73,13 +73,13 @@ async function loadRuntime(root: string, { logger }: { logger: Logger }) {
 
     const manifestFilepath = path.join(root, 'asset-manifest.json');
     if (!fs.existsSync(manifestFilepath)) {
-      logger.warn('[ssr] - Failed finding asset manifest file. Skipping setup.');
+      logger.warn('[ssr] - Skipping setup (cannot find asset manifest file)');
       return undefined;
     }
 
     assets = await parseManifest(manifestFilepath);
     if (!assets) {
-      logger.warn('[ssr] - failed parsing assets manifest. Skipping setup.');
+      logger.warn('[ssr] - Skipping setup (failed parsing assets manifest)');
       return undefined;
     }
 
@@ -101,15 +101,20 @@ async function loadRuntime(root: string, { logger }: { logger: Logger }) {
   };
 }
 
-async function parseManifest(filepath: string) {
+async function parseManifest(filepath: string, logger?: Logger) {
   try {
     const file = await fs.readFile(filepath);
+    logger?.debug('[ssr] - ✓ aread manifest file');
     const contents = file.toString();
     const parsed: ManifestFile = JSON.parse(contents);
+    logger?.debug('[ssr] - ✓ prased manifest file', parsed);
     const assets = getAssets(parsed);
+    logger?.debug('[ssr] - ✓ extracted data from manifest file', assets);
 
     return assets;
   } catch (e: any) {
+    logger?.error('[ssr] - error parsing asset manifest', e);
+    process.exit();
     return undefined;
   }
 }

--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -347,10 +347,11 @@ export default function createWebpackConfig(
           }, seed);
           const entrypointFiles = entrypoints.main.filter((fileName) => !fileName.endsWith('.map'));
 
+          // @ts-ignore - https://github.com/shellscape/webpack-manifest-plugin/issues/276
           return {
-            files: JSON.stringify(manifestFiles),
-            entrypoints: JSON.stringify(entrypointFiles),
-          };
+            files: manifestFiles,
+            entrypoints: entrypointFiles,
+          } as Record<string, string>;
         },
       }),
       // Moment.js is an extremely popular library that bundles large locale files


### PR DESCRIPTION
## Proposed Changes

- fix webpack manifest file (content was stringified twice, Ran was right, types were wrong)
- add logs to ssr middleware

waiting for https://github.com/shellscape/webpack-manifest-plugin/issues/276 to remove console logs
