### PR TITLE
fix: avoid overriding components after merge from main by the remote

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1189,6 +1189,12 @@ describe('bit lane command', function () {
           const status = helper.command.statusJson();
           expect(status.stagedComponents).to.have.lengthOf(2);
         });
+        it('bit import should not reset the component to the remote-state but should keep the merged data', () => {
+          helper.command.import();
+          const status = helper.command.statusJson();
+          expect(status.outdatedComponents).to.have.lengthOf(0);
+          expect(status.stagedComponents).to.have.lengthOf(2);
+        });
         describe('tagging the components', () => {
           before(() => {
             helper.command.tagScope();

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -148,7 +148,7 @@ export class SnappingMain {
     );
     if (R.isEmpty(bitIds)) return null;
 
-    const legacyBitIds = BitIds.fromArray(bitIds);
+    const legacyBitIds = BitIds.uniqFromArray(bitIds);
 
     if (this.workspace.isLegacy) {
       persist = true;

--- a/src/scope/component-ops/model-components-merger.ts
+++ b/src/scope/component-ops/model-components-merger.ts
@@ -27,7 +27,7 @@ export class ModelComponentMerger {
   async merge(): Promise<{ mergedComponent: ModelComponent; mergedVersions: string[] }> {
     logger.debug(`model-component-merger.merge component ${this.incomingComponent.id()}`);
     this.throwComponentNeedsUpdateIfNeeded();
-    const locallyChanged = this.existingComponent.isLocallyChangedRegardlessOfLanes();
+    const locallyChanged = await this.existingComponent.isLocallyChanged();
     this.throwMergeConflictIfNeeded(locallyChanged);
     this.replaceTagHashIfDifferentOnIncoming();
     this.moveTagToOrphanedIfNotExistOnOrigin();

--- a/src/scope/objects-fetcher/objects-writable-stream.ts
+++ b/src/scope/objects-fetcher/objects-writable-stream.ts
@@ -85,6 +85,7 @@ export class ObjectsWritable extends Writable {
       if (isIncomingFromOrigin) incomingComp.remoteHead = incomingComp.head;
       return incomingComp;
     }
+    await existingComp.setDivergeData(this.repo);
     const modelComponentMerger = new ModelComponentMerger(existingComp, incomingComp, true, isIncomingFromOrigin);
     const { mergedComponent } = await modelComponentMerger.merge();
     if (isIncomingFromOrigin) mergedComponent.remoteHead = incomingComp.head;


### PR DESCRIPTION
When a lane is merged into master, there is no indication in the `Component` object that there is a local change, such as the `state.local` created by snap/tag. 
As a result, when running `bit import` afterwards, the `Component` object gets replaced by the remote one and the merge data is gone. 
This fixes it to check for local-changes by traversing the versions and comparing to the remote.