### PR TITLE
fix: remove the previous env when running "bit env set"

### DIFF
--- a/e2e/harmony/env.e2e.ts
+++ b/e2e/harmony/env.e2e.ts
@@ -13,7 +13,7 @@ describe('env', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('run bit env set and then tag', () => {
+  describe('run bit env set and then tag when the variants points to another env', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
@@ -29,6 +29,19 @@ describe('env', function () {
     it('should not change the env to the variants one', () => {
       const env = helper.env.getComponentEnv('comp1');
       expect(env).to.equal('teambit.harmony/aspect');
+    });
+  });
+  describe('run bit env set X and then tag bit env set Y', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.setEnv('comp1', 'teambit.harmony/aspect');
+      helper.command.setEnv('comp1', 'teambit.react/react');
+    });
+    it('should replace the env with the last one and remove the first one', () => {
+      const show = helper.command.showComponent('comp1');
+      expect(show).to.not.have.string('teambit.harmony/aspect');
     });
   });
 });

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1972,6 +1972,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     const envIdStr = envId.toString();
     const existsOnWorkspace = await this.hasId(envId);
     const envIdStrNoVersion = envId.toStringWithoutVersion();
+    await this.unsetEnvFromComponents(componentIds);
     componentIds.forEach((componentId) => {
       this.bitMap.addComponentConfig(componentId, existsOnWorkspace ? envIdStrNoVersion : envIdStr);
       this.bitMap.addComponentConfig(componentId, EnvsAspect.id, { env: envIdStrNoVersion });


### PR DESCRIPTION
Currently, when running `bit env set` and the .bitmap has another env from a previous run of the same command, it only removes it from the envs/envs, but not from the root.

Reported by @NitsanCohen770 