### PR TITLE
Make run app server link clickable

### DIFF
--- a/scopes/harmony/application/run.cmd.tsx
+++ b/scopes/harmony/application/run.cmd.tsx
@@ -33,7 +33,7 @@ export class RunCmd implements Command {
       dev,
     });
 
-    return `${appName} has started on port ${port}`;
+    return `${appName} app is running on http://localhost:${port}`;
   }
 
   async render(
@@ -47,7 +47,7 @@ export class RunCmd implements Command {
 
     return (
       <Text>
-        {appName} app is running on {`http://localhost:${port}`}
+        {appName} app is running on http://localhost:{port}
       </Text>
     );
     // return <UIServerConsole appName={appName} futureUiServer={uiServer} />;


### PR DESCRIPTION
## Proposed Changes

- add localhost before the port.

Before:
`bit-dev has started on port 3000`
After:
`bit-dev app is running on http://localhost:3000`

And now we can click on the link.