### PR TITLE
improvement: avoid compiling unmodified components on capsules

### DIFF
--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -101,6 +101,13 @@ export interface ComponentFactory {
   hasIdNested(componentId: ComponentID, includeCache?: boolean): Promise<boolean>;
 
   /**
+   * whether a component is not the same as its head.
+   * for a new component, it'll return "true" as it has no head yet.
+   * this is relevant for component from the workspace, where it can be locally changed. on the scope it's always false
+   */
+  isModified(component: Component): Promise<boolean>;
+
+  /**
    * determine whether host should be the prior one in case multiple hosts persist.
    */
   priority?: boolean;

--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -168,9 +168,7 @@ export class Component {
    * determines whether this component is modified in the workspace.
    */
   isModified(): Promise<boolean> {
-    if (!this.head) return Promise.resolve(true);
-    return Promise.resolve(this.state.isModified);
-    // return Promise.resolve(this.state.hash !== this.head.hash);
+    return this.factory.isModified(this);
   }
 
   /**

--- a/scopes/component/component/state.ts
+++ b/scopes/component/component/state.ts
@@ -60,9 +60,9 @@ export class State {
   }
 
   /**
-   * is modified
+   * @deprecated please use `component.isModified`.
+   * the way it's implemented here is unreliable and will only work if in the legacy the "isModified" was calculated.
    */
-
   get isModified(): boolean {
     return this._consumer._isModified;
   }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -346,16 +346,31 @@ export class IsolatorMain {
   }
 
   private async writeComponentsInCapsules(components: Component[], capsuleList: CapsuleList, legacyScope?: Scope) {
-    const legacyComponents = components.map((component) => component.state._consumer.clone());
-    if (legacyScope) await importMultipleDistsArtifacts(legacyScope, legacyComponents);
+    const modifiedComps: Component[] = [];
+    const unmodifiedComps: Component[] = [];
+    await Promise.all(
+      components.map(async (component) => {
+        const isModified = await component.isModified();
+        if (isModified) modifiedComps.push(component);
+        else unmodifiedComps.push(component);
+      })
+    );
+    const legacyUnmodifiedComps = unmodifiedComps.map((component) => component.state._consumer.clone());
+    const legacyModifiedComps = modifiedComps.map((component) => component.state._consumer.clone());
+    const legacyComponents = [...legacyUnmodifiedComps, ...legacyModifiedComps];
+    if (legacyScope && unmodifiedComps.length) await importMultipleDistsArtifacts(legacyScope, legacyUnmodifiedComps);
     const allIds = BitIds.fromArray(legacyComponents.map((c) => c.id));
     await Promise.all(
       components.map(async (component) => {
         const capsule = capsuleList.getCapsule(component.id);
         if (!capsule) return;
         const params = this.getComponentWriteParams(component.state._consumer, allIds, legacyScope);
+        if (await component.isModified()) {
+          delete params.scope;
+        }
         const componentWriter = new ComponentWriter(params);
         await componentWriter.populateComponentsFilesToWrite();
+        component.state._consumer.dataToPersist.toConsole();
         await component.state._consumer.dataToPersist.persistAllToCapsule(capsule, { keepExistingCapsule: true });
       })
     );

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -222,7 +222,7 @@ export class BuilderMain {
     builderOptions?: BuilderServiceOptions
   ): Promise<TaskResultsList> {
     const ids = components.map((c) => c.id);
-    const network = await this.isolator.isolateComponents(ids, isolateOptions);
+    const network = await this.isolator.isolateComponents(ids, isolateOptions, this.scope.legacyScope);
     const envs = await this.envs.createEnvironment(network.graphCapsules.getAllComponents());
     const builderServiceOptions = {
       seedersOnly: isolateOptions?.seedersOnly,

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -919,6 +919,10 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
     await this.loadAspects(aspectIds, true, component.id);
   }
 
+  async isModified(): Promise<boolean> {
+    return false;
+  }
+
   /**
    * declare the slots of scope extension.
    */

--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -160,7 +160,10 @@ export class TypescriptCompiler implements Compiler {
    */
   private async runTscBuild(network: Network): Promise<ComponentResult[]> {
     const rootDir = network.capsulesRootDir;
-    const capsules = network.graphCapsules;
+    const capsules = network.originalSeedersCapsules;
+    if (!capsules.length) {
+      return [];
+    }
     const capsuleDirs = capsules.getAllCapsuleDirs();
     const formatHost = {
       getCanonicalFileName: (p) => p,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1148,6 +1148,17 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     };
   }
 
+  async isModified(component: Component): Promise<boolean> {
+    const head = component.head;
+    if (!head) {
+      return true; // it's a new component
+    }
+    const consumerComp = component.state._consumer as ConsumerComponent;
+    if (typeof consumerComp._isModified === 'boolean') return consumerComp._isModified;
+    const componentStatus = await this.consumer.getComponentStatusById(component.id._legacy);
+    return componentStatus.modified === true;
+  }
+
   private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
     const envFromEnvsAspect = envAspect?.config.env;


### PR DESCRIPTION
The performance improvement of this PR is huge when building a small set of components that have many dependencies on the workspace. Currently, when creating the capsules (during `bit build` or `bit tag`), they are written without the dists and the compiler task is responsible of compiling all these components. 
The thing is that if these dependencies weren't changed since the last tag/snap, there is no reason to re-compiling them. It's possible to get the dists and the d.ts files from the last tag/snap. 
This PR does exactly this, it writes the dists to the capsules when creating them in case they weren't modified. 