### PR TITLE
fix: avoid setting Git path as the scope path

### DIFF
--- a/e2e/harmony/init-harmony.e2e.ts
+++ b/e2e/harmony/init-harmony.e2e.ts
@@ -33,4 +33,25 @@ describe('init command on Harmony', function () {
       expect(objectsPath).to.be.a.directory().and.empty;
     });
   });
+  // previously, it would consider the ".git" directory as the scope-path
+  describe('delete "objects" dir from the scope after initiating with git', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony({ initGit: true });
+      helper.scopeHelper.reInitRemoteScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.fs.deletePath('.git/bit/objects');
+    });
+    it('should show a descriptive error', () => {
+      expect(() => helper.command.status()).to.throw(`scope not found at`);
+    });
+    it('bit init should fix it', () => {
+      helper.command.init();
+      helper.general.runWithTryCatch('bit status'); // first run could throw about rebuilding index.json
+      expect(() => helper.command.status()).to.not.throw();
+    });
+  });
 });

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -69,8 +69,9 @@ export default class ScopeHelper {
     this.cleanLocalScope();
     this.initLocalScope();
   }
-  reInitLocalScopeHarmony(opts?: { registry: string }) {
+  reInitLocalScopeHarmony(opts?: { registry?: string; initGit?: boolean }) {
     this.cleanLocalScope();
+    if (opts?.initGit) this.command.runCmd('git init');
     this.initHarmonyWorkspace();
     if (opts?.registry) {
       this.fs.writeFile('.npmrc', `registry=${opts.registry}`);

--- a/src/utils/fs/propogate-until.ts
+++ b/src/utils/fs/propogate-until.ts
@@ -62,5 +62,8 @@ export function propogateUntil(fromPath: string): string | undefined {
     { cwd: fromPath, type: 'directory' }
   );
   if (!filePath) return undefined;
+  if (filePath.endsWith(path.join('.git', 'objects'))) {
+    return undefined; // happens when "objects" dir is deleted from the scope
+  }
   return path.dirname(filePath);
 }


### PR DESCRIPTION
Currently, when Git is initiated and `.git/bit/objects` is deleted, then `loadBit` assumes that `.git/objects` is the scope-path.
As a result, it'll parse Git object files and throw cryptic errors. 