### PR TITLE
improvement: add bit version to the Version object upon tag/snap

### DIFF
--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -11,6 +11,7 @@ import { ScopeAspect, ScopeMain, OnTagResults } from '@teambit/scope';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { IsolateComponentsOptions, IsolatorAspect, IsolatorMain } from '@teambit/isolator';
 import { OnTagOpts } from '@teambit/legacy/dist/scope/scope';
+import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import findDuplications from '@teambit/legacy/dist/utils/array/find-duplications';
 import { ArtifactFiles, ArtifactObject } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
@@ -35,6 +36,7 @@ export type BuilderData = {
   pipeline: PipelineReport[];
   artifacts: ArtifactObject[] | undefined;
   aspectsData: AspectData[];
+  bitVersion?: string;
 };
 
 export class BuilderMain {
@@ -77,7 +79,7 @@ export class BuilderMain {
       const aspectsData = buildPipelineResultList.getDataOfComponent(component.id);
       const pipelineReport = buildPipelineResultList.getPipelineReportOfComponent(component.id);
       const artifactsData = buildPipelineResultList.getArtifactsDataOfComponent(component.id);
-      return { pipeline: pipelineReport, artifacts: artifactsData, aspectsData };
+      return { pipeline: pipelineReport, artifacts: artifactsData, aspectsData, bitVersion: getHarmonyVersion(true) };
     });
   }
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -19,6 +19,7 @@ import { ObjectItem } from '../objects/object-list';
 import Repository from '../objects/repository';
 import validateVersionInstance from '../version-validator';
 import Source from './source';
+import { getHarmonyVersion } from '../../bootstrap';
 
 export type SourceFileModel = {
   name: string;
@@ -65,6 +66,7 @@ export type VersionProps = {
   extensions?: ExtensionDataList;
   buildStatus?: BuildStatus;
   componentId?: BitId;
+  bitVersion?: string;
 };
 
 /**
@@ -92,6 +94,7 @@ export default class Version extends BitObject {
   extensions: ExtensionDataList;
   buildStatus?: BuildStatus;
   componentId?: BitId; // can help debugging errors when validating Version object
+  bitVersion?: string;
 
   constructor(props: VersionProps) {
     super();
@@ -116,6 +119,7 @@ export default class Version extends BitObject {
     this.extensions = props.extensions || ExtensionDataList.fromArray([]);
     this.buildStatus = props.buildStatus;
     this.componentId = props.componentId;
+    this.bitVersion = props.bitVersion;
     this.validateVersion();
   }
 
@@ -326,6 +330,7 @@ export default class Version extends BitObject {
         packageJsonChangedProps: this.packageJsonChangedProps,
         parents: this.parents.map((p) => p.toString()),
         squashed: this.squashed?.map((s) => s.toString()),
+        bitVersion: this.bitVersion,
       },
       (val) => !!val
     );
@@ -369,6 +374,7 @@ export default class Version extends BitObject {
       buildStatus,
       parents,
       squashed,
+      bitVersion,
     } = contentParsed;
 
     const _getDependencies = (deps = []): Dependency[] => {
@@ -469,6 +475,7 @@ export default class Version extends BitObject {
       squashed: squashed ? squashed.map((s) => Ref.from(s)) : undefined,
       extensions: _getExtensions(extensions),
       buildStatus,
+      bitVersion,
     });
   }
 
@@ -514,6 +521,7 @@ export default class Version extends BitObject {
       extensions: component.extensions,
       buildStatus: component.buildStatus,
       componentId: component.id,
+      bitVersion: getHarmonyVersion(true),
     });
     if (isHash(component.version)) {
       version._hash = component.version as string;


### PR DESCRIPTION
It's helpful for debugging. 
Save the current teambit/bit version in the `Version` object and also as the data of the Builder aspect. (on RippleCI, the build pipeline is running separately, so bit-version can be different). 