### PR TITLE
fix: consider locally-configured-remotes when resolving bit-id from scope

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -254,6 +254,25 @@ describe('custom env', function () {
       expect(() => helper.command.tagIncludeUnmodified()).not.to.throw();
     });
   });
+  describe('when the env is exported to a remote scope and is not exist locally', () => {
+    let envId: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      const envName = helper.env.setCustomEnv();
+      envId = `${helper.scopes.remote}/${envName}`;
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.fixtures.populateComponents(1);
+    });
+    // previously, it errored "Cannot read property 'id' of undefined"
+    it('bit env-set should not throw any error', () => {
+      expect(() => helper.command.setEnv('comp1', envId));
+    });
+  });
 });
 
 function getEnvIdFromModel(compModel: any): string {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -822,18 +822,28 @@ export default class Scope {
     }
     const component = await this.loadModelComponentByIdStr(id);
     const idHasScope = Boolean(component && component.scope);
-    if (!idHasScope) {
-      const [idWithoutVersion] = id.toString().split('@');
-      if (idWithoutVersion.includes('.')) {
-        // we allow . only on scope names, so if it has . it must be with scope name
-        return BitId.parse(id, true);
-      }
-      // if it's not in the scope, it's probably new, we assume it doesn't have scope.
+    if (idHasScope) {
+      const bitId: BitId = component.toBitId();
+      const version = BitId.getVersionOnlyFromString(id);
+      return bitId.changeVersion(version || LATEST);
+    }
+    const [idWithoutVersion] = id.toString().split('@');
+    if (idWithoutVersion.includes('.')) {
+      // we allow . only on scope names, so if it has . it must be with scope name
+      return BitId.parse(id, true);
+    }
+    const idSplit = id.split('/');
+    if (idSplit.length === 1) {
+      // it doesn't have any slash, so the id doesn't include the scope-name
       return BitId.parse(id, false);
     }
-    const bitId: BitId = component.toBitId();
-    const version = BitId.getVersionOnlyFromString(id);
-    return bitId.changeVersion(version || LATEST);
+    const maybeScope = idSplit[0];
+    const isRemoteConfiguredLocally = this.scopeJson.remotes[maybeScope];
+    if (isRemoteConfiguredLocally) {
+      return BitId.parse(id, true);
+    }
+    // it's probably new, we assume it doesn't have scope.
+    return BitId.parse(id, false);
   }
 
   async writeObjectsToPendingDir(objectList: ObjectList, clientId: string): Promise<void> {


### PR DESCRIPTION
currently, if the remote was added locally (via `bit remote add some-remote`) and the component doesn't exist in the local scope, it assumes the id doesn't have scope-name. 
with this fix, it'll check whether the first part of the id is the scope-name by comparing it to the local remotes.