### PR TITLE
feat(bit-tag): enable ignoring specific component-issues

### DIFF
--- a/e2e/commands/import2.e2e.1.ts
+++ b/e2e/commands/import2.e2e.1.ts
@@ -341,7 +341,7 @@ console.log(barFoo.default());`;
       }
     });
     it('should not allow tagging the component', () => {
-      const RelativeCompClass = IssuesClasses.relativeComponents;
+      const RelativeCompClass = IssuesClasses.RelativeComponents;
       expect(output).to.have.string('error: issues found with the following component dependencies');
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-string@0.0.1`);
       expect(output).to.have.string(new RelativeCompClass().descriptionWithSolution);
@@ -375,7 +375,7 @@ console.log(barFoo.default());`;
       }
     });
     it('should not allow tagging the component', () => {
-      const RelativeCompClass = IssuesClasses.relativeComponents;
+      const RelativeCompClass = IssuesClasses.RelativeComponents;
       expect(output).to.have.string(new RelativeCompClass().descriptionWithSolution);
     });
   });

--- a/e2e/commands/tag.e2e.1.ts
+++ b/e2e/commands/tag.e2e.1.ts
@@ -587,7 +587,7 @@ describe('bit tag command', function () {
       }
     });
     it('should not tag and throw an error regarding the relative syntax', () => {
-      const RelativeCompClass = IssuesClasses.relativeComponents;
+      const RelativeCompClass = IssuesClasses.RelativeComponents;
       expect(output).to.have.string('error: issues found with the following component dependencies');
       expect(output).to.have.string(new RelativeCompClass().description);
       expect(output).to.have.string(`${helper.scopes.remote}/utils/is-type@0.0.1`);

--- a/e2e/harmony/relative-paths.e2e.3.ts
+++ b/e2e/harmony/relative-paths.e2e.3.ts
@@ -28,7 +28,7 @@ describe('relative paths flow (components requiring each other by relative paths
     });
     it('should block bit tag', () => {
       const output = helper.general.runWithTryCatch('bit tag -a');
-      const RelativeComponentAuthoredClass = IssuesClasses.relativeComponentsAuthored;
+      const RelativeComponentAuthoredClass = IssuesClasses.RelativeComponentsAuthored;
       expect(output).to.have.string(new RelativeComponentAuthoredClass().description);
       expect(output).to.have.string('index.js -> "../comp2" (comp2)');
     });

--- a/scopes/component/component-issues/component-issue.ts
+++ b/scopes/component/component-issues/component-issue.ts
@@ -12,6 +12,7 @@ export class ComponentIssue {
   data: any;
   isTagBlocker = true; // if true, it stops the tag process and shows the issue
   isCacheBlocker = true; // if true, it doesn't cache the component in the filesystem
+  isLegacyIssue = false;
   formatDataFunction: FormatIssueFunc = componentIssueToString;
   get descriptionWithSolution() {
     const solution = this.solution ? ` (${this.solution})` : '';

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -8,8 +8,8 @@ import { MissingDists } from './missing-dists';
 import { MissingLinks } from './missing-links';
 import { MissingPackagesDependenciesOnFs } from './missing-packages-dependencies-on-fs';
 import { ParseErrors } from './parse-errors';
-import { relativeComponents } from './relative-components';
-import { relativeComponentsAuthored } from './relative-components-authored';
+import { RelativeComponents } from './relative-components';
+import { RelativeComponentsAuthored } from './relative-components-authored';
 import { ResolveErrors } from './resolve-errors';
 import { UntrackedDependencies } from './untracked-dependencies';
 import { LegacyInsideHarmony } from './legacy-inside-harmony';
@@ -21,8 +21,8 @@ export const IssuesClasses = {
   MissingComponents,
   UntrackedDependencies,
   ResolveErrors,
-  relativeComponents,
-  relativeComponentsAuthored,
+  RelativeComponents,
+  RelativeComponentsAuthored,
   ParseErrors,
   MissingLinks,
   MissingDists,
@@ -60,6 +60,10 @@ export class IssuesList {
       ...issue.toObject(),
       data: issue.dataToString().trim(),
     }));
+  }
+
+  getHarmonyIssues() {
+    return this.issues.filter((issue) => !issue.isLegacyIssue);
   }
 
   add(issue: ComponentIssue) {

--- a/scopes/component/component-issues/missing-custom-module-resolution-links.ts
+++ b/scopes/component/component-issues/missing-custom-module-resolution-links.ts
@@ -1,6 +1,7 @@
 import { ComponentIssue, StringsPerFilePath } from './component-issue';
 
 export class MissingCustomModuleResolutionLinks extends ComponentIssue {
+  isLegacyIssue = true;
   description = 'missing links';
   solution = 'use "bit link" to build missing component links';
   data: StringsPerFilePath = {};

--- a/scopes/component/component-issues/missing-links.ts
+++ b/scopes/component/component-issues/missing-links.ts
@@ -5,6 +5,7 @@ export class MissingLinks extends ComponentIssue {
   description = 'missing links between components';
   solution = 'use "bit link" to build missing component links';
   data: { [filePath: string]: BitId[] } = {};
+  isLegacyIssue = true;
   deserialize(data: string) {
     return deserializeWithBitId(data);
   }

--- a/scopes/component/component-issues/relative-components-authored.ts
+++ b/scopes/component/component-issues/relative-components-authored.ts
@@ -10,7 +10,7 @@ export type RelativeComponentsAuthoredEntry = {
   };
 };
 
-export class relativeComponentsAuthored extends ComponentIssue {
+export class RelativeComponentsAuthored extends ComponentIssue {
   description = 'components with relative import statements found';
   solution = 'replace to module paths or use "bit link --rewire" to replace';
   data: { [fileName: string]: RelativeComponentsAuthoredEntry[] } = {};

--- a/scopes/component/component-issues/relative-components.ts
+++ b/scopes/component/component-issues/relative-components.ts
@@ -1,7 +1,7 @@
 import { BitId } from '@teambit/legacy-bit-id';
 import { ComponentIssue, deserializeWithBitId } from './component-issue';
 
-export class relativeComponents extends ComponentIssue {
+export class RelativeComponents extends ComponentIssue {
   description = 'components with relative import statements found';
   solution = 'use module paths for imported components';
   data: { [filePath: string]: BitId[] } = {};

--- a/scopes/workspace/workspace/tag-cmd.ts
+++ b/scopes/workspace/workspace/tag-cmd.ts
@@ -12,6 +12,7 @@ import { isString } from '@teambit/legacy/dist/utils';
 import { DEFAULT_BIT_RELEASE_TYPE, WILDCARD_HELP } from '@teambit/legacy/dist/constants';
 import GeneralError from '@teambit/legacy/dist/error/general-error';
 import { isFeatureEnabled, BUILD_ON_CI } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
+import { IssuesClasses } from '@teambit/component-issues';
 
 export class Tag implements Command {
   name = 'tag [id...]';
@@ -37,8 +38,6 @@ export class Tag implements Command {
     ['', 'pre-release [identifier]', 'EXPERIMENTAL. increment a pre-release version (e.g. 1.0.0-dev.1)'],
     ['f', 'force', 'force-tag even if tests are failing and even when component has not changed'],
     ['v', 'verbose', 'show specs output on failure'],
-    ['', 'ignore-unresolved-dependencies', 'DEPRECATED. use --ignore-issues instead'],
-    ['i', 'ignore-issues', 'ignore component issues (shown in "bit status" as "issues found")'],
     ['I', 'ignore-newest-version', 'ignore existing of newer versions (default = false)'],
     ['', 'skip-tests', 'skip running component tests during tag process'],
     ['', 'skip-auto-tag', 'skip auto tagging dependents'],
@@ -52,6 +51,13 @@ export class Tag implements Command {
       '',
       'increment-by <number>',
       '(default to 1) increment semver flag (patch/minor/major) by. e.g. incrementing patch by 2: 0.0.1 -> 0.0.3.',
+    ],
+    [
+      'i',
+      'ignore-issues [issues]',
+      `ignore component issues (shown in "bit status" as "issues found"), issues to ignore:
+[${Object.keys(IssuesClasses).join(', ')}]
+to ignore multiple issues, separate them by a comma and wrap with quotes. to ignore all issues, specify "*".`,
     ],
   ] as CommandOptions;
   migration = true;
@@ -125,7 +131,10 @@ ${WILDCARD_HELP('tag')}`;
       );
     }
     if (typeof ignoreUnresolvedDependencies === 'boolean') {
-      ignoreIssues = ignoreUnresolvedDependencies;
+      throw new Error(`--ignore-unresolved-dependencies has been removed, please use --ignore-issues instead`);
+    }
+    if (ignoreIssues && typeof ignoreIssues === 'boolean') {
+      throw new Error(`--ignore-issues expects issues to be ignored, please run "bit tag -h" for the issues list`);
     }
     if (id.length === 2) {
       const secondArg = id[1];

--- a/src/api/consumer/lib/status.ts
+++ b/src/api/consumer/lib/status.ts
@@ -51,7 +51,7 @@ export default async function status(): Promise<StatusResult> {
   const newAndModified: Component[] = newComponents.concat(modifiedComponent);
   const componentsWithIssues = newAndModified.filter((component: Component) => {
     if (consumer.isLegacy && component.issues) {
-      component.issues.delete(IssuesClasses.relativeComponentsAuthored);
+      component.issues.delete(IssuesClasses.RelativeComponentsAuthored);
     }
     return component.issues && !component.issues.isEmpty();
   });

--- a/src/consumer/component-ops/codemod-components.ts
+++ b/src/consumer/component-ops/codemod-components.ts
@@ -22,7 +22,7 @@ export async function changeCodeFromRelativeToModulePaths(
 ): Promise<CodemodResult[]> {
   const components = await loadComponents(consumer, bitIds);
   const componentsWithRelativeIssues = components.filter(
-    (c) => c.issues && c.issues.getIssue(IssuesClasses.relativeComponentsAuthored)
+    (c) => c.issues && c.issues.getIssue(IssuesClasses.RelativeComponentsAuthored)
   );
   const dataToPersist = new DataToPersist();
   const codemodResults = componentsWithRelativeIssues.map((component) => {
@@ -42,7 +42,7 @@ async function reloadComponents(consumer: Consumer, bitIds: BitId[]) {
   if (!bitIds.length) return;
   const components = await loadComponents(consumer, bitIds);
   const componentsWithRelativeIssues = components.filter(
-    (c) => c.issues && c.issues.getIssue(IssuesClasses.relativeComponentsAuthored)
+    (c) => c.issues && c.issues.getIssue(IssuesClasses.RelativeComponentsAuthored)
   );
   if (componentsWithRelativeIssues.length) {
     const failedComps = componentsWithRelativeIssues.map((c) => c.id.toString()).join(', ');
@@ -60,10 +60,10 @@ async function loadComponents(consumer: Consumer, bitIds: BitId[]): Promise<Comp
 function codemodComponent(consumer: Consumer, component: Component): { files: SourceFile[]; warnings?: string[] } {
   const issues = component.issues;
   const files: SourceFile[] = [];
-  if (!issues || !issues.getIssue(IssuesClasses.relativeComponentsAuthored)) return { files };
+  if (!issues || !issues.getIssue(IssuesClasses.RelativeComponentsAuthored)) return { files };
   const warnings: string[] = [];
   component.files.forEach((file: SourceFile) => {
-    const relativeInstances = issues.getIssue(IssuesClasses.relativeComponentsAuthored)?.data[
+    const relativeInstances = issues.getIssue(IssuesClasses.RelativeComponentsAuthored)?.data[
       pathNormalizeToLinux(file.relative)
     ];
     if (!relativeInstances) return;

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -1306,10 +1306,10 @@ either, use the ignore file syntax or change the require statement to have a mod
     }
   }
   _pushToRelativeComponentsIssues(originFile, componentId: BitId) {
-    (this.issues.getOrCreate(IssuesClasses.relativeComponents).data[originFile] ||= []).push(componentId);
+    (this.issues.getOrCreate(IssuesClasses.RelativeComponents).data[originFile] ||= []).push(componentId);
   }
   _pushToRelativeComponentsAuthoredIssues(originFile, componentId, importSource: string, relativePath: RelativePath) {
-    (this.issues.getOrCreate(IssuesClasses.relativeComponentsAuthored).data[originFile] ||= []).push({
+    (this.issues.getOrCreate(IssuesClasses.RelativeComponentsAuthored).data[originFile] ||= []).push({
       importSource,
       componentId,
       relativePath,


### PR DESCRIPTION
Currently, `--ignore-issues` of `bit tag` ignore all issues. This PR adds an option to ignore specific issues (or all of them by `*`).