### PR TITLE
envs peers as self deps

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -843,6 +843,13 @@ export class DependencyResolverMain {
     return this.getComponentEnvPolicyFromEnv(env);
   }
 
+  async getEnvPolicyFromEnvLegacyId(id: BitId): Promise<EnvPolicy | undefined> {
+    const envDef = await this.envs.getEnvDefinitionByLegacyId(id);
+    if (!envDef) return undefined;
+    const env = envDef.env;
+    return this.getComponentEnvPolicyFromEnv(env);
+  }
+
   async getComponentEnvPolicy(component: Component): Promise<EnvPolicy> {
     const env = this.envs.getEnv(component).env;
     return this.getComponentEnvPolicyFromEnv(env);
@@ -1197,9 +1204,16 @@ export class DependencyResolverMain {
       const workspacePolicy = dependencyResolver.getWorkspacePolicy();
       return workspacePolicy.toManifest();
     });
-    DependencyResolver.registerHarmonyEnvPeersPolicyGetter(async (configuredExtensions: ExtensionDataList) => {
-      const envPolicy = await dependencyResolver.getComponentEnvPolicyFromExtension(configuredExtensions);
-      return envPolicy.peersAutoDetectPolicy.toNameSupportedRangeMap();
+    DependencyResolver.registerHarmonyEnvPeersPolicyForComponentGetter(
+      async (configuredExtensions: ExtensionDataList) => {
+        const envPolicy = await dependencyResolver.getComponentEnvPolicyFromExtension(configuredExtensions);
+        return envPolicy.peersAutoDetectPolicy.toNameSupportedRangeMap();
+      }
+    );
+    DependencyResolver.registerHarmonyEnvPeersPolicyForEnvItselfGetter(async (id: BitId) => {
+      const envPolicy = await dependencyResolver.getEnvPolicyFromEnvLegacyId(id);
+      if (!envPolicy) return undefined;
+      return envPolicy.peersAutoDetectPolicy.toVersionManifest();
     });
     registerUpdateDependenciesOnTag(dependencyResolver.updateDepsOnLegacyTag.bind(dependencyResolver));
     registerUpdateDependenciesOnExport(dependencyResolver.updateDepsOnLegacyExport.bind(dependencyResolver));

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -5,6 +5,7 @@ import { Harmony, Slot, SlotRegistry } from '@teambit/harmony';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { ExtensionDataList, ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config/extension-data';
 import findDuplications from '@teambit/legacy/dist/utils/array/find-duplications';
+import { BitId } from '@teambit/legacy-bit-id';
 import { EnvService } from './services';
 import { Environment } from './environment';
 import { EnvsAspect } from './environments.aspect';
@@ -454,6 +455,12 @@ export class EnvsMain {
       this.getEnvDefinitionByStringId(id.toString()) ||
       this.getEnvDefinitionByStringId(id.toString({ ignoreVersion: true }));
     return envDef;
+  }
+
+  async getEnvDefinitionByLegacyId(id: BitId): Promise<EnvDefinition | undefined> {
+    const host = this.componentMain.getHost();
+    const newId = await host.resolveComponentId(id);
+    return this.getEnvDefinitionById(newId);
   }
 
   private getEnvDefinitionByStringId(envId: string): EnvDefinition | undefined {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -71,7 +71,7 @@ type HarmonyEnvPeersPolicyForComponentGetter = (
   configuredExtensions: ExtensionDataList
 ) => Promise<{ [name: string]: string }>;
 
-type HarmonyEnvPeersPolicyForEnvItselfGetter = (componentId: BitId) => Promise<{ [name: string]: string }>;
+type HarmonyEnvPeersPolicyForEnvItselfGetter = (componentId: BitId) => Promise<{ [name: string]: string } | undefined>;
 
 export default class DependencyResolver {
   component: Component;

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -67,7 +67,11 @@ type WorkspacePolicyGetter = () => {
   peerDependencies?: Record<string, string>;
 };
 
-type HarmonyEnvPeersPolicyGetter = (configuredExtensions: ExtensionDataList) => Promise<{ [name: string]: string }>;
+type HarmonyEnvPeersPolicyForComponentGetter = (
+  configuredExtensions: ExtensionDataList
+) => Promise<{ [name: string]: string }>;
+
+type HarmonyEnvPeersPolicyForEnvItselfGetter = (componentId: BitId) => Promise<{ [name: string]: string }>;
 
 export default class DependencyResolver {
   component: Component;
@@ -95,9 +99,20 @@ export default class DependencyResolver {
     this.getWorkspacePolicy = func;
   }
 
-  static getHarmonyEnvPeersPolicy: HarmonyEnvPeersPolicyGetter;
-  static registerHarmonyEnvPeersPolicyGetter(func: HarmonyEnvPeersPolicyGetter) {
-    this.getHarmonyEnvPeersPolicy = func;
+  /**
+   * This will get the peers policy provided by the env of the component
+   */
+  static getHarmonyEnvPeersPolicyForComponent: HarmonyEnvPeersPolicyForComponentGetter;
+  static registerHarmonyEnvPeersPolicyForComponentGetter(func: HarmonyEnvPeersPolicyForComponentGetter) {
+    this.getHarmonyEnvPeersPolicyForComponent = func;
+  }
+
+  /**
+   * This will get the peers policy provided by the env of the component
+   */
+  static getHarmonyEnvPeersPolicyForEnvItself: HarmonyEnvPeersPolicyForEnvItselfGetter;
+  static registerHarmonyEnvPeersPolicyForEnvItselfGetter(func: HarmonyEnvPeersPolicyForEnvItselfGetter) {
+    this.getHarmonyEnvPeersPolicyForEnvItself = func;
   }
 
   static getDepResolverAspectName: () => string;
@@ -230,7 +245,8 @@ export default class DependencyResolver {
     this.populatePeerPackageDependencies();
     if (!this.consumer.isLegacy) {
       this.applyWorkspacePolicy();
-      await this.applyAutoDetectedPeersFromEnv();
+      await this.applyAutoDetectedPeersFromEnvOnComponent();
+      await this.applyAutoDetectedPeersFromEnvOnEnvItSelf();
     }
     this.manuallyAddDependencies();
     this.applyOverridesOnEnvPackages();
@@ -1179,8 +1195,8 @@ either, use the ignore file syntax or change the require statement to have a mod
     this.allPackagesDependencies.peerPackageDependencies = peerDeps;
   }
 
-  async applyAutoDetectedPeersFromEnv(): Promise<void> {
-    const envPolicy = await DependencyResolver.getHarmonyEnvPeersPolicy(this.component.extensions);
+  async applyAutoDetectedPeersFromEnvOnComponent(): Promise<void> {
+    const envPolicy = await DependencyResolver.getHarmonyEnvPeersPolicyForComponent(this.component.extensions);
     if (!envPolicy || !Object.keys(envPolicy).length) {
       return;
     }
@@ -1199,6 +1215,27 @@ either, use the ignore file syntax or change the require statement to have a mod
     });
     // TODO: handle component deps once we support peers between components
     this.allPackagesDependencies.peerPackageDependencies = peerDeps;
+  }
+  async applyAutoDetectedPeersFromEnvOnEnvItSelf(): Promise<void> {
+    const envPolicy = await DependencyResolver.getHarmonyEnvPeersPolicyForEnvItself(this.component.id);
+    if (!envPolicy || !Object.keys(envPolicy).length) {
+      return;
+    }
+    const deps = this.allPackagesDependencies.packageDependencies || {};
+    // we are not iterate component deps since they are resolved from what actually installed
+    // the policy used for installation only in that case
+    ['packageDependencies', 'devPackageDependencies', 'peerPackageDependencies'].forEach((field) => {
+      R.forEachObjIndexed((_pkgVal, pkgName) => {
+        const peerVersionFromEnvPolicy = envPolicy[pkgName];
+        if (this.overridesDependencies.shouldIgnorePackageByType(pkgName, 'dependencies')) return;
+        if (peerVersionFromEnvPolicy) {
+          delete this.allPackagesDependencies[field][pkgName];
+        }
+      }, this.allPackagesDependencies[field]);
+    });
+    Object.assign(deps, envPolicy);
+    // TODO: handle component deps once we support peers between components
+    this.allPackagesDependencies.packageDependencies = deps;
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- add dependencies added by env.getDependencies().peers to the env itself as regular dependencies
- new getEnvDefinitionByLegacyId API

with this PR, if you have env with something like this:
```js
getDependencies: () => {
  return {
    peers: [
      {
        name: 'graphql',
        version: '14.3.0',
        supportedRange: '^14.0.0',
      }
    ]
  }
}
```
The env itself will have `graphql` with version `14.13.0` as regular dependency