### PR TITLE
deprecate bit-untag, introduce bit-reset

### DIFF
--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -226,7 +226,7 @@ describe('components that are not synced between the scope and the consumer', fu
       helper.fixtures.tagComponentBarFoo();
       helper.command.tagIncludeUnmodified('2.0.0');
       const bitMap = helper.bitMap.read();
-      helper.command.untag('bar/foo@2.0.0');
+      helper.command.untag('bar/foo', '2.0.0');
       helper.bitMap.write(bitMap);
       scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
     });

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -982,7 +982,7 @@ describe('bit lane command', function () {
         helper.scopeHelper.getClonedLocalScope(afterFirstSnap);
         helper.command.snapComponentWithoutBuild('comp1', '--force');
         const head = helper.command.getHeadOfLane('dev', 'comp1');
-        helper.command.untagAll(head);
+        helper.command.untag('comp1', head);
       });
       it('should not show the component as new', () => {
         const status = helper.command.statusJson();

--- a/scopes/component/snapping/reset-cmd.ts
+++ b/scopes/component/snapping/reset-cmd.ts
@@ -1,0 +1,60 @@
+import { BitError } from '@teambit/bit-error';
+import chalk from 'chalk';
+import { Command, CommandOptions } from '@teambit/cli';
+import { unTagAction } from '@teambit/legacy/dist/api/consumer';
+import { BASE_DOCS_DOMAIN, WILDCARD_HELP } from '@teambit/legacy/dist/constants';
+import { untagResult } from '@teambit/legacy/dist/scope/component-ops/untag-component';
+
+export default class ResetCmd implements Command {
+  name = 'reset [component-name] [component-version]';
+  description = 'revert tagged or snapped versions for component(s)';
+  arguments = [
+    {
+      name: 'component-name',
+      description: 'the component name or component id',
+    },
+    {
+      name: 'component-version',
+      description: 'the version to untag (semver for tags. hash for snaps)',
+    },
+  ];
+  group = 'development';
+  extendedDescription = `https://${BASE_DOCS_DOMAIN}/components/tags#undoing-a-tag
+${WILDCARD_HELP('reset')}`;
+  alias = '';
+  options = [
+    ['a', 'all', 'revert tag/snap for all tagged/snapped components'],
+    ['', 'soft', 'revert only soft-tags (components tagged with --soft flag)'],
+    [
+      'f',
+      'force',
+      'revert the tag even if used as a dependency. WARNING: components that depend on this tag will corrupt',
+    ],
+  ] as CommandOptions;
+  loader = true;
+  migration = true;
+
+  async report(
+    [id, version]: [string, string],
+    { all = false, force = false, soft = false }: { all?: boolean; force?: boolean; soft?: boolean }
+  ) {
+    if (!id && !all) {
+      throw new BitError('please specify a component ID or use --all flag');
+    }
+    const getResults = () => {
+      if (all && version) {
+        version = id;
+        return unTagAction(version, force, soft);
+      }
+      return unTagAction(version, force, soft, id);
+    };
+
+    const { results, isSoftUntag }: { results: untagResult[]; isSoftUntag: boolean } = await getResults();
+    const titleSuffix = isSoftUntag ? 'soft-untagged (are not candidate for tagging anymore)' : 'untagged';
+    const title = chalk.green(`${results.length} component(s) were ${titleSuffix}:\n`);
+    const components = results.map((result) => {
+      return `${chalk.cyan(result.id.toStringWithoutVersion())}. version(s): ${result.versions.join(', ')}`;
+    });
+    return title + components.join('\n');
+  }
+}

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -35,6 +35,7 @@ import { SnapCmd } from './snap-cmd';
 import { SnappingAspect } from './snapping.aspect';
 import { TagCmd } from './tag-cmd';
 import { ComponentsHaveIssues } from './components-have-issues';
+import ResetCmd from './reset-cmd';
 
 const HooksManagerInstance = HooksManager.getInstance();
 
@@ -497,7 +498,8 @@ export class SnappingMain {
     const snapping = new SnappingMain(workspace, logger, issues, insights);
     const snapCmd = new SnapCmd(community.getBaseDomain(), snapping, logger);
     const tagCmd = new TagCmd(community.getBaseDomain(), snapping, logger);
-    cli.register(tagCmd, snapCmd);
+    const resetCmd = new ResetCmd();
+    cli.register(tagCmd, snapCmd, resetCmd);
     return snapping;
   }
 }

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -929,6 +929,7 @@ needed-for: ${neededFor?.toString() || '<unknown>'}`);
     return this.filterIdsFromPoolIdsByPattern(pattern, ids, throwForNoMatch);
   }
 
+  // todo: move this to somewhere else (where?)
   filterIdsFromPoolIdsByPattern(pattern: string, ids: ComponentID[], throwForNoMatch = true) {
     const patterns = pattern.split(',').map((p) => p.trim());
     // check also as legacyId.toString, as it doesn't have the defaultScope

--- a/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-set.cmd.ts
@@ -1,5 +1,6 @@
 import { Command } from '@teambit/cli';
 import chalk from 'chalk';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { Workspace } from '../workspace';
 
 export class EnvsSetCmd implements Command {
@@ -8,8 +9,7 @@ export class EnvsSetCmd implements Command {
   arguments = [
     {
       name: 'component-pattern',
-      description:
-        'component name, component id, or component pattern. use component pattern to select multiple components. \nuse commas to separate patterns and "!" to exclude. e.g. "ui/**, !ui/button"\nwrap the pattern with quotes',
+      description: COMPONENT_PATTERN_HELP,
     },
     {
       name: 'env',

--- a/src/cli/commands/public-cmds/untag-cmd.ts
+++ b/src/cli/commands/public-cmds/untag-cmd.ts
@@ -35,11 +35,14 @@ ${WILDCARD_HELP('untag')}`;
   ] as CommandOptions;
   loader = true;
   migration = true;
+  private = true;
 
   action(
     [id, version]: [string, string],
     { all = false, force = false, soft = false }: { all?: boolean; force?: boolean; soft?: boolean }
   ): Promise<{ results: untagResult[]; isSoftUntag: boolean }> {
+    // eslint-disable-next-line no-console
+    console.log(chalk.yellow(`"bit untag" has been deprecated, please use "bit reset" instead`));
     if (!id && !all) {
       throw new GeneralError('please specify a component ID or use --all flag');
     }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -333,13 +333,13 @@ export default class CommandHelper {
     return artifacts;
   }
   untag(id: string, version = '') {
-    return this.runCmd(`bit untag ${id} ${version}`);
+    return this.runCmd(`bit reset ${id} ${version}`);
   }
   untagAll(options = '') {
-    return this.runCmd(`bit untag ${options} --all`);
+    return this.runCmd(`bit reset ${options} --all`);
   }
   untagSoft(id: string) {
-    return this.runCmd(`bit untag ${id} --soft`);
+    return this.runCmd(`bit reset ${id} --soft`);
   }
   exportIds(ids: string, flags = '', assert = true) {
     const result = this.runCmd(`bit export ${ids} ${flags}`);

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -7,7 +7,7 @@ import logger from '../../logger/logger';
 import { Lane } from '../models';
 import ModelComponent from '../models/model-component';
 
-export type untagResult = { id: BitId; versions: string[]; component: ModelComponent };
+export type untagResult = { id: BitId; versions: string[]; component?: ModelComponent };
 
 /**
  * If not specified version, remove all local versions.
@@ -90,7 +90,7 @@ export async function removeLocalVersionsForComponentsMatchedByWildcard(
   return removeLocalVersionsForMultipleComponents(componentsToUntag, lane, version, force, consumer.scope);
 }
 
-async function removeLocalVersionsForMultipleComponents(
+export async function removeLocalVersionsForMultipleComponents(
   componentsToUntag: ModelComponent[],
   lane: Lane | null,
   version?: string,
@@ -127,7 +127,7 @@ async function removeLocalVersionsForMultipleComponents(
   );
 }
 
-async function getComponentsWithOptionToUntag(consumer: Consumer, version?: string): Promise<ModelComponent[]> {
+export async function getComponentsWithOptionToUntag(consumer: Consumer, version?: string): Promise<ModelComponent[]> {
   const componentList = new ComponentsList(consumer);
   const laneObj = await consumer.getCurrentLaneObject();
   const components: ModelComponent[] = await componentList.listExportPendingComponents(laneObj);


### PR DESCRIPTION
Because this command reverts also snaps, not only tags, the name `reset` is more accurate. 
Also, added a new API to be able to untag/unsnap using the Snapping aspect.