### PR TITLE
fix: support passing component-id with default-scope (for new components) to aspects.get()

### DIFF
--- a/scopes/component/component/aspect-list.ts
+++ b/scopes/component/component/aspect-list.ts
@@ -29,7 +29,7 @@ export class AspectList {
    */
   get(id: string): AspectEntry | undefined {
     return this.entries.find((entry) => {
-      return entry.legacy.stringId === id;
+      return entry.legacy.stringId === id || entry.id.toStringWithoutVersion() === id;
     });
   }
 


### PR DESCRIPTION
For example, I created a new workspace, added a new aspect "my-aspect", its legacy string ID is just `my-aspect`, its harmony string ID is `scope.org/my-aspect`.
Currently, getting the aspect data from a component `component.state.aspects.get(MyAspect.id)` doesn't work. This is because the `get()` method uses the `legacyEntry.stringId`, which is not aware of the default-scope, so it compares it to `my-aspect` only.
With this PR it does the comparison against the Harmony string ID as well.