### PR TITLE
improvement: support <pattern> for bit-eject

### DIFF
--- a/scopes/workspace/eject/components-ejector.ts
+++ b/scopes/workspace/eject/components-ejector.ts
@@ -9,7 +9,7 @@
  */
 import { Workspace } from '@teambit/workspace';
 import { Consumer } from '@teambit/legacy/dist/consumer';
-import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
+import { BitIds } from '@teambit/legacy/dist/bit-id';
 import defaultErrorHandler from '@teambit/legacy/dist/cli/default-error-handler';
 import { getScopeRemotes } from '@teambit/legacy/dist/scope/scope-remotes';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
@@ -19,6 +19,7 @@ import * as packageJsonUtils from '@teambit/legacy/dist/consumer/component/packa
 import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
 import RemovePath from '@teambit/legacy/dist/consumer/component/sources/remove-path';
 import { Logger } from '@teambit/logger';
+import { ComponentID } from '@teambit/component-id';
 
 export type EjectResults = {
   ejectedComponents: BitIds;
@@ -39,7 +40,6 @@ type FailedComponents = {
 
 export class ComponentsEjector {
   consumer: Consumer;
-  componentsIds: BitId[];
   idsToEject: BitIds;
   componentsToEject: Component[] = [];
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
@@ -50,11 +50,10 @@ export class ComponentsEjector {
   constructor(
     private workspace: Workspace,
     private logger: Logger,
-    componentsIds: BitId[],
+    private componentsIds: ComponentID[],
     private ejectOptions: EjectOptions
   ) {
     this.consumer = this.workspace.consumer;
-    this.componentsIds = componentsIds;
     this.idsToEject = new BitIds();
     this.failedComponents = {
       modifiedComponents: new BitIds(),
@@ -88,7 +87,8 @@ export class ComponentsEjector {
     if (!this.componentsIds.length) return;
     const remotes = await getScopeRemotes(this.consumer.scope);
     const hubExportedComponents = new BitIds();
-    this.componentsIds.forEach((bitId) => {
+    this.componentsIds.forEach((componentId) => {
+      const bitId = componentId._legacy;
       if (!bitId.hasScope()) this.failedComponents.notExportedComponents.push(bitId);
       else if (remotes.isHub(bitId.scope as string)) hubExportedComponents.push(bitId);
       else this.failedComponents.selfHostedExportedComponents.push(bitId);

--- a/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
@@ -15,7 +15,6 @@ export class EnvsSetCmd implements Command {
   async report([pattern, env]: [string, string]) {
     const envId = await this.workspace.resolveComponentId(env);
     const componentIds = await this.workspace.idsByPattern(pattern);
-    if (!componentIds.length) return chalk.yellow(`unable to find any matching for ${chalk.bold(pattern)} pattern`);
     await this.workspace.setEnvToComponents(envId, componentIds);
     return `added ${chalk.bold(envId.toString())} env to the following component(s):
 ${componentIds.map((compId) => compId.toString()).join('\n')}`;

--- a/scopes/workspace/workspace/pattern.cmd.ts
+++ b/scopes/workspace/workspace/pattern.cmd.ts
@@ -13,12 +13,12 @@ export class PatternCommand implements Command {
   constructor(private workspace: Workspace) {}
 
   async report([pattern]: [string]) {
-    const ids = await this.workspace.idsByPattern(pattern);
+    const ids = await this.json([pattern]);
     const title = chalk.green(`found ${chalk.bold(ids.length.toString())} components matching the pattern`);
     return `${title}\n${ids.join('\n')}`;
   }
 
   async json([pattern]: [string]) {
-    return this.workspace.idsByPattern(pattern);
+    return this.workspace.idsByPattern(pattern, false);
   }
 }


### PR DESCRIPTION
With this PR, it's possible to run `bit eject <pattern>` instead of specific "ids".