### PR TITLE
fix: version dropdown scrolls the page down

### DIFF
--- a/scopes/component/ui/version-dropdown/version-info/version-info.tsx
+++ b/scopes/component/ui/version-dropdown/version-info/version-info.tsx
@@ -26,7 +26,7 @@ export function VersionInfo({ version, currentVersion, latestVersion, date, user
   const currentVersionRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (isCurrent) {
-      currentVersionRef.current?.scrollIntoView();
+      currentVersionRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
     }
   }, [isCurrent]);
 


### PR DESCRIPTION
Fix for issue #5906, which fixes the entire page scroll down when the version dropdown opens
