### PR TITLE
fix(circle-ci): run the build:types task before the tests to fix Windows tests on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1171,6 +1171,7 @@ jobs:
       - run: 'cd bit\bit; bit install'
       - run: 'cd bit\bit; bit compile'
       - run: 'cd bit\bit; npm run build'
+      - run: 'cd bit\bit; npm run build:types:windows'
       - persist_to_workspace:
           root: .
           paths:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,7 +10,6 @@
     "skipLibCheck": true,
     "noImplicitAny": false,
     "typeRoots": ["custom-types", "node_modules/@types"],
-    "removeComments": true,
     "preserveConstEnums": true,
     "strictPropertyInitialization": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## Proposed Changes

- configure Circle to run the build-types task on Windows.
- configure tsconfig.json to preserve comments in the d.ts files of bit-legacy.
