### PR TITLE
added favicon support

### DIFF
--- a/scopes/compilation/bundler/bundler-context.ts
+++ b/scopes/compilation/bundler/bundler-context.ts
@@ -135,6 +135,12 @@ export type HtmlConfig = {
    * Controls if and in what ways the output should be minified
    */
   minify?: boolean;
+
+  /**
+   * The favicon for the html page
+   */
+  favicon?:string; 
+
   // TODO: consider add chunksSortMode if there are more needs
 };
 

--- a/scopes/compilation/bundler/dev-server-context.ts
+++ b/scopes/compilation/bundler/dev-server-context.ts
@@ -20,4 +20,9 @@ export interface DevServerContext extends ExecutionContext {
    * title of the page.
    */
   title?: string;
+
+  /**
+   * favicon of the page.
+   */
+  favicon?: string;
 }

--- a/scopes/react/react/apps/web/react-app-options.ts
+++ b/scopes/react/react/apps/web/react-app-options.ts
@@ -53,7 +53,7 @@ export type ReactAppOptions = {
   portRange?: number[];
 
   /**
-   * favicon for the app.
+   * favicon for the app. You can pass an abs path (using require.resolve()) or a url.
    */
   favicon?: string;
 };

--- a/scopes/react/react/apps/web/react-app-options.ts
+++ b/scopes/react/react/apps/web/react-app-options.ts
@@ -51,4 +51,9 @@ export type ReactAppOptions = {
    * ranges of ports to use to run the app server.
    */
   portRange?: number[];
+
+  /**
+   * favicon for the app.
+   */
+  favicon?: string;
 };

--- a/scopes/react/react/apps/web/react.app-type.ts
+++ b/scopes/react/react/apps/web/react.app-type.ts
@@ -16,7 +16,8 @@ export class ReactAppType implements ApplicationType<ReactAppOptions> {
       options.bundler,
       options.devServer,
       options.webpackTransformers,
-      options.deploy
+      options.deploy,
+      options.favicon
     );
   }
 }

--- a/scopes/react/react/apps/web/react.application.ts
+++ b/scopes/react/react/apps/web/react.application.ts
@@ -118,6 +118,7 @@ export class ReactApp implements Application {
       rootPath: '',
       publicPath: `public/${this.name}`,
       title: this.name,
+      favicon: this.favicon,
     });
   }
 }

--- a/scopes/react/react/apps/web/react.application.ts
+++ b/scopes/react/react/apps/web/react.application.ts
@@ -1,4 +1,3 @@
-import { Console } from '@teambit/capsule';
 import { join, basename } from 'path';
 import { Application, AppContext, AppBuildContext } from '@teambit/application';
 import { Bundler, DevServer, BundlerContext, DevServerContext, BundlerHtmlConfig } from '@teambit/bundler';
@@ -32,7 +31,6 @@ export class ReactApp implements Application {
       await this.devServer.listen(port);
       return port;
     }
-    console.log(this.favicon, 'run');
     const devServerContext = this.getDevServerContext(context);
     const devServer = this.reactEnv.getDevServer(devServerContext, [
       (configMutator) => {
@@ -54,8 +52,6 @@ export class ReactApp implements Application {
   }
 
   async build(context: AppBuildContext): Promise<ReactAppBuildResult> {
-    console.log(this.favicon, 'build favicon');
-    debugger;
     const htmlConfig: BundlerHtmlConfig[] = [
       {
         title: context.name,
@@ -68,10 +64,8 @@ export class ReactApp implements Application {
     Object.assign(context, {
       html: htmlConfig,
     });
-    debugger;
     const bundler = await this.getBundler(context);
     await bundler.run();
-    debugger;
     return { publicDir: `${this.getPublicDir()}/${this.dir}` };
   }
 

--- a/scopes/react/react/apps/web/react.application.ts
+++ b/scopes/react/react/apps/web/react.application.ts
@@ -1,3 +1,4 @@
+import { Console } from '@teambit/capsule';
 import { join, basename } from 'path';
 import { Application, AppContext, AppBuildContext } from '@teambit/application';
 import { Bundler, DevServer, BundlerContext, DevServerContext, BundlerHtmlConfig } from '@teambit/bundler';
@@ -19,9 +20,9 @@ export class ReactApp implements Application {
     readonly bundler?: Bundler,
     readonly devServer?: DevServer,
     readonly transformers?: WebpackConfigTransformer[],
-    readonly deploy?: (context: ReactDeployContext) => Promise<void>
+    readonly deploy?: (context: ReactDeployContext) => Promise<void>,
+    readonly favicon?: string
   ) {}
-
   readonly applicationType = 'react-common-js';
   readonly dir = 'public';
   async run(context: AppContext): Promise<number> {
@@ -31,6 +32,7 @@ export class ReactApp implements Application {
       await this.devServer.listen(port);
       return port;
     }
+    console.log(this.favicon, 'run');
     const devServerContext = this.getDevServerContext(context);
     const devServer = this.reactEnv.getDevServer(devServerContext, [
       (configMutator) => {
@@ -52,19 +54,24 @@ export class ReactApp implements Application {
   }
 
   async build(context: AppBuildContext): Promise<ReactAppBuildResult> {
+    console.log(this.favicon, 'build favicon');
+    debugger;
     const htmlConfig: BundlerHtmlConfig[] = [
       {
         title: context.name,
         templateContent: html(context.name),
         minify: false,
+        favicon: this.favicon,
         // filename: ''.html`,
       },
     ];
     Object.assign(context, {
       html: htmlConfig,
     });
+    debugger;
     const bundler = await this.getBundler(context);
     await bundler.run();
+    debugger;
     return { publicDir: `${this.getPublicDir()}/${this.dir}` };
   }
 

--- a/scopes/webpack/webpack/config/webpack.config.ts
+++ b/scopes/webpack/webpack/config/webpack.config.ts
@@ -18,6 +18,7 @@ export function configFactory(target: Target, context: BundlerContext): Configur
   if (Array.isArray(truthyEntries) && !truthyEntries.length) {
     truthyEntries = {};
   }
+
   const dev = Boolean(context.development);
   const htmlConfig = target.html ?? context.html;
   const compress = target.compress ?? context.compress;
@@ -107,6 +108,7 @@ function getAssetManifestPlugin() {
 function generateHtmlPlugins(configs: BundlerHtmlConfig[]) {
   return configs.map((config) => generateHtmlPlugin(config));
 }
+
 function generateHtmlPlugin(config: BundlerHtmlConfig) {
   const baseConfig = {
     filename: config.filename,
@@ -116,6 +118,7 @@ function generateHtmlPlugin(config: BundlerHtmlConfig) {
     minify: config.minify,
     cache: false,
     chunksSortMode: 'auto' as const,
+    favicon: config.favicon,
   };
   if (baseConfig.chunks && baseConfig.chunks.length) {
     // Make sure the order is that the preview root coming after the preview def

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -148,6 +148,7 @@ export function configFactory(
       new HtmlWebpackPlugin({
         templateContent: html(title || 'Component preview'),
         filename: 'index.html',
+        favicon: resolveWorkspacePath('public/favicon.ico'),
       }),
 
       new webpack.ProvidePlugin(fallbacksProvidePluginConfig),

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -26,7 +26,8 @@ export function configFactory(
   publicRoot: string,
   publicPath: string,
   pubsub: PubsubMain,
-  title?: string
+  title?: string,
+  favicon?: string
 ): WebpackConfigWithDevServer {
   const resolveWorkspacePath = (relativePath) => path.resolve(workspaceDir, relativePath);
 
@@ -149,9 +150,8 @@ export function configFactory(
         templateContent: html(title || 'Component preview'),
         filename: 'index.html',
         // TODO has to be the capsule or the workspace dir of the component
-        // favicon: resolveWorkspacePath('public/favicon.ico'),
+        favicon,
       }),
-
       new webpack.ProvidePlugin(fallbacksProvidePluginConfig),
 
       new WebpackBitReporterPlugin({

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -149,7 +149,6 @@ export function configFactory(
       new HtmlWebpackPlugin({
         templateContent: html(title || 'Component preview'),
         filename: 'index.html',
-        // TODO has to be the capsule or the workspace dir of the component
         favicon,
       }),
       new webpack.ProvidePlugin(fallbacksProvidePluginConfig),

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -148,7 +148,8 @@ export function configFactory(
       new HtmlWebpackPlugin({
         templateContent: html(title || 'Component preview'),
         filename: 'index.html',
-        favicon: resolveWorkspacePath('public/favicon.ico'),
+        // TODO has to be the capsule or the workspace dir of the component
+        // favicon: resolveWorkspacePath('public/favicon.ico'),
       }),
 
       new webpack.ProvidePlugin(fallbacksProvidePluginConfig),

--- a/scopes/webpack/webpack/webpack.dev-server.ts
+++ b/scopes/webpack/webpack/webpack.dev-server.ts
@@ -7,6 +7,7 @@ import { WebpackAspect } from './webpack.aspect';
 
 export interface WebpackConfigWithDevServer extends Configuration {
   devServer: WDS.Configuration;
+  favicon?: string;
 }
 export class WebpackDevServer implements DevServer {
   constructor(


### PR DESCRIPTION
I ended up adding it with the webpackHTML plugin (and not adding another plugin)
closed #5603
## Proposed Changes

-add favicon support to React apps
-have the ability to extend it to more apps in the future (as it is part of the webpack config
