### PR TITLE
Set packageImportMethod to copy

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -380,6 +380,7 @@
       }
     },
     "nodeLinker": "hoisted",
+    "packageImportMethod": "copy",
     "packageManagerArgs": [],
     "devFilePatterns": [
       "**/*.spec.ts"

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -380,6 +380,8 @@
       }
     },
     "nodeLinker": "hoisted",
+    // This is a temporary workaround to fix "bit compile" on macOS and Windows.
+    // "bit compile" breaks node_modules when hard links are used.
     "packageImportMethod": "copy",
     "packageManagerArgs": [],
     "devFilePatterns": [


### PR DESCRIPTION
This is a temporary workaround to fix `bit compile` on macOS and Windows. `bit compile` breaks `node_modules` when hard links are used.

The description of the issue that is fixed:
pnpm uses content-addressable-storage for the files. (so, if the content is the same, it'll have the same source/object).
In this case, originally, the content of the index.js file of these two packages were the same. I tried to npm install them on a new temp dir and verified it.
Later on, when "bit compile" was running, it changes the content of the dist file of toolbox, which effectively changed the content of all other index.js that use the same hard-link.