### PR TITLE
Fix notes icon aligns in mdx

### DIFF
--- a/scopes/mdx/ui/mdx-layout/md-example.md
+++ b/scopes/mdx/ui/mdx-layout/md-example.md
@@ -61,4 +61,7 @@ This is an <b>important</b> message
 This is an <b>info</b> message
 :::
 
+:::info This is a long message title. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec gravida dui vel dignissim facilisis.
+:::
+
 <br />

--- a/scopes/mdx/ui/mdx-layout/mdx-layout.css
+++ b/scopes/mdx/ui/mdx-layout/mdx-layout.css
@@ -18,7 +18,6 @@
 
 .admonition-icon {
   display: inline-flex;
-  align-self: center;
   margin-right: 4px;
 }
 

--- a/scopes/mdx/ui/mdx-layout/mdx-layout.css
+++ b/scopes/mdx/ui/mdx-layout/mdx-layout.css
@@ -18,6 +18,7 @@
 
 .admonition-icon {
   display: inline-flex;
+  padding-top: 1px;
   margin-right: 4px;
 }
 


### PR DESCRIPTION
## Proposed Changes

- Left icon is align center when text is long - fixed.

Before:
![image (6)](https://user-images.githubusercontent.com/35892475/160607486-1fb79d18-b044-4e87-8b2e-84a35e30f281.png)

After:
![image (7)](https://user-images.githubusercontent.com/35892475/160607526-02dfd4f1-2a19-4db7-82cd-5213ab2e33a9.png)

