### PR TITLE
remove gql aspect / apollo from preview

### DIFF
--- a/scopes/component/ui/use-fetch-docs/use-fetch-docs.tsx
+++ b/scopes/component/ui/use-fetch-docs/use-fetch-docs.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { request, gql } from 'graphql-request';
+import { useMemo } from 'react';
+import { useQuery, gql } from '@teambit/graphql.hooks.use-query-light';
 
 const GQL_SERVER = '/graphql';
 const DOCS_QUERY = gql`
@@ -42,27 +42,13 @@ type DocsItem = {
   };
 };
 
-type FetchDocsObj = { docs: DocsItem } | undefined;
-
 export function useFetchDocs(componentId: string) {
-  const [data, setData] = useState<FetchDocsObj>(undefined);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState(undefined);
+  const variables = { id: componentId };
+  const request = useQuery<QueryResults>(DOCS_QUERY, { variables, server: GQL_SERVER });
 
-  useEffect(() => {
-    setLoading(true);
+  const result = useMemo(() => {
+    return { ...request, data: request.data && { docs: request.data?.getHost.getDocs } };
+  }, [request]);
 
-    const variables = { id: componentId };
-    request(GQL_SERVER, DOCS_QUERY, variables)
-      .then((result: QueryResults) => {
-        setData({ docs: result.getHost.getDocs });
-        setLoading(false);
-      })
-      .catch((e) => {
-        setError(e);
-        setLoading(false);
-      });
-  }, [componentId]);
-
-  return { data, loading, error };
+  return result;
 }

--- a/scopes/harmony/graphql/graphql.preview.runtime.tsx
+++ b/scopes/harmony/graphql/graphql.preview.runtime.tsx
@@ -1,7 +1,0 @@
-import { PreviewRuntime } from '@teambit/preview';
-
-import { GraphqlAspect } from './graphql.aspect';
-import { GraphqlUI } from './graphql.ui.runtime';
-
-GraphqlUI.runtime = PreviewRuntime;
-GraphqlAspect.addRuntime(GraphqlUI);

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -160,6 +160,7 @@
         "@teambit/evangelist.surfaces.tooltip": "1.0.1",
         "@teambit/explorer.ui.command-bar": "1.2.0",
         "@teambit/graph.cleargraph": "0.0.1",
+        "@teambit/graphql.hooks.use-query-light": "1.0.0",
         "@teambit/harmony": "0.3.3",
         "@teambit/pkg.content.packages-overview": "1.95.9",
         "@teambit/react.content.react-overview": "1.95.0",
@@ -749,7 +750,7 @@
         ]
       }
     },
-    // overrides for @teambit/bit ("teambit.harmony/bit") package:
+    // overrides for "@teambit/bit", the root package: (aka "teambit.harmony/bit")
     "scopes/harmony/bit": {
       "teambit.component/issues": {
         // This is here because in load-bit, we have to import harmony config from non main file


### PR DESCRIPTION
## Proposed Changes

- remove all traces of apollo and the main graphql aspect during preview

Trying to get rid of `subscriptions-transport-ws`, and found that graphql aspect is not even used in the preview.
Also `@apollo/client` is opinionated, and could conflict between versions, and configurations, So, it's a good idea to remove it from the preview where user code can is running.
