### PR TITLE
fix long notifications

### DIFF
--- a/scopes/ui-foundation/notifications/ui/notification/notification.module.scss
+++ b/scopes/ui-foundation/notifications/ui/notification/notification.module.scss
@@ -42,6 +42,7 @@ $animationTime: 300ms;
 
 .message {
   margin-bottom: 8px;
+  word-break: break-word; // handle long space-less words
 }
 
 .icon {


### PR DESCRIPTION
## Proposed Changes

- handle long notification messages that don't break line correctly
<img width="395" alt="Screen Shot 2022-02-03 at 12 56 47" src="https://user-images.githubusercontent.com/5400361/152329833-5bc076ef-d2a9-49da-ad48-4fab2ba9e4f5.png">

after fix:
<img width="373" alt="Screen Shot 2022-02-03 at 12 59 12" src="https://user-images.githubusercontent.com/5400361/152330201-1c919066-ced9-4e54-988c-e48fb3b33362.png">