### PR TITLE
Env template bundler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -879,6 +879,7 @@ jobs:
       - run: 'echo "starting harmony deploy"'
 
   e2e_test:
+    resource_class: large
     <<: *defaults
     environment:
       # change the npm config to avoid using sudo
@@ -912,6 +913,7 @@ jobs:
           # command: cd bit && npm run e2e-test-circle --debug
           environment:
             MOCHA_FILE: junit/e2e-test-results.xml
+            NODE_OPTIONS: --max_old_space_size=8000
           when: always
       - store_test_results:
           path: bit/junit

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -879,7 +879,6 @@ jobs:
       - run: 'echo "starting harmony deploy"'
 
   e2e_test:
-    resource_class: large
     <<: *defaults
     environment:
       # change the npm config to avoid using sudo
@@ -913,7 +912,6 @@ jobs:
           # command: cd bit && npm run e2e-test-circle --debug
           environment:
             MOCHA_FILE: junit/e2e-test-results.xml
-            NODE_OPTIONS: --max_old_space_size=8000
           when: always
       - store_test_results:
           path: bit/junit

--- a/scopes/envs/envs/environment.ts
+++ b/scopes/envs/envs/environment.ts
@@ -57,6 +57,31 @@ export interface DependenciesEnv extends Environment {
    * Required for any task
    */
   getDependencies?: () => EnvPolicyConfigObject | Promise<EnvPolicyConfigObject>;
+
+  /**
+   * Returns a list of additional host dependencies
+   * this list will be provided as globals on the window after bit preview bundle
+   * by default bit will merge this list with the peers from the getDependencies function
+   * If you want full control use the getHostDependencies function
+   */
+  getAdditionalHostDependencies?: () => string[] | Promise<string[]>;
+
+  /**
+   * Returns a list of host dependencies
+   * this list will be provided as globals on the window after bit preview bundle
+   * If this is provided, bit won't merge getAdditionalHostDependencies and the peers from getDependencies
+   * but give you full control over the list
+   *
+   * The reason we provided both options is the following:
+   * in most cases when you override the deps from you env, you want bit to take your peers
+   * however, if we only provide the getHostDependencies, during the env composition, you will get the peers of the
+   * original env. which doesn't contain your peers.
+   * In that case you might think that we only need the first option of getAdditionalHostDependencies + getDependencies peers
+   * but there are cases when you want a peer to your component, but you don't want it as part of the bundle.
+   * such an example is react-native env which adds react-native as peer, but you don't want it in the bundle as it's not web compatible
+   * so you want full control over it
+   */
+  getHostDependencies?: () => string[] | Promise<string[]>;
 }
 
 export type GetNpmIgnoreContext = {

--- a/scopes/envs/envs/environment.ts
+++ b/scopes/envs/envs/environment.ts
@@ -115,6 +115,13 @@ export interface PreviewEnv extends Environment {
    * Returns preview config like the strategy name to use when bundling the components for the preview
    */
   getPreviewConfig?: () => EnvPreviewConfig;
+
+  /**
+   * Returns a bundler for the env template.
+   * this bundler will be used to bundle the docs/compositions (or other preview) apps
+   * Required for `bit build` & `bit tag`
+   */
+  getTemplateBundler?: (context: BundlerContext, transformers?: any[]) => Promise<Bundler>;
 }
 
 export interface ElementsEnv extends Environment {

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -425,7 +425,7 @@ export class EnvsMain {
     return envsAspect?.config.env;
   }
 
-  private getEnvDefinitionById(id: ComponentID): EnvDefinition | undefined {
+  getEnvDefinitionById(id: ComponentID): EnvDefinition | undefined {
     const envDef =
       this.getEnvDefinitionByStringId(id.toString()) ||
       this.getEnvDefinitionByStringId(id.toString({ ignoreVersion: true }));
@@ -443,6 +443,14 @@ export class EnvsMain {
   getEnvFromComponent(envComponent: Component) {
     const env = this.getEnvDefinitionById(envComponent.id);
     return env;
+  }
+
+  /**
+   * Return the env definition of teambit.envs/env
+   */
+  getEnvsEnvDefinition(): EnvDefinition {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return this.getEnvDefinitionByStringId('teambit.envs/env')!;
   }
 
   private printWarningIfFirstTime(envId: string, message: string) {

--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -5,6 +5,8 @@ import { TsConfigSourceFile } from 'typescript';
 import { ReactEnv } from '@teambit/react';
 import { CAPSULE_ARTIFACTS_DIR } from '@teambit/builder';
 import type { AspectLoaderMain } from '@teambit/aspect-loader';
+import { Bundler, BundlerContext } from '@teambit/bundler';
+import { WebpackConfigTransformer } from '@teambit/webpack';
 
 const tsconfig = require('./typescript/tsconfig.json');
 
@@ -31,6 +33,10 @@ export class AspectEnv implements DependenciesEnv {
 
   createTsCompiler(tsConfig: TsConfigSourceFile): Compiler {
     return this.reactEnv.getCompiler(this.getTsConfig(tsConfig));
+  }
+
+  async getTemplateBundler(context: BundlerContext, transformers: WebpackConfigTransformer[] = []): Promise<Bundler> {
+    return this.reactEnv.createTemplateWebpackBundler(context, transformers);
   }
 
   getNpmIgnore(context: GetNpmIgnoreContext) {

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -90,7 +90,7 @@ export class EnvPreviewTemplateTask implements BuildTask {
       externalizePeer: false,
       development: context.dev,
     });
-    const bundlerResults = await mapSeries(Object.entries(groups), async ([envId, targetsGroup]) => {
+    const bundlerResults = await mapSeries(Object.entries(groups), async ([, targetsGroup]) => {
       bundlerContext.targets = targetsGroup.targets;
       const bundler: Bundler = await targetsGroup.env.getTemplateBundler(bundlerContext);
       const bundlerResult = await bundler.run();

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -80,7 +80,6 @@ export class EnvPreviewTemplateTask implements BuildTask {
         return undefined;
       })
     );
-    console.log('grouped', grouped);
     return this.runBundlerForGroups(context, grouped);
   }
 
@@ -95,13 +94,10 @@ export class EnvPreviewTemplateTask implements BuildTask {
       bundlerContext.targets = targetsGroup.targets;
       const bundler: Bundler = await targetsGroup.env.getTemplateBundler(bundlerContext);
       const bundlerResult = await bundler.run();
-      console.log('bundlerResult', envId, bundlerResult);
       return bundlerResult;
     });
 
     const results = await this.computeResults(bundlerContext, flatten(bundlerResults));
-    console.log('results', results);
-
     return results;
   }
 

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -13,7 +13,7 @@ import { Capsule } from '@teambit/isolator';
 import { Bundler, BundlerContext, BundlerEntryMap, BundlerHtmlConfig, BundlerResult, Target } from '@teambit/bundler';
 import type { EnvDefinition, Environment, EnvsMain } from '@teambit/envs';
 import { join } from 'path';
-import { cloneDeep, compact, flatten } from 'lodash';
+import { cloneDeep, compact, flatten, isEmpty } from 'lodash';
 import { existsSync, mkdirpSync } from 'fs-extra';
 import type { PreviewMain } from './preview.main.runtime';
 import { PreviewDefinition } from '.';
@@ -80,6 +80,9 @@ export class EnvPreviewTemplateTask implements BuildTask {
         return undefined;
       })
     );
+    if (isEmpty(grouped)) {
+      return { componentsResults: [] };
+    }
     return this.runBundlerForGroups(context, grouped);
   }
 

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -6,12 +6,14 @@ import {
   ComponentResult,
   CAPSULE_ARTIFACTS_DIR,
 } from '@teambit/builder';
+import mapSeries from 'p-map-series';
 import { Component, ComponentMap } from '@teambit/component';
+import { AspectLoaderMain } from '@teambit/aspect-loader';
 import { Capsule } from '@teambit/isolator';
 import { Bundler, BundlerContext, BundlerEntryMap, BundlerHtmlConfig, BundlerResult, Target } from '@teambit/bundler';
-import type { EnvDefinition, EnvsMain } from '@teambit/envs';
+import type { EnvDefinition, Environment, EnvsMain } from '@teambit/envs';
 import { join } from 'path';
-import { cloneDeep, compact } from 'lodash';
+import { cloneDeep, compact, flatten } from 'lodash';
 import { existsSync, mkdirpSync } from 'fs-extra';
 import type { PreviewMain } from './preview.main.runtime';
 import { PreviewDefinition } from '.';
@@ -21,6 +23,14 @@ export type ModuleExpose = {
   name: string;
   path: string;
   include?: string[];
+};
+
+type TargetsGroup = {
+  env: Environment;
+  targets: Target[];
+};
+type TargetsGroupMap = {
+  [envId: string]: TargetsGroup;
 };
 
 export const GENERATE_ENV_TEMPLATE_TASK_NAME = 'GenerateEnvTemplate';
@@ -33,82 +43,115 @@ export class EnvPreviewTemplateTask implements BuildTask {
   location: TaskLocation = 'end';
   // readonly dependencies = [CompilerAspect.id];
 
-  constructor(private preview: PreviewMain, private envs: EnvsMain) {}
+  constructor(private preview: PreviewMain, private envs: EnvsMain, private aspectLoader: AspectLoaderMain) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
     const previewDefs = this.preview.getDefs();
     const htmlConfig = this.generateHtmlConfig(previewDefs, PREVIEW_ROOT_CHUNK_NAME, PEERS_CHUNK_NAME, {
       dev: context.dev,
     });
-    const targets: Target[] = compact(
-      await Promise.all(
-        context.components.map(async (component) => {
-          const envDef = this.envs.getEnvFromComponent(component);
-          if (!envDef) return undefined;
-          const env = envDef.env;
-          const bundlingStrategy = this.preview.getBundlingStrategy(envDef.env);
-          if (bundlingStrategy.name === 'env') {
-            return undefined;
-          }
-          const envComponent = component;
-          const envPreviewConfig = this.preview.getEnvPreviewConfig(envDef.env);
-          const isSplitComponentBundle = envPreviewConfig.splitComponentBundle ?? false;
-          const envGetDeps = (await env.getDependencies()) || {};
-          const envComponentPeers = Object.keys(envGetDeps.peerDependencies || {}) || [];
-          const envHostDeps = env.getHostDependencies() || [];
-          const peers = envComponentPeers.concat(envHostDeps);
-
-          // const module = await this.getPreviewModule(envComponent);
-          // const entries = Object.keys(module).map((key) => module.exposes[key]);
-          const capsule = context.capsuleNetwork.graphCapsules.getCapsule(envComponent.id);
-          if (!capsule) throw new Error('no capsule found');
-          // Passing here the env itself to make sure it's preview runtime will be part of the preview root file
-          // that's needed to make sure the providers register there are running correctly
-          const previewRoot = await this.preview.writePreviewRuntime(context, [envComponent.id.toString()]);
-          const previewModules = await this.getPreviewModules(envDef);
-          // const templatesFile = previewModules.map((template) => {
-          //   return this.preview.writeLink(template.name, ComponentMap.create([]), template.path, capsule.path);
-          // });
-          const outputPath = this.computeOutputPath(context, envComponent);
-          if (!existsSync(outputPath)) mkdirpSync(outputPath);
-          const entries = this.getEntries(previewModules, capsule, previewRoot, isSplitComponentBundle, peers);
-
-          // const entries = this.getEntries(
-          //   previewModules.concat({
-          //     name: 'main',
-          //     path: previewRoot,
-          //   })
-          // );
-
-          return {
-            // entries: templatesFile.concat(previewRoot),
-            peers,
-            runtimeChunkName: 'runtime',
-            html: htmlConfig,
-            entries,
-            chunking: {
-              splitChunks: true,
-            },
-            components: [envComponent],
-            outputPath,
-            // modules: [module],
+    const grouped: TargetsGroupMap = {};
+    await Promise.all(
+      context.components.map(async (component) => {
+        const envDef = this.envs.getEnvFromComponent(component);
+        if (!envDef) return undefined;
+        const env = envDef.env;
+        const bundlingStrategy = this.preview.getBundlingStrategy(envDef.env);
+        if (bundlingStrategy.name === 'env') {
+          return undefined;
+        }
+        const target = await this.getEnvTargetFromComponent(context, component, envDef, htmlConfig);
+        if (!target) return undefined;
+        const shouldUseDefaultBundler = this.shouldUseDefaultBundler(envDef);
+        let envToGetBundler = this.envs.getEnvsEnvDefinition().env;
+        let groupEnvId = 'default';
+        if (!shouldUseDefaultBundler) {
+          envToGetBundler = env;
+          groupEnvId = envDef.id;
+        }
+        if (!grouped[groupEnvId]) {
+          grouped[groupEnvId] = {
+            env: envToGetBundler,
+            targets: [target],
           };
-        })
-      )
+        } else {
+          grouped[groupEnvId].targets.push(target);
+        }
+        return undefined;
+      })
     );
+    console.log('grouped', grouped);
+    return this.runBundlerForGroups(context, grouped);
+  }
 
-    if (!targets.length) return { componentsResults: [] };
+  private async runBundlerForGroups(context: BuildContext, groups: TargetsGroupMap): Promise<BuiltTaskResult> {
     const bundlerContext: BundlerContext = Object.assign(cloneDeep(context), {
-      targets,
+      targets: [],
       entry: [],
       externalizePeer: false,
       development: context.dev,
     });
+    const bundlerResults = await mapSeries(Object.entries(groups), async ([envId, targetsGroup]) => {
+      bundlerContext.targets = targetsGroup.targets;
+      const bundler: Bundler = await targetsGroup.env.getTemplateBundler(bundlerContext);
+      const bundlerResult = await bundler.run();
+      console.log('bundlerResult', envId, bundlerResult);
+      return bundlerResult;
+    });
 
-    const bundler: Bundler = await context.env.getBundler(bundlerContext);
-    const bundlerResults = await bundler.run();
-    const results = await this.computeResults(bundlerContext, bundlerResults);
+    const results = await this.computeResults(bundlerContext, flatten(bundlerResults));
+    console.log('results', results);
+
     return results;
+  }
+
+  private shouldUseDefaultBundler(envDef: EnvDefinition): boolean {
+    if (this.aspectLoader.isCoreEnv(envDef.id)) return true;
+    const env = envDef.env;
+    if (env.getTemplateBundler && typeof env.getTemplateBundler === 'function') return false;
+    return true;
+  }
+
+  private async getEnvTargetFromComponent(
+    context: BuildContext,
+    envComponent: Component,
+    envDef: EnvDefinition,
+    htmlConfig: BundlerHtmlConfig[]
+  ): Promise<Target | undefined> {
+    const env = envDef.env;
+    const envPreviewConfig = this.preview.getEnvPreviewConfig(envDef.env);
+    const isSplitComponentBundle = envPreviewConfig.splitComponentBundle ?? false;
+    const envGetDeps = (await env.getDependencies()) || {};
+    const envComponentPeers = Object.keys(envGetDeps.peerDependencies || {}) || [];
+    const envHostDeps = env.getHostDependencies() || [];
+    const peers = envComponentPeers.concat(envHostDeps);
+
+    // const module = await this.getPreviewModule(envComponent);
+    // const entries = Object.keys(module).map((key) => module.exposes[key]);
+    const capsule = context.capsuleNetwork.graphCapsules.getCapsule(envComponent.id);
+    if (!capsule) throw new Error('no capsule found');
+    // Passing here the env itself to make sure it's preview runtime will be part of the preview root file
+    // that's needed to make sure the providers register there are running correctly
+    const previewRoot = await this.preview.writePreviewRuntime(context, [envComponent.id.toString()]);
+    const previewModules = await this.getPreviewModules(envDef);
+    // const templatesFile = previewModules.map((template) => {
+    //   return this.preview.writeLink(template.name, ComponentMap.create([]), template.path, capsule.path);
+    // });
+    const outputPath = this.computeOutputPath(context, envComponent);
+    if (!existsSync(outputPath)) mkdirpSync(outputPath);
+    const entries = this.getEntries(previewModules, capsule, previewRoot, isSplitComponentBundle, peers);
+
+    return {
+      peers,
+      runtimeChunkName: 'runtime',
+      html: htmlConfig,
+      entries,
+      chunking: {
+        splitChunks: true,
+      },
+      components: [envComponent],
+      outputPath,
+    };
   }
 
   private generateHtmlConfig(
@@ -190,25 +233,23 @@ export class EnvPreviewTemplateTask implements BuildTask {
     );
 
     return entries;
-
-    // const mergedEntries = return entriesArr.reduce((entriesMap, entry) => {
-    //   entriesMap[entry.library.name] = entry;
-    //   return entriesMap;
-    // }, {previewRoot: previewRootEntry});
   }
 
   async computeResults(context: BundlerContext, results: BundlerResult[]) {
-    const result = results[0];
-
-    const componentsResults: ComponentResult[] = result.components.map((component) => {
-      return {
-        component,
-        errors: result.errors.map((err) => (typeof err === 'string' ? err : err.message)),
-        warning: result.warnings,
-        startTime: result.startTime,
-        endTime: result.endTime,
-      };
+    const allResults = results.map((result) => {
+      const componentsResults: ComponentResult[] = result.components.map((component) => {
+        return {
+          component,
+          errors: result.errors.map((err) => (typeof err === 'string' ? err : err.message)),
+          warning: result.warnings,
+          startTime: result.startTime,
+          endTime: result.endTime,
+        };
+      });
+      return componentsResults;
     });
+
+    const componentsResults = flatten(allResults);
 
     const artifacts = getArtifactDef();
 
@@ -242,26 +283,6 @@ export class EnvPreviewTemplateTask implements BuildTask {
     if (!capsule) throw new Error('no capsule found');
     return join(capsule.path, getArtifactDirectory());
   }
-
-  // private async getPreviewModule(envComponent: Component): Promise<ModuleTarget> {
-  //   const env = this.envs.getEnv(envComponent);
-  //   const previewDefs = this.preview.getDefs();
-  //   const modules = compact(await Promise.all(previewDefs.map(async (def) => {
-  //     if (!def.renderTemplatePathByEnv) return undefined;
-  //     return [def.prefix, await def.renderTemplatePathByEnv(env.env)];
-  //   })));
-
-  //   const exposes = modules.reduce((exposesAcc, [prefix, path]) => {
-  //     const internalPath = `./${prefix}`;
-  //     exposesAcc[internalPath] = path;
-  //     return exposesAcc;
-  //   }, {});
-
-  //   return {
-  //     component: envComponent,
-  //     exposes
-  //   };
-  // }
 }
 
 export function getArtifactDirectory() {
@@ -272,10 +293,8 @@ export function getArtifactDef() {
   return [
     {
       name: 'env-template',
-      // globPatterns: [`${getArtifactDirectory()}/**`],
       globPatterns: ['**'],
       rootDir: getArtifactDirectory(),
-      // context: env,
     },
   ];
 }

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -552,7 +552,10 @@ export class PreviewMain {
     ]);
 
     if (!config.disabled)
-      builder.registerBuildTasks([new EnvPreviewTemplateTask(preview, envs), new PreviewTask(bundler, preview)]);
+      builder.registerBuildTasks([
+        new EnvPreviewTemplateTask(preview, envs, aspectLoader),
+        new PreviewTask(bundler, preview),
+      ]);
 
     if (workspace) {
       workspace.registerOnComponentAdd((c) =>

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -232,7 +232,7 @@ export class ReactEnv
     const baseConfig = basePreviewConfigFactory(false);
     const envDevConfig = envPreviewDevConfigFactory(context.id);
     const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
-    const peers = this.getAllHostDeps();
+    const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
@@ -251,7 +251,7 @@ export class ReactEnv
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = []
   ): Promise<Bundler> {
-    const peers = this.getAllHostDeps();
+    const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
@@ -269,7 +269,7 @@ export class ReactEnv
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = []
   ): Promise<Bundler> {
-    const peers = this.getAllHostDeps();
+    const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
@@ -292,13 +292,14 @@ export class ReactEnv
   /**
    * Get the peers configured by the env on the components + the host deps configured by the env
    */
-  private getAllHostDeps() {
-    const hostDeps = this.getHostDependencies();
-    const peers = Object.keys(this.getDependencies().peerDependencies).concat(hostDeps);
+  getAllHostDependencies() {
+    const envComponentPeers = Object.keys(this.getDependencies().peerDependencies || {}) || [];
+    const additionalHostDeps = this.getAdditionalHostDependencies() || [];
+    const peers = envComponentPeers.concat(additionalHostDeps);
     return peers;
   }
 
-  getHostDependencies(): string[] {
+  getAdditionalHostDependencies(): string[] {
     return ['@teambit/mdx.ui.mdx-scope-context', '@mdx-js/react'];
   }
 


### PR DESCRIPTION
## Proposed Changes

- add new `getTemplateBundler` API to the envs API interface
- add new `getAdditionalHostDependencies` and `getHostDependencies` API to the envs API interface
- expose `getAdditionalHostDependencies` from react env
- override `getHostDependencies` for react-native env, to filter out react-native from the bundle
- add a new API to get the `teambit.envs/env` env definition
- Add new APIs to react env: `createComponentsWebpackBundler` and `createTemplateWebpackBundler`
- implement `getTemplateBundler` for aspect env to be used as a default bundler for envs templates
- use `getTemplateBundler` from the env if exist or fallback to default one when bundling the env template
- re-write the entire bundling logic for env templates
- only bundle component which are original seeders in the `env-preview-template` task
- support both `getHostDependencies` and `getAdditionalHostDependencies` during `env-preview-template` task
