### PR TITLE
introduce homebrewed react webpack transformer - inject to body

### DIFF
--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -33,6 +33,7 @@ import { ReactEnv } from './react.env';
 import { ReactAppType } from './apps/web';
 import { reactSchema } from './react.graphql';
 import { componentTemplates, workspaceTemplates } from './react.templates';
+import { BodyInjectionTransformer } from './transformers-webpack/body-injection-transformer';
 
 type ReactDeps = [
   EnvsMain,
@@ -363,6 +364,10 @@ export class ReactMain {
       properties: docs.properties,
     };
   }
+
+  webpackTransformers = {
+    bodyInjector: BodyInjectionTransformer,
+  };
 
   static runtime = MainRuntime;
   static dependencies = [

--- a/scopes/react/react/transformers-webpack/body-injection-transformer.ts
+++ b/scopes/react/react/transformers-webpack/body-injection-transformer.ts
@@ -1,0 +1,16 @@
+import InjectBodyPlugin from 'inject-body-webpack-plugin';
+import type { WebpackConfigTransformer } from '@teambit/webpack';
+
+export type BodyInjectionOptions = {
+  content: string;
+  position?: 'start' | 'end';
+};
+
+export function BodyInjectionTransformer(options: BodyInjectionOptions): WebpackConfigTransformer {
+  return (config) => {
+    // @ts-ignore - https://github.com/Jaid/inject-body-webpack-plugin/issues/12
+    const plugin = new InjectBodyPlugin(options);
+
+    return config.addPlugin(plugin);
+  };
+}

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -255,6 +255,7 @@
         "humanize-duration": "3.23.1",
         "humanize-string": "2.1.0",
         "ini": "2.0.0",
+        "inject-body-webpack-plugin": "1.3.0",
         "is-primitive": "3.0.1",
         "jest": "26.6.3",
         "jest-message-util": "26.6.2",


### PR DESCRIPTION
## Proposed Changes

- add new transformer bodyInjector (TBD) for consumers to use

when using `inject-body-webpack-plugin` in a different workspace, it installs a different instance of WebpackHtmlPlugin. It uses this instance during build, and so misses to run.
installing the plugin directly in bit solves it