### PR TITLE
improvement: implement queue mechanism for the watch process

### DIFF
--- a/scopes/workspace/workspace/watch/watch-queue.ts
+++ b/scopes/workspace/workspace/watch/watch-queue.ts
@@ -1,0 +1,17 @@
+import PQueue from 'p-queue';
+
+export class WatchQueue {
+  private queue: PQueue;
+  constructor(concurrency = 1) {
+    this.queue = new PQueue({ concurrency, autoStart: true });
+  }
+  getQueue() {
+    return this.queue;
+  }
+  add<T>(fn: () => T, priority?: number): Promise<T> {
+    return this.queue.add(fn, { priority });
+  }
+  onIdle(): Promise<void> {
+    return this.queue.onIdle();
+  }
+}


### PR DESCRIPTION
Currently, multiple components and .bitmap changes execution can still be processed concurrently.
The following example explains why this is an issue:
compA is changed in the .bitmap file from version 0.0.1 to 0.0.2. its files were changed as well. All these changes get pulled at the same time by "git pull", as a result, the execution of compA and the .bitmap happen at the same time.

During the execution of compA, the component id is parsed as compA@0.0.1, later, it asks for the Workspace for this
id. While the workspace is looking for this id, the .bitmap execution reloaded the consumer and changed all versions.
After this change, the workspace doesn't have this id anymore, which will trigger an error.

To ensure this won't happen, we keep a flag to indicate whether the .bitmap execution is running, and if so, all
other executions are paused until the queue is empty. Once the queue is empty, we know the .bitmap process was done and the workspace has all new ids.
In the example above, at this stage, the id will be resolved to compA@0.0.2.

Also, the queue is configured to have concurrency of 1. to make sure two components are not processed at
the same time. (the same way is done when loading all components from the filesystem/scope).
This way we can also ensure that if compA was started before the .bitmap execution, it will complete before the
.bitmap execution starts.