### PR TITLE
improve resolution for exposed peers rules

### DIFF
--- a/scopes/compilation/bundler/bundler-context.ts
+++ b/scopes/compilation/bundler/bundler-context.ts
@@ -94,6 +94,14 @@ export type Target = {
    * Different configuration related to chunking
    */
   chunking?: Chunking;
+
+  /**
+   * A path for the host root dir
+   * Host root dir is usually the env root dir
+   * This can be used in different bundle options which run require.resolve
+   * for example when configuring webpack aliases or webpack expose loader on the peers deps
+   */
+  hostRootDir?: string;
 };
 
 export type ModuleTarget = {

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -51,7 +51,7 @@ import envPreviewDevConfigFactory from './webpack/webpack.config.env.dev';
 // webpack configs for components only
 import componentPreviewProdConfigFactory from './webpack/webpack.config.component.prod';
 import componentPreviewDevConfigFactory from './webpack/webpack.config.component.dev';
-import { generateAddAliasesFromPeersTransformer } from './webpack/transformers';
+import { generateAddAliasesFromPeersTransformer, generateExposePeersTransformer } from './webpack/transformers';
 
 export const ReactEnvType = 'react';
 const defaultTsConfig = require('./typescript/tsconfig.json');
@@ -321,6 +321,7 @@ export class ReactEnv
   ): Promise<Bundler> {
     const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers, this.logger);
+    const exposePeersTransformer = generateExposePeersTransformer(peers);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
 
@@ -328,7 +329,7 @@ export class ReactEnv
       const merged = configMutator.merge([baseConfig, baseProdConfig]);
       return merged;
     };
-    const mergedTransformers = [defaultTransformer, peerAliasesTransformer, ...transformers];
+    const mergedTransformers = [defaultTransformer, peerAliasesTransformer, exposePeersTransformer, ...transformers];
     return this.createWebpackBundler(context, mergedTransformers);
   }
 

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -321,7 +321,7 @@ export class ReactEnv
   ): Promise<Bundler> {
     const peers = this.getAllHostDependencies();
     const peerAliasesTransformer = generateAddAliasesFromPeersTransformer(peers, this.logger);
-    const exposePeersTransformer = generateExposePeersTransformer(peers);
+    const exposePeersTransformer = generateExposePeersTransformer(peers, this.logger);
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(Boolean(context.externalizePeer), peers, context.development);
 

--- a/scopes/react/react/webpack/get-exposed-rules.ts
+++ b/scopes/react/react/webpack/get-exposed-rules.ts
@@ -1,17 +1,13 @@
 import camelcase from 'camelcase';
 import 'expose-loader';
+import { Logger } from '@teambit/logger';
 import { generateExposeLoaders } from '@teambit/webpack.modules.generate-expose-loaders';
+import { resolvePeerToFile } from './resolve-peer';
 
-export function getExposedRules(peers: string[], hostRootDir?: string) {
+export function getExposedRules(peers: string[], logger: Logger, hostRootDir?: string) {
   const loaderPath = require.resolve('expose-loader');
-  let options;
-  if (hostRootDir) {
-    options = {
-      paths: [hostRootDir, __dirname],
-    };
-  }
   const depsEntries = peers.map((peer) => ({
-    path: require.resolve(peer, options),
+    path: resolvePeerToFile(peer, logger, hostRootDir),
     globalName: camelcase(peer.replace('@', '').replace('/', '-'), { pascalCase: true }),
   }));
   return generateExposeLoaders(depsEntries, { loaderPath });

--- a/scopes/react/react/webpack/get-exposed-rules.ts
+++ b/scopes/react/react/webpack/get-exposed-rules.ts
@@ -2,10 +2,16 @@ import camelcase from 'camelcase';
 import 'expose-loader';
 import { generateExposeLoaders } from '@teambit/webpack.modules.generate-expose-loaders';
 
-export function getExposedRules(peers: string[]) {
+export function getExposedRules(peers: string[], hostRootDir?: string) {
   const loaderPath = require.resolve('expose-loader');
+  let options;
+  if (hostRootDir) {
+    options = {
+      paths: [hostRootDir, __dirname],
+    };
+  }
   const depsEntries = peers.map((peer) => ({
-    path: require.resolve(peer),
+    path: require.resolve(peer, options),
     globalName: camelcase(peer.replace('@', '').replace('/', '-'), { pascalCase: true }),
   }));
   return generateExposeLoaders(depsEntries, { loaderPath });

--- a/scopes/react/react/webpack/resolve-peer.ts
+++ b/scopes/react/react/webpack/resolve-peer.ts
@@ -1,4 +1,4 @@
-import fs from 'fs';
+import fs, { realpathSync } from 'fs';
 import { ResolverFactory, CachedInputFileSystem } from 'enhanced-resolve';
 import findRoot from 'find-root';
 import { Logger } from '@teambit/logger';
@@ -14,7 +14,8 @@ export function resolvePeerToDirOrFile(peerName: string, logger: Logger, hostRoo
     let options;
     if (hostRootDir) {
       options = {
-        paths: [hostRootDir, __dirname],
+        // resolve the host root dir to its real location, as require.resolve is preserve symlink, so we get wrong result otherwise
+        paths: [realpathSync(hostRootDir), __dirname],
       };
     }
     resolved = require.resolve(peerName, options);

--- a/scopes/react/react/webpack/resolve-peer.ts
+++ b/scopes/react/react/webpack/resolve-peer.ts
@@ -1,0 +1,29 @@
+import findRoot from 'find-root';
+import { Logger } from '@teambit/logger';
+
+/**
+ * Get the package folder, and in case it's not found get the resolved file path
+ * @param peerName
+ * @returns
+ */
+export function getResolvedDirOrFile(peerName: string, logger: Logger, hostRootDir?: string): string | undefined {
+  let resolved;
+  try {
+    let options;
+    if (hostRootDir) {
+      options = {
+        paths: [hostRootDir, __dirname],
+      };
+    }
+    resolved = require.resolve(peerName, options);
+    const folder = findRoot(resolved);
+    return folder;
+  } catch (e) {
+    if (resolved) {
+      logger.warn(`Couldn't find root dir for "${peerName}" from path "${resolved}" to add it as webpack alias`);
+    } else {
+      logger.warn(`Couldn't resolve "${peerName}" to add it as webpack alias`);
+    }
+    return resolved;
+  }
+}

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -7,6 +7,14 @@ import { resolvePeerToDirOrFile } from './resolve-peer';
 export function generateAddAliasesFromPeersTransformer(peers: string[], logger: Logger) {
   return (config: WebpackConfigMutator, context: WebpackConfigTransformContext): WebpackConfigMutator => {
     const peerAliases = peers.reduce((acc, peerName) => {
+      // gets the correct module folder of the package.
+      // this allows us to resolve internal files, for example:
+      // node_modules/react-dom/test-utils
+      //
+      // we can't use require.resolve() because it resolves to a specific file.
+      // for example, if we used "react-dom": require.resolve("react-dom"),
+      // it would try to resolve "react-dom/test-utils" as:
+      // node_modules/react-dom/index.js/test-utils
       acc[peerName] = resolvePeerToDirOrFile(peerName, logger, context.target.hostRootDir);
       return acc;
     }, {});

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -1,8 +1,8 @@
-import findRoot from 'find-root';
 import { WebpackConfigTransformContext } from '@teambit/webpack';
 import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 import { Logger } from '@teambit/logger';
 import { getExposedRules } from './get-exposed-rules';
+import { getResolvedDirOrFile } from './resolve-peer';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[], logger: Logger) {
   return (config: WebpackConfigMutator, context: WebpackConfigTransformContext): WebpackConfigMutator => {
@@ -26,31 +26,4 @@ export function generateExposePeersTransformer(peers: string[]) {
     config.addModuleRules(exposedRules);
     return config;
   };
-}
-
-/**
- * Get the package folder, and in case it's not found get the require.resolve path
- * @param peerName
- * @returns
- */
-function getResolvedDirOrFile(peerName: string, logger: Logger, hostRootDir?: string): string | undefined {
-  let resolved;
-  try {
-    let options;
-    if (hostRootDir) {
-      options = {
-        paths: [hostRootDir, __dirname],
-      };
-    }
-    resolved = require.resolve(peerName, options);
-    const folder = findRoot(resolved);
-    return folder;
-  } catch (e) {
-    if (resolved) {
-      logger.warn(`Couldn't find root dir for "${peerName}" from path "${resolved}" to add it as webpack alias`);
-    } else {
-      logger.warn(`Couldn't resolve "${peerName}" to add it as webpack alias`);
-    }
-    return resolved;
-  }
 }

--- a/scopes/react/react/webpack/transformers.ts
+++ b/scopes/react/react/webpack/transformers.ts
@@ -2,12 +2,12 @@ import { WebpackConfigTransformContext } from '@teambit/webpack';
 import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 import { Logger } from '@teambit/logger';
 import { getExposedRules } from './get-exposed-rules';
-import { getResolvedDirOrFile } from './resolve-peer';
+import { resolvePeerToDirOrFile } from './resolve-peer';
 
 export function generateAddAliasesFromPeersTransformer(peers: string[], logger: Logger) {
   return (config: WebpackConfigMutator, context: WebpackConfigTransformContext): WebpackConfigMutator => {
     const peerAliases = peers.reduce((acc, peerName) => {
-      acc[peerName] = getResolvedDirOrFile(peerName, logger, context.target.hostRootDir);
+      acc[peerName] = resolvePeerToDirOrFile(peerName, logger, context.target.hostRootDir);
       return acc;
     }, {});
     config.addAliases(peerAliases);
@@ -20,9 +20,9 @@ export function generateAddAliasesFromPeersTransformer(peers: string[], logger: 
  * @param peers
  * @returns
  */
-export function generateExposePeersTransformer(peers: string[]) {
+export function generateExposePeersTransformer(peers: string[], logger: Logger) {
   return (config: WebpackConfigMutator, context: WebpackConfigTransformContext): WebpackConfigMutator => {
-    const exposedRules = getExposedRules(peers, context.target.hostRootDir);
+    const exposedRules = getExposedRules(peers, logger, context.target.hostRootDir);
     config.addModuleRules(exposedRules);
     return config;
   };

--- a/scopes/react/react/webpack/webpack.config.base.prod.ts
+++ b/scopes/react/react/webpack/webpack.config.base.prod.ts
@@ -3,7 +3,6 @@ import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import TerserPlugin from 'terser-webpack-plugin';
 import { Configuration } from 'webpack';
 import { getExternals } from './get-externals';
-import { getExposedRules } from './get-exposed-rules';
 // import { WebpackManifestPlugin } from 'webpack-manifest-plugin';
 
 // This is the production and development configuration.
@@ -11,13 +10,6 @@ import { getExposedRules } from './get-exposed-rules';
 // eslint-disable-next-line complexity
 export default function (externalizePeer: boolean, peers: string[], dev?: boolean): Configuration {
   const externals = externalizePeer ? (getExternals(peers) as any) : undefined;
-  const exposedRules = externalizePeer ? undefined : getExposedRules(peers);
-
-  const module = externalizePeer
-    ? undefined
-    : {
-        rules: exposedRules,
-      };
 
   const optimization = dev
     ? undefined
@@ -105,7 +97,6 @@ export default function (externalizePeer: boolean, peers: string[], dev?: boolea
       };
 
   return {
-    module,
     externals,
     optimization,
 

--- a/scopes/webpack/config-mutator/config-mutator.ts
+++ b/scopes/webpack/config-mutator/config-mutator.ts
@@ -92,7 +92,7 @@ export class WebpackConfigMutator {
 
   /**
    * Add rule to the module config
-   * @param entry
+   * @param rule
    * @param opts
    * @returns
    */
@@ -105,6 +105,17 @@ export class WebpackConfigMutator {
     }
 
     addToArray(this.raw.module.rules, rule, opts);
+    return this;
+  }
+
+  /**
+   * Add many rules to the module config
+   * @param rules
+   * @param opts
+   * @returns
+   */
+  addModuleRules(rules: RuleSetRule[], opts: AddToArrayOpts = {}): WebpackConfigMutator {
+    rules.forEach((rule) => this.addModuleRule(rule, opts));
     return this;
   }
 


### PR DESCRIPTION
## Proposed Changes

- improve resolution for exposed peers rules (resolve to module field instead of the main field in package.json if exist)
- add new generateExposePeersTransformer to react env
- use the new generateExposePeersTransformer from the react env
- add hostRootDir to the bundler target interface
- support hostRootDir for generateAddAliasesFromPeersTransformer and for generateExposePeersTransformer
- support hostRootDir for getExposedRules
- resolve host root dir to its real location before calling require.resolve
- add new addModuleRules API for webpack config mutator
