### PR TITLE
fix: read strict-ssl

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -639,24 +639,25 @@ export class DependencyResolverMain {
   }
 
   private getNetworkConfigFromDepResolverConfig(): NetworkConfig {
-    return {
-      ...pick(this.config, [
-        'fetchTimeout',
-        'fetchRetries',
-        'fetchRetryFactor',
-        'fetchRetryMintimeout',
-        'fetchRetryMaxtimeout',
-        'maxSockets',
-        'networkConcurrency',
-        'key',
-        'cert',
-        'ca',
-        'cafile',
-      ]),
-      strictSSL: typeof this.config.strictSsl === 'string'
+    const config: NetworkConfig = pick(this.config, [
+      'fetchTimeout',
+      'fetchRetries',
+      'fetchRetryFactor',
+      'fetchRetryMintimeout',
+      'fetchRetryMaxtimeout',
+      'maxSockets',
+      'networkConcurrency',
+      'key',
+      'cert',
+      'ca',
+      'cafile',
+    ]);
+    if (this.config.strictSsl != null) {
+      config.strictSSL = typeof this.config.strictSsl === 'string'
         ? this.config.strictSsl.toLowerCase() === 'true'
-        : this.config.strictSsl,
-    };
+        : this.config.strictSsl;
+    }
+    return config;
   }
 
   private async getNetworkConfigFromPackageManager(): Promise<NetworkConfig> {

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -212,14 +212,18 @@ export class PnpmPackageManager implements PackageManager {
 
   async getNetworkConfig?(): Promise<PackageManagerNetworkConfig> {
     const { config } = await this.readConfig();
+    // We need to use config.rawConfig as it will only contain the settings defined by the user.
+    // config contains default values of the settings when they are not defined by the user.
     return {
-      maxSockets: config.maxSockets,
-      networkConcurrency: config.networkConcurrency,
-      fetchRetries: config.fetchRetries,
-      fetchTimeout: config.fetchTimeout,
-      fetchRetryMaxtimeout: config.fetchRetryMaxtimeout,
-      fetchRetryMintimeout: config.fetchRetryMintimeout,
-      strictSSL: config.strictSsl,
+      maxSockets: config.rawConfig['max-sockets'],
+      networkConcurrency: config.rawConfig['network-concurrency'],
+      fetchRetries: config.rawConfig['fetch-retries'],
+      fetchTimeout: config.rawConfig['fetch-timeout'],
+      fetchRetryMaxtimeout: config.rawConfig['fetch-retry-maxtimeout'],
+      fetchRetryMintimeout: config.rawConfig['fetch-retry-mintimeout'],
+      strictSSL: config.rawConfig['strict-ssl'],
+      // These settings don't have default value, so it is safe to read them from config
+      // ca is automatically populated from the content of the file specified by cafile.
       ca: config.ca,
       cert: config.cert,
       key: config.key,

--- a/scopes/toolbox/network/agent/agent.ts
+++ b/scopes/toolbox/network/agent/agent.ts
@@ -17,7 +17,6 @@ export function getAgent(uri: string, opts: AgentOptions): any {
     };
   }
   return getPnpmAgent(uri, {
-    maxSockets: 15,
     strictSsl: opts.strictSSL,
     ...opts,
   }) as any;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -302,7 +302,7 @@ export const CFG_MAX_SOCKETS = 'network.max_sockets';
 export const CFG_NETWORK_CONCURRENCY = 'network.concurrency';
 export const CFG_NETWORK_CA = 'network.ca';
 export const CFG_NETWORK_CA_FILE = 'network.cafile';
-export const CFG_NETWORK_STRICT_SSL = 'network.strict_ssl';
+export const CFG_NETWORK_STRICT_SSL = 'network.strict-ssl';
 export const CFG_NETWORK_CERT = 'network.cert';
 export const CFG_NETWORK_KEY = 'network.key';
 

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -129,6 +129,7 @@ export class Http implements Network {
   static async getNetworkConfig(): Promise<NetworkConfig> {
     const obj = await list();
 
+    // Reading strictSSL from both network.strict-ssl and network.strict_ssl for backward compatibility.
     const strictSSL = obj[CFG_NETWORK_STRICT_SSL] ?? obj['network.strict_ssl'] ?? obj[CFG_PROXY_STRICT_SSL]
     return {
       fetchRetries: obj[CFG_FETCH_RETRIES] ?? 2,

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -131,14 +131,14 @@ export class Http implements Network {
 
     const strictSSL = obj[CFG_NETWORK_STRICT_SSL] ?? obj['network.strict_ssl'] ?? obj[CFG_PROXY_STRICT_SSL]
     return {
-      fetchRetries: obj[CFG_FETCH_RETRIES],
-      fetchRetryFactor: obj[CFG_FETCH_RETRY_FACTOR],
-      fetchRetryMintimeout: obj[CFG_FETCH_RETRY_MINTIMEOUT],
-      fetchRetryMaxtimeout: obj[CFG_FETCH_RETRY_MAXTIMEOUT],
-      fetchTimeout: obj[CFG_FETCH_TIMEOUT],
+      fetchRetries: obj[CFG_FETCH_RETRIES] ?? 2,
+      fetchRetryFactor: obj[CFG_FETCH_RETRY_FACTOR] ?? 10,
+      fetchRetryMintimeout: obj[CFG_FETCH_RETRY_MINTIMEOUT] ?? 10000,
+      fetchRetryMaxtimeout: obj[CFG_FETCH_RETRY_MAXTIMEOUT] ?? 60000,
+      fetchTimeout: obj[CFG_FETCH_TIMEOUT] ?? 60000,
       localAddress: obj[CFG_LOCAL_ADDRESS],
-      maxSockets: obj[CFG_MAX_SOCKETS],
-      networkConcurrency: obj[CFG_NETWORK_CONCURRENCY],
+      maxSockets: obj[CFG_MAX_SOCKETS] ?? 15,
+      networkConcurrency: obj[CFG_NETWORK_CONCURRENCY] ?? 16,
       strictSSL: typeof strictSSL === 'string' ? strictSSL === 'true' : strictSSL,
       ca: obj[CFG_NETWORK_CA] ?? obj[CFG_PROXY_CA],
       cafile: obj[CFG_NETWORK_CA_FILE] ?? obj[CFG_PROXY_CA_FILE],

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -129,7 +129,7 @@ export class Http implements Network {
   static async getNetworkConfig(): Promise<NetworkConfig> {
     const obj = await list();
 
-    const strictSSL = obj[CFG_NETWORK_STRICT_SSL] ?? obj[CFG_PROXY_STRICT_SSL]
+    const strictSSL = obj[CFG_NETWORK_STRICT_SSL] ?? obj['network.strict_ssl'] ?? obj[CFG_PROXY_STRICT_SSL]
     return {
       fetchRetries: obj[CFG_FETCH_RETRIES],
       fetchRetryFactor: obj[CFG_FETCH_RETRY_FACTOR],


### PR DESCRIPTION
## Proposed Changes

- `network.strict_ssl` setting renamed to `network.strict-ssl`
- do not overwrite strictSSL with `undefined` when Yarn is the package manager and strict SSL is configured through global Bit settings
- do not overwrite strictSSL with `true` when pnpm is the package manager and strict SSL is configured through global Bit settings
- add default values for network settings
