### PR TITLE
fix(checkout): avoid stripping the newline when running Git to merge files

### DIFF
--- a/src/e2e-helper/e2e-fixtures-helper.ts
+++ b/src/e2e-helper/e2e-fixtures-helper.ts
@@ -69,7 +69,7 @@ export default class FixtureHelper {
   }
 
   tagComponentBarFoo() {
-    return this.command.tagComponent('bar/foo');
+    return this.command.tagWithoutBuild('bar/foo');
   }
   getFixturesDir() {
     return path.join(__dirname, '../../e2e/fixtures');

--- a/src/utils/merge-files.ts
+++ b/src/utils/merge-files.ts
@@ -44,19 +44,23 @@ export default async function mergeFiles({
   const mergeResult: MergeFileResult = { filePath, output: null, conflict: null };
   const gitExecutablePath = getGitExecutablePath();
   try {
-    const result = await execa('git', [
-      'merge-file',
-      '-L',
-      currentFile.label,
-      '-L',
-      'Base File',
-      '-L',
-      otherFile.label,
-      currentFile.path,
-      baseFile.path,
-      otherFile.path,
-      '-p',
-    ]);
+    const result = await execa(
+      'git',
+      [
+        'merge-file',
+        '-L',
+        currentFile.label,
+        '-L',
+        'Base File',
+        '-L',
+        otherFile.label,
+        currentFile.path,
+        baseFile.path,
+        otherFile.path,
+        '-p',
+      ],
+      { stripFinalNewline: false }
+    );
     mergeResult.output = result.stdout;
     return mergeResult;
   } catch (err: any) {


### PR DESCRIPTION
Currently, in case of a merge, e.g. when a file has conflicts, then in the written file, the last "\n" is removed.
The culprit was `execa`, which returned the data from Git without the last newline. This PR fixed it by changing the configuration of execa to not strip this newline.