### PR TITLE
fix(lanes): enable switching lanes if the modification on a lane is not source-files related

### DIFF
--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -294,7 +294,9 @@ async function getComponentStatus(consumer: Consumer, id: BitId, switchProps: Sw
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   const baseComponent: Version = await modelComponent.loadVersion(currentlyUsedVersion, consumer.scope.objects);
   const component = await consumer.loadComponent(existingBitMapId);
-  const isModified = await consumer.isComponentModified(baseComponent, component);
+  // don't use `consumer.isModified` here. otherwise, if there are dependency changes, the user can't discard them
+  // and won't be able to switch lanes.
+  const isModified = await consumer.isComponentSourceCodeModified(baseComponent, component);
   let mergeResults: MergeResultsThreeWay | null | undefined;
   const isHeadSameAsMain = () => {
     const head = modelComponent.getHead();

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -556,6 +556,28 @@ export default class Consumer {
     }
   }
 
+  /**
+   * Check whether the component files from the model and from the file-system of the same component is the same.
+   */
+  async isComponentSourceCodeModified(
+    componentFromModel: Version,
+    componentFromFileSystem: Component
+  ): Promise<boolean> {
+    if (componentFromFileSystem._isModified === false) {
+      // we only check for "false". if it's "true", it can be dependency changes not necessarily component files changes
+      return false;
+    }
+    componentFromFileSystem.log = componentFromModel.log; // in order to convert to Version object
+    const { version } = await this.scope.sources.consumerComponentToVersion({
+      consumer: this,
+      consumerComponent: componentFromFileSystem,
+    });
+
+    version.files = R.sortBy(R.prop('relativePath'), version.files);
+    componentFromModel.files = R.sortBy(R.prop('relativePath'), componentFromModel.files);
+    return JSON.stringify(version.files) !== JSON.stringify(componentFromModel.files);
+  }
+
   async getManyComponentsStatuses(ids: BitId[]): Promise<ComponentStatusResult[]> {
     return this.componentStatusLoader.getManyComponentsStatuses(ids);
   }


### PR DESCRIPTION
Currently, if a component has a snap on a lane and the component is modified due to dependencies changes, the user can't switch to another lane. It shows an error: "unable to checkout comp-name, the component is modified and belongs to another lane".
With this change, we check for component files changes specifically.