### PR TITLE
add an option to only check-types of the changed files and not the entire project

### DIFF
--- a/scopes/preview/preview/preview.start-plugin.tsx
+++ b/scopes/preview/preview/preview.start-plugin.tsx
@@ -4,7 +4,7 @@ import { PreviewServerStatus } from '@teambit/preview.cli.preview-server-status'
 import { BundlerMain, ComponentServer } from '@teambit/bundler';
 import { PubsubMain } from '@teambit/pubsub';
 import { ProxyEntry, StartPlugin, StartPluginOptions, UiMain } from '@teambit/ui';
-import { Workspace } from '@teambit/workspace';
+import { Workspace, CheckTypes } from '@teambit/workspace';
 import { SubscribeToWebpackEvents, CompilationResult } from '@teambit/preview.cli.webpack-events-listener';
 import { CompilationInitiator } from '@teambit/compiler';
 import { Logger } from '@teambit/logger';
@@ -35,7 +35,7 @@ export class PreviewStartPlugin implements StartPlugin {
     this.workspace.watcher
       .watchAll({
         spawnTSServer: true,
-        checkTypes: false,
+        checkTypes: CheckTypes.None,
         preCompile: false,
         msgs: {
           onAll: () => {},

--- a/scopes/workspace/workspace/index.ts
+++ b/scopes/workspace/workspace/index.ts
@@ -6,6 +6,7 @@ export type { ResolvedComponent } from '@teambit/harmony.modules.resolved-compon
 export type { AlreadyExistsError as ComponentConfigFileAlreadyExistsError } from './component-config-file';
 export type { WorkspaceMain } from './workspace.main.runtime';
 export type { WatchOptions } from './watch/watcher';
+export { CheckTypes } from './watch/check-types';
 export * from './events';
 export type { WorkspaceUI } from './workspace.ui.runtime';
 export type { SerializableResults, OnComponentEventResult } from './on-component-events';

--- a/scopes/workspace/workspace/watch/check-types.ts
+++ b/scopes/workspace/workspace/watch/check-types.ts
@@ -1,0 +1,5 @@
+export enum CheckTypes {
+  None, // keep this. it equals zero. this way we can do "if checkTypes() ... "
+  EntireProject,
+  ChangedFile,
+}

--- a/scopes/workspace/workspace/watch/watch.cmd.tsx
+++ b/scopes/workspace/workspace/watch/watch.cmd.tsx
@@ -1,6 +1,5 @@
 import chalk from 'chalk';
 import moment from 'moment';
-
 import { Command, CommandOptions } from '@teambit/cli';
 import type { Logger } from '@teambit/logger';
 import type { BitBaseEvent, PubsubMain } from '@teambit/pubsub';
@@ -11,11 +10,12 @@ import { CompilerAspect, CompilerErrorEvent } from '@teambit/compiler';
 import { Watcher, WatchOptions } from './watcher';
 import { formatCompileResults, formatWatchPathsSortByComponent } from './output-formatter';
 import { OnComponentEventResult } from '../on-component-events';
+import { CheckTypes } from './check-types';
 
 export type WatchCmdOpts = {
   verbose?: boolean;
   skipPreCompilation?: boolean;
-  checkTypes?: boolean;
+  checkTypes?: string | boolean;
 };
 
 export class WatchCommand implements Command {
@@ -23,8 +23,7 @@ export class WatchCommand implements Command {
     onAll: (event, path) => this.logger.console(`Event: "${event}". Path: ${path}`),
     onStart: () => {},
     onReady: (workspace, watchPathsSortByComponent, verbose) => {
-      // eslint-disable-next-line no-console
-      console.clear();
+      clearOutdatedData();
       if (verbose) {
         this.logger.console(formatWatchPathsSortByComponent(watchPathsSortByComponent));
       }
@@ -35,8 +34,7 @@ export class WatchCommand implements Command {
       );
     },
     onChange: (filePath: string, buildResults: OnComponentEventResult[], verbose: boolean, duration) => {
-      // eslint-disable-next-line no-console
-      console.clear();
+      clearOutdatedData();
       if (!buildResults.length) {
         this.logger.console(`The file ${filePath} has been changed, but nothing to compile.\n\n`);
         return;
@@ -47,8 +45,7 @@ export class WatchCommand implements Command {
       this.logger.console(chalk.yellow(`Watching for component changes (${moment().format('HH:mm:ss')})...`));
     },
     onAdd: (filePath: string, buildResults: OnComponentEventResult[], verbose: boolean, duration) => {
-      // eslint-disable-next-line no-console
-      console.clear();
+      clearOutdatedData();
       this.logger.console(`The file ${filePath} has been added.\n\n`);
       this.logger.console(formatCompileResults(buildResults, verbose));
       this.logger.console(`Finished. (${duration}ms)`);
@@ -70,7 +67,11 @@ export class WatchCommand implements Command {
   options = [
     ['v', 'verbose', 'showing npm verbose output for inspection and prints stack trace'],
     ['', 'skip-pre-compilation', 'skip the compilation step before starting to watch'],
-    ['t', 'check-types', 'EXPERIMENTAL. for typescript files, load an tsserver instance to check types'],
+    [
+      't',
+      'check-types [string]',
+      'EXPERIMENTAL. show errors/warnings for types. options are [file, project] to investigate only changed file or entire project. defaults to project',
+    ],
   ] as CommandOptions;
 
   constructor(
@@ -107,14 +108,35 @@ export class WatchCommand implements Command {
 
   async report(cliArgs: [], watchCmdOpts: WatchCmdOpts) {
     const { verbose, checkTypes } = watchCmdOpts;
+    const getCheckTypesEnum = () => {
+      switch (checkTypes) {
+        case undefined:
+        case false:
+          return CheckTypes.None;
+        case 'project':
+        case true: // project is the default
+          return CheckTypes.EntireProject;
+        case 'file':
+          return CheckTypes.ChangedFile;
+        default:
+          throw new Error(`check-types can be either "file" or "project". got "${checkTypes}"`);
+      }
+    };
     const watchOpts: WatchOptions = {
       msgs: this.msgs,
       verbose,
       preCompile: !watchCmdOpts.skipPreCompilation,
-      spawnTSServer: checkTypes, // if check-types is enabled, it must spawn the tsserver.
-      checkTypes,
+      spawnTSServer: Boolean(checkTypes), // if check-types is enabled, it must spawn the tsserver.
+      checkTypes: getCheckTypesEnum(),
     };
     await this.watcher.watchAll(watchOpts);
     return 'watcher terminated';
   }
+}
+
+/**
+ * with console.clear() all history is deleted from the console. this function preserver the history.
+ */
+function clearOutdatedData() {
+  process.stdout.write('\x1Bc');
 }

--- a/scopes/workspace/workspace/watch/watcher.ts
+++ b/scopes/workspace/workspace/watch/watcher.ts
@@ -19,6 +19,7 @@ import { WorkspaceAspect } from '../';
 import { OnComponentChangeEvent, OnComponentAddEvent, OnComponentRemovedEvent } from '../events';
 import { Workspace } from '../workspace';
 import { OnComponentEventResult } from '../on-component-events';
+import { CheckTypes } from './check-types';
 
 export type WatcherProcessData = { watchProcess: ChildProcess; compilerId: BitId; componentIds: BitId[] };
 
@@ -27,7 +28,7 @@ export type WatchOptions = {
   initiator?: CompilationInitiator;
   verbose?: boolean; // print watch events to the console. (also ts-server events if spawnTSServer is true)
   spawnTSServer?: boolean; // needed for check types and extract API/docs.
-  checkTypes?: boolean; // if enabled, the spawnTSServer becomes true.
+  checkTypes?: CheckTypes; // if enabled, the spawnTSServer becomes true.
   preCompile?: boolean; // whether compile all components before start watching
 };
 


### PR DESCRIPTION
Currently, `bit watch check-types` scan the entire project for type errors. 
For big projects this can be slow. 
This PR changes the `--check-types` flag to get a string `file` or `project`, the default is `project`. 
Later, we'll add an option of `graph` to only scan the dependents. 