### PR TITLE
improvement: add lanes to cat-scope

### DIFF
--- a/src/api/scope/lib/cat-lane.ts
+++ b/src/api/scope/lib/cat-lane.ts
@@ -8,5 +8,7 @@ export default async function catLane(name: string) {
   const lane = await scope.loadLane(laneId);
   // @todo: throw LaneNotFound
   if (!lane) throw new GeneralError(`lane ${name} was not found!`);
-  return lane.toObject();
+  const obj = lane.toObject();
+  obj.hash = lane.hash().toString();
+  return obj;
 }

--- a/src/api/scope/lib/cat-scope.ts
+++ b/src/api/scope/lib/cat-scope.ts
@@ -6,5 +6,5 @@ export default async function catScope(path: string, full: boolean): Promise<Bit
   const scope: Scope = await loadScope(path);
   return full
     ? scope.objects.list([ModelComponent, Symlink, Lane, Version, ScopeMeta])
-    : scope.objects.list([ModelComponent, Symlink]);
+    : scope.objects.list([ModelComponent, Symlink, Lane]);
 }

--- a/src/cli/commands/private-cmds/cat-scope-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-scope-cmd.ts
@@ -53,7 +53,10 @@ export default class CatScope implements LegacyCommand {
     }
     if (!full) {
       const table = new Table({ head: ['id', 'Object'], style: { head: ['cyan'] } });
-      payload.forEach((co) => table.push([co.id(), `obj: ${co.hash().toString()}`]));
+      payload.forEach((co) => {
+        const id = co.getType() === 'Lane' ? `${co.id()} [lane]` : co.id();
+        table.push([id, `obj: ${co.hash().toString()}`]);
+      });
       return table.toString();
     }
 


### PR DESCRIPTION
with this change, `bit cat-scope` will show lanes with a suffix of `[lane]`. See screenshot.
<img width="527" alt="Screen Shot 2022-05-02 at 11 54 09 AM" src="https://user-images.githubusercontent.com/1963573/166265576-e2b0a1eb-9bae-4c7b-acfb-70ea2865ef8d.png">

