### PR TITLE
feat: add log (author, email, date) upon lane creation

### DIFF
--- a/scopes/lanes/lanes/create-lane.ts
+++ b/scopes/lanes/lanes/create-lane.ts
@@ -30,7 +30,7 @@ export async function createLane(consumer: Consumer, laneName: string, remoteLan
     return currentWorkspaceLane ? currentWorkspaceLane.ids : new BitIds();
   };
   const newLane = remoteLane
-    ? Lane.from({ name: laneName, hash: remoteLane.hash().toString() })
+    ? Lane.from({ name: laneName, hash: remoteLane.hash().toString(), log: remoteLane.log })
     : Lane.create(laneName);
   const dataToPopulate = await getDataToPopulateLaneObjectIfNeeded();
   newLane.setLaneComponents(dataToPopulate);

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -152,7 +152,9 @@ export class LaneShowCmd implements Command {
 
     const onlyLane = lanes[0];
     const title = `showing information for ${chalk.bold(name)}${outputRemoteLane(onlyLane.remote)}\n`;
-    return title + outputComponents(onlyLane.components);
+    const author = `author: ${onlyLane.log.username || 'N/A'} <${onlyLane.log.email || 'N/A'}>\n`;
+    const date = onlyLane.log.date ? `${new Date(parseInt(onlyLane.log.date)).toLocaleString()}\n` : undefined;
+    return title + author + date + outputComponents(onlyLane.components);
   }
 
   async json([name]: [string], laneOptions: LaneOptions) {

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -152,8 +152,8 @@ export class LaneShowCmd implements Command {
 
     const onlyLane = lanes[0];
     const title = `showing information for ${chalk.bold(name)}${outputRemoteLane(onlyLane.remote)}\n`;
-    const author = `author: ${onlyLane.log.username || 'N/A'} <${onlyLane.log.email || 'N/A'}>\n`;
-    const date = onlyLane.log.date ? `${new Date(parseInt(onlyLane.log.date)).toLocaleString()}\n` : undefined;
+    const author = `author: ${onlyLane.log?.username || 'N/A'} <${onlyLane.log?.email || 'N/A'}>\n`;
+    const date = onlyLane.log?.date ? `${new Date(parseInt(onlyLane.log.date)).toLocaleString()}\n` : undefined;
     return title + author + date + outputComponents(onlyLane.components);
   }
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -371,6 +371,7 @@ export class LanesMain {
     return {
       name: DEFAULT_LANE,
       remote: null,
+      log: {},
       components: bitIds.map((bitId) => ({ id: bitId, head: bitId.version as string })),
       isMerged: null,
     };

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -371,7 +371,6 @@ export class LanesMain {
     return {
       name: DEFAULT_LANE,
       remote: null,
-      log: {},
       components: bitIds.map((bitId) => ({ id: bitId, head: bitId.version as string })),
       isMerged: null,
     };

--- a/src/scope/lanes/lanes.ts
+++ b/src/scope/lanes/lanes.ts
@@ -10,6 +10,7 @@ import { Lane } from '../models';
 import { Ref, Repository } from '../objects';
 import { IndexType, LaneItem } from '../objects/components-index';
 import { ScopeJson, TrackLane } from '../scope-json';
+import { Log } from '../models/lane';
 
 export default class Lanes {
   objects: Repository;
@@ -124,6 +125,7 @@ export default class Lanes {
         name: laneName,
         remote: trackingData ? `${trackingData.remoteScope}${LANE_REMOTE_DELIMITER}${trackingData.remoteLane}` : null,
         components: laneObject.components.map((c) => ({ id: c.id, head: c.head.toString() })),
+        log: laneObject.log,
         isMerged: mergeData ? await laneObject.isFullyMerged(scope) : null,
         readmeComponent: laneObject.readmeComponent && {
           id: laneObject.readmeComponent.id,
@@ -150,4 +152,5 @@ export type LaneData = {
   remote: string | null;
   isMerged: boolean | null;
   readmeComponent?: { id: BitId; head?: string };
+  log: Log;
 };

--- a/src/scope/lanes/lanes.ts
+++ b/src/scope/lanes/lanes.ts
@@ -152,5 +152,5 @@ export type LaneData = {
   remote: string | null;
   isMerged: boolean | null;
   readmeComponent?: { id: BitId; head?: string };
-  log: Log;
+  log?: Log;
 };

--- a/src/scope/models/lane.ts
+++ b/src/scope/models/lane.ts
@@ -3,18 +3,22 @@ import { isHash } from '@teambit/component-version';
 import { LaneId, RemoteLaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { Scope } from '..';
 import { BitId } from '../../bit-id';
-import { PREVIOUS_DEFAULT_LANE } from '../../constants';
+import { CFG_USER_EMAIL_KEY, CFG_USER_NAME_KEY, PREVIOUS_DEFAULT_LANE } from '../../constants';
 import ValidationError from '../../error/validation-error';
 import logger from '../../logger/logger';
 import { filterObject, getStringifyArgs, sha1 } from '../../utils';
 import { hasVersionByRef } from '../component-ops/traverse-versions';
 import { BitObject, Ref, Repository } from '../objects';
 import { Version } from '.';
+import * as globalConfig from '../../api/consumer/lib/global-config';
 import GeneralError from '../../error/general-error';
+
+export type Log = { date: string; username?: string; email?: string };
 
 export type LaneProps = {
   name: string;
   scope?: string;
+  log: Log;
   components?: LaneComponent[];
   hash: string;
   readmeComponent?: LaneReadmeComponent;
@@ -28,6 +32,7 @@ export default class Lane extends BitObject {
   scope?: string; // scope is only needed to know where a lane came from, it should not be written to the fs
   remoteLaneId?: RemoteLaneId;
   components: LaneComponent[];
+  log: Log;
   readmeComponent?: LaneReadmeComponent;
   _hash: string; // reason for the underscore prefix is that we already have hash as a method
 
@@ -37,6 +42,7 @@ export default class Lane extends BitObject {
     this.name = props.name;
     this.scope = props.scope;
     this.components = props.components || [];
+    this.log = props.log || {};
     this._hash = props.hash;
     this.readmeComponent = props.readmeComponent;
   }
@@ -66,6 +72,7 @@ export default class Lane extends BitObject {
           id: { scope: component.id.scope, name: component.id.name },
           head: component.head.toString(),
         })),
+        log: this.log,
         readmeComponent: this.readmeComponent && {
           id: { scope: this.readmeComponent.id.scope, name: this.readmeComponent.id.name },
           head: this.readmeComponent.head?.toString() ?? null,
@@ -78,13 +85,19 @@ export default class Lane extends BitObject {
     return new Lane(props);
   }
   static create(name: string) {
-    return new Lane({ name, hash: sha1(v4()) });
+    const log = {
+      date: Date.now().toString(),
+      username: globalConfig.getSync(CFG_USER_NAME_KEY),
+      email: globalConfig.getSync(CFG_USER_EMAIL_KEY),
+    };
+    return new Lane({ name, hash: sha1(v4()), log });
   }
   static parse(contents: string, hash: string): Lane {
     const laneObject = JSON.parse(contents);
     return Lane.from({
       name: laneObject.name,
       scope: laneObject.scope,
+      log: laneObject.log,
       components: laneObject.components.map((component) => ({
         id: new BitId({ scope: component.id.scope, name: component.id.name }),
         head: new Ref(component.head),


### PR DESCRIPTION
For now, it's shown in `bit lane show` (and `bit cat-lane`). 