### PR TITLE
fix(tag): resolve aspect-version correctly during the tag

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -174,6 +174,22 @@ describe('custom env', function () {
       npmCiRegistry.destroy();
     });
   });
+  describe('when the env is tagged and set in workspace.jsonc without exporting it', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      // important! don't disable the preview.
+      helper.bitJsonc.addDefaultScope();
+      const envName = helper.env.setCustomEnv();
+      const envId = `${helper.scopes.remote}/${envName}`;
+      helper.extensions.addExtensionToWorkspace(envId);
+      helper.command.tagAllWithoutBuild();
+    });
+    // previously, it errored "error: component "n8w0pqms-local/3wc3xd3p-remote/node-env@0.0.1" was not found"
+    it('should be able to re-tag with no errors', () => {
+      // important! don't skip the build. it's important for the Preview task to run.
+      expect(() => helper.command.tagScope()).not.to.throw();
+    });
+  });
 });
 
 function getEnvIdFromModel(compModel: any): string {

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -598,7 +598,14 @@ export default class BitMap {
         if (matches && matches.length === 1) {
           return matches[0].id;
         }
+        if (this.updatedIds[idWithoutScope]) {
+          return this.updatedIds[idWithoutScope].id;
+        }
       }
+    }
+
+    if (this.updatedIds[id]) {
+      return this.updatedIds[id].id;
     }
 
     if (shouldThrow) {


### PR DESCRIPTION
Currently, during tag, when asking Harmony for aspect-ids, it returns them with the old version. 
With this fix, once the ids are resolved, they get the correct version.