### PR TITLE
feat: log CLI input and output

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -16,7 +16,7 @@ export class CLIParser {
 
   async parse(args = process.argv.slice(2)) {
     this.throwForNonExistsCommand(args[0]);
-
+    logger.debug(`[+] CLI-INPUT: ${args.join(' ')}`);
     yargs(args);
     yargs.help(false);
     this.configureParser();

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -118,7 +118,7 @@ export class CommandRunner {
 
   private async writeAndExit(data: string, exitCode: number) {
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    return process.stdout.write(data, async () => logger.exitAfterFlush(exitCode, this.commandName));
+    return process.stdout.write(data, async () => logger.exitAfterFlush(exitCode, this.commandName, data));
   }
 
   private async runMigrateIfNeeded(): Promise<any> {

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -69,7 +69,6 @@ import ExtensionInitError from '../legacy-extensions/exceptions/extension-init-e
 import ExtensionLoadError from '../legacy-extensions/exceptions/extension-load-error';
 import ExtensionNameNotValid from '../legacy-extensions/exceptions/extension-name-not-valid';
 import ExtensionSchemaError from '../legacy-extensions/exceptions/extension-schema-error';
-import logger from '../logger/logger';
 import PromptCanceled from '../prompts/exceptions/prompt-canceled';
 import RemoteNotFound from '../remotes/exceptions/remote-not-found';
 import {
@@ -607,6 +606,5 @@ export default (err: Error): { message: string; error: Error } => {
   };
   sendToAnalyticsAndSentry(err);
   const errorMessage = getErrMsg();
-  // logger.error(`user gets the following error: ${errorMessage}`);
   return { message: chalk.red(errorMessage), error: err };
 };

--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -607,6 +607,6 @@ export default (err: Error): { message: string; error: Error } => {
   };
   sendToAnalyticsAndSentry(err);
   const errorMessage = getErrMsg();
-  logger.error(`user gets the following error: ${errorMessage}`);
+  // logger.error(`user gets the following error: ${errorMessage}`);
   return { message: chalk.red(errorMessage), error: err };
 };

--- a/src/cli/handle-errors.ts
+++ b/src/cli/handle-errors.ts
@@ -34,7 +34,7 @@ export async function handleUnhandledRejection(err: Error | null | undefined | {
 export async function logErrAndExit(err: Error | string, commandName: string) {
   if (!err) throw new Error(`logErrAndExit expects to get either an Error or a string, got nothing`);
   console.error(err); // eslint-disable-line
-  await logger.exitAfterFlush(1, commandName);
+  await logger.exitAfterFlush(1, commandName, err.toString());
 }
 
 function serializeErrAndExit(err, commandName: string) {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -160,17 +160,16 @@ class BitLogger implements IBitLogger {
     console ? this.console(fullMsg) : this.info(fullMsg);
   }
 
-  async exitAfterFlush(code = 0, commandName: string) {
+  async exitAfterFlush(code = 0, commandName: string, cliOutput = '') {
     await Analytics.sendData();
-    let level;
-    let msg;
-    if (code === 0) {
-      level = 'info';
-      msg = `[*] the command "${commandName}" has been completed successfully`;
-    } else {
-      level = 'error';
-      msg = `[*] the command "${commandName}" has been terminated with an error code ${code}`;
+    const isSuccess = code === 0;
+    const level = isSuccess ? 'info' : 'error';
+    if (cliOutput) {
+      this.logger[level](`[+] CLI-OUTPUT: ${cliOutput}`);
     }
+    const msg = isSuccess
+      ? `[*] the command "${commandName}" has been completed successfully`
+      : `[*] the command "${commandName}" has been terminated with an error code ${code}`;
     // this should have been helpful to not miss any log message when using `sync: false` in the
     // Pino opts, but sadly, it doesn't help.
     // const finalLogger = pino.final(pinoLogger);

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -413,6 +413,9 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
 
     if (unmergedComponent) {
       version.addParent(unmergedComponent.head);
+      logger.debug(
+        `sources.addSource, unmerged component "${component.name}". adding a parent ${unmergedComponent.head.hash}`
+      );
       version.log.message = version.log.message
         ? version.log.message
         : UnmergedComponents.buildSnapMessage(unmergedComponent);


### PR DESCRIPTION
Currently, from the log it's hard to determine what the user typed in the CLI and what was the received output.
This PR logs these two with a distinctive prefix. E.g.
```
[2022-01-07 10:24:09.287 -0500] DEBUG (42404): [+] CLI-INPUT: lane merge dev
[2022-01-07 10:24:09.434 -0500] ERROR (42404): [+] CLI-OUTPUT: unable to switch to "dev", the lane was not found
```
Later, we can easily parse the log files and extract only the data the user saw in the terminal.