### PR TITLE
fix: avoid coloring the log messages according to the aspect-name

### DIFF
--- a/package.json
+++ b/package.json
@@ -128,7 +128,7 @@
     "async-mutex": "0.3.1",
     "bluebird": "3.7.2",
     "cacache": "15.0.5",
-    "chalk": "2.4.2",
+    "chalk": "4.1.2",
     "checksum": "0.1.1",
     "chokidar": "3.5.1",
     "cli-spinners": "1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,7 +170,6 @@ importers:
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.3.3
       '@teambit/legacy': 1.0.257
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368
       '@teambit/network.agent': 0.0.1
       '@teambit/pkg.content.packages-overview': 1.95.9
       '@teambit/react.content.react-overview': 1.95.0
@@ -232,9 +231,9 @@ importers:
       '@types/postcss-normalize': 9.0.1
       '@types/prettier': 2.3.2
       '@types/puppeteer': 3.0.5
-      '@types/react': '>=17.0.8 <18.0.0'
+      '@types/react': 17.0.8
       '@types/react-dev-utils': 9.0.10
-      '@types/react-dom': '>=17.0.5 <18.0.0'
+      '@types/react-dom': ^17.0.5
       '@types/react-router-dom': 5.1.7
       '@types/react-tabs': 2.3.2
       '@types/react-tooltip': 3.11.0
@@ -295,7 +294,7 @@ importers:
       chai-arrays: 1.1.0
       chai-fs: 1.0.0
       chai-string: 1.5.0
-      chalk: 2.4.2
+      chalk: 4.1.2
       checksum: 0.1.1
       chokidar: 3.5.1
       classnames: 2.2.6
@@ -408,7 +407,7 @@ importers:
       json-schema: 0.4.0
       jsx-to-string: 1.4.0
       junit-report-builder: 3.0.0
-      less: '>=4.1.1 <5.0.0'
+      less: ^4.1.1
       less-loader: 10.0.0
       lint-staged: '>=10'
       loader-utils: 2.0.0
@@ -504,10 +503,10 @@ importers:
       react-docgen: 5.3.1
       react-docgen-typescript: 1.21.0
       react-dom: 17.0.2
-      react-error-boundary: '>=3.0.0 <4.0.0'
+      react-error-boundary: ^3.0.0
       react-error-overlay: 6.0.9
       react-flow-renderer: 8.3.7
-      react-native-web: '>=0.16.0 <0.17.0'
+      react-native-web: ^0.16.0
       react-refresh: 0.10.0
       react-router: 5.2.0
       react-router-dom: 5.2.0
@@ -622,7 +621,7 @@ importers:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
       '@babel/types': registry.npmjs.org/@babel/types/7.17.0
       '@dreysolano/prerender-spa-plugin': registry.npmjs.org/@dreysolano/prerender-spa-plugin/1.0.3_debug@4.3.2
-      '@floating-ui/react-dom': registry.npmjs.org/@floating-ui/react-dom/0.6.0_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@floating-ui/react-dom': registry.npmjs.org/@floating-ui/react-dom/0.6.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@graphql-modules/core': registry.npmjs.org/@graphql-modules/core/0.7.17_e7c6f21e00ffec12c5da54c0b19e38c6
       '@jest/test-result': registry.npmjs.org/@jest/test-result/26.6.2
       '@mdx-js/loader': registry.npmjs.org/@mdx-js/loader/1.6.21_react@17.0.2
@@ -717,10 +716,10 @@ importers:
       '@teambit/design.ui.surfaces.menu.item': registry.npmjs.org/@teambit/design.ui.surfaces.menu.item/0.0.354_react-dom@17.0.2+react@17.0.2
       '@teambit/design.ui.surfaces.menu.link-item': registry.npmjs.org/@teambit/design.ui.surfaces.menu.link-item/0.0.379_react-dom@17.0.2+react@17.0.2
       '@teambit/design.ui.surfaces.menu.section': registry.npmjs.org/@teambit/design.ui.surfaces.menu.section/0.0.347_react-dom@17.0.2+react@17.0.2
-      '@teambit/documenter.code.react-playground': registry.npmjs.org/@teambit/documenter.code.react-playground/4.0.1_bd9a0cf10d71e1eab5fc76da51d132ff
+      '@teambit/documenter.code.react-playground': registry.npmjs.org/@teambit/documenter.code.react-playground/4.0.1_884042120800d1af00337a57c001a17f
       '@teambit/documenter.content.documentation-links': registry.npmjs.org/@teambit/documenter.content.documentation-links/4.1.3_react-dom@17.0.2+react@17.0.2
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_bd9a0cf10d71e1eab5fc76da51d132ff
-      '@teambit/documenter.markdown.mdx': registry.npmjs.org/@teambit/documenter.markdown.mdx/0.1.11_bd9a0cf10d71e1eab5fc76da51d132ff
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_884042120800d1af00337a57c001a17f
+      '@teambit/documenter.markdown.mdx': registry.npmjs.org/@teambit/documenter.markdown.mdx/0.1.11_884042120800d1af00337a57c001a17f
       '@teambit/documenter.routing.external-link': registry.npmjs.org/@teambit/documenter.routing.external-link/4.1.0_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context/4.0.3_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.types.docs-file': registry.npmjs.org/@teambit/documenter.types.docs-file/4.0.10_react-dom@17.0.2+react@17.0.2
@@ -738,7 +737,7 @@ importers:
       '@teambit/documenter.ui.label-list': registry.npmjs.org/@teambit/documenter.ui.label-list/4.0.3_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.linked-heading': registry.npmjs.org/@teambit/documenter.ui.linked-heading/4.1.6_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.ol': registry.npmjs.org/@teambit/documenter.ui.ol/4.1.1_react-dom@17.0.2+react@17.0.2
-      '@teambit/documenter.ui.property-table': registry.npmjs.org/@teambit/documenter.ui.property-table/4.1.3_bd9a0cf10d71e1eab5fc76da51d132ff
+      '@teambit/documenter.ui.property-table': registry.npmjs.org/@teambit/documenter.ui.property-table/4.1.3_884042120800d1af00337a57c001a17f
       '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section/4.1.1_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.separator': registry.npmjs.org/@teambit/documenter.ui.separator/4.1.1_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title/4.1.1_react-dom@17.0.2+react@17.0.2
@@ -756,18 +755,17 @@ importers:
       '@teambit/evangelist.input.input': registry.npmjs.org/@teambit/evangelist.input.input/1.0.2_react-dom@17.0.2+react@17.0.2
       '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/1.0.2_react-dom@17.0.2+react@17.0.2
       '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/1.0.1_react-dom@17.0.2+react@17.0.2
-      '@teambit/explorer.ui.command-bar': registry.npmjs.org/@teambit/explorer.ui.command-bar/1.0.2_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@teambit/explorer.ui.command-bar': registry.npmjs.org/@teambit/explorer.ui.command-bar/1.0.2_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': registry.npmjs.org/@teambit/harmony/0.3.3
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_571fdaa4762feaa8783267392e347fe3
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/network.agent': registry.npmjs.org/@teambit/network.agent/0.0.1_571fdaa4762feaa8783267392e347fe3
       '@teambit/react.instructions.react-native.adding-tests': 0.0.1_571fdaa4762feaa8783267392e347fe3
       '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6_571fdaa4762feaa8783267392e347fe3
       '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6_571fdaa4762feaa8783267392e347fe3
-      '@teambit/react.modules.dom-to-react': registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987
-      '@teambit/react.ui.component-highlighter': registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0_b8199948237381d32641430399d599f8
-      '@teambit/react.ui.hover-selector': registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@teambit/react.modules.dom-to-react': registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
+      '@teambit/react.ui.component-highlighter': registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0_1ad0cf3d03082e4a6729baf909f4a2d4
+      '@teambit/react.ui.hover-selector': registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/string.ellipsis': registry.npmjs.org/@teambit/string.ellipsis/0.0.7_571fdaa4762feaa8783267392e347fe3
       '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.257
       '@teambit/ui.composition-card': registry.npmjs.org/@teambit/ui.composition-card/0.0.259_react-dom@17.0.2+react@17.0.2
@@ -775,56 +773,16 @@ importers:
       '@testing-library/jest-native': registry.npmjs.org/@testing-library/jest-native/4.0.4
       '@tippyjs/react': registry.npmjs.org/@tippyjs/react/4.2.0_react-dom@17.0.2+react@17.0.2
       '@types/bluebird': registry.npmjs.org/@types/bluebird/3.5.33
-      '@types/cacache': registry.npmjs.org/@types/cacache/12.0.1
-      '@types/chai': registry.npmjs.org/@types/chai/4.2.15
       '@types/chai-arrays': registry.npmjs.org/@types/chai-arrays/1.0.3
       '@types/chai-fs': registry.npmjs.org/@types/chai-fs/2.0.2
       '@types/chai-string': registry.npmjs.org/@types/chai-string/1.4.2
-      '@types/classnames': registry.npmjs.org/@types/classnames/2.2.11
-      '@types/cli-table': registry.npmjs.org/@types/cli-table/0.3.0
-      '@types/cors': registry.npmjs.org/@types/cors/2.8.10
-      '@types/dagre': registry.npmjs.org/@types/dagre/0.7.44
-      '@types/didyoumean': registry.npmjs.org/@types/didyoumean/1.2.0
-      '@types/express': registry.npmjs.org/@types/express/4.17.9
-      '@types/find-root': registry.npmjs.org/@types/find-root/1.1.2
-      '@types/fs-extra': registry.npmjs.org/@types/fs-extra/9.0.7
       '@types/get-port': registry.npmjs.org/@types/get-port/4.2.0
       '@types/graphlib': registry.npmjs.org/@types/graphlib/2.1.7
-      '@types/history': registry.npmjs.org/@types/history/4.7.8
-      '@types/http-proxy-agent': registry.npmjs.org/@types/http-proxy-agent/2.0.2
-      '@types/json-schema': registry.npmjs.org/@types/json-schema/7.0.9
-      '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-      '@types/lodash.compact': registry.npmjs.org/@types/lodash.compact/3.0.6
-      '@types/lodash.flatten': registry.npmjs.org/@types/lodash.flatten/4.4.6
-      '@types/lodash.head': registry.npmjs.org/@types/lodash.head/4.0.6
-      '@types/lodash.orderby': registry.npmjs.org/@types/lodash.orderby/4.6.6
-      '@types/lodash.pick': registry.npmjs.org/@types/lodash.pick/4.4.6
-      '@types/mdx-js__react': registry.npmjs.org/@types/mdx-js__react/1.5.3
-      '@types/memoizee': registry.npmjs.org/@types/memoizee/0.4.5
-      '@types/mime': registry.npmjs.org/@types/mime/2.0.3
-      '@types/mini-css-extract-plugin': registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28
-      '@types/minimatch': registry.npmjs.org/@types/minimatch/3.0.4
-      '@types/mousetrap': registry.npmjs.org/@types/mousetrap/1.6.5
-      '@types/node-fetch': registry.npmjs.org/@types/node-fetch/2.5.12
-      '@types/object-hash': registry.npmjs.org/@types/object-hash/1.3.4
       '@types/pino': registry.npmjs.org/@types/pino/6.3.6
-      '@types/pluralize': registry.npmjs.org/@types/pluralize/0.0.29
-      '@types/prettier': registry.npmjs.org/@types/prettier/2.3.2
       '@types/puppeteer': registry.npmjs.org/@types/puppeteer/3.0.5
-      '@types/react-dev-utils': registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2
-      '@types/react-router-dom': registry.npmjs.org/@types/react-router-dom/5.1.7
-      '@types/react-tabs': registry.npmjs.org/@types/react-tabs/2.3.2
-      '@types/react-tooltip': registry.npmjs.org/@types/react-tooltip/3.11.0
       '@types/sass': registry.npmjs.org/@types/sass/1.16.0
-      '@types/semver': registry.npmjs.org/@types/semver/7.3.4
       '@types/socket.io-client': registry.npmjs.org/@types/socket.io-client/1.4.35
-      '@types/ua-parser-js': registry.npmjs.org/@types/ua-parser-js/0.7.35
-      '@types/url-join': registry.npmjs.org/@types/url-join/4.0.0
       '@types/url-parse': registry.npmjs.org/@types/url-parse/1.4.3
-      '@types/uuid': registry.npmjs.org/@types/uuid/3.4.9
-      '@types/webpack': registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28
-      '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1
-      '@types/yargs': registry.npmjs.org/@types/yargs/17.0.0
       '@typescript-eslint/eslint-plugin': registry.npmjs.org/@typescript-eslint/eslint-plugin/4.30.0_8a8a2d3eaa9257455a03c16dce5f55b3
       '@typescript-eslint/parser': registry.npmjs.org/@typescript-eslint/parser/4.30.0_eslint@7.32.0+typescript@4.4.2
       '@typescript-eslint/typescript-estree': registry.npmjs.org/@typescript-eslint/typescript-estree/4.30.0_typescript@4.4.2
@@ -870,7 +828,7 @@ importers:
       chai-arrays: registry.npmjs.org/chai-arrays/1.1.0
       chai-fs: registry.npmjs.org/chai-fs/1.0.0_chai@4.3.0
       chai-string: registry.npmjs.org/chai-string/1.5.0_chai@4.3.0
-      chalk: registry.npmjs.org/chalk/2.4.2
+      chalk: registry.npmjs.org/chalk/4.1.2
       checksum: registry.npmjs.org/checksum/0.1.1
       chokidar: registry.npmjs.org/chokidar/3.5.1
       classnames: registry.npmjs.org/classnames/2.2.6
@@ -962,7 +920,7 @@ importers:
       ini: registry.npmjs.org/ini/2.0.0
       ini-builder: registry.npmjs.org/ini-builder/1.1.1
       inject-body-webpack-plugin: registry.npmjs.org/inject-body-webpack-plugin/1.3.0_html-webpack-plugin@5.3.2
-      ink: registry.npmjs.org/ink/3.0.8_eaaaa9853b905676398845fdfeb1b9b7
+      ink: registry.npmjs.org/ink/3.0.8_bcd8941a3ab2d2525b1c27c04f508879
       ink-spinner: registry.npmjs.org/ink-spinner/4.0.3_ink@3.0.8+react@17.0.2
       inquirer: registry.npmjs.org/inquirer/6.5.2
       inquirer-fuzzy-path: registry.npmjs.org/inquirer-fuzzy-path/2.3.0
@@ -1198,14 +1156,54 @@ importers:
       '@teambit/workspace.content.variants': 1.95.9_571fdaa4762feaa8783267392e347fe3
       '@teambit/workspace.content.workspace-overview': 1.95.0_571fdaa4762feaa8783267392e347fe3
       '@testing-library/react': registry.npmjs.org/@testing-library/react/11.2.6_react-dom@17.0.2+react@17.0.2
+      '@types/cacache': registry.npmjs.org/@types/cacache/12.0.1
+      '@types/chai': registry.npmjs.org/@types/chai/4.2.15
+      '@types/classnames': registry.npmjs.org/@types/classnames/2.2.11
+      '@types/cli-table': registry.npmjs.org/@types/cli-table/0.3.0
+      '@types/cors': registry.npmjs.org/@types/cors/2.8.10
+      '@types/dagre': registry.npmjs.org/@types/dagre/0.7.44
+      '@types/didyoumean': registry.npmjs.org/@types/didyoumean/1.2.0
       '@types/eslint': registry.npmjs.org/@types/eslint/7.28.0
+      '@types/express': registry.npmjs.org/@types/express/4.17.9
+      '@types/find-root': registry.npmjs.org/@types/find-root/1.1.2
+      '@types/fs-extra': registry.npmjs.org/@types/fs-extra/9.0.7
+      '@types/history': registry.npmjs.org/@types/history/4.7.8
+      '@types/http-proxy-agent': registry.npmjs.org/@types/http-proxy-agent/2.0.2
       '@types/jest': registry.npmjs.org/@types/jest/26.0.20
+      '@types/json-schema': registry.npmjs.org/@types/json-schema/7.0.9
+      '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
+      '@types/lodash.compact': registry.npmjs.org/@types/lodash.compact/3.0.6
+      '@types/lodash.flatten': registry.npmjs.org/@types/lodash.flatten/4.4.6
+      '@types/lodash.head': registry.npmjs.org/@types/lodash.head/4.0.6
+      '@types/lodash.orderby': registry.npmjs.org/@types/lodash.orderby/4.6.6
+      '@types/lodash.pick': registry.npmjs.org/@types/lodash.pick/4.4.6
+      '@types/mdx-js__react': registry.npmjs.org/@types/mdx-js__react/1.5.3
+      '@types/memoizee': registry.npmjs.org/@types/memoizee/0.4.5
+      '@types/mime': registry.npmjs.org/@types/mime/2.0.3
+      '@types/mini-css-extract-plugin': registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28
+      '@types/minimatch': registry.npmjs.org/@types/minimatch/3.0.4
       '@types/mocha': registry.npmjs.org/@types/mocha/9.1.0
+      '@types/mousetrap': registry.npmjs.org/@types/mousetrap/1.6.5
       '@types/node': registry.npmjs.org/@types/node/12.20.4
+      '@types/node-fetch': registry.npmjs.org/@types/node-fetch/2.5.12
+      '@types/object-hash': registry.npmjs.org/@types/object-hash/1.3.4
+      '@types/pluralize': registry.npmjs.org/@types/pluralize/0.0.29
       '@types/postcss-normalize': registry.npmjs.org/@types/postcss-normalize/9.0.1
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/prettier': registry.npmjs.org/@types/prettier/2.3.2
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
+      '@types/react-dev-utils': registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2
       '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.14
+      '@types/react-router-dom': registry.npmjs.org/@types/react-router-dom/5.1.7
+      '@types/react-tabs': registry.npmjs.org/@types/react-tabs/2.3.2
+      '@types/react-tooltip': registry.npmjs.org/@types/react-tooltip/3.11.0
+      '@types/semver': registry.npmjs.org/@types/semver/7.3.4
       '@types/testing-library__jest-dom': registry.npmjs.org/@types/testing-library__jest-dom/5.9.5
+      '@types/ua-parser-js': registry.npmjs.org/@types/ua-parser-js/0.7.35
+      '@types/url-join': registry.npmjs.org/@types/url-join/4.0.0
+      '@types/uuid': registry.npmjs.org/@types/uuid/3.4.9
+      '@types/webpack': registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28
+      '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1
+      '@types/yargs': registry.npmjs.org/@types/yargs/17.0.0
       chai: registry.npmjs.org/chai/4.3.0
       react-test-renderer: registry.npmjs.org/react-test-renderer/16.14.0_react@17.0.2
 
@@ -6949,7 +6947,7 @@ packages:
       '@floating-ui/core': registry.npmjs.org/@floating-ui/core/0.6.1
     dev: false
 
-  registry.npmjs.org/@floating-ui/react-dom/0.6.0_b5d7bf22a7b46dd4876f0e926ab0c987:
+  registry.npmjs.org/@floating-ui/react-dom/0.6.0_2bb1c2f6941b337f5f9ecab4a31ade6a:
     resolution: {integrity: sha512-/dF+jpAUtoonjs2lO0F+miqEQlzA9XJGOxWBiJsq/COhK2kz7XzryyJdxfaNEH+RN63vRs9osDolOJXlst50hg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-0.6.0.tgz}
     id: registry.npmjs.org/@floating-ui/react-dom/0.6.0
     name: '@floating-ui/react-dom'
@@ -6961,7 +6959,7 @@ packages:
       '@floating-ui/dom': registry.npmjs.org/@floating-ui/dom/0.4.4
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-      use-isomorphic-layout-effect: registry.npmjs.org/use-isomorphic-layout-effect/1.1.2_03a98942b76c57740a9573edba2d1cc1
+      use-isomorphic-layout-effect: registry.npmjs.org/use-isomorphic-layout-effect/1.1.2_@types+react@17.0.8+react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
     dev: false
@@ -11191,7 +11189,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -11239,7 +11237,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -11257,7 +11255,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -11272,7 +11270,7 @@ packages:
     peerDependencies:
       '@teambit/legacy': 1.0.76
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/legacy-bit-id': registry.npmjs.org/@teambit/legacy-bit-id/0.0.368_571fdaa4762feaa8783267392e347fe3
     transitivePeerDependencies:
       - react
@@ -11307,7 +11305,7 @@ packages:
       '@teambit/legacy': 1.0.76
     dependencies:
       '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_571fdaa4762feaa8783267392e347fe3
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       semver: registry.npmjs.org/semver/7.3.4
     transitivePeerDependencies:
       - react
@@ -11637,7 +11635,7 @@ packages:
       '@teambit/toolbox.types.serializable': registry.npmjs.org/@teambit/toolbox.types.serializable/0.0.483
     dev: true
 
-  registry.npmjs.org/@teambit/documenter.code.react-playground/4.0.1_bd9a0cf10d71e1eab5fc76da51d132ff:
+  registry.npmjs.org/@teambit/documenter.code.react-playground/4.0.1_884042120800d1af00337a57c001a17f:
     resolution: {integrity: sha512-ElhYSW8VpdOA9DOOE+l85TM1R5tH4K1Fz7ofmb1bWcwFOYqk7qIl4r+lTW+H5x9jyNONkn/kn3A8Vu6d+K+7kA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/documenter.code.react-playground/-/documenter.code.react-playground-4.0.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.code.react-playground/4.0.1
     name: '@teambit/documenter.code.react-playground'
@@ -11655,14 +11653,14 @@ packages:
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
       react-live: registry.npmjs.org/react-live/2.4.1_react-dom@17.0.2+react@17.0.2
-      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_7c7fa889c4f6a98d91df0cf78df3db4b
+      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_d0162b0509b34ce9df13ad5570623e8b
       use-debounce: registry.npmjs.org/use-debounce/3.4.3_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
       - typescript
     dev: false
 
-  registry.npmjs.org/@teambit/documenter.code.react-playground/4.1.7_bd9a0cf10d71e1eab5fc76da51d132ff:
+  registry.npmjs.org/@teambit/documenter.code.react-playground/4.1.7_884042120800d1af00337a57c001a17f:
     resolution: {integrity: sha512-FZfWNnDsCe4D4CIc0n2pntVGiT4bicLNGk+lFFM+ndOginc35m/iAiVgES+ev4nqOIlejAaa/9jOZuvKm6f09A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/documenter.code.react-playground/-/documenter.code.react-playground-4.1.7.tgz}
     id: registry.npmjs.org/@teambit/documenter.code.react-playground/4.1.7
     name: '@teambit/documenter.code.react-playground'
@@ -11680,7 +11678,7 @@ packages:
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
       react-live: registry.npmjs.org/react-live/2.4.1_react-dom@17.0.2+react@17.0.2
-      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_7c7fa889c4f6a98d91df0cf78df3db4b
+      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_d0162b0509b34ce9df13ad5570623e8b
       use-debounce: registry.npmjs.org/use-debounce/3.4.3_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -11717,7 +11715,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_bd9a0cf10d71e1eab5fc76da51d132ff:
+  registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_884042120800d1af00337a57c001a17f:
     resolution: {integrity: sha512-LmhadJ1ZVdqTJjKxii+5wwD2uB/rywlZYrduZccAk2+WYHxuj+SVEZ82N7qGvMG4muWb1kaKt9SYmXuV9VV1zw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/-/documenter.markdown.hybrid-live-code-snippet-0.1.10.tgz}
     id: registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10
     name: '@teambit/documenter.markdown.hybrid-live-code-snippet'
@@ -11726,7 +11724,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.code.react-playground': registry.npmjs.org/@teambit/documenter.code.react-playground/4.1.7_bd9a0cf10d71e1eab5fc76da51d132ff
+      '@teambit/documenter.code.react-playground': registry.npmjs.org/@teambit/documenter.code.react-playground/4.1.7_884042120800d1af00337a57c001a17f
       '@teambit/documenter.ui.code-snippet': registry.npmjs.org/@teambit/documenter.ui.code-snippet/4.2.2_react-dom@17.0.2+react@17.0.2
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
@@ -11736,7 +11734,7 @@ packages:
       - typescript
     dev: false
 
-  registry.npmjs.org/@teambit/documenter.markdown.mdx/0.1.11_bd9a0cf10d71e1eab5fc76da51d132ff:
+  registry.npmjs.org/@teambit/documenter.markdown.mdx/0.1.11_884042120800d1af00337a57c001a17f:
     resolution: {integrity: sha512-t8eKR70EUY2tn6JO8lDekZ1+l7f5ZaMOjQ7EVaHOe8obhA6T7ZoLBCS9yP5QeqH9LKiNh/1pBmf0zmu0YyllXQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/documenter.markdown.mdx/-/documenter.markdown.mdx-0.1.11.tgz}
     id: registry.npmjs.org/@teambit/documenter.markdown.mdx/0.1.11
     name: '@teambit/documenter.markdown.mdx'
@@ -11747,7 +11745,7 @@ packages:
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
       '@teambit/documenter.markdown.heading': registry.npmjs.org/@teambit/documenter.markdown.heading/0.1.8_react-dom@17.0.2+react@17.0.2
-      '@teambit/documenter.markdown.hybrid-live-code-snippet': registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_bd9a0cf10d71e1eab5fc76da51d132ff
+      '@teambit/documenter.markdown.hybrid-live-code-snippet': registry.npmjs.org/@teambit/documenter.markdown.hybrid-live-code-snippet/0.1.10_884042120800d1af00337a57c001a17f
       '@teambit/documenter.routing.external-link': registry.npmjs.org/@teambit/documenter.routing.external-link/4.1.2_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.block-quote': registry.npmjs.org/@teambit/documenter.ui.block-quote/4.0.7_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.bold': registry.npmjs.org/@teambit/documenter.ui.bold/4.0.7_react-dom@17.0.2+react@17.0.2
@@ -12393,7 +12391,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/documenter.ui.property-table/4.1.3_bd9a0cf10d71e1eab5fc76da51d132ff:
+  registry.npmjs.org/@teambit/documenter.ui.property-table/4.1.3_884042120800d1af00337a57c001a17f:
     resolution: {integrity: sha512-t1CUrNxhckanyNqkExcVVJGL/llZV5xKgvzOwK5JZFL7ch9kq4LopLv7XApNtPY7hXs1vyIJ69iEAHmj4dYeuA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.property-table/-/documenter.ui.property-table-4.1.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.property-table/4.1.3
     name: '@teambit/documenter.ui.property-table'
@@ -12407,7 +12405,7 @@ packages:
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
-      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_7c7fa889c4f6a98d91df0cf78df3db4b
+      react-use-dimensions: registry.npmjs.org/react-use-dimensions/1.2.1_d0162b0509b34ce9df13ad5570623e8b
       use-debounce: registry.npmjs.org/use-debounce/3.4.3_react@17.0.2
     transitivePeerDependencies:
       - '@types/react'
@@ -12963,7 +12961,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/explorer.ui.command-bar/1.0.2_b5d7bf22a7b46dd4876f0e926ab0c987:
+  registry.npmjs.org/@teambit/explorer.ui.command-bar/1.0.2_2bb1c2f6941b337f5f9ecab4a31ade6a:
     resolution: {integrity: sha512-+W5gQ0zA9Ye4f0z3DxJBtA7ZA5rdR/7LrqUNI9yYFipYqKi+BJaM5xUuVycSLlsn8B8pyf8BENc82BaRYk/Y0A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.command-bar/-/explorer.ui.command-bar-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/explorer.ui.command-bar/1.0.2
     name: '@teambit/explorer.ui.command-bar'
@@ -12976,7 +12974,7 @@ packages:
       '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.3_react-dom@17.0.2+react@17.0.2
       '@teambit/design.ui.surfaces.menu.item': registry.npmjs.org/@teambit/design.ui.surfaces.menu.item/0.0.354_react-dom@17.0.2+react@17.0.2
       '@teambit/ui-foundation.ui.constants.z-indexes': registry.npmjs.org/@teambit/ui-foundation.ui.constants.z-indexes/0.0.487_react-dom@17.0.2+react@17.0.2
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       classnames: registry.npmjs.org/classnames/2.3.1
       core-js: registry.npmjs.org/core-js/3.21.1
       fuse.js: registry.npmjs.org/fuse.js/6.5.3
@@ -12997,7 +12995,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.styles.ellipsis': registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.346_react-dom@17.0.2+react@17.0.2
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/toolbox.string.ellipsis': registry.npmjs.org/@teambit/toolbox.string.ellipsis/0.0.153_@teambit+legacy@1.0.257
       classnames: registry.npmjs.org/classnames/2.2.6
       core-js: registry.npmjs.org/core-js/3.21.1
@@ -13018,7 +13016,7 @@ packages:
     dependencies:
       '@teambit/base-ui.routing.link': registry.npmjs.org/@teambit/base-ui.routing.link/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/explorer.ui.gallery.base-component-card': registry.npmjs.org/@teambit/explorer.ui.gallery.base-component-card/0.0.468_571fdaa4762feaa8783267392e347fe3
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13035,7 +13033,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       classnames: registry.npmjs.org/classnames/2.2.6
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
@@ -13053,7 +13051,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       classnames: registry.npmjs.org/classnames/2.2.6
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
@@ -13084,7 +13082,7 @@ packages:
     dependencies:
       '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_571fdaa4762feaa8783267392e347fe3
       '@teambit/component-version': registry.npmjs.org/@teambit/component-version/0.0.366_571fdaa4762feaa8783267392e347fe3
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       decamelize: registry.npmjs.org/decamelize/1.2.0
       lodash: registry.npmjs.org/lodash/4.17.21
       semver: registry.npmjs.org/semver/7.3.4
@@ -13119,7 +13117,7 @@ packages:
       semver: registry.npmjs.org/semver/7.3.4
     dev: false
 
-  registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0:
+  registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212:
     resolution: {integrity: sha512-zRFyT5+k652QONzcm/0Lyfy+4kexgGdRjnLUDFq7EaE5rHSuK887LS3cknmF/t/GOlt3elaVNTbbf1M3JBWaDA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/legacy/-/legacy-1.0.257.tgz}
     id: registry.npmjs.org/@teambit/legacy/1.0.257
     name: '@teambit/legacy'
@@ -13168,7 +13166,7 @@ packages:
       group-array: registry.npmjs.org/group-array/1.0.0
       ignore: registry.npmjs.org/ignore/3.3.10
       ini-builder: registry.npmjs.org/ini-builder/1.1.1
-      ink: registry.npmjs.org/ink/3.0.8_eaaaa9853b905676398845fdfeb1b9b7
+      ink: registry.npmjs.org/ink/3.0.8_bcd8941a3ab2d2525b1c27c04f508879
       ink-spinner: registry.npmjs.org/ink-spinner/4.0.3_ink@3.0.8+react@17.0.2
       inquirer: registry.npmjs.org/inquirer/6.5.2
       inquirer-fuzzy-path: registry.npmjs.org/inquirer-fuzzy-path/2.3.0
@@ -13270,7 +13268,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13321,7 +13319,7 @@ packages:
       react: 16.13.1
       react-dom: 16.13.1
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/network.proxy-agent': registry.npmjs.org/@teambit/network.proxy-agent/0.0.1_571fdaa4762feaa8783267392e347fe3
       agentkeepalive: registry.npmjs.org/agentkeepalive/4.1.4
       core-js: registry.npmjs.org/core-js/3.8.3
@@ -13342,7 +13340,7 @@ packages:
       react: 16.13.1
       react-dom: 16.13.1
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/network.agent': registry.npmjs.org/@teambit/network.agent/0.0.1_571fdaa4762feaa8783267392e347fe3
       core-js: registry.npmjs.org/core-js/3.8.3
       http-proxy-agent: registry.npmjs.org/http-proxy-agent/4.0.1
@@ -13390,7 +13388,7 @@ packages:
       - '@teambit/legacy'
     dev: false
 
-  registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987:
+  registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a:
     resolution: {integrity: sha512-RrFqKctpDkTGZt+x/M7upJrXNxnO3Lk5iDsTOewM8Ec1tW7Z0eufYPRhUmGj7nJUNjhazYYJgL6rggktEgaETQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.modules.dom-to-react/-/react.modules.dom-to-react-0.1.0.tgz}
     id: registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0
     name: '@teambit/react.modules.dom-to-react'
@@ -13400,13 +13398,13 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0_b8199948237381d32641430399d599f8:
+  registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0_1ad0cf3d03082e4a6729baf909f4a2d4:
     resolution: {integrity: sha512-t5gqq8RF95BiGZZfM3sFB5E+p7VqI1M1Mio+mKB0huGhBxVNvwP0pGaBUZzDrQxUDr0V7Vksl/DQIjp4xNIiEw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.ui.component-highlighter/-/react.ui.component-highlighter-0.1.0.tgz}
     id: registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0
     name: '@teambit/react.ui.component-highlighter'
@@ -13417,16 +13415,16 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@floating-ui/react-dom': registry.npmjs.org/@floating-ui/react-dom/0.6.0_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@floating-ui/react-dom': registry.npmjs.org/@floating-ui/react-dom/0.6.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.402
       '@teambit/component.modules.component-url': registry.npmjs.org/@teambit/component.modules.component-url/0.0.124_react-dom@17.0.2+react@17.0.2
-      '@teambit/react.modules.dom-to-react': registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@teambit/react.modules.dom-to-react': registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/react.ui.highlighter.component-metadata.bit-component-meta': registry.npmjs.org/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/0.0.21_react-dom@17.0.2+react@17.0.2
-      '@teambit/react.ui.hover-selector': registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987
+      '@teambit/react.ui.hover-selector': registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/ui-foundation.ui.constants.z-indexes': registry.npmjs.org/@teambit/ui-foundation.ui.constants.z-indexes/0.0.487_react-dom@17.0.2+react@17.0.2
       '@tippyjs/react': registry.npmjs.org/@tippyjs/react/4.2.0_react-dom@17.0.2+react@17.0.2
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.14
       classnames: registry.npmjs.org/classnames/2.3.1
       core-js: registry.npmjs.org/core-js/3.21.1
@@ -13454,7 +13452,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_b5d7bf22a7b46dd4876f0e926ab0c987:
+  registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a:
     resolution: {integrity: sha512-PDuihLU1/F/tENe+qS3rqqtddDP41Mjt3qZ6/L9pCg5nueuagtwSMlO7CaBU5W8N5HqPQjH0pRZ0p6VsNvnmJQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.ui.hover-selector/-/react.ui.hover-selector-0.1.0.tgz}
     id: registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0
     name: '@teambit/react.ui.hover-selector'
@@ -13464,7 +13462,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13481,7 +13479,7 @@ packages:
       react: 16.13.1
       react-dom: 16.13.1
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.8.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13496,7 +13494,7 @@ packages:
     peerDependencies:
       '@teambit/legacy': 1.0.108
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116_@teambit+legacy@1.0.257
       agentkeepalive: registry.npmjs.org/agentkeepalive/4.1.4
     transitivePeerDependencies:
@@ -13512,7 +13510,7 @@ packages:
     peerDependencies:
       '@teambit/legacy': 1.0.108
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.257
       http-proxy-agent: registry.npmjs.org/http-proxy-agent/4.0.1
       https-proxy-agent: registry.npmjs.org/https-proxy-agent/5.0.0
@@ -13530,7 +13528,7 @@ packages:
     peerDependencies:
       '@teambit/legacy': 1.0.175
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
     dev: true
 
   registry.npmjs.org/@teambit/toolbox.string.ellipsis/0.0.172:
@@ -13573,7 +13571,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_3bec04de6469025a88f951826190c5b0
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.257_725285d85e248e6bf4a5fdeaa5be6212
       core-js: registry.npmjs.org/core-js/3.21.1
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13762,7 +13760,6 @@ packages:
     dependencies:
       '@types/connect': registry.npmjs.org/@types/connect/3.4.35
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/body-parser/1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.2.tgz}
@@ -13771,7 +13768,7 @@ packages:
     dependencies:
       '@types/connect': registry.npmjs.org/@types/connect/3.4.35
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/bonjour/3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz}
@@ -13779,7 +13776,7 @@ packages:
     version: 3.5.10
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/buble/0.20.1:
     resolution: {integrity: sha512-itmN3lGSTvXg9IImY5j290H+n0B3PpZST6AgEfJJDXfaMx2cdJJZro3/Ay+bZZdIAa25Z5rnoo9rHiPCbANZoQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/buble/-/buble-0.20.1.tgz}
@@ -13795,7 +13792,7 @@ packages:
     version: 12.0.1
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/cacheable-request/6.0.2:
     resolution: {integrity: sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz}
@@ -13837,13 +13834,12 @@ packages:
     resolution: {integrity: sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz}
     name: '@types/chai'
     version: 4.2.15
-    dev: false
 
   registry.npmjs.org/@types/classnames/2.2.11:
     resolution: {integrity: sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz}
     name: '@types/classnames'
     version: 2.2.11
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/clean-css/4.2.5:
     resolution: {integrity: sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz}
@@ -13852,13 +13848,13 @@ packages:
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/cli-table/0.3.0:
     resolution: {integrity: sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.0.tgz}
     name: '@types/cli-table'
     version: 0.3.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz}
@@ -13867,7 +13863,7 @@ packages:
     dependencies:
       '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.28
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz}
@@ -13875,7 +13871,6 @@ packages:
     version: 3.4.35
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/content-disposition/0.5.4:
     resolution: {integrity: sha512-0mPF08jn9zYI0n0Q/Pnz7C4kThdSt+6LD4amsrYDDpgBfrVWa3TcCOxKX1zkGgYniGagRv8heN2cbh+CAn+uuQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.4.tgz}
@@ -13898,19 +13893,18 @@ packages:
     resolution: {integrity: sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz}
     name: '@types/cors'
     version: 2.8.10
-    dev: false
 
   registry.npmjs.org/@types/dagre/0.7.44:
     resolution: {integrity: sha512-N6HD+79w77ZVAaVO7JJDW5yJ9LAxM62FpgNGO9xEde+KVYjDRyhIMzfiErXpr1g0JPon9kwlBzoBK6s4fOww9Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/dagre/-/dagre-0.7.44.tgz}
     name: '@types/dagre'
     version: 0.7.44
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/didyoumean/1.2.0:
     resolution: {integrity: sha512-3QMjBOgPEXaOkhfQxiGgzn6JpofPSi8Z0RmQq65FIpZv4kCPT/jvYiYrwqaUrfiHZmwwRvyYJjJmoKopbvLPQw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/didyoumean/-/didyoumean-1.2.0.tgz}
     name: '@types/didyoumean'
     version: 1.2.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/emscripten/1.39.6:
     resolution: {integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz}
@@ -13925,7 +13919,6 @@ packages:
     dependencies:
       '@types/eslint': registry.npmjs.org/@types/eslint/7.28.0
       '@types/estree': registry.npmjs.org/@types/estree/0.0.50
-    dev: false
 
   registry.npmjs.org/@types/eslint-visitor-keys/1.0.0:
     resolution: {integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz}
@@ -13951,7 +13944,6 @@ packages:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz}
     name: '@types/estree'
     version: 0.0.50
-    dev: false
 
   registry.npmjs.org/@types/estree/0.0.51:
     resolution: {integrity: sha512-CuPgU6f3eT/XgKKPqKd/gLZV1Xmvf1a2R5POBOGQa6uv82xpls89HU5zKeVoyR8XzHd1RGNOlQlvUe3CFkjWNQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/estree/-/estree-0.0.51.tgz}
@@ -13966,7 +13958,6 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       '@types/qs': registry.npmjs.org/@types/qs/6.9.7
       '@types/range-parser': registry.npmjs.org/@types/range-parser/1.2.4
-    dev: false
 
   registry.npmjs.org/@types/express/4.17.13:
     resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz}
@@ -13977,7 +13968,6 @@ packages:
       '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.28
       '@types/qs': registry.npmjs.org/@types/qs/6.9.7
       '@types/serve-static': registry.npmjs.org/@types/serve-static/1.13.10
-    dev: false
 
   registry.npmjs.org/@types/express/4.17.9:
     resolution: {integrity: sha512-SDzEIZInC4sivGIFY4Sz1GG6J9UObPwCInYJjko2jzOf/Imx/dlpume6Xxwj1ORL82tBbmN4cPDIDkLbWHk9hw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/express/-/express-4.17.9.tgz}
@@ -13988,13 +13978,13 @@ packages:
       '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.28
       '@types/qs': registry.npmjs.org/@types/qs/6.9.7
       '@types/serve-static': registry.npmjs.org/@types/serve-static/1.13.10
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/find-root/1.1.2:
     resolution: {integrity: sha512-lGuMq71TL466jtCpvh7orGd+mrdBmo2h8ozvtOOTbq3ByfWpuN+UVxv4sOv3YpsD4NhW2k6ESGhnT/FIg4Ouzw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/find-root/-/find-root-1.1.2.tgz}
     name: '@types/find-root'
     version: 1.1.2
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/fs-capacitor/2.0.0:
     resolution: {integrity: sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz}
@@ -14010,7 +14000,7 @@ packages:
     version: 9.0.7
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/get-port/4.2.0:
     resolution: {integrity: sha512-Iv2FAb5RnIk/eFO2CTu8k+0VMmIR15pKbcqRWi+s3ydW+aKXlN2yemP92SrO++ERyJx+p6Ie1ggbLBMbU1SjiQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/get-port/-/get-port-4.2.0.tgz}
@@ -14047,13 +14037,13 @@ packages:
     resolution: {integrity: sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz}
     name: '@types/history'
     version: 4.7.11
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/history/4.7.8:
     resolution: {integrity: sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz}
     name: '@types/history'
     version: 4.7.8
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/html-minifier-terser/5.1.2:
     resolution: {integrity: sha512-h4lTMgMJctJybDp8CQrxTUiiYmedihHWkjnF/8Pxseu2S6Nlfcy8kwboQ8yejh456rP2yWoEVm1sS/FVsfM48w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz}
@@ -14069,7 +14059,7 @@ packages:
       '@types/clean-css': registry.npmjs.org/@types/clean-css/4.2.5
       '@types/relateurl': registry.npmjs.org/@types/relateurl/0.2.29
       '@types/uglify-js': registry.npmjs.org/@types/uglify-js/3.13.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/html-webpack-plugin/3.2.6:
     resolution: {integrity: sha512-U8uJSvlf9lwrKG6sKFnMhqY4qJw2QXad+PHlX9sqEXVUMilVt96aVvFde73tzsdXD+QH9JS6kEytuGO2JcYZog==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/html-webpack-plugin/-/html-webpack-plugin-3.2.6.tgz}
@@ -14079,7 +14069,7 @@ packages:
       '@types/html-minifier': registry.npmjs.org/@types/html-minifier/4.0.2
       '@types/tapable': registry.npmjs.org/@types/tapable/1.0.8
       '@types/webpack': registry.npmjs.org/@types/webpack/4.41.32
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/http-assert/1.5.3:
     resolution: {integrity: sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz}
@@ -14105,7 +14095,7 @@ packages:
     version: 2.0.2
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/http-proxy/1.17.8:
     resolution: {integrity: sha512-5kPLG5BKpWYkw/LVOGWpiq3nEVqxiN32rTgI53Sk12/xHFQ2rG3ehI9IO+O3W2QoKeyB92dJkoka8SUm6BX1pA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.8.tgz}
@@ -14113,7 +14103,6 @@ packages:
     version: 1.17.8
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/istanbul-lib-coverage/2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz}
@@ -14223,7 +14212,7 @@ packages:
     version: 3.0.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.flatten/4.4.6:
     resolution: {integrity: sha512-omCBl4M8EJSmf2DZqh4/zwjgXQpzC7YO/PXTcG8rI9r7xun8CohrHeNx8HZRkqWc61uJfIaZop9MwJEXPVssHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.6.tgz}
@@ -14231,7 +14220,7 @@ packages:
     version: 4.4.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.head/4.0.6:
     resolution: {integrity: sha512-WrbllVqxpgpEnLPNooU9q3h9vFVYUzS4sMDp0UpEnguIHFxdAA161UMnaJ92ccGSc87e901EHFwXbuNysdSaQg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.head/-/lodash.head-4.0.6.tgz}
@@ -14239,7 +14228,7 @@ packages:
     version: 4.0.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.orderby/4.6.6:
     resolution: {integrity: sha512-wQzu6xK+bSwhu45OeMI7fjywiIZiiaBzJB8W3fwnF1SJXHoOXRLutrSnVmq4yHPOM036qsy8lx9wHQcAbXNjJw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.6.tgz}
@@ -14247,7 +14236,7 @@ packages:
     version: 4.6.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.pick/4.4.6:
     resolution: {integrity: sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.pick/-/lodash.pick-4.4.6.tgz}
@@ -14255,13 +14244,13 @@ packages:
     version: 4.4.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash/4.14.165:
     resolution: {integrity: sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz}
     name: '@types/lodash'
     version: 4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash/4.14.181:
     resolution: {integrity: sha512-n3tyKthHJbkiWhDZs3DkhkCzt2MexYHXlX0td5iMplyfwketaOeKboEVBqzceH7juqvEg3q5oUoBFxSLu7zFag==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash/-/lodash-4.14.181.tgz}
@@ -14289,25 +14278,24 @@ packages:
     version: 1.5.3
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/17.0.43
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/memoizee/0.4.5:
     resolution: {integrity: sha512-+ZzZZ3+0a7/ajBPeAAD4+LxrBsCat0EFZQtO3o0rwpIeLmDmSaM8KF/oYPuFxeUFAMiHIHFcGucFnY/8S4Hszg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.5.tgz}
     name: '@types/memoizee'
     version: 0.4.5
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz}
     name: '@types/mime'
     version: 1.3.2
-    dev: false
 
   registry.npmjs.org/@types/mime/2.0.3:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz}
     name: '@types/mime'
     version: 2.0.3
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28:
     resolution: {integrity: sha512-euW/Y51OoAWsAuqtxIGV7Y++EW4dKHMj7NSxHoTRD6SqK1vziYhGfDWTmtlf4jkjIrzUW88NpVXMfiJESysZAA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.0.tgz}
@@ -14323,13 +14311,12 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/minimatch/3.0.4:
     resolution: {integrity: sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz}
     name: '@types/minimatch'
     version: 3.0.4
-    dev: false
 
   registry.npmjs.org/@types/mocha/9.1.0:
     resolution: {integrity: sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz}
@@ -14341,7 +14328,7 @@ packages:
     resolution: {integrity: sha512-OwVhKFim9Y/MprzCe4I6a59p31pMy8+LrtP6qS7J0kaOxYmW6VVJPBw5NYm+g7nSbgPUz22FvqU1F1hC5YGTfg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.5.tgz}
     name: '@types/mousetrap'
     version: 1.6.5
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/node-fetch/2.5.12:
     resolution: {integrity: sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz}
@@ -14350,7 +14337,7 @@ packages:
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
       form-data: registry.npmjs.org/form-data/3.0.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/node/10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz}
@@ -14378,7 +14365,7 @@ packages:
     resolution: {integrity: sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/object-hash/-/object-hash-1.3.4.tgz}
     name: '@types/object-hash'
     version: 1.3.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz}
@@ -14414,7 +14401,7 @@ packages:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz}
     name: '@types/pluralize'
     version: 0.0.29
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/postcss-normalize/9.0.1:
     resolution: {integrity: sha512-lzskydHM/aIjhwycpYbQDjhGfgZir4mMkkSR4pRQJsgHPle9piEI2mtdUX8AgNZGsBbfufqsin83S3SQfJt0eQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/postcss-normalize/-/postcss-normalize-9.0.1.tgz}
@@ -14428,12 +14415,12 @@ packages:
     resolution: {integrity: sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz}
     name: '@types/prettier'
     version: 2.3.2
-    dev: false
 
   registry.npmjs.org/@types/prop-types/15.7.4:
     resolution: {integrity: sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz}
     name: '@types/prop-types'
     version: 15.7.4
+    dev: true
 
   registry.npmjs.org/@types/puppeteer/3.0.5:
     resolution: {integrity: sha512-NkphUMkpbr/us6hp1AqUh/UxX5Tf2UJU94MvaF8OOgIUPBipYodql+yRjcysJKqwnDkchp+cD/8jntI/C9StzA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/puppeteer/-/puppeteer-3.0.5.tgz}
@@ -14453,13 +14440,11 @@ packages:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz}
     name: '@types/qs'
     version: 6.9.7
-    dev: false
 
   registry.npmjs.org/@types/range-parser/1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz}
     name: '@types/range-parser'
     version: 1.2.4
-    dev: false
 
   registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2:
     resolution: {integrity: sha512-kkPY4YbdoEXwf4CZdrEKNEYPHshdRGwHiCixyqaWxmYSj337hMX3YD28+tZkNiV4XUmJ4NevKtgZNbylkLSQ+A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-dev-utils/-/react-dev-utils-9.0.10.tgz}
@@ -14474,7 +14459,7 @@ packages:
       '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/3.11.6_debug@4.3.2
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-dom/17.0.14:
     resolution: {integrity: sha512-H03xwEP1oXmSfl3iobtmQ/2dHF5aBHr8aUMwyGZya6OW45G+xtdzmq6HkncefiBt5JU8DVyaWl/nWZbjZCnzAQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.14.tgz}
@@ -14492,7 +14477,7 @@ packages:
       '@types/history': registry.npmjs.org/@types/history/4.7.8
       '@types/react': registry.npmjs.org/@types/react/17.0.43
       '@types/react-router': registry.npmjs.org/@types/react-router/5.1.18
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-router/5.1.18:
     resolution: {integrity: sha512-YYknwy0D0iOwKQgz9v8nOzt2J6l4gouBmDnWqUUznltOTaon+r8US8ky8HvN0tXvc38U9m6z/t2RsVsnd1zM0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-router/-/react-router-5.1.18.tgz}
@@ -14501,7 +14486,7 @@ packages:
     dependencies:
       '@types/history': registry.npmjs.org/@types/history/4.7.11
       '@types/react': registry.npmjs.org/@types/react/17.0.43
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-tabs/2.3.2:
     resolution: {integrity: sha512-QfMelaJSdMcp+CenKhATp12XFFqqUcLXILgwpX3dgWfVYNZPtsLXZDDCRsVn+kwmBOWB+DFPKpQorxbUhnXINw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-tabs/-/react-tabs-2.3.2.tgz}
@@ -14509,7 +14494,7 @@ packages:
     version: 2.3.2
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/17.0.43
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-tooltip/3.11.0:
     resolution: {integrity: sha512-TkXMgkZ5aAKkFE9Wvt8OlOiPtF9ufgBOL9xWlRSzLBaoL12qSOBiyMcU4/8TyED1fuWkm5VTVarScwOPLSArYw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-3.11.0.tgz}
@@ -14517,7 +14502,7 @@ packages:
     version: 3.11.0
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/17.0.43
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react/17.0.43:
     resolution: {integrity: sha512-8Q+LNpdxf057brvPu1lMtC5Vn7J119xrP1aq4qiaefNioQUYANF/CYeK4NsKorSZyUGJ66g0IM+4bbjwx45o2A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.43.tgz}
@@ -14527,12 +14512,23 @@ packages:
       '@types/prop-types': registry.npmjs.org/@types/prop-types/15.7.4
       '@types/scheduler': registry.npmjs.org/@types/scheduler/0.16.2
       csstype: registry.npmjs.org/csstype/3.0.11
+    dev: true
+
+  registry.npmjs.org/@types/react/17.0.8:
+    resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz}
+    name: '@types/react'
+    version: 17.0.8
+    dependencies:
+      '@types/prop-types': registry.npmjs.org/@types/prop-types/15.7.4
+      '@types/scheduler': registry.npmjs.org/@types/scheduler/0.16.2
+      csstype: registry.npmjs.org/csstype/3.0.11
+    dev: true
 
   registry.npmjs.org/@types/relateurl/0.2.29:
     resolution: {integrity: sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz}
     name: '@types/relateurl'
     version: 0.2.29
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz}
@@ -14568,6 +14564,7 @@ packages:
     resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz}
     name: '@types/scheduler'
     version: 0.16.2
+    dev: true
 
   registry.npmjs.org/@types/semver/6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/semver/-/semver-6.2.3.tgz}
@@ -14579,7 +14576,6 @@ packages:
     resolution: {integrity: sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz}
     name: '@types/semver'
     version: 7.3.4
-    dev: false
 
   registry.npmjs.org/@types/serve-index/1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz}
@@ -14587,7 +14583,7 @@ packages:
     version: 1.9.1
     dependencies:
       '@types/express': registry.npmjs.org/@types/express/4.17.13
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/serve-static/1.13.10:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz}
@@ -14596,7 +14592,6 @@ packages:
     dependencies:
       '@types/mime': registry.npmjs.org/@types/mime/1.3.2
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/socket.io-client/1.4.35:
     resolution: {integrity: sha512-MI8YmxFS+jMkIziycT5ickBWK1sZwDwy16mgH/j99Mcom6zRG/NimNGQ3vJV0uX5G6g/hEw0FG3w3b3sT5OUGw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.35.tgz}
@@ -14617,7 +14612,7 @@ packages:
     resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz}
     name: '@types/source-list-map'
     version: 0.1.2
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/ssri/7.1.1:
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ssri/-/ssri-7.1.1.tgz}
@@ -14637,7 +14632,7 @@ packages:
     resolution: {integrity: sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz}
     name: '@types/tapable'
     version: 1.0.8
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/testing-library__jest-dom/5.9.5:
     resolution: {integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz}
@@ -14662,7 +14657,7 @@ packages:
     resolution: {integrity: sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz}
     name: '@types/ua-parser-js'
     version: 0.7.35
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/uglify-js/3.13.1:
     resolution: {integrity: sha512-O3MmRAk6ZuAKa9CHgg0Pr0+lUOqoMLpc9AS4R8ano2auvsg7IE8syF3Xh/NPr26TWklxYcqoEEFdzLLs1fV9PQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.13.1.tgz}
@@ -14670,7 +14665,7 @@ packages:
     version: 3.13.1
     dependencies:
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/ungap__global-this/0.3.1:
     resolution: {integrity: sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz}
@@ -14688,7 +14683,7 @@ packages:
     resolution: {integrity: sha512-awrJu8yML4E/xTwr2EMatC+HBnHGoDxc2+ImA9QyeUELI1S7dOCIZcyjki1rkwoA8P2D2NVgLAJLjnclkdLtAw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/url-join/-/url-join-4.0.0.tgz}
     name: '@types/url-join'
     version: 4.0.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/url-parse/1.4.3:
     resolution: {integrity: sha512-4kHAkbV/OfW2kb5BLVUuUMoumB3CP8rHqlw48aHvFy5tf9ER0AfOonBlX29l/DD68G70DmyhRlSYfQPSYpC5Vw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.3.tgz}
@@ -14700,7 +14695,7 @@ packages:
     resolution: {integrity: sha512-XDwyIlt/47l2kWLTzw/mtrpLdB+GPSskR2n/PIcPn+VYhVO77rGhRncIR5GPU0KRzXuqkDO+J5qqrG0Y8P6jzQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/uuid/-/uuid-3.4.9.tgz}
     name: '@types/uuid'
     version: 3.4.9
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-middleware/5.3.0_webpack@5.51.1:
     resolution: {integrity: sha512-SklLlklFBfTyIXo1iWXxzeytjlysWfj5QfIcRJrCc7MgzuCjnZOHXviQwe81iFGq9ZkCUXAg2fpbZdHhj5lSWA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz}
@@ -14712,7 +14707,7 @@ packages:
       webpack-dev-middleware: registry.npmjs.org/webpack-dev-middleware/5.3.1_webpack@5.51.1
     transitivePeerDependencies:
       - webpack
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-server/3.11.6_debug@4.3.2:
     resolution: {integrity: sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz}
@@ -14727,7 +14722,7 @@ packages:
       http-proxy-middleware: registry.npmjs.org/http-proxy-middleware/1.3.1_debug@4.3.2
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1:
     resolution: {integrity: sha512-kNcngS7vmFL8P5WZFtpFMTCwXcZEAZE3wz5xtWIuoEa6wXb2LPJl55HZqcevOi0qqzAKOEEJPKJxe2rxJ+ZYxg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-4.0.3.tgz}
@@ -14747,7 +14742,7 @@ packages:
     transitivePeerDependencies:
       - debug
       - webpack
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz}
@@ -14757,7 +14752,7 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       '@types/source-list-map': registry.npmjs.org/@types/source-list-map/0.1.2
       source-map: registry.npmjs.org/source-map/0.7.3
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack/4.41.32:
     resolution: {integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz}
@@ -14770,7 +14765,7 @@ packages:
       '@types/webpack-sources': registry.npmjs.org/@types/webpack-sources/3.2.0
       anymatch: registry.npmjs.org/anymatch/3.1.2
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28:
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack/-/webpack-5.28.0.tgz}
@@ -14786,7 +14781,7 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/websocket/1.0.2:
     resolution: {integrity: sha512-B5m9aq7cbbD/5/jThEr33nUY8WEfVi6A2YKCTOvw5Ldy7mtsOkqRvGjnzy6g7iMMDsgu7xREuCzqATLDLQVKcQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/websocket/-/websocket-1.0.2.tgz}
@@ -14838,7 +14833,7 @@ packages:
     version: 17.0.0
     dependencies:
       '@types/yargs-parser': registry.npmjs.org/@types/yargs-parser/21.0.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/yoga-layout/1.9.2:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/yoga-layout/-/yoga-layout-1.9.2.tgz}
@@ -15372,25 +15367,21 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': registry.npmjs.org/@webassemblyjs/helper-numbers/1.11.1
       '@webassemblyjs/helper-wasm-bytecode': registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz}
     name: '@webassemblyjs/floating-point-hex-parser'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz}
     name: '@webassemblyjs/helper-api-error'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz}
     name: '@webassemblyjs/helper-buffer'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-numbers/1.11.1:
     resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz}
@@ -15400,13 +15391,11 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/1.11.1
       '@webassemblyjs/helper-api-error': registry.npmjs.org/@webassemblyjs/helper-api-error/1.11.1
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz}
     name: '@webassemblyjs/helper-wasm-bytecode'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-wasm-section/1.11.1:
     resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz}
@@ -15417,7 +15406,6 @@ packages:
       '@webassemblyjs/helper-buffer': registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1
       '@webassemblyjs/helper-wasm-bytecode': registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1
       '@webassemblyjs/wasm-gen': registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/ieee754/1.11.1:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz}
@@ -15425,7 +15413,6 @@ packages:
     version: 1.11.1
     dependencies:
       '@xtuc/ieee754': registry.npmjs.org/@xtuc/ieee754/1.2.0
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/leb128/1.11.1:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz}
@@ -15433,13 +15420,11 @@ packages:
     version: 1.11.1
     dependencies:
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz}
     name: '@webassemblyjs/utf8'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-edit/1.11.1:
     resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz}
@@ -15454,7 +15439,6 @@ packages:
       '@webassemblyjs/wasm-opt': registry.npmjs.org/@webassemblyjs/wasm-opt/1.11.1
       '@webassemblyjs/wasm-parser': registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1
       '@webassemblyjs/wast-printer': registry.npmjs.org/@webassemblyjs/wast-printer/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1:
     resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz}
@@ -15466,7 +15450,6 @@ packages:
       '@webassemblyjs/ieee754': registry.npmjs.org/@webassemblyjs/ieee754/1.11.1
       '@webassemblyjs/leb128': registry.npmjs.org/@webassemblyjs/leb128/1.11.1
       '@webassemblyjs/utf8': registry.npmjs.org/@webassemblyjs/utf8/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-opt/1.11.1:
     resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz}
@@ -15477,7 +15460,6 @@ packages:
       '@webassemblyjs/helper-buffer': registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1
       '@webassemblyjs/wasm-gen': registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1
       '@webassemblyjs/wasm-parser': registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1:
     resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz}
@@ -15490,7 +15472,6 @@ packages:
       '@webassemblyjs/ieee754': registry.npmjs.org/@webassemblyjs/ieee754/1.11.1
       '@webassemblyjs/leb128': registry.npmjs.org/@webassemblyjs/leb128/1.11.1
       '@webassemblyjs/utf8': registry.npmjs.org/@webassemblyjs/utf8/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wast-printer/1.11.1:
     resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz}
@@ -15499,7 +15480,6 @@ packages:
     dependencies:
       '@webassemblyjs/ast': registry.npmjs.org/@webassemblyjs/ast/1.11.1
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@wry/context/0.5.4:
     resolution: {integrity: sha512-/pktJKHUXDr4D6TJqWgudOPJW2Z+Nb+bqk40jufA3uTkLbnCRKdJPiYDIa/c7mfcPH8Hr6O8zjCERpg5Sq04Zg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@wry/context/-/context-0.5.4.tgz}
@@ -15537,13 +15517,11 @@ packages:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz}
     name: '@xtuc/ieee754'
     version: 1.2.0
-    dev: false
 
   registry.npmjs.org/@xtuc/long/4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz}
     name: '@xtuc/long'
     version: 4.2.2
-    dev: false
 
   registry.npmjs.org/@yarnpkg/cli/3.2.0-rc.7:
     resolution: {integrity: sha512-4kXnvhUVGjIaXxO8Zgip20HJivGTcMUkeURtYo2Sa36vvST9jVEog0kllbmFXwyRAc/494pj3S5V2782XZG55w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@yarnpkg/cli/-/cli-3.2.0-rc.7.tgz}
@@ -16312,7 +16290,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: registry.npmjs.org/acorn/8.7.0
-    dev: false
 
   registry.npmjs.org/acorn-import-meta/1.1.0_acorn@7.4.1:
     resolution: {integrity: sha512-pshgiVR5mhpjFVdizKTN+kAGRqjJFUOEB3TvpQ6kiAutb1lvHrIVVcGoe5xzMpJkVNifCeymMG7/tsDkWn8CdQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/acorn-import-meta/-/acorn-import-meta-1.1.0.tgz}
@@ -16479,7 +16456,6 @@ packages:
     version: 8.7.0
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   registry.npmjs.org/address/1.1.2:
     resolution: {integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/address/-/address-1.1.2.tgz}
@@ -16584,7 +16560,6 @@ packages:
         optional: true
     dependencies:
       ajv: registry.npmjs.org/ajv/8.11.0
-    dev: false
 
   registry.npmjs.org/ajv-keywords/2.1.1_ajv@5.5.2:
     resolution: {integrity: sha1-YXmX/F9gV2iUxDX5QNgZ4TW4B2I=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz}
@@ -16606,7 +16581,6 @@ packages:
       ajv: ^6.9.1
     dependencies:
       ajv: registry.npmjs.org/ajv/6.12.6
-    dev: false
 
   registry.npmjs.org/ajv-keywords/5.1.0_ajv@8.11.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz}
@@ -16618,7 +16592,6 @@ packages:
     dependencies:
       ajv: registry.npmjs.org/ajv/8.11.0
       fast-deep-equal: registry.npmjs.org/fast-deep-equal/3.1.3
-    dev: false
 
   registry.npmjs.org/ajv/4.11.8:
     resolution: {integrity: sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz}
@@ -16649,7 +16622,6 @@ packages:
       fast-json-stable-stringify: registry.npmjs.org/fast-json-stable-stringify/2.1.0
       json-schema-traverse: registry.npmjs.org/json-schema-traverse/0.4.1
       uri-js: registry.npmjs.org/uri-js/4.4.1
-    dev: false
 
   registry.npmjs.org/ajv/8.11.0:
     resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz}
@@ -16660,7 +16632,6 @@ packages:
       json-schema-traverse: registry.npmjs.org/json-schema-traverse/1.0.0
       require-from-string: registry.npmjs.org/require-from-string/2.0.2
       uri-js: registry.npmjs.org/uri-js/4.4.1
-    dev: false
 
   registry.npmjs.org/amdefine/1.0.1:
     resolution: {integrity: sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz}
@@ -16864,7 +16835,6 @@ packages:
     dependencies:
       normalize-path: registry.npmjs.org/normalize-path/3.0.0
       picomatch: registry.npmjs.org/picomatch/2.3.1
-    dev: false
 
   registry.npmjs.org/apache-md5/1.1.7:
     resolution: {integrity: sha512-JtHjzZmJxtzfTSjsCyHgPR155HBe5WGyUyHTaEkfy46qhwCFKx1Epm6nAxgUG3WfUZP1dWhGqj9Z2NOBeZ+uBw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/apache-md5/-/apache-md5-1.1.7.tgz}
@@ -17677,7 +17647,6 @@ packages:
     resolution: {integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz}
     name: asynckit
     version: 0.4.0
-    dev: false
 
   registry.npmjs.org/at-least-node/1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz}
@@ -18256,7 +18225,6 @@ packages:
     name: binary-extensions
     version: 2.2.0
     engines: {node: '>=8'}
-    dev: false
 
   registry.npmjs.org/bit-mask/0.0.2-alpha:
     resolution: {integrity: sha1-QogPqABVFRFl1foVszG8BFnCc3I=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/bit-mask/-/bit-mask-0.0.2-alpha.tgz}
@@ -18463,7 +18431,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       fill-range: registry.npmjs.org/fill-range/7.0.1
-    dev: false
 
   registry.npmjs.org/brorand/1.1.0:
     resolution: {integrity: sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz}
@@ -18583,7 +18550,6 @@ packages:
       electron-to-chromium: registry.npmjs.org/electron-to-chromium/1.4.104
       escalade: registry.npmjs.org/escalade/3.1.1
       node-releases: registry.npmjs.org/node-releases/1.1.77
-    dev: false
 
   registry.npmjs.org/browserslist/4.20.2:
     resolution: {integrity: sha512-CQOBCqp/9pDvDbx3xfMi+86pr4KXIf2FDkTTdeuYw8OxS9t898LA1Khq57gtufFILXpfgsSx5woNgsBgvGjpsA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/browserslist/-/browserslist-4.20.2.tgz}
@@ -18637,7 +18603,6 @@ packages:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz}
     name: buffer-from
     version: 1.1.2
-    dev: false
 
   registry.npmjs.org/buffer-indexof/1.1.1:
     resolution: {integrity: sha512-4/rOEg86jivtPTeOUUT61jJO1Ya1TrR/OkqCSZDyq84WJh3LuuiphBYJN+fm5xufIk4XAFcEwte/8WzC8If/1g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/buffer-indexof/-/buffer-indexof-1.1.1.tgz}
@@ -19006,7 +18971,6 @@ packages:
     resolution: {integrity: sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz}
     name: caniuse-lite
     version: 1.0.30001325
-    dev: false
 
   registry.npmjs.org/capture-stack-trace/1.0.1:
     resolution: {integrity: sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz}
@@ -19255,7 +19219,6 @@ packages:
       readdirp: registry.npmjs.org/readdirp/3.6.0
     optionalDependencies:
       fsevents: registry.npmjs.org/fsevents/2.3.2
-    dev: false
 
   registry.npmjs.org/chownr/1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz}
@@ -19275,7 +19238,6 @@ packages:
     name: chrome-trace-event
     version: 1.0.3
     engines: {node: '>=6.0'}
-    dev: false
 
   registry.npmjs.org/ci-info/1.6.0:
     resolution: {integrity: sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz}
@@ -19723,13 +19685,11 @@ packages:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz}
     name: colorette
     version: 1.4.0
-    dev: false
 
   registry.npmjs.org/colorette/2.0.16:
     resolution: {integrity: sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz}
     name: colorette
     version: 2.0.16
-    dev: false
 
   registry.npmjs.org/colornames/1.1.1:
     resolution: {integrity: sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colornames/-/colornames-1.1.1.tgz}
@@ -19767,7 +19727,6 @@ packages:
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: registry.npmjs.org/delayed-stream/1.0.0
-    dev: false
 
   registry.npmjs.org/comlink/4.3.0:
     resolution: {integrity: sha512-mu4KKKNuW8TvkfpW/H88HBPeILubBS6T94BdD1VWBXNXfiyqVtwUCVNO1GeNOBTsIswzsMjWlycYr+77F5b84g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/comlink/-/comlink-4.3.0.tgz}
@@ -19803,7 +19762,6 @@ packages:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/commander/-/commander-2.20.3.tgz}
     name: commander
     version: 2.20.3
-    dev: false
 
   registry.npmjs.org/commander/4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/commander/-/commander-4.1.1.tgz}
@@ -20851,6 +20809,7 @@ packages:
     resolution: {integrity: sha512-sa6P2wJ+CAbgyy4KFssIb/JNMLxFvKF1pCYCSXS8ZMuqZnMsrxqI2E5sPyoTpxoPU/gVZMzr2zjOfg8GIZOMsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/csstype/-/csstype-3.0.11.tgz}
     name: csstype
     version: 3.0.11
+    dev: true
 
   registry.npmjs.org/cycle/1.0.3:
     resolution: {integrity: sha1-IegLK+hYD5i0aPN5QwZisEbDStI=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz}
@@ -21364,7 +21323,6 @@ packages:
     name: delayed-stream
     version: 1.0.0
     engines: {node: '>=0.4.0'}
-    dev: false
 
   registry.npmjs.org/delegates/1.0.0:
     resolution: {integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz}
@@ -21884,7 +21842,6 @@ packages:
     resolution: {integrity: sha512-2kjoAyiG7uMyGRM9mx25s3HAzmQG2ayuYXxsFmYugHSDcwxREgLtscZvbL1JcW9S/OemeQ3f/SG6JhDwpnCclQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.104.tgz}
     name: electron-to-chromium
     version: 1.4.104
-    dev: false
 
   registry.npmjs.org/elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz}
@@ -22056,7 +22013,6 @@ packages:
     dependencies:
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
       tapable: registry.npmjs.org/tapable/2.2.1
-    dev: false
 
   registry.npmjs.org/enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz}
@@ -22179,7 +22135,6 @@ packages:
     resolution: {integrity: sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz}
     name: es-module-lexer
     version: 0.7.1
-    dev: false
 
   registry.npmjs.org/es-to-primitive/1.2.1:
     resolution: {integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz}
@@ -22509,7 +22464,6 @@ packages:
     name: escalade
     version: 3.1.1
     engines: {node: '>=6'}
-    dev: false
 
   registry.npmjs.org/escape-html/1.0.3:
     resolution: {integrity: sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz}
@@ -22947,7 +22901,6 @@ packages:
     dependencies:
       esrecurse: registry.npmjs.org/esrecurse/4.3.0
       estraverse: registry.npmjs.org/estraverse/4.3.0
-    dev: false
 
   registry.npmjs.org/eslint-utils/1.4.3:
     resolution: {integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz}
@@ -23212,21 +23165,18 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: registry.npmjs.org/estraverse/5.3.0
-    dev: false
 
   registry.npmjs.org/estraverse/4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz}
     name: estraverse
     version: 4.3.0
     engines: {node: '>=4.0'}
-    dev: false
 
   registry.npmjs.org/estraverse/5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz}
     name: estraverse
     version: 5.3.0
     engines: {node: '>=4.0'}
-    dev: false
 
   registry.npmjs.org/estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz}
@@ -23287,7 +23237,6 @@ packages:
     resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz}
     name: eventemitter3
     version: 4.0.7
-    dev: false
 
   registry.npmjs.org/events/1.1.1:
     resolution: {integrity: sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/events/-/events-1.1.1.tgz}
@@ -23308,7 +23257,6 @@ packages:
     name: events
     version: 3.3.0
     engines: {node: '>=0.8.x'}
-    dev: false
 
   registry.npmjs.org/evp_bytestokey/1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz}
@@ -23714,7 +23662,6 @@ packages:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz}
     name: fast-json-stable-stringify
     version: 2.1.0
-    dev: false
 
   registry.npmjs.org/fast-levenshtein/2.0.6:
     resolution: {integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz}
@@ -23962,7 +23909,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       to-regex-range: registry.npmjs.org/to-regex-range/5.0.1
-    dev: false
 
   registry.npmjs.org/filter-obj/1.1.0:
     resolution: {integrity: sha1-mzERErxsYSehbgFsbF1/GeCAXFs=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/filter-obj/-/filter-obj-1.1.0.tgz}
@@ -24192,7 +24138,6 @@ packages:
         optional: true
     dependencies:
       debug: registry.npmjs.org/debug/4.3.2
-    dev: false
 
   registry.npmjs.org/for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz}
@@ -24276,7 +24221,6 @@ packages:
       asynckit: registry.npmjs.org/asynckit/0.4.0
       combined-stream: registry.npmjs.org/combined-stream/1.0.8
       mime-types: registry.npmjs.org/mime-types/2.1.35
-    dev: false
 
   registry.npmjs.org/form-data/4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz}
@@ -24411,7 +24355,6 @@ packages:
     resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fs-monkey/-/fs-monkey-1.0.3.tgz}
     name: fs-monkey
     version: 1.0.3
-    dev: false
 
   registry.npmjs.org/fs-readdir-recursive/1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz}
@@ -24443,7 +24386,6 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/function-bind/1.1.1:
@@ -24758,7 +24700,6 @@ packages:
     engines: {node: '>= 6'}
     dependencies:
       is-glob: registry.npmjs.org/is-glob/4.0.3
-    dev: false
 
   registry.npmjs.org/glob-to-regexp/0.3.0:
     resolution: {integrity: sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz}
@@ -24770,7 +24711,6 @@ packages:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz}
     name: glob-to-regexp
     version: 0.4.1
-    dev: false
 
   registry.npmjs.org/glob/5.0.15:
     resolution: {integrity: sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob/-/glob-5.0.15.tgz}
@@ -24987,7 +24927,6 @@ packages:
     resolution: {integrity: sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz}
     name: graceful-fs
     version: 4.2.10
-    dev: false
 
   registry.npmjs.org/graceful-git/3.1.2:
     resolution: {integrity: sha512-Xyh9Y43yA23/KQ16mpwO4zkzVGUAXyzuSVZQxw9ddQklssIYIY0el24VYfJBFhyCWGriZPRAB2nCgsDizqna9g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/graceful-git/-/graceful-git-3.1.2.tgz}
@@ -25895,7 +25834,7 @@ packages:
       micromatch: registry.npmjs.org/micromatch/4.0.5
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/http-proxy-middleware/2.0.4_a935ee530f2d2061e30407a8de97da78:
     resolution: {integrity: sha512-m/4FxX17SUvz4lJ5WPXOHDUuCwIqXLfLHs1s0uZ3oYjhoXlx9csYxaOa0ElDEJ+h8Q4iJ1s+lTMbiCa4EXIJqg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.4.tgz}
@@ -25931,7 +25870,6 @@ packages:
       requires-port: registry.npmjs.org/requires-port/1.0.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   registry.npmjs.org/http-signature/1.2.0:
     resolution: {integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz}
@@ -26351,11 +26289,11 @@ packages:
       react: '>=16.8.2'
     dependencies:
       cli-spinners: registry.npmjs.org/cli-spinners/2.6.1
-      ink: registry.npmjs.org/ink/3.0.8_eaaaa9853b905676398845fdfeb1b9b7
+      ink: registry.npmjs.org/ink/3.0.8_bcd8941a3ab2d2525b1c27c04f508879
       react: registry.npmjs.org/react/17.0.2
     dev: false
 
-  registry.npmjs.org/ink/3.0.8_eaaaa9853b905676398845fdfeb1b9b7:
+  registry.npmjs.org/ink/3.0.8_bcd8941a3ab2d2525b1c27c04f508879:
     resolution: {integrity: sha512-ubMFylXYaG4IkXQVhPautbhV/p6Lo0GlvAMI/jh8cGJQ39yeznJbaTTJP2CqZXezA4GOHzalpwCWqux/NEY38w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ink/-/ink-3.0.8.tgz}
     id: registry.npmjs.org/ink/3.0.8
     name: ink
@@ -26368,7 +26306,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       ansi-escapes: registry.npmjs.org/ansi-escapes/4.3.2
       auto-bind: registry.npmjs.org/auto-bind/4.0.0
       chalk: registry.npmjs.org/chalk/4.1.2
@@ -26683,7 +26621,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: registry.npmjs.org/binary-extensions/2.2.0
-    dev: false
 
   registry.npmjs.org/is-boolean-object/1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.1.2.tgz}
@@ -26862,7 +26799,6 @@ packages:
     name: is-extglob
     version: 2.1.1
     engines: {node: '>=0.10.0'}
-    dev: false
 
   registry.npmjs.org/is-fullwidth-code-point/1.0.0:
     resolution: {integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz}
@@ -26936,7 +26872,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: registry.npmjs.org/is-extglob/2.1.1
-    dev: false
 
   registry.npmjs.org/is-gzip/1.0.0:
     resolution: {integrity: sha1-bKiwe5nHeZgCWQDlVc7Y7YCHmoM=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz}
@@ -27046,7 +26981,6 @@ packages:
     name: is-number
     version: 7.0.0
     engines: {node: '>=0.12.0'}
-    dev: false
 
   registry.npmjs.org/is-obj/1.0.1:
     resolution: {integrity: sha1-PkcprB9f3gJc19g6iW2rn09n2w8=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz}
@@ -27090,7 +27024,6 @@ packages:
     name: is-plain-obj
     version: 3.0.0
     engines: {node: '>=10'}
-    dev: false
 
   registry.npmjs.org/is-plain-object/2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz}
@@ -28092,7 +28025,6 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       merge-stream: registry.npmjs.org/merge-stream/2.0.0
       supports-color: registry.npmjs.org/supports-color/8.1.1
-    dev: false
 
   registry.npmjs.org/jest/27.5.1_72ef9f06cb99540da679cbf1bf7a3256:
     resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/jest/-/jest-27.5.1.tgz}
@@ -28364,7 +28296,6 @@ packages:
     resolution: {integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz}
     name: json-parse-better-errors
     version: 1.0.2
-    dev: false
 
   registry.npmjs.org/json-parse-even-better-errors/2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz}
@@ -28382,13 +28313,11 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz}
     name: json-schema-traverse
     version: 0.4.1
-    dev: false
 
   registry.npmjs.org/json-schema-traverse/1.0.0:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
     name: json-schema-traverse
     version: 1.0.0
-    dev: false
 
   registry.npmjs.org/json-schema/0.3.0:
     resolution: {integrity: sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz}
@@ -28926,7 +28855,6 @@ packages:
     name: loader-runner
     version: 4.2.0
     engines: {node: '>=6.11.5'}
-    dev: false
 
   registry.npmjs.org/loader-utils/1.2.3:
     resolution: {integrity: sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz}
@@ -29736,7 +29664,6 @@ packages:
     engines: {node: '>= 4.0.0'}
     dependencies:
       fs-monkey: registry.npmjs.org/fs-monkey/1.0.3
-    dev: false
 
   registry.npmjs.org/memoize-one/5.1.1:
     resolution: {integrity: sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz}
@@ -29800,7 +29727,6 @@ packages:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz}
     name: merge-stream
     version: 2.0.0
-    dev: false
 
   registry.npmjs.org/merge2/1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz}
@@ -29877,7 +29803,6 @@ packages:
     dependencies:
       braces: registry.npmjs.org/braces/3.0.2
       picomatch: registry.npmjs.org/picomatch/2.3.1
-    dev: false
 
   registry.npmjs.org/miller-rabin/4.0.1:
     resolution: {integrity: sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz}
@@ -29894,7 +29819,6 @@ packages:
     name: mime-db
     version: 1.52.0
     engines: {node: '>= 0.6'}
-    dev: false
 
   registry.npmjs.org/mime-types/2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz}
@@ -29903,7 +29827,6 @@ packages:
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: registry.npmjs.org/mime-db/1.52.0
-    dev: false
 
   registry.npmjs.org/mime/1.6.0:
     resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/mime/-/mime-1.6.0.tgz}
@@ -30584,7 +30507,6 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz}
     name: neo-async
     version: 2.6.2
-    dev: false
 
   registry.npmjs.org/nerf-dart/1.0.0:
     resolution: {integrity: sha1-5tq3/r9a2Bbqgc9cYpxaDr3nLBo=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/nerf-dart/-/nerf-dart-1.0.0.tgz}
@@ -30770,7 +30692,6 @@ packages:
     resolution: {integrity: sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz}
     name: node-releases
     version: 1.1.77
-    dev: false
 
   registry.npmjs.org/node-releases/2.0.2:
     resolution: {integrity: sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz}
@@ -30868,7 +30789,6 @@ packages:
     name: normalize-path
     version: 3.0.0
     engines: {node: '>=0.10.0'}
-    dev: false
 
   registry.npmjs.org/normalize-range/0.1.2:
     resolution: {integrity: sha1-LRDAa9/TEuqXd2laTShDlFa3WUI=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz}
@@ -31494,7 +31414,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: registry.npmjs.org/yocto-queue/0.1.0
-    dev: false
 
   registry.npmjs.org/p-locate/2.0.0:
     resolution: {integrity: sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz}
@@ -32123,7 +32042,6 @@ packages:
     name: picomatch
     version: 2.3.1
     engines: {node: '>=8.6'}
-    dev: false
 
   registry.npmjs.org/pidtree/0.3.1:
     resolution: {integrity: sha512-qQbW94hLHEqCg7nhby4yRC7G2+jYHY4Rguc2bjw7Uug4GIJuu1tvf2uHaZv5Q8zdt+WKJ6qK1FOI6amaWUo5FA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/pidtree/-/pidtree-0.3.1.tgz}
@@ -33696,7 +33614,6 @@ packages:
     name: punycode
     version: 2.1.1
     engines: {node: '>=6'}
-    dev: false
 
   registry.npmjs.org/puppeteer/1.20.0:
     resolution: {integrity: sha512-bt48RDBy2eIwZPrkgbcwHtb51mj2nKvHOPMaSH2IsWiv7lOG9k9zhaRzpDZafrk05ajMc3cu+lSQYYOfH2DkVQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/puppeteer/-/puppeteer-1.20.0.tgz}
@@ -33870,7 +33787,6 @@ packages:
     version: 2.1.0
     dependencies:
       safe-buffer: registry.npmjs.org/safe-buffer/5.2.1
-    dev: false
 
   registry.npmjs.org/randomfill/1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz}
@@ -33886,7 +33802,6 @@ packages:
     name: range-parser
     version: 1.2.1
     engines: {node: '>= 0.6'}
-    dev: false
 
   registry.npmjs.org/raw-body/2.4.0:
     resolution: {integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz}
@@ -34391,7 +34306,7 @@ packages:
       tslib: registry.npmjs.org/tslib/2.3.1
     dev: true
 
-  registry.npmjs.org/react-use-dimensions/1.2.1_7c7fa889c4f6a98d91df0cf78df3db4b:
+  registry.npmjs.org/react-use-dimensions/1.2.1_d0162b0509b34ce9df13ad5570623e8b:
     resolution: {integrity: sha512-XL+Rup9Hosxx3Ap9xpyQMbVwuUa4BSqiOjfBb2zDuGs4uv2FesFV+m8Z/huRx2BNptMd9ARPqFuSNA62zhCozg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/react-use-dimensions/-/react-use-dimensions-1.2.1.tgz}
     id: registry.npmjs.org/react-use-dimensions/1.2.1
     name: react-use-dimensions
@@ -34401,7 +34316,7 @@ packages:
       react: ^16.8.x
       typescript: ^3.5.2
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       react: registry.npmjs.org/react/17.0.2
       typescript: registry.npmjs.org/typescript/4.4.2
     dev: false
@@ -34645,7 +34560,6 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: registry.npmjs.org/picomatch/2.3.1
-    dev: false
 
   registry.npmjs.org/realpath-missing/1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/realpath-missing/-/realpath-missing-1.1.0.tgz}
@@ -35255,7 +35169,6 @@ packages:
     name: require-from-string
     version: 2.0.2
     engines: {node: '>=0.10.0'}
-    dev: false
 
   registry.npmjs.org/require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz}
@@ -35667,7 +35580,6 @@ packages:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz}
     name: safe-buffer
     version: 5.2.1
-    dev: false
 
   registry.npmjs.org/safe-execa/0.1.1:
     resolution: {integrity: sha512-2KPID7iC4AMoJVozDPtcLGV+7LdpE0sR1hPkJUCaEnRsiYSZH2wgOFvxZ9UOtj1r8hNk8pVWn1tgmaEyyFZ4NA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.1.tgz}
@@ -35869,7 +35781,6 @@ packages:
       '@types/json-schema': registry.npmjs.org/@types/json-schema/7.0.9
       ajv: registry.npmjs.org/ajv/6.12.6
       ajv-keywords: registry.npmjs.org/ajv-keywords/3.5.2_ajv@6.12.6
-    dev: false
 
   registry.npmjs.org/schema-utils/4.0.0:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz}
@@ -35881,7 +35792,6 @@ packages:
       ajv: registry.npmjs.org/ajv/8.11.0
       ajv-formats: registry.npmjs.org/ajv-formats/2.1.1
       ajv-keywords: registry.npmjs.org/ajv-keywords/5.1.0_ajv@8.11.0
-    dev: false
 
   registry.npmjs.org/screenfull/5.2.0:
     resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz}
@@ -36071,7 +35981,6 @@ packages:
     version: 6.0.0
     dependencies:
       randombytes: registry.npmjs.org/randombytes/2.1.0
-    dev: false
 
   registry.npmjs.org/serve-index/1.9.1:
     resolution: {integrity: sha1-03aNabHn2C5c4FD/9bRTvqEqkjk=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz}
@@ -36659,7 +36568,6 @@ packages:
     dependencies:
       buffer-from: registry.npmjs.org/buffer-from/1.1.2
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
 
   registry.npmjs.org/source-map-url/0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz}
@@ -36702,7 +36610,6 @@ packages:
     name: source-map
     version: 0.7.3
     engines: {node: '>= 8'}
-    dev: false
 
   registry.npmjs.org/source-map/0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz}
@@ -37580,7 +37487,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: registry.npmjs.org/has-flag/4.0.0
-    dev: false
 
   registry.npmjs.org/supports-color/9.2.2:
     resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz}
@@ -37753,7 +37659,6 @@ packages:
     name: tapable
     version: 2.2.1
     engines: {node: '>=6'}
-    dev: false
 
   registry.npmjs.org/tar-stream/2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz}
@@ -37884,7 +37789,6 @@ packages:
       source-map: registry.npmjs.org/source-map/0.6.1
       terser: registry.npmjs.org/terser/5.12.1
       webpack: registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28
-    dev: false
 
   registry.npmjs.org/terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/terser/-/terser-4.8.0.tgz}
@@ -37909,7 +37813,6 @@ packages:
       commander: registry.npmjs.org/commander/2.20.3
       source-map: registry.npmjs.org/source-map/0.7.3
       source-map-support: registry.npmjs.org/source-map-support/0.5.21
-    dev: false
 
   registry.npmjs.org/test-exclude/6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz}
@@ -38109,7 +38012,6 @@ packages:
     engines: {node: '>=8.0'}
     dependencies:
       is-number: registry.npmjs.org/is-number/7.0.0
-    dev: false
 
   registry.npmjs.org/to-regex/3.0.2:
     resolution: {integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz}
@@ -39008,7 +38910,6 @@ packages:
     version: 4.4.1
     dependencies:
       punycode: registry.npmjs.org/punycode/2.1.1
-    dev: false
 
   registry.npmjs.org/urix/0.1.0:
     resolution: {integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/urix/-/urix-0.1.0.tgz}
@@ -39105,7 +39006,7 @@ packages:
       react: registry.npmjs.org/react/17.0.2
     dev: false
 
-  registry.npmjs.org/use-isomorphic-layout-effect/1.1.2_03a98942b76c57740a9573edba2d1cc1:
+  registry.npmjs.org/use-isomorphic-layout-effect/1.1.2_@types+react@17.0.8+react@17.0.2:
     resolution: {integrity: sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz}
     id: registry.npmjs.org/use-isomorphic-layout-effect/1.1.2
     name: use-isomorphic-layout-effect
@@ -39117,7 +39018,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
-      '@types/react': registry.npmjs.org/@types/react/17.0.43
+      '@types/react': registry.npmjs.org/@types/react/17.0.8
       react: registry.npmjs.org/react/17.0.2
     dev: false
 
@@ -39708,7 +39609,6 @@ packages:
     dependencies:
       glob-to-regexp: registry.npmjs.org/glob-to-regexp/0.4.1
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
-    dev: false
 
   registry.npmjs.org/wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz}
@@ -39792,7 +39692,6 @@ packages:
       range-parser: registry.npmjs.org/range-parser/1.2.1
       schema-utils: registry.npmjs.org/schema-utils/4.0.0
       webpack: registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28
-    dev: false
 
   registry.npmjs.org/webpack-dev-server/4.1.0_d62a9df5b4e15422e8598b75c638713a:
     resolution: {integrity: sha512-PnnoCHuLKxH3vYff2EbORntD0Pd+MKclDIO8AcKsDVRToqY9/oeIwwUs5alA2B5OPgXJhaDNkBJAmb0OaWZFJA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.1.0.tgz}
@@ -39890,7 +39789,6 @@ packages:
     name: webpack-sources
     version: 3.2.3
     engines: {node: '>=10.13.0'}
-    dev: false
 
   registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28:
     resolution: {integrity: sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz}
@@ -39933,7 +39831,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   registry.npmjs.org/websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz}
@@ -40829,7 +40726,6 @@ packages:
     name: yocto-queue
     version: 0.1.0
     engines: {node: '>=10'}
-    dev: false
 
   registry.npmjs.org/yoga-layout-prebuilt/1.10.0:
     resolution: {integrity: sha512-YnOmtSbv4MTf7RGJMK0FvZ+KD8OEe/J5BNnR0GHhD8J/XcG/Qvxgszm0Un6FTHWW4uHlTgP0IztiXQnGyIR45g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/yoga-layout-prebuilt/-/yoga-layout-prebuilt-1.10.0.tgz}

--- a/scopes/harmony/logger/logger.ts
+++ b/scopes/harmony/logger/logger.ts
@@ -1,7 +1,6 @@
 import loader from '@teambit/legacy/dist/cli/loader';
 import logger, { IBitLogger } from '@teambit/legacy/dist/logger/logger';
 import chalk from 'chalk';
-import stc from 'string-to-color';
 
 import { LongProcessLogger } from './long-process-logger';
 
@@ -115,8 +114,7 @@ export class Logger implements IBitLogger {
   }
 
   private colorMessage(message: string) {
-    const text = `${this.extensionName}, ${message}`;
-    if (logger.isJsonFormat) return text;
-    return chalk.hex(stc(this.extensionName))(text);
+    if (logger.isJsonFormat) return `${this.extensionName}, ${message}`;
+    return `${chalk.bold(this.extensionName)}, ${message}`;
   }
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -346,7 +346,6 @@
         "socket.io": "2.4.1",
         "socket.io-client": "2.4.0",
         "socks-proxy-agent": "5.0.0",
-        "string-to-color": "2.2.2",
         "strip-ansi": "6.0.0",
         "subscriptions-transport-ws": "0.9.18",
         "table": "6.7.3",


### PR DESCRIPTION
Currently, when the log messages are written by an aspect, it has a unique color to easily differentiate between the aspects.
While this was working well for most aspects, some of them got unreadable colors. Also, in some instances, the background of the log file stream was changed to yellow for some weird reason (happened to @ranm8 ).
In this PR, the log messages are all have the same color. To make is easier to see the aspect-name, it was changed to be bold.