### PR TITLE
resolve generated webpack peers aliases to the folder of the module

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -34,12 +34,12 @@ import type { ComponentMeta } from '@teambit/react.ui.highlighter.component-meta
 import { SchemaExtractor } from '@teambit/schema';
 import { join, resolve } from 'path';
 import { outputFileSync } from 'fs-extra';
+import { Logger } from '@teambit/logger';
 // Makes sure the @teambit/react.ui.docs-app is a dependency
 // TODO: remove this import once we can set policy from component to component with workspace version. Then set it via the component.json
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { ReactMainConfig } from './react.main.runtime';
 import { ReactAspect } from './react.aspect';
-
 // webpack configs for both components and envs
 import basePreviewConfigFactory from './webpack/webpack.config.base';
 import basePreviewProdConfigFactory from './webpack/webpack.config.base.prod';
@@ -113,6 +113,8 @@ export class ReactEnv
     private eslint: ESLintMain,
 
     private prettier: PrettierMain,
+
+    private logger: Logger,
 
     private compilerAspectId: string
   ) {}
@@ -281,7 +283,7 @@ export class ReactEnv
     const envDevConfig = envPreviewDevConfigFactory(context.id);
     const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
     const peers = this.getAllHostDependencies();
-    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
+    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers, this.logger);
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
       const merged = configMutator.merge([baseConfig, envDevConfig, componentDevConfig]);
@@ -300,7 +302,7 @@ export class ReactEnv
     transformers: WebpackConfigTransformer[] = []
   ): Promise<Bundler> {
     const peers = this.getAllHostDependencies();
-    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
+    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers, this.logger);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
     const componentProdConfig = componentPreviewProdConfigFactory();
@@ -318,7 +320,7 @@ export class ReactEnv
     transformers: WebpackConfigTransformer[] = []
   ): Promise<Bundler> {
     const peers = this.getAllHostDependencies();
-    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers);
+    const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers, this.logger);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
 

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -26,6 +26,7 @@ import ts from 'typescript';
 import { ApplicationAspect, ApplicationMain } from '@teambit/application';
 import { FormatterContext } from '@teambit/formatter';
 import { LinterContext } from '@teambit/linter';
+import { LoggerAspect, LoggerMain } from '@teambit/logger';
 import { ESLintMain, ESLintAspect, EslintConfigTransformer } from '@teambit/eslint';
 import { PrettierMain, PrettierAspect, PrettierConfigTransformer } from '@teambit/prettier';
 import { ReactAspect } from './react.aspect';
@@ -48,7 +49,8 @@ type ReactDeps = [
   ESLintMain,
   PrettierMain,
   ApplicationMain,
-  GeneratorMain
+  GeneratorMain,
+  LoggerMain
 ];
 
 export type ReactMainConfig = {
@@ -113,7 +115,7 @@ export class ReactMain {
   async registerApp(reactApp: ReactAppOptions) {
     return this.application.registerApp(await this.reactAppType.createApp(reactApp));
   }
- 
+
   /**
    * override the env's typescript config for both dev and build time.
    * Replaces both overrideTsConfig (devConfig) and overrideBuildTsConfig (buildConfig)
@@ -391,6 +393,7 @@ export class ReactMain {
     PrettierAspect,
     ApplicationAspect,
     GeneratorAspect,
+    LoggerAspect,
   ];
 
   static async provider(
@@ -408,9 +411,11 @@ export class ReactMain {
       prettier,
       application,
       generator,
+      loggerMain,
     ]: ReactDeps,
     config: ReactMainConfig
   ) {
+    const logger = loggerMain.createLogger(ReactAspect.id);
     const reactEnv = new ReactEnv(
       jestAspect,
       tsAspect,
@@ -422,6 +427,7 @@ export class ReactMain {
       config,
       eslint,
       prettier,
+      logger,
       CompilerAspect.id
     );
     const appType = new ReactAppType('react-app', reactEnv);

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -1,13 +1,17 @@
 import findRoot from 'find-root';
 import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
+import { Logger } from '@teambit/logger';
 
-export function generateAddAliasesFromPeersTransformer(peers: string[]) {
+export function generateAddAliasesFromPeersTransformer(peers: string[], logger: Logger) {
   const peerAliases = peers.reduce((acc, peerName) => {
     // Get the dir of the package, to support cases like import react-dom/test-utils
     // in case we just do require.resolve('react=dom') here it wil be resolved to something like
     // node_modules/react-dom/index.js/test-utils which won't work
     // once resolve to the folder it will resolve correctly
-    acc[peerName] = getResolvedDirOrFile(peerName);
+    const resolved = getResolvedDirOrFile(peerName, logger);
+    if (resolved) {
+      acc[peerName] = resolved;
+    }
     return acc;
   }, {});
   return (config: WebpackConfigMutator): WebpackConfigMutator => {
@@ -21,12 +25,18 @@ export function generateAddAliasesFromPeersTransformer(peers: string[]) {
  * @param peerName
  * @returns
  */
-function getResolvedDirOrFile(peerName: string): string {
-  const resolved = require.resolve(peerName);
+function getResolvedDirOrFile(peerName: string, logger: Logger): string | undefined {
+  let resolved;
   try {
+    resolved = require.resolve(peerName);
     const folder = findRoot(resolved);
     return folder;
   } catch (e) {
+    if (resolved) {
+      logger.warn(`Couldn't find root dir for "${peerName}" from path "${resolved}" to add it as webpack alias`);
+    } else {
+      logger.warn(`Couldn't resolve "${peerName}" to add it as webpack alias`);
+    }
     return resolved;
   }
 }

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -4,10 +4,14 @@ import { Logger } from '@teambit/logger';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[], logger: Logger) {
   const peerAliases = peers.reduce((acc, peerName) => {
-    // Get the dir of the package, to support cases like import react-dom/test-utils
-    // in case we just do require.resolve('react=dom') here it wil be resolved to something like
-    // node_modules/react-dom/index.js/test-utils which won't work
-    // once resolve to the folder it will resolve correctly
+    // gets the correct module folder of the package.
+    // this allows us to resolve internal files, for example:
+    // node_modules/react-dom/test-utils
+    //
+    // we can't use require.resolve() because it resolves to a specific file.
+    // for example, if we used "react-dom": require.resolve("react-dom"),
+    // it would try to resolve "react-dom/test-utils" as:
+    // node_modules/react-dom/index.js/test-utils
     const resolved = getResolvedDirOrFile(peerName, logger);
     if (resolved) {
       acc[peerName] = resolved;

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -3,12 +3,11 @@ import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[]) {
   const peerAliases = peers.reduce((acc, peerName) => {
-    const keyName = `${peerName}`;
     // Get the dir of the package, to support cases like import react-dom/test-utils
     // in case we just do require.resolve('react=dom') here it wil be resolved to something like
     // node_modules/react-dom/index.js/test-utils which won't work
     // once resolve to the folder it will resolve correctly
-    acc[keyName] = getResolvedDirOrFile(peerName);
+    acc[peerName] = getResolvedDirOrFile(peerName);
     return acc;
   }, {});
   return (config: WebpackConfigMutator): WebpackConfigMutator => {

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -2,7 +2,8 @@ import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[]) {
   const peerAliases = peers.reduce((acc, peerName) => {
-    acc[peerName] = require.resolve(peerName);
+    const keyName = `${peerName}$`;
+    acc[keyName] = require.resolve(peerName);
     return acc;
   }, {});
   return (config: WebpackConfigMutator): WebpackConfigMutator => {

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -1,13 +1,33 @@
+import findRoot from 'find-root';
 import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[]) {
   const peerAliases = peers.reduce((acc, peerName) => {
-    const keyName = `${peerName}$`;
-    acc[keyName] = require.resolve(peerName);
+    const keyName = `${peerName}`;
+    // Get the dir of the package, to support cases like import react-dom/test-utils
+    // in case we just do require.resolve('react=dom') here it wil be resolved to something like
+    // node_modules/react-dom/index.js/test-utils which won't work
+    // once resolve to the folder it will resolve correctly
+    acc[keyName] = getResolvedDirOrFile(peerName);
     return acc;
   }, {});
   return (config: WebpackConfigMutator): WebpackConfigMutator => {
     config.addAliases(peerAliases);
     return config;
   };
+}
+
+/**
+ * Get the package folder, and in case it's not found get the require.resolve path
+ * @param peerName
+ * @returns
+ */
+function getResolvedDirOrFile(peerName: string): string {
+  const resolved = require.resolve(peerName);
+  try {
+    const folder = findRoot(resolved);
+    return folder;
+  } catch (e) {
+    return resolved;
+  }
 }


### PR DESCRIPTION
## Proposed Changes

- this should solve errors like `ModuleNotFoundError: Module not found: Error: Can't resolve 'react-dom/test-utils' in '.../node_modules/@testing-library/react/'`


