### PR TITLE
show env icon when no preview for aspect env

### DIFF
--- a/scopes/preview/ui/preview-placeholder/preview-placeholder.module.scss
+++ b/scopes/preview/ui/preview-placeholder/preview-placeholder.module.scss
@@ -19,3 +19,8 @@
   max-width: 155px;
   text-align: center;
 }
+
+.envIcon {
+  width: 23.6%;
+  height: auto;
+}

--- a/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
+++ b/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
@@ -1,8 +1,12 @@
 import React, { useMemo } from 'react';
 import { ComponentComposition } from '@teambit/compositions';
-import { Icon } from '@teambit/evangelist.elements.icon';
 import { ComponentModel } from '@teambit/component';
+import { Icon } from '@teambit/design.elements.icon';
+import { EnvIcon } from '@teambit/envs.ui.env-icon';
+
 import styles from './preview-placeholder.module.scss';
+
+const iconAspects = new Set(['teambit.harmony/aspect']);
 
 export function PreviewPlaceholder({
   component,
@@ -24,6 +28,14 @@ export function PreviewPlaceholder({
         <div>Processing preview</div>
       </div>
     );
+
+  if (!component.compositions.length && iconAspects.has(component.environment?.id || '')) {
+    return (
+      <div className={styles.previewPlaceholder} data-tip="" data-for={name}>
+        <EnvIcon component={component} className={styles.envIcon} />
+      </div>
+    );
+  }
 
   if (shouldShowPreview) {
     return <ComponentComposition component={component} composition={selectedPreview} pubsub={false} />;


### PR DESCRIPTION
## Proposed Changes

- show env icon in component card, instead of the "no preview available", specifically for the aspect env

![Screen Shot 2022-03-16 at 15 19 05](https://user-images.githubusercontent.com/5400361/158602868-095b663a-8591-4942-bf1c-96ec2c3a98ac.png)

this effects the component gallery in the workspace and scope overviews
