### PR TITLE
require resolve babel presets and add to component.json

### DIFF
--- a/scopes/react/react-native/component.json
+++ b/scopes/react/react-native/component.json
@@ -9,7 +9,9 @@
     "teambit.dependencies/dependency-resolver": {
       "policy": {
         "dependencies": {
-          "@teambit/legacy": "-"
+          "@teambit/legacy": "-",
+          "@babel/preset-env": "7.12.17",
+          "@babel/preset-react": "7.13.13"
         },
         "devDependencies": {
           "@teambit/legacy": "-",

--- a/scopes/react/react-native/webpack/webpack-transformers.ts
+++ b/scopes/react/react-native/webpack/webpack-transformers.ts
@@ -6,7 +6,7 @@ const reactNativePackagesRule = {
   loader: require.resolve('babel-loader'),
   options: {
     cacheDirectory: false,
-    presets: ['@babel/preset-env', '@babel/preset-react'],
+    presets: [require.resolve('@babel/preset-env'), require.resolve('@babel/preset-react')],
   },
 };
 


### PR DESCRIPTION
## Proposed Changes

- require.resolve for babel presets in rn webpack
- add to component.json (probably not needed, as currently installed in bit because of react env dependency - but best to have it in the rn dependencies too)
-
