### PR TITLE
perf: fix a performance regression in `bit status`

### DIFF
--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -145,4 +145,11 @@ export class BitMap {
   getExportedLaneId() {
     return this.legacyBitMap.remoteLaneId;
   }
+
+  /**
+   * whether .bitmap file has changed in-memory
+   */
+  hasChanged(): boolean {
+    return this.legacyBitMap.hasChanged;
+  }
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -172,7 +172,7 @@ export class Workspace implements ComponentFactory {
   componentsScopeDirsMap: ComponentScopeDirMap;
   componentLoader: WorkspaceComponentLoader;
   bitMap: BitMap;
-  private _cachedWorkspaceComponentIDs?: ComponentID[];
+  private _cachedListIds?: ComponentID[];
   private componentLoadedSelfAsAspects: InMemoryCache<boolean>; // cache loaded components
   private warnedAboutMisconfiguredEnvs: string[] = []; // cache env-ids that have been errored about not having "env" type
   constructor(
@@ -375,12 +375,13 @@ export class Workspace implements ComponentFactory {
    * get ids of all workspace components.
    */
   async listIds(): Promise<ComponentID[]> {
-    if (!this._cachedWorkspaceComponentIDs) {
-      this._cachedWorkspaceComponentIDs = await this.resolveMultipleComponentIds(
-        this.consumer.bitmapIdsFromCurrentLane
-      );
+    if (this._cachedListIds && this.bitMap.hasChanged()) {
+      delete this._cachedListIds;
     }
-    return this._cachedWorkspaceComponentIDs;
+    if (!this._cachedListIds) {
+      this._cachedListIds = await this.resolveMultipleComponentIds(this.consumer.bitmapIdsFromCurrentLane);
+    }
+    return this._cachedListIds;
   }
 
   /**
@@ -560,7 +561,7 @@ export class Workspace implements ComponentFactory {
 
   clearCache() {
     this.logger.debug('clearing the workspace and scope caches');
-    delete this._cachedWorkspaceComponentIDs;
+    delete this._cachedListIds;
     this.componentLoader.clearCache();
     this.scope.clearCache();
     this.componentList = new ComponentsList(this.consumer);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -172,6 +172,7 @@ export class Workspace implements ComponentFactory {
   componentsScopeDirsMap: ComponentScopeDirMap;
   componentLoader: WorkspaceComponentLoader;
   bitMap: BitMap;
+  private _cachedWorkspaceComponentIDs?: ComponentID[];
   private componentLoadedSelfAsAspects: InMemoryCache<boolean>; // cache loaded components
   private warnedAboutMisconfiguredEnvs: string[] = []; // cache env-ids that have been errored about not having "env" type
   constructor(
@@ -374,7 +375,12 @@ export class Workspace implements ComponentFactory {
    * get ids of all workspace components.
    */
   async listIds(): Promise<ComponentID[]> {
-    return this.resolveMultipleComponentIds(this.consumer.bitmapIdsFromCurrentLane);
+    if (!this._cachedWorkspaceComponentIDs) {
+      this._cachedWorkspaceComponentIDs = await this.resolveMultipleComponentIds(
+        this.consumer.bitmapIdsFromCurrentLane
+      );
+    }
+    return this._cachedWorkspaceComponentIDs;
   }
 
   /**
@@ -554,6 +560,7 @@ export class Workspace implements ComponentFactory {
 
   clearCache() {
     this.logger.debug('clearing the workspace and scope caches');
+    delete this._cachedWorkspaceComponentIDs;
     this.componentLoader.clearCache();
     this.scope.clearCache();
     this.componentList = new ComponentsList(this.consumer);


### PR DESCRIPTION
## Proposed Changes

- Cache the list of workspace component IDs, which is accessed hundreds of
times and is an expensive operation.
