### PR TITLE
fix(bit-build): fix error occurring during preview task regarding missing dists files

### DIFF
--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -164,7 +164,7 @@ export class TypescriptCompiler implements Compiler {
    */
   private async runTscBuild(network: Network): Promise<ComponentResult[]> {
     const rootDir = network.capsulesRootDir;
-    const capsules = network.originalSeedersCapsules;
+    const capsules = await network.getCapsulesToCompile();
     if (!capsules.length) {
       return [];
     }


### PR DESCRIPTION
This is happening due to the optimization done in https://github.com/teambit/bit/pull/5636. 
As a result of this optimization, modified components that were not part of the original-seeders weren't compiled by typescript. This PR fixed it by including them as well.