### PR TITLE
fix: export components properly when their head is empty on a lane

### DIFF
--- a/e2e/commands/lane.e2e.1.ts
+++ b/e2e/commands/lane.e2e.1.ts
@@ -486,6 +486,22 @@ describe('bit lane command', function () {
         const defaultLane = lanes.lanes.find((lane) => lane.name === DEFAULT_LANE);
         expect(defaultLane.components).to.have.lengthOf(3);
       });
+      describe('exporting the components to the remote', () => {
+        let exportOutput: string;
+        before(() => {
+          exportOutput = helper.command.export();
+        });
+        it('should indicate that the components were exported successfully', () => {
+          expect(exportOutput).to.not.have.string('nothing to export');
+        });
+        it('the remote should have the updated component objects', () => {
+          const comp1Id = `${helper.scopes.remote}/comp1`;
+          const comp1 = helper.command.catComponent(comp1Id);
+          const remoteComp1 = helper.command.catComponent(comp1Id, helper.scopes.remotePath);
+          expect(remoteComp1).to.have.property('head');
+          expect(remoteComp1.head).to.equal(comp1.head);
+        });
+      });
     });
     describe('merging remote lane into main when components are not in workspace using --existing flag', () => {
       let mergeOutput;

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -630,7 +630,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       existingHeadIsMissingInIncomingComponent
     );
     const { mergedComponent, mergedVersions } = await modelComponentMerger.merge();
-    if (existingComponentHead) {
+    if (existingComponentHead || mergedComponent.hasHead()) {
       const mergedSnaps = await this.getMergedSnaps(existingComponentHead, incomingComp, versionObjects);
       mergedVersions.push(...mergedSnaps);
     }
@@ -639,7 +639,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   }
 
   private async getMergedSnaps(
-    existingHead: Ref,
+    existingHead: Ref | undefined,
     incomingComp: ModelComponent,
     versionObjects: Version[]
   ): Promise<string[]> {


### PR DESCRIPTION
Currently, if the head is empty on the remote-component, e.g. when the component was exported as part of the lane. Then, later, when this component is exported from main it's not saved correctly on the remote. 
This PR fixes it and shows the snaps that were exported.