### PR TITLE
fix: avoid overriding components after merge from main by the remote

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -1189,6 +1189,12 @@ describe('bit lane command', function () {
           const status = helper.command.statusJson();
           expect(status.stagedComponents).to.have.lengthOf(2);
         });
+        it('bit import should not reset the component to the remote-state but should keep the merged data', () => {
+          helper.command.import();
+          const status = helper.command.statusJson();
+          expect(status.outdatedComponents).to.have.lengthOf(0);
+          expect(status.stagedComponents).to.have.lengthOf(2);
+        });
         describe('tagging the components', () => {
           before(() => {
             helper.command.tagScope();

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -396,7 +396,11 @@ export class MergingMain {
     } else {
       // this is main
       const modelComponent = await consumer.scope.getModelComponent(id);
-      if (!consumer.isLegacy) modelComponent.setHead(remoteHead);
+      if (!consumer.isLegacy) {
+        modelComponent.setHead(remoteHead);
+        // mark it as local, otherwise, when importing this component from a remote, it'll override it.
+        modelComponent.markVersionAsLocal(remoteHead.toString());
+      }
       consumer.scope.objects.add(modelComponent);
     }
 


### PR DESCRIPTION
When a lane is merged into master, there is no indication in the `Component` object that there is a local change, such as the `state.local` created by snap/tag. 
As a result, when running `bit import` afterwards, the `Component` object gets replaced by the remote one and the merge data is gone. 
This fixes it by marking the merged head as local. (see another alternative I tried and failed https://github.com/teambit/bit/pull/5616).