### PR TITLE
fix(envs): choose the most concrete env when merging extensions from various sources

### DIFF
--- a/e2e/harmony/multiple-envs.e2e.ts
+++ b/e2e/harmony/multiple-envs.e2e.ts
@@ -1,0 +1,39 @@
+import chai, { expect } from 'chai';
+import { IssuesClasses } from '../../scopes/component/component-issues';
+
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('multiple envs', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('change an env after tag', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      const reactEnv = 'teambit.react/react';
+      helper.extensions.addExtensionToVariant('*', reactEnv);
+      // as an intermediate step, make sure the env is react.
+      const env = helper.env.getComponentEnv('comp1');
+      expect(env).to.equal(reactEnv);
+
+      helper.command.setEnv('comp1', 'teambit.harmony/aspect');
+    });
+    it('bit status should show it as an issue because the previous env was not removed', () => {
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MultipleEnvs.name);
+    });
+    it('expect the env to be the one that was set in the .bitmap file', () => {
+      const env = helper.env.getComponentEnv('comp1');
+      expect(env).to.equal('teambit.harmony/aspect');
+    });
+  });
+});

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -66,7 +66,7 @@ import { pathIsInside } from '@teambit/legacy/dist/utils';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
 import { PathOsBased, PathOsBasedRelative, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import fs from 'fs-extra';
-import { slice, uniqBy, difference, compact, pick } from 'lodash';
+import { slice, uniqBy, difference, compact, pick, partition } from 'lodash';
 import path from 'path';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import type { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
@@ -873,20 +873,16 @@ export class Workspace implements ComponentFactory {
 
   /**
    * Calculate the component config based on:
+   * the config property in the .bitmap file
    * the component.json file in the component folder
    * matching pattern in the variants config
    * defaults extensions from workspace config
-   *
-   * @param {ComponentID} componentId
-   * @param {Component} [componentFromScope]
-   * @returns {Promise<ExtensionDataList>}
-   * @memberof Workspace
    */
   async componentExtensions(componentId: ComponentID, componentFromScope?: Component): Promise<ExtensionDataList> {
     // TODO: consider caching this result
-    let configFileExtensions;
-    let variantsExtensions;
-    let wsDefaultExtensions;
+    let configFileExtensions: ExtensionDataList | undefined;
+    let variantsExtensions: ExtensionDataList | undefined;
+    let wsDefaultExtensions: ExtensionDataList | undefined;
     const mergeFromScope = true;
     const scopeExtensions = componentFromScope?.config?.extensions || new ExtensionDataList();
 
@@ -915,54 +911,84 @@ export class Workspace implements ComponentFactory {
     // We don't stop on each step because we want to merge the default scope even if propagate=false but the default scope is not defined
     // in the case the same extension pushed twice, the former takes precedence (opposite of Object.assign)
     const extensionsToMerge: ExtensionDataList[] = [];
+    let envWasFoundPreviously = false;
+
+    const addAndLoadExtensions = async (extensions: ExtensionDataList) => {
+      const extsWithoutRemoved = extensions.filterRemovedExtensions();
+      const selfInMergedExtensions = extsWithoutRemoved.findExtension(
+        componentId._legacy.toStringWithoutScopeAndVersion(),
+        true,
+        true
+      );
+      const extsWithoutSelf = selfInMergedExtensions?.extensionId
+        ? extsWithoutRemoved.remove(selfInMergedExtensions.extensionId)
+        : extsWithoutRemoved;
+      await this.loadExtensions(extsWithoutSelf);
+      const { extensionDataListFiltered, envIsCurrentlySet } = this.filterEnvsFromExtensionsIfNeeded(
+        extsWithoutSelf,
+        envWasFoundPreviously
+      );
+      if (envIsCurrentlySet) envWasFoundPreviously = true;
+
+      extensionsToMerge.push(extensionDataListFiltered);
+    };
     if (bitMapExtensions) {
       const extensionsDataEntries = Object.keys(bitMapExtensions).map(
         (aspectId) => new ExtensionDataEntry(aspectId, undefined, aspectId, bitMapExtensions[aspectId])
       );
       const extensionDataList = new ExtensionDataList(...extensionsDataEntries);
-      extensionsToMerge.push(extensionDataList);
+      await addAndLoadExtensions(extensionDataList);
     }
     if (configFileExtensions) {
-      extensionsToMerge.push(configFileExtensions);
+      await addAndLoadExtensions(configFileExtensions);
     }
     let continuePropagating = componentConfigFile?.propagate ?? true;
     if (variantsExtensions && continuePropagating) {
       // Put it in the start to make sure the config file is stronger
-      extensionsToMerge.push(variantsExtensions);
+      await addAndLoadExtensions(variantsExtensions);
     }
     continuePropagating = continuePropagating && (variantConfig?.propagate ?? true);
     // Do not apply default extensions on the default extensions (it will create infinite loop when loading them)
-    const isDefaultExtension = wsDefaultExtensions.findExtension(componentId.toString(), true, true);
+    const isDefaultExtension = wsDefaultExtensions?.findExtension(componentId.toString(), true, true);
     if (wsDefaultExtensions && continuePropagating && !isDefaultExtension) {
       // Put it in the start to make sure the config file is stronger
-      extensionsToMerge.push(wsDefaultExtensions);
+      await addAndLoadExtensions(wsDefaultExtensions);
     }
 
     // It's before the scope extensions, since there is no need to resolve extensions from scope they are already resolved
     // await Promise.all(extensionsToMerge.map((extensions) => this.resolveExtensionsList(extensions)));
-
     if (mergeFromScope && continuePropagating) {
-      extensionsToMerge.push(scopeExtensions);
+      await addAndLoadExtensions(scopeExtensions);
     }
 
     // It's important to do this resolution before the merge, otherwise we have issues with extensions
     // coming from scope with local scope name, as opposed to the same extension comes from the workspace with default scope name
-    const promises = extensionsToMerge.map((list) => this.resolveExtensionListIds(list));
-    await Promise.all(promises);
+    await Promise.all(extensionsToMerge.map((list) => this.resolveExtensionListIds(list)));
 
-    let mergedExtensions = ExtensionDataList.mergeConfigs(extensionsToMerge).filterRemovedExtensions();
+    return ExtensionDataList.mergeConfigs(extensionsToMerge);
+  }
 
-    // remove self from merged extensions
-    const selfInMergedExtensions = mergedExtensions.findExtension(
-      componentId._legacy.toStringWithoutScopeAndVersion(),
-      true,
-      true
+  private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
+    const envAspect = extensionDataList.findExtension(EnvsAspect.id);
+    const envFromEnvsAspect = envAspect?.config.env;
+    const [envsNotFromEnvsAspect, nonEnvs] = partition(extensionDataList, (ext) =>
+      this.envs.isEnvRegistered(ext.stringId)
     );
-    if (selfInMergedExtensions && selfInMergedExtensions.extensionId) {
-      mergedExtensions = mergedExtensions.remove(selfInMergedExtensions.extensionId);
+    const extensionDataListFiltered = new ExtensionDataList(...nonEnvs);
+    const envIsCurrentlySet = envFromEnvsAspect || envsNotFromEnvsAspect.length;
+    const shouldIgnoreCurrentEnv = envIsCurrentlySet && envWasFoundPreviously;
+    if (shouldIgnoreCurrentEnv) {
+      // still, aspect env may have other data other then config.env.
+      if (envAspect) {
+        delete envAspect.config.env;
+        extensionDataListFiltered.push(envAspect);
+      }
+    } else {
+      // add the envs
+      if (envAspect) extensionDataListFiltered.push(envAspect);
+      extensionDataListFiltered.push(...envsNotFromEnvsAspect);
     }
-
-    return mergedExtensions;
+    return { extensionDataListFiltered, envIsCurrentlySet };
   }
 
   async triggerOnPreWatch(componentIds: ComponentID[], watchOpts: WatchOptions) {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -142,6 +142,9 @@ export default class CommandHelper {
   setConfig(configName: string, configVal: string) {
     return this.runCmd(`bit config set ${configName} ${configVal}`);
   }
+  setEnv(compId: string, envId: string) {
+    return this.runCmd(`bit envs set ${compId} ${envId}`);
+  }
   untrackComponent(id = '', all = false, cwd: string = this.scopes.localPath) {
     return this.runCmd(`bit untrack ${id} ${all ? '--all' : ''}`, cwd);
   }


### PR DESCRIPTION
Component's extensions are merged from multiple places, such as `workspace.jsonc#variants` and `.bitmap#config`.  Currently, if these sources has different envs, `bit status` shows "multiple-envs" warning.
This PR changes this merge algorithm to ignore envs that are less concrete/strong. 
