### PR TITLE
update use-component to only accept string comp ids

### DIFF
--- a/scopes/component/component/ui/component.tsx
+++ b/scopes/component/component/ui/component.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, ReactNode, useMemo } from 'react';
 import flatten from 'lodash.flatten';
 import { RouteSlot, SlotRouter } from '@teambit/ui-foundation.ui.react-router.slot-router';
 import { SlotRegistry } from '@teambit/harmony';
+import { useLanesContext } from '@teambit/lanes.ui.lanes';
 
 import styles from './component.module.scss';
 import { ComponentProvider, ComponentDescriptorProvider } from './context';
@@ -27,7 +28,24 @@ export type ComponentProps = {
  */
 export function Component({ routeSlot, containerSlot, host, onComponentChange }: ComponentProps) {
   const componentId = useIdFromLocation();
-  const { component, componentDescriptor, error } = useComponent(host, componentId);
+  const lanesContext = useLanesContext();
+  const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
+  const useComponentOptions = laneComponentId
+    ? {
+        version: laneComponentId.version,
+        logFilters: {
+          log: {
+            logHead: laneComponentId.version,
+          },
+        },
+      }
+    : undefined;
+
+  const { component, componentDescriptor, error } = useComponent(
+    host,
+    laneComponentId?.toString() || componentId,
+    useComponentOptions
+  );
   // trigger onComponentChange when component changes
   useEffect(() => onComponentChange?.(component), [component]);
   // cleanup when unmounting component

--- a/scopes/component/component/ui/component.tsx
+++ b/scopes/component/component/ui/component.tsx
@@ -32,12 +32,7 @@ export function Component({ routeSlot, containerSlot, host, onComponentChange }:
   const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
   const useComponentOptions = laneComponentId
     ? {
-        version: laneComponentId.version,
-        logFilters: {
-          log: {
-            logHead: laneComponentId.version,
-          },
-        },
+        logFilters: { log: { logHead: laneComponentId.version } },
       }
     : undefined;
 

--- a/scopes/component/component/ui/component.tsx
+++ b/scopes/component/component/ui/component.tsx
@@ -29,16 +29,14 @@ export type ComponentProps = {
 export function Component({ routeSlot, containerSlot, host, onComponentChange }: ComponentProps) {
   const componentId = useIdFromLocation();
   const lanesContext = useLanesContext();
-  const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
-  const useComponentOptions = laneComponentId
-    ? {
-        logFilters: { log: { logHead: laneComponentId.version } },
+  const laneComponent = componentId ? lanesContext?.resolveComponent(componentId) : undefined;
+  const useComponentOptions = laneComponent && {
+        logFilters: { log: { logHead: laneComponent.version } },
       }
-    : undefined;
 
   const { component, componentDescriptor, error } = useComponent(
     host,
-    laneComponentId?.toString() || componentId,
+    laneComponent?.id.toString() || componentId,
     useComponentOptions
   );
   // trigger onComponentChange when component changes

--- a/scopes/component/component/ui/menu/menu.tsx
+++ b/scopes/component/component/ui/menu/menu.tsx
@@ -50,7 +50,20 @@ export function ComponentMenu({
   consumeMethodSlot,
 }: MenuProps) {
   const componentId = useIdFromLocation();
-  const { component } = useComponent(host, componentId);
+  const lanesContext = useLanesContext();
+  const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
+  const useComponentOptions = laneComponentId
+    ? {
+        version: laneComponentId.version,
+        logFilters: {
+          log: {
+            logHead: laneComponentId.version,
+          },
+        },
+      }
+    : undefined;
+
+  const { component } = useComponent(host, laneComponentId?.toString() || componentId, useComponentOptions);
   const mainMenuItems = useMemo(() => groupBy(flatten(menuItemSlot.values()), 'category'), [menuItemSlot]);
   if (!component) return <FullLoader />;
   return (

--- a/scopes/component/component/ui/menu/menu.tsx
+++ b/scopes/component/component/ui/menu/menu.tsx
@@ -54,12 +54,7 @@ export function ComponentMenu({
   const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
   const useComponentOptions = laneComponentId
     ? {
-        version: laneComponentId.version,
-        logFilters: {
-          log: {
-            logHead: laneComponentId.version,
-          },
-        },
+        logFilters: { log: { logHead: laneComponentId.version } },
       }
     : undefined;
 

--- a/scopes/component/component/ui/menu/menu.tsx
+++ b/scopes/component/component/ui/menu/menu.tsx
@@ -51,14 +51,12 @@ export function ComponentMenu({
 }: MenuProps) {
   const componentId = useIdFromLocation();
   const lanesContext = useLanesContext();
-  const laneComponentId = componentId ? lanesContext?.getLaneComponentIdFromViewedLane(componentId) : undefined;
-  const useComponentOptions = laneComponentId
-    ? {
-        logFilters: { log: { logHead: laneComponentId.version } },
-      }
-    : undefined;
+  const laneComponent = componentId ? lanesContext?.resolveComponent(componentId) : undefined;
+  const useComponentOptions = laneComponent && {
+    logFilters: { log: { logHead: laneComponent.version } },
+  };
 
-  const { component } = useComponent(host, laneComponentId?.toString() || componentId, useComponentOptions);
+  const { component } = useComponent(host, laneComponent?.id.toString() || componentId, useComponentOptions);
   const mainMenuItems = useMemo(() => groupBy(flatten(menuItemSlot.values()), 'category'), [menuItemSlot]);
   if (!component) return <FullLoader />;
   return (

--- a/scopes/component/component/ui/use-component-query.ts
+++ b/scopes/component/component/ui/use-component-query.ts
@@ -142,13 +142,11 @@ const SUB_COMPONENT_REMOVED = gql`
   }
   ${componentIdFields}
 `;
-
+export type Filters = {
+  log?: { logType?: string; logOffset?: number; logLimit?: number; logHead?: string; logSort?: string };
+};
 /** provides data to component ui page, making sure both variables and return value are safely typed and memoized */
-export function useComponentQuery(
-  componentId: string,
-  host: string,
-  filters?: { log?: { logType?: string; logOffset?: number; logLimit?: number; logHead?: string; logSort?: string } }
-) {
+export function useComponentQuery(componentId: string, host: string, filters?: Filters) {
   const idRef = useRef(componentId);
   idRef.current = componentId;
   const { data, error, loading, subscribeToMore } = useDataQuery(GET_COMPONENT, {

--- a/scopes/component/component/ui/use-component.tsx
+++ b/scopes/component/component/ui/use-component.tsx
@@ -1,7 +1,5 @@
-import { ComponentID } from '@teambit/component-id';
 import { useQuery } from '@teambit/ui-foundation.ui.react-router.use-query';
 import { ComponentDescriptor } from '@teambit/component-descriptor';
-import { useLanesContext } from '@teambit/lanes.ui.lanes';
 import { ComponentModel } from './component-model';
 import { ComponentError } from './component-error';
 import { useComponentQuery } from './use-component-query';
@@ -11,30 +9,21 @@ export type Component = {
   error?: ComponentError;
   componentDescriptor?: ComponentDescriptor;
 };
+export type UseComponentOptions = {
+  version?: string;
+  logFilters?: {
+    log?: { logType?: string; logOffset?: number; logLimit?: number; logHead?: string; logSort?: string };
+  };
+};
 
-export function useComponent(host: string, id?: string | ComponentID): Component {
+export function useComponent(host: string, id?: string, options?: UseComponentOptions): Component {
   const query = useQuery();
-  const version = query.get('version') || undefined;
-  const lanesContext = useLanesContext();
+  const { version, logFilters } = options || {};
+  const componentVersion = (version || query.get('version')) ?? undefined;
+  
+  if (!id) throw new TypeError('useComponent received no component id');
 
-  const targetId =
-    (typeof id === 'string' && id) || (typeof id !== 'undefined' && id.toString({ ignoreVersion: true }));
-  if (!targetId) throw new TypeError('useComponent received no component id');
-  const currentLane = lanesContext?.viewedLane;
-  // when on a lane, always fetch all the logs starting from the 'head' version
-  const laneComponentId = lanesContext?.viewedLane?.components.find(
-    (component) => component.id.fullName === targetId
-  )?.id;
-
-  const componentIdStr = laneComponentId ? laneComponentId?.toString() : withVersion(targetId, version);
-
-  const logFilters = currentLane
-    ? {
-        log: {
-          logHead: laneComponentId?.version,
-        },
-      }
-    : undefined;
+  const componentIdStr = withVersion(id, componentVersion);
 
   return useComponentQuery(componentIdStr, host, logFilters);
 }

--- a/scopes/component/component/ui/use-component.tsx
+++ b/scopes/component/component/ui/use-component.tsx
@@ -2,7 +2,7 @@ import { useQuery } from '@teambit/ui-foundation.ui.react-router.use-query';
 import { ComponentDescriptor } from '@teambit/component-descriptor';
 import { ComponentModel } from './component-model';
 import { ComponentError } from './component-error';
-import { useComponentQuery } from './use-component-query';
+import { Filters, useComponentQuery } from './use-component-query';
 
 export type Component = {
   component?: ComponentModel;
@@ -11,9 +11,7 @@ export type Component = {
 };
 export type UseComponentOptions = {
   version?: string;
-  logFilters?: {
-    log?: { logType?: string; logOffset?: number; logLimit?: number; logHead?: string; logSort?: string };
-  };
+  logFilters?: Filters
 };
 
 export function useComponent(host: string, id?: string, options?: UseComponentOptions): Component {

--- a/scopes/lanes/ui/hooks/lanes-context/lanes-model.ts
+++ b/scopes/lanes/ui/hooks/lanes-context/lanes-model.ts
@@ -211,6 +211,8 @@ export class LanesModel {
   setViewedLane = (viewedLaneId?: string) => {
     this.viewedLane = this.lanes.find((lane) => lane.id === viewedLaneId);
   };
-  getLaneComponentIdFromViewedLane = (fullName: string) =>
-    this.viewedLane?.components.find((component) => component.id.fullName === fullName)?.id;
+  resolveComponent = (fullName: string, laneId?: string) =>
+    ((laneId && this.lanes.find((lane) => lane.id === laneId)) || this.viewedLane)?.components.find(
+      (component) => component.id.fullName === fullName
+    );
 }

--- a/scopes/lanes/ui/hooks/lanes-context/lanes-model.ts
+++ b/scopes/lanes/ui/hooks/lanes-context/lanes-model.ts
@@ -211,4 +211,6 @@ export class LanesModel {
   setViewedLane = (viewedLaneId?: string) => {
     this.viewedLane = this.lanes.find((lane) => lane.id === viewedLaneId);
   };
+  getLaneComponentIdFromViewedLane = (fullName: string) =>
+    this.viewedLane?.components.find((component) => component.id.fullName === fullName)?.id;
 }


### PR DESCRIPTION
## Proposed Changes

- update `use-component` to accept only `string` component ids
- remove lanes logic from use components and move it up to the caller
