### PR TITLE
prevent highlighter from overflowing the document

### DIFF
--- a/scopes/react/component-highlighter/element-highlighter/element-highlighter.compositions.tsx
+++ b/scopes/react/component-highlighter/element-highlighter/element-highlighter.compositions.tsx
@@ -80,3 +80,27 @@ export const ElementOnTheEdge = () => {
     </div>
   );
 };
+
+export const FullscreenElement = () => {
+  const targetRef = createRef<HTMLDivElement>();
+
+  return (
+    <div style={{ fontFamily: 'sans-serif' }}>
+      <div
+        ref={targetRef}
+        style={{
+          height: '100vh',
+          width: '100%',
+          background: '#bceed4',
+        }}
+      >
+        This element will cover the entire document,
+        <br />
+        pushing the highlighter to the edge of the window.
+        <br />
+        The highlighter should remain inside and expand no further than the document.
+      </div>
+      <ElementHighlighter targetRef={targetRef} components={[MockTarget]} watchMotion />
+    </div>
+  );
+};

--- a/scopes/react/component-highlighter/frame/frame.tsx
+++ b/scopes/react/component-highlighter/frame/frame.tsx
@@ -103,8 +103,9 @@ export function Frame({ targetRef, watchMotion, className, stylesClass = styles.
         ...style,
         ...dimensionRef.current,
         position: strategy,
-        top: y ?? '',
-        left: x ?? '',
+        // starting at pos [0,0] will ensure the label doesn't increase the document size.
+        top: y ?? 0,
+        left: x ?? 0,
       }}
     />
   );

--- a/scopes/react/component-highlighter/label/label-container.tsx
+++ b/scopes/react/component-highlighter/label/label-container.tsx
@@ -37,7 +37,8 @@ export function LabelContainer({
     middleware: compact([
       offset && offsetMiddleware({ mainAxis: offset[0], crossAxis: offset[1] }),
       flip && flipMiddleware(),
-      shift({ rootBoundary: 'viewport' }),
+      // enabling 'shift' for 'crossAxis' will make floating-ui push the label _inside_, when it has nowhere to go
+      shift({ rootBoundary: 'document', mainAxis: true, crossAxis: true }),
     ]),
   });
 
@@ -60,7 +61,8 @@ export function LabelContainer({
       {...rest}
       ref={floating}
       className={classnames(className, !isReady && styles.hidden)}
-      style={{ ...style, position: strategy, top: y ?? '', left: x ?? '' }}
+      // starting at pos [0,0] will ensure the label doesn't increase the document size.
+      style={{ ...style, position: strategy, top: y ?? 0, left: x ?? 0 }}
     />
   );
 }

--- a/scopes/react/component-highlighter/label/label.module.scss
+++ b/scopes/react/component-highlighter/label/label.module.scss
@@ -24,6 +24,8 @@
 }
 
 .hidden {
+  // label size is needed for position calculations,
+  // so it can't be removed by `display: none`
   visibility: hidden;
   pointer-events: none;
   user-select: none;


### PR DESCRIPTION
## Proposed Changes

- prevent the highlighter overflowing when target element reaches the bottom for the document


![Screen Shot 2022-04-03 at 20 58 08](https://user-images.githubusercontent.com/5400361/161441507-f4800c27-4076-489f-b943-8c77fc6ea0b0.png)

