### PR TITLE
Fix pubsub errors

### DIFF
--- a/scopes/compositions/compositions/ui/composition-preview.tsx
+++ b/scopes/compositions/compositions/ui/composition-preview.tsx
@@ -1,60 +1,27 @@
 import React, { useMemo } from 'react';
-import { ComponentModel } from '@teambit/component';
-import { ComponentPreview } from '@teambit/preview.ui.component-preview';
+import { ComponentPreview, ComponentPreviewProps } from '@teambit/preview.ui.component-preview';
 
 import { Composition } from '../composition';
 
-export type ComponentCompositionProps = {
-  /**
-   * HTML class
-   */
-  className?: string;
-
-  /**
-   * component to render.
-   */
-  component: ComponentModel;
-
+interface ComponentCompositionProps extends ComponentPreviewProps {
   /**
    * composition to use for component rendering.
    */
   composition?: Composition;
+}
 
-  /**
-   * Additional query params to append at the end of the *hash*. Changing this property will not reload the composition.
-   */
-  queryParams?: string | string[];
-
-  /**
-   * skip hot reload
-   */
-  hotReload?: boolean;
-};
-
-export function ComponentComposition({
-  component,
-  composition,
-  hotReload,
-  className,
-  queryParams = [],
-}: ComponentCompositionProps) {
-  const compositionParams = useMemo(() => (composition ? [composition.identifier] : []).concat(queryParams), [
-    composition?.identifier,
-    queryParams,
-  ]);
+export function ComponentComposition({ composition, queryParams = [], ...rest }: ComponentCompositionProps) {
+  const compositionParams = useMemo(
+    () => (composition ? [composition.identifier] : []).concat(queryParams),
+    [composition?.identifier, queryParams]
+  );
 
   return (
     <ComponentPreview
-      className={className}
-      component={component}
+      {...rest}
       style={{ width: '100%', height: '100%' }}
       previewName="compositions"
       queryParams={compositionParams}
-      hotReload={hotReload}
     />
   );
 }
-
-ComponentComposition.defaultProps = {
-  skipHotReload: true,
-};

--- a/scopes/harmony/pubsub/pubsub-context.tsx
+++ b/scopes/harmony/pubsub/pubsub-context.tsx
@@ -22,13 +22,13 @@ export function usePubSub() {
   return useContext(pubsubRegistry);
 }
 
-export function usePubSubIframe(ref: RefObject<HTMLIFrameElement>) {
+export function usePubSubIframe(ref?: RefObject<HTMLIFrameElement>) {
   const pubSub = usePubSub();
 
   useEffect(() => {
-    if (!ref.current || !pubSub) return () => {};
+    if (!ref?.current || !pubSub) return () => {};
 
     const destroyConnection = pubSub.connect(ref.current);
     return () => destroyConnection();
-  }, [ref.current, pubSub]);
+  }, [ref?.current, pubSub]);
 }

--- a/scopes/harmony/pubsub/pubsub.ui.runtime.ts
+++ b/scopes/harmony/pubsub/pubsub.ui.runtime.ts
@@ -53,12 +53,11 @@ export class PubsubUI {
       },
     });
 
-    // absorb valid errors like 'connection destroyed'
     connection.promise
       .then((childConnection) => (this.childApi = childConnection))
-      .catch(() => {
+      .catch((err) => {
         // eslint-disable-next-line no-console
-        console.error('[Pubsub.ui]', 'failed connecting to child iframe');
+        console.error('[Pubsub.ui]', 'failed connecting to child iframe:', err);
       });
 
     const destroy = () => {

--- a/scopes/preview/ui/component-preview/index.ts
+++ b/scopes/preview/ui/component-preview/index.ts
@@ -1,2 +1,3 @@
 export { ComponentPreview } from './preview';
+export type { ComponentPreviewProps } from './preview';
 export { toPreviewUrl, toPreviewServer, toPreviewHash } from './urls';

--- a/scopes/preview/ui/component-preview/preview.tsx
+++ b/scopes/preview/ui/component-preview/preview.tsx
@@ -25,9 +25,10 @@ export interface ComponentPreviewProps extends Omit<IframeHTMLAttributes<HTMLIFr
   queryParams?: string | string[];
 
   /**
-   * enable/disable hot reload for the composition preview.
+   * establish a pubsub connection to the iframe,
+   * allowing sending and receiving messages
    */
-  hotReload?: boolean;
+  pubsub?: boolean;
 
   /**
    * is preview being rendered in full height and should fit view height to content.
@@ -38,24 +39,19 @@ export interface ComponentPreviewProps extends Omit<IframeHTMLAttributes<HTMLIFr
 /**
  * renders a preview of a component.
  */
-// TODO - Kutner fix unused var - 'hotReload' should be used
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function ComponentPreview({
   component,
   previewName,
   queryParams,
+  pubsub = true,
   fullContentHeight = false,
   ...rest
 }: ComponentPreviewProps) {
   const [iframeRef, iframeHeight] = useIframeContentHeight({ skip: !fullContentHeight });
-  usePubSubIframe(iframeRef);
+  usePubSubIframe(pubsub ? iframeRef : undefined);
 
   const url = toPreviewUrl(component, previewName, queryParams);
   return (
     <iframe {...rest} ref={iframeRef} style={{ ...rest.style, height: iframeHeight || rest.style?.height }} src={url} />
   );
 }
-
-ComponentPreview.defaultProps = {
-  hotReload: true,
-};

--- a/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
+++ b/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
@@ -26,7 +26,7 @@ export function PreviewPlaceholder({
     );
 
   if (shouldShowPreview) {
-    return <ComponentComposition component={component} hotReload={false} composition={selectedPreview} />;
+    return <ComponentComposition component={component} composition={selectedPreview} pubsub={false} />;
   }
 
   return (

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -283,7 +283,7 @@
         "parallel-webpack": "2.6.0",
         "parse-package-name": "0.1.0",
         "path-to-regexp": "6.2.0",
-        "penpal": "5.3.0",
+        "penpal": "6.2.1",
         "pluralize": "8.0.0",
         "postcss": "8.2.9",
         "postcss-flexbugs-fixes": "5.0.2",


### PR DESCRIPTION
## Proposed Changes

- update pubsub 
- the update fixes the `[Pubsub.ui] failed connecting to child iframe` error happening when switching between component pages, see [here](https://github.com/Aaronius/penpal/releases/tag/v6.0.0).
- turn off pubsub for gallery pages
- remove the unused hotReload flag that also trigger errors
