### PR TITLE
fix JUnit to not show an empty error tag

### DIFF
--- a/scopes/defender/tester/utils/junit-generator.ts
+++ b/scopes/defender/tester/utils/junit-generator.ts
@@ -10,7 +10,7 @@ export function testsResultsToJUnitFormat(components: ComponentsResults[]): stri
       suite.timestamp(new Date(compResult.results?.start).toISOString());
     }
     compResult.results?.testFiles.forEach((testFile) => {
-      if (testFile.error) {
+      if (testFile.error?.error) {
         const testCase = suite.testCase().className(testFile.file).name(testFile.file);
         testCase.error(stripAnsi(testFile.error.error as string));
       }


### PR DESCRIPTION
Currently, the generated JUnit.xml file shows `</error>` although there was no error. This PR fixes it to now show this empty tag.