### PR TITLE
bump penpal (fix postmessage errors)

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -285,7 +285,7 @@
         "parallel-webpack": "2.6.0",
         "parse-package-name": "0.1.0",
         "path-to-regexp": "6.2.0",
-        "penpal": "6.2.1",
+        "penpal": "6.2.2",
         "pluralize": "8.0.0",
         "postcss": "8.2.9",
         "postcss-flexbugs-fixes": "5.0.2",


### PR DESCRIPTION
## Proposed Changes

- bumping penpal to v6.2.2 to benefit from https://github.com/Aaronius/penpal/issues/85#issuecomment-1062741357
- the new version fix an error showing up in the console  
  `Cannot read properties of null (reading 'postMessage')`
- the error was benign, happened when penpal tried to establish a connection with a closed iframe.