### PR TITLE
fix: send bit-client-version as a valid Semver to the remote

### DIFF
--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -538,7 +538,7 @@ export class Http implements Network {
   }
 
   private getClientVersion(): string {
-    return getHarmonyVersion();
+    return getHarmonyVersion(true);
   }
 
   private addAgentIfExist(opts: { [key: string]: any } = {}): Record<string, any> {


### PR DESCRIPTION
currently, when running from bit-bin repo, it shows `last-tag {version}` , which makes it hard in the remote to parse it.
Instead, send always a valid semver version.