### PR TITLE
improvement: add "originalSeedersCapsules" to the Network API

### DIFF
--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -3,6 +3,7 @@ import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import CapsuleList from './capsule-list';
 
 export class Network {
+  _originalSeeders: ComponentID[] | undefined;
   constructor(
     private _graphCapsules: CapsuleList,
     private seedersIds: ComponentID[],
@@ -10,8 +11,8 @@ export class Network {
   ) {}
 
   /**
-   * seeders capsules only without the entire graph. normally, this includes the capsules of one
-   * env.
+   * for build-tasks (during bit build/tag/snap), this includes the component graph of the current env only.
+   * otherwise, this includes the original components the network was created for.
    */
   get seedersCapsules(): CapsuleList {
     const capsules = this.seedersIds.map((seederId) => {
@@ -20,6 +21,23 @@ export class Network {
       return capsule;
     });
     return CapsuleList.fromArray(capsules);
+  }
+
+  /**
+   * for build-tasks (during bit build/tag/snap), this includes the original components of the current env.
+   * otherwise, this is the same as `this.seedersCapsules()`.
+   */
+  get originalSeedersCapsules(): CapsuleList {
+    const capsules = this.getOriginalSeeders().map((seederId) => {
+      const capsule = this.graphCapsules.getCapsule(seederId);
+      if (!capsule) throw new Error(`unable to find ${seederId.toString()} in the capsule list`);
+      return capsule;
+    });
+    return CapsuleList.fromArray(capsules);
+  }
+
+  private getOriginalSeeders(): ComponentID[] {
+    return this._originalSeeders || this.seedersIds;
   }
 
   /**

--- a/scopes/component/isolator/network.ts
+++ b/scopes/component/isolator/network.ts
@@ -2,6 +2,31 @@ import { ComponentID } from '@teambit/component';
 import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import CapsuleList from './capsule-list';
 
+/**
+ * collection of isolated components (capsules).
+ * normally, "seeders" are the components that this network was created for.
+ * "graphCapsules" is the graph created from the seeders and it includes also the dependencies.
+ *
+ * however, during "bit build"/"bit tag"/"bit snap", things are more complex because there is one more variable in the
+ * picture, which is the "env". the Network is created per env.
+ * in practice, for "build-task", a task is called per env, and the network passed to the task is relevant to that env.
+ * the "originalSeeders" are the ones the network was created for, but only for this env.
+ * the "seeders" are similar to the "graphCapsules" above, which contains also the dependencies, but only for this env.
+ * the "graphCapsules" is the entire graph, including capsules from other envs.
+ *
+ * for example:
+ * comp1 depends on comp2. comp1 env is "react". comp2 env is "aspect".
+ *
+ * when the user is running "bit build comp1", two `Network` instances will be created with the following:
+ * Network for "react" env:  originalSeeders: ['comp1'], seeders: ['comp1'], graphCapsules: ['comp1', 'comp2'].
+ * Network for "aspect" env: originalSeeders: [], seeders: ['comp2'], graphCapsules: ['comp2'].
+ *
+ * on the other hand, when the user is running "bit capsule create comp1", only one `Network` instance is created:
+ * Network: originalSeeders: ['comp1'], seeders: ['comp1'], graphCapsules: ['comp1', 'comp2'].
+ *
+ * (as a side note, another implementation was attempt to have the "seeders" as the original-seeders for build,
+ * however, it's failed. see https://github.com/teambit/bit/pull/5407 for more details).
+ */
 export class Network {
   _originalSeeders: ComponentID[] | undefined;
   constructor(
@@ -36,6 +61,10 @@ export class Network {
     return CapsuleList.fromArray(capsules);
   }
 
+  /**
+   * originalSeeders are not always set (currently, only during build process), so if they're missing, just provide the
+   * seeders, which are probably the original-seeders
+   */
   private getOriginalSeeders(): ComponentID[] {
     return this._originalSeeders || this.seedersIds;
   }

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -224,7 +224,11 @@ export class BuilderMain {
     const ids = components.map((c) => c.id);
     const network = await this.isolator.isolateComponents(ids, isolateOptions);
     const envs = await this.envs.createEnvironment(network.graphCapsules.getAllComponents());
-    const builderServiceOptions = { seedersOnly: isolateOptions?.seedersOnly, ...(builderOptions || {}) };
+    const builderServiceOptions = {
+      seedersOnly: isolateOptions?.seedersOnly,
+      originalSeeders: ids,
+      ...(builderOptions || {}),
+    };
     const buildResult = await envs.runOnce(this.buildService, builderServiceOptions);
     return buildResult;
   }

--- a/scopes/pipelines/builder/builder.service.tsx
+++ b/scopes/pipelines/builder/builder.service.tsx
@@ -4,7 +4,7 @@ import { ScopeMain } from '@teambit/scope';
 import { Text, Newline } from 'ink';
 import { Logger } from '@teambit/logger';
 import { IsolatorMain } from '@teambit/isolator';
-import { Component } from '@teambit/component';
+import { Component, ComponentID } from '@teambit/component';
 import { BuildPipe, TaskResults } from './build-pipe';
 import { TaskResultsList } from './task-results-list';
 import { TaskSlot } from './builder.main.runtime';
@@ -22,6 +22,7 @@ export type BuildServiceResults = {
 
 export type BuilderServiceOptions = {
   seedersOnly?: boolean;
+  originalSeeders?: ComponentID[];
   tasks?: string[];
   skipTests?: boolean;
   previousTasksResults?: TaskResults[];
@@ -94,12 +95,17 @@ export class BuilderService implements EnvService<BuildServiceResults, BuilderDe
     await Promise.all(
       envsExecutionContext.map(async (executionContext) => {
         const componentIds = executionContext.components.map((component) => component.id);
+        const { originalSeeders } = options;
+        const originalSeedersOfThisEnv = componentIds.filter((compId) =>
+          originalSeeders ? originalSeeders.find((seeder) => compId.isEqual(seeder)) : true
+        );
         const capsuleNetwork = await this.isolator.isolateComponents(componentIds, {
           getExistingAsIs: true,
           seedersOnly: options.seedersOnly,
         });
+        capsuleNetwork._originalSeeders = originalSeedersOfThisEnv;
         this.logger.console(
-          `generated graph for env "${executionContext.id}", seeders total: ${capsuleNetwork.seedersCapsules.length}, graph total: ${capsuleNetwork.graphCapsules.length}`
+          `generated graph for env "${executionContext.id}", originalSeedersOfThisEnv: ${originalSeedersOfThisEnv.length}, graphOfThisEnv: ${capsuleNetwork.seedersCapsules.length}, graph total: ${capsuleNetwork.graphCapsules.length}`
         );
         const buildContext = Object.assign(executionContext, {
           capsuleNetwork,


### PR DESCRIPTION
Currently, when running `bit build <some-id>`, the `seedersCapsules` provided by the builder aspect, contains the entire graph of this component that use the same env.  
This PR, provides a way to get only the original seeders of the current env. 

(see https://github.com/teambit/bit/pull/5407 for a different route, which didn't go well).