### PR TITLE
bit-build: remove publish/pack dry-run task

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -152,7 +152,8 @@ describe('publish functionality', function () {
       });
     });
   });
-  describe('with invalid package name', () => {
+  // we ended up not running the publish dry-run tasks
+  describe.skip('with invalid package name', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       npmCiRegistry = new NpmCiRegistry(helper);

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -11,7 +11,7 @@ import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { PackageJsonTransformer } from '@teambit/legacy/dist/consumer/component/package-json-transformer';
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
-import { BuilderMain, BuilderAspect, BuildTaskHelper } from '@teambit/builder';
+import { BuilderMain, BuilderAspect } from '@teambit/builder';
 import { BitError } from '@teambit/bit-error';
 import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
 import { GraphqlMain, GraphqlAspect } from '@teambit/graphql';
@@ -22,7 +22,6 @@ import { Packer, PackOptions, PackResult, TAR_FILE_ARTIFACT_NAME } from './packe
 import { PackCmd } from './pack.cmd';
 import { PkgAspect } from './pkg.aspect';
 import { PreparePackagesTask } from './prepare-packages.task';
-import { PublishDryRunTask } from './publish-dry-run.task';
 import { PublishCmd } from './publish.cmd';
 import { Publisher } from './publisher';
 import { PublishTask } from './publish.task';
@@ -148,10 +147,13 @@ export class PkgMain {
 
     componentAspect.registerRoute([new PackageRoute(pkg)]);
 
-    const dryRunTask = new PublishDryRunTask(PkgAspect.id, publisher, packer, logPublisher);
+    // we ended up not using the publish-dry-run task. It used to run "npm publish --dry-run"
+    // and also "npm pack --dry-run", but it's not that useful and it takes long to complete.
+    // we might revise our decision later.
+    // const dryRunTask = new PublishDryRunTask(PkgAspect.id, publisher, packer, logPublisher);
     const preparePackagesTask = new PreparePackagesTask(PkgAspect.id, logPublisher);
-    dryRunTask.dependencies = [BuildTaskHelper.serializeId(preparePackagesTask)];
-    builder.registerBuildTasks([preparePackagesTask, dryRunTask]);
+    // dryRunTask.dependencies = [BuildTaskHelper.serializeId(preparePackagesTask)];
+    builder.registerBuildTasks([preparePackagesTask]);
     builder.registerTagTasks([packTask, publishTask]);
     builder.registerSnapTasks([packTask]);
     if (workspace) {


### PR DESCRIPTION
This dry-run task, runs `npm publish --dry-run` and `npm pack --dry-run`, which are mostly to show the user some output, but not a real test to make sure the publish will succeed. 
It takes long time to complete and the value it provides doesn't justify the performance penalty.

Also, configure the pack task to run in parallel or 10 at a time. 
