### PR TITLE
revert react-dev-utils to v11.0.4

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -295,7 +295,7 @@
         "process": "0.11.10",
         "query-string": "7.0.0",
         "react-animate-height": "2.0.23",
-        "react-dev-utils": "12.0.0",
+        "react-dev-utils": "11.0.4",
         "react-error-boundary": "^3.0.0",
         "react-error-overlay": "6.0.10",
         "react-flow-renderer": "8.3.7",
@@ -620,6 +620,12 @@
     },
     "scopes/mdx": {
       "defaultScope": "teambit.mdx"
+    },
+    "scopes/base-react": {
+      "defaultScope": "teambit.base-react",
+      "teambit.envs/envs": {
+        "env": "teambit.react/react"
+      }
     },
     "scopes/design": {
       "defaultScope": "teambit.design",


### PR DESCRIPTION
## Proposed Changes

- change react-dev-utils from v12.0.0 to v11.0.4 because of node compatability
- this was the previous version we used, and there doesn't seem to be a lot of difference between the versions.
-
