### PR TITLE
chore(create): improve "bit create --scope" to save the scope as the defaultScope

### DIFF
--- a/e2e/harmony/create.e2e.4.ts
+++ b/e2e/harmony/create.e2e.4.ts
@@ -109,4 +109,34 @@ describe('create extension', function () {
       expect(() => helper.command.create('aspect', 'my-aspect', '--scope ui/')).to.throw('"ui/" is invalid');
     });
   });
+  describe('with --scope flag', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.addDefaultScope('my-scope');
+      helper.command.create('aspect', 'my-aspect', `--scope ${helper.scopes.remote}`);
+    });
+    it('should add the component to the .bitmap file with a new defaultScope prop', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.have.property('my-aspect');
+      expect(bitMap['my-aspect']).to.have.property('defaultScope');
+      expect(bitMap['my-aspect'].defaultScope).to.equal(helper.scopes.remote);
+    });
+    it('bit show should show this scope as the defaultScope', () => {
+      const show = helper.command.showComponent('my-aspect');
+      expect(show).to.include(helper.scopes.remote);
+    });
+    describe('exporting the component', () => {
+      before(() => {
+        helper.command.tagAllWithoutBuild('--ignore-issues');
+        // the fact the export succeed, means the defaultScope from .bitmap taken into account
+        // otherwise, it would have been used the workspace.jsonc defaultScope "my-scope" and fails.
+        helper.command.export();
+      });
+      it('should delete the defaultScope prop from .bitmap', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap).to.have.property('my-aspect');
+        expect(bitMap['my-aspect']).to.not.have.property('defaultScope');
+      });
+    });
+  });
 });

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -806,6 +806,11 @@ export class Workspace implements ComponentFactory {
     if (componentConfigFile && componentConfigFile.defaultScope) {
       return componentConfigFile.defaultScope;
     }
+    const bitMapId = this.consumer.bitMap.getExistingBitId(name);
+    const bitMapEntry = bitMapId ? this.consumer.bitMap.getComponent(bitMapId) : undefined;
+    if (bitMapEntry && bitMapEntry.defaultScope) {
+      return bitMapEntry.defaultScope;
+    }
     return this.componentDefaultScopeFromComponentDirAndNameWithoutConfigFile(relativeComponentDir, name);
   }
 

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -628,6 +628,7 @@ export default class BitMap {
   addComponent({
     componentId,
     files,
+    defaultScope,
     mainFile,
     origin,
     rootDir,
@@ -638,6 +639,7 @@ export default class BitMap {
   }: {
     componentId: BitId;
     files: ComponentMapFile[];
+    defaultScope?: string;
     mainFile: PathLinux;
     origin: ComponentOrigin;
     rootDir?: PathOsBasedAbsolute | PathOsBasedRelative;
@@ -682,6 +684,9 @@ export default class BitMap {
     }
     if (onLanesOnly) {
       componentMap.onLanesOnly = onLanesOnly;
+    }
+    if (defaultScope) {
+      componentMap.defaultScope = defaultScope;
     }
     componentMap.removeTrackDirIfNeeded();
     if (originallySharedDir) {
@@ -778,6 +783,10 @@ export default class BitMap {
       // change the version only on the lane, not on .bitmap
       this.workspaceLane.addEntry(newId);
       componentMap.defaultVersion = componentMap.defaultVersion || oldId.version;
+    }
+    if (updateScopeOnly) {
+      // in case it had defaultScope, no need for it anymore.
+      delete componentMap.defaultScope;
     }
     this._removeFromComponentsArray(oldId);
     this.setComponent(newId, componentMap);

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -39,6 +39,7 @@ type LaneVersion = { remoteLane: RemoteLaneId; version: string };
 export type ComponentMapData = {
   id: BitId;
   files: ComponentMapFile[];
+  defaultScope?: string;
   mainFile: PathLinux;
   rootDir?: PathLinux;
   trackDir?: PathLinux;
@@ -58,6 +59,7 @@ export type PathChange = { from: PathLinux; to: PathLinux };
 export default class ComponentMap {
   id: BitId;
   files: ComponentMapFile[];
+  defaultScope?: string;
   mainFile: PathLinux;
   rootDir?: PathLinux; // always set for IMPORTED and NESTED.
   // reason why trackDir and not re-use rootDir is because using rootDir requires all paths to be
@@ -84,6 +86,7 @@ export default class ComponentMap {
   constructor({
     id,
     files,
+    defaultScope,
     mainFile,
     rootDir,
     trackDir,
@@ -98,6 +101,7 @@ export default class ComponentMap {
   }: ComponentMapData) {
     this.id = id;
     this.files = files;
+    this.defaultScope = defaultScope;
     this.mainFile = mainFile;
     this.rootDir = rootDir;
     this.trackDir = trackDir;
@@ -131,6 +135,7 @@ export default class ComponentMap {
       scope: this.scope,
       version: this.version,
       files: isLegacy || !this.rootDir ? this.files.map((file) => sortObject(file)) : null,
+      defaultScope: this.defaultScope,
       mainFile: this.mainFile,
       rootDir: this.rootDir,
       trackDir: this.trackDir,

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -358,6 +358,7 @@ export default class AddComponents {
       const componentMap = this.bitMap.addComponent({
         componentId,
         files: component.files,
+        defaultScope: this.defaultScope,
         mainFile,
         trackDir: rootDir ? '' : trackDir, // if rootDir exists, no need for trackDir.
         origin: COMPONENT_ORIGINS.AUTHORED,


### PR DESCRIPTION
Currently, upon creating a component, the defaultScope is determined by the workspace.jsonc file. With this PR, the `--scope` flag is taken into account and is used later to export to this scope.

Implementation wise, a new prop is added to the .bitmap file `defaultScope` and gets deleted upon `bit export`.