### PR TITLE
add option disable namespace on express aspect

### DIFF
--- a/scopes/harmony/express/express.main.runtime.ts
+++ b/scopes/harmony/express/express.main.runtime.ts
@@ -97,9 +97,10 @@ export class ExpressMain {
         middlewares.flatMap((middlewareManifest) => app.use(middlewareManifest.middleware))
       );
     allRoutes.forEach((routeInfo) => {
-      const { method, path, middlewares } = routeInfo;
+      const { method, path, middlewares, disableNamespace } = routeInfo;
       // TODO: @guy make sure to support single middleware here.
-      app[method](`/${this.config.namespace}${path}`, this.catchErrorsMiddlewares(middlewares));
+      const namespace = disableNamespace ? '' : this.config.namespace;
+      app[method](`/${namespace}${path}`, this.catchErrorsMiddlewares(middlewares));
     });
 
     return app;
@@ -113,6 +114,7 @@ export class ExpressMain {
         return {
           method: lowerCase(route.method),
           path: route.route,
+          disableNamespace: route.disableNamespace,
           middlewares,
         };
       });

--- a/scopes/harmony/express/types/route.ts
+++ b/scopes/harmony/express/types/route.ts
@@ -19,6 +19,7 @@ export enum Verb {
 export interface Route {
   method: string;
   route: string | RegExp;
+  disableNamespace?: boolean;
   verb?: Verb;
   middlewares: Middleware[];
 }


### PR DESCRIPTION
add an option to disable default `api` namespace on a route  
