### PR TITLE
fix: fix bit-env subcommands to work properly with custom envs

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import chai, { expect } from 'chai';
 import { IssuesClasses } from '../../scopes/component/component-issues';
 
-import { IS_WINDOWS } from '../../src/constants';
+import { Extensions, IS_WINDOWS } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 import { UNABLE_TO_LOAD_EXTENSION } from '../../scopes/harmony/aspect-loader/constants';
@@ -148,6 +148,73 @@ describe('custom env', function () {
         it.skip('should warn or error about the misconfigured env and suggest to enter the version', () => {});
       });
     });
+    describe('set up the env using bit env set without a version', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.fixtures.populateComponents(1);
+        helper.command.setEnv('comp1', envId);
+      });
+      it('should save it with the latest version in root', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.comp1.config).to.have.property(`${envId}@0.0.1`);
+      });
+    });
+    describe('set up the env using bit env set with a version', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.fixtures.populateComponents(1);
+        helper.command.setEnv('comp1', `${envId}@0.0.1`);
+      });
+      it('should save it with a version in root but without version in envs/envs', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.comp1.config).to.have.property(`${envId}@0.0.1`);
+        expect(bitMap.comp1.config[Extensions.envs].env).equal(envId);
+      });
+    });
+    describe('set up the env using bit create --env with a version', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.create('aspect', 'my-aspect', `--env ${envId}@0.0.1`);
+      });
+      it('should save it with a version in root but without version in envs/envs', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.comp1.config).to.have.property(`${envId}@0.0.1`);
+        expect(bitMap.comp1.config[Extensions.envs].env).equal(envId);
+      });
+    });
+    describe('set up the env and then unset it', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.fixtures.populateComponents(1);
+        helper.command.setEnv('comp1', `${envId}@0.0.1`);
+        helper.command.unsetEnv('comp1');
+      });
+      it('should remove the env not only from envs/envs but also from root', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.comp1.config).to.not.have.property(`${envId}@0.0.1`);
+        expect(bitMap.comp1.config).to.not.have.property(Extensions.envs);
+      });
+    });
+    describe('set up the env and then replace it with another env without mentioning the version', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.fixtures.populateComponents(1);
+        helper.command.setEnv('comp1', `${envId}@0.0.1`);
+        helper.command.replaceEnv(envId, `${envId}@0.0.2`);
+      });
+      it('should save it with a version in root but without version in envs/envs', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.comp1.config).to.not.have.property(`${envId}@0.0.1`);
+        expect(bitMap.comp1.config).to.have.property(`${envId}@0.0.2`);
+        expect(bitMap.comp1.config[Extensions.envs].env).equal(envId);
+      });
+    });
+
     describe('missing modules in the env capsule', () => {
       before(() => {
         helper.scopeHelper.reInitLocalScopeHarmony();

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -134,7 +134,7 @@ export class ComponentGenerator {
     };
   }
 
-  private addEnvIfProvidedByFlag(config?: ComponentConfig): ComponentConfig | undefined {
+  private async addEnvIfProvidedByFlag(config?: ComponentConfig): Promise<ComponentConfig | undefined> {
     const userEnv = this.options.env; // env entered by the user when running `bit create --env`
     const templateEnv = config?.[EnvsAspect.id]?.env;
     if (!userEnv || userEnv === templateEnv) {
@@ -145,9 +145,11 @@ export class ComponentGenerator {
       // the component template has an env and the user wants a different env.
       delete config[templateEnv];
     }
-    config[userEnv] = {};
+    const userEnvId = await this.workspace.resolveComponentId(userEnv);
+    const userEnvIdWithPotentialVersion = await this.workspace.resolveEnvIdWithPotentialVersionForConfig(userEnvId);
+    config[userEnvIdWithPotentialVersion] = {};
     config[EnvsAspect.id] = config[EnvsAspect.id] || {};
-    config[EnvsAspect.id].env = userEnv;
+    config[EnvsAspect.id].env = userEnvId.toStringWithoutVersion();
     return config;
   }
 

--- a/scopes/workspace/workspace/envs-subcommands/envs-replace.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-replace.cmd.ts
@@ -12,7 +12,7 @@ export class EnvsReplaceCmd implements Command {
 
   async report([oldEnv, env]: [string, string]) {
     const envId = await this.workspace.resolveComponentId(env);
-    const components = await this.workspace.getComponentsUsingEnv(oldEnv, true);
+    const components = await this.workspace.getComponentsUsingEnv(oldEnv, true, true);
     const componentIds = components.map((comp) => comp.id);
     await this.workspace.setEnvToComponents(envId, componentIds);
     return `added ${chalk.bold(envId.toString())} env to the following component(s):

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -150,6 +150,9 @@ export default class CommandHelper {
   unsetEnv(compId: string) {
     return this.runCmd(`bit envs unset ${compId}`);
   }
+  replaceEnv(oldEnv: string, newEnv: string) {
+    return this.runCmd(`bit envs replace ${oldEnv} ${newEnv}`);
+  }
   setAspect(pattern: string, aspectId: string, config?: Record<string, any>, flags = '') {
     const configStr = config ? `'${JSON.stringify(config)}'` : '';
     return this.runCmd(`bit aspect set ${pattern} ${aspectId} ${configStr} ${flags}`);


### PR DESCRIPTION
## Proposed Changes

- fix `bit env set` of a custom-env to allow entering the env without a version. if this env exists on the workspace, it'll set it without a version. if this env is set in workspace.jsonc, it'll use the version from workspace.jsonc. otherwise, it'll import the env objects and use the latest.
- fix `bit env unset` of a custom-env in case it was added with a version to remove it from the root as well. (before, it was removing it only from envs/envs).
- allow entering <old-id> without a version in `bit env replace <old-id> <new-id>`, which will replace all occurrences of the old-env in any version. 
- fix `bit create --env` of a custom-env to save with a version only in the root, not in envs/envs.
