### PR TITLE
"bit remove --force" archives components rather than deleting them

### DIFF
--- a/e2e/harmony/remove-harmony.e2e.ts
+++ b/e2e/harmony/remove-harmony.e2e.ts
@@ -49,4 +49,38 @@ describe('remove components on Harmony', function () {
       expect(path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}`, 'comp1')).to.not.be.a.path();
     });
   });
+  describe('remove a component that has dependents', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+    });
+    describe('without force', () => {
+      let output: string;
+      it('should not allow removing', () => {
+        output = helper.command.removeComponent('comp3');
+        expect(output).to.have.string('unable to delete');
+      });
+    });
+    describe('with force', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.removeComponent('comp3', '--force');
+      });
+      it('should indicate in the output that the component was archived', () => {
+        expect(output).to.have.string('successfully archived');
+      });
+      it('bit list should show it as archived', () => {
+        const list = helper.command.listLocalScopeParsed();
+        const comp3 = list.find((l) => l.id === `${helper.scopes.remote}/comp3`);
+        expect(comp3?.archived).to.be.true;
+      });
+      it('should delete it from the .bitmap file', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap).to.not.have.property('comp3');
+      });
+    });
+  });
 });

--- a/src/api/scope/lib/delete.ts
+++ b/src/api/scope/lib/delete.ts
@@ -23,6 +23,7 @@ export default async function remove(
   const res = await scope.removeMany(bitIds, force);
   const hookArgs = {
     removedComponentsIds: res.removedComponentIds.serialize(),
+    archivedComponentIds: res.archivedComponentIds.serialize(),
     missingComponentsIds: res.missingComponents.serialize(),
     dependentBitsIds: res.dependentBits,
     force,

--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -96,6 +96,9 @@ export default class BitIds extends Array<BitId> {
   removeMultipleIfExistWithoutVersion(bitIds: BitIds): BitIds {
     return BitIds.fromArray(this.filter((id) => !bitIds.hasWithoutVersion(id)));
   }
+  removeMultipleIfExist(bitIds: BitIds): BitIds {
+    return BitIds.fromArray(this.filter((id) => !bitIds.has(id)));
+  }
 
   /**
    * make sure to pass only bit ids you know they have scope, otherwise, you'll get invalid bit ids.

--- a/src/cli/chalk-box.ts
+++ b/src/cli/chalk-box.ts
@@ -15,18 +15,18 @@ export const formatNewBit = ({ name }: any): string => c.white('     > ') + c.cy
 export const formatBit = ({ scope, name, version }: any) =>
   c.white('     > ') + c.cyan(`${scope ? `${scope}/` : ''}${name} - ${version ? version.toString() : 'latest'}`);
 
-export const formatPlainComponentItem = ({ scope, name, version, deprecated }: any) =>
-  c.cyan(
-    `- ${scope ? `${scope}/` : ''}${name}@${version ? version.toString() : 'latest'}  ${
-      deprecated ? c.yellow('[deprecated]') : ''
-    }`
+export const formatPlainComponentItem = ({ scope, name, version, deprecated, archived }: any) => {
+  const deprecatedStr = deprecated ? c.yellow('[deprecated]') : '';
+  const archivedStr = archived ? c.yellow('[archived]') : '';
+  return c.cyan(
+    `- ${scope ? `${scope}/` : ''}${name}@${version ? version.toString() : 'latest'}  ${deprecatedStr}${archivedStr}`
   );
+};
 
 export const formatPlainComponentItemWithVersions = (component: Component, importDetails: ImportDetails) => {
   const status: ImportStatus = importDetails.status;
   const id = component.id.toStringWithoutVersion();
   const versions = importDetails.versions.length ? `new versions: ${importDetails.versions.join(', ')}` : '';
-  // $FlowFixMe component.version should be set here
   const usedVersion = status === 'added' ? `, currently used version ${component.version}` : '';
   const getConflictMessage = () => {
     if (!importDetails.filesStatus) return '';
@@ -37,12 +37,13 @@ export const formatPlainComponentItemWithVersions = (component: Component, impor
     return `(the following files were saved with conflicts ${conflictedFiles.map((file) => c.bold(file)).join(', ')}) `;
   };
   const deprecated = component.deprecated ? c.yellow('deprecated') : '';
+  const archived = component.archived ? c.yellow('archived') : '';
   const missingDeps = importDetails.missingDeps.length
     ? c.red(`missing dependencies: ${importDetails.missingDeps.map((d) => d.toString()).join(', ')}`)
     : '';
   return `- ${c.green(status)} ${c.cyan(
     id
-  )} ${versions}${usedVersion} ${getConflictMessage()}${deprecated} ${missingDeps}`;
+  )} ${versions}${usedVersion} ${getConflictMessage()}${deprecated}${archived} ${missingDeps}`;
 };
 
 export const formatBitString = (bit: string): string => c.white('     > ') + c.cyan(`${bit}`);

--- a/src/cli/commands/public-cmds/remove-cmd.ts
+++ b/src/cli/commands/public-cmds/remove-cmd.ts
@@ -7,7 +7,7 @@ import RemovedObjects from '../../../scope/removed-components';
 import RemovedLocalObjects from '../../../scope/removed-local-objects';
 import { Group } from '../../command-groups';
 import { CommandOptions, LegacyCommand } from '../../legacy-command';
-import paintRemoved from '../../templates/remove-template';
+import { removeTemplate } from '../../templates/remove-template';
 
 export default class Remove implements LegacyCommand {
   name = 'remove <ids...>';
@@ -65,9 +65,9 @@ export default class Remove implements LegacyCommand {
     remoteResult: RemovedObjects[];
   }): string {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return paintRemoved(localResult, false) + this.paintArray(remoteResult);
+    return removeTemplate(localResult, false) + this.paintArray(remoteResult);
   }
   paintArray(removedObjectsArray: RemovedObjects[]) {
-    return removedObjectsArray.map((item) => paintRemoved(item, true));
+    return removedObjectsArray.map((item) => removeTemplate(item, true));
   }
 }

--- a/src/cli/templates/component-template.ts
+++ b/src/cli/templates/component-template.ts
@@ -144,6 +144,7 @@ export default function paintComponent(
       'files',
       'specs',
       'deprecated',
+      'archived',
     ];
     if (detailed) {
       const extraFields = [

--- a/src/cli/templates/list-template.ts
+++ b/src/cli/templates/list-template.ts
@@ -16,8 +16,10 @@ export default (listScopeResults: ListScopeResult[], json: boolean, showRemoteVe
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       version = color ? c[color](version) : version;
     }
+    const deprecatedStr = listScopeResult.deprecated ? ' [Deprecated]' : '';
+    const archivedStr = listScopeResult.archived ? ' [archived]' : '';
     const data: Row = {
-      id: c.white(`${id}${listScopeResult.deprecated ? ' [Deprecated]' : ''}`),
+      id: c.white(`${id}${deprecatedStr}${archivedStr}`),
       localVersion: version,
       currentVersion: listScopeResult.currentlyUsedVersion || 'N/A',
     };
@@ -42,6 +44,7 @@ export default (listScopeResults: ListScopeResult[], json: boolean, showRemoteVe
       id,
       localVersion: version || '<new>',
       deprecated: listScopeResult.deprecated,
+      archived: listScopeResult.archived,
       currentVersion: listScopeResult.currentlyUsedVersion || 'N/A',
       remoteVersion: listScopeResult.remoteVersion || 'N/A',
     };

--- a/src/consumer/component-ops/components-object-diff.ts
+++ b/src/consumer/component-ops/components-object-diff.ts
@@ -50,6 +50,7 @@ export function componentToPrintableForDiff(component: Component): Record<string
     extensions,
     mainFile,
     deprecated,
+    archived,
   } = component;
   const allDevPackages = {
     ...devPackageDependencies,
@@ -100,6 +101,7 @@ export function componentToPrintableForDiff(component: Component): Record<string
       : null;
   obj.extensions = parseExtensions(extensions);
   obj.deprecated = deprecated ? 'True' : null;
+  obj.archived = archived ? 'True' : null;
   obj.overridesDependencies = parsePackages(overrides.dependencies);
   obj.overridesDevDependencies = parsePackages(overrides.devDependencies);
   obj.overridesPeerDependencies = parsePackages(overrides.peerDependencies);

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -25,6 +25,7 @@ export type ListScopeResult = {
   currentlyUsedVersion?: string | null | undefined;
   remoteVersion?: string;
   deprecated?: boolean;
+  archived?: boolean;
 };
 
 export type DivergedComponent = { id: BitId; diverge: DivergeData };
@@ -441,6 +442,7 @@ export default class ComponentsList {
       return {
         id: component ? component.toBitIdWithLatestVersion() : id,
         deprecated: component ? component.deprecated : false,
+        archived: component ? component.archived : false,
       };
     });
     const componentsIds = listAllResults.map((result) => result.id);
@@ -487,6 +489,7 @@ export default class ComponentsList {
     return componentsSorted.map((component: ModelComponent) => ({
       id: component.toBitIdWithLatestVersion(),
       deprecated: component.deprecated,
+      archived: component.archived,
     }));
   }
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -102,6 +102,7 @@ export type ComponentProps = {
   specsResults?: SpecsResults;
   license?: License;
   deprecated?: boolean;
+  archived?: boolean;
   origin: ComponentOrigin;
   log?: Log;
   schema?: string;
@@ -167,6 +168,7 @@ export default class Component {
   isolatedEnvironment: IsolatedEnvironment;
   issues: IssuesList;
   deprecated: boolean;
+  archived: boolean;
   defaultScope: string | null;
   origin: ComponentOrigin;
   customResolvedPaths: CustomResolvedPath[]; // used when in the same component, one file requires another file using custom-resolve
@@ -224,6 +226,7 @@ export default class Component {
     license,
     log,
     deprecated,
+    archived,
     origin,
     customResolvedPaths,
     scopesList,
@@ -259,6 +262,7 @@ export default class Component {
     this.license = license;
     this.log = log;
     this.deprecated = deprecated || false;
+    this.archived = archived || false;
     this.origin = origin;
     this.customResolvedPaths = customResolvedPaths || [];
     this.scopesList = scopesList;
@@ -838,6 +842,7 @@ export default class Component {
       license: this.license ? this.license.serialize() : null,
       log: this.log,
       deprecated: this.deprecated,
+      archived: this.archived,
     };
   }
 
@@ -907,55 +912,32 @@ export default class Component {
     this.setDevDependencies(componentFromModel.devDependencies.get());
   }
 
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  static async fromObject(object: Record<string, any>): Component {
+  static async fromObject(object: Record<string, any>): Promise<Component> {
     const {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       name,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       box,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       version,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       scope,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       lang,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       bindingPrefix,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       compiler,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       tester,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       dependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       devDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       packageDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       devPackageDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       peerPackageDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       compilerPackageDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       testerPackageDependencies,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       docs,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       mainFile,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       dists,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       files,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       specsResults,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       license,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       overrides,
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       deprecated,
+      archived,
       schema,
     } = object;
     const compilerProps = compiler ? await CompilerExtension.loadFromSerializedModelObject(compiler) : null;
@@ -990,6 +972,7 @@ export default class Component {
       license: license ? License.deserialize(license) : undefined,
       overrides: new ComponentOverrides(overrides),
       deprecated: deprecated || false,
+      archived: archived || false,
       schema,
     });
   }
@@ -1029,6 +1012,7 @@ export default class Component {
       if (!inScopeWithAnyVersion) throw new ComponentsPendingImport();
     }
     const deprecated = componentFromModel ? componentFromModel.deprecated : false;
+    const archived = componentFromModel ? componentFromModel.archived : false;
     const componentDir = componentMap.getComponentDir();
     let dists = componentFromModel ? componentFromModel.dists.get() : undefined;
     const mainDistFile = componentFromModel ? componentFromModel.dists.getMainDistFile() : undefined;
@@ -1152,6 +1136,7 @@ export default class Component {
       compilerPackageDependencies,
       testerPackageDependencies,
       deprecated,
+      archived,
       origin: componentMap.origin,
       overrides,
       schema: getSchema(),

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -74,6 +74,7 @@ export type ComponentProps = {
   scopesList?: ScopeListItem[];
   head?: Ref;
   schema?: string | undefined;
+  archived?: boolean;
 };
 
 const VERSION_ZERO = '0.0.0';
@@ -108,6 +109,7 @@ export default class Component extends BitObject {
   laneHeadLocal?: Ref | null;
   laneHeadRemote?: Ref | null; // doesn't get saved in the scope, used to easier access the remote snap head data
   schema: string | undefined;
+  archived?: boolean;
   private divergeData?: DivergeData;
 
   constructor(props: ComponentProps) {
@@ -125,6 +127,7 @@ export default class Component extends BitObject {
     this.scopesList = props.scopesList || [];
     this.head = props.head;
     this.schema = props.schema;
+    this.archived = props.archived;
   }
 
   get versionArray(): Ref[] {
@@ -134,6 +137,11 @@ export default class Component extends BitObject {
   setVersion(tag: string, ref: Ref) {
     this.versions[tag] = ref;
     delete this.orphanedVersions[tag]; // just in case it's there.
+  }
+
+  markAsArchived() {
+    this.deprecated = false; // just in case it was deprecated before
+    this.archived = true;
   }
 
   setOrphanedVersion(tag: string, ref: Ref) {
@@ -570,6 +578,7 @@ export default class Component extends BitObject {
       bindingPrefix: this.bindingPrefix,
       remotes: this.scopesList,
       schema: this.schema,
+      archived: this.archived,
     };
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     if (this.local) componentObject.local = this.local;
@@ -779,6 +788,7 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
       overrides: ComponentOverrides.loadFromScope(version.overrides),
       packageJsonChangedProps: clone(version.packageJsonChangedProps),
       deprecated: this.deprecated,
+      archived: this.archived,
       scopesList: clone(this.scopesList),
       schema: version.schema,
       extensions,
@@ -920,6 +930,7 @@ make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`
       scopesList: rawComponent.remotes,
       head: rawComponent.head ? Ref.from(rawComponent.head) : undefined,
       schema: rawComponent.schema || (rawComponent.head ? SchemaName.Harmony : SchemaName.Legacy),
+      archived: rawComponent.archived,
     });
   }
 

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -349,6 +349,7 @@ export class Http implements Network {
           _legacyList(namespaces: $namespaces) {
             id
             deprecated
+            archived
           }
         }
       }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -206,8 +206,8 @@ export default class Repository {
         return bitObject;
       })
     );
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return bitObjects.filter((b) => b); // remove nulls;
+
+    return compact(bitObjects);
   }
 
   async loadOptionallyCreateScopeIndex(): Promise<ScopeIndex> {

--- a/src/scope/removed-components.spec.ts
+++ b/src/scope/removed-components.spec.ts
@@ -6,6 +6,7 @@ import RemovedObjects from './removed-components';
 describe('RemovedComponents', () => {
   const payload = {
     removedComponentIds: [],
+    archivedComponentIds: [],
     missingComponents: [],
     removedDependencies: [],
     dependentBits: {},

--- a/src/scope/removed-components.ts
+++ b/src/scope/removed-components.ts
@@ -3,6 +3,7 @@ import { BitIdStr } from '../bit-id/bit-id';
 
 export type RemovedObjectSerialized = {
   removedComponentIds: BitIdStr[];
+  archivedComponentIds: BitIdStr[];
   missingComponents: BitIdStr[];
   removedDependencies: BitIdStr[];
   dependentBits: Record<string, any>;
@@ -12,6 +13,7 @@ export type RemovedObjectSerialized = {
 
 export default class RemovedObjects {
   removedComponentIds: BitIds;
+  archivedComponentIds: BitIds;
   missingComponents: BitIds;
   removedDependencies: BitIds;
   dependentBits: Record<string, any>;
@@ -19,6 +21,7 @@ export default class RemovedObjects {
   removedLanes: string[];
   constructor({
     removedComponentIds,
+    archivedComponentIds,
     missingComponents,
     removedDependencies,
     dependentBits,
@@ -26,6 +29,7 @@ export default class RemovedObjects {
     removedLanes,
   }: {
     removedComponentIds?: BitIds;
+    archivedComponentIds?: BitIds;
     missingComponents?: BitIds;
     removedDependencies?: BitIds;
     dependentBits?: Record<string, any>;
@@ -33,6 +37,7 @@ export default class RemovedObjects {
     removedLanes?: string[];
   }) {
     this.removedComponentIds = removedComponentIds || new BitIds();
+    this.archivedComponentIds = archivedComponentIds || new BitIds();
     this.missingComponents = missingComponents || new BitIds();
     this.removedDependencies = removedDependencies || new BitIds();
     this.dependentBits = dependentBits || {};
@@ -43,6 +48,7 @@ export default class RemovedObjects {
   serialize(): RemovedObjectSerialized {
     return {
       removedComponentIds: this.removedComponentIds.serialize(),
+      archivedComponentIds: this.archivedComponentIds.serialize(),
       missingComponents: this.missingComponents.serialize(),
       removedDependencies: this.removedDependencies.serialize(),
       dependentBits: this.dependentBits,
@@ -53,6 +59,7 @@ export default class RemovedObjects {
 
   static fromObjects(payload: {
     removedComponentIds: string[];
+    archivedComponentIds: string[];
     missingComponents: string[];
     removedDependencies: string[];
     dependentBits: { [key: string]: Record<string, any>[] };
@@ -61,6 +68,7 @@ export default class RemovedObjects {
     // this function being called from an ssh, so the ids must have a remote scope
     const missingComponents = new BitIds(...payload.missingComponents.map((id) => BitId.parse(id, true)));
     const removedComponentIds = new BitIds(...payload.removedComponentIds.map((id) => BitId.parse(id, true)));
+    const archivedComponentIds = new BitIds(...payload.archivedComponentIds.map((id) => BitId.parse(id, true)));
     const removedDependencies = new BitIds(...payload.removedDependencies.map((id) => BitId.parse(id, true)));
     const dependentBits = Object.keys(payload.dependentBits).reduce((acc, current) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -70,6 +78,7 @@ export default class RemovedObjects {
     return new RemovedObjects({
       missingComponents,
       removedComponentIds,
+      archivedComponentIds,
       removedDependencies,
       dependentBits,
       removedLanes: payload.removedLanes,

--- a/src/scope/removed-local-objects.ts
+++ b/src/scope/removed-local-objects.ts
@@ -5,13 +5,21 @@ export default class RemovedLocalObjects extends RemovedObjects {
   modifiedComponents: BitIds;
   constructor(
     removedComponentIds?: BitIds,
+    archivedComponentIds?: BitIds,
     missingComponents?: BitIds,
     modifiedComponents?: BitIds,
     removedDependencies?: BitIds,
     dependentBits?: Record<string, any>,
     removedFromLane?: boolean
   ) {
-    super({ removedComponentIds, missingComponents, removedDependencies, dependentBits, removedFromLane });
+    super({
+      removedComponentIds,
+      archivedComponentIds,
+      missingComponents,
+      removedDependencies,
+      dependentBits,
+      removedFromLane,
+    });
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.modifiedComponents = modifiedComponents;
   }


### PR DESCRIPTION
Implement #4899.
This is a WIP.

- added `archived` property to the `Component`. 
- changed "bit remove --force" locally to mark the component as archived. 
- `bit list` shows the component with `[archived]` suffix. 

Left to do:

- [ ] archive in the remote
- [ ] change other commands to according to #4899.
