### PR TITLE
re-organize pkg and dep-resolver APIs

### DIFF
--- a/scopes/component/capsules-syncer/capsules-syncer.task.ts
+++ b/scopes/component/capsules-syncer/capsules-syncer.task.ts
@@ -9,32 +9,35 @@ import { hardLinkDirectory } from '@teambit/toolbox.fs.hard-link-directory';
 export class CapsulesSyncerTask implements BuildTask {
   readonly name = 'SyncComponents';
   readonly dependencies = [CompilerAspect.id]; // I can put my new task here. And compiler to the deps of this taks
-  constructor(readonly aspectId: string, private devFiles: DevFilesMain,
-    private dependencyResolver: DependencyResolverMain,
+  constructor(
+    readonly aspectId: string,
+    private devFiles: DevFilesMain,
+    private dependencyResolver: DependencyResolverMain
   ) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
-    if (!this.dependencyResolver.config.rootComponents) return {
-      artifacts: [],
-      componentsResults: [],
-    };
-    await Promise.all(context.capsuleNetwork.seedersCapsules.map(async (capsule) => {
-      const relCompDir = path.relative(context.capsuleNetwork.capsulesRootDir, capsule.path).replace(/\\/g, '/');
-      const injectedDirs = await this.dependencyResolver.getInjectedDirs(
-        context.capsuleNetwork.capsulesRootDir,
-        relCompDir,
-        componentIdToPackageName(capsule.component.state._consumer)
-      );
-      return hardLinkDirectory(capsule.path,
-        injectedDirs.map((injectedDir) =>
-          path.join(context.capsuleNetwork.capsulesRootDir, injectedDir)
-        )
-      );
-    }))
+    if (!this.dependencyResolver.hasRootComponents())
+      return {
+        artifacts: [],
+        componentsResults: [],
+      };
+    await Promise.all(
+      context.capsuleNetwork.seedersCapsules.map(async (capsule) => {
+        const relCompDir = path.relative(context.capsuleNetwork.capsulesRootDir, capsule.path).replace(/\\/g, '/');
+        const injectedDirs = await this.dependencyResolver.getInjectedDirs(
+          context.capsuleNetwork.capsulesRootDir,
+          relCompDir,
+          componentIdToPackageName(capsule.component.state._consumer)
+        );
+        return hardLinkDirectory(
+          capsule.path,
+          injectedDirs.map((injectedDir) => path.join(context.capsuleNetwork.capsulesRootDir, injectedDir))
+        );
+      })
+    );
     return {
       artifacts: [],
       componentsResults: [],
     };
   }
 }
-

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -247,7 +247,7 @@ export class IsolatorMain {
     legacyScope?: Scope
   ): Promise<CapsuleList> {
     if (opts.installOptions) {
-      opts.installOptions.useNesting = this.dependencyResolver.config.rootComponents && opts.installOptions.useNesting;
+      opts.installOptions.useNesting = this.dependencyResolver.hasRootComponents() && opts.installOptions.useNesting;
     }
     const config = { installPackages: true, ...opts };
     const capsulesDir = this.getCapsulesRootDir(opts.baseDir as string, opts.rootBaseDir);
@@ -273,7 +273,7 @@ export class IsolatorMain {
     await this.updateWithCurrentPackageJsonData(capsulesWithPackagesData, capsuleList);
     const installOptions = Object.assign({}, DEFAULT_ISOLATE_INSTALL_OPTIONS, opts.installOptions || {});
     if (installOptions.installPackages) {
-      const rootDir = opts.installOptions?.useNesting ? capsuleList[0].path : capsulesDir
+      const rootDir = opts.installOptions?.useNesting ? capsuleList[0].path : capsulesDir;
       await this.installInCapsules(rootDir, capsuleList, installOptions, opts.cachePackagesOnCapsulesRoot ?? false);
       await this.linkInCapsules(capsulesDir, capsuleList, capsulesWithPackagesData, opts.linkingOptions ?? {});
     }
@@ -318,7 +318,7 @@ export class IsolatorMain {
       copyPeerToRuntimeOnRoot: isolateInstallOptions.copyPeerToRuntimeOnRoot,
       installPeersFromEnvs: isolateInstallOptions.installPeersFromEnvs,
       overrides: this.dependencyResolver.config.capsulesOverrides || this.dependencyResolver.config.overrides,
-      rootComponentsForCapsules: this.dependencyResolver.config.rootComponents,
+      rootComponentsForCapsules: this.dependencyResolver.hasRootComponents(),
       useNesting: isolateInstallOptions.useNesting,
     };
     await installer.install(
@@ -342,14 +342,14 @@ export class IsolatorMain {
     });
     const peerOnlyPolicy = this.getWorkspacePeersOnlyPolicy();
     const capsulesWithModifiedPackageJson = this.getCapsulesWithModifiedPackageJson(capsulesWithPackagesData);
-    if (this.dependencyResolver.config.rootComponents) {
+    if (this.dependencyResolver.hasRootComponents()) {
       linkingOptions.linkNestedDepsInNM = false;
     }
     await linker.link(capsulesDir, peerOnlyPolicy, this.toComponentMap(capsuleList), {
       ...linkingOptions,
       legacyLink: false,
     });
-    if (!this.dependencyResolver.config.rootComponents) {
+    if (!this.dependencyResolver.hasRootComponents()) {
       await symlinkOnCapsuleRoot(capsuleList, this.logger, capsulesDir);
       await symlinkDependenciesToCapsules(capsulesWithModifiedPackageJson, capsuleList, this.logger);
     }
@@ -474,7 +474,7 @@ export class IsolatorMain {
       const subcapsulesDir = path.join(baseDir, Capsule.getCapsuleDirName(components[0], opts), `subcapsules`);
       const capsules: Capsule[] = await Promise.all(
         components.map((component: Component, index) => {
-          const dir = index === 0 ? baseDir : subcapsulesDir
+          const dir = index === 0 ? baseDir : subcapsulesDir;
           return Capsule.createFromComponent(component, dir, opts);
         })
       );

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -329,8 +329,8 @@ export class PreviewMain {
         const compilerInstance = environment.getCompiler?.();
         let modulePath =
           compilerInstance?.getPreviewComponentRootPath?.(component) || this.pkg.getModulePath(component);
-        if (this.dependencyResolver.config.rootComponents) {
-          modulePath = `${modulePath}/${modulePath}`
+        if (this.dependencyResolver.hasRootComponents()) {
+          modulePath = `${modulePath}/${modulePath}`;
         }
         return files.map((file) => {
           if (!this.workspace || !compilerInstance) {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1753,7 +1753,7 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
 
     const depsFilterFn = await this.generateFilterFnForDepsFromLocalRemote();
 
-    const hasRootComponents = Boolean(this.dependencyResolver.config.rootComponents);
+    const hasRootComponents = this.dependencyResolver.hasRootComponents();
     const pmInstallOptions: PackageManagerInstallOptions = {
       dedupe: !hasRootComponents && options?.dedupe,
       copyPeerToRuntimeOnRoot: options?.copyPeerToRuntimeOnRoot ?? true,


### PR DESCRIPTION
- move getPackageName, getModulePath and getRuntimeModulePath APIs implementation to the dep resolver aspect
- proxy getPackageName, getModulePath and getRuntimeModulePath APIs from pkg aspect
- add hasRootComponents API to dep resolver aspect
- use the new hasRootComponents API from dep resolver
