### PR TITLE
fix(rename): simplify renaming new components to change the .bitmap only

### DIFF
--- a/e2e/harmony/rename.e2e.ts
+++ b/e2e/harmony/rename.e2e.ts
@@ -59,4 +59,24 @@ describe('bit rename command', function () {
       });
     });
   });
+  describe('rename a new component', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.rename('comp1', 'comp2');
+    });
+    it('should remove the source component', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap).to.not.have.property('comp1');
+    });
+    it('should rename the source to the target id', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap).to.have.property('comp2');
+    });
+    it('workspace should have one component only', () => {
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(1);
+    });
+  });
 });

--- a/scopes/component/renaming/rename.cmd.ts
+++ b/scopes/component/renaming/rename.cmd.ts
@@ -9,7 +9,8 @@ export type RenameOptions = {
 
 export class RenameCmd implements Command {
   name = 'rename <source-id> <target-id>';
-  description = 'EXPERIMENTAL. create a new target-component and deprecate the source-component';
+  description =
+    'EXPERIMENTAL. rename component. if tagged/exported, create a new component and deprecate the source-component';
   group = 'collaborate';
   skipWorkspace = true;
   alias = '';

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -18,11 +18,17 @@ export class RenamingMain {
 
   async rename(sourceIdStr: string, targetIdStr: string, options: RenameOptions): Promise<RenameResult> {
     const sourceId = await this.workspace.resolveComponentId(sourceIdStr);
+    const isTagged = sourceId.hasVersion();
     const sourceComp = await this.workspace.get(sourceId);
     const targetId = this.newComponentHelper.getNewComponentId(targetIdStr, undefined, options?.scope);
-    const config = await this.getConfig(sourceComp);
-    await this.newComponentHelper.writeAndAddNewComp(sourceComp, targetId, options, config);
-    await this.deprecation.deprecate(sourceId, targetId);
+    if (isTagged) {
+      const config = await this.getConfig(sourceComp);
+      await this.newComponentHelper.writeAndAddNewComp(sourceComp, targetId, options, config);
+      await this.deprecation.deprecate(sourceId, targetId);
+    } else {
+      this.workspace.bitMap.renameNewComponent(sourceId, targetId);
+      await this.workspace.bitMap.write();
+    }
 
     return {
       sourceId,

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -40,10 +40,26 @@ export class BitMap {
     await this.consumer.writeBitMap();
   }
 
+  /**
+   * get the data saved in the .bitmap file for this component-id.
+   */
   getBitmapEntry(
     id: ComponentID,
     { ignoreVersion, ignoreScopeAndVersion }: GetBitMapComponentOptions = {}
   ): ComponentMap {
     return this.legacyBitMap.getComponent(id._legacy, { ignoreVersion, ignoreScopeAndVersion });
+  }
+
+  /**
+   * components that were not tagged yet are safe to rename them from the .bitmap file.
+   */
+  renameNewComponent(sourceId: ComponentID, targetId: ComponentID) {
+    const bitMapEntry = this.getBitmapEntry(sourceId);
+    if (bitMapEntry.id.hasVersion()) {
+      throw new Error(`unable to rename tagged or exported component: ${bitMapEntry.id.toString()}`);
+    }
+    this.legacyBitMap.removeComponent(bitMapEntry.id);
+    bitMapEntry.id = targetId._legacy;
+    this.legacyBitMap.setComponent(bitMapEntry.id, bitMapEntry);
   }
 }


### PR DESCRIPTION
For new components, no need to deprecate the source component, as it wasn't saved in the model yet. It's cleaner to just rename the component in the .bitmap file.