### PR TITLE
fix(rename/fork): fix "--scope" flag of bit-rename and bit-fork 

### DIFF
--- a/e2e/harmony/rename.e2e.ts
+++ b/e2e/harmony/rename.e2e.ts
@@ -12,34 +12,51 @@ describe('bit rename command', function () {
     helper.scopeHelper.destroy();
   });
   describe('rename an exported component', () => {
+    let scopeAfterExport: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllWithoutBuild();
       helper.command.export();
-      helper.command.rename('comp1', 'comp2');
+      scopeAfterExport = helper.scopeHelper.cloneLocalScope();
     });
-    it('should create a new component', () => {
-      const status = helper.command.statusJson();
-      expect(status.newComponents).to.have.lengthOf(1);
+    describe('rename with no flag', () => {
+      before(() => {
+        helper.command.rename('comp1', 'comp2');
+      });
+      it('should create a new component', () => {
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(1);
+      });
+      it('should deprecate the original component', () => {
+        const showDeprecation = helper.command.showAspectConfig('comp1', Extensions.deprecation);
+        expect(showDeprecation.config.deprecate).to.be.true;
+        expect(showDeprecation.config).to.have.property('newId');
+        expect(showDeprecation.config.newId.name).to.equal('comp2');
+      });
+      it('should reference the original component in the new component', () => {
+        const showDeprecation = helper.command.showAspectConfig('comp2', Extensions.renaming);
+        expect(showDeprecation.config).to.have.property('renamedFrom');
+        expect(showDeprecation.config.renamedFrom.name).to.equal('comp1');
+      });
+      it('should list both components', () => {
+        const list = helper.command.listParsed();
+        const ids = list.map((_) => _.id);
+        expect(ids).to.include(`${helper.scopes.remote}/comp1`);
+        expect(ids).to.include('comp2');
+      });
     });
-    it('should deprecate the original component', () => {
-      const showDeprecation = helper.command.showAspectConfig('comp1', Extensions.deprecation);
-      expect(showDeprecation.config.deprecate).to.be.true;
-      expect(showDeprecation.config).to.have.property('newId');
-      expect(showDeprecation.config.newId.name).to.equal('comp2');
-    });
-    it('should reference the original component in the new component', () => {
-      const showDeprecation = helper.command.showAspectConfig('comp2', Extensions.renaming);
-      expect(showDeprecation.config).to.have.property('renamedFrom');
-      expect(showDeprecation.config.renamedFrom.name).to.equal('comp1');
-    });
-    it('should list both components', () => {
-      const list = helper.command.listParsed();
-      const ids = list.map((_) => _.id);
-      expect(ids).to.include(`${helper.scopes.remote}/comp1`);
-      expect(ids).to.include('comp2');
+    describe('rename with --scope', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(scopeAfterExport);
+        helper.command.rename('comp1', 'comp2', '--scope org.ui');
+      });
+      it('should save the entered scope as the defaultScope', () => {
+        const show = helper.command.showComponentParsedHarmony('comp2');
+        const scope = show.find((item) => item.title === 'id');
+        expect(scope.json).to.equal('org.ui/comp2');
+      });
     });
   });
 });

--- a/scopes/component/forking/fork.cmd.ts
+++ b/scopes/component/forking/fork.cmd.ts
@@ -14,7 +14,7 @@ export class ForkCmd implements Command {
   skipWorkspace = true;
   alias = '';
   options = [
-    ['s', 'scope', 'default scope for the newly created component'],
+    ['s', 'scope <string>', 'default scope for the newly created component'],
     ['p', 'path <string>', 'relative path in the workspace. by default the path is `<scope>/<namespace>/<name>`'],
   ] as CommandOptions;
   loader = true;

--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -46,16 +46,15 @@ export class ForkingMain {
 please specify the target-id arg`);
     }
     const targetCompId = this.newComponentHelper.getNewComponentId(targetId, undefined, options?.scope);
-    const targetPath = this.newComponentHelper.getNewComponentPath(targetCompId, options?.path);
+
     const config = await this.getConfig(existing);
-    await this.newComponentHelper.writeAndAddNewComp(existing, targetPath, targetCompId, config);
+    await this.newComponentHelper.writeAndAddNewComp(existing, targetCompId, options, config);
 
     return targetCompId;
   }
   private async forkRemoteComponent(sourceId: ComponentID, targetId?: string, options?: ForkOptions) {
     const targetName = targetId || sourceId.fullName;
     const targetCompId = this.newComponentHelper.getNewComponentId(targetName, undefined, options?.scope);
-    const targetPath = this.newComponentHelper.getNewComponentPath(targetCompId, options?.path);
     const comp = await this.workspace.scope.getRemoteComponent(sourceId);
 
     const deps = await this.dependencyResolver.getDependencies(comp);
@@ -71,7 +70,7 @@ please specify the target-id arg`);
       }));
     this.dependencyResolver.addToRootPolicy(workspacePolicyEntries, { updateExisting: true });
     const config = await this.getConfig(comp);
-    await this.newComponentHelper.writeAndAddNewComp(comp, targetPath, targetCompId, config);
+    await this.newComponentHelper.writeAndAddNewComp(comp, targetCompId, options, config);
     await this.dependencyResolver.persistConfig(this.workspace.path);
     await this.workspace.install(undefined, {
       dedupe: true,

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -38,15 +38,17 @@ export class NewComponentHelperMain {
 
   async writeAndAddNewComp(
     comp: Component,
-    targetPath: string,
     targetId: ComponentID,
+    options?: { path?: string; scope?: string },
     config?: { [aspectName: string]: any }
   ) {
+    const targetPath = this.getNewComponentPath(targetId, options?.path);
     await this.workspace.write(targetPath, comp);
     await this.workspace.track({
       rootDir: targetPath,
       componentName: targetId.fullName,
       mainFile: comp.state._consumer.mainFile,
+      defaultScope: options?.scope,
       config,
     });
     await this.workspace.bitMap.write();

--- a/scopes/component/renaming/rename.cmd.ts
+++ b/scopes/component/renaming/rename.cmd.ts
@@ -14,7 +14,7 @@ export class RenameCmd implements Command {
   skipWorkspace = true;
   alias = '';
   options = [
-    ['s', 'scope', 'default scope for the newly created component'],
+    ['s', 'scope <string>', 'default scope for the newly created component'],
     ['p', 'path <string>', 'relative path in the workspace. by default the path is `<scope>/<namespace>/<name>`'],
   ] as CommandOptions;
   loader = true;

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -18,9 +18,8 @@ export class RenamingMain {
     const sourceId = await this.workspace.resolveComponentId(sourceIdStr);
     const sourceComp = await this.workspace.get(sourceId);
     const targetId = this.newComponentHelper.getNewComponentId(targetIdStr, undefined, options?.scope);
-    const targetPath = this.newComponentHelper.getNewComponentPath(targetId, options?.path);
     const config = await this.getConfig(sourceComp);
-    await this.newComponentHelper.writeAndAddNewComp(sourceComp, targetPath, targetId, config);
+    await this.newComponentHelper.writeAndAddNewComp(sourceComp, targetId, options, config);
     await this.deprecation.deprecate(sourceId, targetId);
 
     return {


### PR DESCRIPTION
to add the scope as the defaultScope and use it for the path calculation.