### PR TITLE
treat core envs as regular envs

### DIFF
--- a/scopes/component/component/tag-map.ts
+++ b/scopes/component/component/tag-map.ts
@@ -1,5 +1,6 @@
+import { BitError } from '@teambit/bit-error';
 import { getLatestVersion } from '@teambit/legacy/dist/utils/semver-helper';
-import { SemVer, maxSatisfying } from 'semver';
+import { SemVer, maxSatisfying, validRange } from 'semver';
 
 import { CouldNotFindLatest } from './exceptions';
 import { Hash } from './hash';
@@ -58,6 +59,15 @@ export class TagMap extends Map<SemVer, Tag> {
     const versions = this.toArray().map((tag) => tag.version.raw);
     if (this.isEmpty()) throw new CouldNotFindLatest(versions);
     return getLatestVersion(versions);
+  }
+
+  maxSatisfying(range: string): string | null {
+    if (!validRange(range)) {
+      throw new BitError(`The provided range ${range} is not a valid semver range`);
+    }
+    const versions = this.toArray().map((tag) => tag.version.raw);
+    const max = maxSatisfying(versions, '*', { includePrerelease: true });
+    return max;
   }
 
   isEmpty() {

--- a/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency-factory.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency-factory.ts
@@ -4,12 +4,14 @@ import { compact } from 'lodash';
 import { ComponentID } from '@teambit/component-id';
 import { Dependency as LegacyDependency } from '@teambit/legacy/dist/consumer/component/dependencies';
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
-import { ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config';
+import { BitError } from '@teambit/bit-error';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
 import { ComponentDependency, SerializedComponentDependency, TYPE } from './component-dependency';
 import { DependencyLifecycleType } from '../dependency';
 import { DependencyFactory } from '../dependency-factory';
 import { DependencyList } from '../dependency-list';
+import { VariantPolicy } from '../..';
+import { VariantPolicyEntry } from '../../policy/variant-policy/variant-policy';
 
 // TODO: think about where is the right place to put this
 // export class ComponentDependencyFactory implements DependencyFactory<ComponentDependency, SerializedComponentDependency> {
@@ -40,7 +42,7 @@ export class ComponentDependencyFactory implements DependencyFactory {
       id = await this.componentAspect.getHost().resolveComponentId(serialized.id);
     }
 
-    return (new ComponentDependency(
+    return new ComponentDependency(
       id,
       serialized.isExtension,
       serialized.packageName,
@@ -48,19 +50,16 @@ export class ComponentDependencyFactory implements DependencyFactory {
       serialized.version,
       serialized.lifecycle as DependencyLifecycleType,
       serialized.source
-    ) as unknown) as ComponentDependency;
+    ) as unknown as ComponentDependency;
   }
-
-  async fromLegacyComponent(legacyComponent: LegacyComponent): Promise<DependencyList> {
+  async fromLegacyComponentAndPolicy(legacyComponent: LegacyComponent, policy: VariantPolicy): Promise<DependencyList> {
     const runtimeDeps = await mapSeries(legacyComponent.dependencies.get(), (dep) =>
       this.transformLegacyComponentDepToSerializedDependency(dep, 'runtime')
     );
     const devDeps = await mapSeries(legacyComponent.devDependencies.get(), (dep) =>
       this.transformLegacyComponentDepToSerializedDependency(dep, 'dev')
     );
-    const extensionDeps = await mapSeries(legacyComponent.extensions, (extension) =>
-      this.transformLegacyComponentExtensionToSerializedDependency(extension, 'dev')
-    );
+    const extensionDeps = await this.getExtensionsDepsFromPolicy(policy);
     const filteredExtensionDeps: SerializedComponentDependency[] = compact(extensionDeps);
     const serializedComponentDeps = [...runtimeDeps, ...devDeps, ...filteredExtensionDeps];
     const componentDeps: ComponentDependency[] = await mapSeries(serializedComponentDeps, (dep) => this.parse(dep));
@@ -93,26 +92,45 @@ export class ComponentDependencyFactory implements DependencyFactory {
     };
   }
 
-  private async transformLegacyComponentExtensionToSerializedDependency(
-    extension: ExtensionDataEntry,
+  private async getExtensionsDepsFromPolicy(policy: VariantPolicy): Promise<Array<SerializedComponentDependency>> {
+    const results = await Promise.all(
+      policy.entries.map((entry) => {
+        if (entry.source === 'extensionEntry') {
+          return this.transformPolicyEntryExtensionToSerializedDependency(entry, 'dev');
+        }
+        return undefined;
+      })
+    );
+    return compact(results);
+  }
+
+  private async transformPolicyEntryExtensionToSerializedDependency(
+    entry: VariantPolicyEntry,
     lifecycle: DependencyLifecycleType
   ): Promise<SerializedComponentDependency | undefined> {
-    if (!extension.extensionId) {
-      return undefined;
-    }
     const host = this.componentAspect.getHost();
-    const id = await host.resolveComponentId(extension.extensionId);
+    const id = await host.resolveComponentId(entry.dependencyId);
     const extComponent = await host.get(id);
+    let version: string | null | undefined = '0.0.1';
+    if (!extComponent?.tags.isEmpty()) {
+      const range = entry.value.version;
+      version = extComponent?.tags.maxSatisfying(range);
+      if (!version) {
+        throw new BitError(
+          `could not find matching version for extension with id: ${id.toString()} and version ${range}`
+        );
+      }
+    }
     let packageName = '';
     if (extComponent) {
       packageName = componentIdToPackageName(extComponent.state._consumer);
     }
     return {
-      id: extension.extensionId.toString(),
+      id: id.toString(),
       isExtension: true,
       packageName,
-      componentId: extension.extensionId.serialize(),
-      version: extension.extensionId.getVersion().toString(),
+      componentId: id,
+      version,
       __type: TYPE,
       lifecycle,
     };

--- a/scopes/dependencies/dependency-resolver/dependencies/dependency-factory.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency-factory.ts
@@ -1,4 +1,5 @@
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
+import { VariantPolicy } from '..';
 import { Dependency, SerializedDependency } from './dependency';
 import { DependencyList } from './dependency-list';
 
@@ -13,5 +14,5 @@ import { DependencyList } from './dependency-list';
 export interface DependencyFactory {
   type: string;
   parse: <T extends Dependency, U extends SerializedDependency>(serializedDependency: U) => Promise<T>;
-  fromLegacyComponent?: (legacyComponent: LegacyComponent) => Promise<DependencyList>;
+  fromLegacyComponentAndPolicy?: (legacyComponent: LegacyComponent, policy: VariantPolicy) => Promise<DependencyList>;
 }

--- a/scopes/dependencies/dependency-resolver/dependencies/dependency-list-factory.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency-list-factory.ts
@@ -7,6 +7,7 @@ import { SerializedDependency } from './dependency';
 import { DependencyList } from './dependency-list';
 import { UnknownDepType } from './exceptions';
 import { DependencyResolverAspect } from '../dependency-resolver.aspect';
+import { VariantPolicy } from '..';
 
 export class DependencyListFactory {
   constructor(private factories: Record<string, DependencyFactory>) {}
@@ -24,10 +25,10 @@ export class DependencyListFactory {
     return new DependencyList(dependencies);
   }
 
-  async fromLegacyComponent(legacyComponent: LegacyComponent): Promise<DependencyList> {
+  async fromLegacyComponentAndPolicy(legacyComponent: LegacyComponent, policy: VariantPolicy): Promise<DependencyList> {
     const lists = await mapSeries(Object.values(this.factories), async (factory) => {
-      if (factory.fromLegacyComponent && typeof factory.fromLegacyComponent === 'function') {
-        return factory.fromLegacyComponent(legacyComponent);
+      if (factory.fromLegacyComponentAndPolicy && typeof factory.fromLegacyComponentAndPolicy === 'function') {
+        return factory.fromLegacyComponentAndPolicy(legacyComponent, policy);
       }
       return new DependencyList([]);
     });

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -825,6 +825,7 @@ export class DependencyResolverMain {
     let policiesFromEnv: VariantPolicy = variantPolicyFactory.getEmpty();
     let policiesFromSlots: VariantPolicy = variantPolicyFactory.getEmpty();
     let policiesFromConfig: VariantPolicy = variantPolicyFactory.getEmpty();
+    let extensionsPolicies: VariantPolicy = variantPolicyFactory.getEmpty();
     const env = this.envs.calculateEnvFromExtensions(configuredExtensions).env;
     if (env.getDependencies && typeof env.getDependencies === 'function') {
       const policiesFromEnvConfig = await env.getDependencies();
@@ -855,7 +856,14 @@ export class DependencyResolverMain {
       policiesFromConfig = variantPolicyFactory.fromConfigObject(currentConfig.policy, 'config');
     }
 
-    const result = VariantPolicy.mergePolices([policiesFromEnv, policiesFromSlots, policiesFromConfig]);
+    extensionsPolicies = variantPolicyFactory.fromExtensionDataList(configuredExtensions);
+
+    const result = VariantPolicy.mergePolices([
+      policiesFromEnv,
+      policiesFromSlots,
+      policiesFromConfig,
+      extensionsPolicies,
+    ]);
     return result;
   }
 

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -325,6 +325,7 @@ export class DependencyResolverMain {
 
   /**
    * This function called on component load in order to calculate the dependencies based on the legacy (consumer) component
+   * and the component policy
    * and write them to the dependencyResolver data.
    * Do not use this function for other purpose.
    * If you want to get the component dependencies call getDependencies (which will give you the dependencies from the data itself)
@@ -332,11 +333,11 @@ export class DependencyResolverMain {
    * TODO: once we switch deps resolver <> workspace relation we should remove the resolveId func here
    * @param component
    */
-  async extractDepsFromLegacy(component: Component, policy?: VariantPolicy): Promise<SerializedDependency[]> {
+  async extractDepsFromLegacyAndPolicy(component: Component, policy?: VariantPolicy): Promise<SerializedDependency[]> {
     const componentPolicy = policy || (await this.getPolicy(component));
     const legacyComponent: LegacyComponent = component.state._consumer;
     const listFactory = this.getDependencyListFactory();
-    const dependencyList = await listFactory.fromLegacyComponent(legacyComponent);
+    const dependencyList = await listFactory.fromLegacyComponentAndPolicy(legacyComponent, componentPolicy);
     dependencyList.forEach((dep) => {
       const found = componentPolicy.find(dep.id);
       // if no policy found, the dependency was auto-resolved from the source code

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy-factory.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy-factory.ts
@@ -1,3 +1,4 @@
+import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { PolicyConfigKeysNames } from '../policy';
 import {
   VariantPolicy,
@@ -9,6 +10,8 @@ import {
   DependencySource,
 } from './variant-policy';
 import { LIFECYCLE_TYPE_BY_KEY_NAME, DependencyLifecycleType } from '../../dependencies';
+import { DEV_DEP_LIFECYCLE_TYPE } from '../../dependencies/constants';
+import { compact } from 'lodash';
 
 export class VariantPolicyFactory {
   fromConfigObject(configObject, source?: DependencySource): VariantPolicy {
@@ -17,6 +20,24 @@ export class VariantPolicyFactory {
     const peerEntries = entriesFromKey(configObject, 'peerDependencies', source);
     const entries = runtimeEntries.concat(devEntries).concat(peerEntries);
     return new VariantPolicy(entries);
+  }
+
+  /**
+   * This will return the policy of the extension themselves, not for the config inside of them
+   * @param configuredExtensions
+   */
+  fromExtensionDataList(configuredExtensions: ExtensionDataList): VariantPolicy {
+    const entries = configuredExtensions.map((extEntry) => {
+      if (extEntry.extensionId) {
+        const version =
+          extEntry.extensionId.version === 'latest' || !extEntry.extensionId.version
+            ? '*'
+            : extEntry.extensionId.version;
+        return createEntry(extEntry.stringId, version, DEV_DEP_LIFECYCLE_TYPE, 'extensionEntry');
+      }
+      return undefined;
+    });
+    return new VariantPolicy(compact(entries));
   }
 
   parse(serializedEntries: SerializedVariantPolicy) {

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
@@ -21,7 +21,7 @@ export type VariantPolicyEntryValue = {
   resolveFromEnv?: boolean;
 };
 
-export type DependencySource = 'auto' | 'env' | 'slots' | 'config';
+export type DependencySource = 'auto' | 'env' | 'slots' | 'config' | 'extensionEntry';
 
 export type VariantPolicyEntry = PolicyEntry & {
   value: VariantPolicyEntryValue;

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -74,6 +74,16 @@ export class EnvsMain {
     private componentMain: ComponentMain
   ) {}
 
+  getCoreEnvsIds(): string[] {
+    return [
+      'teambit.react/react',
+      'teambit.harmony/node',
+      'teambit.react/react-native',
+      'teambit.html/html',
+      'teambit.mdx/mdx',
+    ];
+  }
+
   /**
    * creates a new runtime environments for a set of components.
    */

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -12,7 +12,7 @@ import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { loadBit } from '@teambit/bit';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import mapSeries from 'p-map-series';
-import { difference, compact, flatten } from 'lodash';
+import { difference, compact, flatten, intersection } from 'lodash';
 import { AspectDefinition, AspectDefinitionProps } from './aspect-definition';
 import { PluginDefinition } from './plugin-definition';
 import { AspectLoaderAspect } from './aspect-loader.aspect';
@@ -192,6 +192,15 @@ export class AspectLoaderMain {
   getCoreAspectIds() {
     const ids = this.coreAspects.map((aspect) => aspect.id);
     return ids.concat(this._reserved);
+  }
+
+  /**
+   * Get all the core envs ids which is still register in the bit manifest as core aspect
+   */
+  getCoreEnvsIds(): string[] {
+    const envsIds = this.envs.getCoreEnvsIds();
+    const allIds = this.getCoreAspectIds();
+    return intersection(allIds, envsIds);
   }
 
   private _reserved = ['teambit.harmony/bit', 'teambit.harmony/config'];

--- a/scopes/pkg/pkg/package-dependency/package-dependency-factory.ts
+++ b/scopes/pkg/pkg/package-dependency/package-dependency-factory.ts
@@ -3,6 +3,7 @@ import {
   SerializedDependency,
   DependencyFactory,
   DependencyList,
+  VariantPolicy,
 } from '@teambit/dependency-resolver';
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
 import { PackageDependency, SerializedPackageDependency } from './package-dependency';
@@ -21,15 +22,16 @@ export class PackageDependencyFactory implements DependencyFactory {
 
   async parse<PackageDependency, S extends SerializedDependency>(serialized: S): Promise<PackageDependency> {
     // return new PackageDependency(serialized.id, serialized.version, serialized.type, serialized.lifecycle as DependencyLifecycleType) as unknown as PackageDependency;
-    return (new PackageDependency(
+    return new PackageDependency(
       serialized.id,
       serialized.version,
       serialized.lifecycle as DependencyLifecycleType,
       serialized.source
-    ) as unknown) as PackageDependency;
+    ) as unknown as PackageDependency;
   }
 
-  async fromLegacyComponent(legacyComponent: LegacyComponent): Promise<DependencyList> {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async fromLegacyComponentAndPolicy(legacyComponent: LegacyComponent, policy: VariantPolicy): Promise<DependencyList> {
     const runtimePackageDeps = transformLegacyComponentPackageDepsToSerializedDependency(
       legacyComponent.packageDependencies,
       'runtime'

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -41,6 +41,7 @@ export default class ImportCmd implements Command {
     ],
     ['', 'dependencies', 'EXPERIMENTAL. import all dependencies and write them to the workspace'],
     ['', 'dependents', 'EXPERIMENTAL. import component dependents to allow auto-tag updating them upon tag'],
+    ['', 'skip-core-envs', 'EXPERIMENTAL. do not import the core environments objects'],
     [
       '',
       'skip-lane',
@@ -71,6 +72,7 @@ export default class ImportCmd implements Command {
       conf,
       skipNpmInstall = false,
       merge,
+      skipCoreEnvs = false,
       skipLane = false,
       dependencies = false,
       dependents = false,
@@ -85,6 +87,7 @@ export default class ImportCmd implements Command {
       conf?: string;
       skipNpmInstall?: boolean;
       merge?: MergeStrategy;
+      skipCoreEnvs?: boolean;
       skipLane?: boolean;
       dependencies?: boolean;
       dependents?: boolean;
@@ -117,6 +120,7 @@ export default class ImportCmd implements Command {
       writeConfig: Boolean(conf),
       installNpmPackages: !skipNpmInstall,
       skipLane,
+      skipCoreEnvs,
       importDependenciesDirectly: dependencies,
       importDependents: dependents,
       allHistory,

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -1,3 +1,4 @@
+import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
@@ -7,12 +8,17 @@ import { ImporterAspect } from './importer.aspect';
 
 export class ImporterMain {
   static slots = [];
-  static dependencies = [CLIAspect, WorkspaceAspect, DependencyResolverAspect];
+  static dependencies = [CLIAspect, WorkspaceAspect, DependencyResolverAspect, AspectLoaderAspect];
   static runtime = MainRuntime;
-  static async provider([cli, workspace, depResolver]: [CLIMain, Workspace, DependencyResolverMain]) {
+  static async provider([cli, workspace, depResolver, aspectLoader]: [
+    CLIMain,
+    Workspace,
+    DependencyResolverMain,
+    AspectLoaderMain
+  ]) {
     if (workspace && !workspace.consumer.isLegacy) {
       cli.unregister('import');
-      const importer = new Importer(workspace, depResolver);
+      const importer = new Importer(workspace, depResolver, aspectLoader);
       cli.register(new ImportCmd(importer));
     }
     return new ImporterMain();

--- a/scopes/scope/importer/importer.ts
+++ b/scopes/scope/importer/importer.ts
@@ -8,15 +8,21 @@ import ImportComponents, {
 } from '@teambit/legacy/dist/consumer/component-ops/import-components';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
+import { AspectLoaderMain } from '@teambit/aspect-loader';
 
 export class Importer {
-  constructor(private workspace: Workspace, private depResolver: DependencyResolverMain) {}
+  constructor(
+    private workspace: Workspace,
+    private depResolver: DependencyResolverMain,
+    private aspectLoader: AspectLoaderMain
+  ) {}
 
   async import(importOptions: ImportOptions, packageManagerArgs: string[]): Promise<ImportResult> {
     const consumer = this.workspace.consumer;
     consumer.packageManagerArgs = packageManagerArgs;
     this.populateLanesDataIfNeeded(importOptions);
-    const importComponents = new ImportComponents(consumer, importOptions);
+    const coreEnvsIds = this.aspectLoader.getCoreEnvsIds();
+    const importComponents = new ImportComponents(consumer, coreEnvsIds, importOptions);
     const { dependencies, importDetails } = await importComponents.importComponents();
     const bitIds = dependencies.map(R.path(['component', 'id']));
     Analytics.setExtraData('num_components', bitIds.length);

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -240,7 +240,7 @@ to bypass this error, use --skip-new-scope-validation flag (not recommended. it 
   }
 
   private async updateDependencyResolver(component: Component) {
-    const dependencies = await this.dependencyResolver.extractDepsFromLegacy(component);
+    const dependencies = await this.dependencyResolver.extractDepsFromLegacyAndPolicy(component);
     const extId = DependencyResolverAspect.id;
     const data = { dependencies };
     const existingExtension = component.state._consumer.extensions.findExtension(extId);

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -249,7 +249,7 @@ export class WorkspaceComponentLoader {
 
     // Move to deps resolver main runtime once we switch ws<> deps resolver direction
     const policy = await this.dependencyResolver.mergeVariantPolicies(component.config.extensions);
-    const dependencies = await this.dependencyResolver.extractDepsFromLegacy(component, policy);
+    const dependencies = await this.dependencyResolver.extractDepsFromLegacyAndPolicy(component, policy);
 
     const depResolverData = {
       dependencies,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -972,12 +972,16 @@ export class Workspace implements ComponentFactory {
    * @param extensionList
    */
   private async resolveExtensionListIds(extensionList: ExtensionDataList): Promise<ExtensionDataList> {
+    const coreEnvsIds = this.aspectLoader.getCoreEnvsIds();
     const promises = extensionList.map(async (entry) => {
-      if (entry.extensionId) {
-        const id = await this.resolveComponentId(entry.extensionId);
+      let idToResolve: BitId | string | undefined = entry.extensionId;
+      if (!idToResolve && coreEnvsIds.includes(entry.stringId)) {
+        idToResolve = entry.stringId;
+      }
+      if (idToResolve) {
+        const id = await this.resolveComponentId(idToResolve);
         entry.extensionId = id._legacy;
       }
-
       return entry;
     });
     await Promise.all(promises);

--- a/src/api/consumer/lib/fetch.ts
+++ b/src/api/consumer/lib/fetch.ts
@@ -31,7 +31,7 @@ export default async function fetch(ids: string[], lanes: boolean, components: b
     installNpmPackages: false,
     fromOriginalScope,
   };
-  const importComponents = new ImportComponents(consumer, importOptions);
+  const importComponents = new ImportComponents(consumer, [], importOptions);
   if (lanes) {
     const laneIds = await getLaneIds();
     importOptions.lanes = { laneIds };

--- a/src/api/consumer/lib/import.ts
+++ b/src/api/consumer/lib/import.ts
@@ -64,7 +64,7 @@ export default async function importAction(
   if (importOptions.writeConfig && consumer.config.isLegacy) {
     throw new FlagHarmonyOnly('--conf');
   }
-  const importComponents = new ImportComponents(consumer, importOptions);
+  const importComponents = new ImportComponents(consumer, [], importOptions);
   const { dependencies, envComponents, importDetails } = await importComponents.importComponents();
   const bitIds = dependencies.map(R.path(['component', 'id']));
 


### PR DESCRIPTION
## Proposed Changes

- import core envs during import
- save core envs as regular envs in the component data
- set policy as '*' if there is no policy defined for aspect in variants
- set actual dependency of an aspect by the policy configured for it
