### PR TITLE
remove theme from compositions app

### DIFF
--- a/scopes/design/ui/pages/standalone-not-found-page/standalone-not-found.tsx
+++ b/scopes/design/ui/pages/standalone-not-found-page/standalone-not-found.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
-import { Theme } from '@teambit/base-ui.theme.theme-provider';
-// import { IconFont } from '@teambit/design.theme.icons-font';
 import { NotFoundPage, NotFoundPageProps } from '@teambit/design.ui.pages.not-found';
 
 export type StandaloneNotFoundProps = NotFoundPageProps;
 
 /** A 404 page with fonts included  */
 export function StandaloneNotFoundPage() {
-  return (
-    <Theme>
-      {/* <IconFont query="jyyv17" /> */}
-      <NotFoundPage />
-    </Theme>
-  );
+  return <NotFoundPage style={{ fontFamily: '"Helvetica Neue",Helvetica, sans-serif' }} />;
 }


### PR DESCRIPTION
## Proposed Changes

- remove old theme from StandaloneNotFound page

This component is used as a fallback in the compositions-app. Its styles seep into the env template, and break component docs. Removing this theme from the component should fix it:

![Screen Shot 2022-06-13 at 16 30 54](https://user-images.githubusercontent.com/5400361/173364967-f3251159-e148-425f-b38e-d9c0e7f9ce90.png)

