### PR TITLE
fix circle cache and publish version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1706,32 +1706,38 @@ workflows:
   # uncomment and change the filter branch name to debug the bvm bundle jobs
   bvm_bundle_debug:
     jobs:
-      - bundle_version_linux:
+      - checkout_code:
           filters:
             branches:
               only: fix-circle-cache
-      - bundle_version_windows:
-          filters:
-            branches:
-              only: fix-circle-cache
-      - bundle_version_macos:
-          filters:
-            branches:
-              only: fix-circle-cache
-      - harmony_publish_to_gcloud:
-          filters:
-            branches:
-              only: fix-circle-cache
-          requires:
-            - bundle_version_macos
-            - bundle_version_linux
-            - bundle_version_windows
+#       - bundle_version_linux:
+#           filters:
+#             branches:
+#               only: fix-circle-cache
+#       - bundle_version_windows:
+#           filters:
+#             branches:
+#               only: fix-circle-cache
+#       - bundle_version_macos:
+#           filters:
+#             branches:
+#               only: fix-circle-cache
+#       - harmony_publish_to_gcloud:
+#           filters:
+#             branches:
+#               only: fix-circle-cache
+#           requires:
+#             - bundle_version_macos
+#             - bundle_version_linux
+#             - bundle_version_windows
       - docker_build:
           requires:
-            - harmony_publish_to_gcloud
+            - checkout_code
+#             - harmony_publish_to_gcloud
       - docker_non_root_build:
           requires:
-            - harmony_publish_to_gcloud
+            - checkout_code
+#             - harmony_publish_to_gcloud
       - server_docker_build:
           requires:
             - docker_build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,12 +760,12 @@ jobs:
       - run: mkdir esbuild-arm
       # in order to bring new version of esbuild, you need to install it on m1, tar it, and upload to the bucket
       # then you can download it here and change the cache name (don't forget to change both save_cache and restore_cache key)
-      # - run: brew install wget
-      # - run: cd esbuild-arm && wget https://storage.googleapis.com/bvm.bit.dev/external-assets/esbuild-0.14.29-darwin-arm64.tar.gz
-      # - save_cache:
-      #     key: esbuild-0.14.29-darwin-arm64-v1
-      #     paths:
-      #       - esbuild-arm/esbuild-0.14.29-darwin-arm64.tar.gz
+      - run: brew install wget
+      - run: cd esbuild-arm && wget https://storage.googleapis.com/bvm.bit.dev/external-assets/esbuild-0.14.29-darwin-arm64.tar.gz
+      - save_cache:
+          key: esbuild-0.14.29-darwin-arm64-v1
+          paths:
+            - esbuild-arm/esbuild-0.14.29-darwin-arm64.tar.gz
       - restore_cache:
           key: esbuild-0.14.29-darwin-arm64-v1
       - run: cd esbuild-arm && tar -xvf esbuild-0.14.29-darwin-arm64.tar.gz
@@ -1704,23 +1704,34 @@ workflows:
             - harmony_deploy_approval_job
             - docker_build
   # uncomment and change the filter branch name to debug the bvm bundle jobs
-  # bvm_bundle_debug:
-  #   jobs:
-  #     - bundle_version_linux:
-  #         filters:
-  #           branches:
-  #             only: bvm-build-from-bit-dev-registry
-      # - bundle_version_windows:
-      #     filters:
-      #       branches:
-      #         only: bvm-build-from-bit-dev-registry1
-      # - bundle_version_macos:
-      #     filters:
-      #       branches:
-      #         only: bvm-build-from-bit-dev-registry1
-      # - harmony_publish_to_gcloud:
-      #     filters:
-      #       branches:
-      #         only: bvm-build-from-bit-dev-registry1
-      #     requires:
-      #       - bundle_version_macos
+  bvm_bundle_debug:
+    jobs:
+      - bundle_version_linux:
+          filters:
+            branches:
+              only: fix-circle-cache
+      - bundle_version_windows:
+          filters:
+            branches:
+              only: fix-circle-cache
+      - bundle_version_macos:
+          filters:
+            branches:
+              only: fix-circle-cache
+      - harmony_publish_to_gcloud:
+          filters:
+            branches:
+              only: fix-circle-cache
+          requires:
+            - bundle_version_macos
+      - docker_build:
+          requires:
+            - harmony_publish_to_gcloud
+      - docker_non_root_build:
+          requires:
+            - harmony_publish_to_gcloud
+      - server_docker_build:
+          requires:
+            - docker_build
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1704,12 +1704,12 @@ workflows:
             - harmony_deploy_approval_job
             - docker_build
   # uncomment and change the filter branch name to debug the bvm bundle jobs
-  bvm_bundle_debug:
-    jobs:
-      - checkout_code:
-          filters:
-            branches:
-              only: fix-circle-cache
+#   bvm_bundle_debug:
+#     jobs:
+#       - checkout_code:
+#           filters:
+#             branches:
+#               only: fix-circle-cache
 #       - bundle_version_linux:
 #           filters:
 #             branches:
@@ -1730,16 +1730,16 @@ workflows:
 #             - bundle_version_macos
 #             - bundle_version_linux
 #             - bundle_version_windows
-      - docker_build:
-          requires:
-            - checkout_code
+#       - docker_build:
+#           requires:
+#             - checkout_code
 #             - harmony_publish_to_gcloud
-      - docker_non_root_build:
-          requires:
-            - checkout_code
+#       - docker_non_root_build:
+#           requires:
+#             - checkout_code
 #             - harmony_publish_to_gcloud
-      - server_docker_build:
-          requires:
-            - docker_build
+#       - server_docker_build:
+#           requires:
+#             - docker_build
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -760,12 +760,12 @@ jobs:
       - run: mkdir esbuild-arm
       # in order to bring new version of esbuild, you need to install it on m1, tar it, and upload to the bucket
       # then you can download it here and change the cache name (don't forget to change both save_cache and restore_cache key)
-      - run: brew install wget
-      - run: cd esbuild-arm && wget https://storage.googleapis.com/bvm.bit.dev/external-assets/esbuild-0.14.29-darwin-arm64.tar.gz
-      - save_cache:
-          key: esbuild-0.14.29-darwin-arm64-v1
-          paths:
-            - esbuild-arm/esbuild-0.14.29-darwin-arm64.tar.gz
+#       - run: brew install wget
+#       - run: cd esbuild-arm && wget https://storage.googleapis.com/bvm.bit.dev/external-assets/esbuild-0.14.29-darwin-arm64.tar.gz
+#       - save_cache:
+#           key: esbuild-0.14.29-darwin-arm64-v1
+#           paths:
+#             - esbuild-arm/esbuild-0.14.29-darwin-arm64.tar.gz
       - restore_cache:
           key: esbuild-0.14.29-darwin-arm64-v1
       - run: cd esbuild-arm && tar -xvf esbuild-0.14.29-darwin-arm64.tar.gz
@@ -1724,6 +1724,8 @@ workflows:
               only: fix-circle-cache
           requires:
             - bundle_version_macos
+            - bundle_version_linux
+            - bundle_version_windows
       - docker_build:
           requires:
             - harmony_publish_to_gcloud


### PR DESCRIPTION
## Proposed Changes

- the fix was done via running the bvm bundle debug, with the step to re-generate the cache enabled
- this pr does not change anything, just add some more debug steps around docker for the bvm bundle debug workflow

