### PR TITLE
fix(create): don't change newly created component scope from existing component in workspace.jsonc

### DIFF
--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -78,6 +78,7 @@ export class ComponentGenerator {
       rootDir: componentPath,
       mainFile: mainFile?.relativePath,
       componentName: componentId.fullName,
+      defaultScope: this.options.scope,
     });
     const component = await this.workspace.get(componentId);
     const env = this.envs.getEnv(component);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -128,6 +128,7 @@ export type TrackData = {
   rootDir: PathOsBasedRelative; // path relative to the workspace
   componentName?: string; // if empty, it'll be generated from the path
   mainFile?: string; // if empty, attempts will be made to guess the best candidate
+  defaultScope?: string; // can be entered as part of "bit create" command, helpful for out-of-sync logic
 };
 
 export type TrackResult = { componentName: string; files: string[]; warnings: Warnings };
@@ -718,7 +719,13 @@ export class Workspace implements ComponentFactory {
   async track(trackData: TrackData): Promise<TrackResult> {
     const addComponent = new AddComponents(
       { consumer: this.consumer },
-      { componentPaths: [trackData.rootDir], id: trackData.componentName, main: trackData.mainFile, override: false }
+      {
+        componentPaths: [trackData.rootDir],
+        id: trackData.componentName,
+        main: trackData.mainFile,
+        override: false,
+        defaultScope: trackData.defaultScope,
+      }
     );
     const result = await addComponent.add();
     const addedComponent = result.addedComponents[0];

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -91,6 +91,7 @@ export type AddProps = {
   override: boolean;
   trackDirFeature?: boolean;
   origin?: ComponentOrigin;
+  defaultScope?: string;
 };
 // This is the contxt of the add operation. By default, the add is executed in the same folder in which the consumer is located and it is the process.cwd().
 // In that case , give the value false to overridenConsumer .
@@ -121,6 +122,7 @@ export default class AddComponents {
   alternateCwd: string | null | undefined;
   addedComponents: AddResult[];
   isLegacy: boolean;
+  defaultScope?: string; // helpful for out-of-sync
   constructor(context: AddContext, addProps: AddProps) {
     this.alternateCwd = context.alternateCwd;
     this.consumer = context.consumer;
@@ -141,6 +143,7 @@ export default class AddComponents {
     };
     this.addedComponents = [];
     this.isLegacy = context.consumer.isLegacy;
+    this.defaultScope = addProps.defaultScope;
   }
 
   joinConsumerPathIfNeeded(paths: PathOrDSL[]): PathOrDSL[] {
@@ -296,18 +299,21 @@ export default class AddComponents {
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           this.warnings.alreadyUsed[existingIdOfFile] = [file.relativePath];
         }
-        // $FlowFixMe null is removed later on
         return null;
       }
       if (!foundComponentFromBitMap && componentFromScope) {
         const newId = componentFromScope.toBitIdWithLatestVersion();
-        component.componentId = newId;
-        this.warnings.existInScope.push(newId);
+        if (!this.defaultScope || this.defaultScope === newId.scope) {
+          // otherwise, if defaultScope !== newId.scope, they're different components,
+          // and no need to change the id.
+          // for more details about this scenario, see https://github.com/teambit/bit/issues/1543, last case.
+          component.componentId = newId;
+          this.warnings.existInScope.push(newId);
+        }
       }
       return file;
     });
-    // $FlowFixMe it can't be null due to the filter function
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-ignore it can't be null due to the filter function
     const componentFiles: ComponentMapFile[] = (await Promise.all(componentFilesP)).filter((file) => file);
     if (!componentFiles.length) return { id: component.componentId, files: [] };
     if (foundComponentFromBitMap) {


### PR DESCRIPTION
This is related to the out-of-sync mechanism described in https://github.com/teambit/bit/discussions/5074. Specifically the last case. If the added component (during `bit add` or `bit create`) doesn't exist in .bitmap, and a similar component exists in the scope, we assume this is the same component and we re-adding the one from the scope to the .bitmap.
In case `bit create --scope` was used, and we know that the entered scope is different than the scope-name of the component found in the model, no need to make changes to the added component and we add it as new.

Bug was reported by @ranm8 .
