### PR TITLE
fix(lane): enable importing main component when checked out to a new lane

### DIFF
--- a/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
@@ -135,7 +135,7 @@ describe('bit lane command', function () {
         importOutput = helper.command.import();
       });
       it('should indicate that there is nothing to import because the lane is new', () => {
-        expect(importOutput).to.have.string("your lane wasn't exported yet, nothing to import");
+        expect(importOutput).to.have.string('nothing to import');
       });
     });
     describe('when the lane is exported', () => {

--- a/scopes/scope/importer/importer.ts
+++ b/scopes/scope/importer/importer.ts
@@ -23,12 +23,11 @@ export class Importer {
       if (currentRemoteLane) {
         importOptions.lanes = { laneIds: [currentRemoteLane.toLaneId()], lanes: [currentRemoteLane] };
       } else if (!importOptions.ids.length) {
-        // the lane is probably new, it's not yet on the remote, so nothing to import
-        return {
-          dependencies: [],
-          importDetails: [],
-          cancellationMessage: `your lane wasn't exported yet, nothing to import`,
-        };
+        // this is probably a local lane that was never exported.
+        // although no need to fetch from the lane, still, the import is needed for main (which are available on this
+        // local lane)
+        const currentLaneId = this.workspace.getCurrentLaneId();
+        importOptions.lanes = { laneIds: [currentLaneId], lanes: [] };
       }
     }
     const importComponents = new ImportComponents(consumer, importOptions);

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -48,7 +48,10 @@ export type ImportOptions = {
   importDependents?: boolean; // default: false,
   fromOriginalScope?: boolean; // default: false, otherwise, it fetches flattened dependencies from their dependents
   saveInLane?: boolean; // save the imported component on the current lane (won't be available on main)
-  lanes?: { laneIds: LaneId[]; lanes?: Lane[] };
+  lanes?: {
+    laneIds: LaneId[];
+    lanes: Lane[]; // it can be an empty array when a lane is a local lane and doesn't exist on the remote
+  };
   allHistory?: boolean;
 };
 type ComponentMergeStatus = {
@@ -102,15 +105,17 @@ export default class ImportComponents {
   }
 
   async importObjectsOnLane(): Promise<ImportResult> {
-    if (!this.laneObjects.length || !this.options.objectsOnly) {
-      throw new Error(`importObjectsOnLane should have laneObjects and objectsOnly=true`);
+    if (!this.options.objectsOnly) {
+      throw new Error(`importObjectsOnLane should have objectsOnly=true`);
     }
     if (this.laneObjects.length > 1) {
       throw new Error(`importObjectsOnLane does not support more than one lane`);
     }
     const lane = this.laneObjects[0];
     const bitIds: BitIds = await this.getBitIds();
-    logger.debug(`importObjectsOnLane, Lane: ${lane.id()}, Ids: ${bitIds.toString()}`);
+    this.laneObjects.length
+      ? logger.debug(`importObjectsOnLane, Lane: ${lane.id()}, Ids: ${bitIds.toString()}`)
+      : logger.debug(`importObjectsOnLane, the lane does not exist on the remote. importing only the main components`);
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
     const componentsWithDependencies = await this.consumer.importComponentsObjectsHarmony(
       bitIds,


### PR DESCRIPTION
currently, when a lane is not on the remote, it stops the import. However, there are main-components that may need updates. This PR fixes it by importing the main component and ignoring the local lane. 