### PR TITLE
improve cli loader on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -193,7 +193,7 @@
     "object-diff": "0.0.4",
     "object-hash": "2.1.1",
     "open": "7.4.2",
-    "ora": "4.1.1",
+    "ora": "5.4.1",
     "p-event": "4.2.0",
     "p-map": "4.0.0",
     "p-map-series": "2.1.0",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -140,7 +140,7 @@ export const DEFAULT_REMOTES = {};
 
 export const DEFAULT_DEPENDENCIES = {};
 
-export const SPINNER_TYPE = IS_WINDOWS ? cliSpinners.line : cliSpinners.dots12;
+export const SPINNER_TYPE = IS_WINDOWS ? cliSpinners.dots : cliSpinners.dots12;
 
 export const BASE_WEB_DOMAIN = 'bit.dev';
 


### PR DESCRIPTION
With a more recent version of ora, we can use unicode loaders on windows.
I tried the one that we use for unix (`bits12`) but it doesn't render well (not sure if it's just windows or it's just not a great loader?). So I used `bits` instead which is already what the preview loader uses anyway.