### PR TITLE
update scope list http to use the new gql query

### DIFF
--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -24,7 +24,7 @@ export function scopeSchema(scopeMain: ScopeMain) {
         path: String
 
         # list of components contained in the scope.
-        components(offset: Int, limit: Int, includeCache: Boolean): [Component]
+        components(offset: Int, limit: Int, includeCache: Boolean, namespaces: [String!]): [Component]
 
         # get a specific component.
         get(id: String!): Component
@@ -42,7 +42,7 @@ export function scopeSchema(scopeMain: ScopeMain) {
         _legacyLatestVersions(ids: [String]!): [String]
 
         # get serialized list component of components. deprecated. PLEASE DO NOT USE THIS API.
-        _legacyList(namespaces: String): [LegacyMeta]
+        _legacyList(namespaces: String): [LegacyMeta] @deprecated(reason: "Use the component query on Scope")
       }
 
       type Log {
@@ -77,9 +77,12 @@ export function scopeSchema(scopeMain: ScopeMain) {
         backgroundIconColor: (scope: ScopeMain) => {
           return scope.backgroundIconColor;
         },
-        components: (scope: ScopeMain, props?: { offset: number; limit: number; includeCache?: boolean }) => {
+        components: (
+          scope: ScopeMain,
+          props?: { offset: number; limit: number; includeCache?: boolean; namespaces?: string[] }
+        ) => {
           if (!props) return scope.list();
-          return scope.list({ offset: props.offset, limit: props.limit }, props.includeCache);
+          return scope.list({ ...props }, props.includeCache);
         },
 
         get: async (scope: ScopeMain, { id }: { id: string }) => {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -731,11 +731,13 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
    * list all components in the scope.
    */
   async list(
-    filter?: { offset: number; limit: number },
+    filter?: { offset: number; limit: number; namespaces?: string[] },
     includeCache = false,
     includeFromLanes = false
   ): Promise<Component[]> {
-    const componentsIds = await this.listIds(includeCache, includeFromLanes);
+    const patternsWithScope =
+      (filter?.namespaces && filter?.namespaces.map((pattern) => `**/${pattern || '**'}`)) || undefined;
+    const componentsIds = await this.listIds(includeCache, includeFromLanes, patternsWithScope);
 
     return this.getMany(
       filter && filter.limit ? slice(componentsIds, filter.offset, filter.offset + filter.limit) : componentsIds
@@ -755,17 +757,23 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
    * get ids of all scope components.
    * @param includeCache whether or not include components that their scope-name is different than the current scope-name
    */
-  async listIds(includeCache = false, includeFromLanes = false): Promise<ComponentID[]> {
+  async listIds(includeCache = false, includeFromLanes = false, patterns?: string[]): Promise<ComponentID[]> {
     const allModelComponents = await this.legacyScope.list();
     const filterByCacheAndLanes = (modelComponent: ModelComponent) => {
       const cacheFilter = includeCache ? true : this.exists(modelComponent);
       const lanesFilter = includeFromLanes ? true : modelComponent.hasHead();
+
       return cacheFilter && lanesFilter;
     };
     const modelComponentsToList = allModelComponents.filter(filterByCacheAndLanes);
-    const ids = modelComponentsToList.map((component) =>
+    let ids = modelComponentsToList.map((component) =>
       ComponentID.fromLegacy(component.toBitIdWithLatestVersion(), component.scope || this.name)
     );
+    if (patterns && patterns.length > 0) {
+      ids = ids.filter((id) =>
+        patterns?.some((pattern) => isMatchNamespacePatternItem(id.toStringWithoutVersion(), pattern).match)
+      );
+    }
     this.logger.debug(`scope listIds: componentsIds after filter scope: ${JSON.stringify(ids, undefined, 2)}`);
     return ids;
   }
@@ -868,13 +876,11 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
    * load components into the scope through a variants pattern.
    */
   async byPattern(patterns: string[], scope = '**'): Promise<Component[]> {
-    const ids = await this.listIds(true);
-    const finalPatterns = patterns.map((pattern) => `${scope}/${pattern || '**'}`);
-    const targetIds = ids.filter((id) => {
-      return finalPatterns.some((pattern) => isMatchNamespacePatternItem(id.toStringWithoutVersion(), pattern).match);
-    });
+    const patternsWithScope = patterns.map((pattern) => `${scope}/${pattern || '**'}`);
 
-    const components = await this.getMany(targetIds);
+    const ids = await this.listIds(true, false, patternsWithScope);
+
+    const components = await this.getMany(ids);
     return components;
   }
 


### PR DESCRIPTION
## Proposed Changes

- This also fixes the scenario when importing from a remote scope with components that exist only on lane. It filters the components from the scope list query which do not have `head` defined
