### PR TITLE
update component card to support external link

### DIFF
--- a/scopes/explorer/ui/component-card/component-card.composition.tsx
+++ b/scopes/explorer/ui/component-card/component-card.composition.tsx
@@ -8,10 +8,23 @@ export const ComponentCardExample = () => {
     </div>
   );
 };
-export const ComponentCardExample2 = () => {
+
+export const ComponentCardWithPreview = () => {
   return (
     <div style={{ width: '300px' }}>
       <ComponentCard id="ui/concrete/component-card" preview={<div>hello world</div>} />
+    </div>
+  );
+};
+
+export const ComponentCardWithExternalLink = () => {
+  return (
+    <div style={{ width: '300px' }}>
+      <ComponentCard
+        id="teambit/explorer/ui/gallery/component-card"
+        preview={<div>external link example</div>}
+        href="https://bit.dev/teambit/explorer/ui/gallery/component-card"
+      />
     </div>
   );
 };

--- a/scopes/explorer/ui/component-card/component-card.tsx
+++ b/scopes/explorer/ui/component-card/component-card.tsx
@@ -48,7 +48,7 @@ export type ComponentCardProps = {
    */
   isDeprecated?: boolean;
   /**
-   * explicit link, to instead of the component id. Using this opens the link in a new tab, as an external link.
+   * explicit link, to use instead of the component id. Using this opens the link in a new tab, as an external link.
    */
   href?: string;
 } & BaseComponentCardProps;

--- a/scopes/explorer/ui/component-card/component-card.tsx
+++ b/scopes/explorer/ui/component-card/component-card.tsx
@@ -48,7 +48,7 @@ export type ComponentCardProps = {
    */
   isDeprecated?: boolean;
   /**
-   * open the component link in a new tab with this url
+   * explicit link, to instead of the component id. Using this opens the link in a new tab, as an external link.
    */
   href?: string;
 } & BaseComponentCardProps;

--- a/scopes/explorer/ui/component-card/component-card.tsx
+++ b/scopes/explorer/ui/component-card/component-card.tsx
@@ -48,9 +48,9 @@ export type ComponentCardProps = {
    */
   isDeprecated?: boolean;
   /**
-   * true if the component is internal
+   * open the component link in a new tab with this url
    */
-  isInternal?: boolean;
+  href?: string;
 } & BaseComponentCardProps;
 
 export function ComponentCard({
@@ -60,24 +60,21 @@ export function ComponentCard({
   version,
   description,
   envIcon,
-  isDeprecated,
+  isDeprecated = false,
+  href,
 }: ComponentCardProps) {
   return (
     <Card className={className}>
-      <Link className={styles.componentCardLink} href={id}>
+      <Link className={styles.componentCardLink} href={href || id} external={!!href}>
         <DeprecationSticker isDeprecated={isDeprecated} />
         <PreviewContainer preview={preview} />
 
         <ComponentDetails id={id} version={version} description={description} className={styles.content} />
         <div className={styles.bottom}>
-          <div className={styles.left}></div>
+          <div className={styles.left} />
           <img src={envIcon} className={styles.img} />
         </div>
       </Link>
     </Card>
   );
 }
-
-ComponentCard.defaultProps = {
-  isDeprecated: false,
-};


### PR DESCRIPTION
## Proposed Changes

- Add `href` prop to support external link.
- Add a composition with an external link example.
- Remove `isInternal` prop because it's not used at all.
- Move `isDeprecated` default value to the function instead of `defaultProps` object.