### PR TITLE
feat: improve "bit import" output to show the total of up-to-date and total of new-versions

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -149,8 +149,8 @@ describe('import functionality on Harmony', function () {
     });
     it('should not fetch existing versions, only the missing', () => {
       const importOutput = helper.command.import();
-      expect(importOutput).to.not.include('new versions: 0.0.1, 0.0.2, 0.0.3');
-      expect(importOutput).to.include('new versions: 0.0.3');
+      expect(importOutput).to.not.include('3 new version');
+      expect(importOutput).to.include('1 new version(s) available, latest 0.0.3');
     });
   });
   describe('multiple components some are directory of others', () => {

--- a/src/cli/chalk-box.ts
+++ b/src/cli/chalk-box.ts
@@ -25,13 +25,7 @@ export const formatPlainComponentItem = ({ scope, name, version, deprecated }: a
 export const formatPlainComponentItemWithVersions = (component: Component, importDetails: ImportDetails) => {
   const status: ImportStatus = importDetails.status;
   const id = component.id.toStringWithoutVersion();
-  const getVersionsOutput = () => {
-    if (!importDetails.versions.length) return '';
-    if (importDetails.latestVersion)
-      return `${importDetails.versions.length} new versions available, latest ${importDetails.latestVersion}`;
-    return `new versions: ${importDetails.versions.join(', ')}`;
-  };
-  const versions = getVersionsOutput();
+  const versions = importDetails.versions.length ? `new versions: ${importDetails.versions.join(', ')}` : '';
   // $FlowFixMe component.version should be set here
   const usedVersion = status === 'added' ? `, currently used version ${component.version}` : '';
   const getConflictMessage = () => {

--- a/src/cli/chalk-box.ts
+++ b/src/cli/chalk-box.ts
@@ -25,7 +25,13 @@ export const formatPlainComponentItem = ({ scope, name, version, deprecated }: a
 export const formatPlainComponentItemWithVersions = (component: Component, importDetails: ImportDetails) => {
   const status: ImportStatus = importDetails.status;
   const id = component.id.toStringWithoutVersion();
-  const versions = importDetails.versions.length ? `new versions: ${importDetails.versions.join(', ')}` : '';
+  const getVersionsOutput = () => {
+    if (!importDetails.versions.length) return '';
+    if (importDetails.latestVersion)
+      return `${importDetails.versions.length} new versions available, latest ${importDetails.latestVersion}`;
+    return `new versions: ${importDetails.versions.join(', ')}`;
+  };
+  const versions = getVersionsOutput();
   // $FlowFixMe component.version should be set here
   const usedVersion = status === 'added' ? `, currently used version ${component.version}` : '';
   const getConflictMessage = () => {

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -59,6 +59,7 @@ export type ImportStatus = 'added' | 'updated' | 'up to date';
 export type ImportDetails = {
   id: string;
   versions: string[];
+  latestVersion: string | null;
   status: ImportStatus;
   filesStatus: FilesStatus | null | undefined;
   missingDeps: BitId[];
@@ -387,7 +388,7 @@ export default class ImportComponents {
       const modelComponent = await this.consumer.scope.getModelComponentIfExist(id);
       if (!modelComponent) throw new ShowDoctorError(`imported component ${idStr} was not found in the model`);
       const afterImportVersions = modelComponent.listVersions();
-      const versionDifference = R.difference(afterImportVersions, beforeImportVersions);
+      const versionDifference: string[] = R.difference(afterImportVersions, beforeImportVersions);
       const getStatus = (): ImportStatus => {
         if (!versionDifference.length) return 'up to date';
         if (!beforeImportVersions.length) return 'added';
@@ -395,9 +396,11 @@ export default class ImportComponents {
       };
       const filesStatus = this.mergeStatus && this.mergeStatus[idStr] ? this.mergeStatus[idStr] : null;
       const deprecated = await modelComponent.isDeprecated(this.scope.objects);
+      const latestVersion = modelComponent.latest();
       return {
         id: idStr,
         versions: versionDifference,
+        latestVersion: versionDifference.includes(latestVersion) ? latestVersion : null,
         status: getStatus(),
         filesStatus,
         missingDeps: component.missingDependencies,


### PR DESCRIPTION
## Proposed Changes

- instead of listing all component-ids that are up-to-date, add `X components are up to date` to the title.
- instead of listing all the new versions imported to a component, show `N new versions available, latest x.y.z`.
