### PR TITLE
fix: improve handling aspect failures

### DIFF
--- a/e2e/harmony/aspect.e2e.ts
+++ b/e2e/harmony/aspect.e2e.ts
@@ -1,3 +1,4 @@
+import { UNABLE_TO_LOAD_EXTENSION } from '@teambit/aspect-loader/constants';
 import chai, { expect } from 'chai';
 import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
@@ -37,6 +38,27 @@ describe('aspect', function () {
         const compJson = helper.componentJson.read('comp1');
         expect(compJson.extensions).to.not.have.property(Extensions.forking);
       });
+    });
+  });
+  describe('aspect loading failures', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.command.create('aspect', 'my-aspect');
+      helper.bitJsonc.addKeyVal('my-scope/my-aspect', {});
+    });
+    it('commands with loaders should show a descriptive error', () => {
+      const output = helper.command.status();
+      expect(output).to.have.string(
+        UNABLE_TO_LOAD_EXTENSION('my-scope/my-aspect', "Cannot find module '@teambit/harmony'")
+      );
+    });
+    it('commands without loaders should not show the entire stacktrace', () => {
+      const output = helper.command.list();
+      expect(output).to.not.have.string('Require stack');
+    });
+    it('using --log=error it should show the stacktrace', () => {
+      const output = helper.command.list('--log=error');
+      expect(output).to.have.string('Require stack');
     });
   });
 });

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -2,11 +2,9 @@ import fs from 'fs-extra';
 import path from 'path';
 import chai, { expect } from 'chai';
 import { IssuesClasses } from '../../scopes/component/component-issues';
-
 import { Extensions, IS_WINDOWS } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
-import { UNABLE_TO_LOAD_EXTENSION } from '../../scopes/harmony/aspect-loader/constants';
 
 chai.use(require('chai-fs'));
 chai.use(require('chai-string'));
@@ -229,8 +227,7 @@ describe('custom env', function () {
       });
       it('should re-create the capsule dir and should not show any warning/error about loading the env', () => {
         const status = helper.command.status();
-        const errMsg = UNABLE_TO_LOAD_EXTENSION(`${envId}@0.0.1`);
-        expect(status).to.not.include(errMsg);
+        expect(status).to.not.include('unable to load the extension');
       });
       it('bit show should show the correct env', () => {
         const env = helper.env.getComponentEnv('comp1');

--- a/e2e/harmony/load-extensions.e2e.4.ts
+++ b/e2e/harmony/load-extensions.e2e.4.ts
@@ -15,7 +15,6 @@ const assertArrays = require('chai-arrays');
 
 chai.use(assertArrays);
 
-// @TODO: REMOVE THE SKIP ASAP
 describe('load extensions', function () {
   this.timeout(0);
   let helper: Helper;
@@ -69,7 +68,9 @@ describe('load extensions', function () {
           expect(output).to.have.string('new components');
         });
         it('should show a warning about the problematic extension', () => {
-          expect(output).to.have.string(UNABLE_TO_LOAD_EXTENSION('my-scope/non-requireable-aspect'));
+          expect(output).to.have.string(
+            UNABLE_TO_LOAD_EXTENSION('my-scope/non-requireable-aspect', 'error by purpose')
+          );
         });
       });
     });

--- a/e2e/harmony/workspace-config.e2e.ts
+++ b/e2e/harmony/workspace-config.e2e.ts
@@ -13,7 +13,7 @@ describe('workspace config (workspace.jsonc)', function () {
   describe('adding a non-component key', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
-      helper.bitJsonc.addKeyVal(undefined, 'non-comp', {});
+      helper.bitJsonc.addKeyVal('non-comp', {});
     });
     it('any command should throw a descriptive error', () => {
       expect(() => helper.command.status()).to.throw(

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -326,22 +326,21 @@ export class AspectLoaderMain {
       const idStr = requireableExtension.component.id.toString();
       try {
         return await this.doRequire(requireableExtension);
-      } catch (e: any) {
+      } catch (firstErr: any) {
         this.addFailure(idStr);
-        const errorMsg = UNABLE_TO_LOAD_EXTENSION(idStr);
-        this.logger.error(errorMsg, e);
-        const isFixed = await this.triggerOnAspectLoadError(e, requireableExtension.component);
+        this.logger.warn(`failed loading an aspect "${idStr}", will try to fix and reload`, firstErr);
+        const isFixed = await this.triggerOnAspectLoadError(firstErr, requireableExtension.component);
         let errAfterReLoad;
         if (isFixed) {
-          this.logger.info(`the loading issue has been fixed, re-loading ${idStr}`);
+          this.logger.info(`the loading issue might be fixed now, re-loading ${idStr}`);
           try {
             return await this.doRequire(requireableExtension);
           } catch (err: any) {
-            this.logger.error('re-load of the aspect failed as well', err);
+            this.logger.warn(`re-load of the aspect "${idStr}" failed as well`, err);
             errAfterReLoad = err;
           }
         }
-        const error = errAfterReLoad || e;
+        const error = errAfterReLoad || firstErr;
         this.handleExtensionLoadingError(error, idStr, throwOnError);
       }
       return undefined;
@@ -353,18 +352,18 @@ export class AspectLoaderMain {
   }
 
   handleExtensionLoadingError(error: Error, idStr: string, throwOnError: boolean) {
-    const errorMsg = UNABLE_TO_LOAD_EXTENSION(idStr);
+    const errorMsg = error.message.split('\n')[0]; // show only the first line if the error is long (e.g. happens with MODULE_NOT_FOUND errors)
+    const msg = UNABLE_TO_LOAD_EXTENSION(idStr, errorMsg);
     if (throwOnError) {
       // @ts-ignore
       this.logger.console(error);
       throw new CannotLoadExtension(idStr, error);
     }
-    this.logger.error(errorMsg, error);
+    this.logger.error(msg, error);
     if (this.logger.isLoaderStarted) {
-      this.logger.consoleFailure(errorMsg);
+      this.logger.consoleFailure(msg);
     } else {
-      this.logger.console(errorMsg);
-      this.logger.console(error.message);
+      this.logger.console(msg);
     }
   }
 

--- a/scopes/harmony/aspect-loader/constants.ts
+++ b/scopes/harmony/aspect-loader/constants.ts
@@ -1,6 +1,7 @@
-// Warnings
-export const UNABLE_TO_LOAD_EXTENSION = (id: string) =>
-  `error: unable to load the extension "${id}", please use the '--log=error' flag for the full error.`;
+export const UNABLE_TO_LOAD_EXTENSION = (id: string, errMsg?: string) =>
+  `error: unable to load the extension "${id}", due to an error "${
+    errMsg || '<unknown-error>'
+  }", please use the '--log=error' flag for the full error.`;
 export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[]) =>
   `couldn't load one of the following extensions ${ids.join(
     ', '

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -44,6 +44,7 @@ import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
 import { propogateUntil as propagateUntil } from '@teambit/legacy/dist/utils';
+import logger from '@teambit/legacy/dist/logger/logger';
 import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
 import loader from '@teambit/legacy/dist/cli/loader';
 import { readdir } from 'fs-extra';
@@ -199,6 +200,7 @@ function shouldLoadInSafeMode() {
 
 export async function loadBit(path = process.cwd()) {
   clearGlobalsIfNeeded();
+  logger.info(`*** Loading Bit *** argv:\n${process.argv.join('\n')}`);
   const loadCLIOnly = shouldLoadInSafeMode();
   const config = await getConfig(path);
   registerCoreExtensions();

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -111,6 +111,7 @@ export class CommandRunner {
       logger.shouldWriteToConsole = false;
     }
     if (this.flags.log) {
+      // probably not necessary anymore. it is handled in src/logger - determineWritingLogToScreen()
       const logValue = typeof this.flags.log === 'string' ? this.flags.log : undefined;
       logger.switchToConsoleLogger(logValue as LoggerLevel);
     }

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -24,7 +24,7 @@ export default class BitJsoncHelper {
     const content = stringify(bitJsonc, null, 2);
     return fs.writeFileSync(bitJsoncPath, content);
   }
-  addKeyVal(bitJsoncDir: string = this.scopes.localPath, key: string, val: any) {
+  addKeyVal(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
     const bitJsonc = this.read(bitJsoncDir);
     // Using this to keep the comments
     const obj = {
@@ -60,21 +60,21 @@ export default class BitJsoncHelper {
     const variants = bitJsonc['teambit.workspace/variants'];
     const newVariant = config;
     assign(variants, { [variant]: newVariant });
-    this.addKeyVal(bitJsoncDir, 'teambit.workspace/variants', variants);
+    this.addKeyVal('teambit.workspace/variants', variants, bitJsoncDir);
   }
 
   addKeyValToWorkspace(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
     const bitJsonc = this.read(bitJsoncDir);
     const workspace = bitJsonc['teambit.workspace/workspace'];
     assign(workspace, { [key]: val });
-    this.addKeyVal(bitJsoncDir, 'teambit.workspace/workspace', workspace);
+    this.addKeyVal('teambit.workspace/workspace', workspace, bitJsoncDir);
   }
 
   addKeyValToDependencyResolver(key: string, val: any, bitJsoncDir: string = this.scopes.localPath) {
     const bitJsonc = this.read(bitJsoncDir);
     const depResolver = bitJsonc['teambit.dependencies/dependency-resolver'];
     assign(depResolver, { [key]: val });
-    this.addKeyVal(bitJsoncDir, 'teambit.dependencies/dependency-resolver', depResolver);
+    this.addKeyVal('teambit.dependencies/dependency-resolver', depResolver, bitJsoncDir);
   }
 
   getPolicyFromDependencyResolver() {
@@ -95,7 +95,7 @@ export default class BitJsoncHelper {
     this.addKeyValToWorkspace('defaultOwner', owner);
   }
   disablePreview() {
-    this.addKeyVal(undefined, 'teambit.preview/preview', { disabled: true });
+    this.addKeyVal('teambit.preview/preview', { disabled: true });
   }
   setupDefault() {
     this.disablePreview();

--- a/src/e2e-helper/e2e-extensions-helper.ts
+++ b/src/e2e-helper/e2e-extensions-helper.ts
@@ -29,7 +29,7 @@ export default class ExtensionsHelper {
   }
 
   addExtensionToWorkspace(extName: string, extConfig = {}) {
-    this.bitJsonc.addKeyVal(this.scopes.localPath, extName, extConfig);
+    this.bitJsonc.addKeyVal(extName, extConfig);
   }
 
   addExtensionToVariant(variant: string, extName: string, extConfig = {}, replaceExisting = false) {


### PR DESCRIPTION
## Proposed Changes

- fix `--log` flag to print log message right away, even before the aspects are loaded. this way, when the error is happening during bootstrap, it'll be able to print the log.
- remove error-logging duplications. now when using `--log=error`, it shows the aspect-loading failure only once.
- improve the `UNABLE_TO_LOAD_EXTENSION` message to include the first line of the error message. for the most cases, this is enough, and no need to use the `--log=error` flag. 
