### PR TITLE
feat: introduce "--editor" flag for "bit tag" to enable editing tag messages per component

### DIFF
--- a/scopes/workspace/workspace/tag-cmd.ts
+++ b/scopes/workspace/workspace/tag-cmd.ts
@@ -27,6 +27,11 @@ ${WILDCARD_HELP('tag')}`;
     ['m', 'message <message>', 'log message describing the user changes'],
     ['a', 'all [version]', 'tag all new and modified components'],
     ['s', 'scope [version]', 'tag all components of the current scope'],
+    [
+      '',
+      'editor [editor]',
+      'open an editor to edit the tag messages per component, optionally specify the editor-name, default to vim',
+    ],
     ['', 'snapped [version]', 'tag components that their head is a snap (not a tag)'],
     ['', 'ver <version>', 'tag specified components with the given version'],
     ['p', 'patch', 'increment the patch version number'],
@@ -62,6 +67,7 @@ ${WILDCARD_HELP('tag')}`;
       message = '',
       ver,
       all = false,
+      editor = '',
       snapped = false,
       patch,
       minor,
@@ -134,6 +140,12 @@ ${WILDCARD_HELP('tag')}`;
     if (all && persist) {
       throw new GeneralError('you can use either --all or --persist, but not both');
     }
+    if (editor && persist) {
+      throw new GeneralError('you can use either --editor or --persist, but not both');
+    }
+    if (editor && message) {
+      throw new GeneralError('you can use either --editor or --message, but not both');
+    }
 
     const releaseFlags = [patch, minor, major, preRelease].filter((x) => x);
     if (releaseFlags.length > 1) {
@@ -152,6 +164,7 @@ ${WILDCARD_HELP('tag')}`;
       ids: id,
       all: Boolean(all),
       snapped: Boolean(snapped),
+      editor,
       message,
       exactVersion: getVersion(),
       releaseType,

--- a/src/api/consumer/lib/tag.ts
+++ b/src/api/consumer/lib/tag.ts
@@ -40,6 +40,7 @@ export type BasicTagParams = {
   disableTagAndSnapPipelines: boolean;
   forceDeploy: boolean;
   preRelease?: string;
+  editor?: string;
 };
 
 type TagParams = {

--- a/src/bit-id/bit-ids.ts
+++ b/src/bit-id/bit-ids.ts
@@ -97,6 +97,13 @@ export default class BitIds extends Array<BitId> {
     return BitIds.fromArray(this.filter((id) => !bitIds.hasWithoutVersion(id)));
   }
 
+  toObject() {
+    return this.reduce((acc, bitId) => {
+      acc[bitId.toString()] = bitId;
+      return acc;
+    }, {});
+  }
+
   /**
    * make sure to pass only bit ids you know they have scope, otherwise, you'll get invalid bit ids.
    * this is mainly useful for remote commands where it is impossible to have a component without scope.

--- a/src/scope/component-ops/message-per-component.spec.ts
+++ b/src/scope/component-ops/message-per-component.spec.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { BitId, BitIds } from '../../bit-id';
+import { MessagePerComponentFetcher } from './message-per-component';
+
+function getInstance() {
+  return new MessagePerComponentFetcher(new BitIds(new BitId({ name: 'bar' })), new BitIds());
+}
+
+describe('MessagePerComponent', () => {
+  describe('parseFileWithMessages', () => {
+    it('should throw an error when the file has no changes', () => {
+      const messagePerComponent = getInstance();
+      const template = messagePerComponent.getTemplate();
+      expect(() => messagePerComponent.parseFileWithMessages(template)).to.throw();
+    });
+    it('should assign the default message to the component if empty', () => {
+      const messagePerComponent = getInstance();
+      const template = messagePerComponent.getTemplate();
+      const templateChanged = template.replace('DEFAULT:', `DEFAULT: my default msg`);
+      const parsed = messagePerComponent.parseFileWithMessages(templateChanged);
+      expect(parsed[0].msg).to.equal('my default msg');
+    });
+    it('should support multiple lines per id', () => {
+      const messagePerComponent = getInstance();
+      const template = messagePerComponent.getTemplate();
+      const msgWithNewLine = 'msg for bar\nAnother line';
+      const templateChanged = template.replace('bar:', `bar: ${msgWithNewLine}`);
+      const parsed = messagePerComponent.parseFileWithMessages(templateChanged);
+      expect(parsed[0].msg).to.equal(msgWithNewLine);
+    });
+    it('should support multiple lines for the default message', () => {
+      const messagePerComponent = getInstance();
+      const template = messagePerComponent.getTemplate();
+      const msgWithNewLine = 'default msg\nAnother line';
+      const templateChanged = template.replace('DEFAULT:', `DEFAULT: ${msgWithNewLine}`);
+      const parsed = messagePerComponent.parseFileWithMessages(templateChanged);
+      expect(parsed[0].msg).to.equal(msgWithNewLine);
+    });
+  });
+});

--- a/src/scope/component-ops/message-per-component.ts
+++ b/src/scope/component-ops/message-per-component.ts
@@ -1,0 +1,177 @@
+import openEditor from 'open-editor';
+import fs from 'fs-extra';
+import { spawn } from 'child_process';
+import { Tmp } from '../repositories';
+import { BitId, BitIds } from '../../bit-id';
+import loader from '../../cli/loader';
+
+const DEFAULT_MESSAGE = 'DEFAULT:';
+const DEFAULT_AUTO_TAG_MESSAGE = 'DEFAULT-AUTO-TAG:';
+const formatId = (id: string) => `${id}:`;
+const addSpace = (str: string) => `${str} `;
+const DEFAULT_EDITOR = 'vim';
+
+export type MessagePerComponent = { id: BitId; msg: string };
+
+export class MessagePerComponentFetcher {
+  private idsToTagObject: { [bitIdStr: string]: BitId };
+  private idsToAutoTagObject: { [bitIdStr: string]: BitId };
+  constructor(idsToTag: BitIds, idsToAutoTag: BitIds) {
+    this.idsToTagObject = idsToTag.toObject();
+    this.idsToAutoTagObject = idsToAutoTag.toObject();
+  }
+
+  async getMessagesFromEditor(tmp: Tmp, editor: string | boolean): Promise<MessagePerComponent[]> {
+    const template = this.getTemplate();
+    const templateFilePath = await tmp.save(template);
+    const editorName = typeof editor === 'string' ? editor : undefined;
+    await this.openEditor(templateFilePath, editorName);
+    const afterSave = await fs.readFile(templateFilePath, 'utf-8');
+    if (template === afterSave) {
+      throw new Error(`no changes have been done to the messages templates. consider using "--message" flag instead`);
+    }
+    return this.parseFileWithMessages(afterSave);
+  }
+
+  getTemplate() {
+    const idsToTag = this.getIdsToTagStr();
+    const idsToAutoTag = this.getIdsToAutoTagStr();
+    const idsStr = (ids: string[]) => ids.map(formatId).map(addSpace).join('\n');
+    const getAutoTagTemplate = () => {
+      if (!idsToAutoTag.length) return '';
+      return `
+# The following components will be auto-tagged (due to dependencies bump)
+# You can leave the following default message to avoid setting messages for these components
+${DEFAULT_AUTO_TAG_MESSAGE} bump dependencies versions
+${idsStr(idsToAutoTag)}
+`;
+    };
+    return `# Please set the messages for the following components.
+# You can enter a default-message to be applied to all empty components. this is optional.
+${addSpace(DEFAULT_MESSAGE)}
+${idsStr(idsToTag)}
+${getAutoTagTemplate()}
+`;
+  }
+
+  parseFileWithMessages(messagesFileContent: string): MessagePerComponent[] {
+    let defaultMessage: string | null = null;
+    let defaultAutoTagMessage: string | null = null;
+    const results: MessagePerComponent[] = [];
+
+    const idsToTagStr = this.getIdsToTagStr();
+    const idsToAutoTagStr = this.getIdsToAutoTagStr();
+    const messagesSplit = messagesFileContent.split('\n');
+
+    // there are 4 sections in the template file. these 4 variables keep track in what section we're at.
+    let startedDefaultMessage = false;
+    let startedIdsToTag = false;
+    let startedAutoTagDefaultMessage = false;
+    let startedIdsToAutoTag = false;
+
+    messagesSplit.forEach((line) => {
+      line = line.trim();
+      if (!line) {
+        return; // an empty line
+      }
+      if (line.startsWith('#')) {
+        return; // it's a comment
+      }
+      if (line.startsWith(DEFAULT_MESSAGE)) {
+        defaultMessage = line.replace(DEFAULT_MESSAGE, '').trim();
+        startedDefaultMessage = true;
+        return;
+      }
+      const idToTag = idsToTagStr.find((id) => line.startsWith(formatId(id)));
+      const removeId = (id: string) => line.replace(formatId(id), '').trim();
+      if (idToTag) {
+        startedIdsToTag = true;
+        const msg = removeId(idToTag) || defaultMessage;
+        if (!msg) {
+          throw new Error(`error: "${idToTag}" has no message and the default-message was not set`);
+        }
+        results.push({
+          id: this.idsToTagObject[idToTag],
+          msg,
+        });
+        return;
+      }
+      if (line.startsWith(DEFAULT_AUTO_TAG_MESSAGE)) {
+        startedAutoTagDefaultMessage = true;
+        defaultAutoTagMessage = line.replace(DEFAULT_AUTO_TAG_MESSAGE, '').trim();
+        return;
+      }
+      const idToAutoTag = idsToAutoTagStr.find((id) => line.startsWith(formatId(id)));
+      if (idToAutoTag) {
+        startedIdsToAutoTag = true;
+        const msg = removeId(idToAutoTag) || defaultAutoTagMessage;
+        if (!msg) {
+          throw new Error(`error: "${idToTag}" has no message and the default-auto-message was not set`);
+        }
+        results.push({
+          id: this.idsToAutoTagObject[idToAutoTag],
+          msg,
+        });
+        return;
+      }
+      // must be another line of one of the strings above. let's figure out what was it.
+      // the template starts with the default-message, followed by the ids to tag, followed by the
+      // auto-tag-default-message, followed by the ids to auto-tag.
+      if (!startedDefaultMessage) {
+        throw new Error(
+          `error: the following line was added "${line}". please add the messages to the ids and default fields only`
+        );
+      }
+      if (!startedIdsToTag) {
+        defaultMessage += `\n${line}`;
+        return;
+      }
+      if (!startedAutoTagDefaultMessage) {
+        const lastEnteredId = results[results.length - 1];
+        lastEnteredId.msg += `\n${line}`;
+        return;
+      }
+      if (!startedIdsToAutoTag) {
+        defaultAutoTagMessage += `\n${line}`;
+        return;
+      }
+      const lastEnteredId = results[results.length - 1];
+      lastEnteredId.msg += `\n${line}`;
+    });
+
+    return results;
+  }
+
+  private async openEditor(templateFilePath: string, editor?: string) {
+    const file = { file: templateFilePath, column: DEFAULT_MESSAGE.length + 1, line: 3 };
+
+    const editorFromEnvVar = process.env.EDITOR || process.env.VISUAL; // taken from env-editor package
+    if (!editorFromEnvVar && !editor) {
+      editor = DEFAULT_EDITOR;
+    }
+    const editorData = openEditor.make([file], { editor });
+    if (!editorData.isTerminalEditor) {
+      throw new Error(
+        `your editor "${editorData.binary}" is not a terminal editor. either set $EDITOR in your env variable or pass "--editor" with a terminal editor (e.g. "nano", "vim")`
+      );
+    }
+    loader.stop();
+    return new Promise((resolve, reject) => {
+      const editorProcess = spawn(editorData.binary, editorData.arguments, { stdio: 'inherit' });
+      editorProcess.on('exit', (code) => {
+        if (code === 0) {
+          resolve('completed');
+        } else {
+          reject(new Error(`${editor} had non zero exit code: ${code}`));
+        }
+      });
+    });
+  }
+
+  private getIdsToTagStr() {
+    return Object.keys(this.idsToTagObject);
+  }
+  private getIdsToAutoTagStr() {
+    return Object.keys(this.idsToAutoTagObject);
+  }
+}

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -146,6 +146,7 @@
         "@teambit/react.instructions.react.adding-tests": "0.0.6",
         "@teambit/string.ellipsis": "0.0.7",
         "@teambit/ui.composition-card": "0.0.259",
+        "@testing-library/jest-dom": "5.11.10",
         "@testing-library/jest-native": "4.0.1",
         "@testing-library/react": "11.2.6",
         "@tippyjs/react": "4.2.0",
@@ -277,6 +278,7 @@
         "multimatch": "5.0.0",
         "nanoid": "3.1.20",
         "nerf-dart": "1.0.0",
+        "open-editor": "3.0.0",
         "p-limit": "3.1.0",
         "parallel-webpack": "2.6.0",
         "parse-package-name": "0.1.0",
@@ -343,8 +345,7 @@
         "webpack-merge": "5.8.0",
         "workbox-webpack-plugin": "6.2.4",
         "ws": "7.4.2",
-        "yaml": "1.10.2",
-        "@testing-library/jest-dom": "5.11.10"
+        "yaml": "1.10.2"
       },
       "peerDependencies": {
         "@apollo/client": "^3.0.0",


### PR DESCRIPTION
Currently, it's not possible when tagging a component to specify a message per component.
With the new `--editor` flag, it'll open an editor, default to `vim` with the possibility to enter a message per component, or a default message to catch all empty messages.
It also provides an option to specify the messages for auto-tagged components with a pre-filled default ("bump dependencies versions").

The editor is what the user entered in the `--editor` flag. 
If none was specify, it'll use the `$EDITOR` or `$VISUAL` os variables. 
If they're empty, it'll default to `vim`. 


<img width="670" alt="Screen Shot 2022-02-14 at 6 25 57 PM" src="https://user-images.githubusercontent.com/1963573/153963977-bee481c5-98a4-41c4-a994-5d73b6e4ce1b.png">

