### PR TITLE
fix(lanes): avoid importing from main when on a new lane

### DIFF
--- a/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
@@ -120,24 +120,40 @@ describe('bit lane command', function () {
     });
   });
   describe('bit-import with no params when checked out to a lane', () => {
-    let importOutput: string;
-    before(() => {
-      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.setupDefault();
-      helper.command.createLane('dev');
-      helper.fixtures.populateComponents();
-      helper.command.snapAllComponents();
-      helper.command.exportLane();
-
-      helper.scopeHelper.reInitLocalScopeHarmony();
-      helper.scopeHelper.addRemoteScope();
-      helper.command.switchRemoteLane('dev');
-
-      importOutput = helper.command.import();
+    describe('when the lane is new', () => {
+      let importOutput: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.command.createLane('dev');
+        helper.fixtures.populateComponents(1);
+        helper.command.snapAllComponentsWithoutBuild();
+        importOutput = helper.command.import();
+      });
+      it('should indicate that there is nothing to import because the lane is new', () => {
+        expect(importOutput).to.have.string("your lane wasn't exported yet, nothing to import");
+      });
     });
-    // before, it was throwing an error about missing head.
-    it('should import the remote lane successfully', () => {
-      expect(importOutput).to.have.string('successfully imported 3 components');
+    describe('when the lane is exported', () => {
+      let importOutput: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.command.createLane('dev');
+        helper.fixtures.populateComponents();
+        helper.command.snapAllComponents();
+        helper.command.exportLane();
+
+        helper.scopeHelper.reInitLocalScopeHarmony();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.switchRemoteLane('dev');
+
+        importOutput = helper.command.import();
+      });
+      // before, it was throwing an error about missing head.
+      it('should import the remote lane successfully', () => {
+        expect(importOutput).to.have.string('successfully imported 3 components');
+      });
     });
   });
 });

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -17,8 +17,9 @@ export class TesterTask implements BuildTask {
   constructor(readonly aspectId: string, private devFiles: DevFilesMain) {}
 
   async execute(context: BuildContext): Promise<BuiltTaskResult> {
+    const components = context.capsuleNetwork.originalSeedersCapsules.getAllComponents();
     const tester: Tester = context.env.getTester();
-    const componentsSpecFiles = ComponentMap.as(context.components, (component) => {
+    const componentsSpecFiles = ComponentMap.as(components, (component) => {
       return detectTestFiles(component, this.devFiles);
     });
 
@@ -29,7 +30,7 @@ export class TesterTask implements BuildTask {
         componentsResults: [],
       };
 
-    const specFilesWithCapsule = ComponentMap.as(context.components, (component) => {
+    const specFilesWithCapsule = ComponentMap.as(components, (component) => {
       const componentSpecFiles = componentsSpecFiles.get(component);
       if (!componentSpecFiles) throw new Error('capsule not found');
       const [, specs] = componentSpecFiles;

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -186,7 +186,7 @@ ${WILDCARD_HELP('import')}`;
 
     const getImportOutput = () => {
       if (dependenciesOutput) return dependenciesOutput;
-      return chalk.yellow('nothing to import');
+      return chalk.yellow(importResults.cancellationMessage || 'nothing to import');
     };
 
     return getImportOutput();

--- a/scopes/scope/importer/importer.ts
+++ b/scopes/scope/importer/importer.ts
@@ -22,7 +22,7 @@ export class Importer {
       const currentRemoteLane = await this.workspace.getCurrentRemoteLane();
       if (currentRemoteLane) {
         importOptions.lanes = { laneIds: [currentRemoteLane.toLaneId()], lanes: [currentRemoteLane] };
-      } else {
+      } else if (!importOptions.ids) {
         // the lane is probably new, it's not yet on the remote, so nothing to import
         return {
           dependencies: [],

--- a/scopes/scope/importer/importer.ts
+++ b/scopes/scope/importer/importer.ts
@@ -22,7 +22,7 @@ export class Importer {
       const currentRemoteLane = await this.workspace.getCurrentRemoteLane();
       if (currentRemoteLane) {
         importOptions.lanes = { laneIds: [currentRemoteLane.toLaneId()], lanes: [currentRemoteLane] };
-      } else if (!importOptions.ids) {
+      } else if (!importOptions.ids.length) {
         // the lane is probably new, it's not yet on the remote, so nothing to import
         return {
           dependencies: [],

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -137,4 +137,12 @@ export class BitMap {
     bitMapEntry.id = targetId._legacy;
     this.legacyBitMap.setComponent(bitMapEntry.id, bitMapEntry);
   }
+
+  /**
+   * this is the lane-id of the recently exported lane. in case of a new lane, which was not exported yet, this will be
+   * empty.
+   */
+  getExportedLaneId() {
+    return this.legacyBitMap.remoteLaneId;
+  }
 }

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -65,7 +65,7 @@ export default class BitMap {
     public schema: string,
     private isLegacy: boolean,
     public workspaceLane: WorkspaceLane | null, // null if not checked out to a lane
-    private remoteLaneId?: LaneId
+    public remoteLaneId?: LaneId
   ) {
     this.components = [];
     this.hasChanged = false;
@@ -171,11 +171,11 @@ export default class BitMap {
       throw new InvalidBitMap(currentLocation, e.message);
     }
     const schema = componentsJson[SCHEMA_FIELD] || componentsJson.version;
-    const remoteLaneName = componentsJson[LANE_KEY];
+    const laneId = new LaneId(componentsJson[LANE_KEY]);
 
     BitMap.removeNonComponentFields(componentsJson);
 
-    const bitMap = new BitMap(dirPath, currentLocation, schema, isLegacy, workspaceLane, remoteLaneName);
+    const bitMap = new BitMap(dirPath, currentLocation, schema, isLegacy, workspaceLane, laneId);
     bitMap.loadComponents(componentsJson);
     await bitMap.loadFiles();
     return bitMap;

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -171,7 +171,7 @@ export default class BitMap {
       throw new InvalidBitMap(currentLocation, e.message);
     }
     const schema = componentsJson[SCHEMA_FIELD] || componentsJson.version;
-    const laneId = new LaneId(componentsJson[LANE_KEY]);
+    const laneId = componentsJson[LANE_KEY] ? new LaneId(componentsJson[LANE_KEY]) : undefined;
 
     BitMap.removeNonComponentFields(componentsJson);
 

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -70,6 +70,7 @@ export type ImportResult = {
   dependencies: ComponentWithDependencies[];
   envComponents?: Component[];
   importDetails: ImportDetails[];
+  cancellationMessage?: string;
 };
 
 export default class ImportComponents {


### PR DESCRIPTION
When checked out to a lane, `bit import` fetches all objects from the lane-scope. In case the lane is new, it doesn't find it in the remote and falls back to main lane. 
Instead, this PR, stops immediately and shows an error that there is nothing to import because the lane is new.