### PR TITLE
Preview errors

### DIFF
--- a/scopes/preview/preview/exceptions/index.ts
+++ b/scopes/preview/preview/exceptions/index.ts
@@ -1,3 +1,4 @@
 export { PreviewNotFound } from './preview-not-found';
 export { PreviewArtifactNotFound } from './preview-artifact-not-found';
 export { BundlingStrategyNotFound } from './bundling-strategy-not-found';
+export { PreviewOutputFileNotFound } from './preview-output-file-not-found';

--- a/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
+++ b/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
@@ -1,0 +1,12 @@
+import { BitError } from '@teambit/bit-error';
+import { ComponentID } from '@teambit/component';
+
+export class PreviewOutputFileNotFound extends BitError {
+  constructor(componentId: ComponentID, filePath: string) {
+    super(`preview output file for component: "${componentId.toString()}" was not found in the path: "${filePath}".
+
+This is usually a result of an error during the bundling process.
+The error might be an error of another component that uses the same env.
+Run "bit envs" to see other components that uses the same env`);
+  }
+}

--- a/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
+++ b/scopes/preview/preview/exceptions/preview-output-file-not-found.ts
@@ -7,6 +7,7 @@ export class PreviewOutputFileNotFound extends BitError {
 
 This is usually a result of an error during the bundling process.
 The error might be an error of another component that uses the same env.
+Run "bit build" with "--dev" to see more info.
 Run "bit envs" to see other components that uses the same env`);
   }
 }

--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -3,7 +3,7 @@ import { join, resolve, basename } from 'path';
 import { existsSync, mkdirpSync } from 'fs-extra';
 import { Component } from '@teambit/component';
 import { ComponentID } from '@teambit/component-id';
-import { flatten } from 'lodash';
+import { flatten, isEmpty } from 'lodash';
 import { Compiler } from '@teambit/compiler';
 import type { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
 import type { Capsule } from '@teambit/isolator';
@@ -261,7 +261,10 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
   async computeResults(context: BundlerContext, results: BundlerResult[]) {
     const result = results[0];
 
-    this.copyAssetsToCapsules(context, result);
+    if (isEmpty(result.errors)) {
+      // In case there are errors files will not be emitted so trying to copy them will fail anyway
+      this.copyAssetsToCapsules(context, result);
+    }
 
     const componentsResults: ComponentResult[] = result.components.map((component) => {
       const metadata = this.computeComponentMetadata(context, result, component);

--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -16,6 +16,7 @@ import { BundlingStrategy, ComputeTargetsContext } from '../bundling-strategy';
 import type { PreviewDefinition } from '../preview-definition';
 import type { ComponentPreviewMetaData, PreviewMain } from '../preview.main.runtime';
 import { generateComponentLink } from './generate-component-link';
+import { PreviewOutputFileNotFound } from '../exceptions';
 
 export const PREVIEW_CHUNK_SUFFIX = 'preview';
 export const COMPONENT_CHUNK_SUFFIX = 'component';
@@ -164,6 +165,9 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
 
       files.forEach((asset) => {
         const filePath = this.getAssetAbsolutePath(context, asset);
+        if (!existsSync(filePath)) {
+          throw new PreviewOutputFileNotFound(component.id, filePath);
+        }
         const contents = readFileSync(filePath);
         // const exists = capsule.fs.existsSync(this.getArtifactDirectory());
         // if (!exists) capsule.fs.mkdirSync(this.getArtifactDirectory());

--- a/scopes/webpack/webpack/webpack.bundler.ts
+++ b/scopes/webpack/webpack/webpack.bundler.ts
@@ -80,7 +80,6 @@ export class WebpackBundler implements Bundler {
       });
       const errorMessage = compact(lines).join('\n');
       return new BitError(errorMessage);
-      // const { message, moduleId, moduleName, moduleIdentifier, loc } = webpackError;
     });
   }
 

--- a/scopes/webpack/webpack/webpack.bundler.ts
+++ b/scopes/webpack/webpack/webpack.bundler.ts
@@ -1,7 +1,7 @@
 import { BitError } from '@teambit/bit-error';
 import type { Bundler, BundlerResult, Asset, Target, EntriesAssetsMap } from '@teambit/bundler';
 import type { Logger } from '@teambit/logger';
-import { isEmpty } from 'lodash';
+import { compact, isEmpty } from 'lodash';
 import mapSeries from 'p-map-series';
 import type { Compiler, Configuration, StatsCompilation, StatsAsset } from 'webpack';
 
@@ -34,8 +34,6 @@ export class WebpackBundler implements Bundler {
         // TODO: split to multiple processes to reduce time and configure concurrent builds.
         // @see https://github.com/trivago/parallel-webpack
         return compiler.run((err, stats) => {
-          // console.log('err webpack', err);
-
           if (err) {
             this.logger.error('get error from webpack compiler, full error:', err);
 
@@ -56,7 +54,7 @@ export class WebpackBundler implements Bundler {
             assets: Object.values(assetsMap),
             assetsByChunkName: info.assetsByChunkName,
             entriesAssetsMap,
-            errors: info.errors,
+            errors: this.getErrors(info),
             outputPath: stats.compilation.outputOptions.path,
             components,
             warnings: info.warnings,
@@ -68,6 +66,22 @@ export class WebpackBundler implements Bundler {
     });
     longProcessLogger.end();
     return componentOutput as BundlerResult[];
+  }
+
+  private getErrors(stats: StatsCompilation): Error[] {
+    if (!stats.errors) return [];
+    const fieldsToShow = ['message', 'moduleId', 'moduleName', 'moduleIdentifier', 'loc'];
+    return stats.errors.map((webpackError) => {
+      const lines = fieldsToShow.map((fieldName) => {
+        if (webpackError[fieldName]) {
+          return `${fieldName}: ${webpackError[fieldName]}`;
+        }
+        return undefined;
+      });
+      const errorMessage = compact(lines).join('\n');
+      return new BitError(errorMessage);
+      // const { message, moduleId, moduleName, moduleIdentifier, loc } = webpackError;
+    });
   }
 
   private getAssets(stats: StatsCompilation): AssetsMap {


### PR DESCRIPTION
## Proposed Changes

- improve error when preview can't find bundler output files
- improve webpack errors by taking the following error fields: `['message', 'moduleId', 'moduleName', 'moduleIdentifier', 'loc'];`
