### PR TITLE
fix(bit-tag): fix --pre-release flag to not have "true" as identifier if not provided

### DIFF
--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -43,8 +43,8 @@ export class TagCmd implements Command {
     ['p', 'patch', 'syntactic sugar for "--increment patch"'],
     ['', 'minor', 'syntactic sugar for "--increment minor"'],
     ['', 'major', 'syntactic sugar for "--increment major"'],
+    ['', 'pre-release [identifier]', 'syntactic sugar for "--increment prerelease" and "--prerelease-id <identifier>"'],
     ['', 'snapped', 'EXPERIMENTAL. tag components that their head is a snap (not a tag)'],
-    ['', 'pre-release [identifier]', 'DEPRECATED. use "-l prerelease" (and --prerelease-id) instead'],
     ['', 'skip-tests', 'skip running component tests during tag process'],
     ['', 'skip-auto-tag', 'skip auto tagging dependents'],
     ['', 'soft', 'do not persist. only keep note of the changes to be made'],
@@ -192,6 +192,15 @@ https://${docsDomain}/components/tags`;
       if (preRelease) return 'prerelease';
       return DEFAULT_BIT_RELEASE_TYPE;
     };
+    const getPreReleaseId = (): string | undefined => {
+      if (prereleaseId) {
+        return prereleaseId;
+      }
+      if (preRelease && typeof preRelease === 'string') {
+        return preRelease;
+      }
+      return undefined;
+    };
 
     const disableTagAndSnapPipelines = disableTagPipeline || disableDeployPipeline;
 
@@ -201,7 +210,7 @@ https://${docsDomain}/components/tags`;
       editor,
       message,
       releaseType: getReleaseType(),
-      preReleaseId: prereleaseId || preRelease || undefined,
+      preReleaseId: getPreReleaseId(),
       ignoreIssues,
       ignoreNewestVersion,
       skipTests,

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -1,5 +1,5 @@
 import { Command } from '@teambit/legacy/dist/cli/command';
-import { Arguments, CommandModule, Argv } from 'yargs';
+import { Arguments, CommandModule, Argv, Options } from 'yargs';
 import { TOKEN_FLAG } from '@teambit/legacy/dist/constants';
 import { camelCase } from 'lodash';
 import { CommandRunner } from './command-runner';
@@ -51,7 +51,7 @@ export class YargsAdapter implements CommandModule {
     return this.commanderCommand.arguments;
   }
 
-  static optionsToBuilder(command: Command) {
+  static optionsToBuilder(command: Command): { [key: string]: Options } {
     const option = command.options.reduce((acc, [alias, opt, desc]) => {
       const optName = opt.split(' ')[0];
       acc[optName] = {
@@ -60,7 +60,7 @@ export class YargsAdapter implements CommandModule {
         group: STANDARD_GROUP,
         type: opt.includes(' ') ? 'string' : 'boolean',
         requiresArg: opt.includes('<'),
-      };
+      } as Options;
       return acc;
     }, {});
     const globalOptions = YargsAdapter.getGlobalOptions(command);


### PR DESCRIPTION
Before: `bar@0.0.1` => `bar@0.0.2-true.0`
After:    `bar@0.0.1` => `bar@0.0.1-0`