### PR TITLE
fix(tag): switch from "package.json#files" to ".npmignore" 

### DIFF
--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -31,6 +31,13 @@ export class AspectEnv implements DependenciesEnv {
     return this.reactEnv.getCompiler(this.getTsConfig(tsConfig));
   }
 
+  getNpmIgnore() {
+    // ignores only .ts files in the root directory, so d.ts files inside dists are unaffected.
+    // without this change, the package has "index.ts" file in the root, causing typescript to parse it instead of the
+    // d.ts files. (changing the "types" prop in the package.json file doesn't help).
+    return ['/*.ts'];
+  }
+
   async getDependencies() {
     return {
       dependencies: {

--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -70,28 +70,7 @@ export class AspectMain {
       compiler.createTask('TypescriptCompiler', tsCompiler),
     ]);
 
-    const pkgJsonOverride = react.overridePackageJsonProps({
-      files: [
-        babelCompiler.distDir,
-        `!${babelCompiler.distDir}/tsconfig.tsbuildinfo`,
-        '**/*.md',
-        '**/*.mdx',
-        '**/*.js',
-        '**/*.json',
-        '**/*.sass',
-        '**/*.scss',
-        '**/*.less',
-        '**/*.css',
-        '**/*.css',
-        '**/*.jpeg',
-        '**/*.gif',
-      ],
-    });
-
-    const aspectEnv = react.compose(
-      [compilerOverride, compilerTasksOverride, pkgJsonOverride],
-      new AspectEnv(react.reactEnv)
-    );
+    const aspectEnv = react.compose([compilerOverride, compilerTasksOverride], new AspectEnv(react.reactEnv));
 
     const coreExporterTask = new CoreExporterTask(aspectEnv, aspectLoader);
     if (!__dirname.includes('@teambit/bit')) {


### PR DESCRIPTION
To avoid publishing/packing TS files for Aspect env. See https://github.com/teambit/bit/pull/5032 for more context.
The problem we had with white listing the files, is that we ended up with some `**/*.*` patterns which caused out-of-memory upon `npm pack` during `bit tag`. Interestingly enough, this is happening with npm 7 only, not with npm 6.

