### PR TITLE
fix: validate Version object before running the build pipeline

### DIFF
--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -238,7 +238,7 @@ export default async function tagModelComponent({
     await addFlattenedDependenciesToComponents(consumer.scope, allComponentsToTag);
     emptyBuilderData(allComponentsToTag);
     addBuildStatus(allComponentsToTag, BuildStatus.Pending);
-    await addComponentsToScope(consumer, allComponentsToTag, Boolean(resolveUnmerged));
+    await addComponentsToScope(consumer, allComponentsToTag, Boolean(resolveUnmerged), build);
     await consumer.updateComponentsVersions(allComponentsToTag);
   }
 
@@ -262,7 +262,12 @@ export default async function tagModelComponent({
   return { taggedComponents: componentsToTag, autoTaggedResults: autoTagData, publishedPackages };
 }
 
-async function addComponentsToScope(consumer: Consumer, components: Component[], resolveUnmerged: boolean) {
+async function addComponentsToScope(
+  consumer: Consumer,
+  components: Component[],
+  resolveUnmerged: boolean,
+  shouldValidateVersion: boolean
+) {
   const lane = await consumer.getCurrentLaneObject();
   await mapSeries(components, async (component) => {
     await consumer.scope.sources.addSource({
@@ -270,6 +275,7 @@ async function addComponentsToScope(consumer: Consumer, components: Component[],
       consumer,
       lane,
       resolveUnmerged,
+      shouldValidateVersion,
     });
   });
 }

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -266,11 +266,13 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     consumer,
     lane,
     resolveUnmerged = false,
+    shouldValidateVersion = false,
   }: {
     source: ConsumerComponent;
     consumer: Consumer;
     lane: Lane | null;
     resolveUnmerged?: boolean;
+    shouldValidateVersion?: boolean;
   }): Promise<ModelComponent> {
     const objectRepo = this.objects();
     // if a component exists in the model, add a new version. Otherwise, create a new component on the model
@@ -303,7 +305,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
 
     files.forEach((file) => objectRepo.add(file.file));
     if (artifacts) artifacts.forEach((file) => objectRepo.add(file.source));
-
+    if (shouldValidateVersion) version.validate();
     return component;
   }
 


### PR DESCRIPTION
Currently, the version-validation is happening before writing the object to the filesystem, which is after the pipeline is running. As a result, a component during tag could be published to npm as part of the pipeline but end up not tagged. 
