### PR TITLE
Fix zindexes

### DIFF
--- a/scopes/code/ui/code-compare/code-compare.module.scss
+++ b/scopes/code/ui/code-compare/code-compare.module.scss
@@ -31,7 +31,7 @@ $panelBg: #fafafa;
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }

--- a/scopes/code/ui/code-tab-page/code-tab-page.module.scss
+++ b/scopes/code/ui/code-tab-page/code-tab-page.module.scss
@@ -28,7 +28,7 @@ $panelBg: #fafafa;
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }

--- a/scopes/component/component-filters/envs-filter.module.scss
+++ b/scopes/component/component-filters/envs-filter.module.scss
@@ -3,13 +3,12 @@
   > div {
     line-height: 16px;
     display: flex;
-    // otherwise when the dropdown is open it clashes with the content of the tree
-    z-index: $nav-z-index + 2;
   }
 
   .filterIcon {
     display: flex;
     padding: 8px;
+    border-radius: 8px;
 
     &:hover {
       background: var(--bit-bg-heavy, #f6f6f6);
@@ -38,6 +37,9 @@
 
 .envFilterDropdown {
   width: 100%;
+  // otherwise when the dropdown is open it clashes with the content of the tree
+  // (this is bizarre, the tree has no position absolute)
+  z-index: $nav-z-index;
 }
 
 .envDropdownItemContainer {

--- a/scopes/component/ui/compare/aspects/compare-aspects.module.scss
+++ b/scopes/component/ui/compare/aspects/compare-aspects.module.scss
@@ -30,7 +30,7 @@ $panelBg: #fafafa;
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }

--- a/scopes/component/ui/compare/version-picker/component-compare-version-picker.module.scss
+++ b/scopes/component/ui/compare/version-picker/component-compare-version-picker.module.scss
@@ -12,7 +12,7 @@
   width: 100%;
 }
 .showMenuOverNav {
-  z-index: $nav-z-index + 1;
+  z-index: $topBar-zIndex;
 }
 
 .componentCompareVersionPlaceholder {

--- a/scopes/compositions/compositions/compositions.module.scss
+++ b/scopes/compositions/compositions/compositions.module.scss
@@ -38,7 +38,7 @@ $panelBg: #fafafa;
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }

--- a/scopes/compositions/ui/composition-compare/composition-dropdown.module.scss
+++ b/scopes/compositions/ui/composition-compare/composition-dropdown.module.scss
@@ -21,5 +21,4 @@
   max-width: 100%;
   width: 100%;
   padding: 0px;
-  z-index: $nav-z-index + 1;
 }

--- a/scopes/design/ui/pages/standalone-not-found-page/standalone-not-found.tsx
+++ b/scopes/design/ui/pages/standalone-not-found-page/standalone-not-found.tsx
@@ -1,16 +1,9 @@
 import React from 'react';
-import { Theme } from '@teambit/base-ui.theme.theme-provider';
-// import { IconFont } from '@teambit/design.theme.icons-font';
 import { NotFoundPage, NotFoundPageProps } from '@teambit/design.ui.pages.not-found';
 
 export type StandaloneNotFoundProps = NotFoundPageProps;
 
 /** A 404 page with fonts included  */
 export function StandaloneNotFoundPage() {
-  return (
-    <Theme>
-      {/* <IconFont query="jyyv17" /> */}
-      <NotFoundPage />
-    </Theme>
-  );
+  return <NotFoundPage style={{ fontFamily: '"Helvetica Neue",Helvetica, sans-serif' }} />;
 }

--- a/scopes/scope/scope/ui/scope.module.scss
+++ b/scopes/scope/scope/ui/scope.module.scss
@@ -28,7 +28,7 @@
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }

--- a/scopes/ui-foundation/uis/constants/z-indexes/z-indexes.module.scss
+++ b/scopes/ui-foundation/uis/constants/z-indexes/z-indexes.module.scss
@@ -5,6 +5,9 @@
 // 100 < z < 1000 - navigation / hud
 $nav-z-index: 100;
 
+$pane-splitter-zIndex: 101;
+$topBar-zIndex: 102;
+
 // 5000 < z < 6000 - modals and overlays
 $modal-z-index: 5000;
 

--- a/scopes/ui-foundation/uis/top-bar/top-bar.module.scss
+++ b/scopes/ui-foundation/uis/top-bar/top-bar.module.scss
@@ -6,9 +6,9 @@ $topbarHeight: 56px;
   align-items: center;
 
   height: $topbarHeight;
-  background: #ededed;
+  background: var(--bit-bg-heaviest, #ededed);
   box-sizing: border-box;
   font-size: var(--bit-p-xs, 14px);
   // top bar needs to be with higher zindex in order for the menu to go over collapser button and splitter
-  z-index: $nav-z-index + 1;
+  z-index: $topBar-zIndex;
 }

--- a/scopes/workspace/workspace/ui/workspace/workspace.module.scss
+++ b/scopes/workspace/workspace/ui/workspace/workspace.module.scss
@@ -26,7 +26,7 @@
   position: relative;
 
   > :first-child {
-    z-index: $nav-z-index + 1;
+    z-index: $pane-splitter-zIndex;
     position: absolute;
   }
 }


### PR DESCRIPTION
## Proposed Changes

- ensure top bar dropdowns are above split-pane's splitter 
- fix env filter being above the mobile-topbar-menu (and fix border-radius)
- start using named z-index

z-index are an _order_ problem. Since each instance only knows its own index, a _[mediator](https://en.wikipedia.org/wiki/Mediator_pattern)_ is needed to assign the correct values.
(as a metaphor - you'd want the control tower to assign flight heights, not the airplanes themselves)

We should try not to abuse zindexes, and consolidate them where possible. For now we can let the list grow and consolidate when we have a better understanding of the values in our system.

Fixes:
![Screen Shot 2022-06-14 at 12 47 07](https://user-images.githubusercontent.com/5400361/173548260-93566244-b83b-4432-bfac-d187b517253e.png)
