### PR TITLE
fix: avoid removing dependencies when removing a component from the scope

### DIFF
--- a/scopes/workspace/eject/components-ejector.ts
+++ b/scopes/workspace/eject/components-ejector.ts
@@ -174,7 +174,7 @@ your package.json (if existed) has been restored, however, some bit generated da
 
   private async untrackComponents() {
     this.logger.debug('eject: removing the components from the .bitmap');
-    await this.consumer.cleanFromBitMap(this.idsToEject, new BitIds());
+    await this.consumer.cleanFromBitMap(this.idsToEject);
   }
 
   throwEjectError(message: string, originalError: Error) {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -728,6 +728,11 @@ export class Workspace implements ComponentFactory {
    * it supports negate (!) character to exclude ids.
    */
   async idsByPattern(pattern: string): Promise<ComponentID[]> {
+    if (!pattern.includes('*') && !pattern.includes(',')) {
+      // if it's not a pattern but just id, resolve it without multimatch to support specifying id without scope-name
+      const id = await this.resolveComponentId(pattern);
+      return [id];
+    }
     const ids = await this.listIds();
     const patterns = pattern.split(',').map((p) => p.trim());
     // check also as legacyId.toString, as it doesn't have the defaultScope

--- a/src/consumer/component-ops/eject-components.ts
+++ b/src/consumer/component-ops/eject-components.ts
@@ -252,7 +252,7 @@ please use bit remove command to remove them.`,
     // gets the dependencies as npm packages so we don't need to worry much about have extra
     // dependencies on the filesystem
     await deleteComponentsFiles(this.consumer, this.idsToEject, true);
-    await this.consumer.cleanFromBitMap(this.idsToEject, new BitIds());
+    await this.consumer.cleanFromBitMap(this.idsToEject);
   }
 
   throwEjectError(message: string, originalError: Error) {

--- a/src/consumer/component-ops/remove-components.ts
+++ b/src/consumer/component-ops/remove-components.ts
@@ -127,15 +127,17 @@ async function removeLocal(
     idsToRemove.filter((id) => newComponents.hasWithoutScopeAndVersion(id))
   );
   const { components: componentsToRemove, invalidComponents } = await consumer.loadComponents(idsToRemove, false);
-  const { removedComponentIds, missingComponents, dependentBits, removedFromLane, removedDependencies } =
-    await consumer.scope.removeMany(idsToRemoveFromScope, force, true, consumer);
+  const { removedComponentIds, missingComponents, dependentBits, removedFromLane } = await consumer.scope.removeMany(
+    idsToRemoveFromScope,
+    force,
+    consumer
+  );
   if (!removedFromLane) {
     // otherwise, components should still be in .bitmap file
     idsToCleanFromWorkspace.push(...removedComponentIds);
   }
   if (idsToCleanFromWorkspace.length) {
     await deleteComponentsFiles(consumer, idsToCleanFromWorkspace, deleteFiles);
-    await deleteComponentsFiles(consumer, removedDependencies, false);
     if (!track) {
       const invalidComponentsIds = invalidComponents.map((i) => i.id);
       const removedComponents = componentsToRemove.filter((c) => idsToCleanFromWorkspace.hasWithoutVersion(c.id));
@@ -144,14 +146,13 @@ async function removeLocal(
         removedComponents,
         invalidComponentsIds
       );
-      await consumer.cleanFromBitMap(idsToCleanFromWorkspace, removedDependencies);
+      await consumer.cleanFromBitMap(idsToCleanFromWorkspace);
     }
   }
   return new RemovedLocalObjects(
     BitIds.uniqFromArray([...idsToCleanFromWorkspace, ...removedComponentIds]),
     missingComponents,
     modifiedComponents,
-    removedDependencies,
     dependentBits,
     removedFromLane
   );

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -978,12 +978,10 @@ export default class Consumer {
   /**
    * clean up removed components from bitmap
    * @param {BitIds} componentsToRemoveFromFs - delete component that are used by other components.
-   * @param {BitIds} removedDependencies - delete component that are used by other components.
    */
-  async cleanFromBitMap(componentsToRemoveFromFs: BitIds, removedDependencies: BitIds) {
+  async cleanFromBitMap(componentsToRemoveFromFs: BitIds) {
     logger.debug(`consumer.cleanFromBitMap, cleaning ${componentsToRemoveFromFs.toString()} from .bitmap`);
     this.bitMap.removeComponents(componentsToRemoveFromFs);
-    this.bitMap.removeComponents(removedDependencies);
   }
 
   async addRemoteAndLocalVersionsToDependencies(component: Component, loadedFromFileSystem: boolean) {

--- a/src/scope/component-ops/remove-model-components.ts
+++ b/src/scope/component-ops/remove-model-components.ts
@@ -1,62 +1,55 @@
-import { compact } from 'lodash';
 import mapSeries from 'p-map-series';
 import R from 'ramda';
-
 import { BitId, BitIds } from '../../bit-id';
-import { COMPONENT_ORIGINS, LATEST_BIT_VERSION } from '../../constants';
-import ConsumerComponent from '../../consumer/component';
+import { LATEST_BIT_VERSION } from '../../constants';
 import Consumer from '../../consumer/consumer';
 import logger from '../../logger/logger';
-import DependencyGraph from '../graph/scope-graph';
-import { Lane, ModelComponent, Symlink } from '../models';
+import { Lane, Symlink } from '../models';
 import { Ref } from '../objects';
 import RemovedObjects from '../removed-components';
 import Scope from '../scope';
 
+/**
+ * remove components from the model.
+ *
+ * previously, this class also removed dependencies from the scope, see https://github.com/teambit/bit/pull/5380 for
+ * more details.
+ */
 export default class RemoveModelComponents {
   scope: Scope;
   bitIds: BitIds;
   force: boolean;
-  removeSameOrigin = false;
   consumer: Consumer | null | undefined;
   currentLane: Lane | null = null;
-  private dependencyGraph: DependencyGraph;
-  constructor(scope: Scope, bitIds: BitIds, force: boolean, removeSameOrigin: boolean, consumer?: Consumer) {
+  constructor(scope: Scope, bitIds: BitIds, force: boolean, consumer?: Consumer) {
     this.scope = scope;
     this.bitIds = bitIds;
     this.force = force;
-    this.removeSameOrigin = removeSameOrigin;
     this.consumer = consumer;
   }
 
-  async setCurrentLane() {
+  private async setCurrentLane() {
     this.currentLane = await this.scope.lanes.getCurrentLaneObject();
   }
 
   async remove(): Promise<RemovedObjects> {
     const { missingComponents, foundComponents } = await this.scope.filterFoundAndMissingComponents(this.bitIds);
     await this.setCurrentLane();
-    const dependentBits = await this.getDependentsIds(foundComponents);
+    const dependentBits = await this.scope.getDependentsBitIds(foundComponents);
     if (R.isEmpty(dependentBits) || this.force) {
-      // do not run this in parallel (promise.all), otherwise, it may throw an error when
-      // trying to delete the same file at the same time (happens when removing a component with
-      // a dependency and the dependency itself)
       const removalData = await mapSeries(foundComponents, (bitId) => this.getRemoveSingleData(bitId));
       const compIds = new BitIds(...removalData.map((x) => x.compId));
-      const depsIds = new BitIds(...removalData.map((x) => x.depIds).flat());
-      const allIds = [...compIds, ...depsIds];
       const refsToRemoveAll = removalData.map((removed) => removed.refsToRemove).flat();
       if (this.currentLane) {
         await this.scope.objects.writeObjectsToTheFS([this.currentLane]);
       }
       await this.scope.objects.deleteObjectsFromFS(refsToRemoveAll);
-      await this.scope.objects.deleteRecordsFromUnmergedComponents(allIds.map((id) => id.name));
+      await this.scope.objects.deleteRecordsFromUnmergedComponents(compIds.map((id) => id.name));
 
       const removedFromLane = Boolean(this.currentLane && foundComponents.length);
       return new RemovedObjects({
         removedComponentIds: compIds,
         missingComponents,
-        removedDependencies: depsIds,
         removedFromLane,
       });
     }
@@ -64,99 +57,25 @@ export default class RemoveModelComponents {
     return new RemovedObjects({ missingComponents, dependentBits });
   }
 
-  private async getDependentsIds(ids: BitIds, returnResultsWithVersion = false): Promise<{ [key: string]: BitId[] }> {
-    const dependencyGraph = await this.getDependencyGraph();
-    return this.scope.getDependentsBitIds(ids, dependencyGraph, returnResultsWithVersion);
-  }
-
-  private async getDependencyGraph() {
-    if (!this.dependencyGraph) {
-      const idsGraph = await DependencyGraph.buildIdsGraphWithAllVersions(this.scope);
-      this.dependencyGraph = new DependencyGraph(idsGraph);
-    }
-    return this.dependencyGraph;
-  }
-
-  /**
-   * removeSingle - remove single component
-   * @param {BitId} bitId - list of remote component ids to delete
-   * @param {boolean} removeSameOrigin - remove component dependencies from same origin
-   */
-  private async getRemoveSingleData(bitId: BitId): Promise<{ compId: BitId; depIds: BitIds; refsToRemove: Ref[] }> {
-    logger.debug(`scope.removeSingle ${bitId.toString()}, remove dependencies: ${this.removeSameOrigin.toString()}`);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const component = (await this.scope.getModelComponentIfExist(bitId)).toComponentVersion();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    // const consumerComponentToRemove = await component.toConsumer(this.scope.objects);
-    const componentList = await this.scope.listIncludesSymlinks();
-
-    // const dependentBits = await this.getDependentsIds(
-    //   consumerComponentToRemove.flattenedDependencies,
-    //   bitId.version !== LATEST_BIT_VERSION
-    // );
-
-    // const { ids: depIds, refs: depsRefs } = await this.getDataForDependenciesRemoval(
-    //   dependentBits,
-    //   componentList,
-    //   consumerComponentToRemove,
-    //   bitId
-    // );
-    const depIds = new BitIds();
-    const depsRefs = [];
-
-    const componentsRefs = await this.getDataForRemovingComponent(bitId, componentList);
+  private async getRemoveSingleData(bitId: BitId): Promise<{ compId: BitId; refsToRemove: Ref[] }> {
+    logger.debug(`scope.removeSingle ${bitId.toString()}`);
+    const component = (await this.scope.getModelComponent(bitId)).toComponentVersion();
+    const componentsRefs = await this.getDataForRemovingComponent(bitId);
     const version = Object.keys(component.component.versions).length <= 1 ? LATEST_BIT_VERSION : bitId.version;
 
     return {
       compId: bitId.changeVersion(version),
-      depIds,
-      refsToRemove: [...componentsRefs, ...depsRefs],
+      refsToRemove: componentsRefs,
     };
   }
 
-  private async getDataForDependenciesRemoval(
-    dependentBits: Record<string, BitId[]>,
-    componentList: Array<ModelComponent | Symlink>,
-    consumerComponentToRemove: ConsumerComponent,
-    bitId: BitId
-  ): Promise<{ ids: BitIds; refs: Ref[] }> {
-    const refsToRemove: Ref[] = [];
-    const depsToRemoveP = consumerComponentToRemove.flattenedDependencies.map(async (dependencyId: BitId) => {
-      const dependentsIds: BitId[] = dependentBits[dependencyId.toStringWithoutVersion()];
-      const relevantDependents = dependentsIds.filter(
-        (dependent) => !dependent.isEqual(bitId) && dependent.scope === dependencyId.scope
-      );
-      let isPartOfWorkspace = false;
-      if (this.consumer) {
-        const componentMapIgnoreVersion = this.consumer.bitMap.getComponentIfExist(dependencyId, {
-          ignoreVersion: true,
-        });
-        const componentMapExact = this.consumer.bitMap.getComponentIfExist(dependencyId);
-        const componentMap = componentMapExact || componentMapIgnoreVersion;
-        isPartOfWorkspace = Boolean(componentMap && componentMap.origin !== COMPONENT_ORIGINS.NESTED);
-      }
-      if (
-        R.isEmpty(relevantDependents) &&
-        !this.bitIds.searchWithoutVersion(dependencyId) && // don't delete dependency if it is already deleted as an individual
-        (dependencyId.scope !== bitId.scope || this.removeSameOrigin) &&
-        !isPartOfWorkspace
-      ) {
-        const refs = await this.getDataForRemovingComponent(dependencyId, componentList);
-        refsToRemove.push(...refs);
-        return dependencyId;
-      }
-      return null;
-    });
-    const depsToRemove = await Promise.all(depsToRemoveP);
-    return { ids: BitIds.fromArray(compact(depsToRemove)), refs: refsToRemove };
-  }
-
-  private async getDataForRemovingComponent(id: BitId, componentList: Array<ModelComponent | Symlink>): Promise<Ref[]> {
+  private async getDataForRemovingComponent(id: BitId): Promise<Ref[]> {
     if (this.currentLane) {
       const result = this.currentLane.removeComponent(id);
       if (!result) throw new Error(`failed deleting ${id.toString()}, the component was not found on the lane`);
       return [];
     }
+    const componentList = await this.scope.listIncludesSymlinks();
     const symlink = componentList.find(
       (component) => component instanceof Symlink && id.isEqualWithoutScopeAndVersion(component.toBitId())
     );

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -692,7 +692,7 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     return objectRef || Ref.from(version);
   }
 
-  toComponentVersion(versionStr: string | undefined): ComponentVersion {
+  toComponentVersion(versionStr?: string): ComponentVersion {
     const versionParsed = versionParser(versionStr);
     const versionNum = versionParsed.latest ? this.latest() : versionParsed.resolve(this.listVersionsIncludeOrphaned());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion

--- a/src/scope/removed-components.spec.ts
+++ b/src/scope/removed-components.spec.ts
@@ -7,7 +7,6 @@ describe('RemovedComponents', () => {
   const payload = {
     removedComponentIds: [],
     missingComponents: [],
-    removedDependencies: [],
     dependentBits: {},
     removedLanes: [],
   };

--- a/src/scope/removed-components.ts
+++ b/src/scope/removed-components.ts
@@ -4,7 +4,6 @@ import { BitIdStr } from '../bit-id/bit-id';
 export type RemovedObjectSerialized = {
   removedComponentIds: BitIdStr[];
   missingComponents: BitIdStr[];
-  removedDependencies: BitIdStr[];
   dependentBits: Record<string, any>;
   removedFromLane?: boolean;
   removedLanes: string[];
@@ -13,28 +12,24 @@ export type RemovedObjectSerialized = {
 export default class RemovedObjects {
   removedComponentIds: BitIds;
   missingComponents: BitIds;
-  removedDependencies: BitIds;
   dependentBits: Record<string, any>;
   removedFromLane: boolean;
   removedLanes: string[];
   constructor({
     removedComponentIds,
     missingComponents,
-    removedDependencies,
     dependentBits,
     removedFromLane,
     removedLanes,
   }: {
     removedComponentIds?: BitIds;
     missingComponents?: BitIds;
-    removedDependencies?: BitIds;
     dependentBits?: Record<string, any>;
     removedFromLane?: boolean;
     removedLanes?: string[];
   }) {
     this.removedComponentIds = removedComponentIds || new BitIds();
     this.missingComponents = missingComponents || new BitIds();
-    this.removedDependencies = removedDependencies || new BitIds();
     this.dependentBits = dependentBits || {};
     this.removedFromLane = removedFromLane || false;
     this.removedLanes = removedLanes || [];
@@ -44,7 +39,6 @@ export default class RemovedObjects {
     return {
       removedComponentIds: this.removedComponentIds.serialize(),
       missingComponents: this.missingComponents.serialize(),
-      removedDependencies: this.removedDependencies.serialize(),
       dependentBits: this.dependentBits,
       removedFromLane: this.removedFromLane,
       removedLanes: this.removedLanes,
@@ -54,14 +48,12 @@ export default class RemovedObjects {
   static fromObjects(payload: {
     removedComponentIds: string[];
     missingComponents: string[];
-    removedDependencies: string[];
     dependentBits: { [key: string]: Record<string, any>[] };
     removedLanes: string[];
   }): RemovedObjects {
     // this function being called from an ssh, so the ids must have a remote scope
     const missingComponents = new BitIds(...payload.missingComponents.map((id) => BitId.parse(id, true)));
     const removedComponentIds = new BitIds(...payload.removedComponentIds.map((id) => BitId.parse(id, true)));
-    const removedDependencies = new BitIds(...payload.removedDependencies.map((id) => BitId.parse(id, true)));
     const dependentBits = Object.keys(payload.dependentBits).reduce((acc, current) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       acc[current] = new BitIds(...payload.dependentBits[current].map((id) => new BitId(id)));
@@ -70,7 +62,6 @@ export default class RemovedObjects {
     return new RemovedObjects({
       missingComponents,
       removedComponentIds,
-      removedDependencies,
       dependentBits,
       removedLanes: payload.removedLanes,
     });

--- a/src/scope/removed-local-objects.ts
+++ b/src/scope/removed-local-objects.ts
@@ -7,11 +7,10 @@ export default class RemovedLocalObjects extends RemovedObjects {
     removedComponentIds?: BitIds,
     missingComponents?: BitIds,
     modifiedComponents?: BitIds,
-    removedDependencies?: BitIds,
     dependentBits?: Record<string, any>,
     removedFromLane?: boolean
   ) {
-    super({ removedComponentIds, missingComponents, removedDependencies, dependentBits, removedFromLane });
+    super({ removedComponentIds, missingComponents, dependentBits, removedFromLane });
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.modifiedComponents = modifiedComponents;
   }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -518,11 +518,17 @@ export default class Scope {
   /**
    * for each one of the given components, find its dependents
    */
-  async getDependentsBitIds(bitIds: BitIds, returnResultsWithVersion = false): Promise<{ [key: string]: BitId[] }> {
-    const idsGraph = await DependencyGraph.buildIdsGraphWithAllVersions(this);
-    const dependencyGraph = new DependencyGraph(idsGraph);
+  async getDependentsBitIds(
+    bitIds: BitIds,
+    dependencyGraph?: DependencyGraph,
+    returnResultsWithVersion = false
+  ): Promise<{ [key: string]: BitId[] }> {
+    if (!dependencyGraph) {
+      const idsGraph = await DependencyGraph.buildIdsGraphWithAllVersions(this);
+      dependencyGraph = new DependencyGraph(idsGraph);
+    }
     const dependentsGraph = bitIds.reduce((acc, current) => {
-      const dependents = dependencyGraph.getDependentsForAllVersions(current);
+      const dependents = (dependencyGraph as DependencyGraph).getDependentsForAllVersions(current);
       if (dependents.length) {
         const dependentsIds = dependents.map((id) => (returnResultsWithVersion ? id : id.changeVersion(undefined)));
         acc[current.toStringWithoutVersion()] = BitIds.uniqFromArray(dependentsIds);

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -500,35 +500,24 @@ export default class Scope {
    * Remove components from scope
    * @force Boolean - remove component from scope even if other components use it
    */
-  async removeMany(
-    bitIds: BitIds,
-    force: boolean,
-    removeSameOrigin = false,
-    consumer?: Consumer
-  ): Promise<RemovedObjects> {
+  async removeMany(bitIds: BitIds, force: boolean, consumer?: Consumer): Promise<RemovedObjects> {
     logger.debug(`scope.removeMany ${bitIds.toString()} with force flag: ${force.toString()}`);
     Analytics.addBreadCrumb(
       'removeMany',
       `scope.removeMany ${Analytics.hashData(bitIds)} with force flag: ${force.toString()}`
     );
-    const removeComponents = new RemoveModelComponents(this, bitIds, force, removeSameOrigin, consumer);
+    const removeComponents = new RemoveModelComponents(this, bitIds, force, consumer);
     return removeComponents.remove();
   }
 
   /**
    * for each one of the given components, find its dependents
    */
-  async getDependentsBitIds(
-    bitIds: BitIds,
-    dependencyGraph?: DependencyGraph,
-    returnResultsWithVersion = false
-  ): Promise<{ [key: string]: BitId[] }> {
-    if (!dependencyGraph) {
-      const idsGraph = await DependencyGraph.buildIdsGraphWithAllVersions(this);
-      dependencyGraph = new DependencyGraph(idsGraph);
-    }
+  async getDependentsBitIds(bitIds: BitIds, returnResultsWithVersion = false): Promise<{ [key: string]: BitId[] }> {
+    const idsGraph = await DependencyGraph.buildIdsGraphWithAllVersions(this);
+    const dependencyGraph = new DependencyGraph(idsGraph);
     const dependentsGraph = bitIds.reduce((acc, current) => {
-      const dependents = (dependencyGraph as DependencyGraph).getDependentsForAllVersions(current);
+      const dependents = dependencyGraph.getDependentsForAllVersions(current);
       if (dependents.length) {
         const dependentsIds = dependents.map((id) => (returnResultsWithVersion ? id : id.changeVersion(undefined)));
         acc[current.toStringWithoutVersion()] = BitIds.uniqFromArray(dependentsIds);


### PR DESCRIPTION
Currently, when deleting a component, we loop through the flattened-dependencies and delete the dependencies from the scope if the following conditions were met:
1. locally: the dependency is not part of the workspace. (Not exist in .bitmap).
2. on remote: the dependency scope-name is different than the component-to-remove. This is to ensure we only delete "cache", never components belong to the current scope.
3. there is no dependents for this dependency in the scope OR there is a dependent but this dependent has different scope-name as the dependency.

According to the above, in the following scenario, we'll delete the dependency:
Comp-to-remove: scopeA/comp

dep-graph:
scopeA/comp -> scopeB/comp
scopeC/comp -> scopeB/comp

Since the dep "scopeB/comp" has a dependent but from a different scope (scopeC), then, it gets deleted.
This somewhat unexecuted behavior might be related to a few bugs we encountered recently when running `bit remove`.

Besides this complex logic when to delete deps, there is a big performance penalty here. A component can have a large amount of flattened-dependencies. The graph component of the entire scope might be huge as well. Scanning the entire graph for each one of the flattened-dependencies is time consuming. (in the instance I was working on, it took 3 min(!)).

Because of these reasons @ranm8  and I made the decision to cancel it altogether for now. So when removing a component, it doesn't try to search and delete its dependencies.
Later, we'll implement some kind of "garbage collector", which can go through each one of the component of the current scope and find the Refs belong to it. Orphaned refs can be deleted safely.
