### PR TITLE
fix(mdx): parse module decleration with dashes correctly by the mdx detector

### DIFF
--- a/scopes/mdx/mdx/mdx.detector.spec.ts
+++ b/scopes/mdx/mdx/mdx.detector.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { MDXDependencyDetector } from './mdx.detector';
 
-describe.only('MDXDependencyDetector', () => {
+describe('MDXDependencyDetector', () => {
   function expectDependencies(src: string, expectedDeps: string[]) {
     expect(new MDXDependencyDetector(['mdx']).detect(src)).to.deep.equal(expectedDeps);
   }

--- a/scopes/mdx/mdx/mdx.detector.spec.ts
+++ b/scopes/mdx/mdx/mdx.detector.spec.ts
@@ -1,0 +1,26 @@
+import { expect } from 'chai';
+import { MDXDependencyDetector } from './mdx.detector';
+
+describe.only('MDXDependencyDetector', () => {
+  function expectDependencies(src: string, expectedDeps: string[]) {
+    expect(new MDXDependencyDetector(['mdx']).detect(src)).to.deep.equal(expectedDeps);
+  }
+  describe('detect', () => {
+    it('should correctly detect default import', () => {
+      const src = 'import x from "y";';
+      expectDependencies(src, ['y']);
+    });
+    it('should correctly detect star import', () => {
+      const src = 'import * as y from "y";';
+      expectDependencies(src, ['y']);
+    });
+    it('should correctly detect named import', () => {
+      const src = 'import { x } from "y";';
+      expectDependencies(src, ['y']);
+    });
+    it('should correctly detect import with no identifier', () => {
+      const src = 'import "y";';
+      expectDependencies(src, ['y']);
+    });
+  });
+});

--- a/scopes/mdx/mdx/mdx.detector.ts
+++ b/scopes/mdx/mdx/mdx.detector.ts
@@ -4,11 +4,11 @@ import { compileSync } from '@teambit/mdx.modules.mdx-compiler';
 export class MDXDependencyDetector implements DependencyDetector {
   constructor(private supportedExtensions: string[]) {}
 
-  isSupported(context: FileContext) {
+  isSupported(context: FileContext): boolean {
     return this.supportedExtensions.includes(context.ext);
   }
 
-  detect(source: string) {
+  detect(source: string): string[] {
     const output = compileSync(source);
     const imports = output.getImportSpecifiers();
     if (!imports) return [];

--- a/scopes/mdx/modules/compiler/import-specifier.ts
+++ b/scopes/mdx/modules/compiler/import-specifier.ts
@@ -15,22 +15,17 @@ export type NamedImport = {
 
 export type ImportSpecifier = {
   /**
-   * name of the default import if exists.
-   */
-  defaultImport: null | string;
-
-  /**
-   * list of all named imports.
-   */
-  namedImports: NamedImport[];
-
-  /**
-   * If star import was defined.
-   */
-  starImport: null | string;
-
-  /**
-   * file to import from.
+   * relative/absolute or module name. e.g. the `y` in the example of `import x from 'y';`
    */
   fromModule: string;
+
+  /**
+   * is default import (e.g. `import x from 'y';`)
+   */
+  isDefault?: boolean;
+
+  /**
+   * the name used to identify the module, e.g. the `x` in the example of `import x from 'y';`
+   */
+  identifier?: string;
 };

--- a/scopes/mdx/modules/compiler/mdx-compiler.ts
+++ b/scopes/mdx/modules/compiler/mdx-compiler.ts
@@ -137,6 +137,11 @@ function extractImports() {
     visit(tree, 'import', (node: any) => {
       const es6Import = detectiveEs6(node.value);
       const imports: ImportSpecifier[] = Object.keys(es6Import).flatMap((dep) => {
+        if (!es6Import[dep].importSpecifiers) {
+          return {
+            fromModule: dep,
+          };
+        }
         return es6Import[dep].importSpecifiers.map((importSpecifier) => ({
           fromModule: dep,
           identifier: importSpecifier.name,

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-es6/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-es6/index.ts
@@ -1,3 +1,4 @@
+import { Specifier } from '../../types/dependency-tree-type';
 import {
   getDependenciesFromCallExpression,
   getDependenciesFromMemberExpression,
@@ -15,23 +16,23 @@ const Walker = require('node-source-walk');
  * @param  {String|Object} src - File's content or AST
  * @return {String[]}
  */
-export default function (src) {
+export default function (src): { [dependency: string]: { importSpecifiers: Specifier[] } } {
   const walker = new Walker();
 
   const dependencies = {};
-  const addDependency = (dependency) => {
+  const addDependency = (dependency: string) => {
     if (!dependencies[dependency]) {
       dependencies[dependency] = {};
     }
   };
-  const addImportSpecifier = (dependency, importSpecifier) => {
+  const addImportSpecifier = (dependency: string, importSpecifier: Specifier) => {
     if (dependencies[dependency].importSpecifiers) {
       dependencies[dependency].importSpecifiers.push(importSpecifier);
     } else {
       dependencies[dependency].importSpecifiers = [importSpecifier];
     }
   };
-  const addExportedToImportSpecifier = (name) => {
+  const addExportedToImportSpecifier = (name: string) => {
     Object.keys(dependencies).forEach((dependency) => {
       if (!dependencies[dependency].importSpecifiers) return;
       const specifier = dependencies[dependency].importSpecifiers.find((i) => i.name === name);

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/parser-helper.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/parser-helper.ts
@@ -1,3 +1,5 @@
+import { Specifier } from '../types/dependency-tree-type';
+
 export function getDependenciesFromMemberExpression(node) {
   if (
     node.object.type === 'CallExpression' &&
@@ -26,7 +28,7 @@ export function getDependenciesFromCallExpression(node) {
   return null;
 }
 
-export function getSpecifierValueForImportDeclaration(specifier) {
+export function getSpecifierValueForImportDeclaration(specifier): Specifier {
   return {
     isDefault: specifier.type === 'ImportDefaultSpecifier',
     // syntax of `import x from 'file'` doesn't have specifier.imported, only specifier.local

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -270,7 +270,6 @@
         "nerf-dart": "1.0.0",
         "p-limit": "3.1.0",
         "parallel-webpack": "2.6.0",
-        "parse-es6-imports": "1.0.1",
         "parse-package-name": "0.1.0",
         "penpal": "5.3.0",
         "pluralize": "8.0.0",


### PR DESCRIPTION
an interesting bug was found by @debs-obrien , where an mdx file has the following import statement:
```
import { removeFromCart } from './remove-from-cart';
```
and `bit status` shows a component-issue:
```
non-existing dependency files (make sure all files exists on your workspace):
          btn.docs.mdx -> ./remove-
```
Turns out, the parser was used `parse-es6-imports` doesn't handle module names with dashes well. It splits them. So `./remove-from-cart` becomes `./remove-`. 
This PR fixes it by replacing that package with the legacy way of parsing ES6 import.