### PR TITLE
fix: set the correct version when soft tagging a specific id with version

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -145,6 +145,19 @@ describe('tag components on Harmony', function () {
         });
       });
     });
+    describe('soft tag with specific version attached to a component-id', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.fixtures.populateComponents(1);
+        helper.command.softTag('comp1@0.0.5');
+      });
+      it('should save the version into the .bitmap file', () => {
+        const bitMap = helper.bitMap.readComponentsMapOnly();
+        const componentMap = bitMap.comp1;
+        expect(componentMap).to.have.property('nextVersion');
+        expect(componentMap.nextVersion.version).to.equal('0.0.5');
+      });
+    });
     describe('soft tag after soft tag', () => {
       let tagOutput;
       before(() => {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -551,27 +551,23 @@ export default class Consumer {
     return this.componentStatusLoader.getComponentStatusById(id);
   }
 
-  updateNextVersionOnBitmap(
-    taggedComponents: Component[],
-    exactVersion?: string | null,
-    releaseType?: ReleaseType,
-    preRelease?: string
-  ) {
-    taggedComponents.forEach((taggedComponent) => {
-      const log = taggedComponent.log;
+  updateNextVersionOnBitmap(componentsToTag: Component[], preRelease?: string) {
+    componentsToTag.forEach((compToTag) => {
+      const log = compToTag.log;
       if (!log) throw new Error('updateNextVersionOnBitmap, unable to get log');
+      const version = compToTag.version as string;
       const nextVersion: NextVersion = {
-        version: exactVersion || (releaseType as string), // one of them is set for sure
+        version,
         message: log.message,
         username: log.username,
         email: log.email,
       };
       if (preRelease) nextVersion.preRelease = preRelease;
-      if (!taggedComponent.componentMap) throw new Error('updateNextVersionOnBitmap componentMap is missing');
-      taggedComponent.componentMap.updateNextVersion(nextVersion);
+      if (!compToTag.componentMap) throw new Error('updateNextVersionOnBitmap componentMap is missing');
+      compToTag.componentMap.updateNextVersion(nextVersion);
     });
 
-    if (taggedComponents.length) this.bitMap.markAsChanged();
+    if (componentsToTag.length) this.bitMap.markAsChanged();
   }
 
   async updateComponentsVersions(components: Array<ModelComponent | Component>): Promise<any> {


### PR DESCRIPTION
e.g. `bit tag bar@0.0.5 --soft` currently shows "patch" in the `nextVersion` instead of `0.0.5`.

Reported by @GiladShoham .