### PR TITLE
display correct error when switching to an invalid lane

### DIFF
--- a/src/api/consumer/lib/switch.ts
+++ b/src/api/consumer/lib/switch.ts
@@ -37,7 +37,14 @@ async function populateSwitchProps(consumer: Consumer, switchProps: SwitchProps)
   }
 
   async function populatePropsAccordingToRemoteLane() {
-    const remoteLaneId = RemoteLaneId.parse(switchProps.laneName);
+    let remoteLaneId;
+    try {
+      remoteLaneId = RemoteLaneId.parse(switchProps.laneName);
+    } catch (e) {
+      throw new GeneralError(
+        `invalid lane id "${switchProps.laneName}", ${switchProps.laneName} doesn't exist locally or on the remote`
+      );
+    }
     if (remoteLaneId.name === DEFAULT_LANE) {
       throw new GeneralError(`invalid remote lane id "${switchProps.laneName}". to switch to the main lane on remote, 
       run "bit switch main" and then "bit import".`);


### PR DESCRIPTION
## Proposed Changes

- Display correct error message when the user tries to switch to an invalid lane (doesn't exist locally or on the remote)
