### PR TITLE
feat: merge lanes during bit-import with no args

### DIFF
--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -272,8 +272,8 @@ export default class CommandHelper {
     const comp = this.catComponent(id, cwd);
     return comp.head.substring(0, 9);
   }
-  getHeadOfLane(laneName: string, componentName: string) {
-    const lane = this.catLane(laneName);
+  getHeadOfLane(laneName: string, componentName: string, cwd = this.scopes.localPath) {
+    const lane = this.catLane(laneName, cwd);
     const component = lane.components.find((c) => c.id.name === componentName);
     return component.head;
   }

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -360,7 +360,9 @@ export default class Component extends BitObject {
   isLatestGreaterThan(version: string | null | undefined): boolean {
     if (!version) throw TypeError('isLatestGreaterThan expect to get a Version');
     const latest = this.latest();
-    if (this.isEmpty()) return false; // in case a snap was created on another lane
+    if (this.isEmpty() && !this.laneHeadRemote) {
+      return false; // in case a snap was created on another lane
+    }
     if (isTag(latest) && isTag(version)) {
       return semver.gt(latest, version);
     }


### PR DESCRIPTION
Currently, when on a lane, `bit import` (with no args) only updates the ref files (`.bit/refs/remote/<lane-name>`). Not the lane objects. To update the lane objects, `bit lane merge` command is needed.
This is not very intuitive because on main `bit import` does merge the objects when possible and to get the files up-to-date in the filesystem, all needs to be done is `bit checkout latest`.
This PR aligns the behavior of lanes and main to be the same. 