### PR TITLE
Ignore asterisk version during grouping

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -431,7 +431,11 @@ this is a temporary issue with unsupported snaps (hashes) on the registry and wi
     }
     // parseRange does not support `*` as version
     // `*` does not affect resulted version, it might be just ignored
-    if (validRange === '*') return;
+    if (validRange === '*') {
+      // to prevent empty `result.ranges`, it needs to be pushed
+      result.ranges.push(item);
+      return;
+    }
     const parsed = parseRange(validRange);
     if (parsed.condition === '=') {
       result.versions.push(item);

--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -429,6 +429,9 @@ function groupByRangeOrVersion(indexItems: PackageNameIndexComponentItem[]): Ite
       throw new Error(`fatal: the version "${item.range}" originated from a dependent "${item.origin}" is invalid semver range.
 this is a temporary issue with unsupported snaps (hashes) on the registry and will be fixed very soon`);
     }
+    // parseRange does not support `*` as version
+    // `*` does not affect resulted version, it might be just ignored
+    if (validRange === '*') return;
     const parsed = parseRange(validRange);
     if (parsed.condition === '=') {
       result.versions.push(item);


### PR DESCRIPTION
`semver-intersect` does not support `*` asterisk version value and throws an exception
```
Cannot read properties of null (reading '1')
```
asterisk means any version so it could be skipped during grouping

## Proposed Changes
- ignore asterisk symbol during `groupByRangeOrVersion`
