### PR TITLE
fix: improve error-message when PM fails to install packages 

### DIFF
--- a/scopes/harmony/aspect-loader/constants.ts
+++ b/scopes/harmony/aspect-loader/constants.ts
@@ -1,5 +1,7 @@
 // Warnings
 export const UNABLE_TO_LOAD_EXTENSION = (id: string) =>
-  `error: unable to load the extension "${id}", please use the '--log' flag for the full error.`;
+  `error: unable to load the extension "${id}", please use the '--log=error' flag for the full error.`;
 export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[]) =>
-  `couldn't load one of the following extensions ${ids.join(', ')}, please use the '--log' flag for the full error.`;
+  `couldn't load one of the following extensions ${ids.join(
+    ', '
+  )}, please use the '--log=error' flag for the full error.`;

--- a/src/consumer/component-ops/many-components-writer.ts
+++ b/src/consumer/component-ops/many-components-writer.ts
@@ -1,3 +1,4 @@
+import { BitError } from '@teambit/bit-error';
 import fs from 'fs-extra';
 import mapSeries from 'p-map-series';
 import * as path from 'path';
@@ -411,7 +412,14 @@ to move all component files to a different directory, run bit remove and then bi
         installProdPackagesOnly: this.installProdPackagesOnly,
       });
     } else {
-      await ManyComponentsWriter.externalInstaller?.install();
+      try {
+        await ManyComponentsWriter.externalInstaller?.install();
+      } catch (err: any) {
+        logger.error('_installPackagesIfNeeded, external package-installer found an error', err);
+        throw new BitError(`failed installing the packages, consider running the command with "--skip-dependency-installation" flag.
+error from the package-manager: ${err.message}.
+please use the '--log=error' flag for the full error.`);
+      }
       // this compiles all components on the workspace, not only the imported ones.
       // reason being is that the installed above deletes all dists dir of components that are somehow part of the
       // dependency graph. not only the imported components.

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -165,7 +165,7 @@ class BitLogger implements IBitLogger {
     const isSuccess = code === 0;
     const level = isSuccess ? 'info' : 'error';
     if (cliOutput) {
-      this.logger[level](`[+] CLI-OUTPUT: ${cliOutput}`);
+      this.logger.info(`[+] CLI-OUTPUT: ${cliOutput}`);
     }
     const msg = isSuccess
       ? `[*] the command "${commandName}" has been completed successfully`


### PR DESCRIPTION
during import/checkout to suggest using `--skip-dependency-installation` flag.
Asked by @ranm8 .
