### PR TITLE
improve bit-status performance dramatically when components have lots of versions

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -344,7 +344,7 @@ export default class Component extends BitObject {
     // either a user is on main or a lane, check whether the remote is ahead of the local
     await this.setDivergeData(repo, false);
     const divergeData = this.getDivergeData();
-    return divergeData.isLocalAhead() ? latestLocally : remoteHead.toString();
+    return divergeData.isRemoteAhead() ? remoteHead.toString() : latestLocally;
   }
 
   latestVersion(): string {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -340,11 +340,11 @@ export default class Component extends BitObject {
     if (!this.laneHeadLocal && !this.hasHead()) {
       return remoteHead.toString(); // user never merged the remote version, so remote is the latest
     }
+
     // either a user is on main or a lane, check whether the remote is ahead of the local
-    const allLocalHashes = await getAllVersionHashes(this, repo, false);
-    const isRemoteHeadExistsLocally = allLocalHashes.find((localHash) => localHash.isEqual(remoteHead));
-    if (isRemoteHeadExistsLocally) return latestLocally; // remote is behind
-    return remoteHead.toString(); // remote is ahead
+    await this.setDivergeData(repo, false);
+    const divergeData = this.getDivergeData();
+    return divergeData.isLocalAhead() ? latestLocally : remoteHead.toString();
   }
 
   latestVersion(): string {


### PR DESCRIPTION
Currently it's slow due to traversal on the entire versions graph. This is fixed by re-using the `getDivergeData` method which traverse the graph more efficiently. 