### PR TITLE
fix(lane): update lane data when un-snapping on a lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1147,4 +1147,33 @@ describe('bit lane command', function () {
       });
     });
   });
+  // @todo: this is currently failing.
+  describe.skip('snapping and un-tagging on a lane then switching to main', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.untagAll();
+    });
+    it('bit lane show should not show the component as belong to the lane anymore', () => {
+      const lane = helper.command.showOneLaneParsed('dev');
+      expect(lane.components).to.have.lengthOf(0);
+    });
+    // a previous bug kept the WorkspaceLane object as is with the previous, untagged version
+    it('bit list should not show the currentVersion as the untagged version', () => {
+      const list = helper.command.listParsed();
+      expect(list[0].currentVersion).to.equal('<new>');
+    });
+    describe('switching to main', () => {
+      before(() => {
+        helper.command.switchLocalLane('main');
+      });
+      it('bit status should show the component as new', () => {
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(1);
+      });
+    });
+  });
 });

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1147,7 +1147,7 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe('snapping and un-tagging on a lane then switching to main', () => {
+  describe('snapping and un-tagging on a lane', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1147,8 +1147,7 @@ describe('bit lane command', function () {
       });
     });
   });
-  // @todo: this is currently failing.
-  describe.skip('snapping and un-tagging on a lane then switching to main', () => {
+  describe('snapping and un-tagging on a lane then switching to main', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
@@ -1164,7 +1163,7 @@ describe('bit lane command', function () {
     // a previous bug kept the WorkspaceLane object as is with the previous, untagged version
     it('bit list should not show the currentVersion as the untagged version', () => {
       const list = helper.command.listParsed();
-      expect(list[0].currentVersion).to.equal('<new>');
+      expect(list[0].currentVersion).to.equal('N/A');
     });
     describe('switching to main', () => {
       before(() => {

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1147,13 +1147,15 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe('snapping and un-tagging on a lane', () => {
+  describe.only('snapping and un-tagging on a lane', () => {
+    let afterFirstSnap: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
+      afterFirstSnap = helper.scopeHelper.cloneLocalScope();
       helper.command.untagAll();
     });
     it('bit lane show should not show the component as belong to the lane anymore', () => {
@@ -1172,6 +1174,19 @@ describe('bit lane command', function () {
       it('bit status should show the component as new', () => {
         const status = helper.command.statusJson();
         expect(status.newComponents).to.have.lengthOf(1);
+      });
+    });
+    describe('add another snap and then untag only the last snap', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(afterFirstSnap);
+        helper.command.snapComponentWithoutBuild('comp1', '--force');
+        const head = helper.command.getHeadOfLane('dev', 'comp1');
+        helper.command.untagAll(head);
+      });
+      it('should not show the component as new', () => {
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(0);
+        expect(status.stagedComponents).to.have.lengthOf(1);
       });
     });
   });

--- a/scopes/lanes/lanes/lanes.docs.md
+++ b/scopes/lanes/lanes/lanes.docs.md
@@ -50,7 +50,7 @@ Currently, if it imports with no-deps, it doesn't ask for parents, if it imports
 Lane data, for the most cases is a map of component-id:snap-head, in other words, it saves per component the head snap. There are 3 different places where we store such data for different purposes.
 
 - `lane-object` "Lane" is saved in the scope `.bit/objects` (.bit can be .git/bit locally), it has a unique hash and contains a map of components and their heads. This object exists on both local and remote scopes. Its main purpose is to sync lane-data between scopes. See `Lane` class (in scope/model) for the implementation details.
-- `workspace-lane` (component and their heads) is saved in `.bit/workspace/lanes/lane-name`. Remote scopes don't have this data. Its main purpose is to store data that exists only locally and does not exist on the remote. See `WorkspaceLane` class for the implementation details.
+- `workspace-lane` (component and their versions) is saved in `.bit/workspace/lanes/lane-name`. Remote scopes don't have this data. Its main purpose is to store data that exists only locally and does not exist on the remote. See `WorkspaceLane` class for the implementation details. Without this, when a user is on a lane and check out to another snap, we can't save this checked out snap, because .bitmap has only main version and `Lane` object has only the heads.
 - `remote-lane` (component and their heads) is saved in `.bit/refs/remote/remote-name/lane-name`. These refs files are saved in both, local and remote scopes. Its main purpose is to keep track where the remote-heads are per lane. See `RemoteLanes` class for the implementation details.
 
 More places that stores lanes related data:

--- a/src/api/consumer/lib/untag.ts
+++ b/src/api/consumer/lib/untag.ts
@@ -19,19 +19,20 @@ export default async function unTagAction(
   const consumer: Consumer = await loadConsumer();
   const idHasWildcard = hasWildcard(id);
   const untag = async (): Promise<untagResult[]> => {
+    const currentLane = await consumer.getCurrentLaneObject();
     if (idHasWildcard) {
-      return removeLocalVersionsForComponentsMatchedByWildcard(consumer, version, force, id);
+      return removeLocalVersionsForComponentsMatchedByWildcard(consumer, currentLane, version, force, id);
     }
     if (id) {
       const bitId = consumer.getParsedId(id);
       // a user might run the command `bit untag id@version` instead of `bit untag id version`
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       if (bitId.hasVersion() && !version) version = bitId.version;
-      const result = await removeLocalVersion(consumer.scope, bitId, version, force);
+      const result = await removeLocalVersion(consumer.scope, bitId, currentLane, version, force);
       return [result];
     }
     // untag all
-    return removeLocalVersionsForAllComponents(consumer, version, force);
+    return removeLocalVersionsForAllComponents(consumer, currentLane, version, force);
   };
   const softUntag = () => {
     const getIds = (): BitId[] => {

--- a/src/cli/commands/public-cmds/status-cmd.ts
+++ b/src/cli/commands/public-cmds/status-cmd.ts
@@ -237,7 +237,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       snappedComponents.length ? chalk.underline.white('snapped components') + snappedDesc : ''
     ).join('\n');
 
-    const laneStr = laneName ? `\nchecked out to "${chalk.bold(laneName)}" lane` : '';
+    const laneStr = laneName ? `\non ${chalk.bold(laneName)} lane` : '';
 
     const troubleshootingStr = showTroubleshootingLink ? `\n${TROUBLESHOOTING_MESSAGE}` : '';
 

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -781,7 +781,13 @@ export default class BitMap {
     if (this.workspaceLane && !updateScopeOnly) {
       // this code is executed when snapping/tagging and user is on a lane.
       // change the version only on the lane, not on .bitmap
-      this.workspaceLane.addEntry(newId);
+      if (newId.hasVersion()) {
+        this.workspaceLane.addEntry(newId);
+      } else {
+        // component was un-snapped and is back to "new".
+        this.workspaceLane.removeEntry(oldId);
+        componentMap.onLanesOnly = false;
+      }
       componentMap.defaultVersion = componentMap.defaultVersion || oldId.version;
     }
     if (updateScopeOnly) {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -746,21 +746,27 @@ export default class Consumer {
       return componentMap.rootDir;
     };
     const currentLane = this.getCurrentLaneId();
-    const isAvailableOnMain = async (component: ModelComponent | Component): Promise<boolean> => {
-      if (currentLane.isDefault()) return true;
+    const isAvailableOnMain = async (component: ModelComponent | Component, id: BitId): Promise<boolean> => {
+      if (currentLane.isDefault()) {
+        return true;
+      }
+      if (!id.hasVersion()) {
+        // component was unsnapped on the current lane and is back to a new component
+        return true;
+      }
       const modelComponent =
         component instanceof ModelComponent ? component : await this.scope.getModelComponent(component.id);
       return modelComponent.hasHead();
     };
 
-    const updateVersions = async (unknownComponent) => {
+    const updateVersions = async (unknownComponent: ModelComponent | Component) => {
       const id: BitId =
         unknownComponent instanceof ModelComponent
           ? unknownComponent.toBitIdWithLatestVersionAllowNull()
           : unknownComponent.id;
       this.bitMap.updateComponentId(id);
       this.bitMap.removeConfig(id);
-      const availableOnMain = await isAvailableOnMain(unknownComponent);
+      const availableOnMain = await isAvailableOnMain(unknownComponent, id);
       if (!availableOnMain) {
         this.bitMap.setComponentProp(id, 'onLanesOnly', true);
       }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -237,6 +237,11 @@ export default class CommandHelper {
   showOneLane(name: string) {
     return this.runCmd(`bit lane show ${name}`);
   }
+  showOneLaneParsed(name: string) {
+    const results = this.runCmd(`bit lane show ${name} --json`);
+    const parsed = JSON.parse(results);
+    return parsed;
+  }
   showLanesParsed(options = '') {
     const results = this.runCmd(`bit lane list ${options} --json`);
     return JSON.parse(results);
@@ -244,11 +249,6 @@ export default class CommandHelper {
   showRemoteLanesParsed(options = '') {
     const results = this.runCmd(`bit lane list --remote ${this.scopes.remote} ${options} --json`);
     return JSON.parse(results);
-  }
-  showOneLaneParsed(name: string) {
-    const results = this.runCmd(`bit lane show ${name} --json`);
-    const parsed = JSON.parse(results);
-    return parsed;
   }
   diffLane(args = '', onScope = false) {
     const cwd = onScope ? this.scopes.remotePath : this.scopes.localPath;

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -275,8 +275,8 @@ export default class CommandHelper {
   untag(id: string, version = '') {
     return this.runCmd(`bit untag ${id} ${version}`);
   }
-  untagAll() {
-    return this.runCmd(`bit untag --all`);
+  untagAll(options = '') {
+    return this.runCmd(`bit untag ${options} --all`);
   }
   untagSoft(id: string) {
     return this.runCmd(`bit untag ${id} --soft`);

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -6,7 +6,7 @@ import GeneralError from '../../error/general-error';
 import logger from '../../logger/logger';
 import ModelComponent from '../models/model-component';
 
-export type untagResult = { id: BitId; versions: string[]; component?: ModelComponent };
+export type untagResult = { id: BitId; versions: string[]; component: ModelComponent };
 
 /**
  * If not specified version, remove all local versions.
@@ -15,8 +15,7 @@ export async function removeLocalVersion(
   scope: Scope,
   id: BitId,
   version?: string,
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  force? = false
+  force = false
 ): Promise<untagResult> {
   const component: ModelComponent = await scope.getModelComponentIgnoreScope(id);
   const localVersions = component.getLocalTagsOrHashes();

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -4,6 +4,7 @@ import { Consumer } from '../../consumer';
 import ComponentsList from '../../consumer/component/components-list';
 import GeneralError from '../../error/general-error';
 import logger from '../../logger/logger';
+import { Lane } from '../models';
 import ModelComponent from '../models/model-component';
 
 export type untagResult = { id: BitId; versions: string[]; component: ModelComponent };
@@ -14,6 +15,7 @@ export type untagResult = { id: BitId; versions: string[]; component: ModelCompo
 export async function removeLocalVersion(
   scope: Scope,
   id: BitId,
+  lane: Lane | null,
   version?: string,
   force = false
 ): Promise<untagResult> {
@@ -59,22 +61,24 @@ as a result, newer versions have this version as part of their history`);
     localVersions.map((localVer) => component.loadVersion(localVer, scope.objects))
   );
   await component.setDivergeData(scope.objects);
-  scope.sources.removeComponentVersions(component, versionsToRemove, allVersionsObjects);
+  scope.sources.removeComponentVersions(component, versionsToRemove, allVersionsObjects, lane);
 
   return { id, versions: versionsToRemove, component };
 }
 
 export async function removeLocalVersionsForAllComponents(
   consumer: Consumer,
+  lane: Lane | null,
   version?: string,
   force = false
 ): Promise<untagResult[]> {
   const componentsToUntag = await getComponentsWithOptionToUntag(consumer, version);
-  return removeLocalVersionsForMultipleComponents(componentsToUntag, version, force, consumer.scope);
+  return removeLocalVersionsForMultipleComponents(componentsToUntag, lane, version, force, consumer.scope);
 }
 
 export async function removeLocalVersionsForComponentsMatchedByWildcard(
   consumer: Consumer,
+  lane: Lane | null,
   version?: string,
   force = false,
   idWithWildcard?: string
@@ -83,11 +87,12 @@ export async function removeLocalVersionsForComponentsMatchedByWildcard(
   const componentsToUntag = idWithWildcard
     ? ComponentsList.filterComponentsByWildcard(candidateComponents, idWithWildcard)
     : candidateComponents;
-  return removeLocalVersionsForMultipleComponents(componentsToUntag, version, force, consumer.scope);
+  return removeLocalVersionsForMultipleComponents(componentsToUntag, lane, version, force, consumer.scope);
 }
 
 async function removeLocalVersionsForMultipleComponents(
   componentsToUntag: ModelComponent[],
+  lane: Lane | null,
   version?: string,
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   force: boolean,
@@ -118,7 +123,7 @@ async function removeLocalVersionsForMultipleComponents(
   }
   logger.debug(`found ${componentsToUntag.length} components to untag`);
   return Promise.all(
-    componentsToUntag.map((component) => removeLocalVersion(scope, component.toBitId(), version, true))
+    componentsToUntag.map((component) => removeLocalVersion(scope, component.toBitId(), lane, version, true))
   );
 }
 

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -533,6 +533,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     } else {
       // @todo: make sure not to delete the component when it has snaps but not versions!
       // if all versions were deleted, delete also the component itself from the model
+      delete component.laneHeadLocal;
       objectRepo.removeObject(component.hash());
     }
     objectRepo.unmergedComponents.removeComponent(component.name);

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -524,6 +524,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
         } else {
           lane?.removeComponent(component.toBitId());
         }
+        component.laneHeadLocal = head;
         objectRepo.add(lane);
       }
 
@@ -544,12 +545,9 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     if (componentHadHead && !component.hasHead() && component.versionArray.length) {
       throw new Error(`fatal: "head" prop was removed from "${component.id()}", although it has versions`);
     }
-    if (component.versionArray.length || component.hasHead()) {
+    if (component.versionArray.length || component.hasHead() || component.laneHeadLocal) {
       objectRepo.add(component); // add the modified component object
     } else {
-      // @todo: make sure not to delete the component when it has snaps but not versions!
-      // if all versions were deleted, delete also the component itself from the model
-      delete component.laneHeadLocal;
       objectRepo.removeObject(component.hash());
     }
     objectRepo.unmergedComponents.removeComponent(component.name);


### PR DESCRIPTION
## Proposed Changes

- fix workspace-lane to remove the component when unsnapped and is back to new.
- fix lane object to either remove the component or to update to the new head upon untag.
- avoid deleting the component object when one of the snaps were untagged and the head (on the lane) points to another snap.
