### PR TITLE
improvement: change bit build/tag/check-types command to use the new pattern

### DIFF
--- a/scopes/defender/tester/test.cmd.tsx
+++ b/scopes/defender/tester/test.cmd.tsx
@@ -6,7 +6,6 @@ import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import { Timer } from '@teambit/legacy/dist/toolbox/timer';
 import { Box, Text } from 'ink';
 import React from 'react';
-import { NoMatchingComponents } from './exceptions';
 
 import type { TesterMain } from './tester.main.runtime';
 
@@ -21,13 +20,13 @@ type TestFlags = {
 };
 
 export class TestCmd implements Command {
-  name = 'test [component-pattern]';
+  name = 'test [pattern]';
   description = 'test components in the workspace';
   arguments = [
     {
-      name: 'component-pattern',
+      name: 'pattern',
       description:
-        'the components to test (defaults to all components). use component name, component id, or component pattern. use component pattern to select multiple components. \nuse comma to separate patterns. e.g. "ui/**, pages/**"\nwrap the pattern with quotes (note that the "!" exclusion sign cannot be used here)',
+        'the components to test (defaults to all components). use component name, component id, or component pattern. use component pattern to select multiple components. \nuse comma to separate patterns. e.g. "ui/**, pages/**"\nwrap the pattern with quotes',
     },
   ];
   alias = 'at';
@@ -39,7 +38,11 @@ export class TestCmd implements Command {
     ['', 'junit <filepath>', 'write tests results as JUnit XML format into the specified file path'],
     ['', 'coverage', 'show code coverage data'],
     ['e', 'env <id>', 'test only the given env'],
-    ['s', 'scope <scope-name>', 'name of the scope to test'],
+    [
+      's',
+      'scope <scope-name>',
+      'DEPRECATED. (use the pattern instead, e.g. "scopeName/**"). name of the scope to test',
+    ],
     // TODO: we need to reduce this redundant casting every time.
   ] as CommandOptions;
 
@@ -51,6 +54,11 @@ export class TestCmd implements Command {
   ) {
     const timer = Timer.create();
     const scopeName = typeof scope === 'string' ? scope : undefined;
+    if (scopeName) {
+      this.logger.consoleWarning(
+        `--scope is deprecated, use the pattern argument instead. e.g. "scopeName/**" for the entire scope`
+      );
+    }
     timer.start();
     if (!this.workspace) throw new ConsumerNotFound();
 
@@ -62,7 +70,6 @@ export class TestCmd implements Command {
     const patternWithScope = getPatternWithScope();
     const components = await this.workspace.getComponentsByUserInput(all, patternWithScope, true);
     if (!components.length) {
-      if (userPattern) throw new NoMatchingComponents(userPattern);
       return {
         code: 0,
         data: (

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -238,8 +238,9 @@ export class CLIParser {
 
     // show the flags in green
     const optionsColored = options.map((opt) => opt.replace(/(--)([\w-]+)/, replacer).replace(/(-)([\w-]+)/, replacer));
+    const argsColored = args.map((arg) => arg.replace(/^ {2}\S+/, (argName) => chalk.green(argName))); // regex: two spaces then the first word until a white space
     const optionsStr = options.length ? `\n${STANDARD_GROUP}\n${optionsColored.join('\n')}\n` : '';
-    const argumentsStr = args.length ? `\nArguments:\n${args.join('\n')}\n` : '';
+    const argumentsStr = args.length ? `\nArguments:\n${argsColored.join('\n')}\n` : '';
     const examplesStr = examples.length ? `\nExamples:\n${examples.join('\n')}\n` : '';
     const subCommandsStr = subCommands.length ? `\n${'Commands:'}\n${subCommands.join('\n')}\n` : '';
     // show the description in yellow

--- a/scopes/pipelines/builder/build.cmd.ts
+++ b/scopes/pipelines/builder/build.cmd.ts
@@ -1,6 +1,7 @@
 import { Command, CommandOptions } from '@teambit/cli';
 import { Logger } from '@teambit/logger';
 import { Workspace } from '@teambit/workspace';
+import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import chalk from 'chalk';
 import { BuilderMain } from './builder.main.runtime';
@@ -19,6 +20,7 @@ type BuildOpts = {
 export class BuilderCmd implements Command {
   name = 'build [pattern]';
   description = 'run set of tasks for build';
+  arguments = [{ name: 'pattern', description: PATTERN_HELP('build') }];
   alias = '';
   group = 'development';
   options = [
@@ -43,7 +45,7 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
   constructor(private builder: BuilderMain, private workspace: Workspace, private logger: Logger) {}
 
   async report(
-    [userPattern]: [string],
+    [pattern]: [string],
     {
       all = false,
       dev = false,
@@ -60,7 +62,7 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
     }
 
     const longProcessLogger = this.logger.createLongProcessLogger('build');
-    const components = await this.workspace.getComponentsByUserInput(all, userPattern, true);
+    const components = await this.workspace.getComponentsByUserInput(all, pattern, true);
     if (!components.length) {
       return chalk.bold(
         `no components found to build. use "--all" flag to build all components or specify the ids to build, otherwise, only new and modified components will be built`

--- a/scopes/typescript/typescript/cmds/check-types.cmd.ts
+++ b/scopes/typescript/typescript/cmds/check-types.cmd.ts
@@ -3,11 +3,13 @@ import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import { Logger } from '@teambit/logger';
 import { Workspace } from '@teambit/workspace';
 import chalk from 'chalk';
+import { PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { TypescriptMain } from '../typescript.main.runtime';
 
 export class CheckTypesCmd implements Command {
   name = 'check-types [pattern]';
   description = 'check typescript types';
+  arguments = [{ name: 'pattern', description: PATTERN_HELP('check-types') }];
   alias = '';
   group = 'development';
   options = [
@@ -17,9 +19,9 @@ export class CheckTypesCmd implements Command {
 
   constructor(private typescript: TypescriptMain, private workspace: Workspace, private logger: Logger) {}
 
-  async report([userPattern]: [string], { all = false, strict = false }: { all: boolean; strict: boolean }) {
+  async report([pattern]: [string], { all = false, strict = false }: { all: boolean; strict: boolean }) {
     if (!this.workspace) throw new ConsumerNotFound();
-    const components = await this.workspace.getComponentsByUserInput(all, userPattern);
+    const components = await this.workspace.getComponentsByUserInput(all, pattern);
     this.logger.setStatusLine(`checking types for ${components.length} components`);
     const files = this.typescript.getSupportedFilesForTsserver(components);
     await this.typescript.initTsserverClientFromWorkspace({ printTypeErrors: true }, files);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -707,6 +707,8 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
+   * @deprecated use `this.idsByPattern` instead for consistency. also, it supports negation and list of patterns.
+   *
    * load components into the workspace through a variants pattern.
    * @param pattern variants.
    * @param scope scope name.
@@ -757,7 +759,8 @@ export class Workspace implements ComponentFactory {
       return this.list();
     }
     if (pattern) {
-      return this.byPattern(pattern);
+      const ids = await this.idsByPattern(pattern);
+      return this.getMany(ids);
     }
     const newAndModified = await this.newAndModified();
     if (includeDependents) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -480,9 +480,10 @@ export const WILDCARD_HELP = (command: string) =>
   `you can use a pattern for multiple ids, such as bit ${command} "utils/*". (wrap the pattern with quotes to avoid collision with shell commands)`;
 
 export const PATTERN_HELP = (command: string) =>
-  `you can use a \`<pattern>\` for multiple component ids, such as \`bit ${command} "org.scope/utils/**"\`. use comma to separate patterns and "!" to exclude. e.g. "ui/**, !ui/button"
+  `you can use a \`<pattern>\` for multiple component ids, such as \`bit ${command} "org.scope/utils/**"\`.
+use comma to separate patterns and "!" to exclude. e.g. "ui/**, !ui/button"
 always wrap the pattern with quotes to avoid collision with shell commands.
-to validate the pattern before running this command, run \`bit pattern <pattern>\`.
+use \`bit pattern --help\` to understand patterns better and \`bit pattern <pattern>\` to validate the pattern.
 `;
 
 export const CURRENT_UPSTREAM = 'current';


### PR DESCRIPTION
currently, these commands use the old `workspace.byPattern` method, which provides a different behavior of parsing patterns. 
This PR makes the commands consistent. Now all commands that use patterns, use the `idsByPattern` method. 