### PR TITLE
improvement: enable ignore issues for specific components

### DIFF
--- a/scopes/component/issues/issues.main.runtime.ts
+++ b/scopes/component/issues/issues.main.runtime.ts
@@ -1,8 +1,10 @@
 import { BitError } from '@teambit/bit-error';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
+import { Component } from '@teambit/component';
 import { IssuesClasses, IssuesList } from '@teambit/component-issues';
 import { ComponentIssuesCmd } from './issues-cmd';
 import { IssuesAspect } from './issues.aspect';
+import { NonExistIssueError } from './non-exist-issue-error';
 
 export type IssuesConfig = {
   ignoreIssues: string[];
@@ -11,17 +13,26 @@ export type IssuesConfig = {
 export class IssuesMain {
   constructor(private config: IssuesConfig) {}
 
-  getIssuesToIgnore(): string[] {
-    const allIssues = this.listIssues().map((issue) => issue.name);
+  getIssuesToIgnoreGlobally(): string[] {
     const issuesToIgnore = this.config.ignoreIssues || [];
-    issuesToIgnore.forEach((issueToIgnore) => {
-      if (!allIssues.includes(issueToIgnore)) {
-        throw new BitError(
-          `fatal: a non-existing component-issue "${issueToIgnore}" was configured for ${IssuesAspect.id} aspect`
-        );
+    this.validateIssueNames(issuesToIgnore);
+    return issuesToIgnore;
+  }
+
+  getIssuesToIgnorePerComponent(component: Component): string[] {
+    const issuesToIgnore = component.state.aspects.get(IssuesAspect.id)?.config.ignoreIssues;
+    if (!issuesToIgnore) return [];
+    this.validateIssueNames(issuesToIgnore);
+    return issuesToIgnore;
+  }
+
+  private validateIssueNames(issues: string[]) {
+    const allIssues = this.listIssues().map((issue) => issue.name);
+    issues.forEach((issue) => {
+      if (!allIssues.includes(issue)) {
+        throw new NonExistIssueError(issue);
       }
     });
-    return issuesToIgnore;
   }
 
   listIssues() {
@@ -35,6 +46,17 @@ export class IssuesMain {
         solution: issueInstance.solution,
         isTagBlocker: issueInstance.isTagBlocker,
       };
+    });
+  }
+
+  removeIgnoredIssuesFromComponents(components: Component[]) {
+    const issuesToIgnoreGlobally = this.getIssuesToIgnoreGlobally();
+    components.forEach((component) => {
+      const issuesToIgnoreForThisComp = this.getIssuesToIgnorePerComponent(component);
+      const issuesToIgnore = [...issuesToIgnoreGlobally, ...issuesToIgnoreForThisComp];
+      issuesToIgnore.forEach((issueToIgnore) => {
+        component.state.issues.delete(IssuesClasses[issueToIgnore]);
+      });
     });
   }
 

--- a/scopes/component/issues/issues.main.runtime.ts
+++ b/scopes/component/issues/issues.main.runtime.ts
@@ -1,4 +1,3 @@
-import { BitError } from '@teambit/bit-error';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { Component } from '@teambit/component';
 import { IssuesClasses, IssuesList } from '@teambit/component-issues';

--- a/scopes/component/issues/non-exist-issue-error.ts
+++ b/scopes/component/issues/non-exist-issue-error.ts
@@ -1,0 +1,9 @@
+import { BitError } from '@teambit/bit-error';
+import { IssuesAspect } from './issues.aspect';
+
+export class NonExistIssueError extends BitError {
+  constructor(issueToIgnore: string) {
+    super(`fatal: a non-existing component-issue "${issueToIgnore}" was configured for ${IssuesAspect.id} aspect.
+to get the list of component-issues, please run "bit component-issues"`);
+  }
+}

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -59,17 +59,15 @@ export class StatusMain {
     const outdatedComponents = await componentsList.listOutdatedComponents();
     const mergePendingComponents = await componentsList.listMergePendingComponents();
     const newAndModifiedLegacy: ConsumerComponent[] = newComponents.concat(modifiedComponent);
-    const issuesToIgnore = this.issues.getIssuesToIgnore();
-    if (
-      !this.workspace.isLegacy &&
-      newAndModifiedLegacy.length &&
-      !issuesToIgnore.includes(IssuesClasses.CircularDependencies.name)
-    ) {
+    const issuesToIgnore = this.issues.getIssuesToIgnoreGlobally();
+    if (!this.workspace.isLegacy && newAndModifiedLegacy.length) {
       const newAndModified = await this.workspace.getManyByLegacy(newAndModifiedLegacy);
-      await this.insights.addInsightsAsComponentIssues(newAndModified);
+      if (!issuesToIgnore.includes(IssuesClasses.CircularDependencies.name)) {
+        await this.insights.addInsightsAsComponentIssues(newAndModified);
+      }
+      this.issues.removeIgnoredIssuesFromComponents(newAndModified);
     }
     const componentsWithIssues = newAndModifiedLegacy.filter((component: ConsumerComponent) => {
-      issuesToIgnore.forEach((issueToIgnore) => component.issues.delete(IssuesClasses[issueToIgnore]));
       if (consumer.isLegacy && component.issues) {
         component.issues.delete(IssuesClasses.RelativeComponentsAuthored);
       }


### PR DESCRIPTION
Currently, ignoring issues from workspace.jsonc only works globally. With this change it's possible to add the config to the variants to enable it to a specific set of components.