### PR TITLE
schema: fix schema GraphQL query to return the entire JSON object

### DIFF
--- a/scopes/semantics/schema/schema.graphql.ts
+++ b/scopes/semantics/schema/schema.graphql.ts
@@ -1,4 +1,5 @@
 import { ComponentFactory } from '@teambit/component';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import gql from 'graphql-tag';
 
 import { SchemaMain } from './schema.main.runtime';
@@ -6,15 +7,13 @@ import { SchemaMain } from './schema.main.runtime';
 export function schemaSchema(schema: SchemaMain) {
   return {
     typeDefs: gql`
+      scalar JSONObject
       extend type ComponentHost {
-        getSchema(id: String!): SchemaDocs
-      }
-
-      type SchemaDocs {
-        exports: [String]
+        getSchema(id: String!): JSONObject
       }
     `,
     resolvers: {
+      JSONObject: GraphQLJSONObject,
       ComponentHost: {
         getSchema: async (host: ComponentFactory, { id }: { id: string }) => {
           const componentId = await host.resolveComponentId(id);


### PR DESCRIPTION
To get a schema via GraphQL, run the following query:
```
query Schema {
  getHost {
    getSchema(id: "teambit.base-react/buttons/button")
  }
}
```

Once you have the JSON object, you can deserialize it by `getSchemaFromObject()` API of Schema aspect.