### PR TITLE
improvement: rename "circular dependencies" insight to "circular"

### DIFF
--- a/scopes/component/component-issues/circular-dependencies.ts
+++ b/scopes/component/component-issues/circular-dependencies.ts
@@ -2,7 +2,7 @@ import { ComponentIssue, formatTitle } from './component-issue';
 
 export class CircularDependencies extends ComponentIssue {
   description = 'circular dependencies';
-  solution = 'run `bit insights "circular dependencies"` to get the component-ids participating in the circular';
+  solution = 'run `bit insights "circular"` to get the component-ids participating in the circular';
   data: boolean;
   isTagBlocker = true;
   outputForCLI() {

--- a/scopes/explorer/insights/all-insights/find-circulars.ts
+++ b/scopes/explorer/insights/all-insights/find-circulars.ts
@@ -4,7 +4,7 @@ import { GraphBuilder } from '@teambit/graph';
 import { uniq } from 'lodash';
 import { Insight, InsightResult, RawResult } from '../insight';
 
-export const INSIGHT_CIRCULAR_DEPS_NAME = 'circular dependencies';
+export const INSIGHT_CIRCULAR_DEPS_NAME = 'circular';
 
 export default class FindCycles implements Insight {
   name = INSIGHT_CIRCULAR_DEPS_NAME;


### PR DESCRIPTION
(asked by @ranm8 ).