### PR TITLE
improvement(bit-artifact): convert component-id to a filename

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -1,4 +1,5 @@
 import path from 'path';
+import filenamify from 'filenamify';
 import fs from 'fs-extra';
 import { ScopeMain } from '@teambit/scope';
 import { ComponentID } from '@teambit/component-id';
@@ -76,8 +77,9 @@ export class ArtifactExtractor {
         )
       );
       const flattenedVinyls = vinyls.flat();
-      // if asked for only one component, shorten the path by omitting the id
-      const compPath = artifactObjectsPerId.length > 1 ? path.join(outDir, id.toStringWithoutVersion()) : outDir;
+      // make sure the component-dir is just one dir. without this, every slash in the component-id will create a new dir.
+      const idAsFilename = filenamify(id.toStringWithoutVersion(), { replacement: '_' });
+      const compPath = path.join(outDir, idAsFilename);
       await Promise.all(flattenedVinyls.map((vinyl) => fs.outputFile(path.join(compPath, vinyl.path), vinyl.contents)));
     });
   }


### PR DESCRIPTION
so then it will always be one dir.

For example, running this: `bit artifacts teambit.blog-content/developing-mui-components --out-dir dist`.
Before, the root-dir was `teambit.blog-content/developing-mui-components`, now the root-dir is `teambit.blog-content_developing-mui-components`. 
This way, it's easy to write scripts that manipulate this artifacts dir. The component-id always creates one directory.


