### PR TITLE
fix loader fallback getting into highlighter

### DIFF
--- a/scopes/react/react/compositions-app.tsx
+++ b/scopes/react/react/compositions-app.tsx
@@ -3,7 +3,7 @@ import { Composer } from '@teambit/base-ui.utils.composer';
 import { StandaloneNotFoundPage } from '@teambit/design.ui.pages.standalone-not-found-page';
 import { RenderingContext } from '@teambit/preview';
 import { ErrorFallback } from '@teambit/react.ui.error-fallback';
-import { LoaderFallback } from '@teambit/react.ui.loader-fallback';
+import { useFallback } from '@teambit/react.ui.loader-fallback';
 import { ErrorBoundary } from 'react-error-boundary';
 import { ReactAspect } from './react.aspect';
 
@@ -20,11 +20,13 @@ export function CompositionsApp({
   const reactContext = previewContext.get(ReactAspect.id);
   const providers = reactContext?.providers || [];
 
+  const safeComposition = useFallback(Composition && <Composition />, <StandaloneNotFoundPage />);
+
   return (
     <ErrorBoundary FallbackComponent={ErrorFallback} resetKeys={[Composition]}>
       <Composer components={providers}>
         <style>{hideScrollbars}</style>
-        <LoaderFallback Target={Composition} DefaultComponent={StandaloneNotFoundPage} />
+        {safeComposition}
       </Composer>
     </ErrorBoundary>
   );

--- a/scopes/react/ui/loader-fallback/index.ts
+++ b/scopes/react/ui/loader-fallback/index.ts
@@ -1,2 +1,2 @@
-export { LoaderFallback } from './loader-fallback';
-export type { LoaderProps } from './loader-fallback';
+export { LoaderFallback, useFallback } from './loader-fallback';
+export type { LoaderProps, useFallbackOptions } from './loader-fallback';

--- a/scopes/react/ui/loader-fallback/loader-fallback.docs.mdx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.docs.mdx
@@ -1,13 +1,25 @@
 import { LoaderFallback } from './loader-fallback';
 
-Renders a component, and show a placeholder when it is undefined.
+Safely render a component, with a default fallback when it is `undefined`.  
+The `LoaderFallback` component also provides a grace period, where it shows a loader before switching to the default.  
+Set `timeout = 0` to skip the grace period.
 
-Logic is as follows:
+#### Example usage:
 
-1. when component is defined -> render it
-1. when the initial value of the component is undefined -> show the default immediately
-1. when the component had just changed to be undefined -> show Loader for _x_ seconds
-   1. then, after _x_ seconds - show NotFound
+```tsx
+// as a hook:
+const safeTarget = useFallback(Target && <Target />, <DefaultComponent />, { timeout: 10000, loader: <Loader /> });
+
+// as a component:
+<LoaderFallback Target={Target} DefaultComponent={DefaultComponent} timeout={10000} loader={Loader}>
+```
+
+### Logic is as follows:
+
+1. when component is `defined` -> render it
+1. when the initial value of the component is `undefined` -> show the default immediately
+1. when the component changes to be `undefined` -> show Loader for _x_ seconds
+   1. then, after _x_ seconds - show the default.
 
 <!-- live playground doesn't keep state when editing :( -->
 <!-- Try it out:

--- a/scopes/react/ui/loader-fallback/loader-fallback.tsx
+++ b/scopes/react/ui/loader-fallback/loader-fallback.tsx
@@ -42,22 +42,6 @@ export function useFallback(
   return fallback;
 }
 
-/*
- * TIP:
- * useState() and setState() can receive a function as value.
- * So, be careful when using a react Function Component, like:
- * ```
- * useState(ButtonComponent) // will try to run ButtonComponent as a function
- * setState(ButtonComponent)
- *
- * // instead, do:
- * useState(() => ButtonComponent)
- * setState(() => ButtonComponent)
- * ```
- *
- * or don't set components as state to begin with.
- */
-
 function LoaderComponent() {
   return <LoaderRibbon active style={{ position: 'fixed', top: 0, left: 0, right: 0 }} />;
 }


### PR DESCRIPTION
## Proposed Changes

- convert LoaderFallback component into a hook, so it will be included in the highlighter
- refactor

It specifically fixes this:
<img width="484" alt="Screen Shot 2021-12-01 at 16 21 00" src="https://user-images.githubusercontent.com/5400361/144422608-b6c14f76-d280-4f4f-a6dd-54e7676fa805.png">


verified working with compositions and tests.
