### PR TITLE
fix: fix an error "consumer.loadComponents expects to get BitId insta…

### DIFF
--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -408,10 +408,6 @@ export default class BitMap {
     { ignoreVersion = false, ignoreScopeAndVersion = false }: GetBitMapComponentOptions = {}
   ): BitId {
     if (bitId.constructor.name !== BitId.name) {
-      // @todo: this is a workaround due to an issue having teambit/legacy-bit-id package with two different versions
-      // one in the root, and the second in the component-id node_modules dir.
-      // once fixed, please uncomment the line below.
-      // if (!(bitId instanceof BitId)) {
       throw new TypeError(`BitMap.getBitId expects bitId to be an instance of BitId, instead, got ${bitId}`);
     }
     const allIds = this.getAllBitIdsFromAllLanes();

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -407,7 +407,11 @@ export default class BitMap {
     bitId: BitId,
     { ignoreVersion = false, ignoreScopeAndVersion = false }: GetBitMapComponentOptions = {}
   ): BitId {
-    if (!(bitId instanceof BitId)) {
+    if (bitId.constructor.name !== BitId.name) {
+      // @todo: this is a workaround due to an issue having teambit/legacy-bit-id package with two different versions
+      // one in the root, and the second in the component-id node_modules dir.
+      // once fixed, please uncomment the line below.
+      // if (!(bitId instanceof BitId)) {
       throw new TypeError(`BitMap.getBitId expects bitId to be an instance of BitId, instead, got ${bitId}`);
     }
     const allIds = this.getAllBitIdsFromAllLanes();

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -112,10 +112,6 @@ export default class ComponentLoader {
     const idsToProcess: BitId[] = [];
     const invalidComponents: InvalidComponent[] = [];
     ids.forEach((id: BitId) => {
-      // @todo: this is a workaround due to an issue having teambit/legacy-bit-id package with two different versions
-      // one in the root, and the second in the component-id node_modules dir.
-      // once fixed, please uncomment the line below.
-      // if (!(id instanceof BitId)) {
       if (id.constructor.name !== BitId.name) {
         throw new TypeError(`consumer.loadComponents expects to get BitId instances, instead, got "${typeof id}"`);
       }

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -114,6 +114,7 @@ export default class ComponentLoader {
     ids.forEach((id: BitId) => {
       // @todo: this is a workaround due to an issue having teambit/legacy-bit-id package with two different versions
       // one in the root, and the second in the component-id node_modules dir.
+      // once fixed, please uncomment the line below.
       // if (!(id instanceof BitId)) {
       if (id.constructor.name !== BitId.name) {
         throw new TypeError(`consumer.loadComponents expects to get BitId instances, instead, got "${typeof id}"`);

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -112,7 +112,10 @@ export default class ComponentLoader {
     const idsToProcess: BitId[] = [];
     const invalidComponents: InvalidComponent[] = [];
     ids.forEach((id: BitId) => {
-      if (!(id instanceof BitId)) {
+      // @todo: this is a workaround due to an issue having teambit/legacy-bit-id package with two different versions
+      // one in the root, and the second in the component-id node_modules dir.
+      // if (!(id instanceof BitId)) {
+      if (id.constructor.name !== BitId.name) {
         throw new TypeError(`consumer.loadComponents expects to get BitId instances, instead, got "${typeof id}"`);
       }
       const idWithVersion: BitId = getLatestVersionNumber(this.consumer.bitmapIdsFromCurrentLane, id);

--- a/src/scope/version-validator.ts
+++ b/src/scope/version-validator.ts
@@ -238,7 +238,7 @@ export default function validateVersionInstance(version: Version): void {
   const validateFlattenedDependencies = (dependencies: BitIds) => {
     validateType(message, dependencies, 'dependencies', 'array');
     dependencies.forEach((dependency) => {
-      if (!(dependency instanceof BitId)) {
+      if (dependency.constructor.name !== BitId.name) {
         throw new VersionInvalid(`${message}, a flattenedDependency expected to be BitId, got ${typeof dependency}`);
       }
       if (!dependency.hasVersion()) {


### PR DESCRIPTION
…nces, instead, got "object"" when running bit-rename.

This is happening due to multiple copies of `@teambit/legacy-bit-id` which exposes the `BitId` class. One copy is in the root of node_modules, and the other is inside `@teambit/component-id`. 
This PR fixes it by removing the check of `instanceof` and checking the class name instead.
