### PR TITLE
expose routing-provider from react-router aspect

### DIFF
--- a/scopes/ui-foundation/react-router/react-router/index.ts
+++ b/scopes/ui-foundation/react-router/react-router/index.ts
@@ -7,7 +7,9 @@ export type { ReactRouterUI } from './react-router.ui.runtime';
 // this exposes the Link components installed in bit bin, so they can use the same RoutingProvider file from node_modules
 export { Link, LinkProps } from '@teambit/base-ui.routing.link';
 export { NavLink, NavLinkProps } from '@teambit/base-ui.routing.nav-link';
+export { RoutingProvider, useRouting, useLocation } from '@teambit/base-ui.routing.routing-provider';
 export { LinkAnchor, LinkContextProvider, useLinkContext } from '@teambit/ui-foundation.ui.react-router.link-anchor';
+export * as ReactRouter from 'react-router';
 
 export { ReactRouterAspect };
 export default ReactRouterAspect;

--- a/scopes/ui-foundation/react-router/ui/link/link.tsx
+++ b/scopes/ui-foundation/react-router/ui/link/link.tsx
@@ -12,5 +12,5 @@ export function Link({ href = '', ...rest }: LinkProps) {
   }
 
   // @ts-ignore (#4401)
-  return <ReactRouterLink {...rest} to={href} component={LinkAnchor} />;
+  return <ReactRouterLink component={LinkAnchor} {...rest} to={href} />;
 }

--- a/scopes/ui-foundation/react-router/ui/nav-link/nav-link.tsx
+++ b/scopes/ui-foundation/react-router/ui/nav-link/nav-link.tsx
@@ -12,5 +12,5 @@ export function NavLink({ href = '', ...rest }: NavLinkProps) {
   }
 
   // @ts-ignore (#4401)
-  return <ReactRouterNavLink {...rest} to={href} component={LinkAnchor} />;
+  return <ReactRouterNavLink component={LinkAnchor} {...rest} to={href} />;
 }


### PR DESCRIPTION
## Proposed Changes

- allow react-router link implementation to receive the `component` prop
- expose `routing-provider` and `react-router`, so external aspects can get the same singleton instance

this will allow us to move the implementation of link base url to an external plugin