### PR TITLE
improvement: improve performance of component loading from scope

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -132,8 +132,9 @@ export class ScopeComponentLoader {
 
   private getTagMap(modelComponent: ModelComponent): TagMap {
     const tagMap = new TagMap();
-    Object.keys(modelComponent.versionsIncludeOrphaned).forEach((versionStr: string) => {
-      const tag = new Tag(modelComponent.versionsIncludeOrphaned[versionStr].toString(), new SemVer(versionStr));
+    const allVersions = modelComponent.versionsIncludeOrphaned;
+    Object.keys(allVersions).forEach((versionStr: string) => {
+      const tag = new Tag(allVersions[versionStr].toString(), new SemVer(versionStr));
       tagMap.set(tag.version, tag);
     });
     return tagMap;


### PR DESCRIPTION
I don't have a good explanation for this, it's probably related to some internal optimization of v8. the fact is that with this changes, loading 419 versions of one component via `scope.get()` is down from 17 seconds to 4 seconds.