### PR TITLE
support scss "@use" and "@forward" to function the same as "@import"

### DIFF
--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css-and-preprocessors/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css-and-preprocessors/index.ts
@@ -45,7 +45,7 @@ function detective(fileContent, syntax) {
 }
 
 function isImportStatement(node) {
-  if (node.type === 'Atrule' && node.name === 'import') {
+  if (node.type === 'Atrule' && (node.name === 'import' || node.name === 'use' || node.name === 'forward')) {
     return true;
   }
   return false;
@@ -66,7 +66,10 @@ function extractDependencies(importStatementNode) {
     importStatementNode.prelude.children &&
     importStatementNode.prelude.children.tail.data.type !== 'Url'
   ) {
-    return importStatementNode.prelude.children.tail.data.value.replace(/["']/g, '');
+    const name =
+      importStatementNode.prelude.children.tail.data.value || // for import keyword
+      importStatementNode.prelude.children.tail.data.name; // for use keyword
+    return name.replace(/["']/g, '');
   }
 
   // allows imports with no semicolon

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.spec.ts
@@ -51,4 +51,26 @@ describe('detective-sass', function () {
       test('@import reset', ['reset']);
     });
   });
+
+  describe('use keyword', function () {
+    it('returns the dependencies of the given .sass file content', function () {
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@use _foo', ['_foo']);
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@use        _foo', ['_foo']);
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@use reset', ['reset']);
+    });
+  });
+
+  describe('forward keyword', function () {
+    it('returns the dependencies of the given .sass file content', function () {
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@forward _foo', ['_foo']);
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@forward        _foo', ['_foo']);
+      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+      test('@forward reset', ['reset']);
+    });
+  });
 });


### PR DESCRIPTION
The dependency detection currently only recognizes `@import`.
This PR adds support for the newer syntax of `@use` and `@forward`.