### PR TITLE
use react fast refresh loader explicitly where relevant

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -34,7 +34,6 @@ import type { ComponentMeta } from '@teambit/react.ui.highlighter.component-meta
 import { SchemaExtractor } from '@teambit/schema';
 import { join, resolve } from 'path';
 import { outputFileSync } from 'fs-extra';
-import { Configuration } from 'webpack';
 // Makes sure the @teambit/react.ui.docs-app is a dependency
 // TODO: remove this import once we can set policy from component to component with workspace version. Then set it via the component.json
 // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -231,11 +231,7 @@ export class ReactEnv
   getDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
     const baseConfig = basePreviewConfigFactory(false);
     const envDevConfig = envPreviewDevConfigFactory(context.id);
-    const componentsDirs = this.getComponentsModulesDirectories(context.components);
-    // const fileMapPath = this.writeFileMap(context.components, true);
-    // const componentDevConfig = componentPreviewDevConfigFactory(fileMapPath, this.workspace.path);
-    // const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
-    const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id, componentsDirs);
+    const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
       const merged = configMutator.merge([baseConfig, envDevConfig, componentDevConfig]);
@@ -258,33 +254,6 @@ export class ReactEnv
     };
 
     return this.webpack.createPreviewBundler(context, [defaultTransformer, ...transformers]);
-  }
-
-  private getComponentsModulesDirectories(components: Component[]): string[] {
-    const dirs = components.map((component) => {
-      return this.pkg.getModulePath(component, { absPath: true });
-    });
-    return dirs;
-  }
-
-  private getEntriesFromWebpackConfig(config?: Configuration): string[] {
-    if (!config || !config.entry) {
-      return [];
-    }
-    if (typeof config.entry === 'string') {
-      return [config.entry];
-    }
-    if (Array.isArray(config.entry)) {
-      let entries: string[] = [];
-      entries = config.entry.reduce((acc, entry) => {
-        if (typeof entry === 'string') {
-          acc.push(entry);
-        }
-        return acc;
-      }, entries);
-      return entries;
-    }
-    return [];
   }
 
   /**

--- a/scopes/react/react/webpack/webpack.config.component.dev.ts
+++ b/scopes/react/react/webpack/webpack.config.component.dev.ts
@@ -6,11 +6,13 @@ import { ComponentID } from '@teambit/component-id';
 import '@teambit/react.babel.bit-react-transformer';
 import ReactRefreshWebpackPlugin from '@pmmmwh/react-refresh-webpack-plugin';
 
+const matchNothingRegex = 'a^';
+
 // This is the production and development configuration.
 // It is focused on developer experience, fast rebuilds, and a minimal bundle.
 // eslint-disable-next-line complexity
 // export default function (workDir: string, envId: string): Configuration {
-export default function (workDir: string, envId: string, componentsDirs: string[]): Configuration {
+export default function (workDir: string, envId: string): Configuration {
   return {
     module: {
       rules: [
@@ -32,6 +34,7 @@ export default function (workDir: string, envId: string, componentsDirs: string[
           // only apply to packages with componentId in their package.json (ie. bit components)
           descriptionData: { componentId: ComponentID.isValidObject },
           use: [
+            require.resolve('@pmmmwh/react-refresh-webpack-plugin/loader'),
             {
               loader: require.resolve('babel-loader'),
               options: {
@@ -57,6 +60,7 @@ export default function (workDir: string, envId: string, componentsDirs: string[
           // only apply to packages with componentId in their package.json (ie. bit components)
           descriptionData: { componentId: (value) => !!value },
           use: [
+            require.resolve('@pmmmwh/react-refresh-webpack-plugin/loader'),
             {
               loader: require.resolve('babel-loader'),
               options: {
@@ -85,19 +89,10 @@ export default function (workDir: string, envId: string, componentsDirs: string[
           module: require.resolve('./refresh'),
         },
 
-        // // having no value for include, exclude === revert to the defaults!
-        // // original/defaults values:
-        // include: /\.([cm]js|[jt]sx?|flow)$/i,
-        // exclude: /node_modules/,
-
-        include: componentsDirs,
-        exclude: [
-          // prevent recursion:
-          /react-refresh-webpack-plugin/i,
-          // file type filtering was done by `include`, so need to negative-filter them out here
-          // A lookbehind assertion (`?<!`) has to be fixed width
-          /(?<!\.mdx)(?<!\.js)$/i,
-        ],
+        // we use '@pmmmwh/react-refresh-webpack-plugin/loader' directly where relevant.
+        // FYI, original defaults of the plugin are:
+        // include: /\.([cm]js|[jt]sx?|flow)$/i, exclude: /node_modules/,
+        include: matchNothingRegex,
       }),
     ],
   };

--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -78,14 +78,8 @@ export class UIServer {
    */
   async getDevConfig() {
     const aspects = await this.uiRoot.resolveAspects(UIRuntime.name);
-    const aspectsPaths = aspects.map((aspect) => aspect.aspectPath);
 
-    return devConfig(
-      this.uiRoot.path,
-      [await this.ui.generateRoot(aspects, this.uiRootExtension)],
-      this.uiRoot.name,
-      aspectsPaths
-    );
+    return devConfig(this.uiRoot.path, [await this.ui.generateRoot(aspects, this.uiRootExtension)], this.uiRoot.name);
   }
 
   private setReady: () => void;
@@ -186,7 +180,7 @@ export class UIServer {
     const devServerConfig = await this.getDevServerConfig(devServerPort, expressAppPort, config.devServer);
     // @ts-ignore in the capsules it throws an error about compatibilities issues between webpack.compiler and webpackDevServer/webpack/compiler
     const devServer = new WebpackDevServer(devServerConfig, compiler);
-    
+
     await devServer.start();
     this._port = devServerPort;
     return devServer;

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -18,6 +18,7 @@ import { html } from './html';
  * i.e. `bit start --dev`,
  */
 
+const matchNothingRegex = 'a^';
 const clientHost = process.env.WDS_SOCKET_HOST;
 const clientPath = process.env.WDS_SOCKET_PATH; // default is '/sockjs-node';
 const port = process.env.WDS_SOCKET_PORT;
@@ -43,7 +44,7 @@ const moduleFileExtensions = [
   'jsx',
 ];
 
-export function devConfig(workspaceDir, entryFiles, title, aspectPaths): WebpackConfigWithDevServer {
+export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDevServer {
   const resolveWorkspacePath = (relativePath) => path.resolve(workspaceDir, relativePath);
 
   // Host
@@ -201,22 +202,27 @@ export function devConfig(workspaceDir, entryFiles, title, aspectPaths): Webpack
           include: /node_modules/,
           // only apply to packages with componentId in their package.json (ie. bit components)
           descriptionData: { componentId: (value) => !!value },
-          use: [require.resolve('source-map-loader')],
+          use: [require.resolve('@pmmmwh/react-refresh-webpack-plugin/loader'), require.resolve('source-map-loader')],
         },
         {
           test: /\.(js|jsx|tsx|ts)$/,
           exclude: /node_modules/,
           include: workspaceDir,
-          loader: require.resolve('babel-loader'),
-          options: {
-            configFile: false,
-            babelrc: false,
-            presets: [
-              // Preset includes JSX, TypeScript, and some ESnext features
-              require.resolve('babel-preset-react-app'),
-            ],
-            plugins: [require.resolve('react-refresh/babel')],
-          },
+          use: [
+            require.resolve('@pmmmwh/react-refresh-webpack-plugin/loader'),
+            {
+              loader: require.resolve('babel-loader'),
+              options: {
+                configFile: false,
+                babelrc: false,
+                presets: [
+                  // Preset includes JSX, TypeScript, and some ESnext features
+                  require.resolve('babel-preset-react-app'),
+                ],
+                plugins: [require.resolve('react-refresh/babel')],
+              },
+            },
+          ],
         },
         {
           test: stylesRegexps.sassModuleRegex,
@@ -310,14 +316,10 @@ export function devConfig(workspaceDir, entryFiles, title, aspectPaths): Webpack
 
     plugins: [
       new ReactRefreshWebpackPlugin({
-        include: aspectPaths, // original default value was /\.([cm]js|[jt]sx?|flow)$/i
-        // replaces the default value of `/node_modules/`
-        exclude: [
-          /react-refresh-webpack-plugin/i,
-          // file type filtering was done by `include`, so need to negative-filter them out here
-          // A lookbehind assertion (`?<!`) has to be fixed width
-          /(?<!\.jsx)(?<!\.js)(?<!\.tsx)(?<!\.ts)$/i,
-        ],
+        // we use '@pmmmwh/react-refresh-webpack-plugin/loader' directly where relevant.
+        // FYI, original defaults of the plugin are:
+        // include: /\.([cm]js|[jt]sx?|flow)$/i, exclude: /node_modules/,
+        include: matchNothingRegex,
       }),
       // Re-generate index.html with injected script tag.
       // The injected script tag contains a src value of the


### PR DESCRIPTION
## Proposed Changes

- use fast refresh loader explicitly, with the existing Webpack heuristics! Thanks to https://github.com/pmmmwh/react-refresh-webpack-plugin/issues/456
- remove hacks trying to set which packages / components should be included by the plugin.

This should improve:
- webpack perf in large projects
- enable hot reloading for newly created components
- fix race condition errors around MDX.