### PR TITLE
fix: change the extension-loading-failure log level from warn to error

### DIFF
--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -479,7 +479,7 @@ export class AspectLoaderMain {
       const ids = extensionsManifests.map((manifest) => manifest.id || 'unknown');
       // TODO: improve texts
       const warning = UNABLE_TO_LOAD_EXTENSION_FROM_LIST(ids);
-      this.logger.warn(warning, e);
+      this.logger.error(warning, e);
       if (this.logger.isLoaderStarted) {
         this.logger.consoleFailure(warning);
       } else {


### PR DESCRIPTION
This way, the `--log=error` suggested in the error-message will work.