### PR TITLE
fix: print more information on fetch errors

### DIFF
--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -27,6 +27,7 @@ import { ProjectManifest } from '@pnpm/types';
 import { Logger } from '@teambit/logger';
 import toNerfDart from 'nerf-dart';
 import pkgsGraph from 'pkgs-graph';
+import { pnpmErrorToBitError } from './pnpm-error-to-bit-error';
 import { readConfig } from './read-config';
 
 type RegistriesMap = {
@@ -206,6 +207,8 @@ export async function install(
   });
   try {
     await mutateModules(packagesToBuild, opts);
+  } catch (err: any) {
+    throw pnpmErrorToBitError(err)
   } finally {
     stopReporting();
   }
@@ -282,7 +285,7 @@ export async function resolveRemoteVersion(
     };
   } catch (e: any) {
     if (!e.message?.includes('is not a valid string')) {
-      throw e;
+      throw pnpmErrorToBitError(e);
     }
     // The provided package is probably a git url or path to a folder
     const wantedDep: WantedDependency = {

--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
@@ -1,0 +1,15 @@
+import PnpmError from '@pnpm/error';
+import { pnpmErrorToBitError } from "./pnpm-error-to-bit-error";
+
+test('the hint from the fetch error is used', () => {
+  const bitError = pnpmErrorToBitError(new PnpmError('FETCH_404', 'GET https://node.bit.cloud/dsffsdf: Not Found - 404', {
+    hint: `dsffsdf is not in the npm registry, or you have no permission to fetch it.
+
+An authorization header was used: Bearer df96[hidden]`,
+  }));
+  expect(bitError.report()).toEqual(`GET https://node.bit.cloud/dsffsdf: Not Found - 404
+
+dsffsdf is not in the npm registry, or you have no permission to fetch it.
+
+An authorization header was used: Bearer df96[hidden]`);
+});

--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.ts
@@ -1,0 +1,28 @@
+import PnpmError from '@pnpm/error';
+import { BitError } from '@teambit/bit-error';
+
+export class BitErrorWithRichMessage extends BitError {
+  private richMessage: string;
+  constructor (message: string, richMessage: string) {
+    super(message);
+    this.richMessage = richMessage;
+  }
+  public report() {
+    return this.richMessage;
+  }
+}
+
+export function pnpmErrorToBitError (err: PnpmError): BitError {
+  return new BitErrorWithRichMessage(err.message, renderErrorMessage(err));
+}
+
+function renderErrorMessage (err: PnpmError): string {
+  if (err.code.startsWith('ERR_PNPM_FETCH_')) {
+    // On fetching errors, pnpm adds information to the error object about the used auth headers.
+    // This information is safe to print as the tokens are obfuscated.
+    return `${err.message}
+
+${err.hint}`
+  }
+  return err.message;
+}


### PR DESCRIPTION
## Proposed Changes

- On fetching errors, pnpm adds information to the error object about the used auth headers. This information is safe to print as the tokens are obfuscated.

Before/after:

![image](https://user-images.githubusercontent.com/1927579/174483427-af631b4d-3b3e-4917-b8e5-e270a31ababf.png)
