### PR TITLE
fix(multi-compiler): add support for `getPreviewComponentRootPath`

### DIFF
--- a/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
+++ b/scopes/compilation/multi-compiler/multi-compiler.compiler.ts
@@ -9,6 +9,7 @@ import {
 } from '@teambit/compiler';
 import { BuiltTaskResult, BuildContext, TaskResultsList } from '@teambit/builder';
 import { mergeComponentResults } from '@teambit/pipelines.modules.merge-component-results';
+import { Component } from '@teambit/component';
 
 export type MultiCompilerOptions = {
   targetExtension?: string;
@@ -125,6 +126,17 @@ export class MultiCompiler implements Compiler {
 
   private firstMatchedCompiler(filePath: string): Compiler | undefined {
     return this.compilers.find((compiler) => compiler.isFileSupported(filePath));
+  }
+
+  getPreviewComponentRootPath(component: Component): string {
+    const matchedCompiler = this.compilers.find(
+      (compiler) => typeof compiler.getPreviewComponentRootPath !== 'undefined'
+    );
+    if (!matchedCompiler) {
+      return '';
+    }
+
+    return matchedCompiler.getPreviewComponentRootPath!(component);
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- The multi compiler is missing support for `getPreviewComponentRootPath`, making it impossible to support this API in compilers used by multi compilers. As for other methods of the multi compiler, the first matched compiler that supports this method will be used.