### PR TITLE
highlighter ellipsis for long hashes (+ update floating-ui)

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -168,7 +168,7 @@
         "@teambit/react.instructions.react.adding-compositions": "0.0.6",
         "@teambit/react.instructions.react.adding-tests": "0.0.6",
         "@teambit/react.modules.dom-to-react": "0.1.0",
-        "@teambit/react.ui.component-highlighter": "0.1.0",
+        "@teambit/react.ui.component-highlighter": "0.2.0",
         "@teambit/react.ui.hover-selector": "0.1.0",
         "@teambit/scope.content.scope-overview": "1.95.0",
         "@teambit/workspace.content.variants": "1.95.9",


### PR DESCRIPTION
## Proposed Changes

- added Ellipsis for long versions
- updated floating-ui to v0.7.2
- fix dep: move @types/react from peer to regular dev dependencies

<img width="400" alt="Screen Shot 2022-07-11 at 18 16 40" src="https://user-images.githubusercontent.com/5400361/178298665-819571f6-fd6e-468e-9999-f4f57c08039d.png">

Went for `13ch`, which allows 9 digits and 3 dots. Expends on hover to reveal the whole version.
Tested on design scope