### PR TITLE
fix "getDivergeData: unable to find Version" error when merging from main to a lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -581,6 +581,22 @@ describe('bit lane command', function () {
         expect(mergeOutput).to.not.have.string('unable to switch to "main", the lane was not found');
       });
     });
+    describe('merging main into local lane when main has tagged versions', () => {
+      let mergeOutput: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.fixtures.populateComponents(1);
+        helper.command.tagAllWithoutBuild();
+        helper.command.createLane('dev');
+        helper.fixtures.populateComponents(1, undefined, 'v2');
+        helper.command.snapAllComponentsWithoutBuild();
+        mergeOutput = helper.command.mergeLane('main');
+      });
+      it("should not throw an error that main lane doesn't exist", () => {
+        expect(mergeOutput).to.not.have.string('getDivergeData: unable to find Version 0.0.1 of comp1');
+      });
+    });
     describe('merging main lane with no snapped components', () => {
       let mergeOutput: string;
       before(() => {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -246,6 +246,9 @@ export class MergingMain {
     const localHead = laneHeadIsDifferentThanCheckedOut ? Ref.from(currentlyUsedVersion) : null;
 
     const otherLaneHead = modelComponent.getRef(version);
+    if (!otherLaneHead) {
+      throw new Error(`merging: unable finding a hash for the version ${version} of ${id.toString()}`);
+    }
     const divergeData = await getDivergeData(repo, modelComponent, otherLaneHead, localHead);
     if (!divergeData.isDiverged()) {
       if (divergeData.isLocalAhead()) {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -245,7 +245,7 @@ export class MergingMain {
       localLane && currentlyUsedVersion && modelComponent.laneHeadLocal?.toString() !== currentlyUsedVersion;
     const localHead = laneHeadIsDifferentThanCheckedOut ? Ref.from(currentlyUsedVersion) : null;
 
-    const otherLaneHead = new Ref(version);
+    const otherLaneHead = modelComponent.getRef(version);
     const divergeData = await getDivergeData(repo, modelComponent, otherLaneHead, localHead);
     if (!divergeData.isDiverged()) {
       if (divergeData.isLocalAhead()) {


### PR DESCRIPTION
This error is happening when main has tagged version and it's being merged to a lane.
Reported by @NitsanCohen770 .