### PR TITLE
fix: update templates CLI help text

### DIFF
--- a/scopes/generator/generator/templates/component-generator/index.ts
+++ b/scopes/generator/generator/templates/component-generator/index.ts
@@ -7,7 +7,7 @@ import { mainRuntime } from './files/main-runtime';
 export const componentGeneratorTemplate: ComponentTemplate = {
   name: 'component-generator',
   description:
-    'create your own component generator \nDocs: https://harmony-docs.bit.dev/extending-bit/creating-a-custom-generator',
+    'create your own component generator \nDocs: https://bit.dev/docs/dev-services-overview/generator/generate-component',
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/generator/generator/templates/workspace-generator/index.ts
+++ b/scopes/generator/generator/templates/workspace-generator/index.ts
@@ -11,7 +11,7 @@ import { workspaceConfigTemplate } from './files/workspace-config-tpl';
 export const workspaceGeneratorTemplate: ComponentTemplate = {
   name: 'workspace-generator',
   description:
-    'create your own workspace generator - \nDocs: https://harmony-docs.bit.dev/extending-bit/creating-a-custom-workspace-generator',
+    'create your own workspace generator - \nDocs: https://bit.dev/docs/dev-services-overview/generator/generate-workspace',
   generateFiles: (context: ComponentContext) => {
     return [
       {


### PR DESCRIPTION
## Proposed Changes

- Fixes the URLs shown in the help text of the bit CLI command `bit templates`
- URLs fixed for "workspace generator" and "component generator"
