### PR TITLE
fix(lanes): avoid replacing the version in .bitmap with the lane version when switching to a remote lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1282,4 +1282,35 @@ describe('bit lane command', function () {
       expect(comp1.localVersion).to.equal(secondSnap);
     });
   });
+  describe('switch to main after importing a lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild(); // main has 0.0.1
+      helper.command.export();
+
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.bitJsonc.setupDefault();
+      helper.command.importComponent('comp1');
+      helper.command.switchRemoteLane('dev');
+      helper.command.switchLocalLane('main');
+    });
+    // a previous bug was saving the hash from the lane in the bitmap file
+    it('.bitmap should have the component with the main version', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap.comp1.version).to.equal('0.0.1');
+    });
+    it('should list the component as 0.0.1 and not with a hash', () => {
+      const list = helper.command.listParsed();
+      expect(list[0].localVersion).to.equal('0.0.1');
+      expect(list[0].currentVersion).to.equal('0.0.1');
+    });
+  });
 });

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -659,13 +659,16 @@ export default class BitMap {
       if (componentMap) {
         logger.info(`bit.map: updating an exiting component ${componentMap.id.toString()}`);
         componentMap.files = files;
-        componentMap.id = componentId;
         if (componentId.hasVersion() && this.workspaceLane) {
-          // happening during checkout for example
+          // happening during checkout for example or during switch to a remote lane
           // @todo: needs to decide, maybe the best place to sync the workspaceLane is before writing to the .bitmap
           // file. maybe in `toObject` method in this class.
           this.workspaceLane.addEntry(componentId);
+          // this is to make sure the version of the lane is not written to the .bitmap file.
+          // it is saved in the workspaceLane. but the .bitmap has always the "main" version.
+          componentMap.defaultVersion = componentMap.defaultVersion || componentMap.id.version;
         }
+        componentMap.id = componentId;
         return componentMap;
       }
       if (origin === COMPONENT_ORIGINS.IMPORTED || origin === COMPONENT_ORIGINS.AUTHORED) {

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -79,7 +79,7 @@ export default class ComponentMap {
   exported: boolean | null | undefined; // relevant for authored components only, it helps finding out whether a component has a scope
   onLanesOnly? = false; // whether a component is available only on lanes and not on main
   lanes: LaneVersion[]; // save component versions per lanes if they're different than the id
-  defaultVersion?: string | null;
+  defaultVersion?: string | null; // temporarily store the "main" version. so then, once the file is written, this value is saved as the version
   isAvailableOnCurrentLane? = true; // if a component was created on another lane, it might not be available on the current lane
   nextVersion?: NextVersion; // for soft-tag (harmony only), this data is used in the CI to persist
   recentlyTracked?: boolean; // eventually the timestamp is saved in the filesystem cache so it won't be re-tracked if not changed


### PR DESCRIPTION
Normally, when snapping on a lane or switching to a non-main lane, the version is written to the workspace-lane, not to the .bitmap. The .bitmap file represents the main lane. always.
This PR fixes the case when switching lanes from a remote lane to not save the snap inside the .bitmap file.