### PR TITLE
fix an error "unable to save Component object"

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -206,9 +206,9 @@ export default class Component extends BitObject {
   }
 
   get versionsIncludeOrphaned(): Versions {
-    // surprisingly enough, lodash.merge is way faster then the object spread operator.
-    // for bit-bin with 266 components, it takes 60ms instead of 1,700ms with the spread operator.
-    return merge(this.versions, this.orphanedVersions);
+    // for bit-bin with 266 components, it takes about 1,700ms. don't use lodash.merge, it's much faster
+    // but mutates `this.versions`.
+    return { ...this.versions, ...this.orphanedVersions };
   }
 
   hasTagIncludeOrphaned(version: string): boolean {


### PR DESCRIPTION
When running `bit import`, it may show an error:
```
unable to save Component object "teambit.evangelist/elements/icon", the version "0.5.21" exists in orphanedVersions but it exits also in "versions" prop
```

This is a regression caused by https://github.com/teambit/bit/pull/5031.  It is fixed by reverting the merge between orphaned versions and versions to use spread operator and `lodash.merge` to avoid mutating the `versions` prop.