### PR TITLE
Change pnpm cache install option

### DIFF
--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -190,6 +190,7 @@ export async function install(
     workspacePackages,
     preferFrozenLockfile: true,
     pruneLockfileImporters: true,
+    modulesCacheMaxAge: 0,
     registries: registriesMap,
     rawConfig: authConfig,
     ...options,
@@ -208,7 +209,7 @@ export async function install(
   try {
     await mutateModules(packagesToBuild, opts);
   } catch (err: any) {
-    throw pnpmErrorToBitError(err)
+    throw pnpmErrorToBitError(err);
   } finally {
     stopReporting();
   }


### PR DESCRIPTION
## Proposed Changes

Issue when installing a new version and we have an older version already installed.

- it’s preventing vscode error on the code when trying to use a new api of the component.
- node modules are updated correctly with the new version.
- sometimes it’s makes autocomplete correct with the new api and sometimes not, but I think that this is related to vscode.
