### PR TITLE
bit-build: if no pattern is specified, build only new and modified components

### DIFF
--- a/scopes/pipelines/builder/build.cmd.ts
+++ b/scopes/pipelines/builder/build.cmd.ts
@@ -6,6 +6,7 @@ import chalk from 'chalk';
 import { BuilderMain } from './builder.main.runtime';
 
 type BuildOpts = {
+  all: boolean;
   rebuild: boolean;
   install: boolean;
   cachePackagesOnCapsulesRoot: boolean;
@@ -20,6 +21,7 @@ export class BuilderCmd implements Command {
   alias = '';
   group = 'development';
   options = [
+    ['a', 'all', 'build all components, not only modified and new'],
     ['', 'install', 'install core aspects in capsules'],
     ['', 'reuse-capsules', 'avoid deleting the capsules root-dir before starting the build'],
     [
@@ -40,15 +42,28 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
 
   async report(
     [userPattern]: [string],
-    { install = false, cachePackagesOnCapsulesRoot = false, reuseCapsules = false, tasks, listTasks }: BuildOpts
+    {
+      all = false,
+      install = false,
+      cachePackagesOnCapsulesRoot = false,
+      reuseCapsules = false,
+      tasks,
+      listTasks,
+    }: BuildOpts
   ): Promise<string> {
     if (!this.workspace) throw new ConsumerNotFound();
     if (listTasks) {
       return this.getListTasks(listTasks);
     }
+
     const longProcessLogger = this.logger.createLongProcessLogger('build');
-    const pattern = userPattern && userPattern.toString();
-    const components = pattern ? await this.workspace.byPattern(pattern) : await this.workspace.list();
+    const components = await this.workspace.getComponentsByUserInputDefaultToChanged(all, userPattern);
+    if (!components.length) {
+      return chalk.bold(
+        `no components found to build. use "--all" flag to build all components or specify the ids to build, otherwise, only new and modified components will be built`
+      );
+    }
+    this.logger.consoleSuccess(`found ${components.length} components to build`);
 
     const envsExecutionResults = await this.builder.build(
       components,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -365,7 +365,7 @@ export class Workspace implements ComponentFactory {
   /**
    * list all modified components in the workspace.
    */
-  async modified() {
+  async modified(): Promise<Component[]> {
     const ids: any = await this.componentList.listModifiedComponents(false);
     const componentIds = ids.map(ComponentID.fromLegacy);
     return this.getMany(componentIds);
@@ -392,6 +392,11 @@ export class Workspace implements ComponentFactory {
   async getNewAndModifiedIds(): Promise<ComponentID[]> {
     const ids = await this.componentList.listTagPendingComponents();
     return this.resolveMultipleComponentIds(ids);
+  }
+
+  async newAndModified(): Promise<Component[]> {
+    const ids = await this.getNewAndModifiedIds();
+    return this.getMany(ids);
   }
 
   async getLogs(id: ComponentID): Promise<ComponentLog[]> {
@@ -613,6 +618,21 @@ export class Workspace implements ComponentFactory {
 
     const components = await this.getMany(targetIds);
     return components;
+  }
+
+  /**
+   * useful for workspace commands, such as `bit build`, `bit compile`.
+   * by default, it should be running on new and modified components.
+   * a user can specify `--all` to run on all components or specify a pattern to limit to specific components.
+   */
+  async getComponentsByUserInputDefaultToChanged(all?: boolean, pattern?: string): Promise<Component[]> {
+    if (all) {
+      return this.list();
+    }
+    if (pattern) {
+      return this.byPattern(pattern);
+    }
+    return this.newAndModified();
   }
 
   async getMany(ids: Array<ComponentID>, forCapsule = false): Promise<Component[]> {


### PR DESCRIPTION
Implements the `bit build` part of #5050.

## Proposed Changes

- if no pattern entered, build only new and modified components.
- introduce `--all` flag to build all components. 
- indicate how many components are about to be built when build started.
- show a descriptive message when there is no components to build. 
