### PR TITLE
configure non-aspects component to use the node-env instead of the aspect-env

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -562,17 +562,8 @@
         "env": "teambit.harmony/node"
       }
     },
-    "scopes/harmony/bit-error": {
-      "teambit.envs/envs": {
-        "env": "teambit.harmony/node"
-      }
-    },
-    "scopes/defender/tests-results": {
-      "teambit.envs/envs": {
-        "env": "teambit.harmony/node"
-      }
-    },
-    "scopes/typescript/ts-server": {
+    "scopes/harmony/bit-error, scopes/defender/tests-results, scopes/typescript/ts-server": {
+      "teambit.harmony/aspect": "-",
       "teambit.envs/envs": {
         "env": "teambit.harmony/node"
       }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -562,6 +562,21 @@
         "env": "teambit.harmony/node"
       }
     },
+    "scopes/harmony/bit-error": {
+      "teambit.envs/envs": {
+        "env": "teambit.harmony/node"
+      }
+    },
+    "scopes/defender/tests-results": {
+      "teambit.envs/envs": {
+        "env": "teambit.harmony/node"
+      }
+    },
+    "scopes/typescript/ts-server": {
+      "teambit.envs/envs": {
+        "env": "teambit.harmony/node"
+      }
+    },
     "scopes/component/legacy-component-log": {
       "teambit.envs/envs": {
         "env": "teambit.harmony/node"


### PR DESCRIPTION
This fixes the warning shown in the log from time to time about invalid aspects.