### PR TITLE
ts "no emit" in new react workspaces

### DIFF
--- a/scopes/react/react/templates/workspace-common/files/ts-config.ts
+++ b/scopes/react/react/templates/workspace-common/files/ts-config.ts
@@ -1,6 +1,9 @@
 export const tsConfig = `{
   "extends": "./node_modules/@teambit/react/typescript/tsconfig.json",
   // "include": [],
+  "compilerOptions": {
+    "noEmit": true
+  },
   "exclude": [
     "dist"
   ]


### PR DESCRIPTION
## Proposed Changes

- add `"noEmit": true` to the compiler options in the tsconfig file of new workspaces template

this allows users to run `tsc -w` without emitting transpiled files
