### PR TITLE
fix(checkout): write files that were introduce in a new version and does not exist on the filesystem

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -247,4 +247,26 @@ describe('bit checkout command', function () {
       });
     });
   });
+  describe('when a file was added in the new version (and not exists locally)', () => {
+    let afterFirstExport: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      afterFirstExport = helper.scopeHelper.cloneLocalScope();
+      helper.fs.outputFile('comp1/foo.ts');
+      helper.command.compile();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(afterFirstExport);
+      helper.command.import();
+      helper.command.checkout('latest --all');
+    });
+    it('should write the new files', () => {
+      const newFilePath = path.join(helper.scopes.localPath, 'comp1/foo.ts');
+      expect(newFilePath).to.be.a.file();
+    });
+  });
 });

--- a/src/consumer/versions-ops/merge-version/three-way-merge.ts
+++ b/src/consumer/versions-ops/merge-version/three-way-merge.ts
@@ -178,7 +178,11 @@ export default async function threeWayMergeVersions({
     })
   );
   const fsFilesPaths = fsFiles.map((fsFile) => pathNormalizeToLinux(fsFile.relative));
-  const deletedFromFs = currentFiles.filter((currentFile) => !fsFilesPaths.includes(currentFile.relativePath));
+  const baseFilesPaths = baseFiles.map((baseFile) => baseFile.relativePath);
+  const deletedFromFs = currentFiles.filter(
+    (currentFile) =>
+      !fsFilesPaths.includes(currentFile.relativePath) && baseFilesPaths.includes(currentFile.relativePath)
+  );
   deletedFromFs.forEach((file) => results.remainDeletedFiles.push({ filePath: file.relativePath }));
   if (R.isEmpty(results.modifiedFiles)) return results;
 


### PR DESCRIPTION
This PR fixes the following use-case: comp1@0.0.1 has one file. comp1@0.0.2 has another file. When a user is checked out to 0.0.1 and is running `bit checkout latest --all` it doesn't write this new file.
(this is a regression caused by https://github.com/teambit/bit/pull/5192).
Reported by @NitsanCohen770 .
