### PR TITLE
fix: throw an error when running bit import --dependencies/--dependents without ids

### DIFF
--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -104,6 +104,12 @@ ${WILDCARD_HELP('import')}`;
     if (override && merge) {
       throw new GeneralError('you cant use --override and --merge flags combined');
     }
+    if (!ids.length && dependencies) {
+      throw new GeneralError('you have to specify ids to use "--dependencies" flag');
+    }
+    if (!ids.length && dependents) {
+      throw new GeneralError('you have to specify ids to use "--dependents" flag');
+    }
     if (skipNpmInstall) {
       // eslint-disable-next-line no-console
       console.log(


### PR DESCRIPTION
Currently, it just ignores the flag and leave the user confused. 