### PR TITLE
update react refresh to v0.5.1

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -20,7 +20,7 @@
         "@mdx-js/loader": "1.6.21",
         "@mdx-js/mdx": "1.6.21",
         "@mdx-js/react": "1.6.22",
-        "@pmmmwh/react-refresh-webpack-plugin": "0.5.0-rc.6",
+        "@pmmmwh/react-refresh-webpack-plugin": "0.5.1",
         "@pnpm/client": "5.0.8",
         "@pnpm/config": "13.3.0",
         "@pnpm/core": "1.0.0",


### PR DESCRIPTION
## Proposed Changes

- update react fast refresh webpack plugin from 0.5.0-rc.6 to 0.5.1

Tested on the webpack reference project, and symphony-bare-scope