### PR TITLE
fix: the lockfile should not change unless there are changes in the d…

### DIFF
--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -177,8 +177,8 @@ export async function install(
     storeDir,
     dir: rootPathToManifest.rootDir,
     storeController,
-    update: true,
     workspacePackages,
+    preferFrozenLockfile: true,
     registries: registriesMap,
     rawConfig: authConfig,
     // TODO: uncomment when this is solved https://github.com/pnpm/pnpm/issues/2910


### PR DESCRIPTION
…irect dependency specs

## Proposed Changes

- the lockfile should not change if the version ranges of dependencies did not change in the policies
- pnpm should run a faster installation strategy when the lockfile is up-to-date
