### PR TITLE
introduce a new command "bit check-types" to check for typescript errors

### DIFF
--- a/scopes/typescript/ts-server/ts-server-client.ts
+++ b/scopes/typescript/ts-server/ts-server-client.ts
@@ -16,11 +16,12 @@ export type TsserverClientOpts = {
   verbose?: boolean; // print tsserver events to the console.
   tsServerPath?: string; // if not provided, it'll use findTsserverPath() strategies.
   checkTypes?: CheckTypes; // whether errors/warnings are monitored and printed to the console.
+  printTypeErrors?: boolean; // whether print typescript errors to the console.
 };
 
 export class TsserverClient {
   private tsServer: ProcessBasedTsServer;
-  private lastDiagnostics: protocol.DiagnosticEventBody[] = [];
+  public lastDiagnostics: protocol.DiagnosticEventBody[] = [];
   constructor(
     /**
      * absolute root path of the project.
@@ -250,7 +251,7 @@ export class TsserverClient {
   }
 
   private publishDiagnostic(message: protocol.DiagnosticEvent) {
-    if (!message.body?.diagnostics.length || !this.shouldCheckTypes()) {
+    if (!message.body?.diagnostics.length || !this.options.printTypeErrors) {
       return;
     }
     this.lastDiagnostics.push(message.body);

--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -1,0 +1,44 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
+import { Logger } from '@teambit/logger';
+import { Workspace } from '@teambit/workspace';
+import chalk from 'chalk';
+import { TypescriptMain } from '../typescript.main.runtime';
+
+export class CheckTypesCmd implements Command {
+  name = 'check-types [pattern]';
+  description = 'check typescript types';
+  alias = '';
+  group = 'development';
+  options = [
+    ['a', 'all', 'build all components, not only modified and new'],
+    ['', 'strict', 'in case issues found, exit with code 1'],
+  ] as CommandOptions;
+
+  constructor(private typescript: TypescriptMain, private workspace: Workspace, private logger: Logger) {}
+
+  async report([userPattern]: [string], { all = false, strict = false }: { all: boolean; strict: boolean }) {
+    if (!this.workspace) throw new ConsumerNotFound();
+    const components = await this.workspace.getComponentsByUserInputDefaultToChanged(all, userPattern);
+    this.logger.setStatusLine(`checking types for ${components.length} components`);
+    const files = this.typescript.getSupportedFilesForTsserver(components);
+    await this.typescript.initTsserverClientFromWorkspace({ printTypeErrors: true }, files);
+    const tsserver = this.typescript.getTsserverClient();
+    if (!tsserver) throw new Error(`unable to start tsserver`);
+    const start = Date.now();
+    await tsserver.getDiagnostic(files);
+    const end = Date.now() - start;
+    const msg = `completed type checking (${end / 1000} sec)`;
+    tsserver.killTsServer();
+    if (tsserver.lastDiagnostics.length) {
+      return {
+        code: strict ? 1 : 0,
+        data: chalk.red(`${msg}. found errors in ${tsserver.lastDiagnostics.length} files.`),
+      };
+    }
+    return {
+      code: 0,
+      data: chalk.green(`${msg}. no errors were found.`),
+    };
+  }
+}


### PR DESCRIPTION
Currently, checking types is done as part of `bit watch --check-types`. 
At times, this is needed as part of the CI process, so a dedicated command is very helpful.
By default is only type-checks modified/new components. Use `--all` to check them all. 
Use `--strict` to exit with code 1 in case types error were found.