### PR TITLE
React Hook name should be in camelCase instead (#6043)

### DIFF
--- a/scopes/react/react/templates/react-hook/files/index-file.spec.ts
+++ b/scopes/react/react/templates/react-hook/files/index-file.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentID } from '@teambit/component-id';
+import type { ComponentContext } from '@teambit/generator';
+import { indexFile } from './index-file';
+
+// react hook convention is `useX` (lowercase "use")
+// it is required to enable hook-specific linting rules
+const useFoobarSnapshot = `export { useFooBar } from './use-foo-bar';
+`; // trailing line break
+
+describe('templates: react-hook, index-file', () => {
+  it('should match snapshot', () => {
+    const ctx: ComponentContext = {
+      name: 'use-foo-bar',
+      namePascalCase: 'UseFooBar',
+      nameCamelCase: 'useFooBar',
+      componentId: ComponentID.fromString('baz.qux/use/foo/bar'),
+    };
+
+    const result = indexFile(ctx);
+
+    expect(result.content).toEqual(useFoobarSnapshot);
+  });
+});

--- a/scopes/react/react/templates/react-hook/files/index-file.ts
+++ b/scopes/react/react/templates/react-hook/files/index-file.ts
@@ -1,7 +1,7 @@
 import { ComponentContext } from '@teambit/generator';
 
 export const indexFile = (context: ComponentContext) => {
-  const { name, namePascalCase: Name } = context;
+  const { name, nameCamelCase: Name } = context;
 
   return {
     relativePath: 'index.ts',


### PR DESCRIPTION
## Proposed Changes

- Fixes export name casing issue with generated React Hooks.
- closes #6043 