### PR TITLE
Don't extend node path in command shims

### DIFF
--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -200,6 +200,7 @@ export async function install(
   const opts = {
     storeDir: storeController.dir,
     dir: rootManifest.rootDir,
+    extendNodePath: false,
     storeController: storeController.ctrl,
     workspacePackages,
     preferFrozenLockfile: true,


### PR DESCRIPTION
This fixes `bit install` on the bit-bin repository on Windows.

The generated command shims are too big when the node path env variable is set. And this is causing a crash when building dependencies. This property is not needed anyway.

## Proposed Changes

- Don't extend [NODE_PATH](https://pnpm.io/npmrc#extend-node-path) in command shims.