### PR TITLE
ignore import statements of a component to itself

### DIFF
--- a/e2e/harmony/status-harmony.e2e.ts
+++ b/e2e/harmony/status-harmony.e2e.ts
@@ -74,4 +74,19 @@ describe('status command on Harmony', function () {
       expect(status.newComponents).to.have.lengthOf(2);
     });
   });
+  describe('components that imports itself', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fs.outputFile('bar/index.js', 'export const a = "b";');
+      helper.fs.outputFile('bar/foo.js', `import { a } from '@${helper.scopes.remote}/bar';`);
+      helper.command.add('bar');
+      helper.command.link();
+    });
+    // @todo: maybe we should show a component-issue suggesting to fix the import statement
+    it('should not add itself as a dependency', () => {
+      const show = helper.command.showComponentParsed('bar');
+      expect(show.dependencies).to.have.lengthOf(0);
+    });
+  });
 });

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -730,6 +730,11 @@ either, use the ignore file syntax or change the require statement to have a mod
     if (!components || R.isEmpty(components)) return;
     components.forEach((compDep) => {
       let componentId = this.getComponentIdByResolvedPackageData(compDep);
+      if (componentId.isEqual(this.componentId)) {
+        // the component is importing itself, so ignore it. although currently it doesn't cause any issues, (probably
+        // because it filtered out later), it's better to remove it as soon as possible, for less-confusing debugging.
+        return;
+      }
       const depDebug: DebugComponentsDependency = {
         id: componentId,
         dependencyPackageJsonPath: compDep.packageJsonPath,


### PR DESCRIPTION
It could happen that by mistake instead of importing from a file within a component, the import statement has the component-package. 
Although this is not an issue currently, (because it's filtered out before saving the data), it is confusing when debugging the component. 
This PR removes it immediately before setting the `dependencies` prop. 