### PR TITLE
fix(merge-pending): better handling diverge components

### DIFF
--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -721,5 +721,23 @@ describe('bit snap command', function () {
       const firstTag = compData.versions['0.0.1'];
       expect(() => helper.command.catObject(firstTag)).to.not.throw();
     });
+    it('bit status should suggest running either "bit untag" or "bit merge"', () => {
+      const output = helper.command.status();
+      expect(output).to.have.string('bit untag');
+      expect(output).to.have.string('bit merge');
+    });
+    describe('bit untag a diverge component', () => {
+      before(() => {
+        helper.command.untagAll();
+      });
+      it('should change the head to point to the remote head and not to the parent of the untagged version', () => {
+        const head = helper.command.getHead('comp1');
+        const remoteHead = helper.general.getRemoteHead('comp1');
+        expect(head).to.be.equal(remoteHead);
+      });
+      it('bit status after untag should show the component as modified only', () => {
+        helper.command.expectStatusToBeClean(['modifiedComponent']);
+      });
+    });
   });
 });

--- a/e2e/commands/snap.e2e.2.ts
+++ b/e2e/commands/snap.e2e.2.ts
@@ -477,11 +477,10 @@ describe('bit snap command', function () {
             helper.fixtures.createComponentBarFoo('');
             helper.command.untag('bar/foo');
           });
-          it('bit status should not show the component as a component with conflicts but as outdated', () => {
+          it('bit status should not show the component as a component with conflicts but as modified', () => {
             const status = helper.command.statusJson();
             expect(status.componentsDuringMergeState).to.have.lengthOf(0);
             expect(status.modifiedComponent).to.have.lengthOf(1);
-            expect(status.outdatedComponents).to.have.lengthOf(1);
             expect(status.mergePendingComponents).to.have.lengthOf(0);
             expect(status.stagedComponents).to.have.lengthOf(0);
           });

--- a/src/cli/commands/public-cmds/status-cmd.ts
+++ b/src/cli/commands/public-cmds/status-cmd.ts
@@ -153,7 +153,8 @@ export default class Status implements LegacyCommand {
     const outdatedStr = outdatedComponents.length ? [outdatedTitle, outdatedDesc, outdatedComps].join('\n') : '';
 
     const pendingMergeTitle = chalk.underline.white('pending merge');
-    const pendingMergeDesc = '(use "bit merge <remote-name>/<lane-name> [component-id]" to merge changes)\n';
+    const pendingMergeDesc = `(use "bit untag" to add local changes on top of the remote and discard local tags.
+alternatively, to keep local tags/snaps history, use "bit merge <remote-name>/<lane-name> [component-id]")\n`;
     const pendingMergeComps = mergePendingComponents
       .map((component) => {
         return `    > ${chalk.cyan(component.id.toString())} local and remote have diverged and have ${

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -36,6 +36,16 @@ export default class GeneralHelper {
   getRemoteRefPath(lane = DEFAULT_LANE, remote = this.scopes.remote) {
     return path.join(this.scopes.localPath, BIT_HIDDEN_DIR, REMOTE_REFS_DIR, remote, lane);
   }
+  getRemoteRefContent(lane = DEFAULT_LANE, remote = this.scopes.remote) {
+    const refPath = this.getRemoteRefPath(lane, remote);
+    return fs.readJsonSync(refPath);
+  }
+  getRemoteHead(compId: string, lane = DEFAULT_LANE, remote = this.scopes.remote): string {
+    const refContent = this.getRemoteRefContent(lane, remote);
+    const record = refContent.find((_) => _.id.name === compId);
+    if (!record) throw new Error(`unable to find ${compId} in the ref file`);
+    return record.head;
+  }
   getHashPathOfComponent(compId: string, cwd = this.scopes.localPath): string {
     const scope = this.command.catScope(true, cwd);
     const comp3 = scope.find((item) => item.name === compId);

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -59,6 +59,7 @@ as a result, newer versions have this version as part of their history`);
   const allVersionsObjects = await Promise.all(
     localVersions.map((localVer) => component.loadVersion(localVer, scope.objects))
   );
+  await component.setDivergeData(scope.objects);
   scope.sources.removeComponentVersions(component, versionsToRemove, allVersionsObjects);
 
   return { id, versions: versionsToRemove, component };

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -493,13 +493,21 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       const refStr = ref.toString();
       if (!versionObject) throw new Error(`removeComponentVersions failed finding a version object of ${refStr}`);
       // update the snap head if needed
-      if (component.getHeadStr() === refStr) {
+      const getHead = () => {
+        const divergeData = component.getDivergeData();
+        if (divergeData.isDiverged()) {
+          if (!component.remoteHead) throw new Error(`remoteHead must be set when component is diverged`);
+          return component.remoteHead;
+        }
         if (versionObject.parents.length > 1) {
           throw new Error(
             `removeComponentVersions found multiple parents for a local (un-exported) version ${version} of ${component.id()}`
           );
         }
-        const head = versionObject.parents.length === 1 ? versionObject.parents[0] : undefined;
+        return versionObject.parents.length === 1 ? versionObject.parents[0] : undefined;
+      };
+      if (component.getHeadStr() === refStr) {
+        const head = getHead();
         component.setHead(head);
       }
 


### PR DESCRIPTION
Currently, when components have diverged from a remote, they're shown in `bit status` as "pending merge" with a suggestion to use `bit merge <id>`.
This `bit merge` command, creates a snap-merge with two parents, the local and the remote. While this is a good solution to keep the local snaps/tags, it is confusing for users to see the hash in the output of `bit merge` and later on in `bit status` and in the .bitmap file.
This PR, suggests to run `bit untag` instead. It also fixes `bit untag` to point to the remote head instead of the previous head. This way, after bit-untag is running the component model locally is the same as the remote and the status is `modified`.