### PR TITLE
fix(status): parse scoped-packages from a file-path correctly on Windows

### DIFF
--- a/src/utils/packages/resolve-pkg-data.ts
+++ b/src/utils/packages/resolve-pkg-data.ts
@@ -64,14 +64,13 @@ function enrichDataFromDependent(packageData: ResolvedPackageData, dependentDir:
   );
 
   const packageName = resolvePackageNameByPath(packageRelativePath);
-  const packageNameNormalized = packageName.replace('\\', '/');
   const packageVersion =
-    R.path(['dependencies', packageNameNormalized], dependentPackageJson) ||
-    R.path(['devDependencies', packageNameNormalized], dependentPackageJson) ||
-    R.path(['peerDependencies', packageNameNormalized], dependentPackageJson);
+    R.path(['dependencies', packageName], dependentPackageJson) ||
+    R.path(['devDependencies', packageName], dependentPackageJson) ||
+    R.path(['peerDependencies', packageName], dependentPackageJson);
   if (packageVersion) {
     packageData.dependentPackageJsonPath = packageJsonInfo.path;
-    packageData.name = packageNameNormalized;
+    packageData.name = packageName;
     packageData.versionUsedByDependent = packageVersion;
   }
 }

--- a/src/utils/packages/resolve-pkg-name-by-path.ts
+++ b/src/utils/packages/resolve-pkg-name-by-path.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { pathNormalizeToLinux } from '..';
 
 /**
  * return the package name by the import statement path to node package
@@ -7,13 +7,14 @@ import path from 'path';
  * @returns {string} name of the package
  */
 export function resolvePackageNameByPath(packagePath: string): string {
-  const packagePathArr = packagePath.split(path.sep);
+  const packagePathLinux = pathNormalizeToLinux(packagePath);
+  const packagePathArr = packagePathLinux.split('/');
   // Regular package without path. example - import _ from 'lodash'
   if (packagePathArr.length === 1) return packagePath;
   // sass-loader/webpack path. remove the tilda, it's not part of the package name
   if (packagePathArr[0].startsWith('~')) packagePathArr[0] = packagePathArr[0].replace('~', '');
   // Scoped package. example - import getSymbolIterator from '@angular/core/src/util.d.ts';
-  if (packagePathArr[0].startsWith('@')) return path.join(packagePathArr[0], packagePathArr[1]);
+  if (packagePathArr[0].startsWith('@')) return `${packagePathArr[0]}/${packagePathArr[1]}`;
   // Regular package with internal path. example import something from 'mypackage/src/util/isString'
   return packagePathArr[0];
 }


### PR DESCRIPTION
This is happening on Angular component for example. `bit status` shows a package `@angular/core/testing` as missing. 
With this PR, it parses the package-name correctly as `@angular/core` and finds it.

Reported by @ocombe .