### PR TITLE
use `cloneDeep` to copy the context in order to keep getters & setters

### DIFF
--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -1,5 +1,5 @@
 import { MainRuntime, CLIMain, CLIAspect } from '@teambit/cli';
-import { flatten } from 'lodash';
+import { flatten, cloneDeep } from 'lodash';
 import { AspectLoaderMain, AspectLoaderAspect } from '@teambit/aspect-loader';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
@@ -159,7 +159,7 @@ export class ApplicationMain {
     const res = await env.run(this.appService);
     const context = res.results[0].data;
     if (!context) throw new AppNotFound(appName);
-    return Object.assign({}, context, {
+    return Object.assign(cloneDeep(context), {
       appName,
       appComponent: component,
     });

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -11,7 +11,7 @@ import { Capsule } from '@teambit/isolator';
 import { Bundler, BundlerContext, BundlerEntryMap, BundlerHtmlConfig, BundlerResult, Target } from '@teambit/bundler';
 import type { EnvsMain } from '@teambit/envs';
 import { join } from 'path';
-import { compact } from 'lodash';
+import { cloneDeep, compact } from 'lodash';
 import { existsSync, mkdirpSync } from 'fs-extra';
 import type { PreviewMain } from './preview.main.runtime';
 import { PreviewDefinition } from '.';
@@ -98,7 +98,7 @@ export class EnvPreviewTemplateTask implements BuildTask {
     );
 
     if (!targets.length) return { componentsResults: [] };
-    const bundlerContext: BundlerContext = Object.assign({}, context, {
+    const bundlerContext: BundlerContext = Object.assign(cloneDeep(context), {
       targets,
       entry: [],
       externalizePeer: false,


### PR DESCRIPTION
## Proposed Changes
- The Object.assign() method only copies enumerable and own properties from a source object to a target object. It uses [[Get]] on the source and [[Set]] on the target, so it will invoke getters and setters. Therefore it assigns properties, versus copying or defining new properties. This may make it unsuitable for merging new properties into a prototype if the merge sources contain getters.