### PR TITLE
show inner component when highlighting component

### DIFF
--- a/scopes/react/dom-to-react/dom-to-react.spec.tsx
+++ b/scopes/react/dom-to-react/dom-to-react.spec.tsx
@@ -48,20 +48,20 @@ describe('domToReact', () => {
     expect(component).toEqual(BasicFragmentComponent);
   });
 
-  test('should return the outer component, when a component is a decoration of two components', () => {
+  test('should return the inner component, when a component is a decoration of two components', () => {
     const { getByText } = render(<DecoratedDiv />);
 
     const target = getByText('hello');
     const component = domToReact(target);
-    expect(component).toEqual(DecoratedDiv);
+    expect(component).toEqual(DivComponent);
   });
 
-  test('should return the outer component, when a component is wrapper of another component', () => {
+  test('should return the inner component, when a component is wrapper of another component', () => {
     const { getByText } = render(<WrappedDiv />);
 
     const target = getByText('hello');
     const component = domToReact(target);
-    expect(component).toEqual(WrappedDiv);
+    expect(component).toEqual(DivComponent);
   });
 });
 

--- a/scopes/react/dom-to-react/dom-to-react.ts
+++ b/scopes/react/dom-to-react/dom-to-react.ts
@@ -26,7 +26,7 @@ export function toRootElement(element: HTMLElement | null) {
 
 export function domToReact(element: HTMLElement | null) {
   const components = domToReacts(element);
-  return components.pop();
+  return components.shift();
 }
 
 export function domToReacts(element: HTMLElement | null): ComponentType[] {


### PR DESCRIPTION
## Proposed Changes

> WIP! this has not been approved! (product wise) 

- revert showing the "outer" component in the component highlighter 

This should fix the following problem:
<img width="490" alt="Screen Shot 2021-12-01 at 17 11 35" src="https://user-images.githubusercontent.com/5400361/144268905-0fd0aba7-8b3a-4d74-8414-0ddd29a43ef6.png">
In this example, the conditional-show component is irrelevant, and shouldn't be shown.

