### PR TITLE
introduce "bit aspect" command to set/unset/list aspects

### DIFF
--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -109,9 +109,10 @@ ${chalk.bold('data:')}   ${JSON.stringify(data, undefined, 2)}
       });
 
     if (debug) {
-      const jsonObj = beforeMerge.map(({ origin, extensions }) => ({
+      const jsonObj = beforeMerge.map(({ origin, extensions, extraData }) => ({
         origin,
         extensions: extensionsDetailsToObjectsArray(extensions),
+        extraData,
       }));
 
       jsonObj.push({ origin: 'FinalAfterMerge', extensions: extensionsDetailsToObjectsArray(mergedExtensions) });

--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -1,0 +1,109 @@
+// eslint-disable-next-line max-classes-per-file
+import { Command, CommandOptions } from '@teambit/cli';
+import chalk from 'chalk';
+import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
+import { AspectMain } from './aspect.main.runtime';
+
+export class ListAspectCmd implements Command {
+  name = 'list <component-id>';
+  description = 'list all aspect names configured on a component';
+  options = [];
+  group = 'development';
+
+  constructor(private aspect: AspectMain) {}
+
+  async report([name]: [string]) {
+    const aspectIds = await this.aspect.listAspectsOfComponent(name);
+    return aspectIds.join('\n');
+  }
+}
+
+export class SetAspectCmd implements Command {
+  name = 'set <pattern> <aspect-id> [config]';
+  description = `set an aspect to component(s) with optional config.
+enter the config as stringified JSON (e.g. '{"foo":"bar"}' ).
+if no config entered, the aspect will be set with empty config ({}).`;
+  shortDescription = 'set an aspect to component(s) with optional config';
+  options = [];
+  group = 'development';
+
+  constructor(private aspect: AspectMain) {}
+
+  async report([pattern, aspectId, config]: [string, string, string]) {
+    const configParsed = config ? JSON.parse(config) : {};
+    const results = await this.aspect.setAspectsToComponents(pattern, aspectId, configParsed);
+    if (!results.length) return chalk.yellow(`unable to find any matching for ${chalk.bold(pattern)} pattern`);
+    return chalk.green(`the following component(s) have been successfully updated:\n${results.join('\n')}`);
+  }
+}
+
+export class UnsetAspectCmd implements Command {
+  name = 'unset <pattern> <aspect-id>';
+  description = `unset an aspect from component(s).`;
+  options = [];
+  group = 'development';
+
+  constructor(private aspect: AspectMain) {}
+
+  async report([pattern, aspectId]: [string, string]) {
+    const results = await this.aspect.unsetAspectsFromComponents(pattern, aspectId);
+    if (!results.length) return chalk.yellow(`unable to find any matching for ${chalk.bold(pattern)} pattern`);
+    return chalk.green(`the following component(s) have been successfully updated:\n${results.join('\n')}`);
+  }
+}
+
+export class GetAspectCmd implements Command {
+  name = 'get <component-id>';
+  description = "show aspects' data and configuration of the given component";
+  options = [['d', 'debug', 'show the origins were the aspects were taken from']] as CommandOptions;
+  group = 'development';
+
+  constructor(private aspect: AspectMain) {}
+
+  async report([componentName]: [string], { debug }: { debug: boolean }) {
+    const { extensions: mergedExtensions, beforeMerge } = await this.aspect.getAspectsOfComponent(componentName);
+
+    const extensionsDetailsToString = (extensions: ExtensionDataList) =>
+      extensions
+        .map((e) => {
+          const { name, data, config } = e.toComponentObject();
+          return `${chalk.bold('name:')}   ${name}
+${chalk.bold('config:')} ${JSON.stringify(config, undefined, 2)}
+${chalk.bold('data:')}   ${JSON.stringify(data, undefined, 2)}
+`;
+        })
+        .join('\n');
+
+    if (debug) {
+      const beforeMergeOutput = beforeMerge
+        .map(({ origin, extensions }) => {
+          const title = chalk.green.bold(`Origin: ${origin}`);
+          const details = extensionsDetailsToString(extensions);
+          return `${title}\n${details}`;
+        })
+        .join('\n\n');
+
+      const afterMergeTitle = chalk.green.bold('Final - after merging all origins');
+      const afterMergeOutput = `${afterMergeTitle}\n${extensionsDetailsToString(mergedExtensions)}`;
+
+      return `${beforeMergeOutput}\n\n\n${afterMergeOutput}`;
+    }
+
+    return extensionsDetailsToString(mergedExtensions);
+  }
+}
+
+export class AspectCmd implements Command {
+  name = 'aspect <sub-command>';
+  alias = '';
+  description = 'manage aspects';
+  options = [];
+  group = 'development';
+  commands: Command[] = [];
+
+  async report([unrecognizedSubcommand]: [string]) {
+    return chalk.red(
+      `"${unrecognizedSubcommand}" is not a subcommand of "aspect", please run "bit aspect --help" to list the subcommands`
+    );
+  }
+}

--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -66,8 +66,8 @@ export class GetAspectCmd implements Command {
     const extensionsDetailsToString = (extensions: ExtensionDataList) =>
       extensions
         .map((e) => {
-          const { name, data, config } = e.toComponentObject();
-          return `${chalk.bold('name:')}   ${name}
+          const { name, data, config, extensionId } = e.toComponentObject();
+          return `${chalk.bold('name:')}   ${name || extensionId?.toString()}
 ${chalk.bold('config:')} ${JSON.stringify(config, undefined, 2)}
 ${chalk.bold('data:')}   ${JSON.stringify(data, undefined, 2)}
 `;

--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -96,7 +96,7 @@ ${chalk.bold('data:')}   ${JSON.stringify(data, undefined, 2)}
 export class AspectCmd implements Command {
   name = 'aspect <sub-command>';
   alias = '';
-  description = 'manage aspects';
+  description = 'EXPERIMENTAL. manage aspects';
   options = [];
   group = 'development';
   commands: Command[] = [];

--- a/scopes/harmony/aspect/aspect.docs.mdx
+++ b/scopes/harmony/aspect/aspect.docs.mdx
@@ -1,0 +1,34 @@
+## Overview
+
+Aspects can be configured on a component is various ways, some more general and some more specific. Once a component is loaded, Bit calculates all the sources and comes up with the final list of aspects. Each aspect has its config and data.
+Config is what the user entered, Data is a result of the aspect process.
+
+## Debugging aspects
+
+To help understanding why a component has these specific aspects, `bit aspect get --debug` shows each one of the sources, from the more specific one to the general one. At the end, it shows the merged result of all sources.
+The various sources are as follows:
+
+```
+'BitmapFile'
+'Model'
+'WorkspaceVariants'
+'ComponentJsonFile'
+'WorkspaceDefault'
+```
+
+Since the list of all the config+data can be very long and hard to follow, the flag `--json` is very helpful.
+This with help of [fx](https://github.com/antonmedv/fx), it's easy to extract the data needed.
+
+If for example, we're interested in one source only, we can run the following:
+
+```
+bit aspect get ui/text --debug --json | fx .BitmapFile
+```
+
+It's possible to run any arbitrary javascript code with fx, so for example, if you want to debug just one specific aspect, and see its config/data per each one of the source, you can do something like this:
+
+```
+bit aspect get ui/text --debug --json | fx 'Object.keys(this).map(origin => ({ origin, value: this[origin].extensions["teambit.pkg/pkg"] }))'
+```
+
+Another data shown with the `--debug` flag is the rules in the workspace.jsonc#variants applied to this component. It shows the list of these rules sorted with the data about the specifity.

--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -1,27 +1,72 @@
 import { AspectLoaderAspect, AspectLoaderMain } from '@teambit/aspect-loader';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
-import { MainRuntime } from '@teambit/cli';
+import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { Environment, EnvsAspect, EnvsMain, EnvTransformer } from '@teambit/envs';
 import { ReactAspect, ReactMain } from '@teambit/react';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 import { BabelAspect, BabelMain } from '@teambit/babel';
+import { ComponentID } from '@teambit/component-id';
+import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { CompilerAspect, CompilerMain } from '@teambit/compiler';
 import { AspectAspect } from './aspect.aspect';
 import { AspectEnv } from './aspect.env';
 import { CoreExporterTask } from './core-exporter.task';
 import { aspectTemplate } from './templates/aspect';
 import { babelConfig } from './babel/babel-config';
+import { AspectCmd, GetAspectCmd, ListAspectCmd, SetAspectCmd, UnsetAspectCmd } from './aspect.cmd';
 
 const tsconfig = require('./typescript/tsconfig.json');
 
 export class AspectMain {
-  constructor(readonly aspectEnv: AspectEnv, private envs: EnvsMain) {}
+  constructor(readonly aspectEnv: AspectEnv, private envs: EnvsMain, private workspace: Workspace) {}
 
   /**
    * compose your own aspect environment.
    */
   compose(transformers: EnvTransformer[] = [], targetEnv: Environment = {}) {
     return this.envs.compose(this.envs.merge(targetEnv, this.aspectEnv), transformers);
+  }
+
+  async listAspectsOfComponent(id: string | ComponentID): Promise<string[]> {
+    if (typeof id === 'string') {
+      id = await this.workspace.resolveComponentId(id);
+    }
+    const component = await this.workspace.get(id);
+    return component.state.aspects.ids;
+  }
+
+  async setAspectsToComponents(
+    pattern: string,
+    aspectId: string,
+    config: Record<string, any> = {}
+  ): Promise<ComponentID[]> {
+    const components = await this.workspace.byPattern(pattern);
+    const componentIds = components.map((comp) => comp.id);
+    componentIds.forEach((componentId) => {
+      this.workspace.bitMap.addComponentConfig(componentId, aspectId, config);
+    });
+    await this.workspace.bitMap.write();
+
+    return componentIds;
+  }
+
+  async unsetAspectsFromComponents(pattern: string, aspectId: string): Promise<ComponentID[]> {
+    const components = await this.workspace.byPattern(pattern);
+    const componentIds = components.map((comp) => comp.id);
+    componentIds.forEach((componentId) => {
+      this.workspace.bitMap.removeComponentConfig(componentId, aspectId);
+    });
+    await this.workspace.bitMap.write();
+
+    return componentIds;
+  }
+
+  async getAspectsOfComponent(id: string | ComponentID) {
+    if (typeof id === 'string') {
+      id = await this.workspace.resolveComponentId(id);
+    }
+    const componentFromScope = await this.workspace.scope.get(id);
+    return this.workspace.componentExtensions(id, componentFromScope);
   }
 
   static runtime = MainRuntime;
@@ -33,16 +78,20 @@ export class AspectMain {
     CompilerAspect,
     BabelAspect,
     GeneratorAspect,
+    WorkspaceAspect,
+    CLIAspect,
   ];
 
-  static async provider([react, envs, builder, aspectLoader, compiler, babel, generator]: [
+  static async provider([react, envs, builder, aspectLoader, compiler, babel, generator, workspace, cli]: [
     ReactMain,
     EnvsMain,
     BuilderMain,
     AspectLoaderMain,
     CompilerMain,
     BabelMain,
-    GeneratorMain
+    GeneratorMain,
+    Workspace,
+    CLIMain
   ]) {
     const babelCompiler = babel.createCompiler({
       babelTransformOptions: babelConfig,
@@ -82,7 +131,17 @@ export class AspectMain {
 
     envs.registerEnv(aspectEnv);
     generator.registerComponentTemplate([aspectTemplate]);
-    return new AspectMain(aspectEnv as AspectEnv, envs);
+    const aspectMain = new AspectMain(aspectEnv as AspectEnv, envs, workspace);
+    const aspectCmd = new AspectCmd();
+    aspectCmd.commands = [
+      new ListAspectCmd(aspectMain),
+      new GetAspectCmd(aspectMain),
+      new SetAspectCmd(aspectMain),
+      new UnsetAspectCmd(aspectMain),
+    ];
+    cli.register(aspectCmd);
+
+    return aspectMain;
   }
 }
 

--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -219,10 +219,8 @@ export class GraphqlMain {
   private proxySubscription(server: Server, port: number) {
     const proxServer = httpProxy.createProxyServer();
     const subscriptionsPath = this.config.subscriptionsPath;
-    const logger = this.logger;
     server.on('upgrade', function (req, socket, head) {
       if (req.url === subscriptionsPath) {
-        logger.debug(`proxy from ${req.url} to ${port}`);
         proxServer.ws(req, socket, head, { target: { host: 'localhost', port } });
       }
     });

--- a/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.spec.ts
@@ -252,14 +252,17 @@ describe('sortMatchesBySpecificity', () => {
       const match1 = {
         specificity: 5,
         config: {},
+        pattern: '',
       };
       const match2 = {
         specificity: 3,
         config: {},
+        pattern: '',
       };
       const match3 = {
         specificity: 7,
         config: {},
+        pattern: '',
       };
       const matches = [match1, match2, match3];
       const res = sortMatchesBySpecificity(matches);

--- a/scopes/workspace/modules/match-pattern/match-pattern.ts
+++ b/scopes/workspace/modules/match-pattern/match-pattern.ts
@@ -22,17 +22,20 @@ export type MatchedPattern = {
   // rootDir - utils/string/is-string
   // This match all sub patters, but the max is utils/string/is-string which is 3
   maxSpecificity: number;
+  pattern: string;
 };
 
 export type MatchedPatternWithConfig = {
   config: Record<string, any>;
   specificity: number;
+  pattern: string;
 };
 
 export type MatchedPatternItem = {
   // Boolean to indicate if it's matching or no
   match: boolean;
   specificity: number;
+  pattern: string;
 };
 
 export type MatchedPatternItemWithExclude = MatchedPatternItem & {
@@ -52,6 +55,7 @@ export function isMatchPattern(rootDir: PathLinuxRelative, componentName: string
     match: false,
     excluded: false,
     specificity: -1,
+    pattern,
   };
 
   const maxMatch: MatchedPatternItemWithExclude = maxBy(matches, (match) => match.specificity) || defaultVal;
@@ -61,6 +65,7 @@ export function isMatchPattern(rootDir: PathLinuxRelative, componentName: string
     match: maxMatch.match,
     maxSpecificity: maxMatch.specificity,
     excluded,
+    pattern,
   };
 }
 
@@ -77,6 +82,7 @@ export function isMatchPatternItem(
       match: true,
       specificity: 0,
       excluded: false,
+      pattern: patternItem,
     };
   }
   const { excluded, patternItemWithoutExcludeSign } = parseExclusion(patternItemTrimmed);
@@ -97,11 +103,13 @@ export function isMatchDirPatternItem(rootDir: PathLinuxRelative, patternItem: s
     return {
       match: true,
       specificity: patternItemStriped.split('/').length,
+      pattern: patternItem,
     };
   }
   return {
     match: false,
     specificity: -1,
+    pattern: patternItem,
   };
 }
 
@@ -119,6 +127,7 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
     return {
       match: false,
       specificity: -1,
+      pattern: patternItem,
     };
   }
 
@@ -138,6 +147,7 @@ export function isMatchNamespacePatternItem(componentName: string, patternItem: 
   return {
     match: minimatchMatch,
     specificity,
+    pattern: patternItem,
   };
 }
 

--- a/scopes/workspace/variants/variants.main.runtime.ts
+++ b/scopes/workspace/variants/variants.main.runtime.ts
@@ -22,6 +22,7 @@ export type VariantsComponentConfig = {
   defaultScope?: string;
   extensions: ExtensionDataList;
   maxSpecificity: number;
+  sortedMatches: MatchedPatternWithConfig[];
 };
 
 const INTERNAL_FIELDS = ['propagate', 'exclude', 'defaultScope'];
@@ -71,6 +72,7 @@ export class VariantsMain {
         matches.push({
           config: patternConfig,
           specificity: match.maxSpecificity,
+          pattern: match.pattern,
         });
       }
     });
@@ -96,6 +98,7 @@ export class VariantsMain {
       extensions: mergedExtensions,
       propagate,
       maxSpecificity: sortedMatches.length ? sortedMatches[0].specificity : -1,
+      sortedMatches,
     };
     return result;
   }

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -146,13 +146,12 @@ export class WorkspaceComponentLoader {
       if (!componentFromScope) throw new MissingBitMapComponent(id.toString());
       return componentFromScope;
     }
-
-    let extensionDataList = await this.workspace.componentExtensions(id, componentFromScope);
+    const { extensions } = await this.workspace.componentExtensions(id, componentFromScope);
     const extensionsFromConsumerComponent = consumerComponent.extensions || new ExtensionDataList();
     // Merge extensions added by the legacy code in memory (for example data of dependency resolver)
-    extensionDataList = ExtensionDataList.mergeConfigs([
+    const extensionDataList = ExtensionDataList.mergeConfigs([
       extensionsFromConsumerComponent,
-      extensionDataList,
+      extensions,
     ]).filterRemovedExtensions();
 
     // temporarily mutate consumer component extensions until we remove all direct access from legacy to extensions data

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -153,7 +153,7 @@ export default async function provideWorkspace(
     // which in turn run this event, which will make an infinite loop
     // This component from scope here are only used for merging the extensions with the workspace components
     const componentFromScope = await workspace.scope.get(componentId);
-    const extensions = await workspace.componentExtensions(componentId, componentFromScope);
+    const { extensions } = await workspace.componentExtensions(componentId, componentFromScope);
     const defaultScope = await workspace.componentDefaultScope(componentId);
 
     await workspace.loadExtensions(extensions);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -143,11 +143,12 @@ export type TrackData = {
 };
 
 export type ExtensionsOrigin =
-  | '.bitmap file'
-  | 'model'
-  | 'workspace variants'
-  | 'component.json file'
-  | 'workspace default';
+  | 'BitmapFile'
+  | 'Model'
+  | 'WorkspaceVariants'
+  | 'ComponentJsonFile'
+  | 'WorkspaceDefault'
+  | 'FinalAfterMerge';
 
 export type TrackResult = { componentName: string; files: string[]; warnings: Warnings };
 
@@ -1018,28 +1019,28 @@ export class Workspace implements ComponentFactory {
         (aspectId) => new ExtensionDataEntry(aspectId, undefined, aspectId, bitMapExtensions[aspectId])
       );
       const extensionDataList = new ExtensionDataList(...extensionsDataEntries);
-      await addAndLoadExtensions(extensionDataList, '.bitmap file');
+      await addAndLoadExtensions(extensionDataList, 'BitmapFile');
     }
     if (configFileExtensions) {
-      await addAndLoadExtensions(configFileExtensions, 'component.json file');
+      await addAndLoadExtensions(configFileExtensions, 'ComponentJsonFile');
     }
     let continuePropagating = componentConfigFile?.propagate ?? true;
     if (variantsExtensions && continuePropagating) {
       // Put it in the start to make sure the config file is stronger
-      await addAndLoadExtensions(variantsExtensions, 'workspace variants');
+      await addAndLoadExtensions(variantsExtensions, 'WorkspaceVariants');
     }
     continuePropagating = continuePropagating && (variantConfig?.propagate ?? true);
     // Do not apply default extensions on the default extensions (it will create infinite loop when loading them)
     const isDefaultExtension = wsDefaultExtensions?.findExtension(componentId.toString(), true, true);
     if (wsDefaultExtensions && continuePropagating && !isDefaultExtension) {
       // Put it in the start to make sure the config file is stronger
-      await addAndLoadExtensions(wsDefaultExtensions, 'workspace default');
+      await addAndLoadExtensions(wsDefaultExtensions, 'WorkspaceDefault');
     }
 
     // It's before the scope extensions, since there is no need to resolve extensions from scope they are already resolved
     // await Promise.all(extensionsToMerge.map((extensions) => this.resolveExtensionsList(extensions)));
     if (mergeFromScope && continuePropagating) {
-      await addAndLoadExtensions(scopeExtensions, 'model');
+      await addAndLoadExtensions(scopeExtensions, 'Model');
     }
 
     // It's important to do this resolution before the merge, otherwise we have issues with extensions


### PR DESCRIPTION
## Proposed Changes

- `bit aspect list <component-id>` - list all aspect names configured on a component
- `bit aspect get <component-id>` - show aspects' data and configuration of the given component. (with `--debug` flag it shows the origins were the aspects were taken from).
- `bit aspect set <pattern> <aspect-id> [config]` - set an aspect to component(s) with optional config
- `bit aspect unset <pattern> <aspect-id>` - unset an aspect from component(s)

<img width="467" alt="Screen Shot 2022-01-28 at 12 03 53 PM" src="https://user-images.githubusercontent.com/1963573/151590631-1c75a987-d2cf-4a49-8fc5-7961e2310eb2.png">


