### PR TITLE
fix error 'process'

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -298,7 +298,7 @@
         "react-animate-height": "2.0.23",
         "react-dev-utils": "11.0.4",
         "react-error-boundary": "^3.0.0",
-        "react-error-overlay": "6.0.10",
+        "react-error-overlay": "6.0.9", // 6.0.10 breaks hot reloading
         "react-flow-renderer": "8.3.7",
         "react-popper": "2.2.4",
         "react-router-dom": "5.2.0",


### PR DESCRIPTION
## Proposed Changes

Downgraded `react-error-overlay` back to 6.0.9.
Version 6.0.10 is only compatible with `react-dev-utils` v12, which is not compatible with node 12 :(

Fixes this error:
```
Uncaught ReferenceError: process is not defined
    at Object.4043 (<anonymous>:2:13168)
    at r (<anonymous>:2:306599)
    at Object.8048 (<anonymous>:2:9496)
    at r (<anonymous>:2:306599)
    at Object.8641 (<anonymous>:2:1379)
    at r (<anonymous>:2:306599)
    at <anonymous>:2:315627
    at <anonymous>:2:324225
    at <anonymous>:2:324229
    at HTMLIFrameElement.e.onload (main.bundle.js:182081:370
```
