### PR TITLE
consider envs using the env env as valid aspects when loading workspace aspects

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1288,8 +1288,9 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
       const component = await this.get(id);
       const data = this.envs.getEnvData(component);
       const isUsingAspectEnv = this.envs.isUsingAspectEnv(component);
-
-      if (!isUsingAspectEnv && idsWithoutCore.includes(component.id.toString())) {
+      const isUsingEnvEnv = this.envs.isUsingEnvEnv(component);
+      const isValidAspect = isUsingAspectEnv || isUsingEnvEnv;
+      if (!isValidAspect && idsWithoutCore.includes(component.id.toString())) {
         const err = new IncorrectEnvAspect(component.id.toString(), data.type, data.id);
         if (data.id === DEFAULT_ENV) {
           // when cloning a project, or when the node-modules dir is deleted, nothing works and all
@@ -1300,7 +1301,7 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
           throw err;
         }
       }
-      return isUsingAspectEnv;
+      return isValidAspect;
     };
 
     const graph = await this.getAspectsGraphWithoutCore(components, isAspect);


### PR DESCRIPTION
fixing error:
```
"<env id>" is configured in workspace.json, but using the "teambit.envs/env" environment, which is type "env".
please make sure to either apply the aspect environment or a composition of the aspect environment for the aspect to load.
```