### PR TITLE
fix(builder): avoid saving duplicate tasks data during tag

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -1,5 +1,6 @@
 import chai, { expect } from 'chai';
 import chalk from 'chalk';
+import { uniq } from 'lodash';
 import { Extensions } from '../../src/constants';
 import { SchemaName } from '../../src/consumer/component/component-schema';
 import Helper from '../../src/e2e-helper/e2e-helper';
@@ -361,6 +362,20 @@ describe('tag components on Harmony', function () {
       it('should use the data in the .bitmap file and tag as a pre-release version', () => {
         expect(tagOutput).to.have.string('comp1@0.0.1-dev.0');
       });
+    });
+  });
+  describe('builder data saved in the model', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllComponents();
+    });
+    it('should not save the build data twice', () => {
+      const comp1 = helper.command.catComponent('comp1@latest');
+      const builderExt = helper.general.getExtension(comp1, Extensions.builder);
+      const taskIds = builderExt.data.pipeline.map((p) => `${p.taskId}:${p.taskName}`);
+      const taskIdsUniq = uniq(taskIds);
+      expect(taskIds.length).to.equal(taskIdsUniq.length);
     });
   });
 });

--- a/scopes/component/component/component-map/component-map.ts
+++ b/scopes/component/component/component-map/component-map.ts
@@ -52,6 +52,16 @@ export class ComponentMap<T> {
 
     return new ComponentMap(new Map(tuples));
   }
+
+  /**
+   * similar to Array.forEach, but here you get both, the value and the component.
+   */
+  forEach(predicate: (value: T, component: Component) => void): void {
+    this.toArray().forEach(([component, value]) => {
+      predicate(value, component);
+    });
+  }
+
   /**
    * flatten values of all components into a single array.
    */

--- a/scopes/pipelines/builder/build-pipe.ts
+++ b/scopes/pipelines/builder/build-pipe.ts
@@ -47,7 +47,7 @@ export class BuildPipe {
   private failedTasks: BuildTask[] = [];
   private failedDependencyTask: BuildTask | undefined;
   private longProcessLogger: LongProcessLogger;
-  private taskResults: TaskResults[];
+  private taskResults: TaskResults[] = [];
   constructor(
     /**
      * array of services to apply on the components.
@@ -56,9 +56,11 @@ export class BuildPipe {
     readonly envsBuildContext: EnvsBuildContext,
     readonly logger: Logger,
     readonly artifactFactory: ArtifactFactory,
-    previousTaskResults?: TaskResults[]
-  ) {
-    this.taskResults = previousTaskResults || [];
+    private previousTaskResults?: TaskResults[]
+  ) {}
+
+  get allTasksResults(): TaskResults[] {
+    return [...(this.previousTaskResults || []), ...(this.taskResults || [])];
   }
 
   /**
@@ -152,7 +154,7 @@ export class BuildPipe {
   private getBuildContext(envId: string) {
     const buildContext = this.envsBuildContext[envId];
     if (!buildContext) throw new Error(`unable to find buildContext for ${envId}`);
-    buildContext.previousTasksResults = this.taskResults;
+    buildContext.previousTasksResults = this.allTasksResults;
     return buildContext;
   }
 

--- a/scopes/pipelines/builder/build-pipeline-result-list.ts
+++ b/scopes/pipelines/builder/build-pipeline-result-list.ts
@@ -6,8 +6,8 @@ import { TaskResults } from './build-pipe';
 import { Serializable, TaskMetadata } from './types';
 
 export type PipelineReport = {
-  taskId: string;
-  taskName?: string;
+  taskId: string; // task aspect-id
+  taskName: string;
   taskDescription?: string;
   startTime?: number;
   endTime?: number;

--- a/scopes/pipelines/builder/build-task.ts
+++ b/scopes/pipelines/builder/build-task.ts
@@ -112,13 +112,13 @@ export interface BuiltTaskResult {
 }
 
 export class BuildTaskHelper {
-  static serializeId({ aspectId, name }: BuildTask): string {
+  static serializeId({ aspectId, name }: { aspectId: string; name: string }): string {
     return aspectId + TaskIdDelimiter + name;
   }
-  static deserializeId(id: string): { aspectId: string; name?: string } {
+  static deserializeId(id: string): { aspectId: string; name: string } {
     const split = id.split(TaskIdDelimiter);
     if (split.length === 0) throw new Error(`deserializeId, ${id} is empty`);
-    if (split.length === 1) return { aspectId: split[0] };
+    if (split.length === 1) throw new Error(`deserializeId, ${id} has only aspect-id without name`);
     if (split.length === 2) return { aspectId: split[0], name: split[1] };
     throw new Error(`deserializeId, id ${id} has more than one ${TaskIdDelimiter}`);
   }


### PR DESCRIPTION
## Proposed Changes

- fix a bug where builder task-results were saved twice in the models.
- add a validation to throw an error in case the data coming from the builder are duplicated.
