### PR TITLE
fix(bit-status): avoid showing the same packages as missing multiple times

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -3,6 +3,7 @@ import fs from 'fs-extra';
 import R from 'ramda';
 import { isNilOrEmpty } from 'ramda-adjunct';
 import semver from 'semver';
+import { uniq } from 'lodash';
 import { IssuesList, IssuesClasses } from '@teambit/component-issues';
 import { Dependency } from '..';
 import { BitId, BitIds } from '../../../../bit-id';
@@ -1357,7 +1358,7 @@ either, use the ignore file syntax or change the require statement to have a mod
   }
   _pushToMissingPackagesDependenciesIssues(originFile: PathLinuxRelative, missingPackages: string[]) {
     (this.issues.getOrCreate(IssuesClasses.MissingPackagesDependenciesOnFs).data[originFile] ||= []).push(
-      ...missingPackages
+      ...uniq(missingPackages)
     );
   }
   _pushToMissingCustomModuleIssues(originFile: PathLinuxRelative, componentId: string) {


### PR DESCRIPTION
This was happening when the same package was used multiple times for different internal files. For example:
```
import { a } from 'pkg/file-a';
import { b } from 'pkg/file-b';
```

