### PR TITLE
fix "invalid version" error when the head Version is missing

### DIFF
--- a/scopes/component/graph/graph-builder.ts
+++ b/scopes/component/graph/graph-builder.ts
@@ -58,7 +58,6 @@ export class GraphBuilder {
     });
     await Promise.all(setEdgePromise);
 
-    newGraph.versionMap = newGraph._calculateVersionMap();
     return newGraph;
   }
 }


### PR DESCRIPTION
This is happening when a dependency is imported to the local scope in an older version, which, as a result, the head `Version` object is missing.
Two fixes were done in this PR:
1. avoid calculating the latest in the graph unless it's really needed. Only "bit insight" needs this info, so no need to run it every time a capsule is created.
2. avoid using the "laterThan" method, which is not good anymore for hashes.