### PR TITLE
Using a component with different peer dependencies depending from the context

### DIFF
--- a/e2e/harmony/root-components.e2e.ts
+++ b/e2e/harmony/root-components.e2e.ts
@@ -1,0 +1,626 @@
+import chai, { expect } from 'chai';
+import fs from 'fs-extra';
+import path from 'path';
+import { sync as resolveSync } from 'resolve';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('root components', function () {
+  let helper: Helper;
+  this.timeout(0);
+
+  describe('pnpm isolated linker', function () {
+    let virtualStoreDir!: string;
+    let numberOfFilesInVirtualStore!: number;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(4);
+      helper.extensions.bitJsonc.addKeyValToDependencyResolver('rootComponents', [
+        '@my-scope/comp3',
+        '@my-scope/comp4',
+      ]);
+      helper.fs.outputFile(`comp1/index.js`, `const React = require("react")`);
+      helper.fs.outputFile(
+        `comp2/index.js`,
+        `const React = require("react");const comp1 = require("@my-scope/comp1");`
+      );
+      helper.fs.outputFile(
+        `comp3/index.js`,
+        `const React = require("react");const comp2 = require("@my-scope/comp2");`
+      );
+      helper.fs.outputFile(
+        `comp4/index.js`,
+        `const React = require("react");const comp2 = require("@my-scope/comp2");`
+      );
+      helper.extensions.addExtensionToVariant('comp1', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16 || 17',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp2', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16 || 17',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp3', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp4', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '17',
+          },
+        },
+      });
+      helper.command.install();
+      virtualStoreDir = path.join(helper.fixtures.scopes.localPath, 'node_modules/.pnpm');
+      numberOfFilesInVirtualStore = fs.readdirSync(virtualStoreDir).length;
+    });
+    after(() => {
+      helper.scopeHelper.destroy();
+    });
+    it('should install root components', () => {
+      expect(path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root`)).to.be.a.path();
+      expect(path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root`)).to.be.a.path();
+    });
+    it('should install the dependencies of the root component that has react 17 in the dependencies with react 17', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^17\./);
+    });
+    it('should install the dependencies of the root component that has react 16 in the dependencies with react 16', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^16\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^16\./);
+    });
+    it('should install the non-root components with their default React versions', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^16\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+    });
+    it('should create package.json file in every variation of the component', () => {
+      let pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp3__root',
+        '@my-scope/comp2/package.json',
+      ]);
+      expect(pkgJsonLoc).to.contain('.pnpm');
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp4__root',
+        '@my-scope/comp2/package.json',
+      ]);
+      expect(pkgJsonLoc).to.contain('.pnpm');
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp3__root',
+        '@my-scope/comp2',
+        '@my-scope/comp1/package.json',
+      ]);
+      expect(pkgJsonLoc).to.contain('.pnpm');
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp4__root',
+        '@my-scope/comp2',
+        '@my-scope/comp1/package.json',
+      ]);
+      expect(pkgJsonLoc).to.contain('.pnpm');
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+    });
+    describe('repeat install', () => {
+      before(() => {
+        helper.command.install();
+      });
+      it('should not add new or remove old deps', () => {
+        expect(fs.readdirSync(virtualStoreDir).length).to.eq(numberOfFilesInVirtualStore);
+      });
+      it('should install the dependencies of the root component that has react 17 in the dependencies with react 17', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp4__root',
+              '@my-scope/comp2',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp4__root',
+              '@my-scope/comp2',
+              '@my-scope/comp1',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^17\./);
+      });
+      it('should install the dependencies of the root component that has react 16 in the dependencies with react 16', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp3__root',
+              '@my-scope/comp2',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^16\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp3__root',
+              '@my-scope/comp2',
+              '@my-scope/comp1',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^16\./);
+      });
+      it('should install the non-root components with their default React versions', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^16\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+      });
+      it('should create package.json file in every variation of the component', () => {
+        let pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp3__root',
+          '@my-scope/comp2/package.json',
+        ]);
+        expect(pkgJsonLoc).to.contain('.pnpm');
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp4__root',
+          '@my-scope/comp2/package.json',
+        ]);
+        expect(pkgJsonLoc).to.contain('.pnpm');
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp3__root',
+          '@my-scope/comp2',
+          '@my-scope/comp1/package.json',
+        ]);
+        expect(pkgJsonLoc).to.contain('.pnpm');
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp4__root',
+          '@my-scope/comp2',
+          '@my-scope/comp1/package.json',
+        ]);
+        expect(pkgJsonLoc).to.contain('.pnpm');
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+      });
+    });
+    describe('compilation', () => {
+      before(() => {
+        helper.command.compile();
+      });
+      it('should create the dist folder in all the locations of the component', () => {
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3__root/dist/index.js'])).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3__root', '@my-scope/comp2/dist/index.js'])
+        ).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1/dist/index.js',
+          ])
+        ).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4__root/dist/index.js'])).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4__root', '@my-scope/comp2/dist/index.js'])
+        ).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1/dist/index.js',
+          ])
+        ).to.exist;
+      });
+    });
+  });
+
+  describe('pnpm hoisted linker', function () {
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(4);
+      helper.extensions.bitJsonc.addKeyValToDependencyResolver('nodeLinker', 'hoisted');
+      helper.extensions.bitJsonc.addKeyValToDependencyResolver('rootComponents', [
+        '@my-scope/comp3',
+        '@my-scope/comp4',
+      ]);
+      helper.fs.outputFile(`comp1/index.js`, `const React = require("react")`);
+      helper.fs.outputFile(
+        `comp2/index.js`,
+        `const React = require("react");const comp1 = require("@my-scope/comp1");`
+      );
+      helper.fs.outputFile(
+        `comp3/index.js`,
+        `const React = require("react");const comp2 = require("@my-scope/comp2");`
+      );
+      helper.fs.outputFile(
+        `comp4/index.js`,
+        `const React = require("react");const comp2 = require("@my-scope/comp2");`
+      );
+      helper.extensions.addExtensionToVariant('comp1', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16 || 17',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp2', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16 || 17',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp3', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '16',
+          },
+        },
+      });
+      helper.extensions.addExtensionToVariant('comp4', 'teambit.dependencies/dependency-resolver', {
+        policy: {
+          peerDependencies: {
+            react: '17',
+          },
+        },
+      });
+      helper.command.install();
+    });
+    after(() => {
+      helper.scopeHelper.destroy();
+    });
+    it('should install root components', () => {
+      expect(path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root`)).to.be.a.path();
+      expect(path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root`)).to.be.a.path();
+    });
+    it('should use a hoisted layout', () => {
+      expect(
+        path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root/node_modules/@my-scope/comp1`)
+      ).to.be.a.path();
+      expect(
+        path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root/node_modules/@my-scope/comp2`)
+      ).to.be.a.path();
+      expect(
+        path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root/node_modules/@my-scope/comp1`)
+      ).to.be.a.path();
+      expect(
+        path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root/node_modules/@my-scope/comp2`)
+      ).to.be.a.path();
+    });
+    it('should install the dependencies of the root component that has react 17 in the dependencies with react 17', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^17\./);
+    });
+    it('should install the dependencies of the root component that has react 16 in the dependencies with react 16', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^16\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1',
+            'react/package.json',
+          ])
+        ).version
+      ).to.match(/^16\./);
+    });
+    it('should install the non-root components with their default React versions', () => {
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^16\./);
+      expect(
+        fs.readJsonSync(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/index.js', 'react/package.json'])
+        ).version
+      ).to.match(/^17\./);
+    });
+    it('should create package.json file in every variation of the component', () => {
+      let pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp3__root',
+        '@my-scope/comp2/package.json',
+      ]);
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp4__root',
+        '@my-scope/comp2/package.json',
+      ]);
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp3__root',
+        '@my-scope/comp2',
+        '@my-scope/comp1/package.json',
+      ]);
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+
+      pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+        '@my-scope/comp4__root',
+        '@my-scope/comp2',
+        '@my-scope/comp1/package.json',
+      ]);
+      expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+    });
+    describe('repeat install', () => {
+      before(() => {
+        helper.command.install();
+      });
+      it('should use a hoisted layout', () => {
+        expect(
+          path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root/node_modules/@my-scope/comp1`)
+        ).to.be.a.path();
+        expect(
+          path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp3__root/node_modules/@my-scope/comp2`)
+        ).to.be.a.path();
+        expect(
+          path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root/node_modules/@my-scope/comp1`)
+        ).to.be.a.path();
+        expect(
+          path.join(helper.fixtures.scopes.localPath, `node_modules/@my-scope/comp4__root/node_modules/@my-scope/comp2`)
+        ).to.be.a.path();
+      });
+      it('should install the dependencies of the root component that has react 17 in the dependencies with react 17', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp4__root',
+              '@my-scope/comp2',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp4__root',
+              '@my-scope/comp2',
+              '@my-scope/comp1',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^17\./);
+      });
+      it('should install the dependencies of the root component that has react 16 in the dependencies with react 16', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp3__root',
+              '@my-scope/comp2',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^16\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, [
+              '@my-scope/comp3__root',
+              '@my-scope/comp2',
+              '@my-scope/comp1',
+              'react/package.json',
+            ])
+          ).version
+        ).to.match(/^16\./);
+      });
+      it('should install the non-root components with their default React versions', () => {
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^16\./);
+        expect(
+          fs.readJsonSync(
+            resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/index.js', 'react/package.json'])
+          ).version
+        ).to.match(/^17\./);
+      });
+      it('should create package.json file in every variation of the component', () => {
+        let pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp3__root',
+          '@my-scope/comp2/package.json',
+        ]);
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp4__root',
+          '@my-scope/comp2/package.json',
+        ]);
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp2');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp3__root',
+          '@my-scope/comp2',
+          '@my-scope/comp1/package.json',
+        ]);
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+
+        pkgJsonLoc = resolveFrom(helper.fixtures.scopes.localPath, [
+          '@my-scope/comp4__root',
+          '@my-scope/comp2',
+          '@my-scope/comp1/package.json',
+        ]);
+        expect(fs.readJsonSync(pkgJsonLoc).name).to.eq('@my-scope/comp1');
+      });
+    });
+    describe('compilation', () => {
+      before(() => {
+        helper.command.compile();
+      });
+      it('should create the dist folder in all the locations of the component', () => {
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp1/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp2/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4/dist/index.js'])).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3__root/dist/index.js'])).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp3__root', '@my-scope/comp2/dist/index.js'])
+        ).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp3__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1/dist/index.js',
+          ])
+        ).to.exist;
+        expect(resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4__root/dist/index.js'])).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, ['@my-scope/comp4__root', '@my-scope/comp2/dist/index.js'])
+        ).to.exist;
+        expect(
+          resolveFrom(helper.fixtures.scopes.localPath, [
+            '@my-scope/comp4__root',
+            '@my-scope/comp2',
+            '@my-scope/comp1/dist/index.js',
+          ])
+        ).to.exist;
+      });
+    });
+  });
+});
+
+function resolveFrom(fromDir: string, moduleIds: string[]) {
+  if (moduleIds.length === 0) return fromDir;
+  const [moduleId, ...rest] = moduleIds;
+  // We use the "resolve" library because the native "require.resolve" method uses a cache.
+  // So with the native resolve method we cannot check the same path twice.
+  return resolveFrom(resolveSync(moduleId, { basedir: fromDir, preserveSymlinks: false }), rest);
+}

--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -5,6 +5,7 @@ import { Component, ComponentID } from '@teambit/component';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { BitId } from '@teambit/legacy-bit-id';
 
+import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import ManyComponentsWriter from '@teambit/legacy/dist/consumer/component-ops/many-components-writer';
 import { LoggerAspect, LoggerMain } from '@teambit/logger';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
@@ -75,9 +76,21 @@ export class CompilerMain {
     BuilderAspect,
     UIAspect,
     GeneratorAspect,
+    DependencyResolverAspect,
   ];
 
-  static async provider([cli, workspace, envs, loggerMain, pubsub, aspectLoader, builder, ui, generator]: [
+  static async provider([
+    cli,
+    workspace,
+    envs,
+    loggerMain,
+    pubsub,
+    aspectLoader,
+    builder,
+    ui,
+    generator,
+    dependencyResolver,
+  ]: [
     CLIMain,
     Workspace,
     EnvsMain,
@@ -86,10 +99,19 @@ export class CompilerMain {
     AspectLoaderMain,
     BuilderMain,
     UiMain,
-    GeneratorMain
+    GeneratorMain,
+    DependencyResolverMain
   ]) {
     const logger = loggerMain.createLogger(CompilerAspect.id);
-    const workspaceCompiler = new WorkspaceCompiler(workspace, envs, pubsub, aspectLoader, ui, logger);
+    const workspaceCompiler = new WorkspaceCompiler(
+      workspace,
+      envs,
+      pubsub,
+      aspectLoader,
+      ui,
+      logger,
+      dependencyResolver
+    );
     envs.registerService(new CompilerService());
     const compilerMain = new CompilerMain(pubsub, workspaceCompiler, envs, builder);
     cli.register(new CompileCmd(workspaceCompiler, logger, pubsub));

--- a/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency-list.ts
@@ -70,8 +70,8 @@ export class DependencyList {
     return serialized;
   }
 
-  toDependenciesManifest(): DependenciesManifest {
-    const manifest: DependenciesManifest = {
+  toDependenciesManifest(): Required<DependenciesManifest> {
+    const manifest: Required<DependenciesManifest> = {
       dependencies: {},
       devDependencies: {},
       peerDependencies: {},

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -103,8 +103,10 @@ export class DependencyInstaller {
       });
     }
 
-    // remove node modules dir for all components dirs, since it might contain left overs from previous install
-    await this.cleanCompsNodeModules(componentDirectoryMap);
+    if (!packageManagerOptions.rootComponents?.length) {
+      // remove node modules dir for all components dirs, since it might contain left overs from previous install
+      await this.cleanCompsNodeModules(componentDirectoryMap);
+    }
 
     // TODO: the cache should be probably passed to the package manager constructor not to the install function
     await this.packageManager.install(finalRootDir, rootPolicy, componentDirectoryMap, calculatedPmOpts);

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -619,6 +619,7 @@ function resolveModuleDirFromFile(resolvedModulePath: string, moduleId: string):
   }
 
   const [start, end] = resolvedModulePath.split('@');
+  if (!end) return path.basename(resolvedModulePath);
   const versionStr = head(end.split('/'));
   return `${start}@${versionStr}`;
 }

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -9,7 +9,6 @@ import {
   PEER_DEP_LIFECYCLE_TYPE,
   RUNTIME_DEP_LIFECYCLE_TYPE,
 } from '../../dependencies/constants';
-import { ManifestDependenciesObject } from '../manifest';
 import { DependencyLifecycleType, SemverVersion, PackageName } from '../../dependencies';
 import { DedupedDependencies, DedupedDependenciesPeerConflicts } from './dedupe-dependencies';
 import { PackageNameIndex, PackageNameIndexItem, PackageNameIndexComponentItem } from './index-by-dep-id';
@@ -408,7 +407,10 @@ function addToComponentDependenciesMapInDeduped(
         peerDependencies: {},
       };
     }
-    compEntry[depKeyName] = Object.assign({}, compEntry[depKeyName], { [packageName]: indexItem.range });
+    compEntry[depKeyName] = {
+      ...compEntry[depKeyName],
+      [packageName]: indexItem.range,
+    };
     dedupedDependencies.componentDependenciesMap.set(indexItem.origin, compEntry);
   };
 }
@@ -472,7 +474,7 @@ export function getEmptyDedupedDependencies(): DedupedDependencies {
       devDependencies: {},
       peerDependencies: {},
     },
-    componentDependenciesMap: new Map<PackageName, ManifestDependenciesObject>(),
+    componentDependenciesMap: new Map(),
     issus: {
       peerConflicts: [],
     },

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -31,6 +31,8 @@ export type PackageManagerInstallOptions = {
   packageManagerConfigRootDir?: string;
 
   packageImportMethod?: PackageImportMethod;
+
+  rootComponents?: string[];
 };
 
 export type PackageManagerGetPeerDependencyIssuesOptions = PackageManagerInstallOptions;
@@ -73,6 +75,8 @@ export interface PackageManager {
     componentDirectoryMap: ComponentMap<string>,
     options: PackageManagerGetPeerDependencyIssuesOptions
   ): Promise<PeerDependencyIssuesByProjects>;
+
+  getInjectedDirs?(rootDir: string, componentDir: string): Promise<string[]>;
 
   getRegistries?(): Promise<Registries>;
 

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -19,6 +19,7 @@ import { Logger } from '@teambit/logger';
 import { memoize, omit } from 'lodash';
 import { PkgMain } from '@teambit/pkg';
 import { PeerDependencyIssuesByProjects } from '@pnpm/core';
+import { read as readModulesState } from '@pnpm/modules-yaml';
 import { ProjectManifest } from '@pnpm/types';
 import { join } from 'path';
 import userHome from 'user-home';
@@ -131,6 +132,7 @@ export class PnpmPackageManager implements PackageManager {
         hoistPattern: config.hoistPattern,
         publicHoistPattern: ['*eslint*', '@prettier/plugin-*', '*prettier-plugin-*'],
         packageImportMethod: installOptions.packageImportMethod ?? config.packageImportMethod,
+        rootComponents: installOptions.rootComponents,
       },
       this.logger
     );
@@ -251,5 +253,10 @@ export class PnpmPackageManager implements PackageManager {
     }
 
     return new Registries(defaultRegistry, scopesRegistries);
+  }
+
+  async getInjectedDirs(rootDir: string, componentDir: string): Promise<string[]> {
+    const modulesState = await readModulesState(join(rootDir, 'node_modules'));
+    return modulesState?.injectedDeps?.[componentDir] ?? [];
   }
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1715,6 +1715,16 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
       `installing dependencies in workspace using ${chalk.cyan(this.dependencyResolver.getPackageManagerName())}`
     );
     this.logger.debug(`installing dependencies in workspace with options`, options);
+    // TODO: this make duplicate
+    // this.logger.consoleSuccess();
+    // TODO: add the links results to the output
+    await this.link({
+      linkTeambitBit: true,
+      legacyLink: true,
+      linkCoreAspects: false,
+      linkNestedDepsInNM: false,
+    });
+    this.consumer.componentLoader.clearComponentsCache();
     this.clearCache();
     // TODO: pass get install options
     const installer = this.dependencyResolver.getInstaller({});
@@ -1723,20 +1733,23 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
 
     const depsFilterFn = await this.generateFilterFnForDepsFromLocalRemote();
 
+    const rootComponents = this.dependencyResolver.config.rootComponents;
+    const hasRootComponents = Boolean(rootComponents?.length);
+    if (hasRootComponents && this.dependencyResolver.config.packageManager !== 'teambit.dependencies/pnpm') {
+      throw new BitError('rootComponents are only supported by the pnpm package manager');
+    }
     const pmInstallOptions: PackageManagerInstallOptions = {
-      dedupe: options?.dedupe,
+      dedupe: !hasRootComponents && options?.dedupe,
       copyPeerToRuntimeOnRoot: options?.copyPeerToRuntimeOnRoot ?? true,
       copyPeerToRuntimeOnComponents: options?.copyPeerToRuntimeOnComponents ?? false,
       dependencyFilterFn: depsFilterFn,
       overrides: this.dependencyResolver.config.overrides,
       packageImportMethod: this.dependencyResolver.config.packageImportMethod,
+      rootComponents,
     };
     await installer.install(this.path, mergedRootPolicy, compDirMap, { installTeambitBit: false }, pmInstallOptions);
-    // TODO: this make duplicate
-    // this.logger.consoleSuccess();
-    // TODO: add the links results to the output
     await this.link({
-      linkTeambitBit: true,
+      linkTeambitBit: false,
       legacyLink: true,
       linkCoreAspects: true,
       linkNestedDepsInNM: !this.isLegacy,

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -306,6 +306,18 @@ export default class DependencyResolver {
         Object.assign(this.allPackagesDependencies[this._pkgFieldMapping(depField)], packages[depField]);
       }
     });
+    // The automatic dependency detector considers all found dependencies to be runtime dependencies.
+    // But this breaks proper installation of injected subdependencies that are resolved from workspace components.
+    if (this.allPackagesDependencies.packageDependencies && packages.peerDependencies) {
+      for (const peerName of Object.keys(packages.peerDependencies)) {
+        delete this.allPackagesDependencies.packageDependencies[peerName];
+      }
+    }
+    if (this.allPackagesDependencies.packageDependencies && packages.peerPackageDependencies) {
+      for (const peerName of Object.keys(packages.peerPackageDependencies)) {
+        delete this.allPackagesDependencies.packageDependencies[peerName];
+      }
+    }
   }
 
   applyOverridesOnEnvPackages() {


### PR DESCRIPTION
Related PRs:
- https://github.com/pnpm/pnpm/pull/4259
- https://github.com/pnpm/pnpm/commit/c1383044d18c70b430b8a6fbee1ef745aefc09cc
- https://github.com/pnpm/pnpm/pull/4299
- https://github.com/pnpm/pnpm/pull/4300
- https://github.com/pnpm/pnpm/pull/4304

## Proposed Changes

As of this pull request, this feature will be only supported by pnpm as the package manager (but both the hoisted and isolated `nodeLinker` will work).

A new optional setting added to the `dependency-resolver` aspect: `rootComponents`. `rootComponents` is an array of component package names.

Root components are installed in isolation from the workspace. None of the dependencies of root components are symlinked from the workspace. Instead, the dependencies of root components are copied (or hard linked) into the `node_modules` of the root component.

Root components are installed at `<workspace root>/node_modules/<root component pkg name>__root`. The dependencies of the root component are installed either inside the virtual store (`node_modules/.pnpm`) or hoisted inside node_modules using Yarn's hoisting algorithm (pnpm uses Yarn's hoisting algorithm for the "hoisted" linker). 

Let's see how it will work on the following example:

```
button        has react 16 || 17 in peer deps
app1          has react 16 in peer deps   has button in the deps
app2          has react 17 in peer deps   has button in the deps
workspace.jsonc
```

`app1` and `app2` are listed as rootComponents.

In this case, bit will create the following `node_modules` structure:

```
app1
  node_modules/react --> <ROOT>/node_modules/.pnpm/react@16
  app1.tsx
app2
  node_modules/react --> <ROOT>/node_modules/.pnpm/react@17
  app2.tsx
button
  node_modules/react --> <ROOT>/node_modules/.pnpm/react@17
  button.tsx
node_modules
  .pnpm
    react@16
    react@17
    app1
      node_modules
        app1
          dist
            app1.js
          app1.js
          package.json
        button --> ../../button+react@16
        react --> ../../react@16
    button+react@16
      node_modules
        button
          dist
            button.js
          button.js
          package.json
        react --> ../../react@16
    app2
      node_modules
        app2
          dist
            app2.js
          app2.js
          package.json
        button --> ../../button+react@17
        react --> ../../react@17
    button+react@17
      node_modules
        button
          dist
            button.js
          button.js
          package.json
        react --> ../../react@17
  app1__root --> .pnpm/app1/node_modules/app1
  app2__root --> .pnpm/app2/node_modules/app2
  app1
    node_modules/react --> .pnpm/react@16
    dist
      app1.js
    app1.tsx --> <ROOT>/app1/app1.tsx
    package.json
  app2
    node_modules/react --> .pnpm/react@17
    dist
      app2.js
    app2.tsx --> <ROOT>/app2/app2.tsx
    package.json
  button
    node_modules/react --> .pnpm/react@17
    dist
      app2.js
    app2.tsx --> <ROOT>/button/button.tsx
    package.json
```

See how the files in `node_modules/.pnpm/button+react@16/node_modules/button/` are not symlinks? It is important to have real files in the virtual store for proper resolution of dependencies. So the react in `node_modules/.pnpm/button+react@16/node_modules/button/dist/index.js` will be resolved from `node_modules/.pnpm/button+react@16/node_modules/react/`, while the react from `node_modules/.pnpm/button+react@17/node_modules/button/` will be resolved from `node_modules/.pnpm/button+react@17/node_modules/react/`

### Changes to compilation and linking

All the components in the virtual store should have a `dist` folder and a `package.json` file.

The compilation aspect accepts a list of target directories instead of a single target directory. So instead of just compiling the sources of button to `node_modules/button/dist`, bit compiles the sources of button also to the following locations:

```
node_modules/.pnpm/button+react@16/node_modules/button/dist
node_modules/.pnpm/button+react@17/node_modules/button/dist
```

The `package.json` files are linked as a separate task after installation is complete by the pnpm installation engine. So the `package.json` file that is generated into `node_modules/button/package.json` is hard linked into:


```
node_modules/.pnpm/button+react@16/node_modules/button/package.json
node_modules/.pnpm/button+react@17/node_modules/button/package.json
```

### Other changes

* The dependency-resolver aspect is now a dependency of the compiler aspect