### PR TITLE
fix: enter auto-tagged as "patch" in the .bitmap during soft-tag

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -403,7 +403,7 @@ describe('tag components on Harmony', function () {
     it('should not bump the auto-tagged with minor but with patch', () => {
       const bitMap = helper.bitMap.readComponentsMapOnly();
       expect(bitMap.comp2.nextVersion.version).equal('minor');
-      expect(bitMap.comp1.nextVersion.version).equal('0.0.2');
+      expect(bitMap.comp1.nextVersion.version).equal('patch');
     });
   });
 });

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -94,7 +94,10 @@ async function setFutureVersions(
           componentToTag.componentMap?.nextVersion?.preRelease
         );
       } else if (isAutoTag) {
-        componentToTag.version = modelComponent.getVersionToAdd('patch', undefined, incrementBy, preRelease); // auto-tag always bumped as patch
+        // auto-tag always bumped as patch
+        componentToTag.version = soft
+          ? 'patch'
+          : modelComponent.getVersionToAdd('patch', undefined, incrementBy, preRelease);
       } else {
         const versionByEnteredId = getVersionByEnteredId(ids, componentToTag, modelComponent);
         componentToTag.version = soft


### PR DESCRIPTION
rather than a numerical version.

(this is probably a regression caused by #5671).