### PR TITLE
set testing library to match react 17

### DIFF
--- a/scopes/react/react/templates/workspace-common/files/workspace-config.ts
+++ b/scopes/react/react/templates/workspace-common/files/workspace-config.ts
@@ -20,7 +20,7 @@ export async function workspaceConfig({ name, defaultScope }: WorkspaceContext) 
       'eslint-plugin-react': '7.25.1',
     },
     peerDependencies: {
-      '@testing-library/react': '12.0.0',
+      '@testing-library/react': '^12.1.5',
       react: '17.0.2',
       'react-dom': '17.0.2',
     },


### PR DESCRIPTION
## Proposed Changes

- update `bit new react` template to use `@testing-library/react` version `^12.1.15`, which is better compatible with react 17.
