### PR TITLE
fix(pnpm): don't hoist `@types`

### DIFF
--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -119,7 +119,7 @@ export class PnpmPackageManager implements PackageManager {
         nodeLinker: installOptions.nodeLinker,
         overrides: installOptions.overrides,
         hoistPattern: config.hoistPattern,
-        publicHoistPattern: config.publicHoistPattern,
+        publicHoistPattern: ['*eslint*', '@prettier/plugin-*', '*prettier-plugin-*'],
       },
       this.logger
     );


### PR DESCRIPTION
Hoisting types causes issues in some workspaces (for instance, in the symphony workspace).

By default `publicHoistPattern` is hoisting `@types`.
So we are overriding its value in order to exclude types.
