### PR TITLE
feat: allow enforcing minimum supported Bit CLI version

### DIFF
--- a/scopes/harmony/bit/bit.provider.ts
+++ b/scopes/harmony/bit/bit.provider.ts
@@ -2,7 +2,17 @@ import { manifestsMap } from './manifests';
 
 export type BitDeps = [];
 
-export type BitConfig = {};
+export type BitConfig = {
+  cwd: string;
+  /**
+   * if set, during bit bootstrap it checks whether the current bit-version semver.satisfies this version.
+   */
+  engine?: string;
+  /**
+   * if true, it throws an error when "engine" not satisfied. otherwise, it just warns.
+   */
+  engineStrict?: boolean;
+};
 
 export async function provideBit() {
   return {

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -39,7 +39,9 @@ import ComponentLoader from '@teambit/legacy/dist/consumer/component/component-l
 import ComponentConfig from '@teambit/legacy/dist/consumer/config/component-config';
 import ComponentOverrides from '@teambit/legacy/dist/consumer/config/component-overrides';
 import { PackageJsonTransformer } from '@teambit/legacy/dist/consumer/component/package-json-transformer';
+import { satisfies } from 'semver';
 import ManyComponentsWriter from '@teambit/legacy/dist/consumer/component-ops/many-components-writer';
+import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
@@ -52,6 +54,7 @@ import { resolve } from 'path';
 import { manifestsMap } from './manifests';
 import { BitAspect } from './bit.aspect';
 import { registerCoreExtensions } from './bit.main.runtime';
+import { BitConfig } from './bit.provider';
 
 async function loadLegacyConfig(config: any) {
   const harmony = await Harmony.load([ConfigAspect], ConfigRuntime.name, config.toObject());
@@ -201,17 +204,16 @@ function shouldLoadInSafeMode() {
 export async function loadBit(path = process.cwd()) {
   clearGlobalsIfNeeded();
   logger.info(`*** Loading Bit *** argv:\n${process.argv.join('\n')}`);
-  const loadCLIOnly = shouldLoadInSafeMode();
   const config = await getConfig(path);
   registerCoreExtensions();
   await loadLegacyConfig(config);
   const configMap = config.toObject();
-
-  configMap['teambit.harmony/bit'] = {
-    cwd: path,
-  };
+  configMap[BitAspect.id] ||= {};
+  configMap[BitAspect.id].cwd = path;
+  verifyEngine(configMap[BitAspect.id]);
 
   const aspectsToLoad = [CLIAspect];
+  const loadCLIOnly = shouldLoadInSafeMode();
   if (!loadCLIOnly) {
     aspectsToLoad.push(BitAspect);
   }
@@ -225,6 +227,21 @@ export async function loadBit(path = process.cwd()) {
   aspectLoader.setMainAspect(getMainAspect());
   registerCoreAspectsToLegacyDepResolver(aspectLoader);
   return harmony;
+}
+
+function verifyEngine(bitConfig: BitConfig) {
+  if (!bitConfig.engine) {
+    return;
+  }
+  const bitVersion = getHarmonyVersion(true);
+  if (satisfies(bitVersion, bitConfig.engine)) {
+    return;
+  }
+  const msg = `your bit version "${bitVersion}" doesn't satisfies the required "${bitConfig.engine}" version`;
+  if (bitConfig.engineStrict) {
+    throw new Error(`error: ${msg}`);
+  }
+  logger.console(msg, 'warn', 'yellow');
 }
 
 export async function runCLI() {


### PR DESCRIPTION
Implements #5928.

This configuration is part of `teambit.harmony/bit` aspect, and utilizes two properties: `engine` to compare the Semver and `engineStrict` to throw an error instead of just showing a warning. 

Here is an example how to configure it in workspace.jsonc to support Bit version 0.0.700 and above. It'll throw an error if current version is < 0.0.700.
```
"teambit.harmony/bit": {
    "engine": ">0.0.700",
    "engineStrict": true
  },
```