### PR TITLE
fix(lanes): do not throw an error when specifying the component id in "bit untag" command

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1147,7 +1147,7 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe.only('snapping and un-tagging on a lane', () => {
+  describe('snapping and un-tagging on a lane', () => {
     let afterFirstSnap: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
@@ -1187,6 +1187,15 @@ describe('bit lane command', function () {
         const status = helper.command.statusJson();
         expect(status.newComponents).to.have.lengthOf(0);
         expect(status.stagedComponents).to.have.lengthOf(1);
+      });
+    });
+    describe('un-snap by specifying the component name', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(afterFirstSnap);
+      });
+      // a previous bug was showing "unable to untag comp1, the component is not staged" error.
+      it('should not throw an error', () => {
+        expect(() => helper.command.untag('comp1')).to.not.throw();
       });
     });
   });

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -20,8 +20,9 @@ export async function removeLocalVersion(
   force = false
 ): Promise<untagResult> {
   const component: ModelComponent = await scope.getModelComponentIgnoreScope(id);
-  const localVersions = component.getLocalTagsOrHashes();
+  await component.setDivergeData(scope.objects);
   const idStr = id.toString();
+  const localVersions = component.getLocalTagsOrHashes();
   if (!localVersions.length) throw new GeneralError(`unable to untag ${idStr}, the component is not staged`);
   if (version) {
     const hasVersion = await component.hasVersion(version, scope.objects, false);
@@ -60,7 +61,6 @@ as a result, newer versions have this version as part of their history`);
   const allVersionsObjects = await Promise.all(
     localVersions.map((localVer) => component.loadVersion(localVer, scope.objects))
   );
-  await component.setDivergeData(scope.objects);
   scope.sources.removeComponentVersions(component, versionsToRemove, allVersionsObjects, lane);
 
   return { id, versions: versionsToRemove, component };


### PR DESCRIPTION
currently, when on a lane, `bit untag comp1` throws "unable to untag comp1, the component is not staged" error.