### PR TITLE
fix: clarify the solution for multiple-envs, clarify "bit env unset" command

### DIFF
--- a/e2e/harmony/multiple-envs.e2e.ts
+++ b/e2e/harmony/multiple-envs.e2e.ts
@@ -15,7 +15,7 @@ describe('multiple envs', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  describe('change an env after tag', () => {
+  describe('env in the variants and env in the .bitmap', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
@@ -28,12 +28,29 @@ describe('multiple envs', function () {
 
       helper.command.setEnv('comp1', 'teambit.harmony/aspect');
     });
-    it('bit status should show it as an issue because the previous env was not removed', () => {
+    it('bit status should not show it as an issue because the previous env was removed', () => {
       helper.command.expectStatusToNotHaveIssue(IssuesClasses.MultipleEnvs.name);
     });
     it('expect the env to be the one that was set in the .bitmap file', () => {
       const env = helper.env.getComponentEnv('comp1');
       expect(env).to.equal('teambit.harmony/aspect');
+    });
+  });
+  describe('env in the variants global (*) and env in the variants more specific', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      const reactEnv = 'teambit.react/react';
+      helper.extensions.addExtensionToVariant('*', reactEnv);
+      helper.extensions.addExtensionToVariant('comp1', 'teambit.harmony/aspect');
+    });
+    it('bit status should show it as an issue', () => {
+      helper.command.expectStatusToHaveIssue(IssuesClasses.MultipleEnvs.name);
+    });
+    it('bit env set should fix the issue', () => {
+      helper.command.setEnv('comp1', 'teambit.harmony/aspect');
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MultipleEnvs.name);
     });
   });
 });

--- a/scopes/component/component-issues/multiple-envs.ts
+++ b/scopes/component/component-issues/multiple-envs.ts
@@ -2,8 +2,7 @@ import { ComponentIssue, ISSUE_FORMAT_SPACE } from './component-issue';
 
 export class MultipleEnvs extends ComponentIssue {
   description = 'multiple envs';
-  // TODO: pass the docs url into here after fetch it from the community aspect
-  solution = `remove the old envs by setting them with "-" sign in the variants. see https://bit.dev/docs/envs/using-envs#component-must-have-a-single-env`;
+  solution = 'set the desired env by running "bit env set <component> <env>"';
   data: string[]; // env ids
   isTagBlocker = true;
   dataToString() {

--- a/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-unset.cmd.ts
@@ -1,19 +1,26 @@
 import { Command } from '@teambit/cli';
 import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
+import chalk from 'chalk';
 import { Workspace } from '../workspace';
 
 export class EnvsUnsetCmd implements Command {
-  name = 'unset <component>';
-  description = 'unset an environment from component(s)';
+  name = 'unset <pattern>';
+  description = 'unset an environment from component(s) that was set by "bit env set"';
   options = [];
   group = 'development';
-  extendedDescription = `${PATTERN_HELP('env unset')}`;
+  extendedDescription = `keep in mind that this doesn't remove envs that are set in the variants.
+in only removes envs that appear in the .bitmap file, which were previously configured via "bit env set".
+the purpose of this command is to remove the specific settings and let the the variants in workspace.jsonc to control the env.
+${PATTERN_HELP('env unset')}`;
 
   constructor(private workspace: Workspace) {}
 
   async report([pattern]: [string]) {
     const componentIds = await this.workspace.idsByPattern(pattern);
     const { changed } = await this.workspace.unsetEnvFromComponents(componentIds);
+    if (!changed.length) {
+      return chalk.yellow(`unable to find any component matching the pattern with env configured in the .bitmap file`);
+    }
     return `successfully removed env from the following component(s):
 ${changed.map((id) => id.toString()).join('\n')}`;
   }


### PR DESCRIPTION
## Proposed Changes

- in case of "multiple-envs" issue, suggest to run `bit env set` to fix it. (currently, it suggests adding minus key to variants, which it less clear and more work).
- in case `bit env unset` didn't make any changes, show it clearly in the command output.
- clarify in the description of `bit env unset` that it affects only components set by `bit env set` before.
