### PR TITLE
improvement: improve performance of bit-import on lane

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -117,7 +117,7 @@ describe('sign command', function () {
     });
     describe('running bit import on the workspace', () => {
       before(() => {
-        helper.command.importAllComponents();
+        helper.command.import('--all-history');
       });
       it('should bring the updated Version from the remote', () => {
         const comp1 = helper.command.catComponent(`${helper.scopes.remote}/bar@latest`);

--- a/src/api/scope/lib/fetch.ts
+++ b/src/api/scope/lib/fetch.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import { LaneId } from '@teambit/lane-id';
 import { BitIds } from '../../../bit-id';
-import { POST_SEND_OBJECTS, PRE_SEND_OBJECTS } from '../../../constants';
+import { LATEST_BIT_VERSION, POST_SEND_OBJECTS, PRE_SEND_OBJECTS } from '../../../constants';
 import HooksManager from '../../../hooks';
 import logger from '../../../logger/logger';
 import { loadScope, Scope } from '../../../scope';
@@ -13,6 +13,7 @@ import {
   ObjectsReadableGenerator,
 } from '../../../scope/objects/objects-readable-generator';
 import { LaneNotFound } from './exceptions/lane-not-found';
+import { Lane } from '../../../scope/models';
 
 export type FETCH_TYPE = 'component' | 'lane' | 'object' | 'component-delta';
 export type FETCH_OPTIONS = {
@@ -20,6 +21,8 @@ export type FETCH_OPTIONS = {
   withoutDependencies: boolean; // default - true
   includeArtifacts: boolean; // default - false
   allowExternal: boolean; // allow fetching components of other scope from this scope. needed for lanes.
+  laneId?: string; // relevant for "component-delta" type to know where to find the component latest
+  onlyIfBuilt?: boolean; // relevant when fetching with deps. if true, and the component wasn't built successfully, don't fetch it.
 };
 
 const HooksManagerInstance = HooksManager.getInstance();
@@ -50,7 +53,7 @@ export default async function fetch(
   switch (fetchOptions.type) {
     case 'component': {
       const bitIds: BitIds = BitIds.deserialize(ids);
-      const { withoutDependencies, includeArtifacts, allowExternal } = fetchOptions;
+      const { withoutDependencies, includeArtifacts, allowExternal, onlyIfBuilt } = fetchOptions;
       const collectParents = !withoutDependencies;
       const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
       const getComponentsWithOptions = async (): Promise<ComponentWithCollectOptions[]> => {
@@ -63,7 +66,7 @@ export default async function fetch(
             collectParents,
           }));
         }
-        const versionsDependencies = await scopeComponentsImporter.fetchWithDeps(bitIds, allowExternal);
+        const versionsDependencies = await scopeComponentsImporter.fetchWithDeps(bitIds, allowExternal, onlyIfBuilt);
         return versionsDependencies
           .map((versionDep) => [
             {
@@ -89,7 +92,9 @@ export default async function fetch(
     case 'component-delta': {
       const bitIdsWithHashToStop: BitIds = BitIds.deserialize(ids);
       const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
-      const bitIdsLatest = bitIdsWithHashToStop.toVersionLatest();
+      const laneId = fetchOptions.laneId ? LaneId.parse(fetchOptions.laneId) : null;
+      const lane = laneId ? await scope.loadLane(laneId) : null;
+      const bitIdsLatest = bitIdsToLatest(bitIdsWithHashToStop, lane);
       const importedComponents = await scopeComponentsImporter.fetchWithoutDeps(
         bitIdsLatest,
         fetchOptions.allowExternal
@@ -150,4 +155,17 @@ export default async function fetch(
   }
   logger.debug('scope.fetch returns readable');
   return objectsReadableGenerator.readable;
+}
+
+function bitIdsToLatest(bitIds: BitIds, lane: Lane | null) {
+  if (!lane) {
+    return bitIds.toVersionLatest();
+  }
+  const laneIds = lane.toBitIds();
+  return BitIds.fromArray(
+    bitIds.map((bitId) => {
+      const inLane = laneIds.searchWithoutVersion(bitId);
+      return inLane || bitId.changeVersion(LATEST_BIT_VERSION);
+    })
+  );
 }

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -79,13 +79,14 @@ export default class ImportComponents {
   options: ImportOptions;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   mergeStatus: { [id: string]: FilesStatus };
-  private laneObjects: Lane[] = [];
+  private laneObjects: Lane[];
   private divergeData: Array<ModelComponent> = [];
   // @ts-ignore
   constructor(consumer: Consumer, options: ImportOptions) {
     this.consumer = consumer;
     this.scope = consumer.scope;
     this.options = options;
+    this.laneObjects = this.options.lanes ? (this.options.lanes.lanes as Lane[]) : [];
   }
 
   importComponents(): Promise<ImportResult> {
@@ -96,10 +97,47 @@ export default class ImportComponents {
       this.options.installNpmPackages = false;
       this.options.saveDependenciesAsComponents = true;
     }
-    if (!this.options.lanes && (!this.options.ids || R.isEmpty(this.options.ids))) {
-      return this.importAccordingToBitMap();
+    if (this.options.lanes && !this.options.ids.length) {
+      return this.importObjectsOnLane();
     }
-    return this.importSpecificComponents();
+    if (this.options.ids.length) {
+      return this.importSpecificComponents();
+    }
+    return this.importAccordingToBitMap();
+  }
+
+  async importObjectsOnLane(): Promise<ImportResult> {
+    if (!this.laneObjects.length || !this.options.objectsOnly || this.consumer.isLegacy) {
+      throw new Error(`importObjectsOnLane should work on Harmony and have laneObjects and objectsOnly=true`);
+    }
+    if (this.laneObjects.length > 1) {
+      throw new Error(`importObjectsOnLane does not support more than one lane`);
+    }
+    const lane = this.laneObjects[0];
+    const bitIds: BitIds = await this.getBitIds();
+    logger.debug(`importObjectsOnLane, Lane: ${lane.id()}, Ids: ${bitIds.toString()}`);
+    const beforeImportVersions = await this._getCurrentVersions(bitIds);
+    const componentsWithDependencies = await this.consumer.importComponentsObjectsHarmony(
+      bitIds,
+      false,
+      this.options.allHistory,
+      lane
+    );
+
+    // merge the lane objects
+    const mergeAllLanesResults = await pMapSeries(this.laneObjects, (laneObject) =>
+      this.scope.sources.mergeLane(laneObject, true)
+    );
+    const mergedLanes = mergeAllLanesResults.map((result) => result.mergeLane);
+    await Promise.all(mergedLanes.map((mergedLane) => this.scope.lanes.saveLane(mergedLane)));
+
+    const componentsWithDependenciesFiltered = this._filterComponentsWithLowerVersions(componentsWithDependencies);
+    await this._fetchDivergeData(componentsWithDependenciesFiltered);
+    this._throwForDivergedHistory();
+    await this._writeToFileSystem(componentsWithDependenciesFiltered);
+    await this._saveLaneDataIfNeeded(componentsWithDependenciesFiltered);
+    const importDetails = await this._getImportDetails(beforeImportVersions, componentsWithDependencies);
+    return { dependencies: componentsWithDependenciesFiltered, importDetails };
   }
 
   async importSpecificComponents(): Promise<ImportResult> {
@@ -187,7 +225,6 @@ export default class ImportComponents {
     if (!this.options.lanes) {
       throw new Error(`getBitIdsForLanes: this.options.lanes must be set`);
     }
-    this.laneObjects = this.options.lanes.lanes as Lane[];
     const bitIdsFromLane = BitIds.fromArray(this.laneObjects.flatMap((lane) => lane.toBitIds()));
 
     if (!this.options.ids.length) {

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -97,9 +97,9 @@ export default class ImportComponents {
       this.options.installNpmPackages = false;
       this.options.saveDependenciesAsComponents = true;
     }
-    if (this.options.lanes && !this.options.ids.length) {
-      return this.importObjectsOnLane();
-    }
+    // if (this.options.lanes && !this.options.ids.length) {
+    //   return this.importObjectsOnLane();
+    // }
     if (this.options.ids.length) {
       return this.importSpecificComponents();
     }

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -97,9 +97,11 @@ export default class ImportComponents {
       this.options.installNpmPackages = false;
       this.options.saveDependenciesAsComponents = true;
     }
-    // if (this.options.lanes && !this.options.ids.length) {
-    //   return this.importObjectsOnLane();
-    // }
+    if (this.options.lanes && !this.options.ids.length) {
+      // @todo: uncomment this once the code is deployed to the server
+      // return this.importObjectsOnLane();
+      return this.importSpecificComponents();
+    }
     if (this.options.ids.length) {
       return this.importSpecificComponents();
     }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -434,14 +434,15 @@ export default class Consumer {
   async importComponentsObjectsHarmony(
     ids: BitIds,
     fromOriginalScope = false,
-    allHistory = false
+    allHistory = false,
+    lane?: Lane
   ): Promise<ComponentWithDependencies[]> {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
-    await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory);
+    await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory, lane);
     loader.start(`import ${ids.length} components with their dependencies (if missing)`);
     const versionDependenciesArr: VersionDependencies[] = fromOriginalScope
       ? await scopeComponentsImporter.importManyFromOriginalScopes(ids)
-      : await scopeComponentsImporter.importMany({ ids });
+      : await scopeComponentsImporter.importMany({ ids, lanes: lane ? [lane] : undefined });
     const componentWithDependencies = await multipleVersionDependenciesToConsumer(
       versionDependenciesArr,
       this.scope.objects

--- a/src/scope/models/lane.ts
+++ b/src/scope/models/lane.ts
@@ -2,7 +2,7 @@ import { v4 } from 'uuid';
 import { isHash } from '@teambit/component-version';
 import { LaneId, DEFAULT_LANE, LANE_REMOTE_DELIMITER } from '@teambit/lane-id';
 import { Scope } from '..';
-import { BitId } from '../../bit-id';
+import { BitId, BitIds } from '../../bit-id';
 import { CFG_USER_EMAIL_KEY, CFG_USER_NAME_KEY, PREVIOUS_DEFAULT_LANE } from '../../constants';
 import ValidationError from '../../error/validation-error';
 import logger from '../../logger/logger';
@@ -181,8 +181,8 @@ export default class Lane extends BitObject {
     );
     return { merged, unmerged };
   }
-  toBitIds(): BitId[] {
-    return this.components.map((c) => c.id.changeVersion(c.head.toString()));
+  toBitIds(): BitIds {
+    return BitIds.fromArray(this.components.map((c) => c.id.changeVersion(c.head.toString())));
   }
   toLaneId() {
     return new LaneId({ scope: this.scope, name: this.name });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -49,7 +49,7 @@ export type MergeResult = {
   mergedVersions: string[];
 };
 
-const MAX_AGE_UN_BUILT_COMPS_CACHE = 60 * 1000;
+const MAX_AGE_UN_BUILT_COMPS_CACHE = 60 * 1000; // 1 min
 
 export default class SourceRepository {
   scope: Scope;
@@ -153,6 +153,10 @@ export default class SourceRepository {
     version.dependencies = version.dependencies.filter((d) => !d.id.isEqualWithoutVersion(component.toBitId()));
 
     return returnComponent(version as Version);
+  }
+
+  isUnBuiltInCache(bitId: BitId): boolean {
+    return Boolean(this.cacheUnBuiltIds.get(bitId.toString()));
   }
 
   async _findComponent(component: ModelComponent): Promise<ModelComponent | undefined> {


### PR DESCRIPTION
## Proposed Changes

- import only "delta" when on a lane with the same way it is done for main. meaning, send to the server the current hash and only fetch if the server has a newer hash, in which case, fetch the delta between the two.
- in case the components exist locally but their version are unbuilt, avoid fetching them again from the remote with all their dependencies, unless their `builtStatus` has changed and is now successful. 
