### PR TITLE
improvement(bit-create): avoid overriding env from workspace variants by env from the template

### DIFF
--- a/e2e/harmony/create.e2e.4.ts
+++ b/e2e/harmony/create.e2e.4.ts
@@ -146,14 +146,22 @@ describe('create extension', function () {
       helper.extensions.addExtensionToVariant('*', 'teambit.react/react', {});
       helper.command.create('aspect', 'my-aspect', `--scope ${helper.scopes.remote}`);
     });
-    it('should set the env according to the config from the env', () => {
+    it('should set the env according to the variant', () => {
+      const show = helper.command.showComponentParsedHarmony('my-aspect');
+      const env = show.find((item) => item.title === 'env');
+      expect(env.json).to.equal('teambit.react/react');
+    });
+  });
+  describe('with env defined inside the aspect-template when there is no variant', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.command.create('aspect', 'my-aspect', `--scope ${helper.scopes.remote}`);
+    });
+    it('should set the env according to the template env', () => {
       const show = helper.command.showComponentParsedHarmony('my-aspect');
       const env = show.find((item) => item.title === 'env');
       expect(env.json).to.equal('teambit.harmony/aspect');
-    });
-    it('should remove the one from the variants', () => {
-      const show = helper.command.showComponent('my-aspect');
-      expect(show).to.not.include('teambit.react/react');
     });
   });
 });

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -317,6 +317,13 @@ export class EnvsMain {
     return this.getEnvsNotFromEnvsConfig(component);
   }
 
+  /**
+   * whether a component has an env configured (either by variant or .bitmap).
+   */
+  hasEnvConfigured(component: Component): boolean {
+    return Boolean(this.getAllEnvsConfiguredOnComponent(component).length);
+  }
+
   getAllRegisteredEnvs(): string[] {
     return this.envSlot.toArray().map((envData) => envData[0]);
   }

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -3,8 +3,7 @@ import fs from 'fs-extra';
 import pMapSeries from 'p-map-series';
 import path from 'path';
 import { Workspace } from '@teambit/workspace';
-import EnvsAspect, { EnvDefinition, EnvsMain } from '@teambit/envs';
-import { Component } from '@teambit/component';
+import EnvsAspect, { EnvsMain } from '@teambit/envs';
 import camelcase from 'camelcase';
 import { BitError } from '@teambit/bit-error';
 import { PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
@@ -15,7 +14,7 @@ import { ComponentID } from '@teambit/component-id';
 import { ComponentTemplate, ComponentFile, ComponentConfig } from './component-template';
 import { CreateOptions } from './create.cmd';
 
-export type GenerateResult = { id: ComponentID; dir: string; files: string[]; envId: string };
+export type GenerateResult = { id: ComponentID; dir: string; files: string[]; envId: string; envSetBy: string };
 
 export class ComponentGenerator {
   constructor(
@@ -76,31 +75,66 @@ export class ComponentGenerator {
     const nameCamelCase = camelcase(name);
     const files = this.template.generateFiles({ name, namePascalCase, nameCamelCase, componentId });
     const mainFile = files.find((file) => file.isMain);
-    let config = this.template.config;
-    if (config && typeof config === 'function') {
-      config = config({ aspectId: this.aspectId });
-    }
-    const configWithEnv = this.addEnvIfProvidedByUser(config);
     await this.writeComponentFiles(componentPath, files);
     const addResults = await this.workspace.track({
       rootDir: componentPath,
       mainFile: mainFile?.relativePath,
       componentName: componentId.fullName,
       defaultScope: this.options.scope,
-      config: configWithEnv,
     });
     const component = await this.workspace.get(componentId);
-    const env = this.envs.getEnv(component);
-    await this.removeOtherEnvs(component, env, configWithEnv);
+    const hasEnvConfiguredOriginally = this.envs.hasEnvConfigured(component);
+    const envBeforeConfigChanges = this.envs.getEnv(component);
+
+    let config = this.template.config;
+    if (config && typeof config === 'function') {
+      config = config({ aspectId: this.aspectId });
+    }
+
+    const templateEnv = config?.[EnvsAspect.id]?.env;
+
+    if (config && templateEnv && hasEnvConfiguredOriginally) {
+      // remove the env we got from the template.
+      delete config[templateEnv];
+      delete config[EnvsAspect.id].env;
+      if (Object.keys(config[EnvsAspect.id]).length === 0) delete config[EnvsAspect.id];
+      if (Object.keys(config).length === 0) config = undefined;
+    }
+
+    const configWithEnv = this.addEnvIfProvidedByFlag(config);
+    if (configWithEnv) this.workspace.bitMap.setEntireConfig(component.id, configWithEnv);
+
+    const getEnvData = () => {
+      const envFromFlag = this.options.env; // env entered by the user when running `bit create --env`
+      const envFromTemplate = config?.[EnvsAspect.id]?.env;
+      if (envFromFlag) {
+        return {
+          envId: envFromFlag,
+          setBy: '--env flag',
+        };
+      }
+      if (envFromTemplate) {
+        return {
+          envId: envFromTemplate,
+          setBy: 'template',
+        };
+      }
+      return {
+        envId: envBeforeConfigChanges.id,
+        setBy: hasEnvConfiguredOriginally ? 'workspace variants' : '<default>',
+      };
+    };
+    const { envId, setBy } = getEnvData();
     return {
       id: componentId,
       dir: componentPath,
       files: addResults.files,
-      envId: env.id,
+      envId,
+      envSetBy: setBy,
     };
   }
 
-  private addEnvIfProvidedByUser(config?: ComponentConfig): ComponentConfig | undefined {
+  private addEnvIfProvidedByFlag(config?: ComponentConfig): ComponentConfig | undefined {
     const userEnv = this.options.env; // env entered by the user when running `bit create --env`
     const templateEnv = config?.[EnvsAspect.id]?.env;
     if (!userEnv || userEnv === templateEnv) {
@@ -115,18 +149,6 @@ export class ComponentGenerator {
     config[EnvsAspect.id] = config[EnvsAspect.id] || {};
     config[EnvsAspect.id].env = userEnv;
     return config;
-  }
-
-  private async removeOtherEnvs(component: Component, env: EnvDefinition, config?: ComponentConfig) {
-    const envFromTemplate = config?.[EnvsAspect.id]?.env;
-    if (!envFromTemplate) {
-      return;
-    }
-    const envsNotFromConfig = this.envs.getEnvsNotFromEnvsConfig(component).map((envDef) => envDef.id);
-    const envsToRemove = envsNotFromConfig.filter((envId) => envId !== envFromTemplate);
-    envsToRemove.forEach((envId) => (config[envId] = '-'));
-    const bitMapRecord = this.workspace.bitMap.getBitmapEntry(component.id);
-    bitMapRecord.config = config;
   }
 
   /**

--- a/scopes/generator/generator/create.cmd.ts
+++ b/scopes/generator/generator/create.cmd.ts
@@ -35,7 +35,7 @@ export class CreateCmd implements Command {
       .map((result) => {
         return `${chalk.bold(result.id.toString())}
     location: ${result.dir}
-    env:      ${result.envId}
+    env:      ${result.envId} (set by ${result.envSetBy})
 `;
       })
       .join('\n');

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -60,6 +60,12 @@ export class BitMap {
     return true;
   }
 
+  setEntireConfig(id: ComponentID, config: Record<string, any>) {
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    bitMapEntry.config = config;
+    this.legacyBitMap.markAsChanged();
+  }
+
   /**
    * write .bitmap object to the filesystem
    */


### PR DESCRIPTION
## Proposed Changes

- with this change the env is calculate by the following: from the `--env` flag. If not entered, from the variants, if not exists, from the the template.
- improve the output of `bit create` to indicate where the env is coming from.
