### PR TITLE
improvement: suggest alternatives for multiple-envs if bit-env-set does not help

### DIFF
--- a/scopes/component/component-issues/multiple-envs.ts
+++ b/scopes/component/component-issues/multiple-envs.ts
@@ -2,7 +2,8 @@ import { ComponentIssue, ISSUE_FORMAT_SPACE } from './component-issue';
 
 export class MultipleEnvs extends ComponentIssue {
   description = 'multiple envs';
-  solution = 'set the desired env by running "bit env set <component> <env>"';
+  solution =
+    'set the desired env by running "bit env set <component> <env>", if it doesn\'t work, run "bit aspect unset <component> <unwanted-env-id>". to keep troubleshooting run "bit aspect list <component-id>"';
   data: string[]; // env ids
   isTagBlocker = true;
   dataToString() {


### PR DESCRIPTION
In case a component has more than one env, and its config is corrupted, `bit env set` might not help.
For example, this happens when a component doesn't use `teambit.envs/envs` to configure the env, resulting this this output:

This PR suggests running `bit aspect unset` in case `bit env set` is not helpful. 