### PR TITLE
treeNode - allow default undefined value for 'isActive'

### DIFF
--- a/scopes/ui-foundation/tree/tree-node/tree-node.tsx
+++ b/scopes/ui-foundation/tree/tree-node/tree-node.tsx
@@ -23,11 +23,14 @@ export type TreeNodeComponentProps<Payload = any> = {
  * Renders a file node in the file tree
  */
 export function TreeNode<T>(props: TreeNodeComponentProps<T>) {
-  const { node, isActive = false, icon, onClick, widgets, href } = props;
+  const { node, isActive, icon, onClick, widgets, href } = props;
+
+  const active = isActive !== undefined ? () => isActive : undefined;
+
   return (
     <NavLink
       href={href || node.id}
-      isActive={() => isActive}
+      isActive={active}
       exact
       strict
       className={classNames(indentClass, clickable, styles.fileNode)}


### PR DESCRIPTION
## Proposed Changes

- Remove default value `undefined` from TreeNode, so link will be able to calculate activity by itself.

## Usages
- Code Tab tree (used with an explicit value - no defaults) - ✓ verified

Does not seem to be used anywhere else
