### PR TITLE
feat(bit-lane-merge): introduce "--pattern" and "--include-deps" flags to merge part of a lane

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -77,7 +77,7 @@ describe('merge lanes', function () {
       });
       it('should indicate that the components were not merge because they are not in the workspace', () => {
         expect(mergeOutput).to.have.string('the merge has been canceled on the following component(s)');
-        expect(mergeOutput).to.have.string('is not in the workspace');
+        expect(mergeOutput).to.have.string('not in the workspace');
       });
       it('bitmap should not save any component', () => {
         const bitMap = helper.bitMap.readComponentsMapOnly();

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -96,6 +96,9 @@ describe('merge lanes', function () {
         expect(defaultLane.components).to.have.lengthOf(0);
       });
     });
+    // in this case, the lane dev has v1 and v2 on the remote, but only v1 locally.
+    // previously, it was needed `bit lane merge` to get v2 locally.
+    // currently, it's done by `bit import` and then `bit checkout latest`.
     describe('importing a remote lane which is ahead of the local lane', () => {
       before(() => {
         helper.scopeHelper.reInitLocalScopeHarmony();
@@ -254,6 +257,53 @@ describe('merge lanes', function () {
       expect(log[0].hash).to.equal(headOnLane);
       expect(log[0].parents[0]).to.equal(headOnMain);
       expect(log[1].hash).to.equal(headOnMain);
+    });
+  });
+  describe('partial merge', () => {
+    describe('from a lane to main', () => {
+      let comp1HeadOnLane: string;
+      let comp2HeadOnLane: string;
+      let comp3HeadOnLane: string;
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+        helper.bitJsonc.setupDefault();
+        helper.fixtures.populateComponents(3);
+        helper.command.tagAllWithoutBuild();
+        helper.command.export();
+        helper.command.createLane();
+        helper.fixtures.populateComponents(3, undefined, 'v2');
+        helper.command.snapAllComponentsWithoutBuild();
+        comp1HeadOnLane = helper.command.getHeadOfLane('dev', 'comp1');
+        comp2HeadOnLane = helper.command.getHeadOfLane('dev', 'comp2');
+        comp3HeadOnLane = helper.command.getHeadOfLane('dev', 'comp3');
+        helper.command.export();
+        helper.command.switchLocalLane('main');
+      });
+      describe('without --include-deps', () => {
+        it('should throw an error asking to enter --include-deps flag', () => {
+          const mergeFn = () => helper.command.mergeLane('dev', `--pattern ${helper.scopes.remote}/comp2`);
+          expect(mergeFn).to.throw(
+            'it has the following dependencies which were not included in the pattern. consider adding "--include-deps" flag'
+          );
+        });
+      });
+      describe('with --include-deps', () => {
+        before(() => {
+          helper.command.mergeLane('dev', `--pattern ${helper.scopes.remote}/comp2 --include-deps`);
+        });
+        it('should not merge components that were not part of the patterns nor part of the pattern dependencies', () => {
+          const comp1Head = helper.command.getHead(`${helper.scopes.remote}/comp1`);
+          expect(comp1Head).to.not.equal(comp1HeadOnLane);
+        });
+        it('should merge components that merge the pattern', () => {
+          const comp2Head = helper.command.getHead(`${helper.scopes.remote}/comp2`);
+          expect(comp2Head).to.equal(comp2HeadOnLane);
+        });
+        it('should merge components that are dependencies of the given pattern', () => {
+          const comp3Head = helper.command.getHead(`${helper.scopes.remote}/comp3`);
+          expect(comp3Head).to.equal(comp3HeadOnLane);
+        });
+      });
     });
   });
 });

--- a/scopes/component/merging/index.ts
+++ b/scopes/component/merging/index.ts
@@ -1,6 +1,6 @@
 import { MergingAspect } from './merging.aspect';
 
 export { mergeReport } from './merge-cmd';
-export type { MergingMain, ComponentStatus } from './merging.main.runtime';
+export type { MergingMain, ComponentMergeStatus } from './merging.main.runtime';
 export default MergingAspect;
 export { MergingAspect };

--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -132,12 +132,12 @@ export function mergeReport({ components, failedComponents, version, mergeSnapRe
     if (!failedComponents || !failedComponents.length) return '';
     const title = 'the merge has been canceled on the following component(s)';
     const body = failedComponents
-      .map(
-        (failedComponent) =>
-          `${chalk.bold(failedComponent.id.toString())} - ${chalk.red(failedComponent.failureMessage)}`
-      )
+      .map((failedComponent) => {
+        const color = failedComponent.unchangedLegitimately ? 'white' : 'red';
+        return `${chalk.bold(failedComponent.id.toString())} - ${chalk[color](failedComponent.failureMessage)}`;
+      })
       .join('\n');
-    return `${chalk.underline(title)}\n${body}\n\n`;
+    return `\n${chalk.underline(title)}\n${body}\n\n`;
   };
 
   return getSuccessOutput() + getFailureOutput() + getSnapsOutput();

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -31,6 +31,7 @@ import { getDivergeData } from '@teambit/legacy/dist/scope/component-ops/get-div
 import { UnmergedComponent } from '@teambit/legacy/dist/scope/lanes/unmerged-components';
 import { Lane, Version } from '@teambit/legacy/dist/scope/models';
 import { Ref } from '@teambit/legacy/dist/scope/objects';
+import chalk from 'chalk';
 import { Tmp } from '@teambit/legacy/dist/scope/repositories';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 import ManyComponentsWriter from '@teambit/legacy/dist/consumer/component-ops/many-components-writer';
@@ -43,12 +44,12 @@ import { DivergeData } from '@teambit/legacy/dist/scope/component-ops/diverge-da
 import { MergeCmd } from './merge-cmd';
 import { MergingAspect } from './merging.aspect';
 
-export type ComponentStatus = {
+export type ComponentMergeStatus = {
   componentFromFS?: Component | null;
   componentFromModel?: Version;
   id: BitId;
-  failureMessage?: string;
-  unchangedLegitimately?: boolean; // failed to merge but for a legitimate reason, such as, up-to-date
+  unmergedMessage?: string;
+  unmergedLegitimately?: boolean; // failed to merge but for a legitimate reason, such as, up-to-date
   mergeResults?: MergeResultsThreeWay | null;
   divergeData?: DivergeData;
 };
@@ -113,6 +114,16 @@ export class MergingMain {
     const currentLaneId = consumer.getCurrentLaneId();
     const currentLaneObject = await consumer.getCurrentLaneObject();
     const allComponentsStatus = await this.getAllComponentsStatus(bitIds, currentLaneId, currentLaneObject);
+    const failedComponents = allComponentsStatus.filter((c) => c.unmergedMessage && !c.unmergedLegitimately);
+    if (failedComponents.length) {
+      const failureMsgs = failedComponents
+        .map(
+          (failedComponent) =>
+            `${chalk.bold(failedComponent.id.toString())} - ${chalk.red(failedComponent.unmergedMessage as string)}`
+        )
+        .join('\n');
+      throw new BitError(`unable to merge due to the following failures:\n${failureMsgs}`);
+    }
 
     return this.mergeSnaps({
       mergeStrategy,
@@ -140,7 +151,7 @@ export class MergingMain {
     build,
   }: {
     mergeStrategy: MergeStrategy;
-    allComponentsStatus: ComponentStatus[];
+    allComponentsStatus: ComponentMergeStatus[];
     remoteName: string | null;
     laneId: LaneId;
     localLane: Lane | null;
@@ -156,13 +167,13 @@ export class MergingMain {
       mergeStrategy = await getMergeStrategyInteractive();
     }
     const failedComponents: FailedComponents[] = allComponentsStatus
-      .filter((componentStatus) => componentStatus.failureMessage)
+      .filter((componentStatus) => componentStatus.unmergedMessage)
       .map((componentStatus) => ({
         id: componentStatus.id,
-        failureMessage: componentStatus.failureMessage as string,
-        unchangedLegitimately: componentStatus.unchangedLegitimately,
+        failureMessage: componentStatus.unmergedMessage as string,
+        unchangedLegitimately: componentStatus.unmergedLegitimately,
       }));
-    const succeededComponents = allComponentsStatus.filter((componentStatus) => !componentStatus.failureMessage);
+    const succeededComponents = allComponentsStatus.filter((componentStatus) => !componentStatus.unmergedMessage);
     // do not use Promise.all for applyVersion. otherwise, it'll write all components in parallel,
     // which can be an issue when some components are also dependencies of others
     const componentsResults = await mapSeries(succeededComponents, async ({ componentFromFS, id, mergeResults }) => {
@@ -191,28 +202,38 @@ export class MergingMain {
     return { components: componentsResults, failedComponents, mergeSnapResults };
   }
 
+  /**
+   * this function gets called from two different commands:
+   * 1. "bit merge <ids...>", when merging a component from a remote to the local.
+   * in this case, the remote and local are on the same lane or both on main.
+   * 2. "bit lane merge", when merging from one lane to another.
+   * @param id
+   * @param localLane
+   * @param otherLaneName
+   * @param existingOnWorkspaceOnly
+   * @returns
+   */
   async getComponentMergeStatus(
-    id: BitId,
-    localLane: Lane | null,
-    otherLaneName: string,
-    existingOnWorkspaceOnly = false
-  ): Promise<ComponentStatus> {
+    id: BitId, // the id.version is the version we want to merge to the current component
+    localLane: Lane | null, // currently checked out lane. if on main, then it's null.
+    otherLaneName: string // the lane name we want to merged to our lane. (can be also "main").
+  ): Promise<ComponentMergeStatus> {
     const consumer = this.workspace.consumer;
-    const componentStatus: ComponentStatus = { id };
-    const returnFailure = (msg: string, unchangedLegitimately = false) => {
-      componentStatus.failureMessage = msg;
-      componentStatus.unchangedLegitimately = unchangedLegitimately;
+    const componentStatus: ComponentMergeStatus = { id };
+    const returnUnmerged = (msg: string, unmergedLegitimately = false) => {
+      componentStatus.unmergedMessage = msg;
+      componentStatus.unmergedLegitimately = unmergedLegitimately;
       return componentStatus;
     };
     const modelComponent = await consumer.scope.getModelComponentIfExist(id);
     if (!modelComponent) {
-      throw new GeneralError(
-        `component ${id.toString()} is on the lane but its objects were not found, please re-import the lane`
+      return returnUnmerged(
+        `component ${id.toString()} is on the lane/main but its objects were not found, please re-import the lane`
       );
     }
     const unmerged = consumer.scope.objects.unmergedComponents.getEntry(id.name);
     if (unmerged && unmerged.resolved === false) {
-      return returnFailure(
+      return returnUnmerged(
         `component ${id.toStringWithoutVersion()} has conflicts that need to be resolved first, please use bit merge --resolve/--abort`
       );
     }
@@ -220,9 +241,6 @@ export class MergingMain {
     const existingBitMapId = consumer.bitMap.getBitIdIfExist(id, { ignoreVersion: true });
     const existOnCurrentLane = existingBitMapId && consumer.bitMap.isIdAvailableOnCurrentLane(existingBitMapId);
     const componentOnLane: Version = await modelComponent.loadVersion(version, consumer.scope.objects);
-    if (!existingBitMapId && existingOnWorkspaceOnly) {
-      return returnFailure(`component ${id.toStringWithoutVersion()} is not in the workspace`);
-    }
     if (!existingBitMapId || !existOnCurrentLane) {
       return { componentFromFS: null, componentFromModel: componentOnLane, id, mergeResults: null };
     }
@@ -230,13 +248,13 @@ export class MergingMain {
     if (currentlyUsedVersion === version) {
       // @todo: maybe this check is not needed as we check for diverge later on
       if (localLane || modelComponent.hasHead()) {
-        return returnFailure(`component ${id.toStringWithoutVersion()} is already merged`, true);
+        return returnUnmerged(`component ${id.toStringWithoutVersion()} is already merged`, true);
       }
     }
     const component = await consumer.loadComponent(existingBitMapId);
     const componentModificationStatus = await consumer.getComponentStatusById(component.id);
     if (componentModificationStatus.modified) {
-      throw new GeneralError(
+      return returnUnmerged(
         `unable to merge ${id.toStringWithoutVersion()}, the component is modified, please snap/tag it first`
       );
     }
@@ -253,7 +271,7 @@ export class MergingMain {
     if (!divergeData.isDiverged()) {
       if (divergeData.isLocalAhead()) {
         // do nothing!
-        return returnFailure(`component ${component.id.toString()} is ahead, nothing to merge`, true);
+        return returnUnmerged(`component ${component.id.toString()} is ahead, nothing to merge`, true);
       }
       if (divergeData.isRemoteAhead()) {
         // just override with the model data
@@ -266,7 +284,7 @@ export class MergingMain {
         };
       }
       // we know that localHead and remoteHead are set, so if none of them is ahead they must be equal
-      return returnFailure(`component ${component.id.toString()} is already merged`, true);
+      return returnUnmerged(`component ${component.id.toString()} is already merged`, true);
     }
     const baseSnap = divergeData.commonSnapBeforeDiverge as Ref; // must be set when isTrueMerge
     const baseComponent: Version = await modelComponent.loadVersion(baseSnap.toString(), repo);
@@ -439,7 +457,7 @@ export class MergingMain {
     bitIds: BitId[],
     laneId: LaneId,
     localLaneObject: Lane | null
-  ): Promise<ComponentStatus[]> {
+  ): Promise<ComponentMergeStatus[]> {
     const tmp = new Tmp(this.consumer.scope);
     try {
       const componentsStatus = await Promise.all(

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -277,7 +277,13 @@ export class LaneMergeCmd implements Command {
     ['', 'build', 'in case of snap during the merge, run the build-pipeline (similar to bit snap --build)'],
     ['m', 'message <message>', 'override the default message for the auto snap'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
-    ['', 'squash', 'squash multiple snaps. keep the last one only'],
+    ['', 'squash', 'EXPERIMENTAL. squash multiple snaps. keep the last one only'],
+    ['', 'pattern <component-pattern>', 'EXPERIMENTAL. partially merge the lane with the specified component-pattern'],
+    [
+      '',
+      'include-deps',
+      'EXPERIMENTAL. relevant for "--pattern" and "--existing". merge also dependencies of the given components',
+    ],
   ] as CommandOptions;
   loader = true;
   private = true;
@@ -299,6 +305,8 @@ export class LaneMergeCmd implements Command {
       message: snapMessage = '',
       keepReadme = false,
       squash = false,
+      pattern,
+      includeDeps = false,
     }: {
       ours: boolean;
       theirs: boolean;
@@ -310,12 +318,16 @@ export class LaneMergeCmd implements Command {
       message: string;
       keepReadme?: boolean;
       squash: boolean;
+      pattern?: string;
+      includeDeps?: boolean;
     }
   ): Promise<string> {
     build = isFeatureEnabled(BUILD_ON_CI) ? Boolean(build) : true;
     const mergeStrategy = getMergeStrategy(ours, theirs, manual);
     if (noSnap && snapMessage) throw new BitError('unable to use "noSnap" and "message" flags together');
-
+    if (includeDeps && !pattern && !existingOnWorkspaceOnly) {
+      throw new BitError(`"--include-deps" flag is relevant only for --existing and --pattern flags`);
+    }
     const { mergeResults, deleteResults } = await this.lanes.mergeLane(name, {
       // @ts-ignore
       remoteName,
@@ -327,6 +339,8 @@ export class LaneMergeCmd implements Command {
       snapMessage,
       keepReadme,
       squash,
+      pattern,
+      includeDeps,
     });
 
     const mergeResult = `${mergeReport(mergeResults)}`;

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -64,6 +64,8 @@ export type MergeLaneOptions = {
   build: boolean;
   keepReadme: boolean;
   squash: boolean;
+  pattern?: string;
+  includeDeps?: boolean;
 };
 
 export type CreateLaneOptions = {
@@ -337,7 +339,7 @@ export class LanesMain {
     }
     const results = await mergeLanes({
       merging: this.merging,
-      consumer: this.workspace.consumer,
+      workspace: this.workspace,
       laneName,
       ...options,
     });

--- a/scopes/lanes/lanes/merge-lanes.ts
+++ b/scopes/lanes/lanes/merge-lanes.ts
@@ -5,6 +5,7 @@ import pMapSeries from 'p-map-series';
 import { Consumer } from '@teambit/legacy/dist/consumer';
 import { ApplyVersionResults } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
+import { ComponentID } from '@teambit/component-id';
 import { Workspace } from '@teambit/workspace';
 import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { Lane } from '@teambit/legacy/dist/scope/models';
@@ -12,7 +13,6 @@ import { Tmp } from '@teambit/legacy/dist/scope/repositories';
 import { MergingMain, ComponentMergeStatus } from '@teambit/merging';
 import { remove } from '@teambit/legacy/dist/api/consumer';
 import { MergeLaneOptions } from './lanes.main.runtime';
-import { ComponentID } from '@teambit/component-id';
 
 export async function mergeLanes({
   merging,
@@ -141,7 +141,7 @@ export async function mergeLanes({
     const tmp = new Tmp(consumer.scope);
     try {
       const componentsStatus = await Promise.all(
-        bitIds.map((bitId) => merging.getComponentMergeStatus(bitId, localLane, otherLaneName, existingOnWorkspaceOnly))
+        bitIds.map((bitId) => merging.getComponentMergeStatus(bitId, localLane, otherLaneName))
       );
       await tmp.clear();
       return componentsStatus;

--- a/src/cli/commands/public-cmds/dependencies-cmd.ts
+++ b/src/cli/commands/public-cmds/dependencies-cmd.ts
@@ -80,10 +80,10 @@ try running "bit cat-component ${results.id.toStringWithoutVersion()}" to see wh
 
     const scopeTable = generateDependenciesInfoTable(scopeGraph, results.id);
     const workspaceTable = generateDependenciesInfoTable(workspaceGraph, results.id);
-    return `${chalk.bold('Dependents originated from workspace')}
+    return `${chalk.bold('Dependencies originated from workspace')}
 ${workspaceTable || '<none>'}
 
-${chalk.bold('Dependents originated from scope')}
+${chalk.bold('Dependencies originated from scope')}
 ${scopeTable || '<none>'}`;
   }
 }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -177,6 +177,9 @@ export default class Consumer {
     return this.scope.lanes.getCurrentLaneId();
   }
 
+  /**
+   * the name can be a full lane-id or only the lane-name, which can be the alias (local-lane) or the remote-name.
+   */
   async getParsedLaneId(name: string): Promise<LaneId> {
     return this.scope.lanes.parseLaneIdFromString(name);
   }


### PR DESCRIPTION
introduce `--pattern` to merge some of the components from the lane.
If these components have dependencies in the lane that are not part of the pattern, it'll throw an error suggesting to enter `--include-deps` flag which merge also the dependencies.