### PR TITLE
support sass "@use as" syntax

### DIFF
--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css-and-preprocessors/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css-and-preprocessors/index.ts
@@ -60,16 +60,30 @@ function extractDependencies(importStatementNode) {
     return importStatementNode.prelude.children.tail.data.value.value.replace(/["']/g, '');
   }
 
+  // @use and @forward of scss/sass syntax
+  if (
+    (importStatementNode.name === 'use' || importStatementNode.name === 'forward') &&
+    importStatementNode.prelude.type === 'AtrulePrelude' &&
+    importStatementNode.prelude.children?.head?.data
+  ) {
+    const getDepName = () => {
+      const headData = importStatementNode.prelude.children?.head?.data;
+      if (headData.type === 'String' && headData.value) return headData.value;
+      if (headData.type === 'Identifier' && headData.name) return headData.name;
+      return null;
+    };
+    const depName = getDepName();
+    if (!depName) return [];
+    return depName.replace(/["']/g, '');
+  }
+
   // simple @import
   if (
     importStatementNode.prelude.type === 'AtrulePrelude' &&
     importStatementNode.prelude.children &&
     importStatementNode.prelude.children.tail.data.type !== 'Url'
   ) {
-    const name =
-      importStatementNode.prelude.children.tail.data.value || // for import keyword
-      importStatementNode.prelude.children.tail.data.name; // for use keyword
-    return name.replace(/["']/g, '');
+    return importStatementNode.prelude.children.tail.data.value.replace(/["']/g, '');
   }
 
   // allows imports with no semicolon

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.spec.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.spec.ts
@@ -3,7 +3,7 @@ import assert from 'assert';
 import detective from './';
 
 describe('detective-sass', function () {
-  function test(src, deps, opts) {
+  function test(src, deps, opts?: any) {
     // @ts-ignore
     assert.deepEqual(detective(src, opts), deps);
   }
@@ -43,33 +43,31 @@ describe('detective-sass', function () {
 
   describe('sass', function () {
     it('returns the dependencies of the given .sass file content', function () {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@import _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@import        _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@import reset', ['reset']);
     });
   });
 
   describe('use keyword', function () {
     it('returns the dependencies of the given .sass file content', function () {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@use _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@use        _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@use reset', ['reset']);
+    });
+  });
+
+  describe('use as syntax', function () {
+    it('returns the dependencies of the given .sass file content', function () {
+      test('@use "foo" as f', ['foo']);
+      test('@use "_foo" as *', ['_foo']);
     });
   });
 
   describe('forward keyword', function () {
     it('returns the dependencies of the given .sass file content', function () {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@forward _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@forward        _foo', ['_foo']);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       test('@forward reset', ['reset']);
     });
   });


### PR DESCRIPTION
a previous PR added support for `@use foo`. This PR adds support for `@use foo as f` syntax