### PR TITLE
fix(aspect-update): avoid adding the previous aspect with minus to the .bitmap file

### DIFF
--- a/scopes/harmony/aspect/aspect.cmd.ts
+++ b/scopes/harmony/aspect/aspect.cmd.ts
@@ -76,7 +76,8 @@ export class UpdateAspectCmd implements Command {
   arguments = [
     {
       name: 'aspect-id',
-      description: "the aspect's component id",
+      description:
+        "the aspect's component id. optionally, add a version (id@version), otherwise, it finds the latest version on the remote",
     },
     {
       name: 'pattern',

--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -155,7 +155,9 @@ export class AspectMain {
         const aspect = comp.state.aspects.get(aspectCompId.toStringWithoutVersion());
         if (!aspect) return undefined;
         if (aspect.id.version === aspectCompId.version) return undefined; // nothing to update
-        await this.workspace.removeSpecificComponentConfig(comp.id, aspect.id.toString(), true);
+        // don't mark with minus if not exist in .bitmap. it's not needed. when the component is loaded, the
+        // merge-operation of the aspects removes duplicate aspect-id with different versions.
+        await this.workspace.removeSpecificComponentConfig(comp.id, aspect.id.toString(), false);
         await this.workspace.addSpecificComponentConfig(comp.id, aspectCompId.toString(), aspect.config);
         return comp.id;
       })

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -177,6 +177,9 @@ export default class CommandHelper {
   unsetAspect(pattern: string, aspectId: string, flags = '') {
     return this.runCmd(`bit aspect unset ${pattern} ${aspectId} ${flags}`);
   }
+  updateAspect(aspectId: string, pattern = '', flags = '') {
+    return this.runCmd(`bit aspect update ${aspectId} ${pattern} ${flags}`);
+  }
   removeComponent(id: string, flags = '') {
     return this.runCmd(`bit remove ${id} --silent ${flags}`);
   }


### PR DESCRIPTION
When running `bit aspect update`, no need to add the previous aspect with minus. 
The merge operation when a component is load already makes sure to not load the same aspect with different versions. 