### PR TITLE
feat: support import components during bit-new without forking them

### DIFF
--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -12,6 +12,7 @@ import { Slot, SlotRegistry } from '@teambit/harmony';
 import { BitError } from '@teambit/bit-error';
 import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import NewComponentHelperAspect, { NewComponentHelperMain } from '@teambit/new-component-helper';
+import ImporterAspect, { ImporterMain } from '@teambit/importer';
 import { ComponentTemplate } from './component-template';
 import { GeneratorAspect } from './generator.aspect';
 import { CreateCmd, CreateOptions } from './create.cmd';
@@ -51,7 +52,8 @@ export class GeneratorMain {
     private workspace: Workspace,
     private envs: EnvsMain,
     private aspectLoader: AspectLoaderMain,
-    private newComponentHelper: NewComponentHelperMain
+    private newComponentHelper: NewComponentHelperMain,
+    private importer: ImporterMain
   ) {}
 
   /**
@@ -277,19 +279,21 @@ export class GeneratorMain {
     AspectLoaderAspect,
     NewComponentHelperAspect,
     CommunityAspect,
+    ImporterAspect,
   ];
 
   static runtime = MainRuntime;
 
   static async provider(
-    [workspace, cli, graphql, envs, aspectLoader, newComponentHelper, community]: [
+    [workspace, cli, graphql, envs, aspectLoader, newComponentHelper, community, importer]: [
       Workspace,
       CLIMain,
       GraphqlMain,
       EnvsMain,
       AspectLoaderMain,
       NewComponentHelperMain,
-      CommunityMain
+      CommunityMain,
+      ImporterMain
     ],
     config: GeneratorConfig,
     [componentTemplateSlot, workspaceTemplateSlot]: [ComponentTemplateSlot, WorkspaceTemplateSlot]
@@ -301,7 +305,8 @@ export class GeneratorMain {
       workspace,
       envs,
       aspectLoader,
-      newComponentHelper
+      newComponentHelper,
+      importer
     );
     const commands = [
       new CreateCmd(generator, community.getDocsDomain()),

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -179,7 +179,7 @@ export class WorkspaceGenerator {
 
     if (!componentsToImport.length) return;
 
-    componentsToImport.map(async (componentToImport) => {
+    await pMapSeries(componentsToImport, async (componentToImport) => {
       await this.importer.import(
         {
           ids: [componentToImport.id],
@@ -188,12 +188,16 @@ export class WorkspaceGenerator {
           override: false,
           writeDists: false,
           writeConfig: false,
-          installNpmPackages: true,
+          installNpmPackages: false,
           writeToPath: componentToImport.path,
         },
         []
       );
     });
+
+    await this.workspace.bitMap.write();
+    this.workspace.clearCache();
+    await this.compileComponents();
   }
 
   private async compileComponents() {

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -37,7 +37,7 @@ export interface WorkspaceContext {
   aspectComponent?: Component;
 }
 
-export interface ComponentToImport {
+export interface ForkComponentInfo {
   /**
    * full component id
    */
@@ -52,6 +52,23 @@ export interface ComponentToImport {
    * a new component name. if not specified, use the original id (without the scope)
    */
   targetName?: string;
+}
+
+/**
+ * @deprecated use ForkComponentInfo instead.
+ */
+export type ComponentToImport = ForkComponentInfo;
+
+export interface ImportComponentInfo {
+  /**
+   * full component id
+   */
+  id: string;
+
+  /**
+   * path where to write the component
+   */
+  path: string;
 }
 
 export interface WorkspaceTemplate {
@@ -79,17 +96,17 @@ export interface WorkspaceTemplate {
    * @deprecated use `fork()` or `import()` instead
    * this is working similarly to `fork()`
    */
-  importComponents?: () => ComponentToImport[];
+  importComponents?: () => ForkComponentInfo[];
 
   /**
    * populate existing components into the new workspace and add them as new components.
    * don't change their source code.
    */
-  import?: () => ComponentToImport[];
+  import?: () => ImportComponentInfo[];
 
   /**
    * populate existing components into the new workspace and add them as new components.
    * change their source code and update the dependency names according to the new component names.
    */
-  fork?: () => ComponentToImport[];
+  fork?: () => ForkComponentInfo[];
 }

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -76,7 +76,20 @@ export interface WorkspaceTemplate {
   generateFiles(context: WorkspaceContext): Promise<WorkspaceFile[]>;
 
   /**
-   * populate existing components into the new workspace and add them as new components
+   * @deprecated use `fork()` or `import()` instead
+   * this is working similarly to `fork()`
    */
   importComponents?: () => ComponentToImport[];
+
+  /**
+   * populate existing components into the new workspace and add them as new components.
+   * don't change their source code.
+   */
+  import?: () => ComponentToImport[];
+
+  /**
+   * populate existing components into the new workspace and add them as new components.
+   * change their source code and update the dependency names according to the new component names.
+   */
+  fork?: () => ComponentToImport[];
 }

--- a/scopes/react/react-native/templates/react-workspace/index.ts
+++ b/scopes/react/react-native/templates/react-workspace/index.ts
@@ -7,7 +7,7 @@ export const reactWorkspaceTemplate: WorkspaceTemplate = {
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },
-  importComponents: () => {
+  fork: () => {
     return [
       {
         id: 'teambit.react/templates/react-native/envs/my-react-native',

--- a/scopes/react/react/templates/react-workspace-app/index.ts
+++ b/scopes/react/react/templates/react-workspace-app/index.ts
@@ -8,7 +8,7 @@ export const reactWorkspaceAppTemplate: WorkspaceTemplate = {
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },
-  importComponents: () => {
+  fork: () => {
     return [
       { id: 'teambit.react/templates/apps/my-app', path: 'apps/my-app' },
       { id: 'teambit.react/templates/envs/my-react', path: 'envs/my-react' },

--- a/scopes/react/react/templates/react-workspace-deprecated/index.ts
+++ b/scopes/react/react/templates/react-workspace-deprecated/index.ts
@@ -8,7 +8,7 @@ export const deprecatedReactWorkspaceTemplate: WorkspaceTemplate = {
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },
-  importComponents: () => {
+  fork: () => {
     return [
       {
         id: 'teambit.react/templates/envs/my-react',

--- a/scopes/react/react/templates/react-workspace-lib/index.ts
+++ b/scopes/react/react/templates/react-workspace-lib/index.ts
@@ -8,7 +8,7 @@ export const reactWorkspaceLibTemplate: WorkspaceTemplate = {
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },
-  importComponents: () => {
+  fork: () => {
     return [
       { id: 'teambit.react/templates/envs/my-react', targetName: 'envs/my-react', path: 'demo/envs/my-react' },
       { id: 'teambit.react/templates/ui/text', targetName: 'ui/text', path: 'demo/ui/text' },

--- a/scopes/react/react/templates/react-workspace/index.ts
+++ b/scopes/react/react/templates/react-workspace/index.ts
@@ -7,7 +7,7 @@ export const reactWorkspaceTemplate: WorkspaceTemplate = {
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },
-  importComponents: () => {
+  fork: () => {
     return [
       // {
       //   id: 'teambit.react/templates/envs/my-react',

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -1,5 +1,6 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
+import { ImportOptions, ImportResult } from '@teambit/legacy/dist/consumer/component-ops/import-components';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { CommunityAspect } from '@teambit/community';
 import type { CommunityMain } from '@teambit/community';
@@ -9,6 +10,12 @@ import { Importer } from './importer';
 import { ImporterAspect } from './importer.aspect';
 
 export class ImporterMain {
+  constructor(private importer: Importer) {}
+
+  async import(importOptions: ImportOptions, packageManagerArgs: string[]): Promise<ImportResult> {
+    return this.importer.import(importOptions, packageManagerArgs);
+  }
+
   static slots = [];
   static dependencies = [CLIAspect, WorkspaceAspect, DependencyResolverAspect, CommunityAspect];
   static runtime = MainRuntime;
@@ -18,12 +25,12 @@ export class ImporterMain {
     DependencyResolverMain,
     CommunityMain
   ]) {
+    const importer = new Importer(workspace, depResolver);
     if (workspace && !workspace.consumer.isLegacy) {
       cli.unregister('import');
-      const importer = new Importer(workspace, depResolver);
       cli.register(new ImportCmd(importer, community.getDocsDomain()));
     }
-    return new ImporterMain();
+    return new ImporterMain(importer);
   }
 }
 

--- a/src/consumer/component-ops/component-status-loader.ts
+++ b/src/consumer/component-ops/component-status-loader.ts
@@ -83,7 +83,7 @@ export class ComponentStatusLoader {
       throw err;
     }
 
-    if (componentFromFileSystem.componentMap.origin === COMPONENT_ORIGINS.NESTED) {
+    if (this.consumer.isLegacy && componentFromFileSystem.componentMap.origin === COMPONENT_ORIGINS.NESTED) {
       status.nested = true;
       return status;
     }


### PR DESCRIPTION
To use it, in the workspace-template, instead of using `importComponents()` which got deprecated, use `import()`. To fork the components (same behavior as now), use `fork()`.