### PR TITLE
Bug Fix: lane switch command doesn't delete files that don't exist in the switched lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -358,6 +358,27 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe(`switching lanes with deleted files`, () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
+      helper.command.addComponent('utils/', { i: 'utils/is-type' });
+      helper.command.tagAllWithoutBuild();
+      helper.command.createLane('migration');
+      helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
+      helper.fs.createFile('utils', 'is-type.spec.js', fixtures.isTypeSpec(true));
+      helper.npm.installNpmPackage('chai', '4.1.2');
+      helper.command.addComponent('utils/', { i: 'utils/is-type', t: 'utils/is-type.spec.js' });
+      helper.command.install();
+      helper.command.compile();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.switchLocalLane('main');
+    });
+    it('should delete the utils/is-type.spec.js file', () => {
+      expect(path.join(helper.scopes.localPath, 'utils/is-type.spec.js')).to.not.be.a.path();
+    });
+  });
   describe('merging lanes', () => {
     let authorScope;
     let importedScope;

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -358,16 +358,16 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe(`switching lanes with deleted files`, () => {
+  describe.only(`switching lanes with deleted files`, () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
-      helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
+      helper.fs.outputFile('utils/is-type.js', fixtures.isType);
       helper.command.addComponent('utils/', { i: 'utils/is-type' });
       helper.command.tagAllWithoutBuild();
       helper.command.createLane('migration');
-      helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
-      helper.fs.createFile('utils', 'is-type.spec.js', fixtures.isTypeSpec(true));
+      helper.fs.outputFile('utils/is-type.js', fixtures.isType);
+      helper.fs.outputFile('utils/is-type.spec.js', fixtures.isTypeSpec(true));
       helper.npm.installNpmPackage('chai', '4.1.2');
       helper.command.addComponent('utils/', { i: 'utils/is-type', t: 'utils/is-type.spec.js' });
       helper.command.install();

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -362,21 +362,18 @@ describe('bit lane command', function () {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
-      helper.fs.outputFile('utils/is-type.js', fixtures.isType);
-      helper.command.addComponent('utils/', { i: 'utils/is-type' });
+      helper.fixtures.populateComponents(1);
       helper.command.tagAllWithoutBuild();
       helper.command.createLane('migration');
-      helper.fs.outputFile('utils/is-type.js', fixtures.isType);
-      helper.fs.outputFile('utils/is-type.spec.js', fixtures.isTypeSpec(true));
-      helper.npm.installNpmPackage('chai', '4.1.2');
-      helper.command.addComponent('utils/', { i: 'utils/is-type', t: 'utils/is-type.spec.js' });
+      helper.fs.outputFile('comp1/comp1.spec.js');
+      helper.command.addComponent('comp1/', { t: 'comp1/comp1.spec.js' });
       helper.command.install();
       helper.command.compile();
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.switchLocalLane('main');
     });
-    it('should delete the utils/is-type.spec.js file', () => {
-      expect(path.join(helper.scopes.localPath, 'utils/is-type.spec.js')).to.not.be.a.path();
+    it('should delete the comp1/comp1.spec.js file', () => {
+      expect(path.join(helper.scopes.localPath, 'comp1/comp1.spec.js')).to.not.be.a.path();
     });
   });
   describe('merging lanes', () => {

--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -358,7 +358,7 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe.only(`switching lanes with deleted files`, () => {
+  describe(`switching lanes with deleted files`, () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();

--- a/src/consumer/lanes/switch-lanes.ts
+++ b/src/consumer/lanes/switch-lanes.ts
@@ -11,13 +11,7 @@ import { LaneComponent } from '../../scope/models/lane';
 import { Tmp } from '../../scope/repositories';
 import WorkspaceLane from '../bit-map/workspace-lane';
 import ManyComponentsWriter from '../component-ops/many-components-writer';
-import {
-  applyVersion,
-  CheckoutProps,
-  ComponentStatus,
-  applyModifiedVersion,
-  deleteFilesIfNeeded,
-} from '../versions-ops/checkout-version';
+import { applyVersion, CheckoutProps, ComponentStatus, deleteFilesIfNeeded } from '../versions-ops/checkout-version';
 import { FailedComponents, getMergeStrategyInteractive } from '../versions-ops/merge-version';
 import threeWayMerge, { MergeResultsThreeWay } from '../versions-ops/merge-version/three-way-merge';
 import createNewLane from './create-lane';

--- a/src/consumer/lanes/switch-lanes.ts
+++ b/src/consumer/lanes/switch-lanes.ts
@@ -62,15 +62,17 @@ export default async function switchLanes(consumer: Consumer, switchProps: Switc
     return applyVersion(consumer, id, componentFromFS, mergeResults, checkoutProps);
   });
 
-  componentsResults.forEach((cr) => {
-    const existingFilePathsFromModel = cr.applyVersionResult.filesStatus;
-    const filePathsFromFS = succeededComponents.flatMap((sc) => sc.componentFromFS?.files || []);
+  componentsResults.forEach((componentResult) => {
+    const existingFilePathsFromModel = componentResult.applyVersionResult.filesStatus;
+    const filePathsFromFS = succeededComponents.flatMap(
+      (succeededComponent) => succeededComponent.componentFromFS?.files || []
+    );
 
-    filePathsFromFS.forEach((f) => {
-      const key = pathNormalizeToLinux(f.relative);
-      if (!existingFilePathsFromModel[key]) {
+    filePathsFromFS.forEach((file) => {
+      const filename = pathNormalizeToLinux(file.relative);
+      if (!existingFilePathsFromModel[filename]) {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        existingFilePathsFromModel[key] = FileStatus.removed;
+        existingFilePathsFromModel[filename] = FileStatus.removed;
       }
     });
   });

--- a/src/consumer/lanes/switch-lanes.ts
+++ b/src/consumer/lanes/switch-lanes.ts
@@ -56,11 +56,17 @@ export default async function switchLanes(consumer: Consumer, switchProps: Switc
     return applyVersion(consumer, id, componentFromFS, mergeResults, checkoutProps);
   });
 
+  const succeededComponentsByBitId: { [K in string]: ComponentStatus } = succeededComponents.reduce((accum, next) => {
+    const bitId = next.id.toString();
+    if (!accum[bitId]) accum[bitId] = next;
+    return accum;
+  }, {});
+
   componentsResults.forEach((componentResult) => {
     const existingFilePathsFromModel = componentResult.applyVersionResult.filesStatus;
-    const filePathsFromFS = succeededComponents.flatMap(
-      (succeededComponent) => succeededComponent.componentFromFS?.files || []
-    );
+    const bitId = componentResult.applyVersionResult.id.toString();
+    const succeededComponent = succeededComponentsByBitId[bitId];
+    const filePathsFromFS = succeededComponent.componentFromFS?.files || [];
 
     filePathsFromFS.forEach((file) => {
       const filename = pathNormalizeToLinux(file.relative);

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -342,7 +342,10 @@ export function applyModifiedVersion(
  * it's needed in case the checked out version removed files that exist on the current version.
  * without this function, these files would be left on the filesystem.
  */
-async function deleteFilesIfNeeded(componentsResults: ApplyVersionWithComps[], consumer: Consumer): Promise<void> {
+export async function deleteFilesIfNeeded(
+  componentsResults: ApplyVersionWithComps[],
+  consumer: Consumer
+): Promise<void> {
   const pathsToRemoveIncludeNull = componentsResults.map((compResult) => {
     return Object.keys(compResult.applyVersionResult.filesStatus).map((filePath) => {
       if (compResult.applyVersionResult.filesStatus[filePath] === FileStatus.removed) {


### PR DESCRIPTION
## Proposed Changes

- `lane switch` command now identifies the deleted files before switching and deletes them
