### PR TITLE
configure load-asepcts on scope to build capsules for the seeders only

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -430,6 +430,7 @@ export class ScopeMain implements ComponentFactory {
       {
         baseDir: this.getAspectCapsulePath(),
         skipIfExists,
+        seedersOnly: true,
         includeFromNestedHosts: true,
         installOptions: { copyPeerToRuntimeOnRoot: true },
       },


### PR DESCRIPTION
Currently, it builds capsules for the entire graph, which is not needed and causes some issues on bit-sign.