### PR TITLE
feat: introduce "extendedDescription" prop for commands, add details about "<pattern>"

### DIFF
--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line max-classes-per-file
 import { Command, CommandOptions } from '@teambit/cli';
+import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { CLITable } from '@teambit/cli-table';
 import chalk from 'chalk';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
@@ -10,6 +11,7 @@ export class ListAspectCmd implements Command {
   description = 'list all aspects configured on component(s)';
   options = [['d', 'debug', 'show the origins were the aspects were taken from']] as CommandOptions;
   group = 'development';
+  extendedDescription = `${PATTERN_HELP('aspect list')}`;
 
   constructor(private aspect: AspectMain) {}
 
@@ -34,10 +36,10 @@ export class ListAspectCmd implements Command {
 
 export class SetAspectCmd implements Command {
   name = 'set <pattern> <aspect-id> [config]';
-  description = `set an aspect to component(s) with optional config.
-enter the config as stringified JSON (e.g. '{"foo":"bar"}' ).
-if no config entered, the aspect will be set with empty config ({}).`;
-  shortDescription = 'set an aspect to component(s) with optional config';
+  description = 'set an aspect to component(s) with optional config.';
+  extendedDescription = `enter the config as stringified JSON (e.g. '{"foo":"bar"}' ).
+if no config entered, the aspect will be set with empty config ({}).
+${PATTERN_HELP('aspect set')}`;
   options = [];
   group = 'development';
 
@@ -54,6 +56,7 @@ if no config entered, the aspect will be set with empty config ({}).`;
 export class UnsetAspectCmd implements Command {
   name = 'unset <pattern> <aspect-id>';
   description = `unset an aspect from component(s).`;
+  extendedDescription = `${PATTERN_HELP('aspect unset')}`;
   options = [];
   group = 'development';
 

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -1,4 +1,3 @@
-import chalk from 'chalk';
 import { Command } from '@teambit/legacy/dist/cli/command';
 import { Arguments, CommandBuilder, CommandModule } from 'yargs';
 import { TOKEN_FLAG } from '@teambit/legacy/dist/constants';
@@ -15,7 +14,7 @@ export class YargsAdapter implements CommandModule {
   builder: CommandBuilder;
   constructor(private commanderCommand: Command) {
     this.command = commanderCommand.name;
-    this.describe = chalk.yellow(commanderCommand.description as string);
+    this.describe = commanderCommand.description;
     this.aliases = commanderCommand.alias;
     this.builder = this.optionsToBuilder(commanderCommand);
   }

--- a/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
@@ -1,12 +1,14 @@
 import { Command } from '@teambit/cli';
 import chalk from 'chalk';
+import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { Workspace } from '../workspace';
 
 export class EnvsSetCmd implements Command {
   name = 'set <pattern> <env>';
-  description = 'set an environment to component(s)';
+  description = 'set an environment for component(s)';
   options = [];
   group = 'development';
+  extendedDescription = `${PATTERN_HELP('env set')}`;
 
   constructor(private workspace: Workspace) {}
 

--- a/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
@@ -1,11 +1,13 @@
 import { Command } from '@teambit/cli';
+import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { Workspace } from '../workspace';
 
 export class EnvsUnsetCmd implements Command {
-  name = 'unset <pattern>';
+  name = 'unset <component>';
   description = 'unset an environment from component(s)';
   options = [];
   group = 'development';
+  extendedDescription = `${PATTERN_HELP('env unset')}`;
 
   constructor(private workspace: Workspace) {}
 

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -29,6 +29,12 @@ export interface Command {
   description?: string;
 
   /**
+   * The extended description of the command. Will be seen in bit command help, just after the description
+   * `bit add --help`
+   */
+  extendedDescription?: string;
+
+  /**
    * allow grouping of commands to hint summery renderer
    * Places in default automatic help
    */

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -457,6 +457,12 @@ export const COMPONENT_DIST_PATH_TEMPLATE = '{COMPONENT_DIST_PATH}';
 export const WILDCARD_HELP = (command: string) =>
   `you can use a pattern for multiple ids, such as bit ${command} "utils/*". (wrap the pattern with quotes to avoid collision with shell commands)`;
 
+export const PATTERN_HELP = (command: string) =>
+  `you can use a <pattern> for multiple component ids, such as bit ${command} "org.scope/utils/**". use comma to separate patterns and "!" to exclude. e.g. "ui/**, !ui/button"
+always wrap the pattern with quotes to avoid collision with shell commands.
+to validate the pattern before running this command, run "bit pattern <pattern>".
+`;
+
 export const CURRENT_UPSTREAM = 'current';
 
 export const DEPENDENCIES_FIELDS = ['dependencies', 'devDependencies', 'peerDependencies'];


### PR DESCRIPTION
closes #5361 

## Proposed Changes

- introduce "extendedDescription" property for `Command` class. this extended description is shown just after the "description" in the command help output, but not in the "bit --help" page.
- improve the bit env/aspect commands to explain what the `<pattern>` is. 
- re-construct the command help output so it's easier now to manipulate and add more data to different parts of the output.