### PR TITLE
improvement: remove the scope capsule root-dir from "bit capsule list", it is not used

### DIFF
--- a/scopes/workspace/workspace/capsule.cmd.ts
+++ b/scopes/workspace/workspace/capsule.cmd.ts
@@ -89,13 +89,12 @@ export class CapsuleListCmd implements Command {
 
   async report() {
     const list = await this.isolator.list(this.workspace.path);
-    const { workspaceCapsulesRootDir, scopeCapsulesRootDir, scopeAspectsCapsulesRootDir } = this.getCapsulesRootDirs();
+    const { workspaceCapsulesRootDir, scopeAspectsCapsulesRootDir } = this.getCapsulesRootDirs();
     // TODO: improve output
     return chalk.green(`found ${chalk.cyan(list.capsules.length.toString())} capsule(s) for workspace:  ${chalk.cyan(
       list.workspace
     )}
 workspace capsules root-dir:       ${chalk.cyan(workspaceCapsulesRootDir)}
-scope capsules root-dir:           ${chalk.cyan(scopeCapsulesRootDir)}
 scope's aspects capsules root-dir: ${chalk.cyan(scopeAspectsCapsulesRootDir)}
 use --json to get the list of all workspace capsules`);
   }
@@ -108,10 +107,9 @@ use --json to get the list of all workspace capsules`);
 
   private getCapsulesRootDirs() {
     const workspaceCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.path);
-    const scopeCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.path);
     const scopeAspectsCapsulesRootDir = this.isolator.getCapsulesRootDir(this.workspace.scope.getAspectCapsulePath());
 
-    return { workspaceCapsulesRootDir, scopeCapsulesRootDir, scopeAspectsCapsulesRootDir };
+    return { workspaceCapsulesRootDir, scopeAspectsCapsulesRootDir };
   }
 }
 


### PR DESCRIPTION
only the "scope's aspects capsules root-dir" is used, not the "scope capsules root-dir".