### PR TITLE
feat: introduce "bit scope rename" to change a scope-name

### DIFF
--- a/scopes/component/refactoring/index.ts
+++ b/scopes/component/refactoring/index.ts
@@ -1,5 +1,5 @@
 import { RefactoringAspect } from './refactoring.aspect';
 
-export type { RefactoringMain } from './refactoring.main.runtime';
+export type { RefactoringMain, MultipleStringsReplacement } from './refactoring.main.runtime';
 export default RefactoringAspect;
 export { RefactoringAspect };

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -1,24 +1,31 @@
+import path from 'path';
+import { BitError } from '@teambit/bit-error';
+import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import ComponentAspect, { Component, ComponentID, ComponentMain } from '@teambit/component';
 import { DeprecationAspect, DeprecationMain } from '@teambit/deprecation';
 import GraphqlAspect, { GraphqlMain } from '@teambit/graphql';
 import NewComponentHelperAspect, { NewComponentHelperMain } from '@teambit/new-component-helper';
-import RefactoringAspect, { RefactoringMain } from '@teambit/refactoring';
+import RefactoringAspect, { MultipleStringsReplacement, RefactoringMain } from '@teambit/refactoring';
+import { getBindingPrefixByDefaultScope } from '@teambit/legacy/dist/consumer/config/component-config';
+import { ConfigAspect, ConfigMain } from '@teambit/config';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { RenameCmd, RenameOptions } from './rename.cmd';
 import { RenamingAspect } from './renaming.aspect';
 import { RenamingFragment } from './renaming.fragment';
 import { renamingSchema } from './renaming.graphql';
+import { ScopeRenameCmd } from './scope-rename.cmd';
 
 export class RenamingMain {
   constructor(
     private workspace: Workspace,
     private newComponentHelper: NewComponentHelperMain,
     private deprecation: DeprecationMain,
-    private refactoring: RefactoringMain
+    private refactoring: RefactoringMain,
+    private config: ConfigMain
   ) {}
 
-  async rename(sourceIdStr: string, targetIdStr: string, options: RenameOptions): Promise<RenameResult> {
+  async rename(sourceIdStr: string, targetIdStr: string, options: RenameOptions): Promise<RenameDependencyNameResult> {
     const sourceId = await this.workspace.resolveComponentId(sourceIdStr);
     const isTagged = sourceId.hasVersion();
     const sourceComp = await this.workspace.get(sourceId);
@@ -53,6 +60,70 @@ export class RenamingMain {
     };
   }
 
+  /**
+   * change the default-scope for new components. optionally (if refactor is true), change the source code to match the
+   * new scope-name.
+   * keep in mind that this is working for new components only, for tagged/exported it's impossible. See the errors
+   * thrown in such cases in this method.
+   */
+  async renameScope(oldScope: string, newScope: string, options: { refactor?: boolean }): Promise<RenameScopeResult> {
+    const allComponents = await this.workspace.list();
+    const componentsUsingOldScope = allComponents.filter((comp) => comp.id.scope === oldScope);
+    if (!componentsUsingOldScope.length && this.workspace.defaultScope !== oldScope) {
+      throw new BitError(
+        `none of the components is using "${oldScope}". also, the workspace is not configured with "${oldScope}"`
+      );
+    }
+    // verify they're all new.
+    const exported = componentsUsingOldScope.filter((comp) => comp.id._legacy.hasScope());
+    if (exported.length) {
+      const idsStr = exported.map((comp) => comp.id.toString()).join(', ');
+      throw new BitError(`unable to rename the scope for the following exported components:\n${idsStr}
+because these components were exported already, other components may use them and they'll break upon rename.
+instead, deprecate the above components (using "bit deprecate"), tag, export and then eject them.
+once they are not in the workspace, you can fork them ("bit fork") with the new scope-name`);
+    }
+    const tagged = componentsUsingOldScope.filter((comp) => comp.id.hasVersion());
+    if (tagged.length) {
+      const idsStr = tagged.map((comp) => comp.id.toString()).join(', ');
+      throw new BitError(`unable to rename the scope for the following tagged components:\n${idsStr}
+because these components were tagged, the objects have the dependencies data of the old-scope.
+to be able to rename the scope, please untag the components first (using "bit untag" command)`);
+    }
+    if (this.workspace.defaultScope === oldScope) {
+      this.config.workspaceConfig?.setExtension(
+        WorkspaceAspect.id,
+        { defaultScope: newScope },
+        { mergeIntoExisting: true, ignoreVersion: true }
+      );
+      await this.config.workspaceConfig?.write({ dir: path.dirname(this.config.workspaceConfig.path) });
+      componentsUsingOldScope.forEach((comp) => this.workspace.bitMap.removeDefaultScope(comp.id));
+    } else {
+      componentsUsingOldScope.forEach((comp) => this.workspace.bitMap.setDefaultScope(comp.id, newScope));
+    }
+    await this.workspace.bitMap.write();
+    const refactoredIds: ComponentID[] = [];
+    if (options.refactor) {
+      const legacyComps = componentsUsingOldScope.map((c) => c.state._consumer);
+      const packagesToReplace: MultipleStringsReplacement = legacyComps.map((comp) => {
+        return {
+          oldStr: componentIdToPackageName(comp),
+          newStr: componentIdToPackageName({
+            ...comp,
+            bindingPrefix: getBindingPrefixByDefaultScope(newScope),
+            id: comp.id,
+            defaultScope: newScope,
+          }),
+        };
+      });
+      const { changedComponents } = await this.refactoring.renameMultiplePackages(allComponents, packagesToReplace);
+      await Promise.all(changedComponents.map((comp) => this.workspace.write(comp)));
+      refactoredIds.push(...changedComponents.map((c) => c.id));
+    }
+
+    return { scopeRenamedComponentIds: componentsUsingOldScope.map((comp) => comp.id), refactoredIds };
+  }
+
   private async getConfig(comp: Component) {
     const fromExisting = await this.newComponentHelper.getConfigFromExistingToNewComponent(comp);
     return {
@@ -72,19 +143,34 @@ export class RenamingMain {
     ComponentAspect,
     GraphqlAspect,
     RefactoringAspect,
+    ConfigAspect,
   ];
   static runtime = MainRuntime;
-  static async provider([cli, workspace, deprecation, newComponentHelper, componentMain, graphql, refactoring]: [
+  static async provider([
+    cli,
+    workspace,
+    deprecation,
+    newComponentHelper,
+    componentMain,
+    graphql,
+    refactoring,
+    config,
+  ]: [
     CLIMain,
     Workspace,
     DeprecationMain,
     NewComponentHelperMain,
     ComponentMain,
     GraphqlMain,
-    RefactoringMain
+    RefactoringMain,
+    ConfigMain
   ]) {
-    const renaming = new RenamingMain(workspace, newComponentHelper, deprecation, refactoring);
+    const renaming = new RenamingMain(workspace, newComponentHelper, deprecation, refactoring, config);
     cli.register(new RenameCmd(renaming));
+
+    const scopeCommand = cli.getCommand('scope');
+    scopeCommand?.commands?.push(new ScopeRenameCmd(renaming));
+
     graphql.register(renamingSchema(renaming));
     componentMain.registerShowFragments([new RenamingFragment(renaming)]);
     return renaming;
@@ -93,8 +179,10 @@ export class RenamingMain {
 
 RenamingAspect.addRuntime(RenamingMain);
 
-export type RenameResult = { sourceId: ComponentID; targetId: ComponentID };
+export type RenameDependencyNameResult = { sourceId: ComponentID; targetId: ComponentID };
 
 export type RenamingInfo = {
   renamedFrom: ComponentID;
 };
+
+export type RenameScopeResult = { scopeRenamedComponentIds: ComponentID[]; refactoredIds: ComponentID[] };

--- a/scopes/component/renaming/scope-rename.cmd.ts
+++ b/scopes/component/renaming/scope-rename.cmd.ts
@@ -1,0 +1,28 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import chalk from 'chalk';
+import { RenamingMain } from './renaming.main.runtime';
+
+export class ScopeRenameCmd implements Command {
+  name = 'rename <old-name> <new-name>';
+  description = 'rename a scope for components using the old-name, optionally change the dependencies source-code';
+  options = [
+    ['r', 'refactor', 'change the source code of all components using the original scope-name with the new scope-name'],
+  ] as CommandOptions;
+  group = 'development';
+
+  constructor(private renaming: RenamingMain) {}
+
+  async report([oldName, newName]: [string, string], { refactor }: { refactor?: boolean }) {
+    const { scopeRenamedComponentIds, refactoredIds } = await this.renaming.renameScope(oldName, newName, { refactor });
+    const title = chalk.green(`successfully replaced "${oldName}" scope with "${newName}"`);
+    const renamedIdsStr = scopeRenamedComponentIds.length
+      ? `\n${chalk.bold(
+          'the following components were affected by this scope-name change:'
+        )}\n${scopeRenamedComponentIds.join('\n')}`
+      : '';
+    const refactoredStr = refactoredIds.length
+      ? `\n\n${chalk.bold('the following components have been refactored:')}\n${refactoredIds.join('\n')}`
+      : '';
+    return `${title}\n${renamedIdsStr}${refactoredStr}`;
+  }
+}

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -62,7 +62,7 @@ export class CLIMain {
    * get an instance of a registered command. (useful for aspects to modify and extend existing commands)
    */
   getCommand(name: string): Command | undefined {
-    return this.commands.find((command) => command.name === name);
+    return this.commands.find((command) => getCommandId(command.name) === name);
   }
 
   /**

--- a/scopes/harmony/config/config.main.runtime.ts
+++ b/scopes/harmony/config/config.main.runtime.ts
@@ -25,8 +25,9 @@ import { ConfigType, HostConfig } from './types';
 import { ConfigAspect } from './config.aspect';
 
 export type SetExtensionOptions = {
-  overrideExisting: boolean;
+  overrideExisting?: boolean;
   ignoreVersion: boolean;
+  mergeIntoExisting?: boolean;
 };
 
 export type ConfigDeps = [];

--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -132,9 +132,14 @@ export class WorkspaceConfig implements HostConfig {
 
   setExtension(extensionId: string, config: Record<string, any>, options: SetExtensionOptions): any {
     const existing = this.extension(extensionId, options.ignoreVersion);
-    if (existing && !options.overrideExisting) {
-      throw new ExtensionAlreadyConfigured(extensionId);
+    if (existing) {
+      if (options.mergeIntoExisting) {
+        config = { ...existing, ...config };
+      } else if (!options.overrideExisting) {
+        throw new ExtensionAlreadyConfigured(extensionId);
+      }
     }
+
     this.raw[extensionId] = config;
     this.loadExtensions();
   }

--- a/scopes/scope/scope/scope-cmd.ts
+++ b/scopes/scope/scope/scope-cmd.ts
@@ -1,0 +1,17 @@
+import { Command } from '@teambit/cli';
+import chalk from 'chalk';
+
+export class ScopeCmd implements Command {
+  name = 'scope <sub-command>';
+  alias = '';
+  description = 'EXPERIMENTAL. manage scope-name';
+  options = [];
+  group = 'development';
+  commands: Command[] = [];
+
+  async report([unrecognizedSubcommand]: [string]) {
+    return chalk.red(
+      `"${unrecognizedSubcommand}" is not a subcommand of "scope", please run "bit scope --help" to list the subcommands`
+    );
+  }
+}

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -51,6 +51,7 @@ import { scopeSchema } from './scope.graphql';
 import { ScopeUIRoot } from './scope.ui-root';
 import { PutRoute, FetchRoute, ActionRoute, DeleteRoute } from './routes';
 import { ScopeComponentLoader } from './scope-component-loader';
+import { ScopeCmd } from './scope-cmd';
 
 type TagRegistry = SlotRegistry<OnTag>;
 
@@ -1008,6 +1009,7 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
       if (hasWorkspace) return;
       await scope.loadAspects(aspectLoader.getNotLoadedConfiguredExtensions());
     });
+    cli.register(new ScopeCmd());
 
     const onPutHook = async (ids: string[], lanes: Lane[], authData?: AuthData): Promise<void> => {
       logger.debug(`onPutHook, started. (${ids.length} components)`);

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -67,6 +67,20 @@ export class BitMap {
     this.legacyBitMap.markAsChanged();
   }
 
+  removeDefaultScope(id: ComponentID) {
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    if (bitMapEntry.defaultScope) {
+      delete bitMapEntry.defaultScope;
+      this.legacyBitMap.markAsChanged();
+    }
+  }
+
+  setDefaultScope(id: ComponentID, defaultScope: string) {
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    bitMapEntry.defaultScope = defaultScope;
+    this.legacyBitMap.markAsChanged();
+  }
+
   /**
    * write .bitmap object to the filesystem
    */

--- a/src/consumer/config/component-config.ts
+++ b/src/consumer/config/component-config.ts
@@ -277,12 +277,7 @@ export default class ComponentConfig extends AbstractConfig {
       const onLoadResults = await this.runOnLoadEvent(this.componentConfigLoadingRegistry, componentId);
       const wsComponentConfig = onLoadResults[0];
       const defaultScope = wsComponentConfig.defaultScope;
-      const splittedScope = defaultScope.split('.');
-      const defaultOwner = splittedScope.length === 1 ? defaultScope : splittedScope[0];
-      let bindingPrefix = DEFAULT_REGISTRY_DOMAIN_PREFIX;
-      if (defaultOwner && defaultOwner !== DEFAULT_REGISTRY_DOMAIN_PREFIX) {
-        bindingPrefix = defaultOwner.startsWith('@') ? defaultOwner : `@${defaultOwner}`;
-      }
+      const bindingPrefix = getBindingPrefixByDefaultScope(defaultScope);
       componentConfig = new ComponentConfig({
         extensions: wsComponentConfig.extensions,
         defaultScope,
@@ -368,4 +363,15 @@ export default class ComponentConfig extends AbstractConfig {
     }
     return [];
   }
+}
+
+export function getBindingPrefixByDefaultScope(defaultScope: string): string {
+  const splittedScope = defaultScope.split('.');
+  const defaultOwner = splittedScope.length === 1 ? defaultScope : splittedScope[0];
+  let bindingPrefix = DEFAULT_REGISTRY_DOMAIN_PREFIX;
+  if (defaultOwner && defaultOwner !== DEFAULT_REGISTRY_DOMAIN_PREFIX) {
+    bindingPrefix = defaultOwner.startsWith('@') ? defaultOwner : `@${defaultOwner}`;
+  }
+
+  return bindingPrefix;
 }


### PR DESCRIPTION
## Proposed Changes

- introduce `bit scope <sub-command>` command to manage scope.
- introduce `bit scope rename` command to change the scope-name for new components
- add `--refactor` flag to change the source code and replace the old package-name with the new one.
