### PR TITLE
allow config in component template to be a function that return config

### DIFF
--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -43,6 +43,13 @@ export interface ComponentContext {
   componentId: ComponentID;
 }
 
+export interface ConfigContext {
+  /**
+   * Aspect id of the aspect that register the template itself
+   */
+  aspectId: string;
+}
+
 export type ComponentConfig = { [aspectName: string]: any };
 
 export interface ComponentTemplate {
@@ -73,5 +80,5 @@ export interface ComponentTemplate {
    *    "env": "teambit.harmony/aspect"
    * },
    */
-  config?: ComponentConfig;
+  config?: ComponentConfig | ((context: ConfigContext) => ComponentConfig);
 }

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -117,13 +117,13 @@ export class GeneratorMain {
   /**
    * returns a specific component template.
    */
-  getComponentTemplate(name: string, aspectId?: string): ComponentTemplate | undefined {
+  getComponentTemplate(name: string, aspectId?: string): { id: string; template: ComponentTemplate } | undefined {
     const templates = this.getAllComponentTemplatesFlattened();
     const found = templates.find(({ id, template }) => {
       if (aspectId && id !== aspectId) return false;
       return template.name === name;
     });
-    return found?.template;
+    return found;
   }
 
   /**
@@ -198,8 +198,8 @@ export class GeneratorMain {
     if (!this.workspace) throw new ConsumerNotFound();
     await this.loadAspects();
     const { namespace, aspect: aspectId } = options;
-    const template = this.getComponentTemplate(templateName, aspectId);
-    if (!template) throw new BitError(`template "${templateName}" was not found`);
+    const templateWithId = this.getComponentTemplate(templateName, aspectId);
+    if (!templateWithId) throw new BitError(`template "${templateName}" was not found`);
 
     const componentIds = componentNames.map((componentName) =>
       this.newComponentHelper.getNewComponentId(componentName, namespace, options.scope)
@@ -209,9 +209,10 @@ export class GeneratorMain {
       this.workspace,
       componentIds,
       options,
-      template,
+      templateWithId.template,
       this.envs,
-      this.newComponentHelper
+      this.newComponentHelper,
+      templateWithId.id
     );
     return componentGenerator.generate();
   }

--- a/scopes/generator/generator/index.ts
+++ b/scopes/generator/generator/index.ts
@@ -1,4 +1,10 @@
 export type { GeneratorMain } from './generator.main.runtime';
-export { ComponentContext, ComponentTemplate, ComponentFile, ComponentConfig } from './component-template';
+export {
+  ComponentContext,
+  ComponentTemplate,
+  ComponentFile,
+  ComponentConfig,
+  ConfigContext,
+} from './component-template';
 export { WorkspaceContext, WorkspaceTemplate, WorkspaceFile } from './workspace-template';
 export { GeneratorAspect } from './generator.aspect';


### PR DESCRIPTION
## Proposed Changes

- allow config in component template to be a function that return config
- provide the aspect id in the config context

an example template config can be now something like this
```js
config: (context: ConfigContext) => {
    return ({
      [`${context.aspectId}`]: {},
      'teambit.envs/envs': {
        env: 'teambit.harmony/node',
      }
    });
  },
```
