### PR TITLE
fix(`lane merge`): `main` lane is not recognized and cannot be merged if it is empty

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -496,6 +496,35 @@ describe('bit lane command', function () {
         });
       });
     });
+    describe('merging main into local lane', () => {
+      let mergeOutput: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.command.createLane('dev');
+        helper.fixtures.populateComponents(1);
+        helper.command.snapAllComponentsWithoutBuild();
+        mergeOutput = helper.command.mergeLane('main');
+      });
+      it("should not throw an error that main lane doesn't exist", () => {
+        expect(mergeOutput).to.not.have.string('unable to switch to "main", the lane was not found');
+      });
+    });
+    describe('merging main lane with no snapped components', () => {
+      let mergeOutput: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.fixtures.populateComponents(1);
+        helper.command.createLane('dev');
+        mergeOutput = helper.command.mergeLane('main');
+      });
+      it('should not throw an error about missing objects', () => {
+        expect(mergeOutput).to.not.have.string(
+          'component comp1 is on the lane but its objects were not found, please re-import the lane'
+        );
+      });
+    });
   });
   describe('tagging on a lane', () => {
     let output;

--- a/src/consumer/lanes/merge-lanes.ts
+++ b/src/consumer/lanes/merge-lanes.ts
@@ -6,6 +6,7 @@ import { Lane } from '../../scope/models';
 import { Tmp } from '../../scope/repositories';
 import { ApplyVersionResults, MergeStrategy } from '../versions-ops/merge-version';
 import { ComponentStatus, getComponentStatus, merge } from '../versions-ops/merge-version/merge-snaps';
+import { DEFAULT_LANE } from '../../constants';
 
 export async function mergeLanes({
   consumer,
@@ -37,7 +38,15 @@ export async function mergeLanes({
   let otherLane: Lane | null;
   let remoteLane;
   let otherLaneName: string;
-  if (remoteName) {
+  const isDefaultLane = laneName === DEFAULT_LANE;
+
+  if (isDefaultLane) {
+    const allBitIdsOnDefaultLaneWithVersion = consumer.bitMap
+      .getAuthoredAndImportedBitIdsOfDefaultLane()
+      .filter((id) => id.hasVersion());
+    bitIds = allBitIdsOnDefaultLaneWithVersion.map((id) => id.changeVersion(id.version));
+    otherLaneName = DEFAULT_LANE;
+  } else if (remoteName) {
     const remoteLaneId = RemoteLaneId.from(laneId.name, remoteName);
     remoteLane = await consumer.scope.objects.remoteLanes.getRemoteLane(remoteLaneId);
     if (!remoteLane.length) {

--- a/src/consumer/lanes/merge-lanes.ts
+++ b/src/consumer/lanes/merge-lanes.ts
@@ -41,10 +41,7 @@ export async function mergeLanes({
   const isDefaultLane = laneName === DEFAULT_LANE;
 
   if (isDefaultLane) {
-    const allBitIdsOnDefaultLaneWithVersion = consumer.bitMap
-      .getAuthoredAndImportedBitIdsOfDefaultLane()
-      .filter((id) => id.hasVersion());
-    bitIds = allBitIdsOnDefaultLaneWithVersion.map((id) => id.changeVersion(id.version));
+    bitIds = consumer.bitMap.getAuthoredAndImportedBitIdsOfDefaultLane().filter((id) => id.hasVersion());
     otherLaneName = DEFAULT_LANE;
   } else if (remoteName) {
     const remoteLaneId = RemoteLaneId.from(laneId.name, remoteName);


### PR DESCRIPTION
## Proposed Changes

- Update `mergeLanes` function to handle the case when the user is merging the `main` lane
- Update `mergeLanes` function to handle the case when the main lane is empty (has no snapped/tagged components)
