### PR TITLE
fix: populate lanes data on ModelComponent object when it was rewritten

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -110,6 +110,7 @@ export default class Component extends BitObject {
    */
   laneHeadLocal?: Ref | null;
   laneHeadRemote?: Ref | null; // doesn't get saved in the scope, used to easier access the remote snap head data
+  laneDataIsPopulated = false; // doesn't get saved in the scope, used to improve performance of loading the lane data
   schema: string | undefined;
   private divergeData?: DivergeData;
 

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -97,12 +97,12 @@ export default class SourceRepository {
    */
   async get(bitId: BitId, versionShouldBeBuilt = false): Promise<ModelComponent | undefined> {
     const emptyComponent = ModelComponent.fromBitId(bitId);
-    const isInCache = this.objects().getCache(emptyComponent.hash());
     const component: ModelComponent | undefined = await this._findComponent(emptyComponent);
     if (!component) return undefined;
-    if (!isInCache) {
+    if (!component.laneDataIsPopulated) {
       const currentLane = await this.scope.getCurrentLaneObject();
       await component.populateLocalAndRemoteHeads(this.objects(), currentLane);
+      component.laneDataIsPopulated = true;
     }
     if (!bitId.hasVersion()) return component;
 


### PR DESCRIPTION
The bug this is fixes is running `bit checkout latest --all` when on a lane and a component has no head. 
It shows the error `has no versions and the head is empty`. the reason is that during the import process, the model-component is rewritten to the filesystem and re-entered to the cache. Because it's in the cache, Bit assumes that the lanes data is already populated. 