### PR TITLE
support storage resolver for artifacts

### DIFF
--- a/e2e/fixtures/extensions/elements-storage-resolver-env/elements-storage-resolver.env.ts
+++ b/e2e/fixtures/extensions/elements-storage-resolver-env/elements-storage-resolver.env.ts
@@ -1,0 +1,36 @@
+
+
+import { Bundler, BundlerContext } from '@teambit/bundler';
+import { ElementsEnv, BuilderEnv } from "@teambit/envs";
+import { ReactElementsMain } from '@teambit/react-elements';
+import { ElementsWrapperContext } from '@teambit/elements';
+import { WebpackConfigTransformer, WebpackMain } from '@teambit/webpack';
+import { ReactMain } from '@teambit/react';
+import { BuildTask } from '@teambit/builder';
+import { FakeStorageResolver } from './fake-storage-resover';
+
+export class ElementsStorageResolverEnv implements ElementsEnv, BuilderEnv {
+  constructor(
+    private reactElements: ReactElementsMain,
+    private webpack: WebpackMain,
+    private react: ReactMain,
+  ) {}
+  getElementsWrapper(context: ElementsWrapperContext): string {
+    return this.reactElements.getWrapperTemplateFn()(context);
+  }
+  async getElementsBundler(
+    context: BundlerContext,
+    transformers: WebpackConfigTransformer[] = []
+  ): Promise<Bundler> {
+    const reactElementsTransformers =
+      this.reactElements.getWebpackTransformers();
+    const allTransformers = reactElementsTransformers.concat(transformers);
+    return this.webpack.createBundler(context, allTransformers);
+  }
+
+  getBuildPipe(): BuildTask[] {
+    const fakeStorageResolver = new FakeStorageResolver();
+    const elementsTask = this.reactElements.createTask(fakeStorageResolver);
+    return [...this.react.reactEnv.getBuildPipe(), elementsTask];
+  }
+}

--- a/e2e/fixtures/extensions/elements-storage-resolver-env/elements-storage-resolver.extension.ts
+++ b/e2e/fixtures/extensions/elements-storage-resolver-env/elements-storage-resolver.extension.ts
@@ -1,0 +1,19 @@
+import { EnvsMain, EnvsAspect } from '@teambit/envs';
+import { ReactAspect, ReactMain } from '@teambit/react';
+import ReactElementsAspect, { ReactElementsMain } from "@teambit/react-elements";
+import { WebpackAspect, WebpackMain } from '@teambit/webpack';
+
+import {ElementsStorageResolverEnv} from './elements-storage-resolver.env';
+
+export class ElementsStorageResolverMain {
+  static dependencies: any = [EnvsAspect, ReactAspect, WebpackAspect, ReactElementsAspect];
+
+  static async provider([envs, react, webpack, reactElements]: [EnvsMain, ReactMain, WebpackMain, ReactElementsMain]) {
+    const myReactElementsEnv: ElementsStorageResolverEnv = envs.merge(
+      new ElementsStorageResolverEnv(reactElements, webpack, react),
+      react.reactEnv
+    );
+    envs.registerEnv(myReactElementsEnv);
+    return new ElementsStorageResolverMain();
+  }
+}

--- a/e2e/fixtures/extensions/elements-storage-resolver-env/fake-storage-resover.ts
+++ b/e2e/fixtures/extensions/elements-storage-resolver-env/fake-storage-resover.ts
@@ -1,0 +1,18 @@
+import { Component } from "@teambit/component";
+import { Artifact, ArtifactVinyl, FileStorageResolver } from "@teambit/builder";
+
+export class FakeStorageResolver implements FileStorageResolver {
+  name: 'fake-storage-resolver';
+
+  async storeFile(
+    component: Component,
+    artifact: Artifact,
+    file: ArtifactVinyl
+  ): Promise<string> {
+
+    const relativeFilePath = file.relative;
+    const url = `http://fake-url/${relativeFilePath}`;
+
+    return url;
+  }
+}

--- a/e2e/fixtures/extensions/elements-storage-resolver-env/index.ts
+++ b/e2e/fixtures/extensions/elements-storage-resolver-env/index.ts
@@ -1,0 +1,4 @@
+import { ElementsStorageResolverMain } from './elements-storage-resolver.extension';
+
+export default ElementsStorageResolverMain;
+export { ElementsStorageResolverMain };

--- a/e2e/harmony/artifacts-storage-resolver.e2e.ts
+++ b/e2e/harmony/artifacts-storage-resolver.e2e.ts
@@ -1,0 +1,73 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('artifacts storage resolver', function () {
+  this.timeout(0);
+  let helper: Helper;
+  let envId;
+  let envName;
+  before(() => {
+    helper = new Helper();
+    helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+    helper.bitJsonc.setupDefault();
+    // helper.bitJsonc.setPackageManager();
+    envName = helper.env.setCustomEnv('elements-storage-resolver-env');
+    envId = `${helper.scopes.remote}/${envName}`;
+    helper.fixtures.populateComponents(1);
+    helper.extensions.addExtensionToVariant('*', envId);
+    helper.command.compile();
+    helper.command.tagAllComponents();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('store url from storage resolver on local scope', () => {
+    it('should store the urls for the artifacts', () => {
+      const comp1 = helper.command.catComponent('comp1@latest');
+      const files = getElementsArtifactsFromModel(comp1);
+      files.forEach((file) => {
+        const url = file.url;
+        expect(url).to.equal(`http://fake-url/${file.relativePath}`);
+      });
+    });
+  });
+  describe('store url from storage resolver on remote scope', () => {
+    before(() => {
+      helper.command.export();
+    });
+    it('should store the urls for the artifacts', () => {
+      const comp1 = helper.command.catComponent('comp1@latest', helper.scopes.remotePath);
+      const files = getElementsArtifactsFromModel(comp1);
+      files.forEach((file) => {
+        const url = file.url;
+        expect(url).to.equal(`http://fake-url/${file.relativePath}`);
+      });
+    });
+  });
+  describe('store url from storage resolver after import', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importComponent('comp1');
+    });
+    it('should store the urls for the artifacts', () => {
+      const comp1 = helper.command.catComponent('comp1@latest', helper.scopes.remotePath);
+      const files = getElementsArtifactsFromModel(comp1);
+      files.forEach((file) => {
+        const url = file.url;
+        expect(url).to.equal(`http://fake-url/${file.relativePath}`);
+      });
+    });
+  });
+});
+
+type ArtifactFile = { relativePath: string; file: string; url?: string };
+function getElementsArtifactsFromModel(compModel: any): ArtifactFile[] {
+  const builderEntry = compModel.extensions.find((ext) => ext.name === 'teambit.pipelines/builder');
+  const artifacts = builderEntry.data.artifacts;
+  const elementsArtifact = artifacts.find((artifact) => artifact.name === 'elements');
+  return elementsArtifact.files;
+}

--- a/e2e/harmony/artifacts-storage-resolver.e2e.ts
+++ b/e2e/harmony/artifacts-storage-resolver.e2e.ts
@@ -39,7 +39,7 @@ describe('artifacts storage resolver', function () {
       helper.command.export();
     });
     it('should store the urls for the artifacts', () => {
-      const comp1 = helper.command.catComponent('comp1@latest', helper.scopes.remotePath);
+      const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`, helper.scopes.remotePath);
       const files = getElementsArtifactsFromModel(comp1);
       files.forEach((file) => {
         const url = file.url;
@@ -54,7 +54,7 @@ describe('artifacts storage resolver', function () {
       helper.command.importComponent('comp1');
     });
     it('should store the urls for the artifacts', () => {
-      const comp1 = helper.command.catComponent('comp1@latest', helper.scopes.remotePath);
+      const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`, helper.scopes.remotePath);
       const files = getElementsArtifactsFromModel(comp1);
       files.forEach((file) => {
         const url = file.url;

--- a/scopes/pipelines/builder/artifact/artifact-definition.ts
+++ b/scopes/pipelines/builder/artifact/artifact-definition.ts
@@ -1,3 +1,5 @@
+import { ArtifactStorageResolver } from '..';
+
 export type ArtifactDefinition = {
   /**
    * name of the artifact.
@@ -48,5 +50,9 @@ export type ArtifactDefinition = {
    * storage resolver. can be used to replace where artifacts are stored.
    * default resolver persists artifacts on scope. (not recommended for large files!)
    */
+  storageResolver?: ArtifactStorageResolver;
+};
+
+export type ArtifactModelDefinition = Omit<ArtifactDefinition, 'storageResolver'> & {
   storageResolver?: string;
 };

--- a/scopes/pipelines/builder/artifact/artifact-factory.ts
+++ b/scopes/pipelines/builder/artifact/artifact-factory.ts
@@ -3,9 +3,8 @@ import globby from 'globby';
 import { flatten } from 'lodash';
 import { ArtifactFiles } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { Component, ComponentMap } from '@teambit/component';
-import type { StorageResolverSlot } from '../builder.main.runtime';
 import { ArtifactDefinition } from './artifact-definition';
-import { DefaultResolver, StorageResolver } from '../storage';
+import { DefaultResolver } from '../storage';
 import { ArtifactList } from './artifact-list';
 import { Artifact } from './artifact';
 import type { BuildContext, BuildTask } from '../build-task';
@@ -16,14 +15,6 @@ export const DEFAULT_CONTEXT = 'component';
 export type ArtifactMap = ComponentMap<ArtifactList>;
 
 export class ArtifactFactory {
-  constructor(private storageResolverSlot: StorageResolverSlot) {}
-
-  private getResolver(resolvers: StorageResolver[], name?: string) {
-    const defaultResolver = new DefaultResolver();
-    const userResolver = resolvers.find((resolver) => resolver.name === name);
-    return userResolver || defaultResolver;
-  }
-
   private resolvePaths(root: string, def: ArtifactDefinition): string[] {
     const patternsFlattened = flatten(def.globPatterns);
     const paths = globby.sync(patternsFlattened, { cwd: root });
@@ -61,8 +52,7 @@ export class ArtifactFactory {
   }
 
   private getStorageResolver(def: ArtifactDefinition) {
-    const storageResolvers = this.storageResolverSlot.values();
-    return this.getResolver(storageResolvers, def.storageResolver);
+    return def.storageResolver || new DefaultResolver();
   }
 
   private toComponentMap(context: BuildContext, artifactMap: [string, Artifact][]) {

--- a/scopes/pipelines/builder/artifact/artifact.ts
+++ b/scopes/pipelines/builder/artifact/artifact.ts
@@ -1,6 +1,6 @@
 import type { ArtifactFiles, ArtifactObject } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import type { BuildTask } from '../build-task';
-import type { StorageResolver } from '../storage';
+import type { ArtifactStorageResolver } from '../storage';
 import type { ArtifactDefinition } from './artifact-definition';
 
 export class Artifact {
@@ -13,7 +13,7 @@ export class Artifact {
     /**
      * storage resolver. can be used to replace where artifacts are stored.
      */
-    readonly storageResolver: StorageResolver,
+    readonly storageResolver: ArtifactStorageResolver,
 
     readonly files: ArtifactFiles,
 

--- a/scopes/pipelines/builder/artifact/index.ts
+++ b/scopes/pipelines/builder/artifact/index.ts
@@ -1,4 +1,4 @@
-export { ArtifactDefinition } from './artifact-definition';
+export { ArtifactDefinition, ArtifactModelDefinition } from './artifact-definition';
 export { ExtensionArtifact } from './extension-artifact';
 export { Artifact } from './artifact';
 export { ArtifactList } from './artifact-list';

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -20,7 +20,6 @@ import { builderSchema } from './builder.graphql';
 import { BuilderService, BuilderServiceOptions } from './builder.service';
 import { BuilderCmd } from './build.cmd';
 import { BuildTask } from './build-task';
-import { ArtifactStorageResolver } from './storage';
 import { TaskResults } from './build-pipe';
 import { TaskResultsList } from './task-results-list';
 import { ArtifactStorageError } from './exceptions';
@@ -30,8 +29,6 @@ import { ArtifactsCmd } from './artifact/artifacts.cmd';
 import { buildTaskTemplate } from './templates/build-task';
 
 export type TaskSlot = SlotRegistry<BuildTask[]>;
-
-export type StorageResolverSlot = SlotRegistry<ArtifactStorageResolver>;
 
 export type BuilderData = {
   pipeline: PipelineReport[];
@@ -248,12 +245,7 @@ export class BuilderMain {
     return this;
   }
 
-  static slots = [
-    Slot.withType<BuildTask>(),
-    Slot.withType<ArtifactStorageResolver>(),
-    Slot.withType<BuildTask>(),
-    Slot.withType<BuildTask>(),
-  ];
+  static slots = [Slot.withType<BuildTask>(), Slot.withType<BuildTask>(), Slot.withType<BuildTask>()];
 
   static runtime = MainRuntime;
   static dependencies = [

--- a/scopes/pipelines/builder/index.ts
+++ b/scopes/pipelines/builder/index.ts
@@ -4,6 +4,7 @@ export { BuildContext, BuildTask, BuiltTaskResult, TaskLocation, BuildTaskHelper
 export type { BuilderMain, BuilderData } from './builder.main.runtime';
 export type { PipelineReport } from './build-pipeline-result-list';
 export { BuilderAspect } from './builder.aspect';
-export { StorageResolver } from './storage';
-export { Artifact, ArtifactList, ArtifactFactory, ArtifactDefinition } from './artifact';
+export { WholeArtifactStorageResolver, FileStorageResolver, ArtifactStorageResolver } from './storage';
+export { Artifact, ArtifactList, ArtifactFactory, ArtifactDefinition, ArtifactModelDefinition } from './artifact';
 export { TaskResultsList } from './task-results-list';
+export { ArtifactVinyl } from '@teambit/legacy/dist/consumer/component/sources/artifact';

--- a/scopes/pipelines/builder/storage/default-resolver.ts
+++ b/scopes/pipelines/builder/storage/default-resolver.ts
@@ -1,13 +1,11 @@
 import { Component } from '@teambit/component';
-import { StorageResolver } from './storage-resolver';
-import type { ArtifactList } from '../artifact';
+import { WholeArtifactStorageResolver } from './storage-resolver';
+import type { Artifact } from '../artifact';
 
-export class DefaultResolver implements StorageResolver {
+export class DefaultResolver implements WholeArtifactStorageResolver {
   name = 'default';
 
-  async store(component: Component, artifactList: ArtifactList) {
-    artifactList.artifacts.forEach((artifact) => {
-      artifact.files.populateVinylsFromPaths(artifact.rootDir);
-    });
+  async store(component: Component, artifact: Artifact) {
+    artifact.files.populateVinylsFromPaths(artifact.rootDir);
   }
 }

--- a/scopes/pipelines/builder/storage/index.ts
+++ b/scopes/pipelines/builder/storage/index.ts
@@ -1,2 +1,2 @@
-export { StorageResolver } from './storage-resolver';
+export { WholeArtifactStorageResolver, ArtifactStorageResolver, FileStorageResolver } from './storage-resolver';
 export { DefaultResolver } from './default-resolver';

--- a/scopes/pipelines/builder/storage/storage-resolver.ts
+++ b/scopes/pipelines/builder/storage/storage-resolver.ts
@@ -1,18 +1,30 @@
 import { Component } from '@teambit/component';
-import { ArtifactList } from '../artifact';
+import { ArtifactVinyl } from '@teambit/legacy/dist/consumer/component/sources/artifact';
+import { Artifact } from '../artifact';
 
 export type StoreResult = {
   [path: string]: string;
 };
 
-export interface StorageResolver {
+interface BaseStorageResolver {
   /**
    * name of the storage resolver.
    */
   name: string;
+}
 
+export interface WholeArtifactStorageResolver extends BaseStorageResolver {
   /**
    * store artifacts in the storage.
    */
-  store(component: Component, artifacts: ArtifactList): Promise<void>;
+  store(component: Component, artifact: Artifact): Promise<StoreResult | undefined | void>;
 }
+
+export interface FileStorageResolver extends BaseStorageResolver {
+  /**
+   * store artifacts in the storage.
+   */
+  storeFile(component: Component, artifact: Artifact, file: ArtifactVinyl): Promise<string | undefined | void>;
+}
+
+export type ArtifactStorageResolver = FileStorageResolver | WholeArtifactStorageResolver;

--- a/scopes/react/react-elements/react-elements.main.runtime.ts
+++ b/scopes/react/react-elements/react-elements.main.runtime.ts
@@ -1,4 +1,5 @@
 import { MainRuntime } from '@teambit/cli';
+import { ArtifactStorageResolver } from '@teambit/builder';
 import { WebpackConfigTransformer } from '@teambit/webpack';
 import ElementsAspect, { ElementsMain } from '@teambit/elements';
 import { GetWrapperOpts, getWrapperTemplateFn } from './element-wrapper-template';
@@ -9,8 +10,8 @@ import { ReactElementsAspect } from './react-elements.aspect';
 
 export class ReactElementsMain {
   constructor(private elements: ElementsMain) {}
-  createTask() {
-    return this.elements.createTask();
+  createTask(storageResolver?: ArtifactStorageResolver) {
+    return this.elements.createTask(storageResolver);
   }
 
   getWrapperTemplateFn(opts?: Partial<GetWrapperOpts>) {

--- a/scopes/react/ui/docs-app/component-overview/component-overview.tsx
+++ b/scopes/react/ui/docs-app/component-overview/component-overview.tsx
@@ -25,8 +25,11 @@ export function ComponentOverview({
   elementsUrl,
   ...rest
 }: ComponentOverviewProps) {
-  const origin = typeof window !== undefined ? window.location.origin : undefined;
-  const finalElementsUrl = origin && elementsUrl ? `${origin}${elementsUrl}` : undefined;
+  let finalElementsUrl = elementsUrl;
+  if (finalElementsUrl && !finalElementsUrl.startsWith('http')) {
+    const origin = typeof window !== undefined ? window.location.origin : undefined;
+    finalElementsUrl = origin && elementsUrl ? `${origin}${elementsUrl}` : undefined;
+  }
   return (
     <Section {...rest}>
       <div className={textColumn}>

--- a/scopes/web-components/elements/compute-results.ts
+++ b/scopes/web-components/elements/compute-results.ts
@@ -1,7 +1,12 @@
-import { ArtifactDefinition, ComponentResult } from '@teambit/builder';
+import { ArtifactDefinition, ArtifactStorageResolver, ComponentResult } from '@teambit/builder';
 import { BundlerContext, BundlerResult } from '@teambit/bundler';
 
-export async function computeResults(context: BundlerContext, results: BundlerResult[], outDirName: string) {
+export async function computeResults(
+  context: BundlerContext,
+  results: BundlerResult[],
+  outDirName: string,
+  storageResolver?: ArtifactStorageResolver
+) {
   const result = results[0];
 
   const componentsResults: ComponentResult[] = result.components.map((component) => {
@@ -14,7 +19,7 @@ export async function computeResults(context: BundlerContext, results: BundlerRe
     };
   });
 
-  const artifacts = getArtifactDef(outDirName);
+  const artifacts = getArtifactDef(outDirName, storageResolver);
 
   return {
     componentsResults,
@@ -22,11 +27,12 @@ export async function computeResults(context: BundlerContext, results: BundlerRe
   };
 }
 
-function getArtifactDef(outDirName: string): ArtifactDefinition[] {
+function getArtifactDef(outDirName: string, storageResolver?: ArtifactStorageResolver): ArtifactDefinition[] {
   return [
     {
       name: 'element',
       globPatterns: [`${outDirName}/public/**`],
+      storageResolver,
     },
   ];
 }

--- a/scopes/web-components/elements/compute-results.ts
+++ b/scopes/web-components/elements/compute-results.ts
@@ -30,7 +30,7 @@ export async function computeResults(
 function getArtifactDef(outDirName: string, storageResolver?: ArtifactStorageResolver): ArtifactDefinition[] {
   return [
     {
-      name: 'element',
+      name: 'elements',
       globPatterns: [`${outDirName}/public/**`],
       storageResolver,
     },

--- a/scopes/web-components/elements/compute-targets.ts
+++ b/scopes/web-components/elements/compute-targets.ts
@@ -46,7 +46,7 @@ async function getEntryFile(
 ): Promise<string> {
   const mainFilePath = getMainFilePath(context, component);
   const entryContent = elementsWrapperFn({ mainFilePath, componentName: component.id.name });
-  const targetPath = join(outputPath, `__element.js`);
+  const targetPath = join(outputPath, `__elements.js`);
   writeFileSync(targetPath, entryContent);
   return targetPath;
 }

--- a/scopes/web-components/elements/elements-artifact.ts
+++ b/scopes/web-components/elements/elements-artifact.ts
@@ -1,8 +1,8 @@
-import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
+import { ArtifactVinyl } from '@teambit/legacy/dist/consumer/component/sources/artifact';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 
 export class ElementsArtifact {
-  constructor(private artifacts: AbstractVinyl[]) {}
+  constructor(private artifacts: ArtifactVinyl[]) {}
 
   static defaultMainFilePrefix = 'elements';
 
@@ -24,5 +24,12 @@ export class ElementsArtifact {
     return this.artifacts.find((file) => {
       return pathNormalizeToLinux(file.relative).includes(`${this.getDefaultMainFilePrefix()}.`);
     });
+  }
+
+  getMainElementsFileUrl(): string | undefined {
+    const mainFile = this.artifacts.find((file) => {
+      return pathNormalizeToLinux(file.relative).includes(`${this.getDefaultMainFilePrefix()}.`);
+    });
+    return mainFile?.url;
   }
 }

--- a/scopes/web-components/elements/elements.main.runtime.ts
+++ b/scopes/web-components/elements/elements.main.runtime.ts
@@ -1,5 +1,5 @@
 import camelCase from 'camelcase';
-import { BuilderAspect, BuilderMain } from '@teambit/builder';
+import { ArtifactStorageResolver, BuilderAspect, BuilderMain } from '@teambit/builder';
 import { MainRuntime } from '@teambit/cli';
 import ComponentAspect, { Component, ComponentMain } from '@teambit/component';
 import { LoggerAspect, LoggerMain } from '@teambit/logger';
@@ -19,8 +19,8 @@ export class ElementsMain {
     return '__element';
   }
 
-  createTask() {
-    return new ElementTask(this);
+  createTask(storageResolver?: ArtifactStorageResolver) {
+    return new ElementTask(this, storageResolver);
   }
 
   getWebpackTransformers(): WebpackConfigTransformer[] {
@@ -51,9 +51,15 @@ export class ElementsMain {
   }
 
   async getElementUrl(component: Component): Promise<string | undefined> {
+    const artifacts = await this.getElements(component);
     // In case there are no elements return as undefined
-    if (!this.isElementsExist(component)) return undefined;
-    // TODO: Check if deployed
+    if (artifacts?.isEmpty()) return undefined;
+    const url = artifacts?.getMainElementsFileUrl();
+    // In case of public url (like cdn) return the public url
+    if (url) {
+      return url;
+    }
+    // return the url in the scope
     return this.componentExtension.getRoute(component.id, this.baseRoute);
   }
 

--- a/scopes/web-components/elements/elements.main.runtime.ts
+++ b/scopes/web-components/elements/elements.main.runtime.ts
@@ -16,7 +16,7 @@ export class ElementsMain {
   baseRoute = `elements/`;
 
   getElementsDirName(): string {
-    return '__element';
+    return '__bit__elements';
   }
 
   createTask(storageResolver?: ArtifactStorageResolver) {

--- a/scopes/web-components/elements/elements.task.ts
+++ b/scopes/web-components/elements/elements.task.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'path';
 import { ExecutionContext } from '@teambit/envs';
-import { BuildContext, BuiltTaskResult, BuildTask, TaskLocation } from '@teambit/builder';
+import { BuildContext, BuiltTaskResult, BuildTask, TaskLocation, ArtifactStorageResolver } from '@teambit/builder';
 import { CompilerAspect } from '@teambit/compiler';
 import { Bundler, BundlerContext, Target } from '@teambit/bundler';
 import { ElementsMain } from './elements.main.runtime';
@@ -19,7 +19,8 @@ export class ElementTask implements BuildTask {
     /**
      * elements extension.
      */
-    private elements: ElementsMain
+    private elements: ElementsMain,
+    private storageResolver?: ArtifactStorageResolver
   ) {}
 
   aspectId = ElementsAspect.id;
@@ -46,7 +47,7 @@ export class ElementTask implements BuildTask {
     const bundler: Bundler = await context.env.getElementsBundler(bundlerContext, []);
     const bundlerResults = await bundler.run();
 
-    return computeResults(bundlerContext, bundlerResults, outDirName);
+    return computeResults(bundlerContext, bundlerResults, outDirName, this.storageResolver);
   }
 
   getElementsDir(context: ExecutionContext) {

--- a/scopes/web-components/elements/elements.task.ts
+++ b/scopes/web-components/elements/elements.task.ts
@@ -29,7 +29,7 @@ export class ElementTask implements BuildTask {
   readonly dependencies = [CompilerAspect.id];
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
-    const url = `/element/${context.envRuntime.id}`;
+    const url = `/elements/${context.envRuntime.id}`;
 
     const outDirName = this.elements.getElementsDirName();
 

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -634,7 +634,7 @@ export default class Component {
             shouldBuildDependencies,
             writeDists: false,
             installNpmPackages,
-            keepExistingCapsule: true,
+            keepExistingCapsule,
           });
           return new ExtensionIsolateResult(isolator, componentWithDependencies);
         };

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -634,7 +634,7 @@ export default class Component {
             shouldBuildDependencies,
             writeDists: false,
             installNpmPackages,
-            keepExistingCapsule,
+            keepExistingCapsule: true,
           });
           return new ExtensionIsolateResult(isolator, componentWithDependencies);
         };

--- a/src/consumer/component/sources/artifact.ts
+++ b/src/consumer/component/sources/artifact.ts
@@ -1,3 +1,11 @@
 import { AbstractVinyl } from '.';
 
-export class ArtifactVinyl extends AbstractVinyl {}
+export class ArtifactVinyl extends AbstractVinyl {
+  url?: string;
+  constructor(opts) {
+    super(opts);
+    if (opts.url) {
+      this.url = opts.url;
+    }
+  }
+}

--- a/src/e2e-helper/e2e-env-helper.ts
+++ b/src/e2e-helper/e2e-env-helper.ts
@@ -225,15 +225,14 @@ export default class EnvHelper {
     return EXTENSIONS_BASE_FOLDER;
   }
 
-  setCustomEnv(): string {
-    const EXTENSIONS_BASE_FOLDER = 'node-env';
-    this.fixtures.copyFixtureExtensions(EXTENSIONS_BASE_FOLDER);
-    this.command.addComponent(EXTENSIONS_BASE_FOLDER);
-    this.extensions.addExtensionToVariant(EXTENSIONS_BASE_FOLDER, 'teambit.harmony/aspect');
+  setCustomEnv(extensionsBaseFolder = 'node-env'): string {
+    this.fixtures.copyFixtureExtensions(extensionsBaseFolder);
+    this.command.addComponent(extensionsBaseFolder);
+    this.extensions.addExtensionToVariant(extensionsBaseFolder, 'teambit.harmony/aspect');
     this.command.link();
     this.command.install();
     this.command.compile();
-    return EXTENSIONS_BASE_FOLDER;
+    return extensionsBaseFolder;
   }
 
   getComponentEnv(id: string): string {


### PR DESCRIPTION
## Proposed Changes

- Storage resolver for artifacts is a way to provide a resolver that will store the artifact files in remote hosting, and store the public URL of the artifact in bit's objects
- remove unused artifact storage resolver slot
- change element to elements in some internal places
