### PR TITLE
use base collapsable tree node in folder tree node

### DIFF
--- a/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.module.scss
+++ b/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.module.scss
@@ -48,9 +48,3 @@
     margin-right: 8px;
   }
 }
-
-.childrenTree {
-  overflow: hidden;
-  transition: max-height 400ms ease-in-out;
-  font-size: var(--bit-p-xs);
-}

--- a/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
+++ b/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
@@ -5,15 +5,10 @@ import React, { ReactNode, useState, useEffect } from 'react';
 import { TreeNodeProps } from '@teambit/base-ui.graph.tree.recursive-tree';
 import { indentClass } from '@teambit/base-ui.graph.tree.indent';
 import { CollapsableTreeNode } from '@teambit/base-ui.graph.tree.collapsable-tree-node';
-
+import type { FolderPayload } from '@teambit/base-ui.graph.tree.collapsable-tree-node';
 import styles from './folder-tree-node.module.scss';
 
 export type FolderTreeNodeProps = {} & TreeNodeProps<FolderPayload>;
-
-export type FolderPayload = {
-  icon?: string | ReactNode;
-  open?: boolean;
-};
 
 function getCustomIcon(icon: string | ReactNode) {
   if (!icon) return null;

--- a/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
+++ b/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
@@ -5,8 +5,12 @@ import React, { ReactNode, useState, useEffect } from 'react';
 import { TreeNodeProps } from '@teambit/base-ui.graph.tree.recursive-tree';
 import { indentClass } from '@teambit/base-ui.graph.tree.indent';
 import { CollapsableTreeNode } from '@teambit/base-ui.graph.tree.collapsable-tree-node';
-import type { FolderPayload } from '@teambit/base-ui.graph.tree.collapsable-tree-node';
 import styles from './folder-tree-node.module.scss';
+
+export type FolderPayload = {
+  icon?: string | ReactNode;
+  open?: boolean;
+};
 
 export type FolderTreeNodeProps = {} & TreeNodeProps<FolderPayload>;
 

--- a/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
+++ b/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.tsx
@@ -1,18 +1,31 @@
 import { Icon } from '@teambit/design.elements.icon';
 import classNames from 'classnames';
 import React, { ReactNode, useState, useEffect } from 'react';
-import AnimateHeight from 'react-animate-height';
 
-import { TreeLayer, TreeNodeProps } from '@teambit/base-ui.graph.tree.recursive-tree';
-import { indentClass, indentStyle } from '@teambit/base-ui.graph.tree.indent';
+import { TreeNodeProps } from '@teambit/base-ui.graph.tree.recursive-tree';
+import { indentClass } from '@teambit/base-ui.graph.tree.indent';
+import { CollapsableTreeNode } from '@teambit/base-ui.graph.tree.collapsable-tree-node';
+
 import styles from './folder-tree-node.module.scss';
 
-export type FolderTreeNodeProps = {
-} & TreeNodeProps<FolderPayload>;
+export type FolderTreeNodeProps = {} & TreeNodeProps<FolderPayload>;
 
 export type FolderPayload = {
   icon?: string | ReactNode;
   open?: boolean;
+};
+
+function getCustomIcon(icon: string | ReactNode) {
+  if (!icon) return null;
+  if (typeof icon === 'string') {
+    if (icon.startsWith('http')) {
+      return <img src={icon} className={styles.img} />;
+    }
+    // for icomoon icons
+    return <Icon className={styles.icon} of={icon} />;
+  }
+  // for custom elements
+  return icon;
 }
 
 /**
@@ -22,42 +35,20 @@ export function FolderTreeNode({ node, depth }: FolderTreeNodeProps) {
   const [open, setOpen] = useState(node.payload?.open ?? true);
   useEffect(() => {
     // allow node model to override open state
-    node?.payload?.open !== undefined && setOpen(node?.payload?.open)
-  }, [node?.payload?.open])
+    node?.payload?.open !== undefined && setOpen(node?.payload?.open);
+  }, [node?.payload?.open]);
+
   const displayName = node.id.replace(/\/$/, '').split('/').pop();
-
-  const CustomIcon = getCustomIcon(node.payload?.icon)
-
-  return (
-    <div>
-      {node.id && (
-        <div className={classNames(indentClass, styles.folder)} onClick={() => setOpen(!open)}>
-          <div className={styles.left}>
-            <Icon className={classNames(styles.icon, !open && styles.collapsed)} of="fat-arrow-down" />
-            {CustomIcon}
-            <span className={styles.name}>{displayName}</span>
-          </div>
-        </div>
-      )}
-      <AnimateHeight height={open ? 'auto' : 0}>
-        <div style={indentStyle(depth + 1)} className={classNames(styles.childrenTree)}>
-          {node.children && <TreeLayer childNodes={node.children} depth={depth + 1} />}
-        </div>
-      </AnimateHeight>
+  const CustomIcon = getCustomIcon(node.payload?.icon);
+  const Title = node.id && (
+    <div className={classNames(indentClass, styles.folder)} onClick={() => setOpen(!open)}>
+      <div className={styles.left}>
+        <Icon className={classNames(styles.icon, !open && styles.collapsed)} of="fat-arrow-down" />
+        {CustomIcon}
+        <span className={styles.name}>{displayName}</span>
+      </div>
     </div>
   );
-}
 
-
-function getCustomIcon(icon: string | ReactNode) {
-  if(!icon) return null;
-  if(typeof icon === 'string') {
-    if(icon.startsWith('http')) {
-      return <img src={icon} className={styles.img} />
-    }
-    // for icomoon icons
-    return <Icon className={styles.icon} of={icon} />
-  }
-  // for custom elements
-  return icon
+  return <CollapsableTreeNode title={Title} isOpen={open} node={node} depth={depth} />;
 }

--- a/scopes/ui-foundation/tree/folder-tree-node/index.ts
+++ b/scopes/ui-foundation/tree/folder-tree-node/index.ts
@@ -1,2 +1,2 @@
 export { FolderTreeNode } from './folder-tree-node';
-export type { FolderTreeNodeProps } from './folder-tree-node';
+export type { FolderTreeNodeProps, FolderPayload } from './folder-tree-node';

--- a/scopes/ui-foundation/tree/folder-tree-node/index.ts
+++ b/scopes/ui-foundation/tree/folder-tree-node/index.ts
@@ -1,2 +1,2 @@
 export { FolderTreeNode } from './folder-tree-node';
-export type { FolderTreeNodeProps, FolderPayload } from './folder-tree-node';
+export type { FolderTreeNodeProps } from './folder-tree-node';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -51,6 +51,7 @@
         "@teambit/base-ui.elements.image": "1.0.0",
         "@teambit/base-ui.elements.label": "1.0.0",
         "@teambit/base-ui.elements.separator": "1.0.0",
+        "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.2",
         "@teambit/base-ui.graph.tree.indent": "1.0.0",
         "@teambit/base-ui.graph.tree.inflate-paths": "1.0.0",
         "@teambit/base-ui.graph.tree.recursive-tree": "1.0.0",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -51,7 +51,7 @@
         "@teambit/base-ui.elements.image": "1.0.0",
         "@teambit/base-ui.elements.label": "1.0.0",
         "@teambit/base-ui.elements.separator": "1.0.0",
-        "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.3",
+        "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.4",
         "@teambit/base-ui.graph.tree.indent": "1.0.0",
         "@teambit/base-ui.graph.tree.inflate-paths": "1.0.0",
         "@teambit/base-ui.graph.tree.recursive-tree": "1.0.0",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -51,7 +51,7 @@
         "@teambit/base-ui.elements.image": "1.0.0",
         "@teambit/base-ui.elements.label": "1.0.0",
         "@teambit/base-ui.elements.separator": "1.0.0",
-        "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.2",
+        "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.3",
         "@teambit/base-ui.graph.tree.indent": "1.0.0",
         "@teambit/base-ui.graph.tree.inflate-paths": "1.0.0",
         "@teambit/base-ui.graph.tree.recursive-tree": "1.0.0",


### PR DESCRIPTION
## Proposed Changes

- Use base collapsable tree node from [base-ui](https://bit.dev/teambit/base-ui/graph/tree/collapsable-tree-node).
- Move `getCustomIcon` function upper in the file - eslint recommendation.
- Remove unnecessary import with the use of the new collapsable component.
