### PR TITLE
replace v8-compile-cache to support esm loaders

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -663,6 +663,12 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/path/to-windows-compatible-path"
     },
+    "performance/v8-cache": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/toolbox/performance/v8-cache"
+    },
     "pkg": {
         "scope": "teambit.pkg",
         "version": "0.0.562",

--- a/package.json
+++ b/package.json
@@ -234,7 +234,6 @@
     "uniqid": "5.3.0",
     "user-home": "2.0.0",
     "uuid": "3.4.0",
-    "v8-compile-cache": "2.2.0",
     "validate-npm-package-name": "3.0.0",
     "vinyl": "2.2.1",
     "vinyl-file": "3.0.0",

--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -6,7 +6,10 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-require('v8-compile-cache');
+import { nativeCompileCache } from '@teambit/toolbox.performance.v8-cache';
+
+// Enable v8 compile cache, keep this before other imports
+nativeCompileCache?.install();
 
 import './hook-require';
 import { bootstrap } from '@teambit/legacy/dist/bootstrap';

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -6,7 +6,10 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-require('v8-compile-cache');
+import { nativeCompileCache } from '@teambit/toolbox.performance.v8-cache';
+
+// Enable v8 compile cache, keep this before other imports
+nativeCompileCache?.install();
 
 import './hook-require';
 

--- a/scopes/toolbox/performance/v8-cache/file-system-blob-store.ts
+++ b/scopes/toolbox/performance/v8-cache/file-system-blob-store.ts
@@ -1,0 +1,176 @@
+// Copied from https://github.com/zertosh/v8-compile-cache
+import { mkdirSync, readFileSync, statSync, writeFileSync, unlinkSync } from 'fs';
+import path, { join } from 'path';
+
+type DumpMap = { [key: string]: [string, number, number] };
+type Dump = [Buffer[], DumpMap];
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+
+// https://github.com/substack/node-mkdirp/blob/f2003bb/index.js#L55-L98
+function mkdirpSync(p_: string): void {
+  _mkdirpSync(path.resolve(p_), 0o777);
+}
+
+function _mkdirpSync(p: string, mode?: number): void {
+  try {
+    mkdirSync(p, mode);
+  } catch (err0: any) {
+    if (err0.code === 'ENOENT') {
+      _mkdirpSync(path.dirname(p));
+      _mkdirpSync(p);
+    } else {
+      try {
+        const stat = statSync(p);
+        if (!stat.isDirectory()) {
+          throw err0;
+        }
+      } catch (err1) {
+        throw err0;
+      }
+    }
+  }
+}
+
+// https://github.com/zertosh/slash-escape/blob/e7ebb99/slash-escape.js
+function slashEscape(str: string): string {
+  const ESCAPE_LOOKUP = {
+    '\\': 'zB',
+    ':': 'zC',
+    '/': 'zS',
+    '\x00': 'z0',
+    z: 'zZ',
+  };
+  const ESCAPE_REGEX = /[\\:/\x00z]/g; // eslint-disable-line no-control-regex
+  return str.replace(ESCAPE_REGEX, (match) => ESCAPE_LOOKUP[match]);
+}
+
+export class FileSystemBlobStore {
+  private _memoryBlobs: {};
+  private _invalidationKeys: {};
+  private _dirty: boolean;
+  private _storedMap: {};
+  private _storedBlob: Buffer;
+  private _blobFilename: string;
+  private _mapFilename: string;
+  private _lockFilename: string;
+  private _directory: string;
+
+  constructor(directory: string, prefix: string) {
+    const name = prefix ? slashEscape(`${prefix}.`) : '';
+    this._blobFilename = join(directory, `${name}BLOB`);
+    this._mapFilename = join(directory, `${name}MAP`);
+    this._lockFilename = join(directory, `${name}LOCK`);
+    this._directory = directory;
+    try {
+      this._storedBlob = readFileSync(this._blobFilename);
+      this._storedMap = JSON.parse(readFileSync(this._mapFilename, { encoding: 'utf8' }));
+    } catch (e) {
+      this._storedBlob = Buffer.alloc(0);
+      this._storedMap = {};
+    }
+    this._dirty = false;
+    this._memoryBlobs = {};
+    this._invalidationKeys = {};
+  }
+
+  has(key: string, invalidationKey: string) {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      return this._invalidationKeys[key] === invalidationKey;
+    }
+    if (hasOwnProperty.call(this._storedMap, key)) {
+      return this._storedMap[key][0] === invalidationKey;
+    }
+    return false;
+  }
+
+  get(key: string, invalidationKey: string) {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      if (this._invalidationKeys[key] === invalidationKey) {
+        return this._memoryBlobs[key];
+      }
+    } else if (hasOwnProperty.call(this._storedMap, key)) {
+      const mapping = this._storedMap[key];
+      if (mapping[0] === invalidationKey) {
+        return this._storedBlob.slice(mapping[1], mapping[2]);
+      }
+    }
+    return undefined;
+  }
+
+  set(key: string, invalidationKey: string, buffer: Buffer): void {
+    this._invalidationKeys[key] = invalidationKey;
+    this._memoryBlobs[key] = buffer;
+    this._dirty = true;
+  }
+
+  delete(key: string): void {
+    if (hasOwnProperty.call(this._memoryBlobs, key)) {
+      this._dirty = true;
+      delete this._memoryBlobs[key];
+    }
+    if (hasOwnProperty.call(this._invalidationKeys, key)) {
+      this._dirty = true;
+      delete this._invalidationKeys[key];
+    }
+    if (hasOwnProperty.call(this._storedMap, key)) {
+      this._dirty = true;
+      delete this._storedMap[key];
+    }
+  }
+
+  isDirty(): boolean {
+    return this._dirty;
+  }
+
+  save(): boolean {
+    const dump = this._getDump();
+    const blobToStore = Buffer.concat(dump[0]);
+    const mapToStore = JSON.stringify(dump[1]);
+
+    try {
+      mkdirpSync(this._directory);
+      writeFileSync(this._lockFilename, 'LOCK', { flag: 'wx' });
+    } catch (error) {
+      // Swallow the exception if we fail to acquire the lock.
+      return false;
+    }
+
+    try {
+      writeFileSync(this._blobFilename, blobToStore);
+      writeFileSync(this._mapFilename, mapToStore);
+    } finally {
+      unlinkSync(this._lockFilename);
+    }
+
+    return true;
+  }
+
+  _getDump(): Dump {
+    const buffers: Buffer[] = [];
+    const newMap: { [key: string]: [string, number, number] } = {};
+    let offset = 0;
+
+    function push(key, invalidationKey, buffer: Buffer) {
+      buffers.push(buffer);
+      newMap[key] = [invalidationKey, offset, offset + buffer.length];
+      offset += buffer.length;
+    }
+
+    for (const key of Object.keys(this._memoryBlobs)) {
+      const buffer = this._memoryBlobs[key];
+      const invalidationKey = this._invalidationKeys[key];
+      push(key, invalidationKey, buffer);
+    }
+
+    for (const key of Object.keys(this._storedMap)) {
+      if (!hasOwnProperty.call(newMap, key)) {
+        const mapping = this._storedMap[key];
+        const buffer = this._storedBlob.slice(mapping[1], mapping[2]);
+        push(key, mapping[0], buffer);
+      }
+    }
+
+    return [buffers, newMap];
+  }
+}

--- a/scopes/toolbox/performance/v8-cache/index.ts
+++ b/scopes/toolbox/performance/v8-cache/index.ts
@@ -1,0 +1,2 @@
+export { nativeCompileCache } from './v8-compile-cache';
+export type { NativeCompileCache } from './v8-compile-cache';

--- a/scopes/toolbox/performance/v8-cache/v8-compile-cache.ts
+++ b/scopes/toolbox/performance/v8-cache/v8-compile-cache.ts
@@ -1,0 +1,204 @@
+// Copied from https://github.com/zertosh/v8-compile-cache and modified to be disabled on demand
+import { FileSystemBlobStore } from './file-system-blob-store';
+
+const Module = require('module');
+const crypto = require('crypto');
+const path = require('path');
+const vm = require('vm');
+const os = require('os');
+
+export class NativeCompileCache {
+  private _cacheStore: FileSystemBlobStore;
+  private _previousModuleCompile: ((content: string, filename: string) => any) | null = null;
+  private _cachedModuleCompile: ((content: string, filename: string) => any) | null = null;
+
+  constructor(blobStore: FileSystemBlobStore) {
+    this.setCacheStore(blobStore);
+  }
+
+  setCacheStore(cacheStore: FileSystemBlobStore) {
+    this._cacheStore = cacheStore;
+  }
+
+  install() {
+    if (this._previousModuleCompile || process.env.DISABLE_V8_COMPILE_CACHE || !supportsCachedData()) {
+      return;
+    }
+    if (this._cachedModuleCompile) {
+      this._previousModuleCompile = Module.prototype._compile;
+      Module.prototype._compile = this._cachedModuleCompile;
+      return;
+    }
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+    const hasRequireResolvePaths = typeof require.resolve.paths === 'function';
+    this._previousModuleCompile = Module.prototype._compile;
+    Module.prototype._compile = function (content: string, filename: string) {
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
+      const mod = this;
+
+      function require(id) {
+        return mod.require(id);
+      }
+
+      // https://github.com/nodejs/node/blob/v10.15.3/lib/internal/modules/cjs/helpers.js#L28
+      function resolve(request, options) {
+        return Module._resolveFilename(request, mod, false, options);
+      }
+
+      require.resolve = resolve;
+
+      // https://github.com/nodejs/node/blob/v10.15.3/lib/internal/modules/cjs/helpers.js#L37
+      // resolve.resolve.paths was added in v8.9.0
+      if (hasRequireResolvePaths) {
+        resolve.paths = function paths(request) {
+          return Module._resolveLookupPaths(request, mod, true);
+        };
+      }
+
+      require.main = process.mainModule;
+
+      // Enable support to add extra extension types
+      require.extensions = Module._extensions;
+      require.cache = Module._cache;
+
+      const dirname = path.dirname(filename);
+
+      const compiledWrapper = self._moduleCompile(filename, content);
+
+      // We skip the debugger setup because by the time we run, node has already
+      // done that itself.
+
+      // `Buffer` is included for Electron.
+      // See https://github.com/zertosh/v8-compile-cache/pull/10#issuecomment-518042543
+      const args = [mod.exports, require, mod, filename, dirname, process, global, Buffer];
+      return compiledWrapper.apply(mod.exports, args);
+    };
+  }
+
+  uninstall() {
+    if (this._previousModuleCompile) {
+      this._cachedModuleCompile = Module.prototype._compile;
+      Module.prototype._compile = this._previousModuleCompile;
+      this._previousModuleCompile = null;
+    }
+  }
+
+  _moduleCompile(filename: string, content: string) {
+    // https://github.com/nodejs/node/blob/v7.5.0/lib/module.js#L511
+
+    // Remove shebang
+    const contLen = content.length;
+    if (contLen >= 2) {
+      // eslint-disable-next-line
+      if (content.charCodeAt(0) === 35 /*#*/ && content.charCodeAt(1) === 33 /*!*/) {
+        if (contLen === 2) {
+          // Exact match
+          content = '';
+        } else {
+          // Find end of shebang line and slice it off
+          let i = 2;
+          // eslint-disable-next-line no-plusplus
+          for (; i < contLen; ++i) {
+            const code = content.charCodeAt(i);
+            // eslint-disable-next-line
+            if (code === 10 /*\n*/ || code === 13 /*\r*/) break;
+          }
+          if (i === contLen) {
+            content = '';
+          } else {
+            // Note that this actually includes the newline character(s) in the
+            // new output. This duplicates the behavior of the regular
+            // expression that was previously used to replace the shebang line
+            content = content.slice(i);
+          }
+        }
+      }
+    }
+
+    // create wrapper function
+    const wrapper = Module.wrap(content);
+
+    const invalidationKey = crypto.createHash('sha1').update(content, 'utf8').digest('hex');
+
+    const buffer = this._cacheStore.get(filename, invalidationKey);
+
+    const script = new vm.Script(wrapper, {
+      filename,
+      lineOffset: 0,
+      displayErrors: true,
+      cachedData: buffer,
+      produceCachedData: true,
+      // https://nodejs.org/api/vm.html#vm_new_vm_script_code_options
+      importModuleDynamically() {
+        throw new Error(
+          '[v8-compile-cache] Dynamic imports are currently not supported. See https://git.io/Jge6z for more information. You should call `nativeCompileCache.uninstall()` before using dynamic imports.'
+        );
+      },
+    });
+
+    if (script.cachedDataProduced) {
+      this._cacheStore.set(filename, invalidationKey, script.cachedData);
+    } else if (script.cachedDataRejected) {
+      this._cacheStore.delete(filename);
+    }
+
+    const compiledWrapper = script.runInThisContext({
+      filename,
+      lineOffset: 0,
+      columnOffset: 0,
+      displayErrors: true,
+    });
+
+    return compiledWrapper;
+  }
+}
+
+function supportsCachedData(): boolean {
+  const script = new vm.Script('""', { produceCachedData: true });
+  // chakracore, as of v1.7.1.0, returns `false`.
+  return script.cachedDataProduced === true;
+}
+
+function getCacheDir(): string {
+  const v8_compile_cache_cache_dir = process.env.V8_COMPILE_CACHE_CACHE_DIR;
+  if (v8_compile_cache_cache_dir) {
+    return v8_compile_cache_cache_dir;
+  }
+
+  // Avoid cache ownership issues on POSIX systems.
+  const dirname = typeof process.getuid === 'function' ? `v8-compile-cache-${process.getuid()}` : 'v8-compile-cache';
+  const version =
+    // eslint-disable-next-line no-nested-ternary
+    typeof process.versions.v8 === 'string'
+      ? process.versions.v8
+      : typeof (process.versions as any).chakracore === 'string'
+      ? `chakracore-${(process.versions as any).chakracore}`
+      : `node-${process.version}`;
+  return path.join(os.tmpdir(), dirname, version);
+}
+
+function getParentName(): string {
+  // `module.parent.filename` is undefined or null when:
+  //    * node -e 'require("v8-compile-cache")'
+  //    * node -r 'v8-compile-cache'
+  //    * Or, requiring from the REPL.
+  return module.parent && typeof module.parent.filename === 'string' ? module.parent.filename : process.cwd();
+}
+
+// eslint-disable-next-line import/no-mutable-exports
+export let nativeCompileCache: NativeCompileCache | null = null;
+
+if (!process.env.DISABLE_V8_COMPILE_CACHE && supportsCachedData()) {
+  const cacheDir = getCacheDir();
+  const prefix = getParentName();
+  const blobStore = new FileSystemBlobStore(cacheDir, prefix);
+  nativeCompileCache = new NativeCompileCache(blobStore);
+
+  process.once('exit', () => {
+    if (blobStore.isDirty()) {
+      blobStore.save();
+    }
+    nativeCompileCache!.uninstall();
+  });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7632,7 +7632,6 @@ __metadata:
     utf-8-validate: 5.0.5
     util: 0.12.3
     uuid: 3.4.0
-    v8-compile-cache: 2.2.0
     validate-npm-package-name: 3.0.0
     verdaccio: 4.11.0
     vfile: 4.2.0
@@ -34733,6 +34732,12 @@ typescript@^3.9.3:
   checksum: 5575a8a75c13120e2f10e6ddc801b2c7ed7d8f3c8ac22c7ed0c7b2ba6383ec0abda88c905085d630e251719e0777045ae3236f04c812184b7c765f63a70e58df
   languageName: node
   linkType: hard
+
+"v8-cache-817a32@workspace:scopes/toolbox/performance/v8-cache":
+  version: 0.0.0-use.local
+  resolution: "v8-cache-817a32@workspace:scopes/toolbox/performance/v8-cache"
+  languageName: unknown
+  linkType: soft
 
 "v8-compile-cache@npm:2.2.0":
   version: 2.2.0


### PR DESCRIPTION
Replacing v8-compile-cache with a custom version that you can disable on demand until https://github.com/zertosh/v8-compile-cache/issues/30 is fixed because it prevents ESM loaders to work. If TypeScript allows for native imports to work, we could probably re-enable this lib as well.