### PR TITLE
fix: remove non-seeders from the seeder capsules on bit-build

### DIFF
--- a/scopes/compilation/babel/babel.compiler.ts
+++ b/scopes/compilation/babel/babel.compiler.ts
@@ -63,7 +63,7 @@ export class BabelCompiler implements Compiler {
    * compile multiple components on the capsules
    */
   async build(context: BuildContext): Promise<BuiltTaskResult> {
-    const capsules = context.capsuleNetwork.seedersCapsules;
+    const capsules = context.capsuleNetwork.graphCapsulesOfSameEnv;
     const componentsResults: ComponentResult[] = [];
     const longProcessLogger = this.logger.createLongProcessLogger('compile babel components', capsules.length);
     await mapSeries(capsules, async (capsule) => {

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -3,11 +3,11 @@ import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import CapsuleList from './capsule-list';
 
 export class Network {
-  componentIdsOfSameEnv?: ComponentID[];
   constructor(
     private _graphCapsules: CapsuleList,
-    private seedersIds: ComponentID[],
-    private _capsulesRootDir: string
+    readonly seedersIds: ComponentID[],
+    private _capsulesRootDir: string,
+    readonly componentIdsOfSameEnv?: ComponentID[]
   ) {}
 
   /**

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -3,6 +3,7 @@ import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import CapsuleList from './capsule-list';
 
 export class Network {
+  componentIdsOfSameEnv?: ComponentID[];
   constructor(
     private _graphCapsules: CapsuleList,
     private seedersIds: ComponentID[],
@@ -15,6 +16,18 @@ export class Network {
    */
   get seedersCapsules(): CapsuleList {
     const capsules = this.seedersIds.map((seederId) => {
+      const capsule = this.graphCapsules.getCapsule(seederId);
+      if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
+      return capsule;
+    });
+    return CapsuleList.fromArray(capsules);
+  }
+
+  /**
+   * not only seeders, but also the dependencies of the seeder, as long as they belong to the same env.
+   */
+  get graphCapsulesOfSameEnv() {
+    const capsules = (this.componentIdsOfSameEnv || this.seedersIds).map((seederId) => {
       const capsule = this.graphCapsules.getCapsule(seederId);
       if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
       return capsule;

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -7,7 +7,7 @@ export class Network {
     private _graphCapsules: CapsuleList,
     readonly seedersIds: ComponentID[],
     private _capsulesRootDir: string,
-    readonly componentIdsOfSameEnv?: ComponentID[]
+    private _componentIdsOfSameEnv?: ComponentID[]
   ) {}
 
   /**
@@ -27,12 +27,16 @@ export class Network {
    * not only seeders, but also the dependencies of the seeder, as long as they belong to the same env.
    */
   get graphCapsulesOfSameEnv() {
-    const capsules = (this.componentIdsOfSameEnv || this.seedersIds).map((seederId) => {
+    const capsules = this.componentIdsOfSameEnv.map((seederId) => {
       const capsule = this.graphCapsules.getCapsule(seederId);
       if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
       return capsule;
     });
     return CapsuleList.fromArray(capsules);
+  }
+
+  get componentIdsOfSameEnv(): ComponentID[] {
+    return this._componentIdsOfSameEnv || this.seedersIds;
   }
 
   /**

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -224,7 +224,11 @@ export class BuilderMain {
     const ids = components.map((c) => c.id);
     const network = await this.isolator.isolateComponents(ids, isolateOptions);
     const envs = await this.envs.createEnvironment(network.graphCapsules.getAllComponents());
-    const builderServiceOptions = { seedersOnly: isolateOptions?.seedersOnly, ...(builderOptions || {}) };
+    const builderServiceOptions = {
+      seedersOnly: isolateOptions?.seedersOnly,
+      originalSeeders: ids,
+      ...(builderOptions || {}),
+    };
     const buildResult = await envs.runOnce(this.buildService, builderServiceOptions);
     return buildResult;
   }

--- a/scopes/pipelines/builder/builder.service.tsx
+++ b/scopes/pipelines/builder/builder.service.tsx
@@ -4,7 +4,7 @@ import { ScopeMain } from '@teambit/scope';
 import { Text, Newline } from 'ink';
 import { Logger } from '@teambit/logger';
 import { IsolatorMain, Network } from '@teambit/isolator';
-import { Component, ComponentID } from '@teambit/component';
+import { Component } from '@teambit/component';
 import { BuildPipe, TaskResults } from './build-pipe';
 import { TaskResultsList } from './task-results-list';
 import { TaskSlot } from './builder.main.runtime';

--- a/scopes/pkg/pkg/prepare-packages.task.ts
+++ b/scopes/pkg/pkg/prepare-packages.task.ts
@@ -1,11 +1,6 @@
 import { BuildContext, BuiltTaskResult, BuildTask } from '@teambit/builder';
-import { Compiler } from '@teambit/compiler';
-import { Capsule } from '@teambit/isolator';
 import { EnvsMain } from '@teambit/envs';
 import { Logger } from '@teambit/logger';
-import PackageJsonFile from '@teambit/legacy/dist/consumer/component/package-json-file';
-import fs from 'fs-extra';
-import path from 'path';
 import { writeNpmIgnore } from './write-npm-ignore';
 
 /**
@@ -32,54 +27,5 @@ export class PreparePackagesTask implements BuildTask {
         await writeNpmIgnore(capsule, this.envs);
       })
     );
-  }
-
-  /**
-   * remove the source files and copy the dists files
-   * into the root of the capsule.
-   * this is needed when components import from other components internal paths. without this task,
-   * the internal paths are the source, so node will throw an error when trying to use them. this
-   * task makes sure that the internal paths point to the consumable code (dists).
-   */
-  private async executeDistAsRootTask(context: BuildContext) {
-    if (!context.env.getCompiler) return;
-    const compilerInstance: Compiler = context.env.getCompiler();
-    const distDir = compilerInstance.distDir;
-
-    await Promise.all(
-      context.capsuleNetwork.graphCapsules.map(async (capsule) => {
-        await this.removeSourceFiles(capsule, distDir);
-        await this.moveDistToRoot(capsule, distDir);
-        await this.updatePackageJson(capsule, compilerInstance, distDir);
-      })
-    );
-  }
-
-  private async removeSourceFiles(capsule: Capsule, distDir: string) {
-    const excludeDirs = [distDir, 'node_modules', 'public', 'bin'].map((dir) => `${dir}/**`);
-    const excludeFiles = ['package.json'];
-    const allFiles = capsule.getAllFilesPaths('.', { ignore: [...excludeDirs, ...excludeFiles] });
-    this.logger.debug(`delete the following files:\n${allFiles.join('\n')}`);
-    await Promise.all(allFiles.map((file) => fs.remove(path.join(capsule.path, file))));
-  }
-
-  private async moveDistToRoot(capsule: Capsule, distDir: string) {
-    const from = path.join(capsule.path, distDir);
-    const to = capsule.path;
-    this.logger.debug(`move from ${from} to: ${to}`);
-    // for some reason `fs.move` throws an error "dest already exists.".
-    fs.moveSync(from, to);
-  }
-
-  /**
-   * by default, the "main" prop points to the dist file (e.g. "dist/index./js").
-   * here, we have to change it because there is no dist dir anymore.
-   */
-  private async updatePackageJson(capsule: Capsule, compiler: Compiler, distDir: string) {
-    const distMainFile = compiler.getDistPathBySrcPath(capsule.component.state._consumer.mainFile);
-    const distMainFileWithoutDistDir = distMainFile.replace(`${distDir}${path.sep}`, '');
-    const packageJson = PackageJsonFile.loadFromCapsuleSync(capsule.path);
-    packageJson.addOrUpdateProperty('main', distMainFileWithoutDistDir);
-    await packageJson.write();
   }
 }

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -87,7 +87,7 @@ export class TypescriptCompiler implements Compiler {
   }
 
   async preBuild(context: BuildContext) {
-    const capsules = context.capsuleNetwork.seedersCapsules;
+    const capsules = context.capsuleNetwork.graphCapsulesOfSameEnv;
     const capsuleDirs = capsules.map((capsule) => capsule.path);
     await this.writeTsConfig(capsuleDirs);
     await this.writeTypes(capsuleDirs);

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -160,7 +160,7 @@ export class TypescriptCompiler implements Compiler {
    */
   private async runTscBuild(network: Network): Promise<ComponentResult[]> {
     const rootDir = network.capsulesRootDir;
-    const capsules = network.seedersCapsules;
+    const capsules = network.graphCapsulesOfSameEnv;
     const capsuleDirs = capsules.getAllCapsuleDirs();
     const formatHost = {
       getCanonicalFileName: (p) => p,

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -160,7 +160,7 @@ export class TypescriptCompiler implements Compiler {
    */
   private async runTscBuild(network: Network): Promise<ComponentResult[]> {
     const rootDir = network.capsulesRootDir;
-    const capsules = network.graphCapsules;
+    const capsules = network.seedersCapsules;
     const capsuleDirs = capsules.getAllCapsuleDirs();
     const formatHost = {
       getCanonicalFileName: (p) => p,


### PR DESCRIPTION
Currently, when running `bit build <some-id>`, the `seedersCapsules` provided by the builder aspect, contains the entire graph of this component that use the same env. 

Edit: I'm closing this PR as it didn't went well. You can see the commits and the tests/build failed at each one of them.
In short, in this PR the "seeders" were changed to include only the original-seeders. However, then, in some scenarios, for some env the seeders is empty, and they weren't include originally. As a result, some tasks weren't running on them, e.g. "babel-compile" and these capsules weren't consumable. Even when this fixed to run on the previously "seeder" graph for some tasks, still the typescript task wasn't happy as you can see the result of the last commit.

I ended up with a different route. Leaving the current Network props as is, and just adding a new one to get the original seeders. See https://github.com/teambit/bit/pull/5430.