### PR TITLE
fix(test-task): avoid showing the same error multiple times in bit-build

### DIFF
--- a/e2e/fixtures/extensions/custom-react-env/custom-react-env.aspect.ts
+++ b/e2e/fixtures/extensions/custom-react-env/custom-react-env.aspect.ts
@@ -1,0 +1,5 @@
+import { Aspect } from '@teambit/harmony';
+
+export const CustomReactEnvAspect = Aspect.create({
+  id: 'my-scope/custom-react-env',
+});

--- a/e2e/fixtures/extensions/custom-react-env/custom-react-env.main.runtime.ts
+++ b/e2e/fixtures/extensions/custom-react-env/custom-react-env.main.runtime.ts
@@ -1,0 +1,79 @@
+import { MainRuntime } from '@teambit/cli';
+import { ReactAspect, ReactMain } from '@teambit/react';
+import { EnvsAspect, EnvsMain } from '@teambit/envs';
+import { CustomReactEnvAspect } from './custom-react-env.aspect';
+// import { previewConfigTransformer, devServerConfigTransformer } from './webpack/webpack-transformers';
+
+/**
+ * Uncomment to include config files for overrides of Typescript or Webpack
+ */
+// const tsconfig = require('./typescript/tsconfig');
+
+export class CustomReactEnvMain {
+  static slots = [];
+
+  static dependencies = [ReactAspect, EnvsAspect];
+
+  static runtime = MainRuntime;
+
+  static async provider([react, envs]: [ReactMain, EnvsMain]) {
+    const templatesReactEnv = envs.compose(react.reactEnv, [
+      /**
+       * Uncomment to override the config files for TypeScript, Webpack or Jest
+       * Your config gets merged with the defaults
+       */
+
+      // react.overrideTsConfig(tsconfig),
+      // react.useWebpack({
+      //   previewConfig: [previewConfigTransformer],
+      //   devServerConfig: [devServerConfigTransformer],
+      // }),
+      react.overrideJestConfig(require.resolve('./jest/jest.config')),
+
+      /**
+       * override the ESLint default config here then check your files for lint errors
+       * @example
+       * bit lint
+       * bit lint --fix
+       */
+      react.useEslint({
+        transformers: [
+          (config) => {
+            config.setRule('no-console', ['error']);
+            return config;
+          }
+        ]
+      }),
+
+      /**
+       * override the Prettier default config here the check your formatting
+       * @example
+       * bit format --check
+       * bit format
+       */
+      react.usePrettier({
+        transformers: [
+          (config) => {
+            config.setKey('tabWidth', 2);
+            return config;
+          }
+        ]
+      }),
+
+      /**
+       * override dependencies here
+       * @example
+       * Uncomment types to include version 17.0.3 of the types package
+       */
+      react.overrideDependencies({
+        devDependencies: {
+          // '@types/react': '17.0.3'
+        }
+      })
+    ]);
+    envs.registerEnv(templatesReactEnv);
+    return new CustomReactEnvMain();
+  }
+}
+
+CustomReactEnvAspect.addRuntime(CustomReactEnvMain);

--- a/e2e/fixtures/extensions/custom-react-env/index.ts
+++ b/e2e/fixtures/extensions/custom-react-env/index.ts
@@ -1,0 +1,5 @@
+import { CustomReactEnvAspect } from './custom-react-env.aspect';
+
+export type { CustomReactEnvMain } from './custom-react-env.main.runtime';
+export default CustomReactEnvAspect;
+export { CustomReactEnvAspect };

--- a/e2e/fixtures/extensions/custom-react-env/jest/jest.config.js
+++ b/e2e/fixtures/extensions/custom-react-env/jest/jest.config.js
@@ -1,0 +1,18 @@
+
+  // Override the Jest config to ignore transpiling from specific folders
+  // See the base Jest config: https://bit.dev/teambit/react/react/~code/jest/jest.config.js
+
+  // const reactJestConfig = require('@teambit/react/jest/jest.config');
+  // uncomment the line below and install the package if you want to use this function
+  // const {
+  //   generateNodeModulesPattern,
+  // } = require('@teambit/dependencies.modules.packages-excluder');
+  // const packagesToExclude = ['@my-org', 'my-package-name'];
+
+  // module.exports = {
+  //   ...reactJestConfig,
+  //   transformIgnorePatterns: [
+  //     '^.+\.module\.(css|sass|scss)$',
+  //     generateNodeModulesPattern({ packages: packagesToExclude }),
+  //   ],
+  // };

--- a/e2e/fixtures/extensions/custom-react-env/typescript/tsconfig.json
+++ b/e2e/fixtures/extensions/custom-react-env/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // add your compiler options here
+
+  "compilerOptions": {
+    // "target": "es2017",
+    // "module": "es2015",
+    // "moduleResolution": "node",
+    // "lib": ["es2017", "dom"],
+    // "experimentalDecorators": true,
+    // "esModuleInterop": true,
+    // "outDir": "dist",
+    // "sourceMap": true,
+    // "emitDecoratorMetadata": true,
+    // "allowJs": true,
+    // "baseUrl": ".",
+    // "jsx": "react"
+  }
+}

--- a/e2e/fixtures/extensions/custom-react-env/webpack/webpack-transformers.ts
+++ b/e2e/fixtures/extensions/custom-react-env/webpack/webpack-transformers.ts
@@ -1,0 +1,45 @@
+
+  import { WebpackConfigTransformer, WebpackConfigMutator, WebpackConfigTransformContext } from '@teambit/webpack';
+
+  /**
+   * Transformation to apply for both preview and dev server
+   * @param config
+   * @param _context
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function commonTransformation(config: WebpackConfigMutator, _context: WebpackConfigTransformContext) {
+    // Merge config with the webpack.config.js file if you choose to import a module export format config.
+    // config.merge([webpackConfig]);
+    // config.addAliases({});
+    // config.addModuleRule(youRuleHere);
+    return config;
+  }
+
+  /**
+   * Transformation for the preview only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const previewConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+
+  /**
+   * Transformation for the dev server only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const devServerConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+

--- a/e2e/harmony/deps-in-capsules.e2e.ts
+++ b/e2e/harmony/deps-in-capsules.e2e.ts
@@ -60,15 +60,13 @@ chai.use(require('chai-string'));
     it('all packages are correctly installed inside capsules', () => {
       const { scopeAspectsCapsulesRootDir } = helper.command.capsuleListParsed();
       const capsuleDirs = fs.readdirSync(scopeAspectsCapsulesRootDir);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const nodeEnv1CapsuleDir = path.join(
         scopeAspectsCapsulesRootDir,
-        capsuleDirs.find((dir) => dir.includes('node-env-1'))!
+        capsuleDirs.find((dir) => dir.includes('node-env-1')) as string
       );
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       const nodeEnv2CapsuleDir = path.join(
         scopeAspectsCapsulesRootDir,
-        capsuleDirs.find((dir) => dir.includes('node-env-2'))!
+        capsuleDirs.find((dir) => dir.includes('node-env-2')) as string
       );
       expect(path.join(nodeEnv1CapsuleDir, 'node_modules/lodash.get')).to.be.a.path();
       expect(path.join(nodeEnv2CapsuleDir, 'node_modules/lodash.flatten')).to.be.a.path();

--- a/e2e/harmony/deps-in-capsules.e2e.ts
+++ b/e2e/harmony/deps-in-capsules.e2e.ts
@@ -58,13 +58,21 @@ chai.use(require('chai-string'));
       expect(env2).to.equal(`${envId2}@0.0.1`);
     });
     it('all packages are correctly installed inside capsules', () => {
-      const { scopeAspectsCapsulesRootDir } = helper.command.capsuleListParsed()
-      const capsuleDirs = fs.readdirSync(scopeAspectsCapsulesRootDir)
-      const nodeEnv1CapsuleDir = path.join(scopeAspectsCapsulesRootDir, capsuleDirs.find((dir) => dir.includes('node-env-1'))!)
-      const nodeEnv2CapsuleDir = path.join(scopeAspectsCapsulesRootDir, capsuleDirs.find((dir) => dir.includes('node-env-2'))!)
-      expect(path.join(nodeEnv1CapsuleDir, 'node_modules/lodash.get')).to.be.a.path()
-      expect(path.join(nodeEnv2CapsuleDir, 'node_modules/lodash.flatten')).to.be.a.path()
-    })
+      const { scopeAspectsCapsulesRootDir } = helper.command.capsuleListParsed();
+      const capsuleDirs = fs.readdirSync(scopeAspectsCapsulesRootDir);
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const nodeEnv1CapsuleDir = path.join(
+        scopeAspectsCapsulesRootDir,
+        capsuleDirs.find((dir) => dir.includes('node-env-1'))!
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      const nodeEnv2CapsuleDir = path.join(
+        scopeAspectsCapsulesRootDir,
+        capsuleDirs.find((dir) => dir.includes('node-env-2'))!
+      );
+      expect(path.join(nodeEnv1CapsuleDir, 'node_modules/lodash.get')).to.be.a.path();
+      expect(path.join(nodeEnv2CapsuleDir, 'node_modules/lodash.flatten')).to.be.a.path();
+    });
   });
   describe('using Yarn', () => {
     before(() => {
@@ -87,10 +95,10 @@ chai.use(require('chai-string'));
       expect(env2).to.equal(`${envId2}@0.0.1`);
     });
     it('all packages are correctly installed inside capsules', () => {
-      const { scopeAspectsCapsulesRootDir } = helper.command.capsuleListParsed()
-      expect(path.join(scopeAspectsCapsulesRootDir, 'node_modules/lodash.get')).to.be.a.path()
-      expect(path.join(scopeAspectsCapsulesRootDir, 'node_modules/lodash.flatten')).to.be.a.path()
-    })
+      const { scopeAspectsCapsulesRootDir } = helper.command.capsuleListParsed();
+      expect(path.join(scopeAspectsCapsulesRootDir, 'node_modules/lodash.get')).to.be.a.path();
+      expect(path.join(scopeAspectsCapsulesRootDir, 'node_modules/lodash.flatten')).to.be.a.path();
+    });
   });
   after(() => {
     npmCiRegistry.destroy();

--- a/e2e/harmony/jest.e2e.ts
+++ b/e2e/harmony/jest.e2e.ts
@@ -86,7 +86,7 @@ describe('Jest Tester', function () {
       helper.fixtures.populateComponents(1);
       helper.fs.outputFile('comp1/comp1.spec.ts', specFilePassingFixture());
       helper.env.setCustomEnv('custom-react-env');
-      helper.fs.outputFile('custom-react-env/jest/jest.config.js', specFilePassingFixture());
+      helper.fs.outputFile('custom-react-env/jest/jest.config.js', invalidJestConfigFixture());
       helper.command.compile();
       helper.command.install();
       helper.command.setEnv('comp1', 'custom-react-env');
@@ -96,11 +96,11 @@ describe('Jest Tester', function () {
     });
     it('bit test should show the error', () => {
       const output = helper.general.runWithTryCatch('bit test');
-      expect(output).to.have.string('describe is not defined');
+      expect(output).to.have.string('someUndefinedFunc is not defined');
     });
     it('bit build should show the error', () => {
       const output = helper.general.runWithTryCatch('bit build');
-      expect(output).to.have.string('describe is not defined');
+      expect(output).to.have.string('someUndefinedFunc is not defined');
     });
   });
 });

--- a/e2e/harmony/jest.e2e.ts
+++ b/e2e/harmony/jest.e2e.ts
@@ -80,6 +80,29 @@ describe('Jest Tester', function () {
       expect(output).to.have.string('SomeError');
     });
   });
+  describe('env with an incorrect Jest config', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFilePassingFixture());
+      helper.env.setCustomEnv('custom-react-env');
+      helper.fs.outputFile('custom-react-env/jest/jest.config.js', specFilePassingFixture());
+      helper.command.compile();
+      helper.command.install();
+      helper.command.setEnv('comp1', 'custom-react-env');
+    });
+    it('bit test should exit with non-zero code', () => {
+      expect(() => helper.command.test()).to.throw();
+    });
+    it('bit test should show the error', () => {
+      const output = helper.general.runWithTryCatch('bit test');
+      expect(output).to.have.string('describe is not defined');
+    });
+    it('bit build should show the error', () => {
+      const output = helper.general.runWithTryCatch('bit build');
+      expect(output).to.have.string('describe is not defined');
+    });
+  });
 });
 
 function specFilePassingFixture() {
@@ -108,4 +131,13 @@ function specFileErroringFixture() {
   });
 });
 `;
+}
+
+function invalidJestConfigFixture() {
+  return `module.exports = {
+    transformIgnorePatterns: [
+      someUndefinedFunc(),
+    ],
+  };
+  `;
 }

--- a/e2e/harmony/jest.e2e.ts
+++ b/e2e/harmony/jest.e2e.ts
@@ -1,0 +1,111 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('Jest Tester', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('component without any test file', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+    });
+    it('bit test should not throw any error', () => {
+      expect(() => helper.command.test()).not.to.throw();
+    });
+    it('bit test should indicate that no tests found', () => {
+      const output = helper.command.test();
+      expect(output).to.have.string('no tests found');
+    });
+    it('bit build should not fail', () => {
+      expect(() => helper.command.build()).not.to.throw();
+    });
+  });
+  describe('component with a passing test', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFilePassingFixture());
+    });
+    it('bit test should show the passing component via Jest output', () => {
+      const output = helper.command.test('', true);
+      expect(output).to.have.string('✓ should pass');
+    });
+    it('bit build should show the passing component via Jest output', () => {
+      const output = helper.command.build('', true);
+      expect(output).to.have.string('✓ should pass');
+    });
+  });
+  describe('component with a failing test', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFileFailingFixture());
+    });
+    it('bit test should exit with non-zero code', () => {
+      expect(() => helper.command.test()).to.throw();
+    });
+    it('bit test should show the failing component via Jest output', () => {
+      const output = helper.general.runWithTryCatch('bit test');
+      expect(output).to.have.string('✕ should fail');
+    });
+    it('bit build should show the failing component via Jest output', () => {
+      const output = helper.general.runWithTryCatch('bit build');
+      expect(output).to.have.string('✕ should fail');
+    });
+  });
+  describe('component with an errored test', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFileErroringFixture());
+    });
+    it('bit test should exit with non-zero code', () => {
+      expect(() => helper.command.test()).to.throw();
+    });
+    it('bit test should show the error', () => {
+      const output = helper.general.runWithTryCatch('bit test');
+      expect(output).to.have.string('SomeError');
+      expect(output).to.have.string('1 failed');
+    });
+    it('bit build should show the error', () => {
+      const output = helper.general.runWithTryCatch('bit build');
+      expect(output).to.have.string('SomeError');
+    });
+  });
+});
+
+function specFilePassingFixture() {
+  return `describe('test', () => {
+  it('should pass', () => {
+    expect(true).toBeTruthy();
+  });
+});
+`;
+}
+
+function specFileFailingFixture() {
+  return `describe('test', () => {
+  it('should fail', () => {
+    expect(false).toBeTruthy();
+  });
+});
+`;
+}
+
+function specFileErroringFixture() {
+  return `describe('test', () => {
+    throw new Error('SomeError');
+  it('should not reach here', () => {
+    expect(true).toBeTruthy();
+  });
+});
+`;
+}

--- a/package.json
+++ b/package.json
@@ -186,6 +186,7 @@
     "object-diff": "0.0.4",
     "object-hash": "2.1.1",
     "open": "7.4.2",
+    "open-editor": "3.0.0",
     "ora": "5.4.1",
     "p-event": "4.2.0",
     "p-map": "4.0.0",

--- a/scopes/defender/jest/jest.tester.ts
+++ b/scopes/defender/jest/jest.tester.ts
@@ -85,10 +85,7 @@ export class JestTester implements Tester {
           );
         });
         const filePath = file?.basename || test.testFilePath;
-        const error = {
-          failureMessage: test.testExecError ? test.failureMessage : undefined,
-          error: test.testExecError?.message,
-        };
+        const error = test.testExecError?.message;
         return new TestsFiles(
           filePath,
           testResults,

--- a/scopes/defender/jest/jest.tester.ts
+++ b/scopes/defender/jest/jest.tester.ts
@@ -154,22 +154,16 @@ export class JestTester implements Tester {
     });
 
     const withEnv = Object.assign(jestConfigWithSpecs, config);
-    try {
-      const testsOutPut = await this.jestModule.runCLI(withEnv, [this.jestConfig]);
-      const testResults = testsOutPut.results.testResults;
-      const componentsWithTests = this.attachTestsToComponent(context, testResults);
-      const componentTestResults = this.buildTestsObj(
-        testsOutPut.results,
-        componentsWithTests,
-        context,
-        jestConfigWithSpecs
-      );
-      const globalErrors = this.getErrors(testResults);
-      return { components: componentTestResults, errors: globalErrors };
-    } catch (e) {
-      const components = context.components.map((comp) => ({ componentId: comp.id }));
-      return { components, errors: [e as Error] };
-    }
+    const testsOutPut = await this.jestModule.runCLI(withEnv, [this.jestConfig]);
+    const testResults = testsOutPut.results.testResults;
+    const componentsWithTests = this.attachTestsToComponent(context, testResults);
+    const componentTestResults = this.buildTestsObj(
+      testsOutPut.results,
+      componentsWithTests,
+      context,
+      jestConfigWithSpecs
+    );
+    return { components: componentTestResults };
   }
 
   async watch(context: TesterContext): Promise<Tests> {

--- a/scopes/defender/jest/jest.tester.ts
+++ b/scopes/defender/jest/jest.tester.ts
@@ -88,8 +88,8 @@ export class JestTester implements Tester {
         const filePath = file?.basename || test.testFilePath;
         const getError = () => {
           if (!test.testExecError) return undefined;
-          if (testerContext.watch) return test.failureMessage as string;
-          return test.testExecError?.message;
+          if (testerContext.watch) return new JestError(test.failureMessage as string);
+          return new JestError(test.testExecError?.message, test.testExecError?.stack);
         };
         const error = getError();
         return new TestsFiles(

--- a/scopes/defender/tester/index.ts
+++ b/scopes/defender/tester/index.ts
@@ -1,6 +1,14 @@
 import { TesterAspect } from './tester.aspect';
 
-export type { Tester, Tests, TesterContext, CallbackFn, SpecFiles, ComponentPatternsMap } from './tester';
+export type {
+  Tester,
+  Tests,
+  TesterContext,
+  CallbackFn,
+  SpecFiles,
+  ComponentPatternsMap,
+  ComponentsResults,
+} from './tester';
 export type { TesterMain } from './tester.main.runtime';
 export type { TesterUI } from './tester.ui.runtime';
 

--- a/scopes/defender/tester/test.cmd.tsx
+++ b/scopes/defender/tester/test.cmd.tsx
@@ -91,7 +91,7 @@ export class TestCmd implements Command {
         junit,
         coverage,
       });
-      tests?.results?.forEach((test) => (test.data?.errors?.length ? (code = 1) : null));
+      if (tests.hasErrors()) code = 1;
     }
     const { seconds } = timer.stop();
 

--- a/scopes/defender/tester/test.cmd.tsx
+++ b/scopes/defender/tester/test.cmd.tsx
@@ -103,9 +103,7 @@ export class TestCmd implements Command {
       code,
       data: (
         <Box>
-          <Text>tested </Text>
-          <Text color="cyan">{components.length} </Text>
-          <Text>components in </Text>
+          <Text>test has been completed in </Text>
           <Text color="cyan">{seconds} </Text>
           <Text>seconds.</Text>
         </Box>

--- a/scopes/defender/tester/test.cmd.tsx
+++ b/scopes/defender/tester/test.cmd.tsx
@@ -43,7 +43,6 @@ export class TestCmd implements Command {
     [userPattern]: [string],
     { watch = false, debug = false, all = false, env, scope, junit, coverage = false }: TestFlags
   ) {
-    this.logger.off();
     const timer = Timer.create();
     const scopeName = typeof scope === 'string' ? scope : undefined;
     timer.start();
@@ -77,6 +76,10 @@ export class TestCmd implements Command {
 
     let code = 0;
     if (watch && !debug) {
+      // avoid turning off the logger for non-watch scenario. otherwise, when this aspect throws errors, they'll be
+      // swallowed. (Jest errors are shown regardless via Jest, but if the tester is unable to run Jest in the first
+      // place, these errors won't be shown)
+      this.logger.off();
       await this.tester.watch(components, {
         watch,
         debug,

--- a/scopes/defender/tester/tester.graphql.ts
+++ b/scopes/defender/tester/tester.graphql.ts
@@ -40,11 +40,6 @@ export function testerSchema(tester: TesterMain, graphql: GraphqlMain): Schema {
         pending: Int
         duration: Int
         slow: Boolean
-        error: TestError
-      }
-
-      type TestError {
-        failureMessage: String
         error: String
       }
 

--- a/scopes/defender/tester/tester.graphql.ts
+++ b/scopes/defender/tester/tester.graphql.ts
@@ -40,7 +40,7 @@ export function testerSchema(tester: TesterMain, graphql: GraphqlMain): Schema {
         pending: Int
         duration: Int
         slow: Boolean
-        error: String
+        errorStr: String
       }
 
       type Tests {

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -112,7 +112,9 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       return acc;
     }, 0);
 
-    if (testCount === 0 && !options.ui) throw new NoTestFilesFound(this.patterns.join(','));
+    if (testCount === 0 && !options.ui) {
+      return { components: [] };
+    }
 
     if (!options.ui)
       this.logger.console(`testing ${componentWithTests} components with environment ${chalk.cyan(context.id)}\n`);

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -112,6 +112,7 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
     }, 0);
 
     if (testCount === 0 && !options.ui) {
+      this.logger.consoleWarning(`no tests found for environment ${chalk.cyan(context.id)}\n`);
       return { components: [] };
     }
 

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -12,7 +12,6 @@ import { Tester, Tests, CallbackFn } from './tester';
 import { TesterAspect } from './tester.aspect';
 import { TesterOptions } from './tester.main.runtime';
 import { detectTestFiles } from './utils';
-import { NoTestFilesFound } from './exceptions';
 
 const chalk = require('chalk');
 

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -158,10 +158,6 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
 
     const results = await tester.test(testerContext);
 
-    results.errors?.forEach((error) => {
-      this.logger.console(error?.message);
-    });
-
     return results;
   }
 }

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -70,17 +70,7 @@ export class TesterTask implements BuildTask {
     return {
       artifacts: getArtifactDef(), // @ts-ignore
       componentsResults: testsResults.components.map((componentTests) => {
-        const componentErrors = componentTests.results?.testFiles.reduce((errors: string[], file) => {
-          if (file?.error) {
-            errors.push(file.error);
-          }
-          file.tests.forEach((test) => {
-            if (test.error) errors.push(test.error);
-            if (test.failure) errors.push(test.failure);
-          });
-
-          return errors;
-        }, []);
+        const componentErrors = componentTests.errors;
         const component = context.capsuleNetwork.graphCapsules.getCapsule(componentTests.componentId)?.component;
         if (!component) {
           throw new Error(`unable to find ${componentTests.componentId.toString()} in capsules`);

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -55,7 +55,6 @@ export class TesterTask implements BuildTask {
     // TODO: remove after fix AbstractVinyl on capsule
     // @ts-ignore
     const testsResults = await tester.test(testerContext);
-    const generalErrorsMessages = flatten(testsResults.errors).map((err) => err.message) || [];
 
     // write junit files
     await Promise.all(
@@ -73,8 +72,8 @@ export class TesterTask implements BuildTask {
       artifacts: getArtifactDef(), // @ts-ignore
       componentsResults: testsResults.components.map((componentTests) => {
         const componentErrors = componentTests.results?.testFiles.reduce((errors: string[], file) => {
-          if (file?.error?.failureMessage) {
-            errors.push(file.error.failureMessage);
+          if (file?.error) {
+            errors.push(file.error);
           }
           file.tests.forEach((test) => {
             if (test.error) errors.push(test.error);
@@ -87,12 +86,11 @@ export class TesterTask implements BuildTask {
         if (!component) {
           throw new Error(`unable to find ${componentTests.componentId.toString()} in capsules`);
         }
-        const errors = (componentErrors || []).concat(generalErrorsMessages);
 
         return {
           component,
           metadata: { tests: componentTests.results },
-          errors,
+          errors: componentErrors,
         };
       }),
     };

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -1,7 +1,6 @@
 import { BuildContext, BuiltTaskResult, BuildTask, CAPSULE_ARTIFACTS_DIR } from '@teambit/builder';
 import fs from 'fs-extra';
 import { join } from 'path';
-import { flatten } from 'lodash';
 import { Compiler, CompilerAspect } from '@teambit/compiler';
 import { DevFilesMain } from '@teambit/dev-files';
 import { ComponentMap } from '@teambit/component';

--- a/scopes/defender/tester/tester.ts
+++ b/scopes/defender/tester/tester.ts
@@ -5,7 +5,7 @@ import { TestsResult } from '@teambit/tests-results';
 
 export type Tests = {
   components: ComponentsResults[];
-  errors?: Error[];
+  errors?: Error[]; // global errors for watch
 };
 
 export type ComponentsResults = {

--- a/scopes/defender/tester/tester.ts
+++ b/scopes/defender/tester/tester.ts
@@ -5,7 +5,7 @@ import { TestsResult } from '@teambit/tests-results';
 
 export type Tests = {
   components: ComponentsResults[];
-  errors?: Error[]; // global errors for watch
+  errors?: Error[]; // aggregated errors from all components
 };
 
 export type ComponentsResults = {
@@ -17,6 +17,10 @@ export type ComponentsResults = {
    * test results for the component.
    */
   results?: TestsResult;
+  /**
+   * aggregated errors from all files
+   */
+  errors?: Error[];
 
   /**
    * loading.

--- a/scopes/defender/tester/ui/tests-page.tsx
+++ b/scopes/defender/tester/ui/tests-page.tsx
@@ -22,7 +22,7 @@ const TESTS_SUBSCRIPTION_CHANGED = gql`
           pass
           failed
           pending
-          error
+          errorStr
           tests {
             ancestor
             duration
@@ -49,7 +49,7 @@ const GET_COMPONENT = gql`
             pass
             failed
             pending
-            error
+            errorStr
             tests {
               ancestor
               duration

--- a/scopes/defender/tester/ui/tests-page.tsx
+++ b/scopes/defender/tester/ui/tests-page.tsx
@@ -22,9 +22,7 @@ const TESTS_SUBSCRIPTION_CHANGED = gql`
           pass
           failed
           pending
-          error {
-            failureMessage
-          }
+          error
           tests {
             ancestor
             duration
@@ -39,7 +37,7 @@ const TESTS_SUBSCRIPTION_CHANGED = gql`
 `;
 
 const GET_COMPONENT = gql`
-  query($id: String!) {
+  query ($id: String!) {
     getHost {
       id # for GQL caching
       getTests(id: $id) {
@@ -51,9 +49,7 @@ const GET_COMPONENT = gql`
             pass
             failed
             pending
-            error {
-              failureMessage
-            }
+            error
             tests {
               ancestor
               duration

--- a/scopes/defender/tester/utils/junit-generator.ts
+++ b/scopes/defender/tester/utils/junit-generator.ts
@@ -10,9 +10,9 @@ export function testsResultsToJUnitFormat(components: ComponentsResults[]): stri
       suite.timestamp(new Date(compResult.results?.start).toISOString());
     }
     compResult.results?.testFiles.forEach((testFile) => {
-      if (testFile.error?.error) {
+      if (testFile.error) {
         const testCase = suite.testCase().className(testFile.file).name(testFile.file);
-        testCase.error(stripAnsi(testFile.error.error as string));
+        testCase.error(stripAnsi(testFile.error as string));
       }
       testFile.tests.forEach((test) => {
         const testCase = suite.testCase().className(testFile.file).name(test.name);

--- a/scopes/defender/tester/utils/junit-generator.ts
+++ b/scopes/defender/tester/utils/junit-generator.ts
@@ -12,7 +12,7 @@ export function testsResultsToJUnitFormat(components: ComponentsResults[]): stri
     compResult.results?.testFiles.forEach((testFile) => {
       if (testFile.error) {
         const testCase = suite.testCase().className(testFile.file).name(testFile.file);
-        testCase.error(stripAnsi(testFile.error as string));
+        testCase.error(stripAnsi(testFile.error.message as string));
       }
       testFile.tests.forEach((test) => {
         const testCase = suite.testCase().className(testFile.file).name(test.name);

--- a/scopes/defender/tests-results/tests-files.ts
+++ b/scopes/defender/tests-results/tests-files.ts
@@ -1,10 +1,4 @@
 import { TestResult } from './test-results';
-
-export type Error = {
-  failureMessage?: string | null;
-  error?: string;
-};
-
 export class TestsFiles {
   constructor(
     public file: string,
@@ -21,7 +15,7 @@ export class TestsFiles {
 
     public slow?: boolean,
 
-    public error?: Error
+    public error?: string
   ) {}
 
   get totalTests() {

--- a/scopes/defender/tests-results/tests-files.ts
+++ b/scopes/defender/tests-results/tests-files.ts
@@ -1,4 +1,5 @@
 import { TestResult } from './test-results';
+
 export class TestsFiles {
   constructor(
     public file: string,

--- a/scopes/defender/tests-results/tests-files.ts
+++ b/scopes/defender/tests-results/tests-files.ts
@@ -16,10 +16,15 @@ export class TestsFiles {
 
     public slow?: boolean,
 
-    public error?: string
+    public error?: Error
   ) {}
 
   get totalTests() {
     return this.tests.length;
+  }
+
+  get errorStr() {
+    if (!this.error) return undefined;
+    return this.error.message;
   }
 }

--- a/scopes/defender/ui/test-table/test-table.tsx
+++ b/scopes/defender/ui/test-table/test-table.tsx
@@ -17,7 +17,7 @@ export function TestTable({ testResults, ...rest }: TestTableProps) {
   return (
     <div {...rest}>
       {testResults.map((testFile, index) => {
-        const testHasErrors = testFile?.error?.failureMessage;
+        const testHasErrors = testFile?.error;
         const borderColor = testFile.failed > 0 || testHasErrors ? '#e62e5c' : '#37b26c';
         return (
           <div key={index} className={styles.testTable}>

--- a/scopes/defender/ui/test-table/test-table.tsx
+++ b/scopes/defender/ui/test-table/test-table.tsx
@@ -17,7 +17,7 @@ export function TestTable({ testResults, ...rest }: TestTableProps) {
   return (
     <div {...rest}>
       {testResults.map((testFile, index) => {
-        const testHasErrors = testFile?.error;
+        const testHasErrors = testFile?.errorStr;
         const borderColor = testFile.failed > 0 || testHasErrors ? '#e62e5c' : '#37b26c';
         return (
           <div key={index} className={styles.testTable}>

--- a/scopes/envs/envs/runtime/runtime.ts
+++ b/scopes/envs/envs/runtime/runtime.ts
@@ -83,7 +83,7 @@ export class Runtime {
         };
       } catch (err: any) {
         this.logger.error(err.message, err);
-        this.logger.consoleFailure(`service ${service.name} env ${env.id} has failed. ${err.message}`);
+        this.logger.consoleFailure(`service "${service.name}" of env "${env.id}" has failed. error: ${err.message}`);
         errors.push(err);
         return {
           env,

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -278,7 +278,6 @@
         "multimatch": "5.0.0",
         "nanoid": "3.1.20",
         "nerf-dart": "1.0.0",
-        "open-editor": "3.0.0",
         "p-limit": "3.1.0",
         "parallel-webpack": "2.6.0",
         "parse-package-name": "0.1.0",


### PR DESCRIPTION
## Proposed Changes

- a major refactoring to the way how errors are handled for tests. During "bit test", "bit build" and "bit start".
- currently, errors are saved as "general-errors" and shown in bit-build for each one of the component. So the exact same error will be shown 10 times, if there are 10 components. This is fixed to not show duplicate errors.
- change the `error` of the `testFiles` to be string, no need to have two properties: `failureMessage` and `error`. Only the "error" is needed because if Jest encountered an issue, e.g. syntax error, it'll report it as error. The failureMessage of Jest is just an aggregation of the failures of all individual tests. The only place this failureMessage is needed is when running `bit start`, which for some reason the error is empty and the `failureMessage` has the error. 
- enable the logger for non-watch, so then errors coming from the envs aspect are correctly printed to the terminal. (this covers the case of https://github.com/teambit/bit/pull/5422 which its code is reverted in this PR).
- add e2e-tests to cover bit-test and bit build for the following: passed tests, failed tests, tests with errors, and invalid Jest config (or in general, a specific tester is unable to start).