### PR TITLE
fix(fork): change component tracking to handle the out-of-sync only when running bit-add

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -24,8 +24,9 @@ export class ForkingMain {
 
   async fork(sourceIdStr: string, targetId?: string, options?: ForkOptions): Promise<ComponentID> {
     const sourceId = await this.workspace.resolveComponentId(sourceIdStr);
-    const existingInWorkspace = await this.workspace.getIfExist(sourceId);
-    if (existingInWorkspace) {
+    const exists = this.workspace.exists(sourceId);
+    if (exists) {
+      const existingInWorkspace = await this.workspace.get(sourceId);
       return this.forkExistingInWorkspace(existingInWorkspace, targetId, options);
     }
     const sourceIdWithScope = sourceId._legacy.scope

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -689,6 +689,13 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
+   * whether a component exists in the workspace
+   */
+  exists(componentId: ComponentID): boolean {
+    return Boolean(this.consumer.bitmapIdsFromCurrentLane.find((_) => _.isEqualWithoutVersion(componentId._legacy)));
+  }
+
+  /**
    * This will make sure to fetch the objects prior to load them
    * do not use it if you are not sure you need it.
    * It will influence the performance

--- a/src/api/consumer/lib/add.ts
+++ b/src/api/consumer/lib/add.ts
@@ -17,6 +17,7 @@ const HooksManagerInstance = HooksManager.getInstance();
 export async function addOne(addProps: AddProps): Promise<AddActionResults> {
   const consumer: Consumer = await loadConsumer();
   const addContext: AddContext = { consumer };
+  addProps.shouldHandleOutOfSync = true;
   const addComponents = new AddComponents(addContext, addProps);
   const addResults = await addComponents.add();
   await consumer.onDestroy();

--- a/src/consumer/component-ops/add-components/add-components.ts
+++ b/src/consumer/component-ops/add-components/add-components.ts
@@ -93,6 +93,7 @@ export type AddProps = {
   origin?: ComponentOrigin;
   defaultScope?: string;
   config?: Config;
+  shouldHandleOutOfSync?: boolean;
 };
 // This is the contxt of the add operation. By default, the add is executed in the same folder in which the consumer is located and it is the process.cwd().
 // In that case , give the value false to overridenConsumer .
@@ -125,6 +126,7 @@ export default class AddComponents {
   isLegacy: boolean;
   defaultScope?: string; // helpful for out-of-sync
   config?: Config;
+  shouldHandleOutOfSync?: boolean; // only bit-add (not bit-create/new) should handle out-of-sync scenario
   constructor(context: AddContext, addProps: AddProps) {
     this.alternateCwd = context.alternateCwd;
     this.consumer = context.consumer;
@@ -147,6 +149,7 @@ export default class AddComponents {
     this.isLegacy = context.consumer.isLegacy;
     this.defaultScope = addProps.defaultScope;
     this.config = addProps.config;
+    this.shouldHandleOutOfSync = addProps.shouldHandleOutOfSync;
   }
 
   joinConsumerPathIfNeeded(paths: PathOrDSL[]): PathOrDSL[] {
@@ -304,7 +307,7 @@ export default class AddComponents {
         }
         return null;
       }
-      if (!foundComponentFromBitMap && componentFromScope) {
+      if (!foundComponentFromBitMap && componentFromScope && this.shouldHandleOutOfSync) {
         const newId = componentFromScope.toBitIdWithLatestVersion();
         if (!this.defaultScope || this.defaultScope === newId.scope) {
           // otherwise, if defaultScope !== newId.scope, they're different components,


### PR DESCRIPTION
Currently, when running `bit create` or `bit new` or `bit fork` and a similar component with the same name exists in the scope, Bit assume that this is the same component, which got out-of-sync and re-add it to the .bitmap. (see the last case here: https://github.com/teambit/bit/issues/1543 ). 
While this makes sense for `bit add`, it doesn't normally happen for other commands, such as create/new/fork. Recently, users having more and more different component with the same name in the scope and they expect these commands to create new components and not re-adding from the scope.
