### PR TITLE
feat: add an option to clone a capsule

### DIFF
--- a/scopes/component/isolator/capsule/capsule.ts
+++ b/scopes/component/isolator/capsule/capsule.ts
@@ -114,6 +114,10 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
     return files.map((file) => path.join(dir, file));
   }
 
+  async clone(baseDir: string): Promise<Capsule> {
+    return Capsule.createFromComponent(this.component, baseDir);
+  }
+
   static getCapsuleDirName(component: Component, config: { alwaysNew?: boolean; name?: string } = {}) {
     return config.name || filenamify(component.id.toString(), { replacement: '_' });
   }
@@ -125,7 +129,7 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
   static async createFromComponent(
     component: Component,
     baseDir: string,
-    config: { alwaysNew?: boolean; name?: string } = {}
+    config: { alwaysNew?: boolean } = {}
   ): Promise<Capsule> {
     // TODO: make this a static method and combine with ComponentCapsule
     const capsuleDirName = Capsule.getCapsuleDirName(component, config);

--- a/scopes/component/isolator/capsule/capsule.ts
+++ b/scopes/component/isolator/capsule/capsule.ts
@@ -114,10 +114,6 @@ export default class Capsule extends CapsuleTemplate<Exec, NodeFS> {
     return files.map((file) => path.join(dir, file));
   }
 
-  async clone(baseDir: string): Promise<Capsule> {
-    return Capsule.createFromComponent(this.component, baseDir);
-  }
-
   static getCapsuleDirName(component: Component, config: { alwaysNew?: boolean; name?: string } = {}) {
     return config.name || filenamify(component.id.toString(), { replacement: '_' });
   }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -220,6 +220,20 @@ export class IsolatorMain {
   }
 
   /**
+   *
+   * @param originalCapsule the capsule that contains the original component
+   * @param newBaseDir relative path. (it will be saved inside `this.getRootDirOfAllCapsules()`. the final path of the capsule will be getRootDirOfAllCapsules() + newBaseDir + filenameify(component.id))
+   * @returns a new capsule with the same content of the original capsule but with a new baseDir and all packages
+   * installed in the newBaseDir.
+   */
+  async cloneCapsule(originalCapsule: Capsule, newBaseDir: string): Promise<Capsule> {
+    const network = await this.isolateComponents([originalCapsule.component.id], { baseDir: newBaseDir });
+    const clonedCapsule = network.seedersCapsules[0];
+    await fs.copy(originalCapsule.path, clonedCapsule.path);
+    return clonedCapsule;
+  }
+
+  /**
    * Create capsules for the provided components
    * do not use this outside directly, use isolate components which build the entire network
    * @param components
@@ -278,7 +292,7 @@ export class IsolatorMain {
     capsulesDir: string,
     capsuleList: CapsuleList,
     isolateInstallOptions: IsolateComponentsInstallOptions,
-    cachePackagesOnCapsulesRoot: boolean
+    cachePackagesOnCapsulesRoot?: boolean
   ) {
     const installer = this.dependencyResolver.getInstaller({
       rootDir: capsulesDir,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -45,7 +45,6 @@ import { Logger } from '@teambit/logger';
 import type { ScopeMain } from '@teambit/scope';
 import { isMatchNamespacePatternItem } from '@teambit/workspace.modules.match-pattern';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
-import { ResolvedComponent } from '@teambit/harmony.modules.resolved-component';
 import type { VariantsMain, Patterns } from '@teambit/variants';
 import { link } from '@teambit/legacy/dist/api/consumer';
 import LegacyGraph from '@teambit/legacy/dist/scope/graph/graph';
@@ -464,32 +463,6 @@ export class Workspace implements ComponentFactory {
     const dependentsLegacyNoDup = BitIds.uniqFromArray(dependentsLegacyIds);
     const dependentsIds = await this.resolveMultipleComponentIds(dependentsLegacyNoDup);
     return dependentsIds;
-  }
-
-  async loadCapsules(bitIds: string[]) {
-    // throw new Error("Method not implemented.");
-    const components = await this.load(bitIds);
-    return components.map((comp) => comp.capsule);
-  }
-  /**
-   * fully load components, including dependency resolution and prepare them for runtime.
-   * @todo: remove the string option, use only BitId
-   */
-  async load(ids: Array<BitId | string>): Promise<ResolvedComponent[]> {
-    const componentIds = await this.resolveMultipleComponentIds(ids);
-    const components = await this.getMany(componentIds);
-    const network = await this.isolator.isolateComponents(
-      components.map((c) => c.id),
-      {
-        packageManagerConfigRootDir: this.path,
-      }
-    );
-    const resolvedComponents = components.map((component) => {
-      const capsule = network.graphCapsules.getCapsule(component.id);
-      if (!capsule) throw new Error(`unable to find capsule for ${component.id.toString()}`);
-      return new ResolvedComponent(component, capsule);
-    });
-    return resolvedComponents;
   }
 
   public async createAspectList(extensionDataList: ExtensionDataList) {


### PR DESCRIPTION
## Proposed Changes

- add a new API to the Isolator for cloning a capsule and having all packages installed in the new capsule. The content inside the capsule is the same as the original.
- remove some unneeded methods from `Workspace`. 
