### PR TITLE
fix: avoid traversing tags on Harmony

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -868,6 +868,47 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('multiple scopes when main is ahead', () => {
+    let anotherRemote: string;
+    let localScope: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fs.outputFile('bar1/foo1.js', 'console.log("v1");');
+      helper.fs.outputFile('bar2/foo2.js', 'console.log("v1");');
+      helper.command.addComponent('bar1');
+      helper.command.addComponent('bar2');
+      helper.command.setScope(anotherRemote, 'bar2');
+      helper.command.compile();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      localScope = helper.scopeHelper.cloneLocalScope();
+
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.command.import(`${scopeName}/bar2`);
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.getClonedLocalScope(localScope);
+      helper.command.import();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // previously, it used to error with "error: version "0.0.2" of component jozc1y79-remote2/bar2 was not found."
+    it('should be able to export', () => {
+      expect(helper.command.export()).to.not.throw();
+      // import used to throw as well
+      expect(helper.command.import()).to.not.throw();
+    });
+  });
   describe('snapping and un-tagging on a lane', () => {
     let afterFirstSnap: string;
     before(() => {

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -904,9 +904,9 @@ describe('bit lane command', function () {
     });
     // previously, it used to error with "error: version "0.0.2" of component jozc1y79-remote2/bar2 was not found."
     it('should be able to export', () => {
-      expect(helper.command.export()).to.not.throw();
+      expect(() => helper.command.export()).to.not.throw();
       // import used to throw as well
-      expect(helper.command.import()).to.not.throw();
+      expect(() => helper.command.import()).to.not.throw();
     });
   });
   describe('snapping and un-tagging on a lane', () => {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -155,6 +155,9 @@ export default class CommandHelper {
   setConfig(configName: string, configVal: string) {
     return this.runCmd(`bit config set ${configName} ${configVal}`);
   }
+  setScope(scopeName: string, component: string) {
+    return this.runCmd(`bit scope set ${scopeName} ${component}`);
+  }
   setEnv(compId: string, envId: string) {
     return this.runCmd(`bit envs set ${compId} ${envId}`);
   }

--- a/src/scope/component-ops/traverse-versions.ts
+++ b/src/scope/component-ops/traverse-versions.ts
@@ -114,6 +114,7 @@ export async function getAllVersionsInfo({
     if (head) await addParentsRecursively(head);
   }
   if (stopped) return results;
+  if (!modelComponent.isLegacy) return results;
   // backward compatibility.
   // components created before v15, might not have head.
   // even if they do have head (as a result of tag/snap after v15), they


### PR DESCRIPTION
Currently, when traversing the component versions, once the traversal is done, it goes to each one of the tags and search for it as well. It was done originally to support legacy that didn't have the concept of head/parents. 
This PR avoid this extra work if the component is Harmony. 
In case when the traversal starts at a certain point, it also avoid errors of VersionNotFound when they're not part of the graph. (the attached e2e-test demonstrates it).