### PR TITLE
fix: strip "__specific" field from .bitmap and "bit diff"

### DIFF
--- a/e2e/harmony/extensions-config-diff.e2e.ts
+++ b/e2e/harmony/extensions-config-diff.e2e.ts
@@ -49,6 +49,10 @@ describe('extensions config diff', function () {
         expect(output).to.have.string('+++ Ext4@0.0.1 configuration (0.0.1 modified)');
         expect(output).to.have.string('+ "key": "val-component-json"');
       });
+      it('bit diff should not show internal config fields', () => {
+        output = helper.command.diff();
+        expect(output).to.not.have.string('__specific');
+      });
     });
     describe('remove extension', () => {
       before(() => {

--- a/e2e/harmony/fork.e2e.ts
+++ b/e2e/harmony/fork.e2e.ts
@@ -29,6 +29,10 @@ describe('bit fork command', function () {
       expect(showFork.config).to.have.property('forkedFrom');
       expect(showFork.config.forkedFrom.name).to.equal('comp1');
     });
+    it('.bitmap should not have internal config fields', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap.comp2.config[Extensions.forking]).to.not.have.property('__specific');
+    });
   });
   describe('fork a remote component with no --target-id flag', () => {
     before(() => {

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -14,6 +14,7 @@ import AddComponents from '../component-ops/add-components';
 import { AddContext, getFilesByDir, getGitIgnoreHarmony } from '../component-ops/add-components/add-components';
 import { EmptyDirectory, NoFiles } from '../component-ops/add-components/exceptions';
 import ComponentNotFoundInPath from '../component/exceptions/component-not-found-in-path';
+import { removeInternalConfigFields } from '../config/extension-data';
 import Consumer from '../consumer';
 import OutsideRootDir from './exceptions/outside-root-dir';
 
@@ -154,13 +155,22 @@ export default class ComponentMap {
         ? this.lanes.map((l) => ({ remoteLane: l.remoteLane.toString(), version: l.version }))
         : null,
       nextVersion: this.nextVersion,
-      config: this.config,
+      config: this.configToObject(),
     };
     const notNil = (val) => {
       return !R.isNil(val);
     };
     res = R.filter(notNil, res);
     return res;
+  }
+
+  private configToObject() {
+    if (!this.config) return undefined;
+    const config = {};
+    Object.keys(this.config).forEach((aspectId) => {
+      config[aspectId] = removeInternalConfigFields(this.config?.[aspectId]);
+    });
+    return config;
   }
 
   static getPathWithoutRootDir(rootDir: PathLinux, filePath: PathLinux): PathLinux {

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -1,6 +1,6 @@
 /* eslint-disable max-classes-per-file */
 import R, { forEachObjIndexed } from 'ramda';
-import { compact } from 'lodash';
+import { compact, isEmpty, cloneDeep } from 'lodash';
 
 import { BitId, BitIds } from '../../bit-id';
 import { sortObject } from '../../utils';
@@ -11,20 +11,23 @@ import {
 } from '../component/sources/artifact-files';
 
 const mergeReducer = (accumulator, currentValue) => R.unionWith(ignoreVersionPredicate, accumulator, currentValue);
+type ExtensionConfig = { [extName: string]: any } | RemoveExtensionSpecialSign;
 type ConfigOnlyEntry = {
   id: string;
-  config: Record<string, any> | RemoveExtensionSpecialSign;
+  config: ExtensionConfig;
 };
 
 export const REMOVE_EXTENSION_SPECIAL_SIGN = '-';
 type RemoveExtensionSpecialSign = '-';
+
+export const INTERNAL_CONFIG_FIELDS = ['__specific'];
 
 export class ExtensionDataEntry {
   constructor(
     public legacyId?: string,
     public extensionId?: BitId,
     public name?: string,
-    public rawConfig: { [key: string]: any } | RemoveExtensionSpecialSign = {},
+    public rawConfig: ExtensionConfig = {},
     public data: { [key: string]: any } = {},
     public newExtensionId: any = undefined
   ) {}
@@ -199,8 +202,9 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
   toConfigObject() {
     const res = {};
     this.forEach((entry) => {
-      if (entry.rawConfig && !R.isEmpty(entry.rawConfig)) {
-        res[entry.stringId] = entry.rawConfig;
+      if (entry.rawConfig && !isEmpty(entry.rawConfig)) {
+        res[entry.stringId] = removeInternalConfigFields(entry.rawConfig);
+        if (isEmpty(res[entry.stringId])) delete res[entry.stringId];
       }
     });
     return res;
@@ -293,4 +297,11 @@ function ignoreVersionPredicate(extensionEntry1: ExtensionDataEntry, extensionEn
     return extensionEntry1.name === extensionEntry2.name;
   }
   return false;
+}
+
+export function removeInternalConfigFields(config?: ExtensionConfig): ExtensionConfig | undefined {
+  if (!config || config === REMOVE_EXTENSION_SPECIAL_SIGN) return config;
+  const clonedConfig = cloneDeep(config);
+  INTERNAL_CONFIG_FIELDS.forEach((field) => delete clonedConfig[field]);
+  return clonedConfig;
 }


### PR DESCRIPTION
This is an internal field used to calculate the config priority, it should not be visible via `bit diff` nor written in the `.bitmap` file.