### PR TITLE
fix(lanes): remove lane-key from .bitmap file when switching to main

### DIFF
--- a/e2e/harmony/lanes/import-lanes.e2e.ts
+++ b/e2e/harmony/lanes/import-lanes.e2e.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_LANE } from '@teambit/lane-id';
 import chai, { expect } from 'chai';
 import path from 'path';
 import { statusWorkspaceIsCleanMsg } from '../../../src/constants';
@@ -91,6 +92,18 @@ describe('import lanes', function () {
       it('should save the lane object with the same hash as the original lane', () => {
         const laneObj = helper.command.catLane('dev');
         expect(laneObj.hash).to.eq(laneHash);
+      });
+      describe('switching to main', () => {
+        before(() => {
+          helper.command.switchLocalLane('main');
+        });
+        it('should remove the lane key from the .bitmap', () => {
+          const bitMap = helper.bitMap.read();
+          expect(bitMap).to.not.have.property(LANE_KEY);
+        });
+        it('should switch successfully', () => {
+          helper.command.expectCurrentLaneToBe(DEFAULT_LANE);
+        });
       });
     });
     describe('importing the lane and checking out with a different local lane-name', () => {

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -753,6 +753,7 @@ export default class BitMap {
     this.components.forEach((componentMap) =>
       componentMap.updatePerLane(this.remoteLaneId, this.workspaceLane ? this.workspaceLane.ids : null)
     );
+    this.markAsChanged();
   }
 
   sortValidateAndMarkAsChanged(componentMap: ComponentMap) {


### PR DESCRIPTION
This fixes a bug where switching from a lane to main, it shows a success message but the lane was still checked out.
It happened when the lane-switch didn't make any change to the .bitmap other than the lane-key and lane-key removal didn't trigger a bitmap-change. As a result, the .bitmap lane-key was still pointing to the previous lane.