### PR TITLE
regression: version dropdown fixes

### DIFF
--- a/scopes/component/ui/version-dropdown/version-dropdown-placeholder.module.scss
+++ b/scopes/component/ui/version-dropdown/version-dropdown-placeholder.module.scss
@@ -93,4 +93,7 @@
     margin-right: 2px;
     text-align: right;
   }
+  .versionUserAvatar {
+    flex: none;
+  }
 }

--- a/scopes/component/ui/version-dropdown/version-dropdown-placeholder.tsx
+++ b/scopes/component/ui/version-dropdown/version-dropdown-placeholder.tsx
@@ -23,6 +23,7 @@ const getVersionDetails = (version, tags, snaps) => {
 };
 
 export function SimpleVersion({ currentVersion, className, disabled, tags, snaps }: VersionProps) {
+  const showArrowDown = useMemo(() => (snaps || []).concat(tags).length > 1, [tags, snaps]);
   const versionDetails = useMemo(() => getVersionDetails(currentVersion, tags, snaps), [currentVersion, tags, snaps]);
 
   return (
@@ -36,12 +37,13 @@ export function SimpleVersion({ currentVersion, className, disabled, tags, snaps
       >
         {currentVersion}
       </Ellipsis>
-      <Icon of="fat-arrow-down" />
+      {showArrowDown && <Icon of="fat-arrow-down" />}
     </div>
   );
 }
 
 export function DetailedVersion({ currentVersion, className, disabled, snaps, tags }: VersionProps) {
+  const showArrowDown = useMemo(() => (snaps || []).concat(tags).length > 1, [tags, snaps]);
   const versionDetails = useMemo(() => getVersionDetails(currentVersion, tags, snaps), [currentVersion, tags, snaps]);
 
   const timestamp = useMemo(
@@ -72,7 +74,7 @@ export function DetailedVersion({ currentVersion, className, disabled, snaps, ta
       <Ellipsis className={styles.versionTimestamp}>
         <TimeAgo date={timestamp} />
       </Ellipsis>
-      <Icon of="fat-arrow-down" />
+      {showArrowDown && <Icon of="fat-arrow-down" />}
     </div>
   );
 }

--- a/scopes/component/ui/version-dropdown/version-info/version-info.tsx
+++ b/scopes/component/ui/version-dropdown/version-info/version-info.tsx
@@ -40,7 +40,7 @@ export function VersionInfo({
   const currentVersionRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
     if (isCurrent) {
-      currentVersionRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      currentVersionRef.current?.scrollIntoView({ block: 'nearest' });
     }
   }, [isCurrent]);
 


### PR DESCRIPTION
## Proposed Changes

- remove `smooth` scrolling to the current version when the version dropdown opens
- hide down arrow in the version placeholder when there is only one version present
