### PR TITLE
esm tag link

### DIFF
--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -365,10 +365,10 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
     const moduleMapsPromise = defs.map(async (previewDef) => {
       const moduleMap = await previewDef.getModuleMap([component]);
       const maybeFiles = moduleMap.get(component);
-      if (!maybeFiles || !capsule) return [];
+      if (!maybeFiles || !capsule) return { prefix: previewDef.prefix, paths: [] };
+
       const [, files] = maybeFiles;
       const compiledPaths = this.getPaths(context, component, files);
-      // const files = flatten(paths.toArray().map(([, file]) => file));
 
       return {
         prefix: previewDef.prefix,
@@ -376,7 +376,7 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
       };
     });
 
-    const moduleMaps = flatten(await Promise.all(moduleMapsPromise));
+    const moduleMaps = await Promise.all(moduleMapsPromise);
 
     const contents = generateComponentLink(moduleMaps);
     return this.preview.writeLinkContents(contents, this.getComponentOutputPath(capsule), 'preview');

--- a/scopes/preview/preview/strategies/generate-component-link.ts
+++ b/scopes/preview/preview/strategies/generate-component-link.ts
@@ -6,14 +6,26 @@ export type ModuleVar = {
 };
 
 export function generateComponentLink(modules: ModuleVar[]): string {
-  return `${modules
-    .map((moduleVar) => {
-      return `export const ${moduleVar.prefix} = [${moduleVar.paths
-        .map((path) => `require('${toWindowsCompatiblePath(path)}')`)
-        .join(', ')}]`;
+  const links = modules.map(({ prefix, paths }) => ({
+    name: prefix,
+    entries: paths.map((path, idx) => ({
+      path: toWindowsCompatiblePath(path),
+      linkName: `${prefix}_${idx}`,
+    })),
+  }));
 
-      // return `export { * as ${moduleVar.prefix} } from '${toWindowsCompatiblePath(moduleVar.paths)}'`;
-    })
-    .join('\n')}
+  // import per preview file
+  const importStr: string = links
+    .map(({ entries }) => entries.map(({ path, linkName }) => `import * as ${linkName} from '${path}'`).join(';\n'))
+    .join('\n');
+
+  // export files group per preview
+  const exportsString: string = links
+    .map(({ name, entries }) => `export const ${name} = [${entries.map((entry) => entry.linkName).join(', ')}]`)
+    .join(';\n');
+
+  return `${importStr}
+
+${exportsString}
 `;
 }


### PR DESCRIPTION
## Proposed Changes

- upgrade tag link file to use esm syntax (and not mixed export/require)
- handle previews with no files

setup for fixing the `preview for name: "overview" was not found` error.


<details>
  <summary>externals sample</summary>

before this PR:
```js
export const compositions = [require('/Users/kutner/Library/Caches/Bit/capsules/5ac02f09bfe0eccb84aec7cb198a40776d572fff/my-org.my-scope_comp01@0.0.1/dist/comp01.composition.js')]
export const overview = [require('/Users/kutner/Library/Caches/Bit/capsules/5ac02f09bfe0eccb84aec7cb198a40776d572fff/my-org.my-scope_comp01@0.0.1/dist/comp01.docs.mdx')]
```

after this PR:
```js
import * as compositions_0 from '/Users/kutner/Library/Caches/Bit/capsules/5ac02f09bfe0eccb84aec7cb198a40776d572fff/my-org.my-scope_comp01@0.0.1/dist/comp01.composition.js'
import * as overview_0 from '/Users/kutner/Library/Caches/Bit/capsules/5ac02f09bfe0eccb84aec7cb198a40776d572fff/my-org.my-scope_comp01@0.0.1/dist/comp01.docs.mdx'

export const compositions = [compositions_0];
export const overview = [overview_0];
```
</details>