### PR TITLE
fix: gql(component/latest) return head version when there are no tags

### DIFF
--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -99,7 +99,7 @@ export class Component {
       return this.tags.getLatest();
     } catch (err: any) {
       if (err instanceof CouldNotFindLatest) {
-        return this.head.toString();
+        return this.head.hash;
       }
       throw err;
     }


### PR DESCRIPTION
## Proposed Changes

- Currently, if a component has no tags (only snaps), the graphql query returns '[object Object]', as it tries to `toString()` the entire head `Snap` object, instead of returning the `head hash`. This fixes the query to return the `head hash` if there are no tags. 
