### PR TITLE
fix: update husky

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npm run lint-staged

--- a/package.json
+++ b/package.json
@@ -13,11 +13,6 @@
   "engines": {
     "node": ">=12.22.0"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
     "*.{ts,js,jsx,tsx,css,scss,md,mdx}": [
       "prettier --write",
@@ -78,10 +73,10 @@
     "build:types:windows": ".\\scripts\\build-types.bat",
     "link-bit-legacy": "node ./scripts/link-bit-legacy.js",
     "setup": "bit install &&  bit compile && npm run build && npm run build:types && npm run link-bit-legacy",
-    "full-setup": "rm -rf node_modules/.bin/bit && rm -rf node_modules/@teambit/legacy && bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types",
-    "full-setup:bbit": "rm -rf node_modules/.bin/bbit && rm -rf node_modules/@teambit/legacy && bbit install && npm run link-bit-legacy && bbit compile && npm run build && npm run build:types",
-    "full-setup:windows": "bit install && npm run link-bit-legacy && bit compile && npm run build && npm run build:types:windows",
-    "full-setup:windows:bbit": "bbit install && npm run link-bit-legacy && bbit compile && npm run build && npm run build:types:windows",
+    "full-setup": "rm -rf node_modules/.bin/bit && rm -rf node_modules/@teambit/legacy && bit install && npm run link-bit-legacy && husky install && bit compile && npm run build && npm run build:types",
+    "full-setup:bbit": "rm -rf node_modules/.bin/bbit && rm -rf node_modules/@teambit/legacy && bbit install && npm run link-bit-legacy && husky install && bbit compile && npm run build && npm run build:types",
+    "full-setup:windows": "bit install && npm run link-bit-legacy && husky install && bit compile && npm run build && npm run build:types:windows",
+    "full-setup:windows:bbit": "bbit install && npm run link-bit-legacy && husky install && bbit compile && npm run build && npm run build:types:windows",
     "build-centos-image": "docker build ./scripts/linux/centos -t centos-rpm",
     "build-debian-image": "docker build ./scripts/linux/debian -t debian-deb",
     "doc-gen": "node ./scripts/doc-generator.js",
@@ -108,7 +103,8 @@
     "build:pjson": "cp package.json dist/",
     "build:src": "babel src -d dist --verbose --extensions \".ts,.tsx,.js\" --copy-files",
     "generate-cli-reference": "bit cli generate > scopes/harmony/cli-reference/cli-reference.mdx && prettier scopes/harmony/cli-reference/cli-reference.mdx --write",
-    "generate-cli-reference-json": "bit cli generate --json > scopes/harmony/cli-reference/cli-reference.json"
+    "generate-cli-reference-json": "bit cli generate --json > scopes/harmony/cli-reference/cli-reference.json",
+    "lint-staged": "lint-staged"
   },
   "dependencies": {
     "@teambit/toolbox.network.agent": "0.0.116",
@@ -283,7 +279,7 @@
     "eslint-plugin-react-hooks": "4.2.0",
     "eslint-plugin-simple-import-sort": "5.0.3",
     "gh-release": "3.5.0",
-    "husky": "4.3.8",
+    "husky": "7.0.4",
     "lint-staged": "^12.5.0",
     "mocha": "9.2.0",
     "mocha-circleci-reporter": "0.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,8 +173,7 @@ importers:
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/graphql.hooks.use-query-light': 1.0.0
       '@teambit/harmony': 0.3.3
-      '@teambit/legacy': 1.0.297
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368
+      '@teambit/legacy': 1.0.298
       '@teambit/pkg.content.packages-overview': 1.95.9
       '@teambit/react.content.react-overview': 1.95.0
       '@teambit/react.instructions.react-native.adding-tests': 0.0.1
@@ -199,7 +198,7 @@ importers:
       '@types/chai-fs': 2.0.2
       '@types/chai-string': 1.4.2
       '@types/classnames': 2.2.11
-      '@types/cli-table': ^0.3.0
+      '@types/cli-table': '>=0.3.0 <0.4.0'
       '@types/cors': 2.8.10
       '@types/dagre': 0.7.44
       '@types/didyoumean': 1.2.0
@@ -231,7 +230,7 @@ importers:
       '@types/pluralize': 0.0.29
       '@types/postcss-normalize': 9.0.1
       '@types/prettier': 2.3.2
-      '@types/react': '>=17.0.8 <18.0.0'
+      '@types/react': 17.0.8
       '@types/react-dev-utils': 9.0.10
       '@types/react-dom': '>=17.0.5 <18.0.0'
       '@types/react-tabs': 2.3.2
@@ -380,7 +379,7 @@ importers:
       https-proxy-agent: 5.0.0
       humanize-duration: 3.23.1
       humanize-string: 2.1.0
-      husky: 4.3.8
+      husky: 7.0.4
       identity-obj-proxy: 3.0.0
       ignore: 3.3.10
       ini: 2.0.0
@@ -700,10 +699,10 @@ importers:
       '@teambit/base-ui.utils.sub-paths': registry.npmjs.org/@teambit/base-ui.utils.sub-paths/1.0.0_react-dom@17.0.2+react@17.0.2
       '@teambit/base-ui.utils.time-ago': registry.npmjs.org/@teambit/base-ui.utils.time-ago/1.0.1_react-dom@17.0.2+react@17.0.2
       '@teambit/bvm.config': registry.npmjs.org/@teambit/bvm.config/0.0.26
-      '@teambit/bvm.list': registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.297
+      '@teambit/bvm.list': registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.298
       '@teambit/capsule': registry.npmjs.org/@teambit/capsule/0.0.12
       '@teambit/component-version': link:scopes/component/component-version
-      '@teambit/component.instructions.exporting-components': registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component.instructions.exporting-components': registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6_0411e9e030dc74716c213f46c459e2d9
       '@teambit/design.elements.icon': registry.npmjs.org/@teambit/design.elements.icon/1.0.5_react-dom@17.0.2+react@17.0.2
       '@teambit/design.inputs.dropdown': registry.npmjs.org/@teambit/design.inputs.dropdown/0.0.7_react-dom@17.0.2+react@17.0.2
       '@teambit/design.inputs.selectors.multi-select': registry.npmjs.org/@teambit/design.inputs.selectors.multi-select/0.0.20_react-dom@17.0.2+react@17.0.2
@@ -757,66 +756,31 @@ importers:
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/graphql.hooks.use-query-light': 1.0.0_6e9344d803266e4097ebffffc8f3d95e
       '@teambit/harmony': registry.npmjs.org/@teambit/harmony/0.3.3
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/react.instructions.react-native.adding-tests': 0.0.1_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/react.instructions.react-native.adding-tests': 0.0.1_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6_0411e9e030dc74716c213f46c459e2d9
       '@teambit/react.modules.dom-to-react': registry.npmjs.org/@teambit/react.modules.dom-to-react/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
       '@teambit/react.ui.component-highlighter': registry.npmjs.org/@teambit/react.ui.component-highlighter/0.1.0_e5ba80cae8cf09ec7a8002d74eca577e
       '@teambit/react.ui.hover-selector': registry.npmjs.org/@teambit/react.ui.hover-selector/0.1.0_2bb1c2f6941b337f5f9ecab4a31ade6a
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.297
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.298
       '@teambit/ui-foundation.ui.navigation.react-router-adapter': 6.1.1_019772ce6ce6aea5f9d386ae25f28ea0
       '@testing-library/jest-dom': registry.npmjs.org/@testing-library/jest-dom/5.16.2
       '@testing-library/jest-native': registry.npmjs.org/@testing-library/jest-native/4.0.4
       '@tippyjs/react': registry.npmjs.org/@tippyjs/react/4.2.0_react-dom@17.0.2+react@17.0.2
       '@types/bluebird': registry.npmjs.org/@types/bluebird/3.5.33
-      '@types/cacache': registry.npmjs.org/@types/cacache/12.0.1
-      '@types/chai': registry.npmjs.org/@types/chai/4.2.15
       '@types/chai-arrays': registry.npmjs.org/@types/chai-arrays/1.0.3
       '@types/chai-fs': registry.npmjs.org/@types/chai-fs/2.0.2
       '@types/chai-string': registry.npmjs.org/@types/chai-string/1.4.2
-      '@types/classnames': registry.npmjs.org/@types/classnames/2.2.11
-      '@types/cli-table': registry.npmjs.org/@types/cli-table/0.3.0
-      '@types/cors': registry.npmjs.org/@types/cors/2.8.10
-      '@types/dagre': registry.npmjs.org/@types/dagre/0.7.44
-      '@types/didyoumean': registry.npmjs.org/@types/didyoumean/1.2.0
-      '@types/express': registry.npmjs.org/@types/express/4.17.13
-      '@types/find-root': registry.npmjs.org/@types/find-root/1.1.2
-      '@types/fs-extra': registry.npmjs.org/@types/fs-extra/9.0.7
       '@types/graphlib': registry.npmjs.org/@types/graphlib/2.1.7
       '@types/http-proxy-agent': registry.npmjs.org/@types/http-proxy-agent/2.0.2
       '@types/json-schema': registry.npmjs.org/@types/json-schema/7.0.9
-      '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-      '@types/lodash.compact': registry.npmjs.org/@types/lodash.compact/3.0.6
-      '@types/lodash.flatten': registry.npmjs.org/@types/lodash.flatten/4.4.6
-      '@types/lodash.head': registry.npmjs.org/@types/lodash.head/4.0.6
-      '@types/lodash.orderby': registry.npmjs.org/@types/lodash.orderby/4.6.6
-      '@types/lodash.pick': registry.npmjs.org/@types/lodash.pick/4.4.6
-      '@types/mdx-js__react': registry.npmjs.org/@types/mdx-js__react/1.5.5
-      '@types/memoizee': registry.npmjs.org/@types/memoizee/0.4.5
-      '@types/mime': registry.npmjs.org/@types/mime/2.0.3
-      '@types/mini-css-extract-plugin': registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28
-      '@types/minimatch': registry.npmjs.org/@types/minimatch/3.0.4
-      '@types/mousetrap': registry.npmjs.org/@types/mousetrap/1.6.5
-      '@types/node-fetch': registry.npmjs.org/@types/node-fetch/2.5.12
-      '@types/object-hash': registry.npmjs.org/@types/object-hash/1.3.4
       '@types/pino': registry.npmjs.org/@types/pino/6.3.6
-      '@types/pluralize': registry.npmjs.org/@types/pluralize/0.0.29
-      '@types/prettier': registry.npmjs.org/@types/prettier/2.3.2
-      '@types/react-dev-utils': registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2
-      '@types/react-tabs': registry.npmjs.org/@types/react-tabs/2.3.2
       '@types/react-tooltip': registry.npmjs.org/@types/react-tooltip/3.11.0
       '@types/sass': registry.npmjs.org/@types/sass/1.16.0
-      '@types/semver': registry.npmjs.org/@types/semver/7.3.4
       '@types/socket.io-client': registry.npmjs.org/@types/socket.io-client/1.4.35
-      '@types/ua-parser-js': registry.npmjs.org/@types/ua-parser-js/0.7.35
       '@types/url-join': registry.npmjs.org/@types/url-join/4.0.0
       '@types/url-parse': registry.npmjs.org/@types/url-parse/1.4.3
-      '@types/uuid': registry.npmjs.org/@types/uuid/8.3.4
-      '@types/webpack': registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28
-      '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1
-      '@types/yargs': registry.npmjs.org/@types/yargs/17.0.0
       '@typescript-eslint/eslint-plugin': registry.npmjs.org/@typescript-eslint/eslint-plugin/4.30.0_8a8a2d3eaa9257455a03c16dce5f55b3
       '@typescript-eslint/parser': registry.npmjs.org/@typescript-eslint/parser/4.30.0_eslint@7.32.0+typescript@4.4.2
       '@typescript-eslint/typescript-estree': registry.npmjs.org/@typescript-eslint/typescript-estree/4.30.0_typescript@4.4.2
@@ -949,7 +913,7 @@ importers:
       https-proxy-agent: registry.npmjs.org/https-proxy-agent/5.0.0
       humanize-duration: registry.npmjs.org/humanize-duration/3.23.1
       humanize-string: registry.npmjs.org/humanize-string/2.1.0
-      husky: registry.npmjs.org/husky/4.3.8
+      husky: registry.npmjs.org/husky/7.0.4
       identity-obj-proxy: registry.npmjs.org/identity-obj-proxy/3.0.0
       ignore: registry.npmjs.org/ignore/3.3.10
       ini: registry.npmjs.org/ini/2.0.0
@@ -1168,32 +1132,66 @@ importers:
       yargs: registry.npmjs.org/yargs/17.0.1
       yn: registry.npmjs.org/yn/2.0.0
     devDependencies:
-      '@teambit/bit.content.what-is-bit': 1.96.2_8300323ebd5a026f85e3cef9b6d3860f
+      '@teambit/bit.content.what-is-bit': 1.96.2_60905eb2c2a4a2f46664b048e7e1d9dd
       '@teambit/code.ui.object-formatter': 0.0.1_react@17.0.2
-      '@teambit/compilation.content.compiler-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/component.content.component-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/component.content.dev-files': 1.95.9_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/defender.content.formatter-overview': 1.96.1_0a43466038c32317ef5df0c69fcd0d50
-      '@teambit/defender.content.linter-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/defender.content.tester-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/compilation.content.compiler-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/component.content.component-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/component.content.dev-files': 1.95.9_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/defender.content.formatter-overview': 1.96.1_18435c9ed3991821240607706d724c7b
+      '@teambit/defender.content.linter-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/defender.content.tester-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
       '@teambit/design.ui.brand.logo': 1.96.2_150be2d4515131e54e0531e15473f3a8
-      '@teambit/docs.content.docs-overview': 1.95.9_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/docs.content.docs-overview': 1.95.9_0411e9e030dc74716c213f46c459e2d9
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions/4.1.1_react-dom@17.0.2+react@17.0.2
       '@teambit/documenter.ui.paragraph': registry.npmjs.org/@teambit/documenter.ui.paragraph/4.1.1_react-dom@17.0.2+react@17.0.2
-      '@teambit/pkg.content.packages-overview': 1.95.9_0a43466038c32317ef5df0c69fcd0d50
-      '@teambit/react.content.react-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/scope.content.scope-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/workspace.content.variants': 1.95.9_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/workspace.content.workspace-overview': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/pkg.content.packages-overview': 1.95.9_18435c9ed3991821240607706d724c7b
+      '@teambit/react.content.react-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/scope.content.scope-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/workspace.content.variants': 1.95.9_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/workspace.content.workspace-overview': 1.95.0_0411e9e030dc74716c213f46c459e2d9
       '@testing-library/react': registry.npmjs.org/@testing-library/react/12.1.5_react-dom@17.0.2+react@17.0.2
+      '@types/cacache': registry.npmjs.org/@types/cacache/12.0.1
+      '@types/chai': registry.npmjs.org/@types/chai/4.2.15
+      '@types/classnames': registry.npmjs.org/@types/classnames/2.2.11
+      '@types/cli-table': registry.npmjs.org/@types/cli-table/0.3.0
+      '@types/cors': registry.npmjs.org/@types/cors/2.8.10
+      '@types/dagre': registry.npmjs.org/@types/dagre/0.7.44
+      '@types/didyoumean': registry.npmjs.org/@types/didyoumean/1.2.0
       '@types/eslint': registry.npmjs.org/@types/eslint/7.28.0
+      '@types/express': registry.npmjs.org/@types/express/4.17.13
+      '@types/find-root': registry.npmjs.org/@types/find-root/1.1.2
+      '@types/fs-extra': registry.npmjs.org/@types/fs-extra/9.0.7
       '@types/jest': registry.npmjs.org/@types/jest/26.0.20
+      '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
+      '@types/lodash.compact': registry.npmjs.org/@types/lodash.compact/3.0.6
+      '@types/lodash.flatten': registry.npmjs.org/@types/lodash.flatten/4.4.6
+      '@types/lodash.head': registry.npmjs.org/@types/lodash.head/4.0.6
+      '@types/lodash.orderby': registry.npmjs.org/@types/lodash.orderby/4.6.6
+      '@types/lodash.pick': registry.npmjs.org/@types/lodash.pick/4.4.6
+      '@types/mdx-js__react': registry.npmjs.org/@types/mdx-js__react/1.5.5
+      '@types/memoizee': registry.npmjs.org/@types/memoizee/0.4.5
+      '@types/mime': registry.npmjs.org/@types/mime/2.0.3
+      '@types/mini-css-extract-plugin': registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28
+      '@types/minimatch': registry.npmjs.org/@types/minimatch/3.0.4
       '@types/mocha': registry.npmjs.org/@types/mocha/9.1.0
+      '@types/mousetrap': registry.npmjs.org/@types/mousetrap/1.6.5
       '@types/node': registry.npmjs.org/@types/node/12.20.4
+      '@types/node-fetch': registry.npmjs.org/@types/node-fetch/2.5.12
+      '@types/object-hash': registry.npmjs.org/@types/object-hash/1.3.4
+      '@types/pluralize': registry.npmjs.org/@types/pluralize/0.0.29
       '@types/postcss-normalize': registry.npmjs.org/@types/postcss-normalize/9.0.1
+      '@types/prettier': registry.npmjs.org/@types/prettier/2.3.2
       '@types/react': registry.npmjs.org/@types/react/17.0.8
+      '@types/react-dev-utils': registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2
       '@types/react-dom': registry.npmjs.org/@types/react-dom/17.0.17
+      '@types/react-tabs': registry.npmjs.org/@types/react-tabs/2.3.2
+      '@types/semver': registry.npmjs.org/@types/semver/7.3.4
       '@types/testing-library__jest-dom': registry.npmjs.org/@types/testing-library__jest-dom/5.9.5
+      '@types/ua-parser-js': registry.npmjs.org/@types/ua-parser-js/0.7.35
+      '@types/uuid': registry.npmjs.org/@types/uuid/8.3.4
+      '@types/webpack': registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28
+      '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1
+      '@types/yargs': registry.npmjs.org/@types/yargs/17.0.0
       chai: registry.npmjs.org/chai/4.3.0
       react-test-renderer: registry.npmjs.org/react-test-renderer/17.0.2_react@17.0.2
 
@@ -1788,6 +1786,9 @@ importers:
   scopes/react/react-native:
     specifiers: {}
 
+  scopes/react/ui/compositions-app:
+    specifiers: {}
+
   scopes/react/ui/docs-app:
     specifiers: {}
 
@@ -2182,7 +2183,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  /@teambit/bit.content.what-is-bit/1.96.2_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/bit.content.what-is-bit/1.96.2_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-F6iK8JMYsiTXqPK4KiYe2lUP42k=, tarball: '@teambit/bit.content.what-is-bit/-/@teambit-bit.content.what-is-bit-1.96.2.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -2192,7 +2193,7 @@ packages:
       '@teambit/design.ui.brand.logo': 1.96.2_150be2d4515131e54e0531e15473f3a8
       '@teambit/design.ui.layouts.sections.left-right': 1.96.2_880756725f1916ba0cbce7bdeefb526a
       '@teambit/explorer.ui.gallery.component-card-group': 1.96.1_150be2d4515131e54e0531e15473f3a8
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
       - '@teambit/legacy'
@@ -2211,20 +2212,20 @@ packages:
       react: registry.npmjs.org/react/17.0.2
     dev: true
 
-  /@teambit/community.entity.graph.bubble-graph/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/community.entity.graph.bubble-graph/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: '@teambit/community.entity.graph.bubble-graph/-/@teambit-community.entity.graph.bubble-graph-1.95.0.tgz'}
     dependencies:
-      '@teambit/community.entity.graph.grid-graph': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/community.entity.graph.grid-graph': 1.95.0_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - '@teambit/legacy'
       - react
       - react-dom
     dev: true
 
-  /@teambit/community.entity.graph.grid-graph/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/community.entity.graph.grid-graph/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: '@teambit/community.entity.graph.grid-graph/-/@teambit-community.entity.graph.grid-graph-1.95.0.tgz'}
     dependencies:
-      '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.369_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.369_0411e9e030dc74716c213f46c459e2d9
       react-xarrows: registry.npmjs.org/react-xarrows/2.0.2_react@17.0.2
     transitivePeerDependencies:
       - '@teambit/legacy'
@@ -2232,14 +2233,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/compilation.content.compiler-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/compilation.content.compiler-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: '@teambit/compilation.content.compiler-overview/-/@teambit-compilation.content.compiler-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2247,16 +2248,16 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/component.content.component-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/component.content.component-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: '@teambit/component.content.component-overview/-/@teambit-component.content.component-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/community.entity.graph.bubble-graph': 1.95.0_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/community.entity.graph.bubble-graph': 1.95.0_0411e9e030dc74716c213f46c459e2d9
       '@teambit/docs.ui.zoomable-image': 1.95.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2264,28 +2265,28 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/component.content.dev-files/1.95.9_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/component.content.dev-files/1.95.9_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: '@teambit/component.content.dev-files/-/@teambit-component.content.dev-files-1.95.9.tgz'}
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - '@teambit/legacy'
       - react
       - react-dom
     dev: true
 
-  /@teambit/components.blocks.component-card-display/0.0.13_0a43466038c32317ef5df0c69fcd0d50:
+  /@teambit/components.blocks.component-card-display/0.0.13_18435c9ed3991821240607706d724c7b:
     resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: '@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.13.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
-      '@teambit/components.hooks.use-components': 0.0.11_3ac867d4d9d534866d7e9391c27ad523
-      '@teambit/explorer.plugins.env-plugin': 0.0.10_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/explorer.plugins.preview-plugin': 0.0.4_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/explorer.ui.component-card': 0.0.11_8300323ebd5a026f85e3cef9b6d3860f
-      '@teambit/explorer.ui.component-card-grid': 0.0.12_8300323ebd5a026f85e3cef9b6d3860f
+      '@teambit/components.hooks.use-components': 0.0.11_5eb98f4c603814b7794aef14f7349be8
+      '@teambit/explorer.plugins.env-plugin': 0.0.10_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/explorer.plugins.preview-plugin': 0.0.4_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/explorer.ui.component-card': 0.0.11_60905eb2c2a4a2f46664b048e7e1d9dd
+      '@teambit/explorer.ui.component-card-grid': 0.0.12_60905eb2c2a4a2f46664b048e7e1d9dd
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2296,20 +2297,20 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.blocks.component-card-display/0.0.24_0a43466038c32317ef5df0c69fcd0d50:
+  /@teambit/components.blocks.component-card-display/0.0.24_18435c9ed3991821240607706d724c7b:
     resolution: {integrity: sha1-OlVc0FyFcCB5yfe3qAG/tJbiAco=, tarball: '@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.24.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.402
-      '@teambit/components.descriptors.component-descriptor': 0.0.14_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/components.hooks.use-component-count': 0.0.7_3ac867d4d9d534866d7e9391c27ad523
-      '@teambit/components.hooks.use-components': 0.0.10_8384ba2dcf3b87b982e499ce013b8a5d
-      '@teambit/components.hooks.use-list-components': 0.0.7_3ac867d4d9d534866d7e9391c27ad523
-      '@teambit/explorer.plugins.env-plugin': 0.0.13_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/explorer.plugins.preview-plugin': 0.0.9_8300323ebd5a026f85e3cef9b6d3860f
-      '@teambit/explorer.ui.component-card': 0.0.14_8300323ebd5a026f85e3cef9b6d3860f
-      '@teambit/explorer.ui.component-card-grid': 0.0.15_8300323ebd5a026f85e3cef9b6d3860f
+      '@teambit/components.descriptors.component-descriptor': 0.0.14_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/components.hooks.use-component-count': 0.0.7_5eb98f4c603814b7794aef14f7349be8
+      '@teambit/components.hooks.use-components': 0.0.10_76ae3ff49099ad578eb72965496a55f2
+      '@teambit/components.hooks.use-list-components': 0.0.7_5eb98f4c603814b7794aef14f7349be8
+      '@teambit/explorer.plugins.env-plugin': 0.0.13_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/explorer.plugins.preview-plugin': 0.0.9_60905eb2c2a4a2f46664b048e7e1d9dd
+      '@teambit/explorer.ui.component-card': 0.0.14_60905eb2c2a4a2f46664b048e7e1d9dd
+      '@teambit/explorer.ui.component-card-grid': 0.0.15_60905eb2c2a4a2f46664b048e7e1d9dd
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2338,10 +2339,10 @@ packages:
       graphql-tag: registry.npmjs.org/graphql-tag/2.12.1_graphql@14.7.0
     dev: true
 
-  /@teambit/components.descriptors.component-descriptor/0.0.14_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/components.descriptors.component-descriptor/0.0.14_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-ZeYw+0jEa9tTCVUggXlIVFTJxaE=, tarball: '@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.14.tgz'}
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.3_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.3_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.402
       '@teambit/scopes.scope-id': 0.0.3
     transitivePeerDependencies:
@@ -2350,10 +2351,10 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.descriptors.component-descriptor/0.0.6_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/components.descriptors.component-descriptor/0.0.6_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-VoayQSccNGOoiQn0eXOQUTylk6Q=, tarball: '@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.6.tgz'}
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
       '@teambit/scopes.scope-id': 0.0.1
     transitivePeerDependencies:
@@ -2362,10 +2363,10 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.descriptors.component-descriptor/0.0.7_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/components.descriptors.component-descriptor/0.0.7_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-HkbSWB5GKqJNAMc3Eo8n3AiRkOo=, tarball: '@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.7.tgz'}
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.3_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.3_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
       '@teambit/scopes.scope-id': 0.0.1
     transitivePeerDependencies:
@@ -2374,13 +2375,13 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.hooks.use-component-count/0.0.7_3ac867d4d9d534866d7e9391c27ad523:
+  /@teambit/components.hooks.use-component-count/0.0.7_5eb98f4c603814b7794aef14f7349be8:
     resolution: {integrity: sha1-CjYLTYK0d4z4soJFrz3oU0+z81M=, tarball: '@teambit/components.hooks.use-component-count/-/@teambit-components.hooks.use-component-count-0.0.7.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/analytics.timeseries': 0.0.25_graphql@14.7.0+react@17.0.2
-      '@teambit/graphql.hooks.use-query': 0.0.7_96c41039adeadc6ae20230df509b27c6
+      '@teambit/graphql.hooks.use-query': 0.0.7_65c18445cb0815917ac3e464c0c87bd8
       core-js: registry.npmjs.org/core-js/3.23.3
       graphql-tag: registry.npmjs.org/graphql-tag/2.12.1_graphql@14.7.0
       react: registry.npmjs.org/react/17.0.2
@@ -2391,12 +2392,12 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.hooks.use-components/0.0.10_8384ba2dcf3b87b982e499ce013b8a5d:
+  /@teambit/components.hooks.use-components/0.0.10_76ae3ff49099ad578eb72965496a55f2:
     resolution: {integrity: sha1-sSRUFzKDbhghNcEX8/UteRwCjdM=, tarball: '@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.10.tgz'}
     dependencies:
       '@teambit/components.clients.components-node': 0.0.5_graphql@14.7.0
-      '@teambit/components.descriptors.component-descriptor': 0.0.6_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/graphql.hooks.use-query': 0.0.1_96c41039adeadc6ae20230df509b27c6
+      '@teambit/components.descriptors.component-descriptor': 0.0.6_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/graphql.hooks.use-query': 0.0.1_65c18445cb0815917ac3e464c0c87bd8
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
       - '@apollo/client'
@@ -2405,14 +2406,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.hooks.use-components/0.0.11_3ac867d4d9d534866d7e9391c27ad523:
+  /@teambit/components.hooks.use-components/0.0.11_5eb98f4c603814b7794aef14f7349be8:
     resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: '@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.11.tgz'}
     peerDependencies:
       react: 17.0.2
     dependencies:
       '@teambit/components.clients.components-node': 0.0.6_graphql@14.7.0
-      '@teambit/components.descriptors.component-descriptor': 0.0.7_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/graphql.hooks.use-query': 0.0.1_96c41039adeadc6ae20230df509b27c6
+      '@teambit/components.descriptors.component-descriptor': 0.0.7_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/graphql.hooks.use-query': 0.0.1_65c18445cb0815917ac3e464c0c87bd8
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
       - '@apollo/client'
@@ -2421,14 +2422,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/components.hooks.use-list-components/0.0.7_3ac867d4d9d534866d7e9391c27ad523:
+  /@teambit/components.hooks.use-list-components/0.0.7_5eb98f4c603814b7794aef14f7349be8:
     resolution: {integrity: sha1-rj+nJVVF4Wp2GAPOkzrVdAt5WKE=, tarball: '@teambit/components.hooks.use-list-components/-/@teambit-components.hooks.use-list-components-0.0.7.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/components.descriptors.component-descriptor': 0.0.14_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/components.hooks.use-component-count': 0.0.7_3ac867d4d9d534866d7e9391c27ad523
-      '@teambit/graphql.hooks.use-query': 0.0.7_96c41039adeadc6ae20230df509b27c6
+      '@teambit/components.descriptors.component-descriptor': 0.0.14_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/components.hooks.use-component-count': 0.0.7_5eb98f4c603814b7794aef14f7349be8
+      '@teambit/graphql.hooks.use-query': 0.0.7_65c18445cb0815917ac3e464c0c87bd8
       core-js: registry.npmjs.org/core-js/3.23.3
       graphql-tag: registry.npmjs.org/graphql-tag/2.12.1_graphql@14.7.0
       react: registry.npmjs.org/react/17.0.2
@@ -2439,14 +2440,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/defender.content.formatter-overview/1.96.1_0a43466038c32317ef5df0c69fcd0d50:
+  /@teambit/defender.content.formatter-overview/1.96.1_18435c9ed3991821240607706d724c7b:
     resolution: {integrity: sha1-r+8A4YQj5e9uNgpqwFhEVQ4UpoA=, tarball: '@teambit/defender.content.formatter-overview/-/@teambit-defender.content.formatter-overview-1.96.1.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/components.blocks.component-card-display': 0.0.24_0a43466038c32317ef5df0c69fcd0d50
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/components.blocks.component-card-display': 0.0.24_18435c9ed3991821240607706d724c7b
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
       - '@apollo/client'
@@ -2456,14 +2457,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/defender.content.linter-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/defender.content.linter-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: '@teambit/defender.content.linter-overview/-/@teambit-defender.content.linter-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2471,14 +2472,14 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/defender.content.tester-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/defender.content.tester-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: '@teambit/defender.content.tester-overview/-/@teambit-defender.content.tester-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2512,12 +2513,12 @@ packages:
       react: registry.npmjs.org/react/17.0.2
     dev: true
 
-  /@teambit/docs.content.docs-overview/1.95.9_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/docs.content.docs-overview/1.95.9_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: '@teambit/docs.content.docs-overview/-/@teambit-docs.content.docs-overview-1.95.9.tgz'}
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
       '@teambit/docs.ui.zoomable-image': 1.95.8_react-dom@17.0.2+react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - '@teambit/legacy'
       - react
@@ -2552,12 +2553,12 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.plugins.env-plugin/0.0.10_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/explorer.plugins.env-plugin/0.0.10_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: '@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.10.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2565,12 +2566,12 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.plugins.env-plugin/0.0.13_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/explorer.plugins.env-plugin/0.0.13_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-C1OuYM2sDr31NrxpBce2W8bIQgI=, tarball: '@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.13.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2578,12 +2579,12 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.plugins.preview-plugin/0.0.4_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/explorer.plugins.preview-plugin/0.0.4_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: '@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.4.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9
       classnames: registry.npmjs.org/classnames/2.3.1
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
@@ -2592,14 +2593,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.plugins.preview-plugin/0.0.9_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/explorer.plugins.preview-plugin/0.0.9_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: '@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz'}
     peerDependencies:
       '@testing-library/react': 12.1.3
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.46_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.46_0411e9e030dc74716c213f46c459e2d9
       '@testing-library/react': registry.npmjs.org/@testing-library/react/12.1.5_react-dom@17.0.2+react@17.0.2
       classnames: registry.npmjs.org/classnames/2.3.1
       core-js: registry.npmjs.org/core-js/3.23.3
@@ -2609,15 +2610,15 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/explorer.ui.component-card-grid/0.0.12_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/explorer.ui.component-card-grid/0.0.12_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: '@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.12.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
-      '@teambit/explorer.ui.component-card': 0.0.11_8300323ebd5a026f85e3cef9b6d3860f
-      '@teambit/explorer.ui.gallery.component-grid': registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/explorer.ui.component-card': 0.0.11_60905eb2c2a4a2f46664b048e7e1d9dd
+      '@teambit/explorer.ui.gallery.component-grid': registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2626,15 +2627,15 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.ui.component-card-grid/0.0.15_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/explorer.ui.component-card-grid/0.0.15_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-nw+ae8xtNXYeGHCfeGh/7kjMHpc=, tarball: '@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.15.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
-      '@teambit/explorer.ui.component-card': 0.0.14_8300323ebd5a026f85e3cef9b6d3860f
-      '@teambit/explorer.ui.gallery.component-grid': registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/explorer.ui.component-card': 0.0.14_60905eb2c2a4a2f46664b048e7e1d9dd
+      '@teambit/explorer.ui.gallery.component-grid': registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
     transitivePeerDependencies:
@@ -2643,13 +2644,13 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.ui.component-card/0.0.11_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/explorer.ui.component-card/0.0.11_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: '@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.11.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 1.23.0_150be2d4515131e54e0531e15473f3a8
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
       '@teambit/design.ui.styles.ellipsis': registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.346_react-dom@17.0.2+react@17.0.2
       '@teambit/docs.entities.doc': registry.npmjs.org/@teambit/docs.entities.doc/0.0.2
@@ -2664,13 +2665,13 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/explorer.ui.component-card/0.0.14_8300323ebd5a026f85e3cef9b6d3860f:
+  /@teambit/explorer.ui.component-card/0.0.14_60905eb2c2a4a2f46664b048e7e1d9dd:
     resolution: {integrity: sha1-NXxynFuK+QaIgLiPjuVV9PpH1uY=, tarball: '@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.14.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 1.23.0_150be2d4515131e54e0531e15473f3a8
-      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/component-descriptor': registry.npmjs.org/@teambit/component-descriptor/0.0.18_0411e9e030dc74716c213f46c459e2d9
       '@teambit/component-id': registry.npmjs.org/@teambit/component-id/0.0.401
       '@teambit/design.ui.styles.ellipsis': registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.346_react-dom@17.0.2+react@17.0.2
       '@teambit/docs.entities.doc': registry.npmjs.org/@teambit/docs.entities.doc/0.0.2
@@ -2731,7 +2732,7 @@ packages:
       - encoding
     dev: false
 
-  /@teambit/graphql.hooks.use-query/0.0.1_96c41039adeadc6ae20230df509b27c6:
+  /@teambit/graphql.hooks.use-query/0.0.1_65c18445cb0815917ac3e464c0c87bd8:
     resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: '@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz'}
     peerDependencies:
       '@apollo/client': 3.3.7
@@ -2739,7 +2740,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': registry.npmjs.org/@apollo/client/3.3.7_133e36027c98268c306d4b5e6fceaa93
-      '@teambit/ui-foundation.ui.global-loader': registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/ui-foundation.ui.global-loader': registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2747,7 +2748,7 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/graphql.hooks.use-query/0.0.7_96c41039adeadc6ae20230df509b27c6:
+  /@teambit/graphql.hooks.use-query/0.0.7_65c18445cb0815917ac3e464c0c87bd8:
     resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: '@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz'}
     peerDependencies:
       '@apollo/client': 3.3.7
@@ -2755,7 +2756,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': registry.npmjs.org/@apollo/client/3.3.7_133e36027c98268c306d4b5e6fceaa93
-      '@teambit/ui-foundation.ui.global-loader': registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/ui-foundation.ui.global-loader': registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2763,12 +2764,12 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/pkg.content.packages-overview/1.95.9_0a43466038c32317ef5df0c69fcd0d50:
+  /@teambit/pkg.content.packages-overview/1.95.9_18435c9ed3991821240607706d724c7b:
     resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: '@teambit/pkg.content.packages-overview/-/@teambit-pkg.content.packages-overview-1.95.9.tgz'}
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/components.blocks.component-card-display': 0.0.13_0a43466038c32317ef5df0c69fcd0d50
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/components.blocks.component-card-display': 0.0.13_18435c9ed3991821240607706d724c7b
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - '@apollo/client'
       - '@teambit/legacy'
@@ -2778,14 +2779,14 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/react.content.react-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/react.content.react-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: '@teambit/react.content.react-overview/-/@teambit-react.content.react-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2793,14 +2794,14 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/react.instructions.react-native.adding-tests/0.0.1_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/react.instructions.react-native.adding-tests/0.0.1_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: '@teambit/react.instructions.react-native.adding-tests/-/@teambit-react.instructions.react-native.adding-tests-0.0.1.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2808,7 +2809,7 @@ packages:
       - '@teambit/legacy'
     dev: false
 
-  /@teambit/scope.content.scope-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/scope.content.scope-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: '@teambit/scope.content.scope-overview/-/@teambit-scope.content.scope-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -2816,7 +2817,7 @@ packages:
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
       '@teambit/docs.ui.zoomable-image': 1.95.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -2862,18 +2863,18 @@ packages:
       url-parse: registry.npmjs.org/url-parse/1.5.3
     dev: true
 
-  /@teambit/workspace.content.variants/1.95.9_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/workspace.content.variants/1.95.9_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: '@teambit/workspace.content.variants/-/@teambit-workspace.content.variants-1.95.9.tgz'}
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - '@teambit/legacy'
       - react
       - react-dom
     dev: true
 
-  /@teambit/workspace.content.workspace-overview/1.95.0_e562d771bc6a93ecb9d502a92e5e662d:
+  /@teambit/workspace.content.workspace-overview/1.95.0_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: '@teambit/workspace.content.workspace-overview/-/@teambit-workspace.content.workspace-overview-1.95.0.tgz'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -2881,7 +2882,7 @@ packages:
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
       '@teambit/docs.ui.zoomable-image': 1.95.0_react-dom@17.0.2+react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -3189,7 +3190,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@babel/core/7.12.9:
-    resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz}
+    resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@babel/core/-/core-7.12.9.tgz}
     name: '@babel/core'
     version: 7.12.9
     engines: {node: '>=6.9.0'}
@@ -3215,7 +3216,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@babel/core/7.18.6:
-    resolution: {integrity: sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@babel/core/-/core-7.18.6.tgz}
+    resolution: {integrity: sha512-cQbWBpxcbbs/IUredIPkHiAGULLV8iwgNRMFzvbhEXISp4f3rUUXE5+TIw6KwUWUR3DwyI6gmBRnmAtYaWehwQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@babel/core/-/core-7.18.6.tgz}
     name: '@babel/core'
     version: 7.18.6
     engines: {node: '>=6.9.0'}
@@ -7128,7 +7129,7 @@ packages:
       regenerator-runtime: registry.npmjs.org/regenerator-runtime/0.13.7
 
   registry.npmjs.org/@babel/runtime/7.18.6:
-    resolution: {integrity: sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz}
+    resolution: {integrity: sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz}
     name: '@babel/runtime'
     version: 7.18.6
     engines: {node: '>=6.9.0'}
@@ -8233,7 +8234,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': registry.npmjs.org/@jridgewell/gen-mapping/0.3.2
       '@jridgewell/trace-mapping': registry.npmjs.org/@jridgewell/trace-mapping/0.3.14
-    dev: false
 
   registry.npmjs.org/@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz}
@@ -8359,7 +8359,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@nicolo-ribaudo/chokidar-2/2.1.8-no-fsevents:
-    resolution: {integrity: sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz}
+    resolution: {integrity: sha512-+nb9vWloHNNMFHjGofEam3wopE3m1yuambrrd/fnPc+lFOMB9ROTqQlche9ByFWNkdNqfSgR/kkQtQ8DzEWt2w==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.tgz}
     name: '@nicolo-ribaudo/chokidar-2'
     version: 2.1.8-no-fsevents
     requiresBuild: true
@@ -8370,7 +8370,7 @@ packages:
       glob-parent: registry.npmjs.org/glob-parent/3.1.0
       inherits: registry.npmjs.org/inherits/2.0.4
       is-binary-path: registry.npmjs.org/is-binary-path/1.0.1
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       normalize-path: registry.npmjs.org/normalize-path/3.0.0
       path-is-absolute: registry.npmjs.org/path-is-absolute/1.0.1
       readdirp: registry.npmjs.org/readdirp/2.2.1
@@ -8755,7 +8755,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@pnpm/extensions/0.0.0_@yarnpkg+core@3.2.2:
-    resolution: {integrity: sha512-reWwjbkAhrcB5quwASQWw5RVHvxXjDUz+7oS5LZGbroR2MJfDvjlBVBmlmf6tjB1Z9CuPAl6sGCBVfvY3ZY4nA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@pnpm/extensions/-/extensions-0.0.0.tgz}
+    resolution: {integrity: sha512-reWwjbkAhrcB5quwASQWw5RVHvxXjDUz+7oS5LZGbroR2MJfDvjlBVBmlmf6tjB1Z9CuPAl6sGCBVfvY3ZY4nA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@pnpm/extensions/-/extensions-0.0.0.tgz}
     id: registry.npmjs.org/@pnpm/extensions/0.0.0
     name: '@pnpm/extensions'
     version: 0.0.0
@@ -11425,8 +11425,8 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/bit-error/0.0.365_e562d771bc6a93ecb9d502a92e5e662d:
-    resolution: {integrity: sha512-btMRc0fX+Rhx+baLRF2pKwlQEHVMHB9TPYvBWKdyX4AgRBO6mdonkVXxH6RWWR13w4WvYO0kX90z0tLLaPr2fg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/bit-error/-/bit-error-0.0.365.tgz}
+  registry.npmjs.org/@teambit/bit-error/0.0.365_0411e9e030dc74716c213f46c459e2d9:
+    resolution: {integrity: sha512-btMRc0fX+Rhx+baLRF2pKwlQEHVMHB9TPYvBWKdyX4AgRBO6mdonkVXxH6RWWR13w4WvYO0kX90z0tLLaPr2fg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/bit-error/-/bit-error-0.0.365.tgz}
     id: registry.npmjs.org/@teambit/bit-error/0.0.365
     name: '@teambit/bit-error'
     version: 0.0.365
@@ -11440,14 +11440,14 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
   registry.npmjs.org/@teambit/bit-error/0.0.394:
-    resolution: {integrity: sha512-qp2GJ59LpUevArHCfpSvotB2cpUHV4hDAEBGWE0q6MOdESboHuadZMuVrQO5dmXN5BX6tFN7qfBF+pQKHOfqIg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/bit-error/-/bit-error-0.0.394.tgz}
+    resolution: {integrity: sha512-qp2GJ59LpUevArHCfpSvotB2cpUHV4hDAEBGWE0q6MOdESboHuadZMuVrQO5dmXN5BX6tFN7qfBF+pQKHOfqIg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/bit-error/-/bit-error-0.0.394.tgz}
     name: '@teambit/bit-error'
     version: 0.0.394
     engines: {node: '>=12.22.0'}
@@ -11465,7 +11465,7 @@ packages:
       semver: registry.npmjs.org/semver/7.3.4
       user-home: registry.npmjs.org/user-home/2.0.0
 
-  registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.297:
+  registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.298:
     resolution: {integrity: sha512-o/nMawb0gZNbl6IaOLpTqeoyQsrXxR7bsyw0cZJF2j0OphKCUjjMhpnTHIhP4zFqh6kNMe8K1dvWmD8QkkoUkw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/bvm.list/-/bvm.list-0.0.33.tgz}
     id: registry.npmjs.org/@teambit/bvm.list/0.0.33
     name: '@teambit/bvm.list'
@@ -11473,7 +11473,7 @@ packages:
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/bvm.config': registry.npmjs.org/@teambit/bvm.config/0.0.26
-      '@teambit/gcp.storage': registry.npmjs.org/@teambit/gcp.storage/0.0.21_@teambit+legacy@1.0.297
+      '@teambit/gcp.storage': registry.npmjs.org/@teambit/gcp.storage/0.0.21_@teambit+legacy@1.0.298
       fs-extra: registry.npmjs.org/fs-extra/9.1.0
       semver: registry.npmjs.org/semver/7.3.4
       semver-sort: registry.npmjs.org/semver-sort/0.0.4
@@ -11491,7 +11491,7 @@ packages:
       p-limit: registry.npmjs.org/p-limit/2.3.0
     dev: false
 
-  registry.npmjs.org/@teambit/component-descriptor/0.0.12_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component-descriptor/0.0.12_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-vF+p5bbUKRbqE3KEnNxHMfaRIHBKjMhcmeFFZSGGJbf2JxC4OT9DI6urxyUMKSzIvpTPuxaoJ5C9KzvHTWhpIw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-descriptor/-/component-descriptor-0.0.12.tgz}
     id: registry.npmjs.org/@teambit/component-descriptor/0.0.12
     name: '@teambit/component-descriptor'
@@ -11506,13 +11506,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/component-descriptor/0.0.18_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component-descriptor/0.0.18_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-TbR5WTJ+hqyZ0ZR+zlbMJkAeWHztOJCLXTEeximC9nZj9DkvXBiXFiKyc4O9m4YMlKRqD6L8/T9XEoNYLrYkMg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-descriptor/-/component-descriptor-0.0.18.tgz}
     id: registry.npmjs.org/@teambit/component-descriptor/0.0.18
     name: '@teambit/component-descriptor'
@@ -11527,13 +11527,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/component-descriptor/0.0.3_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component-descriptor/0.0.3_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-/OEPdA80xS76HvGaSlZqNTyvQ/WlO3lERzUNnPnldLye2OWST69vhga8tefBRKMeNpPsITck6adfiLm1DH8m6g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-descriptor/-/component-descriptor-0.0.3.tgz}
     id: registry.npmjs.org/@teambit/component-descriptor/0.0.3
     name: '@teambit/component-descriptor'
@@ -11548,13 +11548,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/component-descriptor/0.0.46_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component-descriptor/0.0.46_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-OZuUsAOChiGdqU2fc8G/N1I6QisbeRw4UdeUjuLYdXqRVUEYPAzsjiyit+jRonP8/als9SDoXCO2xz/nckAOFw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-descriptor/-/component-descriptor-0.0.46.tgz}
     id: registry.npmjs.org/@teambit/component-descriptor/0.0.46
     name: '@teambit/component-descriptor'
@@ -11569,13 +11569,13 @@ packages:
         optional: true
     dependencies:
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/component-id/0.0.369_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component-id/0.0.369_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-TuJ1g/QHScRX9tG96wrdiLR5kC3XRMdK5NdOduzumChMXPO9tGe6jnCwMSiIqdvXbZXfZr1NSvyu80aqYsHpvA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-id/-/component-id-0.0.369.tgz}
     id: registry.npmjs.org/@teambit/component-id/0.0.369
     name: '@teambit/component-id'
@@ -11587,8 +11587,8 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/legacy-bit-id': registry.npmjs.org/@teambit/legacy-bit-id/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy-bit-id': registry.npmjs.org/@teambit/legacy-bit-id/0.0.368_0411e9e030dc74716c213f46c459e2d9
     transitivePeerDependencies:
       - react
       - react-dom
@@ -11604,15 +11604,15 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/component-id/0.0.402:
-    resolution: {integrity: sha512-S8jweaIlvlOuUa8x9qYfUKeAL4K0IozNEJJfnVzJLFZy5922NXrdi0TNW+dbegS9mlIOJ/S7+3TZKeT7ITBhMg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-id/-/component-id-0.0.402.tgz}
+    resolution: {integrity: sha512-S8jweaIlvlOuUa8x9qYfUKeAL4K0IozNEJJfnVzJLFZy5922NXrdi0TNW+dbegS9mlIOJ/S7+3TZKeT7ITBhMg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component-id/-/component-id-0.0.402.tgz}
     name: '@teambit/component-id'
     version: 0.0.402
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/legacy-bit-id': registry.npmjs.org/@teambit/legacy-bit-id/0.0.399
 
-  registry.npmjs.org/@teambit/component-version/0.0.366_e562d771bc6a93ecb9d502a92e5e662d:
-    resolution: {integrity: sha512-ouewvgwqxESGVFqb25u9E0+Cd0cCVyOl3lTc8IKzBxyc+EmPDq9ZEGLLr4PoKJg/YlM2ZsJfLgJwNZPMT7bCxA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-version/-/component-version-0.0.366.tgz}
+  registry.npmjs.org/@teambit/component-version/0.0.366_0411e9e030dc74716c213f46c459e2d9:
+    resolution: {integrity: sha512-ouewvgwqxESGVFqb25u9E0+Cd0cCVyOl3lTc8IKzBxyc+EmPDq9ZEGLLr4PoKJg/YlM2ZsJfLgJwNZPMT7bCxA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component-version/-/component-version-0.0.366.tgz}
     id: registry.npmjs.org/@teambit/component-version/0.0.366
     name: '@teambit/component-version'
     version: 0.0.366
@@ -11623,8 +11623,8 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       semver: registry.npmjs.org/semver/7.3.4
     transitivePeerDependencies:
       - react
@@ -11632,7 +11632,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/component-version/0.0.395:
-    resolution: {integrity: sha512-eT9krk/eOizS9yTXgcD7oIOCtXsCoFUx8P4DO5Crm78RwinsNwNjcd1beeKJqoguAvjQvqy+6WV8U46hBBcJkw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component-version/-/component-version-0.0.395.tgz}
+    resolution: {integrity: sha512-eT9krk/eOizS9yTXgcD7oIOCtXsCoFUx8P4DO5Crm78RwinsNwNjcd1beeKJqoguAvjQvqy+6WV8U46hBBcJkw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component-version/-/component-version-0.0.395.tgz}
     name: '@teambit/component-version'
     version: 0.0.395
     engines: {node: '>=12.22.0'}
@@ -11640,7 +11640,7 @@ packages:
       '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.394
       semver: registry.npmjs.org/semver/7.3.4
 
-  registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/component.instructions.exporting-components/-/component.instructions.exporting-components-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6
     name: '@teambit/component.instructions.exporting-components'
@@ -11650,7 +11650,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -11919,7 +11919,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/design.ui.styles.colors-by-letter/0.0.30_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-zHRt8+gFD0LGTBPUfNa+jWWxpchEa0zkEM7a0VdXK8SG/9zcWVwlIpJp7EIJXmNzVeQXqL5fGzPyLZhkWEa1ww==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.colors-by-letter/-/design.ui.styles.colors-by-letter-0.0.30.tgz}
+    resolution: {integrity: sha512-zHRt8+gFD0LGTBPUfNa+jWWxpchEa0zkEM7a0VdXK8SG/9zcWVwlIpJp7EIJXmNzVeQXqL5fGzPyLZhkWEa1ww==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.colors-by-letter/-/design.ui.styles.colors-by-letter-0.0.30.tgz}
     id: registry.npmjs.org/@teambit/design.ui.styles.colors-by-letter/0.0.30
     name: '@teambit/design.ui.styles.colors-by-letter'
     version: 0.0.30
@@ -11950,7 +11950,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.347_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-VSTZQ2FM59wFjsPHZHx4p0mIvRI54jnzcIuHXllGnaLmaE9oEso5+n38i0bvBrLMbPs01qDyyOioCduOiHqOVg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.347.tgz}
+    resolution: {integrity: sha512-VSTZQ2FM59wFjsPHZHx4p0mIvRI54jnzcIuHXllGnaLmaE9oEso5+n38i0bvBrLMbPs01qDyyOioCduOiHqOVg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.347.tgz}
     id: registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.347
     name: '@teambit/design.ui.styles.ellipsis'
     version: 0.0.347
@@ -13361,7 +13361,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/explorer.ui.gallery.base-component-card/0.0.492_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-lwtHUj4GY0ffkFfKdu8jQpjX/LLgSeJIJBQhcw9a4+IfZgs3FQYWPnzNoNM6X4FuRFE0tVMES8/gklTxkKJmwg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.gallery.base-component-card/-/explorer.ui.gallery.base-component-card-0.0.492.tgz}
+    resolution: {integrity: sha512-lwtHUj4GY0ffkFfKdu8jQpjX/LLgSeJIJBQhcw9a4+IfZgs3FQYWPnzNoNM6X4FuRFE0tVMES8/gklTxkKJmwg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.gallery.base-component-card/-/explorer.ui.gallery.base-component-card-0.0.492.tgz}
     id: registry.npmjs.org/@teambit/explorer.ui.gallery.base-component-card/0.0.492
     name: '@teambit/explorer.ui.gallery.base-component-card'
     version: 0.0.492
@@ -13395,7 +13395,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-oSBDDO9n3lRB5PAD2Hxk1BcdyGH5xnzazYKUwYHNMXbniaADBBJGHVguPp9qR/aj8eMYmw82XXO344MyEAKywQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/-/explorer.ui.gallery.component-grid-0.0.484.tgz}
     id: registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.484
     name: '@teambit/explorer.ui.gallery.component-grid'
@@ -13409,7 +13409,7 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       classnames: registry.npmjs.org/classnames/2.2.6
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
@@ -13417,7 +13417,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.486_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-JVYEB7JIMioWCwwO2tGYZdJfUvLpeERD873BtXmg5IUtMXiDS65LTraCSK4QmOi/4i2RYLN126a7yfeE0nGRjw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/-/explorer.ui.gallery.component-grid-0.0.486.tgz}
+    resolution: {integrity: sha512-JVYEB7JIMioWCwwO2tGYZdJfUvLpeERD873BtXmg5IUtMXiDS65LTraCSK4QmOi/4i2RYLN126a7yfeE0nGRjw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/-/explorer.ui.gallery.component-grid-0.0.486.tgz}
     id: registry.npmjs.org/@teambit/explorer.ui.gallery.component-grid/0.0.486
     name: '@teambit/explorer.ui.gallery.component-grid'
     version: 0.0.486
@@ -13432,14 +13432,14 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: true
 
-  registry.npmjs.org/@teambit/gcp.storage/0.0.21_@teambit+legacy@1.0.297:
+  registry.npmjs.org/@teambit/gcp.storage/0.0.21_@teambit+legacy@1.0.298:
     resolution: {integrity: sha512-GXYnxTE2nxk0NhwQG7erd3p378SrJHPPUm4nntPhcG0oyDK17ntDBXRCqJbfmDnbalcW9ibHqjuIew7vltBqWg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/gcp.storage/-/gcp.storage-0.0.21.tgz}
     id: registry.npmjs.org/@teambit/gcp.storage/0.0.21
     name: '@teambit/gcp.storage'
     version: 0.0.21
     engines: {node: '>=12.15.0'}
     dependencies:
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.297
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.298
       node-fetch: registry.npmjs.org/node-fetch/2.6.1
     transitivePeerDependencies:
       - '@teambit/legacy'
@@ -13458,7 +13458,7 @@ packages:
       user-home: registry.npmjs.org/user-home/2.0.0
     dev: false
 
-  registry.npmjs.org/@teambit/legacy-bit-id/0.0.368_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/legacy-bit-id/0.0.368_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-7vt07radnL9dcdzVfD1Rr8pfKc4I30Rv9H6wnu6hnGLHdqzmzUkovAM6Fg6Bzw53w4OrdbPUWuH+aaUGReT33A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/legacy-bit-id/-/legacy-bit-id-0.0.368.tgz}
     id: registry.npmjs.org/@teambit/legacy-bit-id/0.0.368
     name: '@teambit/legacy-bit-id'
@@ -13470,9 +13470,9 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/component-version': registry.npmjs.org/@teambit/component-version/0.0.366_e562d771bc6a93ecb9d502a92e5e662d
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/bit-error': registry.npmjs.org/@teambit/bit-error/0.0.365_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/component-version': registry.npmjs.org/@teambit/component-version/0.0.366_0411e9e030dc74716c213f46c459e2d9
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       decamelize: registry.npmjs.org/decamelize/1.2.0
       lodash: registry.npmjs.org/lodash/4.17.21
       semver: registry.npmjs.org/semver/7.3.4
@@ -13495,7 +13495,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/legacy-bit-id/0.0.399:
-    resolution: {integrity: sha512-Jy1HDmOWJY0NnW9aKzU9IZbHQc6kl2TuNoJ1hNwUMj93EcowOEBXb3900VlZFuG07tHw30mXDspkCKF3Yfb2Qg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/legacy-bit-id/-/legacy-bit-id-0.0.399.tgz}
+    resolution: {integrity: sha512-Jy1HDmOWJY0NnW9aKzU9IZbHQc6kl2TuNoJ1hNwUMj93EcowOEBXb3900VlZFuG07tHw30mXDspkCKF3Yfb2Qg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/legacy-bit-id/-/legacy-bit-id-0.0.399.tgz}
     name: '@teambit/legacy-bit-id'
     version: 0.0.399
     engines: {node: '>=12.22.0'}
@@ -13506,19 +13506,19 @@ packages:
       lodash: registry.npmjs.org/lodash/4.17.21
       semver: registry.npmjs.org/semver/7.3.4
 
-  registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730:
-    resolution: {integrity: sha512-Mm402moDJc3Cs5T4+z4xg14fG8qHYkfulxNtLzwIHWaC0CXSt2BpAcVyMqNdC22WFr5ATt/Fk5+Aie4y8cxORg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/legacy/-/legacy-1.0.297.tgz}
-    id: registry.npmjs.org/@teambit/legacy/1.0.297
+  registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730:
+    resolution: {integrity: sha512-qMikNTrQJkuHIB/bAHoeUXgKrn9mpg98FISg7F6D/D/LOIdt2MQYiixZJY3CWwDNgWa1bOd81JFPCX11gthQkQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/legacy/-/legacy-1.0.298.tgz}
+    id: registry.npmjs.org/@teambit/legacy/1.0.298
     name: '@teambit/legacy'
-    version: 1.0.297
+    version: 1.0.298
     engines: {node: '>=12.22.0'}
     hasBin: true
     dependencies:
       '@babel/core': registry.npmjs.org/@babel/core/7.12.17
       '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
-      '@teambit/bvm.list': registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.297
+      '@teambit/bvm.list': registry.npmjs.org/@teambit/bvm.list/0.0.33_@teambit+legacy@1.0.298
       '@teambit/component-version': registry.npmjs.org/@teambit/component-version/0.0.395
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.297
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.298
       '@vuedoc/parser': registry.npmjs.org/@vuedoc/parser/3.4.0
       acorn: registry.npmjs.org/acorn/6.4.2
       ajv: registry.npmjs.org/ajv/6.12.6
@@ -13645,7 +13645,7 @@ packages:
       - typescript
       - utf-8-validate
 
-  registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/-/mdx.ui.mdx-scope-context-0.0.368.tgz}
     id: registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368
     name: '@teambit/mdx.ui.mdx-scope-context'
@@ -13659,12 +13659,12 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
 
-  registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/-/react.instructions.react.adding-compositions-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6
     name: '@teambit/react.instructions.react.adding-compositions'
@@ -13674,7 +13674,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13682,7 +13682,7 @@ packages:
       - '@teambit/legacy'
     dev: false
 
-  registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-tests/-/react.instructions.react.adding-tests-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6
     name: '@teambit/react.instructions.react.adding-tests'
@@ -13692,7 +13692,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': registry.npmjs.org/@mdx-js/react/1.6.22_react@17.0.2
-      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_e562d771bc6a93ecb9d502a92e5e662d
+      '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368_0411e9e030dc74716c213f46c459e2d9
       core-js: registry.npmjs.org/core-js/3.13.0
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13750,7 +13750,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/0.0.21_react-dom@17.0.2+react@17.0.2:
-    resolution: {integrity: sha512-dwC1U5ugqMKEs3l8KS7il0OHUKnFPvNjaUmp5NPmvSr9sK6Q6ZUrR8b5Q06FVeB9sfns2Fu690xDrJoZzvl21Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
+    resolution: {integrity: sha512-dwC1U5ugqMKEs3l8KS7il0OHUKnFPvNjaUmp5NPmvSr9sK6Q6ZUrR8b5Q06FVeB9sfns2Fu690xDrJoZzvl21Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
     id: registry.npmjs.org/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/0.0.21
     name: '@teambit/react.ui.highlighter.component-metadata.bit-component-meta'
     version: 0.0.21
@@ -13780,7 +13780,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.297:
+  registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.298:
     resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.agent/-/toolbox.network.agent-0.0.116.tgz}
     id: registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116
     name: '@teambit/toolbox.network.agent'
@@ -13792,14 +13792,14 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116_@teambit+legacy@1.0.297
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116_@teambit+legacy@1.0.298
       agentkeepalive: registry.npmjs.org/agentkeepalive/4.1.4
     transitivePeerDependencies:
       - supports-color
 
-  registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.297:
-    resolution: {integrity: sha512-x7JDFqVtPP2ruz4/5Cn20Xvz/3FdJ8tJLEohhyi0t5Tuo7Qd4YegDPaTxUz8r+f6i38T0YTcQoLAUSc6RDsUSg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.agent/-/toolbox.network.agent-0.0.245.tgz}
+  registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.298:
+    resolution: {integrity: sha512-x7JDFqVtPP2ruz4/5Cn20Xvz/3FdJ8tJLEohhyi0t5Tuo7Qd4YegDPaTxUz8r+f6i38T0YTcQoLAUSc6RDsUSg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.agent/-/toolbox.network.agent-0.0.245.tgz}
     id: registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245
     name: '@teambit/toolbox.network.agent'
     version: 0.0.245
@@ -13810,13 +13810,13 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.245_@teambit+legacy@1.0.297
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.245_@teambit+legacy@1.0.298
       agentkeepalive: registry.npmjs.org/agentkeepalive/4.1.4
     transitivePeerDependencies:
       - supports-color
 
-  registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116_@teambit+legacy@1.0.297:
+  registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116_@teambit+legacy@1.0.298:
     resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.proxy-agent/-/toolbox.network.proxy-agent-0.0.116.tgz}
     id: registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116
     name: '@teambit/toolbox.network.proxy-agent'
@@ -13828,15 +13828,15 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.297
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116_@teambit+legacy@1.0.298
       http-proxy-agent: registry.npmjs.org/http-proxy-agent/4.0.1
       https-proxy-agent: registry.npmjs.org/https-proxy-agent/5.0.0
       socks-proxy-agent: registry.npmjs.org/socks-proxy-agent/5.0.0
     transitivePeerDependencies:
       - supports-color
 
-  registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.245_@teambit+legacy@1.0.297:
+  registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.245_@teambit+legacy@1.0.298:
     resolution: {integrity: sha512-Dw6DBw0rmV48BcPrYJNKJapq0vFZDxHOskmkPRZW8zz95sq0nhMMrWhE45dWfVLGGk6LW9xnTUTriN5GJiuq6A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.proxy-agent/-/toolbox.network.proxy-agent-0.0.245.tgz}
     id: registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.245
     name: '@teambit/toolbox.network.proxy-agent'
@@ -13848,8 +13848,8 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.297
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent/0.0.245_@teambit+legacy@1.0.298
       http-proxy-agent: registry.npmjs.org/http-proxy-agent/4.0.1
       https-proxy-agent: registry.npmjs.org/https-proxy-agent/5.0.0
       socks-proxy-agent: registry.npmjs.org/socks-proxy-agent/5.0.0
@@ -13864,28 +13864,28 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/toolbox.string.ellipsis/0.0.173:
-    resolution: {integrity: sha512-DGUZQWKmVq//fKDoDuPUdNT8dAdJmwM7U+kiWOsOSdDFPVBWrQusplO6oci7teQgoW+jXc5JCJm/9/pSz0FdDg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.string.ellipsis/-/toolbox.string.ellipsis-0.0.173.tgz}
+    resolution: {integrity: sha512-DGUZQWKmVq//fKDoDuPUdNT8dAdJmwM7U+kiWOsOSdDFPVBWrQusplO6oci7teQgoW+jXc5JCJm/9/pSz0FdDg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.string.ellipsis/-/toolbox.string.ellipsis-0.0.173.tgz}
     name: '@teambit/toolbox.string.ellipsis'
     version: 0.0.173
     engines: {node: '>=12.22.0'}
     dev: true
 
   registry.npmjs.org/@teambit/toolbox.string.get-initials/0.0.483:
-    resolution: {integrity: sha512-wH4tdAgPg5dasXVe1PsbQIeTOnV0qSjlI+W3HHLMaVaz/AEm8uuqcWbRaPmG3XJruaTYNCcC5xjPk5u9l47o2Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.string.get-initials/-/toolbox.string.get-initials-0.0.483.tgz}
+    resolution: {integrity: sha512-wH4tdAgPg5dasXVe1PsbQIeTOnV0qSjlI+W3HHLMaVaz/AEm8uuqcWbRaPmG3XJruaTYNCcC5xjPk5u9l47o2Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.string.get-initials/-/toolbox.string.get-initials-0.0.483.tgz}
     name: '@teambit/toolbox.string.get-initials'
     version: 0.0.483
     engines: {node: '>=12.22.0'}
     dev: false
 
   registry.npmjs.org/@teambit/toolbox.types.serializable/0.0.483:
-    resolution: {integrity: sha512-d03KRgHYgH89zBsxQbxd9sotV4NRwgXyNdNUPIaiSnCSayIw3wv/dULV8mPcRzjjmLYvhheWatNrDV/6bWo+Lw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.types.serializable/-/toolbox.types.serializable-0.0.483.tgz}
+    resolution: {integrity: sha512-d03KRgHYgH89zBsxQbxd9sotV4NRwgXyNdNUPIaiSnCSayIw3wv/dULV8mPcRzjjmLYvhheWatNrDV/6bWo+Lw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.types.serializable/-/toolbox.types.serializable-0.0.483.tgz}
     name: '@teambit/toolbox.types.serializable'
     version: 0.0.483
     engines: {node: '>=12.22.0'}
     dev: true
 
   registry.npmjs.org/@teambit/toolbox.url.add-avatar-query-params/0.0.483:
-    resolution: {integrity: sha512-lTP7CZnPyuSdsOdWmIBbR0rjvpLPpg98BTuZMREml2hi0ZzfWGXjAgqDURFnYFUsIffJDxlKJrJVax7DL73d5w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/toolbox.url.add-avatar-query-params/-/toolbox.url.add-avatar-query-params-0.0.483.tgz}
+    resolution: {integrity: sha512-lTP7CZnPyuSdsOdWmIBbR0rjvpLPpg98BTuZMREml2hi0ZzfWGXjAgqDURFnYFUsIffJDxlKJrJVax7DL73d5w==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.url.add-avatar-query-params/-/toolbox.url.add-avatar-query-params-0.0.483.tgz}
     name: '@teambit/toolbox.url.add-avatar-query-params'
     version: 0.0.483
     engines: {node: '>=12.22.0'}
@@ -13906,7 +13906,7 @@ packages:
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
     dev: false
 
-  registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_e562d771bc6a93ecb9d502a92e5e662d:
+  registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474_0411e9e030dc74716c213f46c459e2d9:
     resolution: {integrity: sha512-X0qIYDhNlRZ4MO7VVb0hw8pkBt4dpddUSFgW3uzWA8ExSVzOcTGdicrASMxFmTxBSyzPb5pO9pcbJJCwRzehLQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/-/ui-foundation.ui.global-loader-0.0.474.tgz}
     id: registry.npmjs.org/@teambit/ui-foundation.ui.global-loader/0.0.474
     name: '@teambit/ui-foundation.ui.global-loader'
@@ -13920,7 +13920,7 @@ packages:
       '@teambit/legacy':
         optional: true
     dependencies:
-      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.297_04f503e274e8d606be3f9d1fadded730
+      '@teambit/legacy': registry.npmjs.org/@teambit/legacy/1.0.298_04f503e274e8d606be3f9d1fadded730
       core-js: registry.npmjs.org/core-js/3.23.3
       react: registry.npmjs.org/react/17.0.2
       react-dom: registry.npmjs.org/react-dom/17.0.2_react@17.0.2
@@ -13934,7 +13934,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       '@babel/code-frame': registry.npmjs.org/@babel/code-frame/7.18.6
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.18.6
       '@types/aria-query': registry.npmjs.org/@types/aria-query/4.2.2
       aria-query: registry.npmjs.org/aria-query/5.0.0
       chalk: registry.npmjs.org/chalk/4.1.2
@@ -14094,7 +14094,6 @@ packages:
     dependencies:
       '@types/connect': registry.npmjs.org/@types/connect/3.4.35
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/bonjour/3.5.10:
     resolution: {integrity: sha512-p7ienRMiS41Nu2/igbJxxLDWrSZ0WxM8UQgCeO9KhoVF7cOVFkrKsiDr1EsJIla8vV3oEEjGcz11jc5yimhzZw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.10.tgz}
@@ -14102,7 +14101,7 @@ packages:
     version: 3.5.10
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/buble/0.20.1:
     resolution: {integrity: sha512-itmN3lGSTvXg9IImY5j290H+n0B3PpZST6AgEfJJDXfaMx2cdJJZro3/Ay+bZZdIAa25Z5rnoo9rHiPCbANZoQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/buble/-/buble-0.20.1.tgz}
@@ -14118,7 +14117,7 @@ packages:
     version: 12.0.1
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/cacheable-request/6.0.2:
     resolution: {integrity: sha512-B3xVo+dlKM6nnKTcmm5ZtY/OL8bOAOd2Olee9M1zft65ox50OzjEHW91sDiU9j6cvW8Ejg1/Qkf4xd2kugApUA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.2.tgz}
@@ -14160,13 +14159,12 @@ packages:
     resolution: {integrity: sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz}
     name: '@types/chai'
     version: 4.2.15
-    dev: false
 
   registry.npmjs.org/@types/classnames/2.2.11:
     resolution: {integrity: sha512-2koNhpWm3DgWRp5tpkiJ8JGc1xTn2q0l+jUNUE7oMKXUf5NpI9AIdC4kbjGNFBdHtcxBD18LAksoudAVhFKCjw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/classnames/-/classnames-2.2.11.tgz}
     name: '@types/classnames'
     version: 2.2.11
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/clean-css/4.2.5:
     resolution: {integrity: sha512-NEzjkGGpbs9S9fgC4abuBvTpVwE3i+Acu9BBod3PUyjDVZcNsGx61b8r2PphR61QGPnn0JHVs5ey6/I4eTrkxw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/clean-css/-/clean-css-4.2.5.tgz}
@@ -14175,13 +14173,13 @@ packages:
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/cli-table/0.3.0:
-    resolution: {integrity: sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.0.tgz}
+    resolution: {integrity: sha512-QnZUISJJXyhyD6L1e5QwXDV/A5i2W1/gl6D6YMc8u0ncPepbv/B4w3S+izVvtAg60m6h+JP09+Y/0zF2mojlFQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@types/cli-table/-/cli-table-0.3.0.tgz}
     name: '@types/cli-table'
     version: 0.3.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/connect-history-api-fallback/1.3.5:
     resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.3.5.tgz}
@@ -14190,7 +14188,7 @@ packages:
     dependencies:
       '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.29
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/connect/3.4.35:
     resolution: {integrity: sha512-cdeYyv4KWoEgpBISTxWvqYsVy444DOqehiF3fM3ne10AmJ62RSyNkUnxMJXHQWRQQX2eR94m5y1IZyDwBjV9FQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/connect/-/connect-3.4.35.tgz}
@@ -14198,7 +14196,6 @@ packages:
     version: 3.4.35
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/content-disposition/0.5.5:
     resolution: {integrity: sha512-v6LCdKfK6BwcqMo+wYW05rLS12S0ZO0Fl4w1h4aaZMD7bqT3gVUns6FvLJKGZHQmYn3SX55JWGpziwJRwVgutA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/content-disposition/-/content-disposition-0.5.5.tgz}
@@ -14221,19 +14218,18 @@ packages:
     resolution: {integrity: sha512-C7srjHiVG3Ey1nR6d511dtDkCEjxuN9W1HWAEjGq8kpcwmNM6JJkpC0xvabM7BXTG2wDq8Eu33iH9aQKa7IvLQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/cors/-/cors-2.8.10.tgz}
     name: '@types/cors'
     version: 2.8.10
-    dev: false
 
   registry.npmjs.org/@types/dagre/0.7.44:
     resolution: {integrity: sha512-N6HD+79w77ZVAaVO7JJDW5yJ9LAxM62FpgNGO9xEde+KVYjDRyhIMzfiErXpr1g0JPon9kwlBzoBK6s4fOww9Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/dagre/-/dagre-0.7.44.tgz}
     name: '@types/dagre'
     version: 0.7.44
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/didyoumean/1.2.0:
     resolution: {integrity: sha512-3QMjBOgPEXaOkhfQxiGgzn6JpofPSi8Z0RmQq65FIpZv4kCPT/jvYiYrwqaUrfiHZmwwRvyYJjJmoKopbvLPQw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/didyoumean/-/didyoumean-1.2.0.tgz}
     name: '@types/didyoumean'
     version: 1.2.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/emscripten/1.39.6:
     resolution: {integrity: sha512-H90aoynNhhkQP6DRweEjJp5vfUVdIj7tdPLsu7pq89vODD/lcugKfZOsfgwpvM6XUewEp2N5dCg1Uf3Qe55Dcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/emscripten/-/emscripten-1.39.6.tgz}
@@ -14248,7 +14244,6 @@ packages:
     dependencies:
       '@types/eslint': registry.npmjs.org/@types/eslint/7.28.0
       '@types/estree': registry.npmjs.org/@types/estree/0.0.50
-    dev: false
 
   registry.npmjs.org/@types/eslint-visitor-keys/1.0.0:
     resolution: {integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz}
@@ -14274,7 +14269,6 @@ packages:
     resolution: {integrity: sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz}
     name: '@types/estree'
     version: 0.0.50
-    dev: false
 
   registry.npmjs.org/@types/estree/0.0.52:
     resolution: {integrity: sha512-BZWrtCU0bMVAIliIV+HJO1f1PR41M7NKjfxrFJwwhKI1KwhwOxYw1SXg9ao+CIMt774nFuGiG6eU+udtbEI9oQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/estree/-/estree-0.0.52.tgz}
@@ -14289,7 +14283,6 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       '@types/qs': registry.npmjs.org/@types/qs/6.9.7
       '@types/range-parser': registry.npmjs.org/@types/range-parser/1.2.4
-    dev: false
 
   registry.npmjs.org/@types/express/4.17.13:
     resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/express/-/express-4.17.13.tgz}
@@ -14300,13 +14293,12 @@ packages:
       '@types/express-serve-static-core': registry.npmjs.org/@types/express-serve-static-core/4.17.29
       '@types/qs': registry.npmjs.org/@types/qs/6.9.7
       '@types/serve-static': registry.npmjs.org/@types/serve-static/1.13.10
-    dev: false
 
   registry.npmjs.org/@types/find-root/1.1.2:
     resolution: {integrity: sha512-lGuMq71TL466jtCpvh7orGd+mrdBmo2h8ozvtOOTbq3ByfWpuN+UVxv4sOv3YpsD4NhW2k6ESGhnT/FIg4Ouzw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/find-root/-/find-root-1.1.2.tgz}
     name: '@types/find-root'
     version: 1.1.2
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/fs-capacitor/2.0.0:
     resolution: {integrity: sha512-FKVPOCFbhCvZxpVAMhdBdTfVfXUpsh15wFHgqOKxh9N9vzWZVuWCSijZ5T4U34XYNnuj2oduh6xcs1i+LPI+BQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/fs-capacitor/-/fs-capacitor-2.0.0.tgz}
@@ -14322,7 +14314,7 @@ packages:
     version: 9.0.7
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/graceful-fs/4.1.5:
     resolution: {integrity: sha512-anKkLmZZ+xm4p8JWBf4hElkM4XR+EZeA2M9BAkkTldmcyDY4mbdIJnRghDJH3Ov5ooY7/UAoENtmdMSkaAd7Cw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz}
@@ -14360,7 +14352,7 @@ packages:
       '@types/clean-css': registry.npmjs.org/@types/clean-css/4.2.5
       '@types/relateurl': registry.npmjs.org/@types/relateurl/0.2.29
       '@types/uglify-js': registry.npmjs.org/@types/uglify-js/3.16.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/html-webpack-plugin/3.2.6:
     resolution: {integrity: sha512-U8uJSvlf9lwrKG6sKFnMhqY4qJw2QXad+PHlX9sqEXVUMilVt96aVvFde73tzsdXD+QH9JS6kEytuGO2JcYZog==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/html-webpack-plugin/-/html-webpack-plugin-3.2.6.tgz}
@@ -14370,7 +14362,7 @@ packages:
       '@types/html-minifier': registry.npmjs.org/@types/html-minifier/4.0.2
       '@types/tapable': registry.npmjs.org/@types/tapable/1.0.8
       '@types/webpack': registry.npmjs.org/@types/webpack/4.41.32
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/http-assert/1.5.3:
     resolution: {integrity: sha512-FyAOrDuQmBi8/or3ns4rwPno7/9tJTijVW6aQQjK02+kOQ8zmoNg2XJtAuQhvQcy1ASJq38wirX5//9J1EqoUA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/http-assert/-/http-assert-1.5.3.tgz}
@@ -14404,7 +14396,6 @@ packages:
     version: 1.17.9
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/istanbul-lib-coverage/2.0.4:
     resolution: {integrity: sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz}
@@ -14464,7 +14455,6 @@ packages:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz}
     name: '@types/json-schema'
     version: 7.0.11
-    dev: false
 
   registry.npmjs.org/@types/json-schema/7.0.9:
     resolution: {integrity: sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz}
@@ -14520,7 +14510,7 @@ packages:
     version: 3.0.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.flatten/4.4.6:
     resolution: {integrity: sha512-omCBl4M8EJSmf2DZqh4/zwjgXQpzC7YO/PXTcG8rI9r7xun8CohrHeNx8HZRkqWc61uJfIaZop9MwJEXPVssHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.flatten/-/lodash.flatten-4.4.6.tgz}
@@ -14528,7 +14518,7 @@ packages:
     version: 4.4.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.head/4.0.6:
     resolution: {integrity: sha512-WrbllVqxpgpEnLPNooU9q3h9vFVYUzS4sMDp0UpEnguIHFxdAA161UMnaJ92ccGSc87e901EHFwXbuNysdSaQg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.head/-/lodash.head-4.0.6.tgz}
@@ -14536,7 +14526,7 @@ packages:
     version: 4.0.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.orderby/4.6.6:
     resolution: {integrity: sha512-wQzu6xK+bSwhu45OeMI7fjywiIZiiaBzJB8W3fwnF1SJXHoOXRLutrSnVmq4yHPOM036qsy8lx9wHQcAbXNjJw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.orderby/-/lodash.orderby-4.6.6.tgz}
@@ -14544,7 +14534,7 @@ packages:
     version: 4.6.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash.pick/4.4.6:
     resolution: {integrity: sha512-u8bzA16qQ+8dY280z3aK7PoWb3fzX5ATJ0rJB6F+uqchOX2VYF02Aqa+8aYiHiHgPzQiITqCgeimlyKFy4OA6g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash.pick/-/lodash.pick-4.4.6.tgz}
@@ -14552,13 +14542,13 @@ packages:
     version: 4.4.6
     dependencies:
       '@types/lodash': registry.npmjs.org/@types/lodash/4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash/4.14.165:
     resolution: {integrity: sha512-tjSSOTHhI5mCHTy/OOXYIhi2Wt1qcbHmuXD1Ha7q70CgI/I71afO4XtLb/cVexki1oVYchpul/TOuu3Arcdxrg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash/-/lodash-4.14.165.tgz}
     name: '@types/lodash'
     version: 4.14.165
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/lodash/4.14.182:
     resolution: {integrity: sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/lodash/-/lodash-4.14.182.tgz}
@@ -14586,25 +14576,24 @@ packages:
     version: 1.5.5
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/17.0.8
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/memoizee/0.4.5:
     resolution: {integrity: sha512-+ZzZZ3+0a7/ajBPeAAD4+LxrBsCat0EFZQtO3o0rwpIeLmDmSaM8KF/oYPuFxeUFAMiHIHFcGucFnY/8S4Hszg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.5.tgz}
     name: '@types/memoizee'
     version: 0.4.5
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/mime/1.3.2:
     resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mime/-/mime-1.3.2.tgz}
     name: '@types/mime'
     version: 1.3.2
-    dev: false
 
   registry.npmjs.org/@types/mime/2.0.3:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mime/-/mime-2.0.3.tgz}
     name: '@types/mime'
     version: 2.0.3
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/mini-css-extract-plugin/2.2.0_esbuild@0.14.28:
     resolution: {integrity: sha512-euW/Y51OoAWsAuqtxIGV7Y++EW4dKHMj7NSxHoTRD6SqK1vziYhGfDWTmtlf4jkjIrzUW88NpVXMfiJESysZAA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mini-css-extract-plugin/-/mini-css-extract-plugin-2.2.0.tgz}
@@ -14620,13 +14609,12 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/minimatch/3.0.4:
     resolution: {integrity: sha512-1z8k4wzFnNjVK/tlxvrWuK5WMt6mydWWP7+zvH5eFep4oj+UkrfiJTRtjCeBXNpwaA/FYqqtb4/QS4ianFpIRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.4.tgz}
     name: '@types/minimatch'
     version: 3.0.4
-    dev: false
 
   registry.npmjs.org/@types/mocha/9.1.0:
     resolution: {integrity: sha512-QCWHkbMv4Y5U9oW10Uxbr45qMMSzl4OzijsozynUAgx3kEHUdXB00udx2dWDQ7f2TU2a2uuiFaRZjCe3unPpeg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mocha/-/mocha-9.1.0.tgz}
@@ -14638,7 +14626,7 @@ packages:
     resolution: {integrity: sha512-OwVhKFim9Y/MprzCe4I6a59p31pMy8+LrtP6qS7J0kaOxYmW6VVJPBw5NYm+g7nSbgPUz22FvqU1F1hC5YGTfg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/mousetrap/-/mousetrap-1.6.5.tgz}
     name: '@types/mousetrap'
     version: 1.6.5
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/node-fetch/2.5.12:
     resolution: {integrity: sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz}
@@ -14647,7 +14635,7 @@ packages:
     dependencies:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
       form-data: registry.npmjs.org/form-data/3.0.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/node/10.17.60:
     resolution: {integrity: sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz}
@@ -14664,7 +14652,6 @@ packages:
     resolution: {integrity: sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/node/-/node-13.13.52.tgz}
     name: '@types/node'
     version: 13.13.52
-    dev: false
 
   registry.npmjs.org/@types/normalize-package-data/2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz}
@@ -14675,7 +14662,7 @@ packages:
     resolution: {integrity: sha512-xFdpkAkikBgqBdG9vIlsqffDV8GpvnPEzs0IUtr1v3BEB97ijsFQ4RXVbUZwjFThhB4MDSTUfvmxUD5PGx0wXA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/object-hash/-/object-hash-1.3.4.tgz}
     name: '@types/object-hash'
     version: 1.3.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/parse-json/4.0.0:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz}
@@ -14711,7 +14698,7 @@ packages:
     resolution: {integrity: sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/pluralize/-/pluralize-0.0.29.tgz}
     name: '@types/pluralize'
     version: 0.0.29
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/postcss-normalize/9.0.1:
     resolution: {integrity: sha512-lzskydHM/aIjhwycpYbQDjhGfgZir4mMkkSR4pRQJsgHPle9piEI2mtdUX8AgNZGsBbfufqsin83S3SQfJt0eQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/postcss-normalize/-/postcss-normalize-9.0.1.tgz}
@@ -14725,10 +14712,9 @@ packages:
     resolution: {integrity: sha512-eI5Yrz3Qv4KPUa/nSIAi0h+qX0XyewOliug5F2QAtuRg6Kjg6jfmxe1GIwoIRhZspD1A0RP8ANrPwvEXXtRFog==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/prettier/-/prettier-2.3.2.tgz}
     name: '@types/prettier'
     version: 2.3.2
-    dev: false
 
   registry.npmjs.org/@types/prop-types/15.7.5:
-    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz}
+    resolution: {integrity: sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz}
     name: '@types/prop-types'
     version: 15.7.5
 
@@ -14742,13 +14728,11 @@ packages:
     resolution: {integrity: sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz}
     name: '@types/qs'
     version: 6.9.7
-    dev: false
 
   registry.npmjs.org/@types/range-parser/1.2.4:
     resolution: {integrity: sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz}
     name: '@types/range-parser'
     version: 1.2.4
-    dev: false
 
   registry.npmjs.org/@types/react-dev-utils/9.0.10_debug@4.3.2:
     resolution: {integrity: sha512-kkPY4YbdoEXwf4CZdrEKNEYPHshdRGwHiCixyqaWxmYSj337hMX3YD28+tZkNiV4XUmJ4NevKtgZNbylkLSQ+A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-dev-utils/-/react-dev-utils-9.0.10.tgz}
@@ -14763,7 +14747,7 @@ packages:
       '@types/webpack-dev-server': registry.npmjs.org/@types/webpack-dev-server/3.11.6_debug@4.3.2
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-dom/17.0.17:
     resolution: {integrity: sha512-VjnqEmqGnasQKV0CWLevqMTXBYG9GbwuE6x3VetERLh0cq2LTptFE73MrQi2S7GkKXCf2GgwItB/melLnxfnsg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.17.tgz}
@@ -14778,7 +14762,7 @@ packages:
     version: 2.3.2
     dependencies:
       '@types/react': registry.npmjs.org/@types/react/17.0.8
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/react-tooltip/3.11.0:
     resolution: {integrity: sha512-TkXMgkZ5aAKkFE9Wvt8OlOiPtF9ufgBOL9xWlRSzLBaoL12qSOBiyMcU4/8TyED1fuWkm5VTVarScwOPLSArYw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react-tooltip/-/react-tooltip-3.11.0.tgz}
@@ -14789,7 +14773,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@types/react/17.0.8:
-    resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz}
+    resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@types/react/-/react-17.0.8.tgz}
     name: '@types/react'
     version: 17.0.8
     dependencies:
@@ -14801,7 +14785,7 @@ packages:
     resolution: {integrity: sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/relateurl/-/relateurl-0.2.29.tgz}
     name: '@types/relateurl'
     version: 0.2.29
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/resolve/1.17.1:
     resolution: {integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz}
@@ -14834,7 +14818,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@types/scheduler/0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz}
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz}
     name: '@types/scheduler'
     version: 0.16.2
 
@@ -14848,7 +14832,6 @@ packages:
     resolution: {integrity: sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/semver/-/semver-7.3.4.tgz}
     name: '@types/semver'
     version: 7.3.4
-    dev: false
 
   registry.npmjs.org/@types/serve-index/1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.1.tgz}
@@ -14856,7 +14839,7 @@ packages:
     version: 1.9.1
     dependencies:
       '@types/express': registry.npmjs.org/@types/express/4.17.13
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/serve-static/1.13.10:
     resolution: {integrity: sha512-nCkHGI4w7ZgAdNkrEu0bv+4xNV/XDqW+DydknebMOQwkpDGx8G+HTlj7R7ABI8i8nKxVw0wtKPi1D+lPOkh4YQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.10.tgz}
@@ -14865,7 +14848,6 @@ packages:
     dependencies:
       '@types/mime': registry.npmjs.org/@types/mime/1.3.2
       '@types/node': registry.npmjs.org/@types/node/13.13.52
-    dev: false
 
   registry.npmjs.org/@types/socket.io-client/1.4.35:
     resolution: {integrity: sha512-MI8YmxFS+jMkIziycT5ickBWK1sZwDwy16mgH/j99Mcom6zRG/NimNGQ3vJV0uX5G6g/hEw0FG3w3b3sT5OUGw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.35.tgz}
@@ -14886,7 +14868,7 @@ packages:
     resolution: {integrity: sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz}
     name: '@types/source-list-map'
     version: 0.1.2
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/ssri/7.1.1:
     resolution: {integrity: sha512-DPP/jkDaqGiyU75MyMURxLWyYLwKSjnAuGe9ZCsLp9QZOpXmDfuevk769F0BS86TmRuD5krnp06qw9nSoNO+0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ssri/-/ssri-7.1.1.tgz}
@@ -14906,7 +14888,7 @@ packages:
     resolution: {integrity: sha512-ipixuVrh2OdNmauvtT51o3d8z12p6LtFW9in7U79der/kwejjdNchQC5UMn5u/KxNoM7VHHOs/l8KS8uHxhODQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/tapable/-/tapable-1.0.8.tgz}
     name: '@types/tapable'
     version: 1.0.8
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/testing-library__jest-dom/5.9.5:
     resolution: {integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.9.5.tgz}
@@ -14931,7 +14913,7 @@ packages:
     resolution: {integrity: sha512-PsPx0RLbo2Un8+ff2buzYJnZjzwhD3jQHPOG2PtVIeOhkRDddMcKU8vJtHpzzfLB95dkUi0qAkfLg2l2Fd0yrQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.35.tgz}
     name: '@types/ua-parser-js'
     version: 0.7.35
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/uglify-js/3.16.0:
     resolution: {integrity: sha512-0yeUr92L3r0GLRnBOvtYK1v2SjqMIqQDHMl7GLb+l2L8+6LSFWEEWEIgVsPdMn5ImLM8qzWT8xFPtQYpp8co0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.16.0.tgz}
@@ -14939,7 +14921,7 @@ packages:
     version: 3.16.0
     dependencies:
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/ungap__global-this/0.3.1:
     resolution: {integrity: sha512-+/DsiV4CxXl6ZWefwHZDXSe1Slitz21tom38qPCaG0DYCS1NnDPIQDTKcmQ/tvK/edJUKkmuIDBJbmKDiB0r/g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/ungap__global-this/-/ungap__global-this-0.3.1.tgz}
@@ -14968,7 +14950,7 @@ packages:
     resolution: {integrity: sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/uuid/-/uuid-8.3.4.tgz}
     name: '@types/uuid'
     version: 8.3.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-middleware/5.3.0_webpack@5.51.1:
     resolution: {integrity: sha512-SklLlklFBfTyIXo1iWXxzeytjlysWfj5QfIcRJrCc7MgzuCjnZOHXviQwe81iFGq9ZkCUXAg2fpbZdHhj5lSWA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-middleware/-/webpack-dev-middleware-5.3.0.tgz}
@@ -14980,7 +14962,7 @@ packages:
       webpack-dev-middleware: registry.npmjs.org/webpack-dev-middleware/5.3.3_webpack@5.51.1
     transitivePeerDependencies:
       - webpack
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-server/3.11.6_debug@4.3.2:
     resolution: {integrity: sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-3.11.6.tgz}
@@ -14995,7 +14977,7 @@ packages:
       http-proxy-middleware: registry.npmjs.org/http-proxy-middleware/1.3.1_debug@4.3.2
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-dev-server/4.0.3_debug@4.3.2+webpack@5.51.1:
     resolution: {integrity: sha512-kNcngS7vmFL8P5WZFtpFMTCwXcZEAZE3wz5xtWIuoEa6wXb2LPJl55HZqcevOi0qqzAKOEEJPKJxe2rxJ+ZYxg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-dev-server/-/webpack-dev-server-4.0.3.tgz}
@@ -15015,7 +14997,7 @@ packages:
     transitivePeerDependencies:
       - debug
       - webpack
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack-sources/3.2.0:
     resolution: {integrity: sha512-Ft7YH3lEVRQ6ls8k4Ff1oB4jN6oy/XmU6tQISKdhfh+1mR+viZFphS6WL0IrtDOzvefmJg5a0s7ZQoRXwqTEFg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-3.2.0.tgz}
@@ -15025,7 +15007,7 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/13.13.52
       '@types/source-list-map': registry.npmjs.org/@types/source-list-map/0.1.2
       source-map: registry.npmjs.org/source-map/0.7.4
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack/4.41.32:
     resolution: {integrity: sha512-cb+0ioil/7oz5//7tZUSwbrSAN/NWHrQylz5cW8G0dWTcF/g+/dSdMlKVZspBYuMAN1+WnwHrkxiRrLcwd0Heg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack/-/webpack-4.41.32.tgz}
@@ -15038,7 +15020,7 @@ packages:
       '@types/webpack-sources': registry.npmjs.org/@types/webpack-sources/3.2.0
       anymatch: registry.npmjs.org/anymatch/3.1.2
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/webpack/5.28.0_esbuild@0.14.28:
     resolution: {integrity: sha512-8cP0CzcxUiFuA9xGJkfeVpqmWTk9nx6CWwamRGCj95ph1SmlRRk9KlCZ6avhCbZd4L68LvYT6l1kpdEnQXrF8w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/webpack/-/webpack-5.28.0.tgz}
@@ -15054,7 +15036,6 @@ packages:
       - esbuild
       - uglify-js
       - webpack-cli
-    dev: false
 
   registry.npmjs.org/@types/websocket/1.0.2:
     resolution: {integrity: sha512-B5m9aq7cbbD/5/jThEr33nUY8WEfVi6A2YKCTOvw5Ldy7mtsOkqRvGjnzy6g7iMMDsgu7xREuCzqATLDLQVKcQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/websocket/-/websocket-1.0.2.tgz}
@@ -15106,10 +15087,10 @@ packages:
     version: 17.0.0
     dependencies:
       '@types/yargs-parser': registry.npmjs.org/@types/yargs-parser/21.0.0
-    dev: false
+    dev: true
 
   registry.npmjs.org/@types/yauzl/2.10.0:
-    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz}
+    resolution: {integrity: sha512-Cn6WYCm0tXv8p6k+A8PvbDG763EDpBoTzHdA+Q/MF6H3sapGjCm9NzoaJncJS9tUKSuCoDs9XHxYYsQDgxR6kw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.0.tgz}
     name: '@types/yauzl'
     version: 2.10.0
     requiresBuild: true
@@ -15403,7 +15384,7 @@ packages:
       debug: registry.npmjs.org/debug/4.3.4
       eslint-visitor-keys: registry.npmjs.org/eslint-visitor-keys/1.3.0
       glob: registry.npmjs.org/glob/7.2.0
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       lodash: registry.npmjs.org/lodash/4.17.21
       semver: registry.npmjs.org/semver/7.3.7
       tsutils: registry.npmjs.org/tsutils/3.21.0_typescript@4.4.2
@@ -15427,10 +15408,10 @@ packages:
       '@typescript-eslint/types': registry.npmjs.org/@typescript-eslint/types/3.10.1
       '@typescript-eslint/visitor-keys': registry.npmjs.org/@typescript-eslint/visitor-keys/3.10.1
       debug: registry.npmjs.org/debug/4.3.4
-      glob: registry.npmjs.org/glob/7.1.6
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      glob: registry.npmjs.org/glob/7.2.0
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       lodash: registry.npmjs.org/lodash/4.17.21
-      semver: registry.npmjs.org/semver/7.3.4
+      semver: registry.npmjs.org/semver/7.3.7
       tsutils: registry.npmjs.org/tsutils/3.21.0_typescript@3.9.10
       typescript: registry.npmjs.org/typescript/3.9.10
     transitivePeerDependencies:
@@ -15477,7 +15458,7 @@ packages:
       '@typescript-eslint/visitor-keys': registry.npmjs.org/@typescript-eslint/visitor-keys/4.33.0
       debug: registry.npmjs.org/debug/4.3.4
       globby: registry.npmjs.org/globby/11.1.0
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       semver: registry.npmjs.org/semver/7.3.7
       tsutils: registry.npmjs.org/tsutils/3.21.0_typescript@4.4.2
       typescript: registry.npmjs.org/typescript/4.4.2
@@ -15641,25 +15622,21 @@ packages:
     dependencies:
       '@webassemblyjs/helper-numbers': registry.npmjs.org/@webassemblyjs/helper-numbers/1.11.1
       '@webassemblyjs/helper-wasm-bytecode': registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.1.tgz}
     name: '@webassemblyjs/floating-point-hex-parser'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-api-error/1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.1.tgz}
     name: '@webassemblyjs/helper-api-error'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.11.1.tgz}
     name: '@webassemblyjs/helper-buffer'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-numbers/1.11.1:
     resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.1.tgz}
@@ -15669,13 +15646,11 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/1.11.1
       '@webassemblyjs/helper-api-error': registry.npmjs.org/@webassemblyjs/helper-api-error/1.11.1
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.1.tgz}
     name: '@webassemblyjs/helper-wasm-bytecode'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/helper-wasm-section/1.11.1:
     resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.11.1.tgz}
@@ -15686,7 +15661,6 @@ packages:
       '@webassemblyjs/helper-buffer': registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1
       '@webassemblyjs/helper-wasm-bytecode': registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/1.11.1
       '@webassemblyjs/wasm-gen': registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/ieee754/1.11.1:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.1.tgz}
@@ -15694,7 +15668,6 @@ packages:
     version: 1.11.1
     dependencies:
       '@xtuc/ieee754': registry.npmjs.org/@xtuc/ieee754/1.2.0
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/leb128/1.11.1:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.1.tgz}
@@ -15702,13 +15675,11 @@ packages:
     version: 1.11.1
     dependencies:
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/utf8/1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.1.tgz}
     name: '@webassemblyjs/utf8'
     version: 1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-edit/1.11.1:
     resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.11.1.tgz}
@@ -15723,7 +15694,6 @@ packages:
       '@webassemblyjs/wasm-opt': registry.npmjs.org/@webassemblyjs/wasm-opt/1.11.1
       '@webassemblyjs/wasm-parser': registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1
       '@webassemblyjs/wast-printer': registry.npmjs.org/@webassemblyjs/wast-printer/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1:
     resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.11.1.tgz}
@@ -15735,7 +15705,6 @@ packages:
       '@webassemblyjs/ieee754': registry.npmjs.org/@webassemblyjs/ieee754/1.11.1
       '@webassemblyjs/leb128': registry.npmjs.org/@webassemblyjs/leb128/1.11.1
       '@webassemblyjs/utf8': registry.npmjs.org/@webassemblyjs/utf8/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-opt/1.11.1:
     resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.11.1.tgz}
@@ -15746,7 +15715,6 @@ packages:
       '@webassemblyjs/helper-buffer': registry.npmjs.org/@webassemblyjs/helper-buffer/1.11.1
       '@webassemblyjs/wasm-gen': registry.npmjs.org/@webassemblyjs/wasm-gen/1.11.1
       '@webassemblyjs/wasm-parser': registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wasm-parser/1.11.1:
     resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.11.1.tgz}
@@ -15759,7 +15727,6 @@ packages:
       '@webassemblyjs/ieee754': registry.npmjs.org/@webassemblyjs/ieee754/1.11.1
       '@webassemblyjs/leb128': registry.npmjs.org/@webassemblyjs/leb128/1.11.1
       '@webassemblyjs/utf8': registry.npmjs.org/@webassemblyjs/utf8/1.11.1
-    dev: false
 
   registry.npmjs.org/@webassemblyjs/wast-printer/1.11.1:
     resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.11.1.tgz}
@@ -15768,7 +15735,6 @@ packages:
     dependencies:
       '@webassemblyjs/ast': registry.npmjs.org/@webassemblyjs/ast/1.11.1
       '@xtuc/long': registry.npmjs.org/@xtuc/long/4.2.2
-    dev: false
 
   registry.npmjs.org/@wry/context/0.5.4:
     resolution: {integrity: sha512-/pktJKHUXDr4D6TJqWgudOPJW2Z+Nb+bqk40jufA3uTkLbnCRKdJPiYDIa/c7mfcPH8Hr6O8zjCERpg5Sq04Zg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@wry/context/-/context-0.5.4.tgz}
@@ -15812,13 +15778,11 @@ packages:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz}
     name: '@xtuc/ieee754'
     version: 1.2.0
-    dev: false
 
   registry.npmjs.org/@xtuc/long/4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz}
     name: '@xtuc/long'
     version: 4.2.2
-    dev: false
 
   registry.npmjs.org/@yarnpkg/cli/3.2.1:
     resolution: {integrity: sha512-yyxDEg4Y6z9RErREFDXa2ZFMy7dc5l3TF7WsfIZdw7/B1ZbBO7PdcHxenGZE62zO6PO17SrKZgJlwv1xVbUpcQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@yarnpkg/cli/-/cli-3.2.1.tgz}
@@ -16428,7 +16392,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@zkochan/hosted-git-info/4.0.2:
-    resolution: {integrity: sha512-DviFQfIuMzstXzcutxWP5uaAdzEg6AtAWtMKFkqVSgx6otqZ2hJaSML6saK1a1cVOfhu/ZqjV7qTSnYAdX2nhw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@zkochan/hosted-git-info/-/hosted-git-info-4.0.2.tgz}
+    resolution: {integrity: sha512-DviFQfIuMzstXzcutxWP5uaAdzEg6AtAWtMKFkqVSgx6otqZ2hJaSML6saK1a1cVOfhu/ZqjV7qTSnYAdX2nhw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@zkochan/hosted-git-info/-/hosted-git-info-4.0.2.tgz}
     name: '@zkochan/hosted-git-info'
     version: 4.0.2
     engines: {node: '>=10'}
@@ -16437,7 +16401,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@zkochan/js-yaml/0.0.5:
-    resolution: {integrity: sha512-/uaB1kf+t+UATNUSyzHSzy4JqKOh2Y77gdCnhQEKTX/vrpQp8qjvohvC6eG9X4spQf0a8TKL0qF5LiFNj+GrJw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.5.tgz}
+    resolution: {integrity: sha512-/uaB1kf+t+UATNUSyzHSzy4JqKOh2Y77gdCnhQEKTX/vrpQp8qjvohvC6eG9X4spQf0a8TKL0qF5LiFNj+GrJw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@zkochan/js-yaml/-/js-yaml-0.0.5.tgz}
     name: '@zkochan/js-yaml'
     version: 0.0.5
     hasBin: true
@@ -16473,7 +16437,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@zkochan/which/2.0.3:
-    resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/@zkochan/which/-/which-2.0.3.tgz}
+    resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/@zkochan/which/-/which-2.0.3.tgz}
     name: '@zkochan/which'
     version: 2.0.3
     engines: {node: '>= 8'}
@@ -16556,7 +16520,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: registry.npmjs.org/acorn/8.7.1
-    dev: false
 
   registry.npmjs.org/acorn-jsx/3.0.1:
     resolution: {integrity: sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz}
@@ -16592,7 +16555,7 @@ packages:
     dev: false
 
   registry.npmjs.org/acorn/3.3.0:
-    resolution: {integrity: sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz}
+    resolution: {integrity: sha512-OLUyIIZ7mF5oaAUT1w0TFqQS81q3saT46x8t7ukpPjMNk+nbs4ZHhs7ToV8EWnLYLepjETXd4XaCE4uxkMeqUw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz}
     name: acorn
     version: 3.3.0
     engines: {node: '>=0.4.0'}
@@ -16600,7 +16563,7 @@ packages:
     dev: false
 
   registry.npmjs.org/acorn/5.7.4:
-    resolution: {integrity: sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz}
+    resolution: {integrity: sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz}
     name: acorn
     version: 5.7.4
     engines: {node: '>=0.4.0'}
@@ -16615,7 +16578,7 @@ packages:
     hasBin: true
 
   registry.npmjs.org/acorn/7.4.1:
-    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz}
+    resolution: {integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz}
     name: acorn
     version: 7.4.1
     engines: {node: '>=0.4.0'}
@@ -16628,7 +16591,6 @@ packages:
     version: 8.7.1
     engines: {node: '>=0.4.0'}
     hasBin: true
-    dev: false
 
   registry.npmjs.org/address/1.1.2:
     resolution: {integrity: sha512-aT6camzM4xEA54YVJYSqxz1kv4IHnQZRtThJJHhUMRExaU5spC7jX5ugSwTaTgJliIgs4VhZOk7htClvQ/LmRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/address/-/address-1.1.2.tgz}
@@ -16740,7 +16702,6 @@ packages:
         optional: true
     dependencies:
       ajv: registry.npmjs.org/ajv/8.11.0
-    dev: false
 
   registry.npmjs.org/ajv-keywords/2.1.1_ajv@5.5.2:
     resolution: {integrity: sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz}
@@ -16762,7 +16723,6 @@ packages:
       ajv: ^6.9.1
     dependencies:
       ajv: registry.npmjs.org/ajv/6.12.6
-    dev: false
 
   registry.npmjs.org/ajv-keywords/5.1.0_ajv@8.11.0:
     resolution: {integrity: sha512-YCS/JNFAUyr5vAuhk1DWm1CBxRHW9LbJ2ozWeemrIqpbsqKjHVxYPyi5GC0rjZIT5JxJ3virVTS8wk4i/Z+krw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-5.1.0.tgz}
@@ -16774,7 +16734,6 @@ packages:
     dependencies:
       ajv: registry.npmjs.org/ajv/8.11.0
       fast-deep-equal: registry.npmjs.org/fast-deep-equal/3.1.3
-    dev: false
 
   registry.npmjs.org/ajv/4.11.8:
     resolution: {integrity: sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz}
@@ -16786,7 +16745,7 @@ packages:
     dev: false
 
   registry.npmjs.org/ajv/5.5.2:
-    resolution: {integrity: sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz}
+    resolution: {integrity: sha512-Ajr4IcMXq/2QmMkEmSvxqfLN5zGmJ92gHXAeOXq1OekoH2rfDNsgdDoL2f7QaRCy7G/E6TpxBVdRuNraMztGHw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz}
     name: ajv
     version: 5.5.2
     dependencies:
@@ -16807,7 +16766,7 @@ packages:
       uri-js: registry.npmjs.org/uri-js/4.4.1
 
   registry.npmjs.org/ajv/8.11.0:
-    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz}
+    resolution: {integrity: sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz}
     name: ajv
     version: 8.11.0
     dependencies:
@@ -16815,7 +16774,6 @@ packages:
       json-schema-traverse: registry.npmjs.org/json-schema-traverse/1.0.0
       require-from-string: registry.npmjs.org/require-from-string/2.0.2
       uri-js: registry.npmjs.org/uri-js/4.4.1
-    dev: false
 
   registry.npmjs.org/amdefine/1.0.1:
     resolution: {integrity: sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz}
@@ -17454,7 +17412,7 @@ packages:
     dev: false
 
   registry.npmjs.org/argparse/2.0.1:
-    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz}
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz}
     name: argparse
     version: 2.0.1
     dev: false
@@ -17492,7 +17450,7 @@ packages:
     version: 4.2.2
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.18.6
       '@babel/runtime-corejs3': registry.npmjs.org/@babel/runtime-corejs3/7.18.6
     dev: false
 
@@ -18068,7 +18026,7 @@ packages:
     name: babel-plugin-macros
     version: 2.8.0
     dependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.18.6
       cosmiconfig: registry.npmjs.org/cosmiconfig/6.0.0
       resolve: registry.npmjs.org/resolve/1.20.0
     dev: false
@@ -18272,7 +18230,7 @@ packages:
     dev: false
 
   registry.npmjs.org/balanced-match/1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz}
     name: balanced-match
     version: 1.0.2
 
@@ -18536,7 +18494,7 @@ packages:
       concat-map: registry.npmjs.org/concat-map/0.0.1
 
   registry.npmjs.org/brace-expansion/2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz}
+    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz}
     name: brace-expansion
     version: 2.0.1
     dependencies:
@@ -18689,7 +18647,6 @@ packages:
       electron-to-chromium: registry.npmjs.org/electron-to-chromium/1.4.179
       escalade: registry.npmjs.org/escalade/3.1.1
       node-releases: registry.npmjs.org/node-releases/1.1.77
-    dev: false
 
   registry.npmjs.org/browserslist/4.21.1:
     resolution: {integrity: sha512-Nq8MFCSrnJXSc88yliwlzQe3qNe3VntIjhsArW9IJOEPSHNx23FalwApUVbzAWABLhYJJ7y8AynWI/XM8OdfjQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/browserslist/-/browserslist-4.21.1.tgz}
@@ -18899,7 +18856,7 @@ packages:
       - bluebird
 
   registry.npmjs.org/cacache/15.3.0_bluebird@3.7.2:
-    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz}
+    resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/cacache/-/cacache-15.3.0.tgz}
     id: registry.npmjs.org/cacache/15.3.0
     name: cacache
     version: 15.3.0
@@ -19093,7 +19050,6 @@ packages:
     resolution: {integrity: sha512-HpQhpzTGGPVMnCjIomjt+jvyUu8vNFo3TaDiZ/RcoTrlOq/5+tC8zHdsbgFB6MxmaY+jCpsH09aD80Bb4Ow3Sg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001363.tgz}
     name: caniuse-lite
     version: 1.0.30001363
-    dev: false
 
   registry.npmjs.org/capture-stack-trace/1.0.1:
     resolution: {integrity: sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz}
@@ -19331,7 +19287,7 @@ packages:
       braces: registry.npmjs.org/braces/3.0.2
       glob-parent: registry.npmjs.org/glob-parent/5.1.2
       is-binary-path: registry.npmjs.org/is-binary-path/2.1.0
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       normalize-path: registry.npmjs.org/normalize-path/3.0.0
       readdirp: registry.npmjs.org/readdirp/3.6.0
     optionalDependencies:
@@ -19353,7 +19309,6 @@ packages:
     name: chrome-trace-event
     version: 1.0.3
     engines: {node: '>=6.0'}
-    dev: false
 
   registry.npmjs.org/ci-info/1.6.0:
     resolution: {integrity: sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ci-info/-/ci-info-1.6.0.tgz}
@@ -19796,13 +19751,11 @@ packages:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz}
     name: colorette
     version: 1.4.0
-    dev: false
 
   registry.npmjs.org/colorette/2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz}
     name: colorette
     version: 2.0.19
-    dev: false
 
   registry.npmjs.org/colors/1.0.3:
     resolution: {integrity: sha512-pFGrxThWcWQ2MsAz6RtgeWe4NK2kUE1WfsrvvlctdII745EW9I0yflqhe7++M5LEc7bV2c/9/5zc8sFcpL0Drw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/colors/-/colors-1.0.3.tgz}
@@ -19928,12 +19881,6 @@ packages:
       private: registry.npmjs.org/private/0.1.8
       q: registry.npmjs.org/q/1.5.1
       recast: registry.npmjs.org/recast/0.11.23
-    dev: false
-
-  registry.npmjs.org/compare-versions/3.6.0:
-    resolution: {integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz}
-    name: compare-versions
-    version: 3.6.0
     dev: false
 
   registry.npmjs.org/component-bind/1.0.0:
@@ -20266,7 +20213,7 @@ packages:
     dev: false
 
   registry.npmjs.org/core-js/1.2.7:
-    resolution: {integrity: sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz}
+    resolution: {integrity: sha512-ZiPp9pZlgxpWRu0M+YWbm6+aQ84XEfH1JRXvfOc/fILWI0VKhLC2LX13X1NYq4fULzLMq7Hfh43CSo2/aIaUPA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz}
     name: core-js
     version: 1.2.7
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
@@ -20287,13 +20234,13 @@ packages:
     requiresBuild: true
 
   registry.npmjs.org/core-js/3.23.3:
-    resolution: {integrity: sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz}
+    resolution: {integrity: sha512-oAKwkj9xcWNBAvGbT//WiCdOMpb9XQG92/Fe3ABFM/R16BsHgePG00mFOgKf7IsCtfj8tA1kHtf/VwErhriz5Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/core-js/-/core-js-3.23.3.tgz}
     name: core-js
     version: 3.23.3
     requiresBuild: true
 
   registry.npmjs.org/core-js/3.9.0:
-    resolution: {integrity: sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz}
+    resolution: {integrity: sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz}
     name: core-js
     version: 3.9.0
     deprecated: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
@@ -20359,7 +20306,7 @@ packages:
     dev: false
 
   registry.npmjs.org/cpu-features/0.0.2:
-    resolution: {integrity: sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz}
+    resolution: {integrity: sha512-/2yieBqvMcRj8McNzkycjW2v3OIUOibBfd2dLEJ0nWts8NobAxwiyw9phVNS6oDL8x8tz9F7uNVFEVpJncQpeA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/cpu-features/-/cpu-features-0.0.2.tgz}
     name: cpu-features
     version: 0.0.2
     engines: {node: '>=8.0.0'}
@@ -20685,7 +20632,7 @@ packages:
     dev: false
 
   registry.npmjs.org/css-tree/1.0.0-alpha.37:
-    resolution: {integrity: sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz}
+    resolution: {integrity: sha512-DMxWJg0rnz7UgxKT0Q1HU/L9BeJI0M6ksor0OgqOnF+aRCDWg/N2641HmVyU9KVIu0OVVWOb2IpC9A+BJRnejg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.37.tgz}
     name: css-tree
     version: 1.0.0-alpha.37
     engines: {node: '>=8.0.0'}
@@ -20704,7 +20651,7 @@ packages:
       source-map: registry.npmjs.org/source-map/0.6.1
 
   registry.npmjs.org/css-tree/1.1.3:
-    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz}
+    resolution: {integrity: sha512-tRpdppF7TRazZrjJ6v3stzv93qxRcSsFmW6cX0Zm2NVKpxE1WV1HblnghVv9TreireHkqI/VDEsfolRF1p6y7Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/css-tree/-/css-tree-1.1.3.tgz}
     name: css-tree
     version: 1.1.3
     engines: {node: '>=8.0.0'}
@@ -20855,7 +20802,7 @@ packages:
     version: 4.2.0
     engines: {node: '>=8.0.0'}
     dependencies:
-      css-tree: registry.npmjs.org/css-tree/1.1.2
+      css-tree: registry.npmjs.org/css-tree/1.1.3
     dev: false
 
   registry.npmjs.org/cssom/0.3.8:
@@ -20888,7 +20835,7 @@ packages:
     dev: false
 
   registry.npmjs.org/csstype/3.1.0:
-    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz}
+    resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/csstype/-/csstype-3.1.0.tgz}
     name: csstype
     version: 3.1.0
 
@@ -21086,7 +21033,7 @@ packages:
     dev: false
 
   registry.npmjs.org/debug/3.1.0:
-    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/debug/-/debug-3.1.0.tgz}
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/debug/-/debug-3.1.0.tgz}
     name: debug
     version: 3.1.0
     peerDependencies:
@@ -21098,7 +21045,7 @@ packages:
       ms: registry.npmjs.org/ms/2.0.0
 
   registry.npmjs.org/debug/3.1.0_supports-color@5.4.0:
-    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/debug/-/debug-3.1.0.tgz}
+    resolution: {integrity: sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/debug/-/debug-3.1.0.tgz}
     id: registry.npmjs.org/debug/3.1.0
     name: debug
     version: 3.1.0
@@ -21113,7 +21060,7 @@ packages:
     dev: false
 
   registry.npmjs.org/debug/3.2.7:
-    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz}
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/debug/-/debug-3.2.7.tgz}
     name: debug
     version: 3.2.7
     peerDependencies:
@@ -21212,7 +21159,7 @@ packages:
     dev: false
 
   registry.npmjs.org/decamelize/4.0.0:
-    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz}
+    resolution: {integrity: sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz}
     name: decamelize
     version: 4.0.0
     engines: {node: '>=10'}
@@ -21392,7 +21339,7 @@ packages:
     dependencies:
       globby: registry.npmjs.org/globby/11.1.0
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       is-path-cwd: registry.npmjs.org/is-path-cwd/2.2.0
       is-path-inside: registry.npmjs.org/is-path-inside/3.0.3
       p-map: registry.npmjs.org/p-map/4.0.0
@@ -21494,7 +21441,7 @@ packages:
     engines: {node: '>=4'}
 
   registry.npmjs.org/detect-indent/6.1.0:
-    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz}
+    resolution: {integrity: sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz}
     name: detect-indent
     version: 6.1.0
     engines: {node: '>=8'}
@@ -21946,7 +21893,6 @@ packages:
     resolution: {integrity: sha512-1XeTb/U/8Xgh2YgPOqhakLYsvCcU4U7jUjTMbEnhIJoIWd/Qt3yC8y0cbG+fHzn4zUNF99Ey1xiPf20bwgLO3Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.179.tgz}
     name: electron-to-chromium
     version: 1.4.179
-    dev: false
 
   registry.npmjs.org/elliptic/6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz}
@@ -22114,7 +22060,6 @@ packages:
     dependencies:
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
       tapable: registry.npmjs.org/tapable/2.2.1
-    dev: false
 
   registry.npmjs.org/enquirer/2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz}
@@ -22180,7 +22125,7 @@ packages:
     dev: false
 
   registry.npmjs.org/errno/0.1.8:
-    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/errno/-/errno-0.1.8.tgz}
+    resolution: {integrity: sha512-dJ6oBr5SQ1VSd9qkk7ByRgb/1SH4JZjCHSW/mr63/QcXO9zLVxvJ6Oy13nio03rxpSnVDDjFor75SjVeZWPW/A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/errno/-/errno-0.1.8.tgz}
     name: errno
     version: 0.1.8
     hasBin: true
@@ -22241,7 +22186,6 @@ packages:
     resolution: {integrity: sha512-MgtWFl5No+4S3TmhDmCz2ObFGm6lEpTnzbQi+Dd+pw4mlTIZTmM2iAs5gRlmx5zS9luzobCSBSI90JM/1/JgOw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.7.1.tgz}
     name: es-module-lexer
     version: 0.7.1
-    dev: false
 
   registry.npmjs.org/es-shim-unscopables/1.0.0:
     resolution: {integrity: sha512-Jm6GPcCdC30eMLbZ2x8z2WuRwAws3zTBBKuusffYVUrNj/GVSUAZ+xKMaUpfNDR5IbyNA5LJbaecoUVbmUcB1w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.0.0.tgz}
@@ -22318,223 +22262,203 @@ packages:
       es6-symbol: registry.npmjs.org/es6-symbol/3.1.3
 
   registry.npmjs.org/esbuild-android-64/0.14.28:
-    resolution: {integrity: sha512-A52C3zq+9tNwCqZ+4kVLBxnk/WnrYM8P2+QNvNE9B6d2OVPs214lp3g6UyO+dKDhUdefhfPCuwkP8j2A/+szNA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.28.tgz}
+    resolution: {integrity: sha512-A52C3zq+9tNwCqZ+4kVLBxnk/WnrYM8P2+QNvNE9B6d2OVPs214lp3g6UyO+dKDhUdefhfPCuwkP8j2A/+szNA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-android-64/-/esbuild-android-64-0.14.28.tgz}
     name: esbuild-android-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-android-arm64/0.14.28:
-    resolution: {integrity: sha512-sm0fDEGElZhMC3HLZeECI2juE4aG7uPfMBMqNUhy9CeX399Pz8rC6e78OXMXInGjSdEAwQmCOHmfsP7uv3Q8rA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.28.tgz}
+    resolution: {integrity: sha512-sm0fDEGElZhMC3HLZeECI2juE4aG7uPfMBMqNUhy9CeX399Pz8rC6e78OXMXInGjSdEAwQmCOHmfsP7uv3Q8rA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-android-arm64/-/esbuild-android-arm64-0.14.28.tgz}
     name: esbuild-android-arm64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [android]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-darwin-64/0.14.28:
-    resolution: {integrity: sha512-nzDd7mQ44FvsFHtOafZdBgn3Li5SMsnMnoz1J2MM37xJmR3wGNTFph88KypjHgWqwbxCI7MXS1U+sN4qDeeW6Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.28.tgz}
+    resolution: {integrity: sha512-nzDd7mQ44FvsFHtOafZdBgn3Li5SMsnMnoz1J2MM37xJmR3wGNTFph88KypjHgWqwbxCI7MXS1U+sN4qDeeW6Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-darwin-64/-/esbuild-darwin-64-0.14.28.tgz}
     name: esbuild-darwin-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-darwin-arm64/0.14.28:
-    resolution: {integrity: sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.28.tgz}
+    resolution: {integrity: sha512-XEq/bLR/glsUl+uGrBimQzOVs/CmwI833fXUhP9xrLI3IJ+rKyrZ5IA8u+1crOEf1LoTn8tV+hInmX6rGjbScw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-darwin-arm64/-/esbuild-darwin-arm64-0.14.28.tgz}
     name: esbuild-darwin-arm64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [darwin]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-freebsd-64/0.14.28:
-    resolution: {integrity: sha512-rTKLgUj/HEcPeE5XZ7IZwWpFx7IWMfprN7QRk/TUJE1s1Ipb58esboIesUpjirJz/BwrgHq+FDG9ChAI8dZAtQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.28.tgz}
+    resolution: {integrity: sha512-rTKLgUj/HEcPeE5XZ7IZwWpFx7IWMfprN7QRk/TUJE1s1Ipb58esboIesUpjirJz/BwrgHq+FDG9ChAI8dZAtQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-freebsd-64/-/esbuild-freebsd-64-0.14.28.tgz}
     name: esbuild-freebsd-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-freebsd-arm64/0.14.28:
-    resolution: {integrity: sha512-sBffxD1UMOsB7aWMoExmipycjcy3HJGwmqE4GQZUTZvdiH4GhjgUiVdtPyt7kSCdL40JqnWQJ4b1l8Y51oCF4Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.28.tgz}
+    resolution: {integrity: sha512-sBffxD1UMOsB7aWMoExmipycjcy3HJGwmqE4GQZUTZvdiH4GhjgUiVdtPyt7kSCdL40JqnWQJ4b1l8Y51oCF4Q==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-freebsd-arm64/-/esbuild-freebsd-arm64-0.14.28.tgz}
     name: esbuild-freebsd-arm64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [freebsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-32/0.14.28:
-    resolution: {integrity: sha512-+Wxidh3fBEQ9kHcCsD4etlBTMb1n6QY2uXv3rFhVn88CY/JP782MhA57/ipLMY4kOLeSKEuFGN4rtjHuhmRMig==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.28.tgz}
+    resolution: {integrity: sha512-+Wxidh3fBEQ9kHcCsD4etlBTMb1n6QY2uXv3rFhVn88CY/JP782MhA57/ipLMY4kOLeSKEuFGN4rtjHuhmRMig==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-32/-/esbuild-linux-32-0.14.28.tgz}
     name: esbuild-linux-32
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-64/0.14.28:
-    resolution: {integrity: sha512-7+xgsC4LvR6cnzaBdiljNnPDjbkwzahogN+S9uy9AoYw7ZjPnnXc6sjQAVCbqGb7MEgrWdpa6u/Tao79i4lWxg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.28.tgz}
+    resolution: {integrity: sha512-7+xgsC4LvR6cnzaBdiljNnPDjbkwzahogN+S9uy9AoYw7ZjPnnXc6sjQAVCbqGb7MEgrWdpa6u/Tao79i4lWxg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-64/-/esbuild-linux-64-0.14.28.tgz}
     name: esbuild-linux-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-arm/0.14.28:
-    resolution: {integrity: sha512-L5isjmlLbh9E0WVllXiVETbScgMbth/+XkXQii1WwgO1RvLIfaGrVFz8d2n6EH/ImtgYxPYGx+OcvIKQBc91Rg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.28.tgz}
+    resolution: {integrity: sha512-L5isjmlLbh9E0WVllXiVETbScgMbth/+XkXQii1WwgO1RvLIfaGrVFz8d2n6EH/ImtgYxPYGx+OcvIKQBc91Rg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-arm/-/esbuild-linux-arm-0.14.28.tgz}
     name: esbuild-linux-arm
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-arm64/0.14.28:
-    resolution: {integrity: sha512-EjRHgwg+kgXABzyoPGPOPg4d5wZqRnZ/ZAxBDzLY+i6DS8OUfTSlZHWIOZzU4XF7125WxRBg9ULbrFJBl+57Eg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.28.tgz}
+    resolution: {integrity: sha512-EjRHgwg+kgXABzyoPGPOPg4d5wZqRnZ/ZAxBDzLY+i6DS8OUfTSlZHWIOZzU4XF7125WxRBg9ULbrFJBl+57Eg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-arm64/-/esbuild-linux-arm64-0.14.28.tgz}
     name: esbuild-linux-arm64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-mips64le/0.14.28:
-    resolution: {integrity: sha512-krx9SSg7yfiUKk64EmjefOyiEF6nv2bRE4um/LiTaQ6Y/6FP4UF3/Ou/AxZVyR154uSRq63xejcAsmswXAYRsw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.28.tgz}
+    resolution: {integrity: sha512-krx9SSg7yfiUKk64EmjefOyiEF6nv2bRE4um/LiTaQ6Y/6FP4UF3/Ou/AxZVyR154uSRq63xejcAsmswXAYRsw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-mips64le/-/esbuild-linux-mips64le-0.14.28.tgz}
     name: esbuild-linux-mips64le
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-ppc64le/0.14.28:
-    resolution: {integrity: sha512-LD0Xxu9g+DNuhsEBV5QuVZ4uKVBMup0xPIruLweuAf9/mHXFnaCuNXUBF5t0DxKl7GQ5MSioKtnb92oMo+QXEw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.28.tgz}
+    resolution: {integrity: sha512-LD0Xxu9g+DNuhsEBV5QuVZ4uKVBMup0xPIruLweuAf9/mHXFnaCuNXUBF5t0DxKl7GQ5MSioKtnb92oMo+QXEw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-ppc64le/-/esbuild-linux-ppc64le-0.14.28.tgz}
     name: esbuild-linux-ppc64le
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [ppc64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-riscv64/0.14.28:
-    resolution: {integrity: sha512-L/DWfRh2P0vxq4Y+qieSNXKGdMg+e9Qe8jkbN2/8XSGYDTPzO2OcAxSujob4qIh7iSl+cknbXV+BvH0YFR0jbg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.28.tgz}
+    resolution: {integrity: sha512-L/DWfRh2P0vxq4Y+qieSNXKGdMg+e9Qe8jkbN2/8XSGYDTPzO2OcAxSujob4qIh7iSl+cknbXV+BvH0YFR0jbg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-riscv64/-/esbuild-linux-riscv64-0.14.28.tgz}
     name: esbuild-linux-riscv64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-linux-s390x/0.14.28:
-    resolution: {integrity: sha512-rrgxmsbmL8QQknWGnAL9bGJRQYLOi2AzXy5OTwfhxnj9eqjo5mSVbJXjgiq5LPUAMQZGdPH5yaNK0obAXS81Zw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.28.tgz}
+    resolution: {integrity: sha512-rrgxmsbmL8QQknWGnAL9bGJRQYLOi2AzXy5OTwfhxnj9eqjo5mSVbJXjgiq5LPUAMQZGdPH5yaNK0obAXS81Zw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-linux-s390x/-/esbuild-linux-s390x-0.14.28.tgz}
     name: esbuild-linux-s390x
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [s390x]
     os: [linux]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-netbsd-64/0.14.28:
-    resolution: {integrity: sha512-h8wntIyOR8/xMVVM6TvJxxWKh4AjmLK87IPKpuVi8Pq0kyk0RMA+eo4PFGk5j2XK0D7dj8PcSF5NSlP9kN/j0A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.28.tgz}
+    resolution: {integrity: sha512-h8wntIyOR8/xMVVM6TvJxxWKh4AjmLK87IPKpuVi8Pq0kyk0RMA+eo4PFGk5j2XK0D7dj8PcSF5NSlP9kN/j0A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-netbsd-64/-/esbuild-netbsd-64-0.14.28.tgz}
     name: esbuild-netbsd-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-openbsd-64/0.14.28:
-    resolution: {integrity: sha512-HBv18rVapbuDx52/fhZ/c/w6TXyaQAvRxiDDn5Hz/pBcwOs3cdd2WxeIKlWmDoqm2JMx5EVlq4IWgoaRX9mVkw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.28.tgz}
+    resolution: {integrity: sha512-HBv18rVapbuDx52/fhZ/c/w6TXyaQAvRxiDDn5Hz/pBcwOs3cdd2WxeIKlWmDoqm2JMx5EVlq4IWgoaRX9mVkw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-openbsd-64/-/esbuild-openbsd-64-0.14.28.tgz}
     name: esbuild-openbsd-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [openbsd]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-sunos-64/0.14.28:
-    resolution: {integrity: sha512-zlIxePhZxKYheR2vBCgPVvTixgo/ozOfOMoP6RZj8dxzquU1NgeyhjkcRXucbLCtmoNJ+i4PtWwPZTLuDd3bGg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.28.tgz}
+    resolution: {integrity: sha512-zlIxePhZxKYheR2vBCgPVvTixgo/ozOfOMoP6RZj8dxzquU1NgeyhjkcRXucbLCtmoNJ+i4PtWwPZTLuDd3bGg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-sunos-64/-/esbuild-sunos-64-0.14.28.tgz}
     name: esbuild-sunos-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-windows-32/0.14.28:
-    resolution: {integrity: sha512-am9DIJxXlld1BOAY/VlvBQHMUCPL7S3gB/lnXIY3M4ys0gfuRqPf4EvMwZMzYUbFKBY+/Qb8SRgPRRGhwnJ8Kg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.28.tgz}
+    resolution: {integrity: sha512-am9DIJxXlld1BOAY/VlvBQHMUCPL7S3gB/lnXIY3M4ys0gfuRqPf4EvMwZMzYUbFKBY+/Qb8SRgPRRGhwnJ8Kg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-windows-32/-/esbuild-windows-32-0.14.28.tgz}
     name: esbuild-windows-32
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-windows-64/0.14.28:
-    resolution: {integrity: sha512-78PhySDnmRZlsPNp/W/5Fim8iivlBQQxfhBFIqR7xwvfDmCFUSByyMKP7LCHgNtb04yNdop8nJJkJaQ8Xnwgiw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.28.tgz}
+    resolution: {integrity: sha512-78PhySDnmRZlsPNp/W/5Fim8iivlBQQxfhBFIqR7xwvfDmCFUSByyMKP7LCHgNtb04yNdop8nJJkJaQ8Xnwgiw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-windows-64/-/esbuild-windows-64-0.14.28.tgz}
     name: esbuild-windows-64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild-windows-arm64/0.14.28:
-    resolution: {integrity: sha512-VhXGBTo6HELD8zyHXynV6+L2jWx0zkKnGx4TmEdSBK7UVFACtOyfUqpToG0EtnYyRZ0HESBhzPSVpP781ovmvA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.28.tgz}
+    resolution: {integrity: sha512-VhXGBTo6HELD8zyHXynV6+L2jWx0zkKnGx4TmEdSBK7UVFACtOyfUqpToG0EtnYyRZ0HESBhzPSVpP781ovmvA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/esbuild-windows-arm64/-/esbuild-windows-arm64-0.14.28.tgz}
     name: esbuild-windows-arm64
     version: 0.14.28
     engines: {node: '>=12'}
     cpu: [arm64]
     os: [win32]
     requiresBuild: true
-    dev: false
     optional: true
 
   registry.npmjs.org/esbuild/0.14.28:
@@ -22565,7 +22489,6 @@ packages:
       esbuild-windows-32: registry.npmjs.org/esbuild-windows-32/0.14.28
       esbuild-windows-64: registry.npmjs.org/esbuild-windows-64/0.14.28
       esbuild-windows-arm64: registry.npmjs.org/esbuild-windows-arm64/0.14.28
-    dev: false
 
   registry.npmjs.org/escalade/3.1.1:
     resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz}
@@ -23029,7 +22952,6 @@ packages:
     dependencies:
       esrecurse: registry.npmjs.org/esrecurse/4.3.0
       estraverse: registry.npmjs.org/estraverse/4.3.0
-    dev: false
 
   registry.npmjs.org/eslint-utils/1.4.3:
     resolution: {integrity: sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz}
@@ -23097,7 +23019,7 @@ packages:
       esutils: registry.npmjs.org/esutils/2.0.3
       file-entry-cache: registry.npmjs.org/file-entry-cache/2.0.0
       functional-red-black-tree: registry.npmjs.org/functional-red-black-tree/1.0.1
-      glob: registry.npmjs.org/glob/7.1.6
+      glob: registry.npmjs.org/glob/7.2.0
       globals: registry.npmjs.org/globals/11.12.0
       ignore: registry.npmjs.org/ignore/3.3.10
       imurmurhash: registry.npmjs.org/imurmurhash/0.1.4
@@ -23152,7 +23074,7 @@ packages:
       import-fresh: registry.npmjs.org/import-fresh/3.3.0
       imurmurhash: registry.npmjs.org/imurmurhash/0.1.4
       inquirer: registry.npmjs.org/inquirer/7.3.3
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       js-yaml: registry.npmjs.org/js-yaml/3.14.1
       json-stable-stringify-without-jsonify: registry.npmjs.org/json-stable-stringify-without-jsonify/1.0.1
       levn: registry.npmjs.org/levn/0.3.0
@@ -23295,7 +23217,6 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: registry.npmjs.org/estraverse/5.3.0
-    dev: false
 
   registry.npmjs.org/estraverse/4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz}
@@ -23308,7 +23229,6 @@ packages:
     name: estraverse
     version: 5.3.0
     engines: {node: '>=4.0'}
-    dev: false
 
   registry.npmjs.org/estree-walker/1.0.1:
     resolution: {integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz}
@@ -23386,7 +23306,6 @@ packages:
     name: events
     version: 3.3.0
     engines: {node: '>=0.8.x'}
-    dev: false
 
   registry.npmjs.org/evp_bytestokey/1.0.3:
     resolution: {integrity: sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz}
@@ -23398,7 +23317,7 @@ packages:
     dev: false
 
   registry.npmjs.org/execa/0.7.0:
-    resolution: {integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/execa/-/execa-0.7.0.tgz}
+    resolution: {integrity: sha512-RztN09XglpYI7aBBrJCPW95jEH7YF1UEPOoX9yDhUTPdp7mK+CQvnLTuD10BNXZ3byLTu2uehZ8EcKT/4CGiFw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/execa/-/execa-0.7.0.tgz}
     name: execa
     version: 0.7.0
     engines: {node: '>=4'}
@@ -24082,7 +24001,7 @@ packages:
     dev: false
 
   registry.npmjs.org/find-up/2.1.0:
-    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz}
+    resolution: {integrity: sha512-NWzkk0jSJtTt08+FBFMvXoeZnOJD+jTtsRmBYbAIzJdX6l7dLgR7CTubCM5/eDdPUBvLCeVasP1brfVR/9/EZQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz}
     name: find-up
     version: 2.1.0
     engines: {node: '>=4'}
@@ -24091,7 +24010,7 @@ packages:
     dev: false
 
   registry.npmjs.org/find-up/3.0.0:
-    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz}
+    resolution: {integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz}
     name: find-up
     version: 3.0.0
     engines: {node: '>=6'}
@@ -24116,15 +24035,6 @@ packages:
     dependencies:
       locate-path: registry.npmjs.org/locate-path/6.0.0
       path-exists: registry.npmjs.org/path-exists/4.0.0
-
-  registry.npmjs.org/find-versions/4.0.0:
-    resolution: {integrity: sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/find-versions/-/find-versions-4.0.0.tgz}
-    name: find-versions
-    version: 4.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      semver-regex: registry.npmjs.org/semver-regex/3.1.4
-    dev: false
 
   registry.npmjs.org/find-yarn-workspace-root2/1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/find-yarn-workspace-root2/-/find-yarn-workspace-root2-1.2.16.tgz}
@@ -24257,7 +24167,6 @@ packages:
         optional: true
     dependencies:
       debug: registry.npmjs.org/debug/4.3.2
-    dev: false
 
   registry.npmjs.org/for-each/0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz}
@@ -24490,7 +24399,7 @@ packages:
     version: 1.0.0
 
   registry.npmjs.org/fsevents/2.3.2:
-    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz}
     name: fsevents
     version: 2.3.2
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -24813,7 +24722,7 @@ packages:
     version: 5.1.2
     engines: {node: '>= 6'}
     dependencies:
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
 
   registry.npmjs.org/glob-to-regexp/0.3.0:
     resolution: {integrity: sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz}
@@ -24825,10 +24734,9 @@ packages:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz}
     name: glob-to-regexp
     version: 0.4.1
-    dev: false
 
   registry.npmjs.org/glob/5.0.15:
-    resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob/-/glob-5.0.15.tgz}
+    resolution: {integrity: sha512-c9IPMazfRITpmAAKi22dK1VKxGDX9ehhqfABDriL/lzO92xcUKEJPQHrVA/2YHSNFB4iFlykVmWvwo48nr3OxA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/glob/-/glob-5.0.15.tgz}
     name: glob
     version: 5.0.15
     dependencies:
@@ -24840,7 +24748,7 @@ packages:
     dev: false
 
   registry.npmjs.org/glob/6.0.4:
-    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob/-/glob-6.0.4.tgz}
+    resolution: {integrity: sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/glob/-/glob-6.0.4.tgz}
     name: glob
     version: 6.0.4
     dependencies:
@@ -24852,7 +24760,7 @@ packages:
     dev: false
 
   registry.npmjs.org/glob/7.1.2:
-    resolution: {integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/glob/-/glob-7.1.2.tgz}
+    resolution: {integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/glob/-/glob-7.1.2.tgz}
     name: glob
     version: 7.1.2
     dependencies:
@@ -24955,7 +24863,7 @@ packages:
       slash: registry.npmjs.org/slash/3.0.0
 
   registry.npmjs.org/globby/11.0.3:
-    resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/globby/-/globby-11.0.3.tgz}
+    resolution: {integrity: sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/globby/-/globby-11.0.3.tgz}
     name: globby
     version: 11.0.3
     engines: {node: '>=10'}
@@ -25639,7 +25547,7 @@ packages:
       react-is: registry.npmjs.org/react-is/16.13.1
 
   registry.npmjs.org/hosted-git-info/2.8.9:
-    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz}
+    resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz}
     name: hosted-git-info
     version: 2.8.9
 
@@ -25892,7 +25800,7 @@ packages:
     engines: {node: '>=4.0.0'}
     dependencies:
       http-proxy: registry.npmjs.org/http-proxy/1.18.1_debug@4.3.2
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       lodash: registry.npmjs.org/lodash/4.17.21
       micromatch: registry.npmjs.org/micromatch/3.1.10
     transitivePeerDependencies:
@@ -25909,12 +25817,12 @@ packages:
     dependencies:
       '@types/http-proxy': registry.npmjs.org/@types/http-proxy/1.17.9
       http-proxy: registry.npmjs.org/http-proxy/1.18.1_debug@4.3.2
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       is-plain-obj: registry.npmjs.org/is-plain-obj/3.0.0
       micromatch: registry.npmjs.org/micromatch/4.0.5
     transitivePeerDependencies:
       - debug
-    dev: false
+    dev: true
 
   registry.npmjs.org/http-proxy-middleware/2.0.6_a008e9e7aa7c4863998e827f3fa58721:
     resolution: {integrity: sha512-ya/UeJ6HVBYxrgYotAZo1KvPWlgB48kUJLDePFeneHsVujFaW5WNj2NgWCAE//B1Dl02BIfYlpNgBy8Kf8Rjmw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.6.tgz}
@@ -25931,7 +25839,7 @@ packages:
       '@types/express': registry.npmjs.org/@types/express/4.17.13
       '@types/http-proxy': registry.npmjs.org/@types/http-proxy/1.17.9
       http-proxy: registry.npmjs.org/http-proxy/1.18.1_debug@4.3.2
-      is-glob: registry.npmjs.org/is-glob/4.0.1
+      is-glob: registry.npmjs.org/is-glob/4.0.3
       is-plain-obj: registry.npmjs.org/is-plain-obj/3.0.0
       micromatch: registry.npmjs.org/micromatch/4.0.5
     transitivePeerDependencies:
@@ -25950,7 +25858,6 @@ packages:
       requires-port: registry.npmjs.org/requires-port/1.0.0
     transitivePeerDependencies:
       - debug
-    dev: false
 
   registry.npmjs.org/http-signature/1.2.0:
     resolution: {integrity: sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz}
@@ -26047,24 +25954,12 @@ packages:
       decamelize: registry.npmjs.org/decamelize/2.0.0
     dev: false
 
-  registry.npmjs.org/husky/4.3.8:
-    resolution: {integrity: sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/husky/-/husky-4.3.8.tgz}
+  registry.npmjs.org/husky/7.0.4:
+    resolution: {integrity: sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/husky/-/husky-7.0.4.tgz}
     name: husky
-    version: 4.3.8
-    engines: {node: '>=10'}
+    version: 7.0.4
+    engines: {node: '>=12'}
     hasBin: true
-    requiresBuild: true
-    dependencies:
-      chalk: registry.npmjs.org/chalk/4.1.2
-      ci-info: registry.npmjs.org/ci-info/2.0.0
-      compare-versions: registry.npmjs.org/compare-versions/3.6.0
-      cosmiconfig: registry.npmjs.org/cosmiconfig/7.0.1
-      find-versions: registry.npmjs.org/find-versions/4.0.0
-      opencollective-postinstall: registry.npmjs.org/opencollective-postinstall/2.0.3
-      pkg-dir: registry.npmjs.org/pkg-dir/5.0.0
-      please-upgrade-node: registry.npmjs.org/please-upgrade-node/3.2.0
-      slash: registry.npmjs.org/slash/3.0.0
-      which-pm-runs: registry.npmjs.org/which-pm-runs/1.1.0
     dev: false
 
   registry.npmjs.org/hyperquest/2.0.0:
@@ -26188,7 +26083,7 @@ packages:
     engines: {node: '>= 4'}
 
   registry.npmjs.org/image-size/0.5.5:
-    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz}
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/image-size/-/image-size-0.5.5.tgz}
     name: image-size
     version: 0.5.5
     engines: {node: '>=0.10.0'}
@@ -26459,7 +26354,7 @@ packages:
       strip-ansi: registry.npmjs.org/strip-ansi/4.0.0
 
   registry.npmjs.org/inquirer/3.3.0:
-    resolution: {integrity: sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz}
+    resolution: {integrity: sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz}
     name: inquirer
     version: 3.3.0
     dependencies:
@@ -26500,7 +26395,7 @@ packages:
       through: registry.npmjs.org/through/2.3.8
 
   registry.npmjs.org/inquirer/7.3.3:
-    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz}
+    resolution: {integrity: sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/inquirer/-/inquirer-7.3.3.tgz}
     name: inquirer
     version: 7.3.3
     engines: {node: '>=8.0.0'}
@@ -26909,7 +26804,7 @@ packages:
     dev: false
 
   registry.npmjs.org/is-glob/3.1.0:
-    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz}
+    resolution: {integrity: sha512-UFpDDrPgM6qpnFNI+rh/p3bUaq9hKLZN8bMUWzxmcnZVS3omf4IPK+BrewlnWjO1WmUsMYuSjKh4UJuV4+Lqmw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz}
     name: is-glob
     version: 3.1.0
     engines: {node: '>=0.10.0'}
@@ -26927,13 +26822,12 @@ packages:
       is-extglob: registry.npmjs.org/is-extglob/2.1.1
 
   registry.npmjs.org/is-glob/4.0.3:
-    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz}
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz}
     name: is-glob
     version: 4.0.3
     engines: {node: '>=0.10.0'}
     dependencies:
       is-extglob: registry.npmjs.org/is-extglob/2.1.1
-    dev: false
 
   registry.npmjs.org/is-gzip/1.0.0:
     resolution: {integrity: sha512-rcfALRIb1YewtnksfRIHGcIY93QnK8BIQ/2c9yDYcG/Y6+vRoJuTWBmmSEbyLLYtXm7q35pHOHbZFQBaLrhlWQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-gzip/-/is-gzip-1.0.0.tgz}
@@ -27083,7 +26977,6 @@ packages:
     name: is-plain-obj
     version: 3.0.0
     engines: {node: '>=10'}
-    dev: false
 
   registry.npmjs.org/is-plain-object/2.0.4:
     resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz}
@@ -27341,7 +27234,7 @@ packages:
     engines: {node: '>= 8.0.0'}
 
   registry.npmjs.org/isexe/2.0.0:
-    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz}
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz}
     name: isexe
     version: 2.0.0
 
@@ -28067,7 +27960,6 @@ packages:
       '@types/node': registry.npmjs.org/@types/node/12.20.4
       merge-stream: registry.npmjs.org/merge-stream/2.0.0
       supports-color: registry.npmjs.org/supports-color/8.1.1
-    dev: false
 
   registry.npmjs.org/jest/27.5.1_72ef9f06cb99540da679cbf1bf7a3256:
     resolution: {integrity: sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/jest/-/jest-27.5.1.tgz}
@@ -28361,7 +28253,6 @@ packages:
     resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz}
     name: json-schema-traverse
     version: 1.0.0
-    dev: false
 
   registry.npmjs.org/json-schema/0.3.0:
     resolution: {integrity: sha512-TYfxx36xfl52Rf1LU9HyWSLGPdYLL+SQ8/E/0yVyKG8wCCDaSrhPap0vEdlsZWRaS6tnKKLPGiEJGiREVC8kxQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/json-schema/-/json-schema-0.3.0.tgz}
@@ -28885,7 +28776,6 @@ packages:
     name: loader-runner
     version: 4.3.0
     engines: {node: '>=6.11.5'}
-    dev: false
 
   registry.npmjs.org/loader-utils/1.2.3:
     resolution: {integrity: sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz}
@@ -29141,7 +29031,7 @@ packages:
     dev: false
 
   registry.npmjs.org/lodash/4.17.15:
-    resolution: {integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz}
+    resolution: {integrity: sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz}
     name: lodash
     version: 4.17.15
     dev: false
@@ -29284,7 +29174,7 @@ packages:
     dev: false
 
   registry.npmjs.org/lru-cache/4.1.5:
-    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz}
+    resolution: {integrity: sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz}
     name: lru-cache
     version: 4.1.5
     dependencies:
@@ -29293,7 +29183,7 @@ packages:
     dev: false
 
   registry.npmjs.org/lru-cache/5.1.1:
-    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz}
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz}
     name: lru-cache
     version: 5.1.1
     dependencies:
@@ -29359,7 +29249,7 @@ packages:
     dev: false
 
   registry.npmjs.org/make-dir/2.1.0:
-    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz}
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz}
     name: make-dir
     version: 2.1.0
     engines: {node: '>=6'}
@@ -29406,7 +29296,7 @@ packages:
       - supports-color
 
   registry.npmjs.org/make-fetch-happen/9.1.0_bluebird@3.7.2:
-    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz}
+    resolution: {integrity: sha512-+zopwDy7DNknmwPQplem5lAZX/eCOzSvSNNcSKm5eVwTkOBzoktEfXsa9L23J/GIRhxRsaxzkPEhrJEpE2F4Gg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-9.1.0.tgz}
     id: registry.npmjs.org/make-fetch-happen/9.1.0
     name: make-fetch-happen
     version: 9.1.0
@@ -29658,13 +29548,12 @@ packages:
       fs-monkey: registry.npmjs.org/fs-monkey/1.0.3
 
   registry.npmjs.org/memfs/3.4.7:
-    resolution: {integrity: sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz}
+    resolution: {integrity: sha512-ygaiUSNalBX85388uskeCyhSAoOSgzBbtVCr9jA2RROssFL9Q19/ZXFqS+2Th2sr1ewNIWgFdLzLC3Yl1Zv+lw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/memfs/-/memfs-3.4.7.tgz}
     name: memfs
     version: 3.4.7
     engines: {node: '>= 4.0.0'}
     dependencies:
       fs-monkey: registry.npmjs.org/fs-monkey/1.0.3
-    dev: false
 
   registry.npmjs.org/memoize-one/5.1.1:
     resolution: {integrity: sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz}
@@ -29828,7 +29717,7 @@ packages:
       mime-db: registry.npmjs.org/mime-db/1.52.0
 
   registry.npmjs.org/mime/1.6.0:
-    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/mime/-/mime-1.6.0.tgz}
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/mime/-/mime-1.6.0.tgz}
     name: mime
     version: 1.6.0
     engines: {node: '>=4'}
@@ -29923,7 +29812,7 @@ packages:
       brace-expansion: registry.npmjs.org/brace-expansion/1.1.11
 
   registry.npmjs.org/minimatch/5.1.0:
-    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz}
+    resolution: {integrity: sha512-9TPBGGak4nHfGZsPBohm9AWg6NoT7QTCehS3BIJABslyZbzxfV78QM2Y6+i741OPZIafFAaiiEMh5OyIrJPgtg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/minimatch/-/minimatch-5.1.0.tgz}
     name: minimatch
     version: 5.1.0
     engines: {node: '>=10'}
@@ -30339,7 +30228,7 @@ packages:
     dev: false
 
   registry.npmjs.org/nan/2.16.0:
-    resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/nan/-/nan-2.16.0.tgz}
+    resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/nan/-/nan-2.16.0.tgz}
     name: nan
     version: 2.16.0
     optional: true
@@ -30461,7 +30350,7 @@ packages:
     dev: false
 
   registry.npmjs.org/needle/3.1.0:
-    resolution: {integrity: sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/needle/-/needle-3.1.0.tgz}
+    resolution: {integrity: sha512-gCE9weDhjVGCRqS8dwDR/D3GTAeyXLXuqp7I8EzH6DllZGXSUyxuqqLh+YX9rMAWaaTFyVAg6rHGL25dqvczKw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/needle/-/needle-3.1.0.tgz}
     name: needle
     version: 3.1.0
     engines: {node: '>= 4.4.x'}
@@ -30572,7 +30461,7 @@ packages:
     dev: false
 
   registry.npmjs.org/node-fetch/2.6.1:
-    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz}
+    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz}
     name: node-fetch
     version: 2.6.1
     engines: {node: 4.x || >=6.0.0}
@@ -30659,7 +30548,6 @@ packages:
     resolution: {integrity: sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-releases/-/node-releases-1.1.77.tgz}
     name: node-releases
     version: 1.1.77
-    dev: false
 
   registry.npmjs.org/node-releases/2.0.5:
     resolution: {integrity: sha512-U9h1NLROZTq9uE1SNffn6WuPDg8icmi3ns4rEl/oTfIle4iLjTliCzgTsbaIFMq/Xn078/lfY/BL0GWZ+psK4Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-releases/-/node-releases-2.0.5.tgz}
@@ -30676,7 +30564,7 @@ packages:
       '@babel/parser': registry.npmjs.org/@babel/parser/7.18.6
 
   registry.npmjs.org/node-source-walk/4.3.0:
-    resolution: {integrity: sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.3.0.tgz}
+    resolution: {integrity: sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/node-source-walk/-/node-source-walk-4.3.0.tgz}
     name: node-source-walk
     version: 4.3.0
     engines: {node: '>=6.0'}
@@ -30855,7 +30743,7 @@ packages:
       path-key: registry.npmjs.org/path-key/3.1.1
 
   registry.npmjs.org/npmlog/4.1.2:
-    resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz}
+    resolution: {integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz}
     name: npmlog
     version: 4.1.2
     requiresBuild: true
@@ -30927,7 +30815,7 @@ packages:
     dev: false
 
   registry.npmjs.org/object-assign/2.1.1:
-    resolution: {integrity: sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz}
+    resolution: {integrity: sha512-CdsOUYIh5wIiozhJ3rLQgmUTgcyzFwZZrqhkKhODMoGtPKM+wt0h0CNIoauJWMsS9822EdzPsF/6mb4nLvPN5g==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/object-assign/-/object-assign-2.1.1.tgz}
     name: object-assign
     version: 2.1.1
     engines: {node: '>=0.10.0'}
@@ -31173,13 +31061,6 @@ packages:
       is-wsl: registry.npmjs.org/is-wsl/2.2.0
     dev: false
 
-  registry.npmjs.org/opencollective-postinstall/2.0.3:
-    resolution: {integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz}
-    name: opencollective-postinstall
-    version: 2.0.3
-    hasBin: true
-    dev: false
-
   registry.npmjs.org/optimism/0.14.1:
     resolution: {integrity: sha512-7+1lSN+LJEtaj3uBLLFk8uFCFKy3txLvcvln5Dh1szXjF9yghEMeWclmnk0qdtYZ+lcMNyu48RmQQRw+LRYKSQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/optimism/-/optimism-0.14.1.tgz}
     name: optimism
@@ -31398,7 +31279,7 @@ packages:
     engines: {node: '>=8'}
 
   registry.npmjs.org/p-map/2.1.0:
-    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz}
+    resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz}
     name: p-map
     version: 2.1.0
     engines: {node: '>=6'}
@@ -31828,7 +31709,7 @@ packages:
     engines: {node: '>=8'}
 
   registry.npmjs.org/path-name/1.0.0:
-    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/path-name/-/path-name-1.0.0.tgz}
+    resolution: {integrity: sha512-/dcAb5vMXH0f51yvMuSUqFpxUcA8JelbRmE5mW/p4CUJxrNgK24IkstnV7ENtg2IDGBOu6izKTG6eilbnbNKWQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/path-name/-/path-name-1.0.0.tgz}
     name: path-name
     version: 1.0.0
     dev: false
@@ -32024,7 +31905,7 @@ packages:
       sonic-boom: registry.npmjs.org/sonic-boom/1.4.1
 
   registry.npmjs.org/pino/6.14.0:
-    resolution: {integrity: sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/pino/-/pino-6.14.0.tgz}
+    resolution: {integrity: sha512-iuhEDel3Z3hF9Jfe44DPXR8l07bhjuFY3GMHIXbjnY9XcafbyDDwl2sN2vw2GjMPf5Nkoe+OFao7ffn9SXaKDg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/pino/-/pino-6.14.0.tgz}
     name: pino
     version: 6.14.0
     hasBin: true
@@ -32063,15 +31944,6 @@ packages:
       find-up: registry.npmjs.org/find-up/4.1.0
     dev: false
 
-  registry.npmjs.org/pkg-dir/5.0.0:
-    resolution: {integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz}
-    name: pkg-dir
-    version: 5.0.0
-    engines: {node: '>=10'}
-    dependencies:
-      find-up: registry.npmjs.org/find-up/5.0.0
-    dev: false
-
   registry.npmjs.org/pkg-up/3.1.0:
     resolution: {integrity: sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz}
     name: pkg-up
@@ -32097,14 +31969,6 @@ packages:
       '@pnpm/resolve-workspace-range': registry.npmjs.org/@pnpm/resolve-workspace-range/2.1.0
       '@zkochan/npm-package-arg': registry.npmjs.org/@zkochan/npm-package-arg/2.0.1
       ramda: registry.npmjs.org/ramda/0.27.2
-    dev: false
-
-  registry.npmjs.org/please-upgrade-node/3.2.0:
-    resolution: {integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz}
-    name: please-upgrade-node
-    version: 3.2.0
-    dependencies:
-      semver-compare: registry.npmjs.org/semver-compare/1.0.0
     dev: false
 
   registry.npmjs.org/pluralize/1.2.1:
@@ -33752,7 +33616,6 @@ packages:
     version: 2.1.0
     dependencies:
       safe-buffer: registry.npmjs.org/safe-buffer/5.2.1
-    dev: false
 
   registry.npmjs.org/randomfill/1.0.4:
     resolution: {integrity: sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz}
@@ -33768,7 +33631,6 @@ packages:
     name: range-parser
     version: 1.2.1
     engines: {node: '>= 0.6'}
-    dev: false
 
   registry.npmjs.org/raw-body/2.4.0:
     resolution: {integrity: sha512-4Oz8DUIwdvoa5qMJelxipzi/iJIi40O5cGV1wNYp5hvZP8ZN0T+jiNkL0QepXs+EsQ9XJ8ipEDoiH70ySUJP3Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/raw-body/-/raw-body-2.4.0.tgz}
@@ -34167,7 +34029,7 @@ packages:
     peerDependencies:
       react: '>= 0.14.0'
     dependencies:
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.18.6
       highlight.js: registry.npmjs.org/highlight.js/10.7.3
       lowlight: registry.npmjs.org/lowlight/1.20.0
       prismjs: registry.npmjs.org/prismjs/1.28.0
@@ -34405,7 +34267,7 @@ packages:
       mute-stream: registry.npmjs.org/mute-stream/0.0.8
 
   registry.npmjs.org/readable-stream/1.0.34:
-    resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz}
+    resolution: {integrity: sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz}
     name: readable-stream
     version: 1.0.34
     dependencies:
@@ -34416,7 +34278,7 @@ packages:
     dev: false
 
   registry.npmjs.org/readable-stream/1.1.14:
-    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz}
+    resolution: {integrity: sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz}
     name: readable-stream
     version: 1.1.14
     dependencies:
@@ -34427,7 +34289,7 @@ packages:
     dev: false
 
   registry.npmjs.org/readable-stream/2.0.6:
-    resolution: {integrity: sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz}
+    resolution: {integrity: sha512-TXcFfb63BQe1+ySzsHZI/5v1aJPCShfqvWJ64ayNImXMsN1Cd0YGk/wm8KB7/OeessgPc9QvS9Zou8QTkFzsLw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz}
     name: readable-stream
     version: 2.0.6
     dependencies:
@@ -34440,7 +34302,7 @@ packages:
     dev: false
 
   registry.npmjs.org/readable-stream/2.3.7:
-    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz}
+    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz}
     name: readable-stream
     version: 2.3.7
     dependencies:
@@ -34610,7 +34472,7 @@ packages:
     dev: false
 
   registry.npmjs.org/regenerator-runtime/0.11.1:
-    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz}
+    resolution: {integrity: sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz}
     name: regenerator-runtime
     version: 0.11.1
 
@@ -35064,7 +34926,6 @@ packages:
     name: require-from-string
     version: 2.0.2
     engines: {node: '>=0.10.0'}
-    dev: false
 
   registry.npmjs.org/require-main-filename/2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz}
@@ -35328,7 +35189,7 @@ packages:
     version: 3.0.2
     hasBin: true
     dependencies:
-      glob: registry.npmjs.org/glob/7.1.6
+      glob: registry.npmjs.org/glob/7.2.0
 
   registry.npmjs.org/ripemd160/2.0.2:
     resolution: {integrity: sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz}
@@ -35453,7 +35314,7 @@ packages:
     version: 5.2.1
 
   registry.npmjs.org/safe-execa/0.1.1:
-    resolution: {integrity: sha512-2KPID7iC4AMoJVozDPtcLGV+7LdpE0sR1hPkJUCaEnRsiYSZH2wgOFvxZ9UOtj1r8hNk8pVWn1tgmaEyyFZ4NA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.1.tgz}
+    resolution: {integrity: sha512-2KPID7iC4AMoJVozDPtcLGV+7LdpE0sR1hPkJUCaEnRsiYSZH2wgOFvxZ9UOtj1r8hNk8pVWn1tgmaEyyFZ4NA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/safe-execa/-/safe-execa-0.1.1.tgz}
     name: safe-execa
     version: 0.1.1
     engines: {node: '>=12'}
@@ -35604,7 +35465,6 @@ packages:
       '@types/json-schema': registry.npmjs.org/@types/json-schema/7.0.11
       ajv: registry.npmjs.org/ajv/6.12.6
       ajv-keywords: registry.npmjs.org/ajv-keywords/3.5.2_ajv@6.12.6
-    dev: false
 
   registry.npmjs.org/schema-utils/4.0.0:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz}
@@ -35616,7 +35476,6 @@ packages:
       ajv: registry.npmjs.org/ajv/8.11.0
       ajv-formats: registry.npmjs.org/ajv-formats/2.1.1
       ajv-keywords: registry.npmjs.org/ajv-keywords/5.1.0_ajv@8.11.0
-    dev: false
 
   registry.npmjs.org/screenfull/5.2.0:
     resolution: {integrity: sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz}
@@ -35655,12 +35514,6 @@ packages:
       node-forge: registry.npmjs.org/node-forge/0.10.0
     dev: false
 
-  registry.npmjs.org/semver-compare/1.0.0:
-    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz}
-    name: semver-compare
-    version: 1.0.0
-    dev: false
-
   registry.npmjs.org/semver-diff/2.1.0:
     resolution: {integrity: sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz}
     name: semver-diff
@@ -35694,13 +35547,6 @@ packages:
     version: 1.0.0
     engines: {node: '>=0.10.0'}
 
-  registry.npmjs.org/semver-regex/3.1.4:
-    resolution: {integrity: sha512-6IiqeZNgq01qGf0TId0t3NvKzSvUsjcpdEO3AQNeIjR6A2+ckTnQlDpl4qu1bjRv0RzN3FP9hzFmws3lKqRWkA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver-regex/-/semver-regex-3.1.4.tgz}
-    name: semver-regex
-    version: 3.1.4
-    engines: {node: '>=8'}
-    dev: false
-
   registry.npmjs.org/semver-sort/0.0.4:
     resolution: {integrity: sha1-NP293GprK0FhOYw8TbpWJDv+qos=, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver-sort/-/semver-sort-0.0.4.tgz}
     name: semver-sort
@@ -35723,14 +35569,14 @@ packages:
     hasBin: true
 
   registry.npmjs.org/semver/6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver/-/semver-6.3.0.tgz}
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/semver/-/semver-6.3.0.tgz}
     name: semver
     version: 6.3.0
     hasBin: true
     dev: false
 
   registry.npmjs.org/semver/7.0.0:
-    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver/-/semver-7.0.0.tgz}
+    resolution: {integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/semver/-/semver-7.0.0.tgz}
     name: semver
     version: 7.0.0
     hasBin: true
@@ -35746,7 +35592,7 @@ packages:
       lru-cache: registry.npmjs.org/lru-cache/6.0.0
 
   registry.npmjs.org/semver/7.3.5:
-    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/semver/-/semver-7.3.5.tgz}
+    resolution: {integrity: sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/semver/-/semver-7.3.5.tgz}
     name: semver
     version: 7.3.5
     engines: {node: '>=10'}
@@ -35833,7 +35679,6 @@ packages:
     version: 6.0.0
     dependencies:
       randombytes: registry.npmjs.org/randombytes/2.1.0
-    dev: false
 
   registry.npmjs.org/serve-index/1.9.1:
     resolution: {integrity: sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz}
@@ -36419,7 +36264,6 @@ packages:
     dependencies:
       buffer-from: registry.npmjs.org/buffer-from/1.1.2
       source-map: registry.npmjs.org/source-map/0.6.1
-    dev: false
 
   registry.npmjs.org/source-map-url/0.4.1:
     resolution: {integrity: sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz}
@@ -36451,7 +36295,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   registry.npmjs.org/source-map/0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz}
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz}
     name: source-map
     version: 0.6.1
     engines: {node: '>=0.10.0'}
@@ -36461,7 +36305,6 @@ packages:
     name: source-map
     version: 0.7.4
     engines: {node: '>= 8'}
-    dev: false
 
   registry.npmjs.org/source-map/0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/source-map/-/source-map-0.8.0-beta.0.tgz}
@@ -37292,7 +37135,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       has-flag: registry.npmjs.org/has-flag/4.0.0
-    dev: false
 
   registry.npmjs.org/supports-color/9.2.2:
     resolution: {integrity: sha512-XC6g/Kgux+rJXmwokjm9ECpD6k/smUoS5LKlUCcsYr4IY3rW0XyAympon2RmxGrlnZURMpg5T18gWDP9CsHXFA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/supports-color/-/supports-color-9.2.2.tgz}
@@ -37413,7 +37255,7 @@ packages:
     dev: false
 
   registry.npmjs.org/table/4.0.2:
-    resolution: {integrity: sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/table/-/table-4.0.2.tgz}
+    resolution: {integrity: sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/table/-/table-4.0.2.tgz}
     name: table
     version: 4.0.2
     dependencies:
@@ -37460,7 +37302,6 @@ packages:
     name: tapable
     version: 2.2.1
     engines: {node: '>=6'}
-    dev: false
 
   registry.npmjs.org/tar-fs/2.1.1:
     resolution: {integrity: sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz}
@@ -37582,7 +37423,6 @@ packages:
       source-map: registry.npmjs.org/source-map/0.6.1
       terser: registry.npmjs.org/terser/5.14.1
       webpack: registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28
-    dev: false
 
   registry.npmjs.org/terser/4.8.0:
     resolution: {integrity: sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/terser/-/terser-4.8.0.tgz}
@@ -37608,7 +37448,6 @@ packages:
       acorn: registry.npmjs.org/acorn/8.7.1
       commander: registry.npmjs.org/commander/2.20.3
       source-map-support: registry.npmjs.org/source-map-support/0.5.21
-    dev: false
 
   registry.npmjs.org/test-exclude/6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz}
@@ -38134,7 +37973,7 @@ packages:
       typescript: 2 || 3 || 4
     dependencies:
       fast-glob: registry.npmjs.org/fast-glob/3.2.11
-      minimatch: registry.npmjs.org/minimatch/3.0.4
+      minimatch: registry.npmjs.org/minimatch/5.1.0
       normalize-path: registry.npmjs.org/normalize-path/3.0.0
       tslib: registry.npmjs.org/tslib/2.4.0
       tsutils: registry.npmjs.org/tsutils/3.21.0_typescript@4.4.2
@@ -38299,7 +38138,7 @@ packages:
     dev: false
 
   registry.npmjs.org/uglify-js/3.16.2:
-    resolution: {integrity: sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz}
+    resolution: {integrity: sha512-AaQNokTNgExWrkEYA24BTNMSjyqEXPSfhqoS0AxmHkCJ4U+Dyy5AvbGV/sqxuxficEfGGoX3zWw9R7QpLFfEsg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/uglify-js/-/uglify-js-3.16.2.tgz}
     name: uglify-js
     version: 3.16.2
     engines: {node: '>=0.8.0'}
@@ -38951,14 +38790,14 @@ packages:
     dev: false
 
   registry.npmjs.org/uuid/3.4.0:
-    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz}
+    resolution: {integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz}
     name: uuid
     version: 3.4.0
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
 
   registry.npmjs.org/uuid/7.0.3:
-    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz}
+    resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==, registry: https://node.bit.cloud/, tarball: https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz}
     name: uuid
     version: 7.0.3
     hasBin: true
@@ -39335,7 +39174,6 @@ packages:
     dependencies:
       glob-to-regexp: registry.npmjs.org/glob-to-regexp/0.4.1
       graceful-fs: registry.npmjs.org/graceful-fs/4.2.10
-    dev: false
 
   registry.npmjs.org/wbuf/1.7.3:
     resolution: {integrity: sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/wbuf/-/wbuf-1.7.3.tgz}
@@ -39417,7 +39255,6 @@ packages:
       range-parser: registry.npmjs.org/range-parser/1.2.1
       schema-utils: registry.npmjs.org/schema-utils/4.0.0
       webpack: registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28
-    dev: false
 
   registry.npmjs.org/webpack-dev-server/4.1.0_737992ea871ed5b121f22ec7a7c2c9ec:
     resolution: {integrity: sha512-PnnoCHuLKxH3vYff2EbORntD0Pd+MKclDIO8AcKsDVRToqY9/oeIwwUs5alA2B5OPgXJhaDNkBJAmb0OaWZFJA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.1.0.tgz}
@@ -39515,7 +39352,6 @@ packages:
     name: webpack-sources
     version: 3.2.3
     engines: {node: '>=10.13.0'}
-    dev: false
 
   registry.npmjs.org/webpack/5.51.1_esbuild@0.14.28:
     resolution: {integrity: sha512-xsn3lwqEKoFvqn4JQggPSRxE4dhsRcysWTqYABAZlmavcoTmwlOb9b1N36Inbt/eIispSkuHa80/FJkDTPos1A==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/webpack/-/webpack-5.51.1.tgz}
@@ -39558,7 +39394,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: false
 
   registry.npmjs.org/websocket-driver/0.7.4:
     resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz}
@@ -39658,13 +39493,6 @@ packages:
     resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz}
     name: which-module
     version: 2.0.0
-    dev: false
-
-  registry.npmjs.org/which-pm-runs/1.1.0:
-    resolution: {integrity: sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA==, registry: https://node.bit.dev/, tarball: https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.1.0.tgz}
-    name: which-pm-runs
-    version: 1.1.0
-    engines: {node: '>=4'}
     dev: false
 
   registry.npmjs.org/which-pm/2.0.0:
@@ -39829,7 +39657,7 @@ packages:
       '@apideck/better-ajv-errors': registry.npmjs.org/@apideck/better-ajv-errors/0.2.7_ajv@8.11.0
       '@babel/core': registry.npmjs.org/@babel/core/7.18.6
       '@babel/preset-env': registry.npmjs.org/@babel/preset-env/7.12.17_@babel+core@7.18.6
-      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.12.18
+      '@babel/runtime': registry.npmjs.org/@babel/runtime/7.18.6
       '@rollup/plugin-babel': registry.npmjs.org/@rollup/plugin-babel/5.3.1_@babel+core@7.18.6+rollup@2.75.7
       '@rollup/plugin-node-resolve': registry.npmjs.org/@rollup/plugin-node-resolve/11.2.1_rollup@2.75.7
       '@rollup/plugin-replace': registry.npmjs.org/@rollup/plugin-replace/2.4.2_rollup@2.75.7


### PR DESCRIPTION
## Proposed Changes

- The old version of husky doesn't work well with side-effects cache because it uses postinstall scripts to setup the hooks. The new version works because it requires a prepare script to install the hooks. We don't have a prepare script but we have a full setup script that we recommend contributors to run.
