### PR TITLE
fix(checkout): remove config from .bitmap upon bit checkout --reset

### DIFF
--- a/e2e/harmony/deprecate.e2e.1.ts
+++ b/e2e/harmony/deprecate.e2e.1.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
 describe('bit deprecate and undeprecate commands', function () {
@@ -18,12 +19,8 @@ describe('bit deprecate and undeprecate commands', function () {
       helper.command.tagAllWithoutBuild();
       helper.command.deprecateComponent('comp2');
     });
-    const getDeprecationData = (compId: string) => {
-      const show = helper.command.showComponentParsedHarmony(compId);
-      return show.find((_) => _.title === 'configuration').json.find((_) => _.id === 'teambit.component/deprecation');
-    };
     it('bit show should show the component as deprecated', () => {
-      const deprecationData = getDeprecationData('comp2');
+      const deprecationData = helper.command.showAspectConfig('comp2', Extensions.deprecation);
       expect(deprecationData.config.deprecate).to.be.true;
     });
     it('bit status should show the component as modified', () => {
@@ -40,7 +37,7 @@ describe('bit deprecate and undeprecate commands', function () {
         expect(status.modifiedComponent).to.have.lengthOf(0);
       });
       it('bit show should show the component as deprecated', () => {
-        const deprecationData = getDeprecationData('comp2');
+        const deprecationData = helper.command.showAspectConfig('comp2', Extensions.deprecation);
         expect(deprecationData.config.deprecate).to.be.true;
       });
       it('.bitmap should not containing the config', () => {
@@ -68,7 +65,7 @@ describe('bit deprecate and undeprecate commands', function () {
           });
           // @todo: fix. currently it overrides the data unexpectedly.
           it.skip('should not delete the deprecation data from the config', () => {
-            const deprecationData = getDeprecationData('comp2');
+            const deprecationData = helper.command.showAspectConfig('comp2', Extensions.deprecation);
             expect(deprecationData.config.deprecate).to.be.true;
           });
         });
@@ -95,6 +92,23 @@ describe('bit deprecate and undeprecate commands', function () {
           });
         });
       });
+    });
+  });
+  describe('reverting the deprecation by "bit checkout --reset"', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.deprecateComponent('comp1');
+      // intermediate test
+      const deprecationData = helper.command.showAspectConfig('comp1', Extensions.deprecation);
+      expect(deprecationData.config.deprecate).to.be.true;
+
+      helper.command.checkout('comp1 --reset');
+    });
+    it('should remove the deprecation config', () => {
+      const deprecationData = helper.command.showAspectConfig('comp1', Extensions.deprecation);
+      expect(deprecationData).to.be.undefined;
     });
   });
 });

--- a/scopes/component/deprecation/deprecation.fragment.ts
+++ b/scopes/component/deprecation/deprecation.fragment.ts
@@ -19,7 +19,7 @@ export class DeprecationFragment implements ShowFragment {
   async json(component: Component) {
     return {
       title: this.title,
-      json: this.deprecation.getDeprecationInfo(component),
+      json: await this.deprecation.getDeprecationInfo(component),
     };
   }
 

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -49,6 +49,7 @@ export interface ManyComponentsWriterParams {
   saveOnLane?: boolean;
   isLegacy?: boolean;
   applyPackageJsonTransformers?: boolean;
+  resetConfig?: boolean;
 }
 
 /**
@@ -90,6 +91,7 @@ export default class ManyComponentsWriter {
   packageManager?: string;
   isLegacy?: boolean;
   applyPackageJsonTransformers?: boolean;
+  resetConfig?: boolean;
   // Apply config added by extensions
 
   constructor(params: ManyComponentsWriterParams) {
@@ -117,6 +119,7 @@ export default class ManyComponentsWriter {
     this.packageManager = params.packageManager;
     this.isLegacy = this.consumer ? this.consumer.isLegacy : params.isLegacy;
     this.applyPackageJsonTransformers = params.applyPackageJsonTransformers ?? true;
+    this.resetConfig = params.resetConfig;
     if (this.consumer && !this.isolated) this.basePath = this.consumer.getPath();
   }
 
@@ -190,6 +193,11 @@ export default class ManyComponentsWriter {
       componentWriter.existingComponentMap =
         componentWriter.existingComponentMap || componentWriter.addComponentToBitMap(componentWriter.writeToPath);
     });
+    if (this.resetConfig) {
+      componentWriterInstances.forEach((componentWriter: ComponentWriter) => {
+        delete componentWriter.existingComponentMap?.config;
+      });
+    }
     this.writtenComponents = await mapSeries(componentWriterInstances, (componentWriter: ComponentWriter) =>
       componentWriter.populateComponentsFilesToWrite(this.packageManager)
     );

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -102,6 +102,7 @@ export default async function checkoutVersion(
       writeDists: !checkoutProps.ignoreDist,
       writeConfig: checkoutProps.writeConfig,
       writePackageJson: !checkoutProps.ignorePackageJson,
+      resetConfig: checkoutProps.reset,
     });
     await manyComponentsWriter.writeAll();
     await deleteFilesIfNeeded(componentsResults, consumer);


### PR DESCRIPTION
Currently, when deprecating a component and trying to undo it by running `bit checkout --reset`, it doesn't do anything.
With this change, the config is removed and the component is not shown as modified anymore.