### PR TITLE
Babel & multi compiler changes for apps

### DIFF
--- a/scopes/compilation/babel/compiler-options.ts
+++ b/scopes/compilation/babel/compiler-options.ts
@@ -12,4 +12,11 @@ export type BabelCompilerOptions = {
    * ```
    */
   babelTransformOptions?: TransformOptions;
+
+  /**
+   * Determines which files should be compiled by the Babel compiler.
+   * It only works with the file types supported by Babel (.ts, .tsx, .js, .jsx, .d.ts).
+   * See https://github.com/mrmlnc/fast-glob for the supported glob patters syntax.
+   */
+  supportedFilesGlobPatterns?: string[];
 } & Partial<CompilerOptions>;

--- a/scopes/compilation/compiler/compiler.cmd.ts
+++ b/scopes/compilation/compiler/compiler.cmd.ts
@@ -3,7 +3,7 @@ import { Logger } from '@teambit/logger';
 import type { PubsubMain, BitBaseEvent } from '@teambit/pubsub';
 import chalk from 'chalk';
 import prettyTime from 'pretty-time';
-import type ConsumerComponent from '@teambit/legacy/dist/consumer/component';
+import { Component } from '@teambit/component';
 import { formatCompileResults } from './output-formatter';
 import { CompileError, WorkspaceCompiler, CompileOptions } from './workspace-compiler';
 import { CompilationInitiator } from './types';
@@ -12,14 +12,14 @@ import { CompilationInitiator } from './types';
 import { CompilerAspect } from './compiler.aspect';
 import { ComponentCompilationOnDoneEvent } from './events';
 
-type ComponentsStatus = {
+export type ComponentsStatus = {
   buildResults: string[];
-  component: Array<ConsumerComponent>;
-  errors: Array<CompileError>;
+  component: Component;
+  errors: CompileError[];
 };
 
 export class CompileCmd implements Command {
-  componentsStatus: Array<ComponentsStatus> = [];
+  componentsStatus: ComponentsStatus[] = [];
   name = 'compile [component...]';
   description = 'compile components in the development workspace';
   alias = '';
@@ -47,7 +47,7 @@ export class CompileCmd implements Command {
 
     outputString += '\n';
     outputString += `  ${chalk.underline('STATUS')}\t${chalk.underline('COMPONENT ID')}\n`;
-    outputString += formatCompileResults(this.componentsStatus, compilerOptions.verbose);
+    outputString += formatCompileResults(this.componentsStatus, !!compilerOptions.verbose);
     outputString += '\n';
 
     outputString += this.getStatusLine(this.componentsStatus, compileTimeLength);

--- a/scopes/compilation/compiler/events/component-compilation-on-done.ts
+++ b/scopes/compilation/compiler/events/component-compilation-on-done.ts
@@ -1,14 +1,10 @@
 /* eslint-disable max-classes-per-file */
 import { BitBaseEvent } from '@teambit/pubsub';
-import type ConsumerComponent from '@teambit/legacy/dist/consumer/component';
+import { Component } from '@teambit/component';
 import { CompileError } from '../workspace-compiler';
 
 class ComponentCompilationOnDoneEventData {
-  constructor(
-    readonly errors: Array<CompileError>,
-    readonly component: ConsumerComponent,
-    readonly buildResults: string[]
-  ) {}
+  constructor(readonly errors: Array<CompileError>, readonly component: Component, readonly buildResults: string[]) {}
 }
 
 export class ComponentCompilationOnDoneEvent extends BitBaseEvent<ComponentCompilationOnDoneEventData> {
@@ -16,7 +12,7 @@ export class ComponentCompilationOnDoneEvent extends BitBaseEvent<ComponentCompi
 
   constructor(
     readonly errors: Array<CompileError>,
-    readonly component: ConsumerComponent,
+    readonly component: Component,
     readonly buildResults: string[],
     readonly timestamp = Date.now()
   ) {

--- a/scopes/compilation/compiler/output-formatter.ts
+++ b/scopes/compilation/compiler/output-formatter.ts
@@ -1,9 +1,10 @@
 import chalk from 'chalk';
+import { ComponentsStatus } from './compiler.cmd';
 
-export const formatCompileResults = (compileResults, verbose) =>
+export const formatCompileResults = (compileResults: ComponentsStatus[], verbose: boolean) =>
   compileResults
-    .map((componentResult) => ({
-      componentId: componentResult.component.name,
+    .map((componentResult: ComponentsStatus) => ({
+      componentId: componentResult.component.id.fullName,
       files: componentResult.buildResults,
       status: componentResult.errors.length ? 'FAILURE' : 'SUCCESS',
       icon: componentResult.errors.length ? chalk.red('✗') : chalk.green('✔'),

--- a/scopes/compilation/compiler/types.ts
+++ b/scopes/compilation/compiler/types.ts
@@ -1,5 +1,4 @@
 import { BuildContext, BuildTask, BuiltTaskResult, TaskResultsList } from '@teambit/builder';
-import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import type { Component } from '@teambit/component';
 
 export type TranspileFileParams = {
@@ -19,7 +18,7 @@ export enum CompilationInitiator {
 }
 
 export type TranspileComponentParams = {
-  component: ConsumerComponent;
+  component: Component;
   componentDir: string; // absolute path of the component's root directory
   outputDir: string; // absolute path of the component's output directory
   initiator: CompilationInitiator; // origin of the compilation's request

--- a/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
+++ b/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
@@ -1,6 +1,12 @@
 import { join } from 'path';
 import pMapSeries from 'p-map-series';
-import { Compiler, CompilerOptions, TranspileFileOutput, TranspileFileParams } from '@teambit/compiler';
+import {
+  Compiler,
+  CompilerOptions,
+  TranspileComponentParams,
+  TranspileFileOutput,
+  TranspileFileParams,
+} from '@teambit/compiler';
 import { BuiltTaskResult, BuildContext, TaskResultsList } from '@teambit/builder';
 import { mergeComponentResults } from '@teambit/pipelines.modules.merge-component-results';
 
@@ -59,6 +65,9 @@ export class MultiCompiler implements Compiler {
   transpileFile(fileContent: string, options: TranspileFileParams): TranspileFileOutput {
     const outputs = this.compilers.reduce<any>(
       (files, compiler) => {
+        if (!compiler.transpileFile) {
+          return files;
+        }
         return files?.flatMap((file) => {
           if (!compiler.isFileSupported(file?.outputPath)) return [file];
           const params = Object.assign({}, options, {
@@ -74,6 +83,14 @@ export class MultiCompiler implements Compiler {
     );
 
     return outputs;
+  }
+
+  async transpileComponent(params: TranspileComponentParams): Promise<void> {
+    await Promise.all(
+      this.compilers.map((compiler) => {
+        return compiler.transpileComponent?.(params);
+      })
+    );
   }
 
   async build(context: BuildContext): Promise<BuiltTaskResult> {

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -20,7 +20,7 @@ const DEFAULT_INSTALL_OPTIONS: InstallOptions = {
   installTeambitBit: false,
 };
 
-type InstallArgs = {
+export type InstallArgs = {
   rootDir: string | undefined;
   rootPolicy: WorkspacePolicy;
   componentDirectoryMap: ComponentMap<string>;

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -62,8 +62,8 @@ export {
   NestedNMDepsLinksResult,
   LinkToDirResult,
 } from './dependency-linker';
-export { InstallOptions } from './dependency-installer';
+export { InstallOptions, InstallArgs, DependencyInstaller } from './dependency-installer';
 export { DependencyDetector, FileContext } from './dependency-detector';
 export { DependencySource } from './policy/variant-policy/variant-policy';
 export { OutdatedPkg } from './get-all-policy-pkgs';
-export { extendWithComponentsFromDir } from './extend-with-components-from-dir'
+export { extendWithComponentsFromDir } from './extend-with-components-from-dir';

--- a/scopes/harmony/application/app.plugin.ts
+++ b/scopes/harmony/application/app.plugin.ts
@@ -5,7 +5,7 @@ import { ApplicationSlot } from './application.main.runtime';
 export class AppPlugin implements PluginDefinition {
   constructor(private appSlot: ApplicationSlot) {}
 
-  pattern = '*.app.*';
+  pattern = '*.app.*?(ts|tsx|js|jsx)$';
 
   runtimes = [MainRuntime.name];
 

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -142,7 +142,7 @@ export class PreviewMain {
       PreviewAspect.id,
       PREVIEW_TASK_NAME
     );
-    if (!artifacts || !artifacts.length) return undefined;
+    if (!artifacts) return undefined;
     return new PreviewArtifact(artifacts);
   }
 


### PR DESCRIPTION
## Proposed Changes

- [only build supported files with the babel compiler](https://github.com/teambit/bit/commit/3d9d51ffcf79c9b0250052ca21411c40db463076)
- [fix preview throwing a 404 when there are no compositions](https://github.com/teambit/bit/commit/ade6b76ba30a089bd0a55cb7ef6e3d83e203ec7b)
- [add supportedFilesGlobPatterns option to the babel compiler](https://github.com/teambit/bit/commit/a4e0e239116b977ee43296170f64de4dc7344b6f)
- [fix multi compiler to support transpiling all files at once](https://github.com/teambit/bit/commit/90c4e1bf31061c093be7701a056497b435a76c9e)
- [replace ConsumerComponent by Component in workspace compiler](https://github.com/teambit/bit/commit/b180b0ef57684eeda39b12ee863430734b59c078)
- [add missing exports from dependency installer](https://github.com/teambit/bit/pull/5440/commits/701c860536a2e9aa72ced6b6732f72d43c558ce7)