### PR TITLE
don't wait for non-js assets to load the preview

### DIFF
--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -157,7 +157,13 @@ export class PreviewPreview {
     if (previewBundleFileName.endsWith('.js')) {
       return this.addComponentFileScriptElement(id, previewBundleFileName);
     }
-    return this.addComponentFileLinkElement(id, previewBundleFileName);
+
+    // TODO - should we load assets other than .css / .js?
+    // if (previewBundleFileName.endsWith('.css')) {
+    this.addComponentFileLinkElement(id, previewBundleFileName).catch((err) => {
+      console.error('[preview.preview]', 'failed loading asset', previewBundleFileName, err);
+    });
+    return undefined;
   }
 
   private async fetchComponentPreviewFiles(id: ComponentID, previewName: string): Promise<string[] | null> {


### PR DESCRIPTION
## Proposed Changes

resolves #6080 
- only await js files, when loading component assets for preview
