### PR TITLE
improvement: sort "bit envs" table by the component-id alphabetically

### DIFF
--- a/scopes/envs/envs/envs.cmd.tsx
+++ b/scopes/envs/envs/envs.cmd.tsx
@@ -114,6 +114,7 @@ export class EnvsCmd implements Command {
       },
     ];
     const table = CLITable.fromObject(header, tableData);
+    table.sort();
     return table.render();
   }
 }

--- a/scopes/toolbox/tables/cli-table/cli-table.ts
+++ b/scopes/toolbox/tables/cli-table/cli-table.ts
@@ -14,6 +14,19 @@ export class CLITable {
     return table.toString();
   }
 
+  /**
+   * sort by the first column
+   */
+  sort() {
+    this.body.sort((a, b) => {
+      const aValue = a[0];
+      const bValue = b[0];
+      if (aValue < bValue) return -1;
+      if (aValue > bValue) return 1;
+      return 0;
+    });
+  }
+
   static fromObject(header: { value: string }[], data: Record<string, string>[]) {
     const headers = Object.values(header).map((d) => colors.cyan(d.value));
     return new CLITable(


### PR DESCRIPTION
Asked by @ocombe . 
(Windows does't have Ctrl+F in the CLI so it's hard to find when is not sorted). 