### PR TITLE
feat(lanes): add switch command as a sub-command of "bit lane" as well

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -25,6 +25,7 @@ import {
   LaneTrackCmd,
 } from './lane.cmd';
 import { lanesSchema } from './lanes.graphql';
+import { SwitchCmd } from './switch.cmd';
 
 export type LaneResults = {
   lanes: LaneData[];
@@ -175,10 +176,12 @@ export class LanesMain {
   static async provider([cli, scope, workspace, graphql]: [CLIMain, ScopeMain, Workspace, GraphqlMain]) {
     const lanesMain = new LanesMain(workspace, scope);
     const isLegacy = workspace && workspace.consumer.isLegacy;
+    const switchCmd = new SwitchCmd();
     if (!isLegacy) {
       const laneCmd = new LaneCmd(lanesMain, workspace, scope);
       laneCmd.commands = [
         new LaneListCmd(lanesMain, workspace, scope),
+        switchCmd,
         new LaneShowCmd(lanesMain, workspace, scope),
         new LaneCreateCmd(lanesMain),
         new LaneMergeCmd(lanesMain),
@@ -186,7 +189,7 @@ export class LanesMain {
         new LaneTrackCmd(lanesMain),
         new LaneDiffCmd(workspace, scope),
       ];
-      cli.register(laneCmd);
+      cli.register(laneCmd, switchCmd);
       graphql.register(lanesSchema(lanesMain));
     }
     return lanesMain;

--- a/src/cli/command-registry-builder.ts
+++ b/src/cli/command-registry-builder.ts
@@ -51,7 +51,6 @@ import ScopeConfig from './commands/public-cmds/scope-config-cmd';
 import Show from './commands/public-cmds/show-cmd';
 import Snap from './commands/public-cmds/snap-cmd';
 import Status from './commands/public-cmds/status-cmd';
-import Switch from './commands/public-cmds/switch-cmd';
 import Test from './commands/public-cmds/test-cmd';
 import Undeprecate from './commands/public-cmds/undeprecate-cmd';
 import Untag from './commands/public-cmds/untag-cmd';
@@ -153,8 +152,6 @@ export default function registerCommands(extensionsCommands: Array<Commands>): C
       new Doctor(),
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       new Graph(),
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      new Switch(),
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       new Fetch(),
       new RunAction(),


### PR DESCRIPTION
Currently, to switch between lanes, you should run `bit switch`. This PR adds the command to be a sub-command of `bit lane`, so you could run also `bit lane switch`.