### PR TITLE
chore: fix full-setup script to delete the binary "bit" first from the local node-modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "build:types": "./scripts/build-types.bash",
     "build:types:windows": ".\\scripts\\build-types.bat",
     "link-bit-legacy": "node ./scripts/link-bit-legacy.js",
-    "full-setup": "rm -rf node_modules/@teambit/legacy && bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types",
+    "full-setup": "rm -rf node_modules/.bin/bit && rm -rf node_modules/@teambit/legacy && bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types",
     "full-setup:bbit": "rm -rf node_modules/.bin/bbit && rm -rf node_modules/@teambit/legacy && bbit install && npm run link-bit-legacy && bbit compile && npm run build && npm run build:types",
     "full-setup:windows": "bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types:windows",
     "full-setup:windows:bbit": "bbit install && npm run link-bit-legacy && bbit compile && npm run build && npm run build:types:windows",


### PR DESCRIPTION
otherwise, instead of running `bit` from the BVM, NPM tries to run them from the local binary.