### PR TITLE
improvement(bit-artifacts): shorten the out-dir path when asked for one component

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -76,7 +76,8 @@ export class ArtifactExtractor {
         )
       );
       const flattenedVinyls = vinyls.flat();
-      const compPath = path.join(outDir, id.toStringWithoutVersion());
+      // if asked for only one component, shorten the path by omitting the id
+      const compPath = artifactObjectsPerId.length > 1 ? path.join(outDir, id.toStringWithoutVersion()) : outDir;
       await Promise.all(flattenedVinyls.map((vinyl) => fs.outputFile(path.join(compPath, vinyl.path), vinyl.contents)));
     });
   }


### PR DESCRIPTION
by omitting the component-id from the path.