### PR TITLE
fix(lanes): preserve the same Lane hash during lane-import

### DIFF
--- a/e2e/harmony/lanes/import-lanes.e2e.ts
+++ b/e2e/harmony/lanes/import-lanes.e2e.ts
@@ -18,6 +18,7 @@ describe('import lanes', function () {
   });
   describe('importing lanes', () => {
     let appOutput: string;
+    let laneHash: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
@@ -25,6 +26,9 @@ describe('import lanes', function () {
       helper.command.createLane('dev');
       helper.command.snapAllComponents();
       helper.command.exportLane();
+
+      const laneObj = helper.command.catLane('dev');
+      laneHash = laneObj.hash;
     });
     describe('fetching lanes objects', () => {
       before(() => {
@@ -83,6 +87,10 @@ describe('import lanes', function () {
         const bitMap = helper.bitMap.read();
         expect(bitMap.comp1.onLanesOnly).to.be.true;
         expect(bitMap.comp2.onLanesOnly).to.be.true;
+      });
+      it('should save the lane object with the same hash as the original lane', () => {
+        const laneObj = helper.command.catLane('dev');
+        expect(laneObj.hash).to.eq(laneHash);
       });
     });
     describe('importing the lane and checking out with a different local lane-name', () => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -147,7 +147,8 @@ describe('merge lanes', function () {
         });
       });
     });
-    describe('creating a new lane with the same name on a different workspace', () => {
+    // @todo: enable this once we're good with the breaking change on sources.ts mergeLane()
+    describe.skip('creating a new lane with the same name on a different workspace', () => {
       before(() => {
         helper.scopeHelper.reInitLocalScopeHarmony();
         helper.scopeHelper.addRemoteScope();

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -16,7 +16,7 @@ describe('merge lanes', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('merging lanes', () => {
+  describe('export a local lane into a remote scope', () => {
     let authorScope;
     let importedScope;
     let appOutput: string;
@@ -147,69 +147,83 @@ describe('merge lanes', function () {
         });
       });
     });
-    describe('merging main into local lane', () => {
-      let mergeOutput: string;
+    describe('creating a new lane with the same name on a different workspace', () => {
       before(() => {
-        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
         helper.bitJsonc.setupDefault();
         helper.command.createLane('dev');
-        helper.fixtures.populateComponents(1);
+        helper.fixtures.createComponentBarFoo();
+        helper.fixtures.addComponentBarFooAsDir();
         helper.command.snapAllComponentsWithoutBuild();
-        mergeOutput = helper.command.mergeLane('main');
       });
-      it("should not throw an error that main lane doesn't exist", () => {
-        expect(mergeOutput).to.not.have.string('unable to switch to "main", the lane was not found');
+      it('should not merge the two lanes on the remote, instead, it should throw', () => {
+        expect(() => helper.command.export()).to.throw('unable to merge');
       });
     });
-    describe('merging main into local lane when main has tagged versions', () => {
-      let mergeOutput: string;
-      before(() => {
-        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-        helper.bitJsonc.setupDefault();
-        helper.fixtures.populateComponents(1);
-        helper.command.tagAllWithoutBuild();
-        helper.command.createLane('dev');
-        helper.fixtures.populateComponents(1, undefined, 'v2');
-        helper.command.snapAllComponentsWithoutBuild();
-        mergeOutput = helper.command.mergeLane('main');
-      });
-      it("should not throw an error that main lane doesn't exist", () => {
-        expect(mergeOutput).to.not.have.string('getDivergeData: unable to find Version 0.0.1 of comp1');
-      });
+  });
+  describe('merging main into local lane', () => {
+    let mergeOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      mergeOutput = helper.command.mergeLane('main');
     });
-    describe('merging main lane with no snapped components', () => {
-      let mergeOutput: string;
-      before(() => {
-        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-        helper.bitJsonc.setupDefault();
-        helper.fixtures.populateComponents(1);
-        helper.command.createLane('dev');
-        mergeOutput = helper.command.mergeLane('main');
-      });
-      it('should not throw an error about missing objects', () => {
-        expect(mergeOutput).to.not.have.string(
-          'component comp1 is on the lane but its objects were not found, please re-import the lane'
-        );
-      });
+    it("should not throw an error that main lane doesn't exist", () => {
+      expect(mergeOutput).to.not.have.string('unable to switch to "main", the lane was not found');
     });
-    describe('merging a lane into main when main is empty', () => {
-      let mergeOutput: string;
-      before(() => {
-        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-        helper.bitJsonc.setupDefault();
-        helper.fixtures.populateComponents(1);
-        helper.command.createLane('dev');
-        helper.command.snapAllComponentsWithoutBuild();
-        helper.command.switchLocalLane('main');
-        mergeOutput = helper.command.mergeLane('dev');
-      });
-      it('should not throw an error that head is empty', () => {
-        expect(mergeOutput).to.have.string('successfully merged');
-      });
-      it('the component should be available on main', () => {
-        const list = helper.command.listParsed();
-        expect(list).to.have.lengthOf(1);
-      });
+  });
+  describe('merging main into local lane when main has tagged versions', () => {
+    let mergeOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      mergeOutput = helper.command.mergeLane('main');
+    });
+    it("should not throw an error that main lane doesn't exist", () => {
+      expect(mergeOutput).to.not.have.string('getDivergeData: unable to find Version 0.0.1 of comp1');
+    });
+  });
+  describe('merging main lane with no snapped components', () => {
+    let mergeOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane('dev');
+      mergeOutput = helper.command.mergeLane('main');
+    });
+    it('should not throw an error about missing objects', () => {
+      expect(mergeOutput).to.not.have.string(
+        'component comp1 is on the lane but its objects were not found, please re-import the lane'
+      );
+    });
+  });
+  describe('merging a lane into main when main is empty', () => {
+    let mergeOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane('dev');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.switchLocalLane('main');
+      mergeOutput = helper.command.mergeLane('dev');
+    });
+    it('should not throw an error that head is empty', () => {
+      expect(mergeOutput).to.have.string('successfully merged');
+    });
+    it('the component should be available on main', () => {
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(1);
     });
   });
 });

--- a/scopes/lanes/lanes/create-lane.ts
+++ b/scopes/lanes/lanes/create-lane.ts
@@ -1,41 +1,37 @@
-import { Consumer } from '..';
-import { BitIds } from '../../bit-id';
-import GeneralError from '../../error/general-error';
-import Lane, { LaneComponent } from '../../scope/models/lane';
-import WorkspaceLane from '../bit-map/workspace-lane';
+import { BitError } from '@teambit/bit-error';
+import { Consumer } from '@teambit/legacy/dist/consumer';
+import { BitIds } from '@teambit/legacy/dist/bit-id';
+import Lane, { LaneComponent } from '@teambit/legacy/dist/scope/models/lane';
+import WorkspaceLane from '@teambit/legacy/dist/consumer/bit-map/workspace-lane';
 
-export default async function createNewLane(
-  consumer: Consumer,
-  laneName: string,
-  laneComponents?: LaneComponent[]
-): Promise<Lane> {
+export async function createLane(consumer: Consumer, laneName: string, remoteLane?: Lane): Promise<Lane> {
   const lanes = await consumer.scope.listLanes();
   if (lanes.find((lane) => lane.name === laneName)) {
-    throw new GeneralError(
-      `lane "${laneName}" already exists, to switch to this lane, please use "bit switch" command`
-    );
+    throw new BitError(`lane "${laneName}" already exists, to switch to this lane, please use "bit switch" command`);
   }
   if (!isValidLaneName(laneName)) {
-    throw new GeneralError(
+    throw new BitError(
       `lane "${laneName}" has invalid characters. lane name can only contain alphanumeric, lowercase characters, and the following ["-", "_", "$", "!"]`
     );
   }
 
   const getDataToPopulateLaneObjectIfNeeded = async (): Promise<LaneComponent[]> => {
-    if (laneComponents) return laneComponents;
+    if (remoteLane) return remoteLane.components;
     // when branching from one lane to another, copy components from the origin lane
     // when branching from main, no need to copy anything
     const currentLaneObject = await consumer.getCurrentLaneObject();
     return currentLaneObject ? currentLaneObject.components : [];
   };
   const getDataToPopulateWorkspaceLaneIfNeeded = (): BitIds => {
-    if (laneComponents) return new BitIds(); // if laneComponent, this got created when importing a remote lane
+    if (remoteLane) return new BitIds(); // if remoteLane, this got created when importing a remote lane
     // when branching from one lane to another, copy components from the origin workspace-lane
     // when branching from main, no need to copy anything
     const currentWorkspaceLane = consumer.bitMap.workspaceLane;
     return currentWorkspaceLane ? currentWorkspaceLane.ids : new BitIds();
   };
-  const newLane = Lane.create(laneName);
+  const newLane = remoteLane
+    ? Lane.from({ name: laneName, hash: remoteLane.hash().toString() })
+    : Lane.create(laneName);
   const dataToPopulate = await getDataToPopulateLaneObjectIfNeeded();
   newLane.setLaneComponents(dataToPopulate);
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -7,7 +7,6 @@ import { LaneDiffCmd, LaneDiffGenerator } from '@teambit/lanes.modules.diff';
 import { LaneData } from '@teambit/legacy/dist/scope/lanes/lanes';
 import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { BitError } from '@teambit/bit-error';
-import createNewLane from '@teambit/legacy/dist/consumer/lanes/create-lane';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { DiffOptions } from '@teambit/legacy/dist/consumer/component-ops/components-diff';
 import {
@@ -41,6 +40,7 @@ import { lanesSchema } from './lanes.graphql';
 import { SwitchCmd } from './switch.cmd';
 import { mergeLanes } from './merge-lanes';
 import { LaneSwitcher } from './switch-lanes';
+import { createLane } from './create-lane';
 
 export type LaneResults = {
   lanes: LaneData[];
@@ -125,7 +125,7 @@ export class LanesMain {
     if (!this.workspace) {
       throw new BitError(`unable to create a lane outside of Bit workspace`);
     }
-    await createNewLane(this.workspace.consumer, name);
+    await createLane(this.workspace.consumer, name);
     this.scope.legacyScope.lanes.setCurrentLane(name);
     const trackLaneData = {
       localLane: name,

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -6,7 +6,6 @@ import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/sc
 import { BitId } from '@teambit/legacy-bit-id';
 import { ComponentWithDependencies } from '@teambit/legacy/dist/scope';
 import { Version, Lane } from '@teambit/legacy/dist/scope/models';
-import { LaneComponent } from '@teambit/legacy/dist/scope/models/lane';
 import { Tmp } from '@teambit/legacy/dist/scope/repositories';
 import WorkspaceLane from '@teambit/legacy/dist/consumer/bit-map/workspace-lane';
 import {
@@ -22,12 +21,13 @@ import {
   getMergeStrategyInteractive,
   ApplyVersionResults,
 } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
-import createNewLane from '@teambit/legacy/dist/consumer/lanes/create-lane';
 import threeWayMerge, {
   MergeResultsThreeWay,
 } from '@teambit/legacy/dist/consumer/versions-ops/merge-version/three-way-merge';
 import { Workspace } from '@teambit/workspace';
 import { Logger } from '@teambit/logger';
+import { BitError } from '@teambit/bit-error';
+import { createLane } from './create-lane';
 
 export type SwitchProps = {
   laneName: string;
@@ -37,7 +37,7 @@ export type SwitchProps = {
   localLaneName?: string;
   remoteLaneScope?: string;
   remoteLaneName?: string;
-  remoteLaneComponents?: LaneComponent[];
+  remoteLane?: Lane;
   localTrackedLane?: string;
   newLaneName?: string;
 };
@@ -130,7 +130,7 @@ export class LaneSwitcher {
       );
     }
     if (remoteLaneId.name === DEFAULT_LANE) {
-      throw new GeneralError(`invalid remote lane id "${this.switchProps.laneName}". to switch to the main lane on remote,
+      throw new BitError(`invalid remote lane id "${this.switchProps.laneName}". to switch to the main lane on remote,
       run "bit switch main" and then "bit import".`);
     }
     // fetch the remote to update all heads
@@ -141,26 +141,30 @@ export class LaneSwitcher {
     this.logger.debug(`populatePropsAccordingToRemoteLane, remoteLaneId: ${remoteLaneId.toString()}`);
     this.switchProps.localLaneName = this.switchProps.newLaneName || localTrackedLane || remoteLaneId.name;
     if (this.consumer.getCurrentLaneId().name === this.switchProps.localLaneName) {
-      throw new GeneralError(`already checked out to "${this.switchProps.localLaneName}"`);
+      throw new BitError(`already checked out to "${this.switchProps.localLaneName}"`);
     }
     const scopeComponentImporter = ScopeComponentsImporter.getInstance(this.consumer.scope);
     const remoteLaneObjects = await scopeComponentImporter.importFromLanes([remoteLaneId]);
     if (remoteLaneObjects.length === 0) {
-      throw new GeneralError(
+      throw new BitError(
         `invalid lane id "${this.switchProps.laneName}", the lane ${this.switchProps.laneName} doesn't exist.`
       );
     }
-    const remoteLaneComponents = remoteLaneObjects[0].components;
+    if (remoteLaneObjects.length > 1) {
+      const allLanes = remoteLaneObjects.map((l) => l.id()).join(', ');
+      throw new BitError(`switching to multiple lanes is not supported. got: ${allLanes}`);
+    }
+    const remoteLane = remoteLaneObjects[0];
     this.switchProps.remoteLaneName = remoteLaneId.name;
     this.switchProps.laneName = remoteLaneId.name;
     this.switchProps.remoteLaneScope = remoteLaneId.scope;
     this.switchProps.remoteScope = remoteLaneId.scope;
-    this.switchProps.ids = remoteLaneComponents.map((l) => l.id.changeVersion(l.head.toString()));
-    this.switchProps.remoteLaneComponents = remoteLaneComponents;
+    this.switchProps.ids = remoteLane.components.map((l) => l.id.changeVersion(l.head.toString()));
     this.switchProps.localTrackedLane = localTrackedLane || undefined;
+    this.switchProps.remoteLane = remoteLane;
     const laneExistsLocally = lanes.find((l) => l.name === this.switchProps.localLaneName);
     if (laneExistsLocally) {
-      throw new GeneralError(`unable to checkout to a remote lane ${this.switchProps.remoteScope}/${this.switchProps.laneName}.
+      throw new BitError(`unable to checkout to a remote lane ${this.switchProps.remoteScope}/${this.switchProps.laneName}.
 the local lane "${this.switchProps.localLaneName}" already exists, please switch to the local lane first by running "bit switch ${this.switchProps.localLaneName}"
 then, to merge the remote lane into the local lane, run "bit lane merge ${this.switchProps.localLaneName} --remote ${this.switchProps.remoteScope}"`);
     }
@@ -198,59 +202,44 @@ then, to merge the remote lane into the local lane, run "bit lane merge ${this.s
       throw err;
     }
   }
+
   private async saveLanesData() {
-    await saveCheckedOutLaneInfo(this.consumer, {
-      remoteLaneScope: this.switchProps.remoteLaneScope,
-      remoteLaneName: this.switchProps.remoteLaneName,
-      localLaneName: this.switchProps.localLaneName,
-      addTrackingInfo: !this.switchProps.localTrackedLane,
-      laneComponents: this.switchProps.remoteLaneComponents,
-    });
-  }
-}
+    const saveRemoteLaneToBitmap = () => {
+      if (this.switchProps.remoteLaneScope) {
+        this.consumer.bitMap.setRemoteLane(
+          RemoteLaneId.from(this.switchProps.remoteLaneName as string, this.switchProps.remoteLaneScope)
+        );
+        // add versions to lane
+      }
+    };
+    const throwIfLaneExists = async () => {
+      const allLanes = await this.consumer.scope.listLanes();
+      if (allLanes.find((l) => l.name === this.switchProps.localLaneName)) {
+        throw new GeneralError(`unable to checkout to lane "${this.switchProps.localLaneName}".
+  the lane already exists. please switch to the lane and merge`);
+      }
+    };
 
-async function saveCheckedOutLaneInfo(
-  consumer: Consumer,
-  opts: {
-    remoteLaneScope?: string;
-    remoteLaneName?: string;
-    localLaneName?: string;
-    addTrackingInfo?: boolean;
-    laneComponents?: LaneComponent[];
-  }
-) {
-  const saveRemoteLaneToBitmap = () => {
-    if (opts.remoteLaneScope) {
-      consumer.bitMap.setRemoteLane(RemoteLaneId.from(opts.remoteLaneName as string, opts.remoteLaneScope));
-      // add versions to lane
+    if (this.switchProps.remoteLane) {
+      await throwIfLaneExists();
+      await createLane(this.consumer, this.switchProps.localLaneName as string, this.switchProps.remoteLane);
+      if (!this.switchProps.localTrackedLane) {
+        this.consumer.scope.lanes.trackLane({
+          localLane: this.switchProps.localLaneName as string,
+          remoteLane: this.switchProps.remoteLaneName as string,
+          remoteScope: this.switchProps.remoteLaneScope as string,
+        });
+      }
     }
-  };
-  const throwIfLaneExists = async () => {
-    const allLanes = await consumer.scope.listLanes();
-    if (allLanes.find((l) => l.name === opts.localLaneName)) {
-      throw new GeneralError(`unable to checkout to lane "${opts.localLaneName}".
-the lane already exists. please switch to the lane and merge`);
-    }
-  };
 
-  if (opts.remoteLaneScope) {
-    await throwIfLaneExists();
-    await createNewLane(consumer, opts.localLaneName as string, opts.laneComponents);
-    if (opts.addTrackingInfo) {
-      // otherwise, it is tracked already
-      consumer.scope.lanes.trackLane({
-        localLane: opts.localLaneName as string,
-        remoteLane: opts.remoteLaneName as string,
-        remoteScope: opts.remoteLaneScope as string,
-      });
-    }
+    saveRemoteLaneToBitmap();
+    this.consumer.scope.lanes.setCurrentLane(this.switchProps.localLaneName as string);
+    const workspaceLane =
+      this.switchProps.localLaneName === DEFAULT_LANE
+        ? null
+        : WorkspaceLane.load(this.switchProps.localLaneName as string, this.consumer.scope.path);
+    this.consumer.bitMap.syncWithLanes(workspaceLane);
   }
-
-  saveRemoteLaneToBitmap();
-  consumer.scope.lanes.setCurrentLane(opts.localLaneName as string);
-  const workspaceLane =
-    opts.localLaneName === DEFAULT_LANE ? null : WorkspaceLane.load(opts.localLaneName as string, consumer.scope.path);
-  consumer.bitMap.syncWithLanes(workspaceLane);
 }
 
 async function getComponentStatus(consumer: Consumer, id: BitId, switchProps: SwitchProps): Promise<ComponentStatus> {

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -718,9 +718,10 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     const repo = this.objects();
     const existingLane = await this.scope.loadLane(lane.toLaneId());
     if (existingLane && !existingLane.hash().isEqual(lane.hash())) {
-      throw new BitError(`unable to merge "${lane.toLaneId()}" lane. a lane with the same id already exists with a different hash.
-you can either export to a different scope (use bit lane track) or create a new lane with a different name and export.
-otherwise, to collaborate on the same lane as the remote, you'll need to remove the local lane and import the remote lane (bit lane import)`);
+      // @todo: uncomment this to activate the error. It's going to be a breaking change.
+      //       throw new BitError(`unable to merge "${lane.toLaneId()}" lane. a lane with the same id already exists with a different hash.
+      // you can either export to a different scope (use bit lane track) or create a new lane with a different name and export.
+      // otherwise, to collaborate on the same lane as the remote, you'll need to remove the local lane and import the remote lane (bit lane import)`);
     }
     const mergeResults: MergeResult[] = [];
     const mergeErrors: ComponentNeedsUpdate[] = [];

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -1,6 +1,6 @@
 import R from 'ramda';
 import pMap from 'p-map';
-import { BitError } from '@teambit/bit-error';
+// import { BitError } from '@teambit/bit-error';
 import { isHash } from '@teambit/component-version';
 import { BitId, BitIds } from '../../bit-id';
 import { BuildStatus, COMPONENT_ORIGINS, Extensions } from '../../constants';


### PR DESCRIPTION
## Proposed Changes

- avoid creating a new Lane object with a new hash upon import
- move the create-lane code from legacy to Harmony.