### PR TITLE
fix: show a descriptive error upon zlib failure

### DIFF
--- a/src/scope/objects/object.ts
+++ b/src/scope/objects/object.ts
@@ -12,7 +12,6 @@ function parse(buffer: Buffer): BitObject {
   const headers = buffer.slice(0, firstNullByteLocation).toString();
   const contents = buffer.slice(firstNullByteLocation + 1, buffer.length);
   const [type, hash] = headers.split(SPACE_DELIMITER);
-
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   return types[type].parse(contents, hash);
 }
@@ -112,8 +111,9 @@ path: ${err.path}`);
   /**
    * see `this.parseSync` for the sync version
    */
-  static parseObject(fileContents: Buffer): Promise<BitObject> {
-    return inflate(fileContents).then((buffer) => parse(buffer));
+  static async parseObject(fileContents: Buffer, filePath?: string): Promise<BitObject> {
+    const buffer = await inflate(fileContents, filePath);
+    return parse(buffer);
   }
 
   // static parse(fileContents: Buffer, types: { [key: string]: Function }): Promise<BitObject> {

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -115,18 +115,19 @@ export default class Repository {
       return cached;
     }
     let fileContentsRaw: Buffer;
+    const objectPath = this.objectPath(ref);
     try {
-      fileContentsRaw = await fs.readFile(this.objectPath(ref));
+      fileContentsRaw = await fs.readFile(objectPath);
     } catch (err: any) {
       if (err.code !== 'ENOENT') {
-        logger.error(`Failed reading a ref file ${this.objectPath(ref)}. Error: ${err.message}`);
+        logger.error(`Failed reading a ref file ${objectPath}. Error: ${err.message}`);
         throw err;
       }
-      logger.trace(`Failed finding a ref file ${this.objectPath(ref)}.`);
+      logger.trace(`Failed finding a ref file ${objectPath}.`);
       if (throws) {
         // if we just `throw err` we loose the stack trace.
         // see https://stackoverflow.com/questions/68022123/no-stack-in-fs-promises-readfile-enoent-error
-        const msg = `fatal: failed finding an object file ${this.objectPath(ref)} in the filesystem at ${err.path}`;
+        const msg = `fatal: failed finding an object file ${objectPath} in the filesystem at ${err.path}`;
         throw Object.assign(err, { stack: new Error(msg).stack });
       }
       // @ts-ignore @todo: fix! it should return BitObject | null.
@@ -134,7 +135,7 @@ export default class Repository {
     }
     const size = fileContentsRaw.byteLength;
     const fileContents = await this.onRead(fileContentsRaw);
-    const parsedObject = await BitObject.parseObject(fileContents);
+    const parsedObject = await BitObject.parseObject(fileContents, objectPath);
     const maxSizeToCache = 100 * 1024; // 100KB
     if (size < maxSizeToCache) {
       // don't cache big files (mainly artifacts) to prevent out-of-memory

--- a/src/utils/zlib-deflate.ts
+++ b/src/utils/zlib-deflate.ts
@@ -1,11 +1,12 @@
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+import { promisify } from 'util';
 import zlib from 'zlib';
 
-export default function deflate(buffer: Buffer): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    zlib.deflate(buffer, (err, res) => {
-      if (err) return reject(err);
-      return resolve(res);
-    });
-  });
+export default async function deflate(buffer: Buffer, filePath?: string): Promise<Buffer> {
+  const deflateP = promisify(zlib.deflate);
+  try {
+    return await deflateP(buffer);
+  } catch (err: any) {
+    const filePathStr = filePath ? ` of "${filePath}"` : '';
+    throw new Error(`fatal: zlib.deflate${filePathStr} has failed with an error: "${err.message}"`);
+  }
 }

--- a/src/utils/zlib-inflate.ts
+++ b/src/utils/zlib-inflate.ts
@@ -1,11 +1,12 @@
-// @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+import { promisify } from 'util';
 import zlib from 'zlib';
 
-export default function inflate(buffer: Buffer): Promise<Buffer> {
-  return new Promise((resolve, reject) => {
-    zlib.inflate(buffer, (err, res) => {
-      if (err) return reject(err);
-      return resolve(res);
-    });
-  });
+export default async function inflate(buffer: Buffer, filePath?: string): Promise<Buffer> {
+  const inflateP = promisify(zlib.inflate);
+  try {
+    return await inflateP(buffer);
+  } catch (err: any) {
+    const filePathStr = filePath ? ` of "${filePath}"` : '';
+    throw new Error(`fatal: zlib.inflate${filePathStr} has failed with an error: "${err.message}"`);
+  }
 }


### PR DESCRIPTION
Currently, when an object file is empty, it'd show "unexpected end of file", with no context. 
In this PR, the error explains what the issue is and where the file located, so the user could delete it.