### PR TITLE
fix: allow specifying id without scope-name when "pattern" is required

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -728,6 +728,11 @@ export class Workspace implements ComponentFactory {
    * it supports negate (!) character to exclude ids.
    */
   async idsByPattern(pattern: string): Promise<ComponentID[]> {
+    if (!pattern.includes('*') && !pattern.includes(',')) {
+      // if it's not a pattern but just id, resolve it without multimatch to support specifying id without scope-name
+      const id = await this.resolveComponentId(pattern);
+      return [id];
+    }
     const ids = await this.listIds();
     const patterns = pattern.split(',').map((p) => p.trim());
     // check also as legacyId.toString, as it doesn't have the defaultScope


### PR DESCRIPTION
Needed for `bit env set` for example, when `<pattern>` is required.
Currently, since it uses `multimatch` to match the id, if the scope-name is omitted, it won't match, unless it's prefixed with `**/`. 
This PR checks whether it's a pattern, and if not, it allows resolving the id without the scope-name.