### PR TITLE
Injected-peers--webpack-paths

### DIFF
--- a/scopes/compilation/bundler/bundler-context.ts
+++ b/scopes/compilation/bundler/bundler-context.ts
@@ -94,6 +94,14 @@ export type Target = {
    * Different configuration related to chunking
    */
   chunking?: Chunking;
+
+  /**
+   * A path for the host root dir
+   * Host root dir is usually the env root dir
+   * This can be used in different bundle options which run require.resolve
+   * for example when configuring webpack aliases or webpack expose loader on the peers deps
+   */
+  hostRootDir?: string;
 };
 
 export type ModuleTarget = {

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -156,6 +156,8 @@ export class EnvPreviewTemplateTask implements BuildTask {
     const outputPath = this.computeOutputPath(context, envComponent);
     if (!existsSync(outputPath)) mkdirpSync(outputPath);
     const entries = this.getEntries(previewModules, capsule, previewRoot, isSplitComponentBundle, peers);
+    const resolvedEnvAspects = await this.preview.resolveAspects(undefined, [envComponent.id]);
+    const hostRootDir = resolvedEnvAspects[0].aspectPath;
 
     return {
       peers,
@@ -167,6 +169,7 @@ export class EnvPreviewTemplateTask implements BuildTask {
       },
       components: [envComponent],
       outputPath,
+      hostRootDir,
     };
   }
 

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -327,11 +327,8 @@ export class PreviewMain {
       const withPaths = map.map<string[]>((files, component) => {
         const environment = this.envs.getEnv(component).env;
         const compilerInstance = environment.getCompiler?.();
-        let modulePath =
-          compilerInstance?.getPreviewComponentRootPath?.(component) || this.pkg.getModulePath(component);
-        if (this.dependencyResolver.hasRootComponents()) {
-          modulePath = `${modulePath}/${modulePath}`;
-        }
+        const modulePath =
+          compilerInstance?.getPreviewComponentRootPath?.(component) || this.pkg.getRuntimeModulePath(component);
         return files.map((file) => {
           if (!this.workspace || !compilerInstance) {
             return file.path;

--- a/scopes/preview/preview/preview.main.runtime.tsx
+++ b/scopes/preview/preview/preview.main.runtime.tsx
@@ -7,7 +7,7 @@ import { Component, ComponentAspect, ComponentMain, ComponentMap, ComponentID } 
 import { EnvsAspect } from '@teambit/envs';
 import type { EnvsMain, ExecutionContext, PreviewEnv } from '@teambit/envs';
 import { Slot, SlotRegistry, Harmony } from '@teambit/harmony';
-import { UIAspect, UiMain } from '@teambit/ui';
+import { UIAspect, UiMain, UIRoot } from '@teambit/ui';
 import { CACHE_ROOT } from '@teambit/legacy/dist/constants';
 import { BitError } from '@teambit/bit-error';
 import objectHash from 'object-hash';
@@ -350,13 +350,28 @@ export class PreviewMain {
   }
 
   async writePreviewRuntime(context: { components: Component[] }, aspectsIdsToNotFilterOut: string[] = []) {
-    const ui = this.ui.getUi();
-    if (!ui) throw new Error('ui not found');
-    const [name, uiRoot] = ui;
-    const resolvedAspects = await uiRoot.resolveAspects(PreviewRuntime.name);
+    const [name, uiRoot] = this.getUi();
+    const resolvedAspects = await this.resolveAspects(PreviewRuntime.name, undefined, uiRoot);
     const filteredAspects = this.filterAspectsByExecutionContext(resolvedAspects, context, aspectsIdsToNotFilterOut);
     const filePath = await this.ui.generateRoot(filteredAspects, name, 'preview', PreviewAspect.id);
     return filePath;
+  }
+
+  async resolveAspects(
+    runtimeName?: string,
+    componentIds?: ComponentID[],
+    uiRoot?: UIRoot
+  ): Promise<AspectDefinition[]> {
+    const root = uiRoot || this.getUi()[1];
+    runtimeName = runtimeName || MainRuntime.name;
+    const resolvedAspects = await root.resolveAspects(runtimeName, componentIds);
+    return resolvedAspects;
+  }
+
+  private getUi() {
+    const ui = this.ui.getUi();
+    if (!ui) throw new Error('ui not found');
+    return ui;
   }
 
   /**

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -52,7 +52,7 @@ import envPreviewDevConfigFactory from './webpack/webpack.config.env.dev';
 // webpack configs for components only
 import componentPreviewProdConfigFactory from './webpack/webpack.config.component.prod';
 import componentPreviewDevConfigFactory from './webpack/webpack.config.component.dev';
-import { generateAddAliasesFromPeersTransformer } from './webpack/transformers';
+import { generateAddAliasesFromPeersTransformer, generateExposePeersTransformer } from './webpack/transformers';
 
 export const ReactEnvType = 'react';
 const defaultTsConfig = require('./typescript/tsconfig.json');
@@ -117,7 +117,7 @@ export class ReactEnv
 
     private compilerAspectId: string,
 
-    private capsulesSyncer: CapsulesSyncerMain,
+    private capsulesSyncer: CapsulesSyncerMain
   ) {}
 
   getTsConfig(targetTsConfig?: TsConfigSourceFile): TsConfigSourceFile {
@@ -322,6 +322,7 @@ export class ReactEnv
   ): Promise<Bundler> {
     const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
+    const exposePeersTransformer = generateExposePeersTransformer(peers);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
 
@@ -329,7 +330,7 @@ export class ReactEnv
       const merged = configMutator.merge([baseConfig, baseProdConfig]);
       return merged;
     };
-    const mergedTransformers = [defaultTransformer, peerAliasesTransformer, ...transformers];
+    const mergedTransformers = [defaultTransformer, peerAliasesTransformer, exposePeersTransformer, ...transformers];
     return this.createWebpackBundler(context, mergedTransformers);
   }
 

--- a/scopes/react/react/webpack/get-exposed-rules.ts
+++ b/scopes/react/react/webpack/get-exposed-rules.ts
@@ -2,10 +2,16 @@ import camelcase from 'camelcase';
 import 'expose-loader';
 import { generateExposeLoaders } from '@teambit/webpack.modules.generate-expose-loaders';
 
-export function getExposedRules(peers: string[]) {
+export function getExposedRules(peers: string[], hostRootDir?: string) {
   const loaderPath = require.resolve('expose-loader');
+  let options;
+  if (hostRootDir) {
+    options = {
+      paths: [hostRootDir, __dirname],
+    };
+  }
   const depsEntries = peers.map((peer) => ({
-    path: require.resolve(peer),
+    path: require.resolve(peer, options),
     globalName: camelcase(peer.replace('@', '').replace('/', '-'), { pascalCase: true }),
   }));
   return generateExposeLoaders(depsEntries, { loaderPath });

--- a/scopes/react/react/webpack/webpack.config.base.prod.ts
+++ b/scopes/react/react/webpack/webpack.config.base.prod.ts
@@ -3,7 +3,6 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { Configuration } from 'webpack';
 import { getExternals } from './get-externals';
-import { getExposedRules } from './get-exposed-rules';
 // import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 
 // This is the production and development configuration.
@@ -11,13 +10,6 @@ import { getExposedRules } from './get-exposed-rules';
 // eslint-disable-next-line complexity
 export default function (externalizePeer: boolean, peers: string[], dev?: boolean): Configuration {
   const externals = externalizePeer ? (getExternals(peers) as any) : undefined;
-  const exposedRules = externalizePeer ? undefined : getExposedRules(peers);
-
-  const module = externalizePeer
-    ? undefined
-    : {
-        rules: exposedRules,
-      };
 
   const optimization = dev
     ? undefined
@@ -105,7 +97,6 @@ export default function (externalizePeer: boolean, peers: string[], dev?: boolea
       };
 
   return {
-    module,
     externals,
     optimization,
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -658,6 +658,17 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
     if (runtimeName) {
       defs = defs.filter((def) => def.runtimePath);
     }
+
+    if (componentIds && componentIds.length) {
+      const componentIdsString = componentIds.map((id) => id.toString());
+      defs = defs.filter((def) => {
+        return (
+          (def.id && componentIdsString.includes(def.id)) ||
+          (def.component && componentIdsString.includes(def.component?.id.toString()))
+        );
+      });
+    }
+
     return defs;
   }
 

--- a/scopes/scope/scope/scope.ui-root.ts
+++ b/scopes/scope/scope/scope.ui-root.ts
@@ -1,3 +1,4 @@
+import { ComponentID } from '@teambit/component-id';
 import { UIRoot } from '@teambit/ui';
 
 import type { ScopeMain } from './scope.main.runtime';
@@ -30,8 +31,8 @@ export class ScopeUIRoot implements UIRoot {
     ssr: true,
   };
 
-  resolveAspects(runtime: string) {
-    return this.scope.resolveAspects(runtime);
+  resolveAspects(runtime: string, componentIds?: ComponentID[]) {
+    return this.scope.resolveAspects(runtime, componentIds);
   }
 
   async resolvePattern() {

--- a/scopes/ui-foundation/ui/ui-root.tsx
+++ b/scopes/ui-foundation/ui/ui-root.tsx
@@ -1,6 +1,6 @@
 import { AspectDefinition } from '@teambit/aspect-loader';
 import { ComponentDir } from '@teambit/bundler';
-import { Component } from '@teambit/component';
+import { Component, ComponentID } from '@teambit/component';
 import { ProxyConfigArrayItem } from 'webpack-dev-server';
 
 // TODO: remove this extends "ComponentDir", this should be part of the workspace alone since scope
@@ -27,9 +27,9 @@ export interface UIRoot extends ComponentDir {
   };
 
   /**
-   * resolve all aspects in the UI root.
+   * resolve aspects in the UI root. (resolve all if componentIds not provided)
    */
-  resolveAspects(runtimeName: string): Promise<AspectDefinition[]>;
+  resolveAspects(runtimeName: string, componentIds?: ComponentID[]): Promise<AspectDefinition[]>;
 
   /**
    * resolve components from a given pattern.

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -424,7 +424,7 @@ export class UiMain {
       runtimeName,
       this.harmony.config.toObject()
     );
-    const filepath = resolve(join(__dirname, `${runtimeName}.root${sha1(contents)}.js`));
+    const filepath = resolve(join(__dirname, `${runtimeName}.root.${sha1(contents)}.js`));
     if (fs.existsSync(filepath)) return filepath;
     fs.outputFileSync(filepath, contents);
     return filepath;

--- a/scopes/webpack/config-mutator/config-mutator.ts
+++ b/scopes/webpack/config-mutator/config-mutator.ts
@@ -92,7 +92,7 @@ export class WebpackConfigMutator {
 
   /**
    * Add rule to the module config
-   * @param entry
+   * @param rule
    * @param opts
    * @returns
    */
@@ -105,6 +105,17 @@ export class WebpackConfigMutator {
     }
 
     addToArray(this.raw.module.rules, rule, opts);
+    return this;
+  }
+
+  /**
+   * Add many rules to the module config
+   * @param rules
+   * @param opts
+   * @returns
+   */
+  addModuleRules(rules: RuleSetRule[], opts: AddToArrayOpts = {}): WebpackConfigMutator {
+    rules.forEach((rule) => this.addModuleRule(rule, opts));
     return this;
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1404,7 +1404,7 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
     const wsComponents = await this.getMany(workspaceIds);
     const aspectDefs = await this.aspectLoader.resolveAspects(wsComponents, async (component) => {
       stringIds.push(component.id._legacy.toString());
-      const localPath = this.getComponentPackagePath(component.state._consumer);
+      const localPath = this.getComponentPackagePath(component);
       const isExist = await fs.pathExists(localPath);
       if (!isExist) {
         missingPaths = true;
@@ -1884,11 +1884,9 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     this.clearCache();
   }
 
-  getComponentPackagePath(component: ConsumerComponent | Component) {
-    const packageName = componentIdToPackageName(
-      component instanceof ConsumerComponent ? component : component.state._consumer
-    );
-    return path.join(this.modulesPath, packageName);
+  getComponentPackagePath(component: Component) {
+    const relativePath = this.dependencyResolver.getRuntimeModulePath(component);
+    return path.join(this.path, relativePath);
   }
 
   // TODO: should we return here the dir as it defined (aka components) or with /{name} prefix (as it used in legacy)

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1446,6 +1446,16 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
       defs = defs.filter((def) => def.runtimePath);
     }
 
+    if (componentIds && componentIds.length) {
+      const componentIdsString = componentIds.map((id) => id.toString());
+      defs = defs.filter((def) => {
+        return (
+          (def.id && componentIdsString.includes(def.id)) ||
+          (def.component && componentIdsString.includes(def.component?.id.toString()))
+        );
+      });
+    }
+
     return defs;
   }
 

--- a/scopes/workspace/workspace/workspace.ui-root.ts
+++ b/scopes/workspace/workspace/workspace.ui-root.ts
@@ -38,8 +38,8 @@ export class WorkspaceUIRoot implements UIRoot {
     launchBrowserOnStart: true,
   };
 
-  async resolveAspects(runtimeName: string) {
-    return this.workspace.resolveAspects(runtimeName);
+  async resolveAspects(runtimeName: string, componentIds?: ComponentID[]) {
+    return this.workspace.resolveAspects(runtimeName, componentIds);
   }
 
   // TODO: @gilad please implement with variants.


### PR DESCRIPTION
## Proposed Changes

- fix preview root file name (add '.' separator)
- use the runtime module path when updating preview link files
- update the getComponentPackagePath in the workspace to use the new dep resolver getRuntimeModulePath
- add hostRootDir to the bundler target interface
- update ui root interface to have optional component ids in resolve aspects
- pass on component ids from workspace and scope ui roots to resolve aspects
- filter results from resolve aspects by provided component ids
- add resolve aspects API to preview aspect
- add new addModuleRules API to webpack config mutator
- pass host root dir to bundler target for env preview template task
- add new generateExposePeersTransformer to react env
- support hostRootDir for generateAddAliasesFromPeersTransformer and for generateExposePeersTransformer
- support hostRootDir for getExposedRules