### PR TITLE
improvement: introduce "--skip-dependency-installation" flag for lanes commands

### DIFF
--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -332,15 +332,20 @@ export class LaneImportCmd implements Command {
   name = 'import <lane>';
   description = `import a remote lane to your workspace`;
   alias = '';
-  options = [];
+  options = [
+    ['', 'skip-dependency-installation', 'do not install packages of the imported components'],
+  ] as CommandOptions;
   loader = true;
   private = true;
   migration = true;
 
   constructor(private switchCmd: SwitchCmd) {}
 
-  async report([lane]: [string]): Promise<string> {
-    return this.switchCmd.report([lane], { getAll: true });
+  async report(
+    [lane]: [string],
+    { skipDependencyInstallation = false }: { skipDependencyInstallation: boolean }
+  ): Promise<string> {
+    return this.switchCmd.report([lane], { getAll: true, skipDependencyInstallation });
   }
 }
 

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -28,6 +28,7 @@ export class SwitchCmd implements Command {
       'merge local changes with the checked out version. strategy should be "theirs", "ours" or "manual"',
     ],
     ['a', 'get-all', 'checkout all components in a lane include ones that do not exist in the workspace'],
+    ['', 'skip-dependency-installation', 'do not install packages of the imported components'],
     ['v', 'verbose', 'showing verbose output for inspection'],
     ['j', 'json', 'return the output as JSON'],
   ] as CommandOptions;
@@ -39,12 +40,14 @@ export class SwitchCmd implements Command {
       as,
       merge,
       getAll = false,
+      skipDependencyInstallation = false,
       verbose = false,
       json = false,
     }: {
       as?: string;
       merge?: MergeStrategy;
       getAll?: boolean;
+      skipDependencyInstallation?: boolean;
       verbose?: boolean;
       override?: boolean;
       json?: boolean;
@@ -67,7 +70,7 @@ export class SwitchCmd implements Command {
     const checkoutProps: CheckoutProps = {
       mergeStrategy,
       verbose,
-      skipNpmInstall: false, // not relevant in Harmony
+      skipNpmInstall: skipDependencyInstallation, // not relevant in Harmony
       ignorePackageJson: true, // not relevant in Harmony
       ignoreDist: true, // not relevant in Harmony
       isLane: true,


### PR DESCRIPTION
specifically, for  `bit switch` and `bit lane import`.