### PR TITLE
fix(lanes): fix an error when snapping on a lane, switching to main, then back to the lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -718,6 +718,20 @@ describe('bit lane command', function () {
       it('lane-a should not include lane-b component, although locally it switched from it', () => {});
     });
   });
+  describe('main => lane => main => lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.switchLocalLane('main');
+    });
+    // previously it errored with "error: version "latest" of component comp1 was not found."
+    it('should be able to switch back to the lane with no error', () => {
+      expect(() => helper.command.switchLocalLane('dev')).to.not.throw();
+    });
+  });
   describe('exporting a lane to a different scope than the component scope', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();

--- a/src/consumer/lanes/switch-lanes.ts
+++ b/src/consumer/lanes/switch-lanes.ts
@@ -179,8 +179,13 @@ async function getComponentStatus(consumer: Consumer, id: BitId, switchProps: Sw
     if (switchProps.existingOnWorkspaceOnly) {
       return returnFailure(`component ${id.toStringWithoutVersion()} is not in the workspace`);
     }
-    // @ts-ignore
-    return { componentFromFS: null, componentFromModel: componentOnLane, id, mergeResults: null };
+    return { componentFromFS: undefined, componentFromModel: componentOnLane, id, mergeResults: null };
+  }
+  if (!existingBitMapId.hasVersion()) {
+    // happens when switching from main to a lane and a component was snapped on the lane.
+    // in the .bitmap file, the version is "latest" or empty. so we just need to write the component according to the
+    // model. we don't care about the componentFromFS
+    return { componentFromFS: undefined, componentFromModel: componentOnLane, id, mergeResults: null };
   }
   const currentlyUsedVersion = existingBitMapId.version;
   if (currentlyUsedVersion === version) {


### PR DESCRIPTION
currently, it shows an error `error: version "latest" of component comp1 was not found.`.