### PR TITLE
bugfix fixed 'list' param alias not working

### DIFF
--- a/src/cli/commands/public-cmds/list-cmd.ts
+++ b/src/cli/commands/public-cmds/list-cmd.ts
@@ -17,7 +17,7 @@ export default class List implements LegacyCommand {
   description = `list components on a local or a remote scope.\n  https://${BASE_DOCS_DOMAIN}/docs/view#list`;
   alias = 'ls';
   opts = [
-    ['ids', 'ids', 'show only component ids unformatted'],
+    ['i', 'ids', 'show only component ids unformatted'],
     ['s', 'scope', 'show only components stored in the local scope, including indirect dependencies'],
     ['b', 'bare', 'DEPRECATED. use --raw instead'],
     ['r', 'raw', 'show raw output (only components ids, no styling)'],


### PR DESCRIPTION
## Proposed Changes

- Fixed subparam alias 'ids' that was not working for command 'list'

Steps to reproduce:
`bit list -ids`

> bit list -h
> Usage: list|ls [options] [scope]
> 
> list components on a local or a remote scope.
>   https://docs.bit.dev/docs/view#list
> 
> Options:
>   **-ids**, --ids               show only component ids unformatted
>   -s, --scope               show all components of the scope, including indirect dependencies
>   -b, --bare                DEPRECATED. use --raw instead
>   -r, --raw                 show raw output (only components ids, no styling)
>   -o, --outdated            show latest versions from remotes
>   -j, --json                show the output in JSON format
>   -n, --namespace <string>  show only specified namespace by using wildcards
>   --skip-update             Skips auto updates
>   -h, --help                output usage information
>
> $**bit list -ids**
> **error: unknown option `-i'**
