### PR TITLE
fix: delete orphaned components upon lane removal

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -950,7 +950,7 @@ describe('bit lane command', function () {
         helper.bitJsonc.setupDefault();
         helper.command.createLane();
         helper.fixtures.populateComponents();
-        helper.command.snapAllComponents();
+        helper.command.snapAllComponentsWithoutBuild();
         helper.command.export();
       });
       it('as an intermediate step, make sure the lane is on the remote', () => {
@@ -972,6 +972,10 @@ describe('bit lane command', function () {
         it('the remote should not have the lane anymore', () => {
           const lanes = helper.command.showRemoteLanesParsed();
           expect(lanes.lanes).to.have.lengthOf(0);
+        });
+        it('the remote should not have the components anymore as they dont belong to any lane', () => {
+          const remoteComps = helper.command.catScope(undefined, helper.scopes.remotePath);
+          expect(remoteComps).to.have.lengthOf(0);
         });
         describe('removing again after the lane was removed', () => {
           let removeOutput;

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -60,7 +60,7 @@ export class LaneListCmd implements Command {
       return chalk.green(unmergedLanes.map((m) => m.name).join('\n'));
     }
     const currentLane = this.lanes.getCurrentLane();
-    let currentLaneStr = currentLane ? `current lane - ${chalk.bold(currentLane as string)}` : '';
+    let currentLaneStr = currentLane ? `current lane - ${chalk.green.bold(currentLane as string)}` : '';
     if (details) {
       const laneDataOfCurrentLane = lanes.find((l) => l.name === currentLane);
       const remoteOfCurrentLane = laneDataOfCurrentLane ? laneDataOfCurrentLane.remote : null;
@@ -75,11 +75,11 @@ export class LaneListCmd implements Command {
       // @ts-ignore
       .map((laneData) => {
         if (details) {
-          const laneTitle = `> ${chalk.green(laneData.name)}${outputRemoteLane(laneData.remote)}\n`;
+          const laneTitle = `> ${chalk.bold(laneData.name)}${outputRemoteLane(laneData.remote)}\n`;
           const components = outputComponents(laneData.components);
           return laneTitle + components;
         }
-        return `    > ${chalk.green(laneData.name)} (${laneData.components.length} components)`;
+        return `    > ${chalk.bold(laneData.name)} (${laneData.components.length} components)`;
       })
       .join('\n');
 


### PR DESCRIPTION
Currently, when deleting a lane from a remote, the components are not getting deleted although they were used only in that scope. In this fix, it is validated that the components from the deleted lanes are not used anywhere else, and then get deleted.