### PR TITLE
 delete the dist dir during compilation according to the specific compiler configuration

### DIFF
--- a/scopes/compilation/babel/babel.compiler.ts
+++ b/scopes/compilation/babel/babel.compiler.ts
@@ -35,6 +35,7 @@ export class BabelCompiler implements Compiler {
   }
 
   displayName = 'Babel';
+  deleteDistDir = false;
 
   version() {
     return this.babelModule.version;

--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -28,6 +28,7 @@ export class CompileCmd implements Command {
     ['c', 'changed', 'compile only new and modified components'],
     ['v', 'verbose', 'show more data, such as, dist paths'],
     ['j', 'json', 'return the compile results in json format'],
+    ['d', 'delete-dist-dir', 'delete existing dist folder before writing new compiled files'],
   ] as CommandOptions;
 
   constructor(private compile: WorkspaceCompiler, private logger: Logger, private pubsub: PubsubMain) {}
@@ -41,7 +42,6 @@ export class CompileCmd implements Command {
     await this.compile.compileComponents(components, {
       ...compilerOptions,
       initiator: CompilationInitiator.CmdReport,
-      deleteDistDir: true,
     });
     const compileTimeLength = process.hrtime(startTimestamp);
 
@@ -66,7 +66,6 @@ export class CompileCmd implements Command {
     const compileResults = await this.compile.compileComponents(components, {
       ...compilerOptions,
       initiator: CompilationInitiator.CmdJson,
-      deleteDistDir: true,
     });
     return {
       data: compileResults,

--- a/scopes/compilation/compiler/types.ts
+++ b/scopes/compilation/compiler/types.ts
@@ -71,6 +71,11 @@ export interface Compiler extends CompilerOptions {
   id: string;
 
   /**
+   * Delete dist folder before writing the new compiled files
+   */
+  deleteDistDir?: boolean;
+
+  /**
    * serialized config of the compiler.
    */
   displayConfig?(): string;

--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -53,8 +53,9 @@ export class ComponentCompiler {
 
   async compile(noThrow = true, options: CompileOptions): Promise<BuildResult> {
     let dataToPersist;
+    const deleteDistDir = options.deleteDistDir ?? this.compilerInstance.deleteDistDir;
     // delete dist folder before transpilation (because some compilers (like ngPackagr) can generate files there during the compilation process)
-    if (options.deleteDistDir) {
+    if (deleteDistDir) {
       dataToPersist = new DataToPersist();
       dataToPersist.removePath(new RemovePath(this.distDir));
       dataToPersist.addBasePath(this.workspace.path);

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -32,6 +32,7 @@ export class TypescriptCompiler implements Compiler {
   }
 
   displayName = 'TypeScript';
+  deleteDistDir = false;
 
   displayConfig() {
     return this.stringifyTsconfig(this.options.tsconfig);


### PR DESCRIPTION
This should fix an issue when you run `bit compile` when `bit start` is running in the background and get errors as a result of it