### PR TITLE
mdx build - use same logic for build as for preview

### DIFF
--- a/scopes/mdx/mdx/mdx.compiler.ts
+++ b/scopes/mdx/mdx/mdx.compiler.ts
@@ -57,27 +57,21 @@ export class MDXCompiler implements Compiler {
 
       const errors = srcFiles.map((srcFile) => {
         try {
-          const afterMdxCompile = mdxCompileSync(srcFile.contents.toString('utf-8'));
-          const afterBabelCompile = babelTranspileFileContent(
-            afterMdxCompile.contents,
-            {
-              rootDir: capsule.path,
-              filePath: this.replaceFileExtToJs(srcFile.relative),
-            },
-            this.config.babelTransformOptions || {}
-          );
-          if (!afterBabelCompile) {
+          const transpiled = this.transpileFile(srcFile.contents.toString('utf-8'), {
+            filePath: this.replaceFileExtToJs(srcFile.relative),
+            componentDir: capsule.path,
+          });
+
+          if (!transpiled) {
             return undefined;
           }
+
           outputFileSync(
-            join(capsule.path, this.getDistPathBySrcPath(afterBabelCompile[0].outputPath)),
-            afterBabelCompile[0].outputText
+            join(capsule.path, this.getDistPathBySrcPath(transpiled[0].outputPath)),
+            transpiled[0].outputText
           );
-          if (afterBabelCompile.length > 1) {
-            outputFileSync(
-              join(capsule.path, this.distDir, afterBabelCompile[1].outputPath),
-              afterBabelCompile[1].outputText
-            );
+          if (transpiled.length > 1) {
+            outputFileSync(join(capsule.path, this.distDir, transpiled[1].outputPath), transpiled[1].outputText);
           }
           return undefined;
         } catch (err: any) {


### PR DESCRIPTION
## Proposed Changes

- remove 'bit flavor' of mdx in production builds
- already removed in regular preview and compilation, so it will create a more consistent experience
- this fixes a bug where highlighter shows "mdx-scope-context" instead of the component name
