### PR TITLE
fix(untag): set the component head correctly when untagging multiple versions

### DIFF
--- a/e2e/harmony/untag-harmony.e2e.ts
+++ b/e2e/harmony/untag-harmony.e2e.ts
@@ -64,4 +64,24 @@ describe('untag components on Harmony', function () {
       helper.command.expectStatusToBeClean(['newComponents']);
     });
   });
+  describe('untagging multiple versions when the new head is exported', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagScopeWithoutBuild(); // 0.0.1
+      helper.command.export();
+      helper.command.tagScopeWithoutBuild(); // 0.0.2
+      helper.command.tagScopeWithoutBuild(); // 0.0.3
+      helper.command.untagAll();
+    });
+    // a previous bug saved the hash of 0.0.2 as the head.
+    it('bit status should be clean', () => {
+      helper.command.expectStatusToBeClean();
+    });
+    it('bitmap should show a version, not a hash', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap.comp1.version).to.equal('0.0.1');
+    });
+  });
 });

--- a/e2e/harmony/untag-harmony.e2e.ts
+++ b/e2e/harmony/untag-harmony.e2e.ts
@@ -51,4 +51,17 @@ describe('untag components on Harmony', function () {
       );
     });
   });
+  describe('untagging multiple versions', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagScopeWithoutBuild(); // 0.0.1
+      helper.command.tagScopeWithoutBuild(); // 0.0.2
+      helper.command.untagAll();
+    });
+    // a previous bug saved the hash of 0.0.1 as the head, which made the component both: staged and snapped.
+    it('should show the component as new only, not as staged nor snapped', () => {
+      helper.command.expectStatusToBeClean(['newComponents']);
+    });
+  });
 });

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -59,7 +59,7 @@ as a result, newer versions have this version as part of their history`);
   }
 
   const allVersionsObjects = await Promise.all(
-    localVersions.map((localVer) => component.loadVersion(localVer, scope.objects))
+    versionsToRemove.map((localVer) => component.loadVersion(localVer, scope.objects))
   );
   scope.sources.removeComponentVersions(component, versionsToRemove, allVersionsObjects, lane);
 

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -491,10 +491,11 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
         if (!component.remoteHead) throw new Error(`remoteHead must be set when component is diverged`);
         return component.remoteHead;
       }
-      if (!component.head) {
+      const head = component.head || laneItem?.head;
+      if (!head) {
         return undefined;
       }
-      const headVersion = allVersionsObjects.find((ver) => ver.hash().isEqual(component.head as Ref));
+      const headVersion = allVersionsObjects.find((ver) => ver.hash().isEqual(head));
       return this.findHeadInExistingVersions(allVersionsObjects, component.id(), headVersion);
     };
     const refWasDeleted = (ref: Ref) => removedRefs.find((removedRef) => ref.isEqual(removedRef));


### PR DESCRIPTION
Currently, when tagging multiple versions locally and untagging them all, it shows a hash in the .bitmap as the version unexpectedly. 
Reported by @benjgil . 