### PR TITLE
improvement: show a descriptive error when scope-name might be self-hosted or missing the org-name

### DIFF
--- a/scopes/component/legacy-bit-id/exceptions/index.ts
+++ b/scopes/component/legacy-bit-id/exceptions/index.ts
@@ -2,5 +2,6 @@ import InvalidBitId from './invalid-bit-id';
 import InvalidIdChunk from './invalid-id-chunk';
 import InvalidName from './invalid-name';
 import InvalidScopeName from './invalid-scope-name';
+import InvalidScopeNameFromRemote from './invalid-scope-name-from-remote';
 
-export { InvalidBitId, InvalidIdChunk, InvalidName, InvalidScopeName };
+export { InvalidBitId, InvalidIdChunk, InvalidName, InvalidScopeName, InvalidScopeNameFromRemote };

--- a/scopes/component/legacy-bit-id/exceptions/invalid-scope-name-from-remote.ts
+++ b/scopes/component/legacy-bit-id/exceptions/invalid-scope-name-from-remote.ts
@@ -1,0 +1,9 @@
+import { BitError } from '@teambit/bit-error';
+
+export default class InvalidScopeNameFromRemote extends BitError {
+  constructor(scopeName: string) {
+    super(`cannot find scope '${scopeName}'.
+if you are targeting a self-hosted scope, please ensure the scope is configured in your remotes (via "bit remote" command) and that the scope name is correct.
+if this is a scope on bit.dev please add the organization name before the scope (yourOrg.some-scope-name)`);
+  }
+}

--- a/scopes/component/legacy-bit-id/index.ts
+++ b/scopes/component/legacy-bit-id/index.ts
@@ -1,5 +1,14 @@
 import BitId, { BitIdProps, VERSION_DELIMITER, BitIdStr } from './bit-id';
-import { InvalidName, InvalidScopeName } from './exceptions';
+import { InvalidName, InvalidScopeName, InvalidScopeNameFromRemote } from './exceptions';
 import isValidScopeName from './utils/is-valid-scope-name';
 
-export { BitId, BitIdProps, BitIdStr, VERSION_DELIMITER, isValidScopeName, InvalidName, InvalidScopeName };
+export {
+  BitId,
+  BitIdProps,
+  BitIdStr,
+  VERSION_DELIMITER,
+  isValidScopeName,
+  InvalidName,
+  InvalidScopeName,
+  InvalidScopeNameFromRemote,
+};

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -52,7 +52,7 @@ import LegacyGraph from '@teambit/legacy/dist/scope/graph/graph';
 import { ImportOptions } from '@teambit/legacy/dist/consumer/component-ops/import-components';
 import { NothingToImport } from '@teambit/legacy/dist/consumer/exceptions';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
-import { BitId, InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
+import { BitId, InvalidScopeName, InvalidScopeNameFromRemote, isValidScopeName } from '@teambit/legacy-bit-id';
 import { LocalLaneId, RemoteLaneId } from '@teambit/legacy/dist/lane-id/lane-id';
 import { Consumer, loadConsumer } from '@teambit/legacy/dist/consumer';
 import { GetBitMapComponentOptions } from '@teambit/legacy/dist/consumer/bit-map/bit-map';
@@ -662,7 +662,12 @@ export class Workspace implements ComponentFactory {
         lane: lanes[0],
       };
     } catch (err) {
-      if (err instanceof InvalidScopeName || err instanceof ScopeNotFoundOrDenied || err instanceof LaneNotFound) {
+      if (
+        err instanceof InvalidScopeName ||
+        err instanceof ScopeNotFoundOrDenied ||
+        err instanceof LaneNotFound ||
+        err instanceof InvalidScopeNameFromRemote
+      ) {
         // the lane could be a local lane so no need to throw an error in such case
         loader.stop();
         this.logger.warn(`unable to get lane's data from a remote due to an error:\n${err.message}`);

--- a/src/api/consumer/lib/fetch.ts
+++ b/src/api/consumer/lib/fetch.ts
@@ -1,6 +1,6 @@
 import R from 'ramda';
 
-import { InvalidScopeName } from '@teambit/legacy-bit-id';
+import { InvalidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import logger from '@teambit/legacy/dist/logger/logger';
 import ScopeComponentsImporter from '../../../scope/component-ops/scope-components-importer';
 import { Analytics } from '../../../analytics/analytics';
@@ -66,7 +66,12 @@ export default async function fetch(ids: string[], lanes: boolean, components: b
       result.laneIds.push(...remoteLaneIds);
       result.lanes.push(...remoteLanes);
     } catch (err) {
-      if (err instanceof InvalidScopeName || err instanceof ScopeNotFoundOrDenied || err instanceof LaneNotFound) {
+      if (
+        err instanceof InvalidScopeName ||
+        err instanceof ScopeNotFoundOrDenied ||
+        err instanceof LaneNotFound ||
+        err instanceof InvalidScopeNameFromRemote
+      ) {
         // the lane could be a local lane so no need to throw an error in such case
         loader.stop();
         logger.console(`unable to get lane's data from a remote due to an error:\n${err.message}`, 'warn', 'yellow');

--- a/src/remotes/remote-resolver/remote-resolver.ts
+++ b/src/remotes/remote-resolver/remote-resolver.ts
@@ -1,5 +1,5 @@
 import { GraphQLClient, gql } from 'graphql-request';
-import { InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
+import { InvalidScopeName, isValidScopeName, InvalidScopeNameFromRemote } from '@teambit/legacy-bit-id';
 import { getSync } from '../../api/consumer/lib/global-config';
 import {
   CFG_HUB_DOMAIN_KEY,
@@ -13,7 +13,6 @@ import Scope from '../../scope/scope';
 import { getAuthHeader, getFetcherWithAgent } from '../../scope/network/http/http';
 import logger from '../../logger/logger';
 import { ScopeNotFoundOrDenied } from '../exceptions/scope-not-found-or-denied';
-import { BitError } from '@teambit/bit-error';
 
 const hubDomain = getSync(CFG_HUB_DOMAIN_KEY) || DEFAULT_HUB_DOMAIN;
 const symphonyUrl = getSync(CFG_SYMPHONY_URL_KEY) || SYMPHONY_URL;
@@ -58,9 +57,7 @@ async function getScope(name: string) {
     }
     if (errorCode === 'InvalidScopeID') {
       if (isValidScopeName(name)) {
-        throw new BitError(`cannot find scope '${name}'.
-if you are targeting a self-hosted scope, please ensure the scope is configured in your remotes (via "bit remote" command) and that the scope name is correct.
-if this is a scope on bit.dev please add the organization name before the scope (yourOrg.some-scope-name)`);
+        throw new InvalidScopeNameFromRemote(name);
       }
       throw new InvalidScopeName(name);
     }


### PR DESCRIPTION
Currently, when the scope-name has no dot, it shows the following error:
```
error: "my-scope" is invalid, component scope names can only contain alphanumeric, lowercase characters, and the following ["-", "_", "$", "!"]
```
which is confusing to the end user, as the scope-name does comply with the scope-name requirements.

With this PR, when this happens, it shows the following error-message instead:
```
cannot find scope 'my-scope'.
if you are targeting a self-hosted scope, please ensure the scope is configured in your remotes (via "bit remote" command) and that the scope name is correct.
if this is a scope on bit.dev please add the organization name before the scope (yourOrg.some-scope-name)
```
Requested by @benjgil .