### PR TITLE
fix(bit-sign): avoid fetching dists of build-failed

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -358,8 +358,12 @@ export class IsolatorMain {
     await Promise.all(
       components.map(async (component) => {
         const isModified = await component.isModified();
-        if (isModified) modifiedComps.push(component);
-        else unmodifiedComps.push(component);
+        if (!isModified && component.buildStatus === 'succeed') {
+          // the "component.buildStatus" check is important for "bit sign" when on lane to not go to the original scope
+          unmodifiedComps.push(component);
+        } else {
+          modifiedComps.push(component);
+        }
       })
     );
     const legacyUnmodifiedComps = unmodifiedComps.map((component) => component.state._consumer.clone());

--- a/src/consumer/component-ops/component-writer.ts
+++ b/src/consumer/component-ops/component-writer.ts
@@ -224,6 +224,10 @@ export default class ComponentWriter {
       // build-pipeline. when capsules are written via the scope, we do need the dists.
       return;
     }
+    if (this.component.buildStatus !== 'succeed') {
+      // this is important for "bit sign" when on lane to not go to the original scope
+      return;
+    }
     const extensionsNamesForArtifacts = ['teambit.compilation/compiler'];
     const artifactsFiles = flatten(
       extensionsNamesForArtifacts.map((extName) => getArtifactFilesByExtension(this.component.extensions, extName))


### PR DESCRIPTION
Currently if the component's build-status is failed, `bit sign` throws an error when on a lane:
```
ENOENT: no such file or directory, open '/tmp/scope-fs/objects/ed/af2594be2b2603149910c7ae86197e7c3d3975
```
Because the dists paths are saved into the model, Bit tries to fetch them when writing the capsule from the original-scope. 
This PR fixes it to not fetch the dists from the remote in case the build was not success. 
(if the build is success, then bit-sign won't try to get the dists anyway, so no issues there).
