### PR TITLE
fix(types): fix typescript error in src/cli/handle-errors.ts 

### DIFF
--- a/src/cli/handle-errors.ts
+++ b/src/cli/handle-errors.ts
@@ -1,6 +1,6 @@
 import { serializeError } from 'serialize-error';
-import logger from '@teambit/legacy/dist/logger/logger';
-import { buildCommandMessage, isNumeric, packCommand } from '@teambit/legacy/dist/utils';
+import logger from '../logger/logger';
+import { buildCommandMessage, isNumeric, packCommand } from '../utils';
 import defaultHandleError from './default-error-handler';
 import loader from './loader';
 


### PR DESCRIPTION
Error was "Expected 2 arguments, but got 3". It happened because for some reason the import statement in the legacy referred to the package "@teambit/legacy" instead of using the relative paths.
