### PR TITLE
feat: configuring Node.js engine checks

### DIFF
--- a/scopes/dependencies/aspect-docs/dependency-resolver/dependency-resolver.mdx
+++ b/scopes/dependencies/aspect-docs/dependency-resolver/dependency-resolver.mdx
@@ -418,6 +418,23 @@ Side-effects cache can be turned off by setting the `sideEffectsCache` field to 
 }
 ```
 
+## Node.js engine checks
+
+If you want to prevent contributors of your project from adding new incompatible dependencies, use `nodeVersion` and `engineStrict` in your `workspace.jsonc`:
+
+```json
+{
+  "@teambit.dependencies/dependency-resolver": {
+    "engineStrict": true,
+    "nodeVersion": "12.22.0"
+  }
+}
+```
+
+This way, even if someone is using Node.js v16, they will not be able to install a new dependency that doesn't support Node.js v12.22.0.
+
+NOTE: This works only with pnpm currently.
+
 ## CLI reference
 
 ### install

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -6,7 +6,7 @@ import { ComponentMap } from '@teambit/component';
 import { Logger } from '@teambit/logger';
 import { PathAbsolute } from '@teambit/legacy/dist/utils/path';
 import { MainAspectNotInstallable, RootDirNotDefined } from './exceptions';
-import { PackageManager, PackageManagerInstallOptions } from './package-manager';
+import { PackageManager, PackageManagerInstallOptions, PackageImportMethod } from './package-manager';
 import { WorkspacePolicy } from './policy';
 
 const DEFAULT_PM_INSTALL_OPTIONS: PackageManagerInstallOptions = {
@@ -58,7 +58,15 @@ export class DependencyInstaller {
 
     private postInstallSubscriberList?: PostInstallSubscriberList,
 
-    private nodeLinker?: 'hoisted' | 'isolated'
+    private nodeLinker?: 'hoisted' | 'isolated',
+
+    private packageImportMethod?: PackageImportMethod,
+
+    private sideEffectsCache?: boolean,
+
+    private nodeVersion?: string,
+
+    private engineStrict?: boolean,
   ) {}
 
   async install(
@@ -86,6 +94,10 @@ export class DependencyInstaller {
       ...DEFAULT_PM_INSTALL_OPTIONS,
       cacheRootDir: this.cacheRootDir,
       nodeLinker: this.nodeLinker,
+      packageImportMethod: this.packageImportMethod,
+      sideEffectsCache: this.sideEffectsCache,
+      nodeVersion: this.nodeVersion,
+      engineStrict: this.engineStrict,
       packageManagerConfigRootDir: options.packageManagerConfigRootDir,
       ...packageManagerOptions,
     };

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -224,7 +224,17 @@ export interface DependencyResolverWorkspaceConfig {
   /*
    * Use and cache the results of (pre/post)install hooks.
    */
-  sideEffectsCache?: boolean
+  sideEffectsCache?: boolean;
+
+  /*
+   * The node version to use when checking a package's engines setting.
+   */
+  nodeVersion?: string;
+
+  /*
+   * Refuse to install any package that claims to not be compatible with the current Node.js version.
+   */
+  engineStrict?: boolean;
 }
 
 export interface DependencyResolverVariantConfig {
@@ -506,7 +516,11 @@ export class DependencyResolverMain {
       cacheRootDir,
       preInstallSubscribers,
       postInstallSubscribers,
-      this.config.nodeLinker
+      this.config.nodeLinker,
+      this.config.packageImportMethod,
+      this.config.sideEffectsCache,
+      this.config.nodeVersion,
+      this.config.engineStrict,
     );
   }
 

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -33,6 +33,10 @@ export type PackageManagerInstallOptions = {
   packageImportMethod?: PackageImportMethod;
 
   sideEffectsCache?: boolean
+
+  engineStrict?: boolean
+
+  nodeVersion?: string
 };
 
 export type PackageManagerGetPeerDependencyIssuesOptions = PackageManagerInstallOptions;

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -161,7 +161,7 @@ export async function install(
   options?: {
     nodeLinker?: 'hoisted' | 'isolated';
     overrides?: Record<string, string>;
-  } & Pick<InstallOptions, 'publicHoistPattern' | 'hoistPattern'> &
+  } & Pick<InstallOptions, 'publicHoistPattern' | 'hoistPattern' | 'nodeVersion' | 'engineStrict'> &
     Pick<CreateStoreControllerOptions, 'packageImportMethod'>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   logger?: Logger

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -126,7 +126,9 @@ export class PnpmPackageManager implements PackageManager {
       proxyConfig,
       networkConfig,
       {
+        engineStrict: installOptions.engineStrict ?? config.engineStrict,
         nodeLinker: installOptions.nodeLinker,
+        nodeVersion: installOptions.nodeVersion ?? config.nodeVersion,
         overrides: installOptions.overrides,
         hoistPattern: config.hoistPattern,
         publicHoistPattern: ['*eslint*', '@prettier/plugin-*', '*prettier-plugin-*'],

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1800,7 +1800,6 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
       copyPeerToRuntimeOnComponents: options?.copyPeerToRuntimeOnComponents ?? false,
       dependencyFilterFn: depsFilterFn,
       overrides: this.dependencyResolver.config.overrides,
-      packageImportMethod: this.dependencyResolver.config.packageImportMethod,
     };
     await installer.install(this.path, mergedRootPolicy, compDirMap, { installTeambitBit: false }, pmInstallOptions);
     // TODO: this make duplicate

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -392,6 +392,8 @@
       }
     },
     "nodeLinker": "hoisted",
+    "nodeVersion": "12.22.0",
+    "engineStrict": true,
     // This is a temporary workaround to fix "bit compile" on macOS and Windows.
     // "bit compile" breaks node_modules when hard links are used.
     "packageImportMethod": "copy",


### PR DESCRIPTION
## Proposed Changes

- allow to set which node.js version should be used when checking the engines field of dependencies.
- allow to set strict-engine to true
