### PR TITLE
fix(test): remove redundant ids when calculating the dependents of modified and new components

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -421,7 +421,8 @@ export class Workspace implements ComponentFactory {
     const workspaceDependencyGraph = new DependencyGraph(workspaceGraph);
     const workspaceDependents = ids.map((id) => workspaceDependencyGraph.getDependentsInfo(id._legacy));
     const dependentsLegacyIds = workspaceDependents.flat().map((_) => _.id);
-    const dependentsIds = await this.resolveMultipleComponentIds(dependentsLegacyIds);
+    const dependentsLegacyNoDup = BitIds.uniqFromArray(dependentsLegacyIds);
+    const dependentsIds = await this.resolveMultipleComponentIds(dependentsLegacyNoDup);
     return dependentsIds;
   }
 


### PR DESCRIPTION
Due to a recent change to `bit test` to include the dependents of the modified and new component, a new error appeared when multiple components have the same dependent:
```
found duplicated components: component-name@0.0.1
```
This PR fixes it by making sure the dependents ids are unique and there are no duplications. 