### PR TITLE
install new version of documenter markdown mdx

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -96,7 +96,7 @@
         "@teambit/design.ui.icon-button": "1.0.10",
         "@teambit/documenter.code.react-playground": "4.0.1",
         "@teambit/documenter.markdown.hybrid-live-code-snippet": "0.1.3",
-        "@teambit/documenter.markdown.mdx": "0.1.3",
+        "@teambit/documenter.markdown.mdx": "0.1.6",
         "@teambit/documenter.routing.external-link": "4.1.0",
         "@teambit/documenter.theme.theme-compositions": "4.1.1",
         "@teambit/documenter.theme.theme-context": "4.0.3",


### PR DESCRIPTION
## Proposed Changes

- This new version includes a fix for Heading titles that was only an h3, now they will be h1, h2, h3, h4, h5, h6.
- CSS fix with `max-width: 100%` to only img instead of everything.