### PR TITLE
fix(checkout): avoid writing files that were deleted locally but exist on the checked out version

### DIFF
--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -489,8 +489,8 @@ export default class ImportComponents {
     const component = componentMergeStatus.componentWithDependencies.component;
     const files = component.files;
 
-    const filesStatus = {};
     if (mergeResults.hasConflicts && this.options.mergeStrategy === MergeOptions.ours) {
+      const filesStatus = {};
       // don't write the files to the filesystem, only bump the bitmap version.
       files.forEach((file) => {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -501,6 +501,7 @@ export default class ImportComponents {
       return filesStatus;
     }
     if (mergeResults.hasConflicts && this.options.mergeStrategy === MergeOptions.theirs) {
+      const filesStatus = {};
       // the local changes will be overridden (as if the user entered --override flag for this component)
       files.forEach((file) => {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -508,13 +509,16 @@ export default class ImportComponents {
       });
       return filesStatus;
     }
-    return applyModifiedVersion(
+    const { filesStatus, modifiedFiles } = applyModifiedVersion(
       component.files,
       mergeResults,
       this.options.mergeStrategy,
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       component.originallySharedDir
     );
+    component.files = modifiedFiles;
+
+    return filesStatus;
   }
 
   /**

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -225,7 +225,7 @@ export async function applyVersion(
   if (!checkoutProps.isLane && !componentFromFS)
     throw new Error(`applyVersion expect to get componentFromFS for ${id.toString()}`);
   const { mergeStrategy } = checkoutProps;
-  const filesStatus = {};
+  let filesStatus = {};
   if (mergeResults && mergeResults.hasConflicts && mergeStrategy === MergeOptions.ours) {
     // even when isLane is true, the mergeResults is possible only when the component is on the filesystem
     // otherwise it's impossible to have conflicts
@@ -247,22 +247,23 @@ export async function applyVersion(
   files.forEach((file) => {
     filesStatus[pathNormalizeToLinux(file.relative)] = FileStatus.updated;
   });
-  let modifiedStatus = {};
   if (mergeResults) {
     // update files according to the merge results
-    modifiedStatus = applyModifiedVersion(
+    const { filesStatus: modifiedStatus, modifiedFiles } = applyModifiedVersion(
       files,
       mergeResults,
       mergeStrategy,
       componentWithDependencies.component.originallySharedDir
     );
+    filesStatus = { ...filesStatus, ...modifiedStatus };
+    componentWithDependencies.component.files = modifiedFiles;
   }
   const shouldDependenciesSaveAsComponents = await consumer.shouldDependenciesSavedAsComponents([id]);
   componentWithDependencies.component.dependenciesSavedAsComponents =
     shouldDependenciesSaveAsComponents[0].saveDependenciesAsComponents;
 
   return {
-    applyVersionResult: { id, filesStatus: Object.assign(filesStatus, modifiedStatus) },
+    applyVersionResult: { id, filesStatus },
     component: componentWithDependencies,
   };
 }
@@ -279,13 +280,16 @@ export function applyModifiedVersion(
   mergeResults: MergeResultsThreeWay,
   mergeStrategy: MergeStrategy | null | undefined,
   sharedDir?: string
-): Record<string, any> {
+): { filesStatus: Record<string, any>; modifiedFiles: SourceFile[] } {
+  let modifiedFiles = componentFiles.map((file) => file.clone());
   const filesStatus = {};
-  if (mergeResults.hasConflicts && mergeStrategy !== MergeOptions.manual) return filesStatus;
+  if (mergeResults.hasConflicts && mergeStrategy !== MergeOptions.manual) {
+    return { filesStatus, modifiedFiles };
+  }
   mergeResults.modifiedFiles.forEach((file) => {
     const filePath: PathOsBased = path.normalize(file.filePath);
     const pathWithSharedDir = (p: string) => (sharedDir ? path.join(sharedDir, p) : p);
-    const foundFile = componentFiles.find((componentFile) => pathWithSharedDir(componentFile.relative) === filePath);
+    const foundFile = modifiedFiles.find((componentFile) => pathWithSharedDir(componentFile.relative) === filePath);
     if (!foundFile) throw new GeneralError(`file ${filePath} not found`);
     if (file.conflict) {
       foundFile.contents = Buffer.from(file.conflict);
@@ -302,32 +306,41 @@ export function applyModifiedVersion(
     }
   });
   mergeResults.addFiles.forEach((file) => {
-    componentFiles.push(file.fsFile);
+    modifiedFiles.push(file.fsFile);
     filesStatus[file.filePath] = FileStatus.added;
   });
   mergeResults.removeFiles.forEach((file) => {
     const filePath: PathOsBased = path.normalize(file.filePath);
     filesStatus[file.filePath] = FileStatus.removed;
-    componentFiles = componentFiles.filter((f) => f.relative !== filePath);
+    modifiedFiles = modifiedFiles.filter((f) => f.relative !== filePath);
+  });
+  mergeResults.remainDeletedFiles.forEach((file) => {
+    const filePath: PathOsBased = path.normalize(file.filePath);
+    modifiedFiles = modifiedFiles.filter((f) => f.relative !== filePath);
+    filesStatus[file.filePath] = FileStatus.remainDeleted;
   });
   mergeResults.overrideFiles.forEach((file) => {
     const filePath: PathOsBased = path.normalize(file.filePath);
-    const foundFile = componentFiles.find((componentFile) => componentFile.relative === filePath);
+    const foundFile = modifiedFiles.find((componentFile) => componentFile.relative === filePath);
     if (!foundFile) throw new GeneralError(`file ${filePath} not found`);
     foundFile.contents = file.fsFile.contents;
     filesStatus[file.filePath] = FileStatus.overridden;
   });
   mergeResults.updatedFiles.forEach((file) => {
     const filePath: PathOsBased = path.normalize(file.filePath);
-    const foundFile = componentFiles.find((componentFile) => componentFile.relative === filePath);
+    const foundFile = modifiedFiles.find((componentFile) => componentFile.relative === filePath);
     if (!foundFile) throw new GeneralError(`file ${filePath} not found`);
     foundFile.contents = file.content;
     filesStatus[file.filePath] = FileStatus.updated;
   });
 
-  return filesStatus;
+  return { filesStatus, modifiedFiles };
 }
 
+/**
+ * it's needed in case the checked out version removed files that exist on the current version.
+ * without this function, these files would be left on the filesystem.
+ */
 async function deleteFilesIfNeeded(componentsResults: ApplyVersionWithComps[], consumer: Consumer): Promise<void> {
   const pathsToRemoveIncludeNull = componentsResults.map((compResult) => {
     return Object.keys(compResult.applyVersionResult.filesStatus).map((filePath) => {

--- a/src/consumer/versions-ops/merge-version/merge-version.ts
+++ b/src/consumer/versions-ops/merge-version/merge-version.ts
@@ -26,6 +26,7 @@ export const FileStatus = {
   removed: chalk.green('removed'),
   overridden: chalk.yellow('overridden'),
   unchanged: chalk.green('unchanged'),
+  remainDeleted: chalk.green('remain-deleted'),
 };
 // fileName is PathLinux. TS doesn't let anything else in the keys other than string and number
 export type FilesStatus = { [fileName: string]: keyof typeof FileStatus };

--- a/src/consumer/versions-ops/merge-version/three-way-merge.ts
+++ b/src/consumer/versions-ops/merge-version/three-way-merge.ts
@@ -19,6 +19,9 @@ export type MergeResultsThreeWay = {
   removeFiles: Array<{
     filePath: PathLinux;
   }>;
+  remainDeletedFiles: Array<{
+    filePath: PathLinux;
+  }>;
   modifiedFiles: Array<{
     filePath: PathLinux;
     fsFile: SourceFile;
@@ -114,6 +117,7 @@ export default async function threeWayMergeVersions({
   const results: MergeResultsThreeWay = {
     addFiles: [],
     removeFiles: [],
+    remainDeletedFiles: [],
     modifiedFiles: [],
     unModifiedFiles: [],
     overrideFiles: [],
@@ -173,6 +177,9 @@ export default async function threeWayMergeVersions({
       await getFileResult(fsFile, baseFile, currentFile);
     })
   );
+  const fsFilesPaths = fsFiles.map((fsFile) => pathNormalizeToLinux(fsFile.relative));
+  const deletedFromFs = currentFiles.filter((currentFile) => !fsFilesPaths.includes(currentFile.relativePath));
+  deletedFromFs.forEach((file) => results.remainDeletedFiles.push({ filePath: file.relativePath }));
   if (R.isEmpty(results.modifiedFiles)) return results;
 
   const conflictResults = await getMergeResults(consumer, results.modifiedFiles);


### PR DESCRIPTION
Two bugs were fixed here:
1. component `comp` has a file `foo.ts` in version 0.0.1 and 0.0.2 and the user is on 0.0.1 and deleted foo.ts locally. When running `bit checkout latest comp`, the file was rewritten. This PR fixes it to leave the file deleted.  (reported by @GiladShoham ). 
2. the function `applyModifiedVersion` was updating the component files by mutating the `componentFiles` arg. It worked for most cases, but when files were removed, this arg was re-assigned, and as a result wasn't updating the original component files. It is fixed by returning a new array of modified files instead of mutating the existing one.
