### PR TITLE
remove the "create capsules network" message in the cli

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -179,7 +179,6 @@ export class IsolatorMain {
     legacyScope?: LegacyScope
   ): Promise<Network> {
     const host = this.componentAspect.getHost();
-    const longProcessLogger = this.logger.createLongProcessLogger('create capsules network');
     legacyLogger.debug(
       `isolatorExt, createNetwork ${seeders.join(', ')}. opts: ${JSON.stringify(
         Object.assign({}, opts, { host: opts.host?.name })
@@ -191,8 +190,6 @@ export class IsolatorMain {
       : await this.createGraph(seeders, createGraphOpts);
     opts.baseDir = opts.baseDir || host.path;
     const capsuleList = await this.createCapsules(componentsToIsolate, opts, legacyScope);
-    longProcessLogger.end();
-    this.logger.consoleSuccess();
     return new Network(capsuleList, seeders, this.getCapsulesRootDir(opts.baseDir, opts.rootBaseDir));
   }
 


### PR DESCRIPTION
It's being shown also when all capsules are retrieved from the cache, which makes it confusing. 
It was needed in the past when the package-installation wasn't shown, currently, it's not needed.