### PR TITLE
improve performance of loading components 

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -37,7 +37,7 @@ export class ScopeComponentLoader {
     const version = await modelComponent.loadVersion(versionStr, this.scope.legacyScope.objects);
     const snap = this.createSnapFromVersion(version);
     const state = await this.createStateFromVersion(id, version);
-    const tagMap = await this.getTagMap(modelComponent);
+    const tagMap = this.getTagMap(modelComponent);
 
     const component = new Component(newId, snap, state, tagMap, this.scope);
     this.componentsCache.set(idStr, component);
@@ -54,7 +54,7 @@ export class ScopeComponentLoader {
       (await modelComponent.loadVersion(legacyId.version as string, this.scope.legacyScope.objects));
     const snap = this.createSnapFromVersion(version);
     const state = await this.createStateFromVersion(id, version);
-    const tagMap = await this.getTagMap(modelComponent);
+    const tagMap = this.getTagMap(modelComponent);
 
     return new Component(id, snap, state, tagMap, this.scope);
   }
@@ -116,7 +116,7 @@ export class ScopeComponentLoader {
     return undefined;
   }
 
-  private async getTagMap(modelComponent: ModelComponent): Promise<TagMap> {
+  private getTagMap(modelComponent: ModelComponent): TagMap {
     const tagMap = new TagMap();
     Object.keys(modelComponent.versionsIncludeOrphaned).forEach((versionStr: string) => {
       const tag = new Tag(modelComponent.versionsIncludeOrphaned[versionStr].toString(), new SemVer(versionStr));

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import memoize from 'memoizee';
 import mapSeries from 'p-map-series';
 import type { PubsubMain } from '@teambit/pubsub';
 import { IssuesList } from '@teambit/component-issues';
@@ -201,6 +202,15 @@ export class Workspace implements ComponentFactory {
     this.owner = this.config?.defaultOwner;
     this.componentLoader = new WorkspaceComponentLoader(this, logger, dependencyResolver, envs);
     this.validateConfig();
+    // memoize this method to improve performance.
+    this.componentDefaultScopeFromComponentDirAndNameWithoutConfigFile = memoize(
+      this.componentDefaultScopeFromComponentDirAndNameWithoutConfigFile.bind(this),
+      {
+        primitive: true,
+        promise: true,
+        maxAge: 60 * 1000, // 1 min
+      }
+    );
   }
 
   private validateConfig() {
@@ -1448,11 +1458,18 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
         return ComponentID.fromLegacy(legacyId);
       }
     }
-    const relativeComponentDir = this.componentDirFromLegacyId(legacyId, undefined, { relative: true });
-    const defaultScope = await this.componentDefaultScopeFromComponentDirAndName(
-      relativeComponentDir,
-      legacyId.toStringWithoutScopeAndVersion()
-    );
+    const getDefaultScope = async (bitId: BitId) => {
+      if (bitId.scope) {
+        return bitId.scope;
+      }
+      const relativeComponentDir = this.componentDirFromLegacyId(bitId, undefined, { relative: true });
+      const defaultScope = await this.componentDefaultScopeFromComponentDirAndName(
+        relativeComponentDir,
+        bitId.toStringWithoutScopeAndVersion()
+      );
+      return defaultScope;
+    };
+    const defaultScope = await getDefaultScope(legacyId);
     return ComponentID.fromLegacy(legacyId, defaultScope);
   }
 

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1,5 +1,5 @@
 import { clone, equals, forEachObjIndexed } from 'ramda';
-import { isEmpty } from 'lodash';
+import { isEmpty, merge } from 'lodash';
 import * as semver from 'semver';
 import { versionParser, isHash, isTag } from '@teambit/component-version';
 import { v4 } from 'uuid';
@@ -206,7 +206,9 @@ export default class Component extends BitObject {
   }
 
   get versionsIncludeOrphaned(): Versions {
-    return { ...this.orphanedVersions, ...this.versions };
+    // surprisingly enough, lodash.merge is way faster then the object spread operator.
+    // for bit-bin with 266 components, it takes 60ms instead of 1,700ms with the spread operator.
+    return merge(this.versions, this.orphanedVersions);
   }
 
   hasTagIncludeOrphaned(version: string): boolean {


### PR DESCRIPTION
Done by memoization and replacing object spread with Lodash `merge`.

@GiladShoham , I need your approval for the change I made in `workspace.resolveComponentId`. 
The change is basically to check whether the legacy-id had a scope and if it does, return it, instead of the expensive check of the default-scope by component-dir. 


