### PR TITLE
improvement: remove suggestion to run bit-dependents when component was not found

### DIFF
--- a/src/cli/default-error-handler.ts
+++ b/src/cli/default-error-handler.ts
@@ -186,13 +186,11 @@ const errorsMap: Array<[Class<Error>, (err: Class<Error>) => string]> = [
   [
     ComponentNotFound,
     (err) => {
-      const baseMsg = err.dependentId
+      return err.dependentId
         ? `error: the component dependency "${chalk.bold(err.id)}" required by "${chalk.bold(
             err.dependentId
           )}" was not found`
         : `error: component "${chalk.bold(err.id)}" was not found`;
-      const msg = `${baseMsg}\nconsider running "bit dependents ${err.id}" to understand why this component was needed`;
-      return msg;
     },
   ],
   [


### PR DESCRIPTION
In 90% of the cases this suggestion doesn't help and only causes more confusion. 