### PR TITLE
feat(new)!: default to an empty react template if no template provided to bit-new

### DIFF
--- a/scopes/generator/generator/new.cmd.ts
+++ b/scopes/generator/generator/new.cmd.ts
@@ -11,9 +11,9 @@ export type NewOptions = {
 };
 
 export class NewCmd implements Command {
-  name = 'new <templateName> <workspaceName>';
-  description = 'Create a new workspace from a template';
-  shortDescription = '';
+  name = 'new <workspaceName> [templateName]';
+  description = 'create a new workspace from a template, default to an empty react workspace';
+  shortDescription = 'create a new workspace from a template';
   alias = '';
   loader = true;
   group = 'start';
@@ -36,8 +36,12 @@ export class NewCmd implements Command {
 
   constructor(private generator: GeneratorMain) {}
 
-  async report([templateName, workspaceName]: [string, string], options: NewOptions & { standalone: boolean }) {
+  async report([workspaceName, templateName]: [string, string], options: NewOptions & { standalone: boolean }) {
     options.skipGit = options.skipGit ?? options.standalone;
+    if (!templateName) {
+      options.empty = true;
+      templateName = 'react';
+    }
     const results = await this.generator.generateWorkspaceTemplate(workspaceName, templateName, options);
     return chalk.white(
       `${chalk.green(`

--- a/scopes/generator/generator/templates.cmd.ts
+++ b/scopes/generator/generator/templates.cmd.ts
@@ -31,7 +31,7 @@ export class TemplatesCmd implements Command {
     const grouped = groupBy(results, 'aspectId');
     const titleStr = this.generator.isRunningInsideWorkspace()
       ? `The following template(s) are available with the command bit create:  \nExample - bit create <template-name> <component-name>`
-      : `The following template(s) are available with the command bit new: \nExample - bit new <template-name> <workspace-name>`;
+      : `The following template(s) are available with the command bit new: \nExample - bit new <workspace-name> [template-name]`;
     const title = chalk.green(`\n${titleStr}\n`);
     const templateOutput = (template: TemplateDescriptor) => {
       const desc = template.description ? ` (${template.description})` : '';

--- a/scopes/generator/generator/templates/workspace-generator/files/docs-file.ts
+++ b/scopes/generator/generator/templates/workspace-generator/files/docs-file.ts
@@ -25,13 +25,13 @@ See the docs for more info on [Customizing your Generator](https://harmony-docs.
 How to use this generator locally, essentially for development purposes:
 
 \`\`\`js
-bit new <template-name> <workspace-name> --load-from /Users/me/path/to/this/dir --aspect <workspace-template-id>
+bit new <workspace-name> <template-name> --load-from /Users/me/path/to/this/dir --aspect <workspace-template-id>
 \`\`\`
 
 How to use this generator after exporting to a remote scope:
 
 \`\`\`js
-bit new <template-name> <workspace-name> --aspect <workspace-template-id>
+bit new <workspace-name> <template-name> --aspect <workspace-template-id>
 \`\`\`
 `;
 }

--- a/scopes/generator/generator/templates/workspace-generator/files/readme-tpl.ts
+++ b/scopes/generator/generator/templates/workspace-generator/files/readme-tpl.ts
@@ -25,13 +25,13 @@ See the docs for more info on [Customizing your Generator](https://harmony-docs.
 How to use this generator locally, essentially for development purposes:
 
 \\\`\\\`\\\`js
-bit new <template-name> <workspace-name> --load-from /Users/me/path/to/this/dir --aspect <workspace-template-id>
+bit new <workspace-name> <template-name> --load-from /Users/me/path/to/this/dir --aspect <workspace-template-id>
 \\\`\\\`\\\`
 
 How to use this generator after exporting to a remote scope:
 
 \\\`\\\`\\\`js
-bit new <template-name> <workspace-name> --aspect <workspace-template-id>
+bit new <workspace-name> <template-name> --aspect <workspace-template-id>
 \\\`\\\`\\\`
 \`;
 }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -543,8 +543,8 @@ export default class CommandHelper {
   create(templateName: string, componentName: string, flags = '') {
     return this.runCmd(`bit create ${templateName} ${componentName} ${flags}`);
   }
-  new(templateName: string, flags = '', workspaceName = 'my-workspace', cwd = this.scopes.localPath) {
-    return this.runCmd(`bit new ${templateName} ${workspaceName} ${flags}`, cwd);
+  new(templateName = '', flags = '', workspaceName = 'my-workspace', cwd = this.scopes.localPath) {
+    return this.runCmd(`bit new ${workspaceName} ${templateName} ${flags}`, cwd);
   }
   moveComponent(id: string, to: string) {
     return this.runCmd(`bit move ${id} ${path.normalize(to)} --component`);


### PR DESCRIPTION
BREAKING CHANGE: the arguments of the `workspaceName` and `templateName` were switched.
Before: `new <templateName> <workspaceName>`
Now: `new <workspaceName> [templateName]`

With this PR, running `bit new demo` result in a new React workspace without components. Similar to running `bit new demo react --empty`.
Requested by @ranm8 .