### PR TITLE
move loader from legacy to harmony

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -609,6 +609,12 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/modules/resolved-component"
     },
+    "modules/cli/loader": {
+        "scope": "",
+        "version": "",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/harmony/modules/cli/loader"
+    },
     "modules/style-regexps": {
         "scope": "teambit.webpack",
         "version": "0.0.131",

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -42,7 +42,7 @@ import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
 import { propogateUntil as propagateUntil } from '@teambit/legacy/dist/utils';
-import loader from '@teambit/legacy/dist/cli/loader';
+import loader from '@teambit/harmony.modules.cli.loader';
 import { readdir } from 'fs-extra';
 import { resolve } from 'path';
 import { manifestsMap } from './manifests';

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -4,7 +4,7 @@ import { Command } from '@teambit/legacy/dist/cli/command';
 import { GroupsType } from '@teambit/legacy/dist/cli/command-groups';
 import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
 import logger from '@teambit/legacy/dist/logger/logger';
-import loader from '@teambit/legacy/dist/cli/loader';
+import loader from '@teambit/harmony.modules.cli.loader';
 import chalk from 'chalk';
 import { getCommandId } from './get-command-id';
 import { formatHelp } from './help';

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -3,7 +3,7 @@ import { migrate } from '@teambit/legacy/dist/api/consumer';
 import logger, { LoggerLevel } from '@teambit/legacy/dist/logger/logger';
 import { CLIArgs, Command, Flags, RenderResult } from '@teambit/legacy/dist/cli/command';
 import { parseCommandName } from '@teambit/legacy/dist/cli/command-registry';
-import loader from '@teambit/legacy/dist/cli/loader';
+import loader from '@teambit/harmony.modules.cli.loader';
 import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
 import { TOKEN_FLAG_NAME } from '@teambit/legacy/dist/constants';
 import globalFlags from '@teambit/legacy/dist/cli/global-flags';

--- a/scopes/harmony/logger/logger.ts
+++ b/scopes/harmony/logger/logger.ts
@@ -1,4 +1,4 @@
-import loader from '@teambit/legacy/dist/cli/loader';
+import loader from '@teambit/harmony.modules.cli.loader';
 import logger, { IBitLogger } from '@teambit/legacy/dist/logger/logger';
 import chalk from 'chalk';
 import stc from 'string-to-color';

--- a/scopes/harmony/modules/cli/loader/index.ts
+++ b/scopes/harmony/modules/cli/loader/index.ts
@@ -1,0 +1,3 @@
+import loader from './loader';
+
+export default loader;

--- a/scopes/harmony/modules/cli/loader/loader.ts
+++ b/scopes/harmony/modules/cli/loader/loader.ts
@@ -1,0 +1,3 @@
+import loader from '@teambit/legacy/dist/cli/loader';
+
+export default loader;

--- a/scopes/workspace/workspace/watch/watcher.ts
+++ b/scopes/workspace/workspace/watch/watcher.ts
@@ -3,7 +3,7 @@ import { dirname, sep } from 'path';
 import { difference } from 'lodash';
 import { ComponentID } from '@teambit/component';
 import { BitId } from '@teambit/legacy-bit-id';
-import loader from '@teambit/legacy/dist/cli/loader';
+import loader from '@teambit/harmony.modules.cli.loader';
 import { BIT_MAP, COMPONENT_ORIGINS } from '@teambit/legacy/dist/constants';
 import { Consumer } from '@teambit/legacy/dist/consumer';
 import logger from '@teambit/legacy/dist/logger/logger';


### PR DESCRIPTION
Created a new loader component in harmony. We still re-export the loader from legacy because if there are 2 instances of the loader it creates bugs in the cli, in the long term we should be able to completely move the code to harmony, but for now we need to re-export.