### PR TITLE
fix: ignore invalid bit object paths

### DIFF
--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import { Mutex } from 'async-mutex';
 import { compact, uniqBy } from 'lodash';
+import { isHash } from '@teambit/component-version';
 import * as path from 'path';
 import pMap from 'p-map';
 import { OBJECTS_DIR } from '../../constants';
@@ -173,9 +174,13 @@ export default class Repository {
     const matches = await glob(path.join('*', '*'), { cwd });
     const refs = matches.map((str) => {
       const hash = str.replace(path.sep, '');
+      if (!isHash(hash)) {
+        logger.error(`fatal: the file "${str}" is not a valid bit object path`);
+        return null;
+      }
       return new Ref(hash);
     });
-    return refs;
+    return compact(refs);
   }
 
   async listRawObjects(): Promise<any> {


### PR DESCRIPTION
Currently, when a component object got a different path for some reason, it is still showing in `bit cat-scope`, it is indexed into the `index.json` file. However, when Bit tries to load it, it fails since the hash path doesn't exist.
This PR makes sure to never consider objects with malformed paths.