### PR TITLE
improvement(lanes): fetch updates from main when on a lane

### DIFF
--- a/e2e/flows/id-with-wildcard.e2e.2.ts
+++ b/e2e/flows/id-with-wildcard.e2e.2.ts
@@ -174,12 +174,12 @@ describe('component id with wildcard', function () {
           expect(ls).to.have.lengthOf(2);
         });
         it('should not export the non matched components', () => {
-          const status = helper.command.statusJson();
+          const staged = helper.command.getStagedIdsFromStatus();
           // (staged components were not exported)
-          expect(status.stagedComponents).to.have.lengthOf(3);
-          expect(status.stagedComponents).to.include('bar/foo');
-          expect(status.stagedComponents).to.include('utils/is/string');
-          expect(status.stagedComponents).to.include('utils/is/type');
+          expect(staged).to.have.lengthOf(3);
+          expect(staged).to.include('bar/foo');
+          expect(staged).to.include('utils/is/string');
+          expect(staged).to.include('utils/is/type');
         });
       });
     });

--- a/e2e/functionalities/auto-tagging.e2e.2.ts
+++ b/e2e/functionalities/auto-tagging.e2e.2.ts
@@ -59,9 +59,10 @@ describe('auto tagging functionality', function () {
     it('bit-status should show them all as staged and not modified', () => {
       const status = helper.command.statusJson();
       expect(status.modifiedComponent).to.be.empty;
-      expect(status.stagedComponents).to.include('comp1');
-      expect(status.stagedComponents).to.include('comp2');
-      expect(status.stagedComponents).to.include('comp3');
+      const staged = helper.command.getStagedIdsFromStatus();
+      expect(staged).to.include('comp1');
+      expect(staged).to.include('comp2');
+      expect(staged).to.include('comp3');
     });
     describe('with --skip-auto-tag', () => {
       before(() => {

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -362,8 +362,8 @@ describe('bit lane command', function () {
       // main components belong to lane-a only if they are snapped on lane-a, so utils/is-type
       // doesn't belong to lane-a and should not appear as staged when on lane-a.
       it('bit status should not show neither lane-b nor main components as staged', () => {
-        const statusParsed = helper.command.statusJson();
-        expect(statusParsed.stagedComponents).to.deep.equal(['utils/is-string']);
+        const staged = helper.command.getStagedIdsFromStatus();
+        expect(staged).to.deep.equal(['utils/is-string']);
         const status = helper.command.status();
         expect(status).to.not.have.string('bar/foo');
       });
@@ -383,8 +383,8 @@ describe('bit lane command', function () {
         expect(list).to.have.lengthOf(1);
       });
       it('bit status should show only main components as staged', () => {
-        const statusParsed = helper.command.statusJson();
-        expect(statusParsed.stagedComponents).to.deep.equal(['utils/is-type']);
+        const staged = helper.command.getStagedIdsFromStatus();
+        expect(staged).to.deep.equal(['utils/is-type']);
         const status = helper.command.status();
         expect(status).to.not.have.string('bar/foo');
         expect(status).to.not.have.string('utils/is-string');
@@ -401,8 +401,8 @@ describe('bit lane command', function () {
         expect(list).to.have.lengthOf(1);
       });
       it('bit status should show only main components as staged', () => {
-        const statusParsed = helper.command.statusJson();
-        expect(statusParsed.stagedComponents).to.deep.equal(['utils/is-type']);
+        const staged = helper.command.getStagedIdsFromStatus();
+        expect(staged).to.deep.equal(['utils/is-type']);
         const status = helper.command.status();
         expect(status).to.not.have.string('bar/foo');
         expect(status).to.not.have.string('utils/is-string');
@@ -545,9 +545,10 @@ describe('bit lane command', function () {
     it('bit-status should show them all as staged and not modified', () => {
       const status = helper.command.statusJson();
       expect(status.modifiedComponent).to.be.empty;
-      expect(status.stagedComponents).to.include('comp1');
-      expect(status.stagedComponents).to.include('comp2');
-      expect(status.stagedComponents).to.include('comp3');
+      const staged = helper.command.getStagedIdsFromStatus();
+      expect(staged).to.include('comp1');
+      expect(staged).to.include('comp2');
+      expect(staged).to.include('comp3');
     });
     // @todo
     describe.skip('importing the component to another scope', () => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -306,4 +306,35 @@ describe('merge lanes', function () {
       });
     });
   });
+  describe('getting updates from main when lane is diverge', () => {
+    let workspaceOnLane: string;
+    let comp2HeadOnMain: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(2, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      workspaceOnLane = helper.scopeHelper.cloneLocalScope();
+      helper.command.switchLocalLane('main');
+      helper.fixtures.populateComponents(2, undefined, 'v3');
+      helper.command.snapAllComponentsWithoutBuild();
+      comp2HeadOnMain = helper.command.getHead(`${helper.scopes.remote}/comp2`);
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(workspaceOnLane);
+      helper.command.import();
+    });
+    it('bit import should bring the latest main objects', () => {
+      const head = helper.command.getHead(`${helper.scopes.remote}/comp2`);
+      expect(head).to.equal(comp2HeadOnMain);
+    });
+    it('bit status should indicate that the main is ahead', () => {
+      const status = helper.command.status();
+      expect(status).to.have.string(`${helper.scopes.remote}/comp1 ... main is ahead by 1 snaps`);
+    });
+  });
 });

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -336,5 +336,21 @@ describe('merge lanes', function () {
       const status = helper.command.status();
       expect(status).to.have.string(`${helper.scopes.remote}/comp1 ... main is ahead by 1 snaps`);
     });
+    describe('merging the lane', () => {
+      let status;
+      before(() => {
+        helper.command.mergeLane('main', '--theirs');
+        status = helper.command.statusJson();
+      });
+      it('bit status should show two staging versions, the main-head and merge-snap', () => {
+        const stagedVersions = status.stagedComponents.find((c) => c.id === `${helper.scopes.remote}/comp2`);
+        expect(stagedVersions.versions).to.have.lengthOf(2);
+        expect(stagedVersions.versions).to.include(comp2HeadOnMain);
+        expect(stagedVersions.versions).to.include(helper.command.getHeadOfLane('dev', 'comp2'));
+      });
+      it('bit status should not show the components in pending-merge', () => {
+        expect(status.mergePendingComponents).to.have.lengthOf(0);
+      });
+    });
   });
 });

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -629,9 +629,10 @@ describe('bit snap command', function () {
     it('bit-status should show them all as staged and not modified', () => {
       const status = helper.command.statusJson();
       expect(status.modifiedComponent).to.be.empty;
-      expect(status.stagedComponents).to.include('comp1');
-      expect(status.stagedComponents).to.include('comp2');
-      expect(status.stagedComponents).to.include('comp3');
+      const staged = helper.command.getStagedIdsFromStatus();
+      expect(staged).to.include('comp1');
+      expect(staged).to.include('comp2');
+      expect(staged).to.include('comp3');
     });
     describe('importing the component to another scope', () => {
       before(() => {

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -56,11 +56,12 @@ export class StatusCmd implements Command {
       componentsWithIndividualFiles,
       softTaggedComponents,
       snappedComponents,
+      pendingUpdatesFromMain,
     }: StatusResult = await this.status.status();
     return {
       newComponents,
       modifiedComponent: modifiedComponent.map((c) => c.id.toString()),
-      stagedComponents: stagedComponents.map((c) => c.id()),
+      stagedComponents: stagedComponents.map((c) => ({ id: c.id(), versions: c.getLocalTagsOrHashes() })),
       componentsWithIssues: componentsWithIssues.map((c) => ({
         id: c.id.toString(),
         issues: c.issues?.toObject(),
@@ -74,6 +75,7 @@ export class StatusCmd implements Command {
       componentsWithIndividualFiles: componentsWithIndividualFiles.map((c) => c.id.toString()),
       softTaggedComponents: softTaggedComponents.map((s) => s.toString()),
       snappedComponents: snappedComponents.map((s) => s.toString()),
+      pendingUpdatesFromMain: pendingUpdatesFromMain.map((p) => ({ id: p.id.toString(), divergeData: p.divergeData })),
     };
   }
 

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -237,11 +237,17 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       snappedComponents.length ? chalk.underline.white('snapped components') + snappedDesc : ''
     ).join('\n');
 
-    const updatesFromMainDesc = '\n(use "bit tag [version]" or "bit tag --snapped [version]" to lock a version)\n';
+    // @todo: once the merge from main is working, uncomment this.
+    const updatesFromMainDesc =
+      '\n(EXPERIMENTAL. use "bit merge" to merge the changes. Better to wait with this merge until it is stable)\n';
+    const pendingUpdatesFromMainIds = pendingUpdatesFromMain.map((c) => {
+      const msg = c.divergeData.err
+        ? c.divergeData.err.message
+        : `main is ahead by ${c.divergeData.snapsOnRemoteOnly.length || 0} snaps`;
+      return format(c.id, true, msg);
+    });
     const updatesFromMainOutput = immutableUnshift(
-      pendingUpdatesFromMain.map((c) =>
-        format(c.id, true, `main is ahead by ${c.divergeData.snapsOnRemoteOnly.length || 0} snaps`)
-      ),
+      pendingUpdatesFromMainIds,
       pendingUpdatesFromMain.length ? chalk.underline.white('pending updates from main') + updatesFromMainDesc : ''
     ).join('\n');
 

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -248,8 +248,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       }
       return msg;
     };
-    const updatesFromMainDesc =
-      '\n(EXPERIMENTAL. use "bit lane merge main --partial <component-name>" to merge the changes)\n';
+    const updatesFromMainDesc = '\n(EXPERIMENTAL. use "bit lane merge main" to merge the changes)\n';
     const pendingUpdatesFromMainIds = pendingUpdatesFromMain.map((c) =>
       format(c.id, true, getUpdateFromMainMsg(c.divergeData))
     );

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -243,7 +243,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
     const getUpdateFromMainMsg = (divergeData: DivergeData): string => {
       if (divergeData.err) return divergeData.err.message;
       let msg = `main is ahead by ${divergeData.snapsOnRemoteOnly.length || 0} snaps`;
-      if (divergeData.snapsOnLocalOnly) {
+      if (divergeData.snapsOnLocalOnly && verbose) {
         msg += ` (diverged since ${divergeData.commonSnapBeforeDiverge?.toShortString()})`;
       }
       return msg;

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -91,6 +91,7 @@ export class StatusCmd implements Command {
       componentsWithIndividualFiles,
       softTaggedComponents,
       snappedComponents,
+      pendingUpdatesFromMain,
       laneName,
     }: StatusResult = await this.status.status();
     // If there is problem with at least one component we want to show a link to the
@@ -229,11 +230,19 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       stagedComponents.length ? chalk.underline.white('staged components') + stagedDesc : ''
     ).join('\n');
 
-    const snappedDesc = '\n(use "bit tag --all [version]" or "bit tag --snapped [version]" to lock a version)\n';
+    const snappedDesc = '\n(use "bit tag [version]" or "bit tag --snapped [version]" to lock a version)\n';
     const snappedComponentsOutput = immutableUnshift(
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       snappedComponents.map((c) => format(c, true)),
       snappedComponents.length ? chalk.underline.white('snapped components') + snappedDesc : ''
+    ).join('\n');
+
+    const updatesFromMainDesc = '\n(use "bit tag [version]" or "bit tag --snapped [version]" to lock a version)\n';
+    const updatesFromMainOutput = immutableUnshift(
+      pendingUpdatesFromMain.map((c) =>
+        format(c.id, true, `main is ahead by ${c.divergeData.snapsOnRemoteOnly.length || 0} snaps`)
+      ),
+      pendingUpdatesFromMain.length ? chalk.underline.white('pending updates from main') + updatesFromMainDesc : ''
     ).join('\n');
 
     const laneStr = laneName ? `\non ${chalk.bold(laneName)} lane` : '';
@@ -245,6 +254,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       [
         outdatedStr,
         pendingMergeStr,
+        updatesFromMainOutput,
         compWithConflictsStr,
         newComponentsOutput,
         modifiedComponentOutput,

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -7,7 +7,10 @@ import loader from '@teambit/legacy/dist/cli/loader';
 import { BEFORE_STATUS } from '@teambit/legacy/dist/cli/loader/loader-messages';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import ComponentsPendingImport from '@teambit/legacy/dist/consumer/component-ops/exceptions/components-pending-import';
-import ComponentsList, { DivergedComponent } from '@teambit/legacy/dist/consumer/component/components-list';
+import ComponentsList, {
+  DivergeDataPerId,
+  DivergedComponent,
+} from '@teambit/legacy/dist/consumer/component/components-list';
 import { InvalidComponent } from '@teambit/legacy/dist/consumer/component/consumer-component';
 import { ModelComponent } from '@teambit/legacy/dist/scope/models';
 import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
@@ -30,6 +33,7 @@ export type StatusResult = {
   componentsWithIndividualFiles: ConsumerComponent[];
   softTaggedComponents: BitId[];
   snappedComponents: BitId[];
+  pendingUpdatesFromMain: DivergeDataPerId[];
   laneName: string | null; // null if default
 };
 
@@ -72,6 +76,7 @@ export class StatusMain {
     const componentsDuringMergeState = componentsList.listDuringMergeStateComponents();
     const softTaggedComponents = componentsList.listSoftTaggedComponents();
     const snappedComponents = (await componentsList.listSnappedComponentsOnMain()).map((c) => c.toBitId());
+    const pendingUpdatesFromMain = await componentsList.listUpdatesFromMainPending();
     const currentLane = consumer.getCurrentLaneId();
     const laneName = currentLane.isDefault() ? null : currentLane.name;
     Analytics.setExtraData('new_components', newComponents.length);
@@ -96,6 +101,7 @@ export class StatusMain {
       componentsWithIndividualFiles: await componentsList.listComponentsWithIndividualFiles(),
       softTaggedComponents,
       snappedComponents,
+      pendingUpdatesFromMain,
       laneName,
     };
   }

--- a/scopes/lanes/lanes/lanes.docs.mdx
+++ b/scopes/lanes/lanes/lanes.docs.mdx
@@ -87,6 +87,12 @@ Summary of when/what lanes data is saved per command:
 - in case the merge wasn't done and the user is trying to export, the remote blocks is as it finds out that its head doesn't exist on the incoming component.
 - in case the snap-merge failed due to a conflict, it saves the conflict and heads data into `.bit/unmerged.json` file.
 
+### Merge components
+
+- to merge an entire lane, use `bit lane merge`.
+- to get updates from a remote lane, run `bit import`, and then `bit checkout head`. alternatively, run `bit merge <component-id>` in one command.
+- to merge an individual component from a lane to main, run `bit lane merge <lane> --pattern <component-id>` when on main.
+
 ### Useful APIs
 
 - bit-map `getAllIdsAvailableOnLane()` filters the currently checked out lane.

--- a/scopes/lanes/lanes/merge-lanes.ts
+++ b/scopes/lanes/lanes/merge-lanes.ts
@@ -36,7 +36,9 @@ export async function mergeLanes({
   const consumer = workspace.consumer;
   const currentLaneId = consumer.getCurrentLaneId();
   if (!remoteName && laneName === currentLaneId.name) {
-    throw new BitError(`unable to switch to lane "${laneName}", you're already checked out to this lane`);
+    throw new BitError(
+      `unable to merge lane "${laneName}", you're already at this lane. to get updates, simply run "bit checkout head"`
+    );
   }
   const parsedLaneId = await consumer.getParsedLaneId(laneName);
   const localLane = currentLaneId.isDefault() ? null : await consumer.scope.loadLane(currentLaneId);
@@ -47,7 +49,8 @@ export async function mergeLanes({
   const isDefaultLane = laneName === DEFAULT_LANE;
 
   if (isDefaultLane) {
-    bitIds = consumer.bitMap.getAuthoredAndImportedBitIdsOfDefaultLane().filter((id) => id.hasVersion());
+    if (!localLane) throw new Error(`unable to merge ${DEFAULT_LANE}, the current lane was not found`);
+    bitIds = await consumer.scope.getDefaultLaneIdsFromLane(localLane);
     otherLaneName = DEFAULT_LANE;
   } else if (remoteName) {
     const remoteLaneId = LaneId.from(parsedLaneId.name, remoteName);

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -163,6 +163,11 @@ export default class BitMap {
     const currentLaneId = consumer.getCurrentLaneId();
     const laneName = consumer.scope.lanes.getAliasByLaneId(currentLaneId);
     if (laneId && currentLaneId.isDefault()) {
+      logger.console(
+        `workspace is auto-synced to "${laneId.toString()}" lane, please run "bit import" to obtain the missing objects`,
+        'warn',
+        'yellow'
+      );
       const scopeJson = consumer.scope.scopeJson;
       scopeJson.trackLane({
         remoteLane: laneId.name,

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -125,12 +125,13 @@ export default class ImportComponents {
     );
 
     // import lane components from their original scope, this way, it's possible to run diff/merge on them
-    const bitIdsFromLane = lane?.toBitIds();
-    if (bitIdsFromLane?.length) {
-      // @todo: optimize this. currently, it imports twice.
+    if (lane) {
+      const mainIds = await this.scope.getDefaultLaneIdsFromLane(lane);
+      const mainIdsLatest = BitIds.fromArray(mainIds.map((m) => m.changeVersion(undefined)));
+      // @todo: optimize this maybe. currently, it imports twice.
       // try to make the previous `importComponentsObjectsHarmony` import the same component once from the original
       // scope and once from the lane-scope.
-      await this.consumer.importComponentsObjectsHarmony(bitIdsFromLane, false, this.options.allHistory);
+      await this.consumer.importComponentsObjectsHarmony(mainIdsLatest, false, this.options.allHistory);
     }
 
     // merge the lane objects

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -131,7 +131,13 @@ export default class ImportComponents {
       // @todo: optimize this maybe. currently, it imports twice.
       // try to make the previous `importComponentsObjectsHarmony` import the same component once from the original
       // scope and once from the lane-scope.
-      await this.consumer.importComponentsObjectsHarmony(mainIdsLatest, false, this.options.allHistory);
+      await this.consumer.importComponentsObjectsHarmony(
+        mainIdsLatest,
+        false,
+        this.options.allHistory,
+        undefined,
+        true
+      );
     }
 
     // merge the lane objects

--- a/src/consumer/component-ops/import-components.ts
+++ b/src/consumer/component-ops/import-components.ts
@@ -117,12 +117,10 @@ export default class ImportComponents {
       ? logger.debug(`importObjectsOnLane, Lane: ${lane.id()}, Ids: ${bitIds.toString()}`)
       : logger.debug(`importObjectsOnLane, the lane does not exist on the remote. importing only the main components`);
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
-    const componentsWithDependencies = await this.consumer.importComponentsObjectsHarmony(
-      bitIds,
-      false,
-      this.options.allHistory,
-      lane
-    );
+    const componentsWithDependencies = await this.consumer.importComponentsObjects(bitIds, {
+      allHistory: this.options.allHistory,
+      lane,
+    });
 
     // import lane components from their original scope, this way, it's possible to run diff/merge on them
     if (lane) {
@@ -131,13 +129,10 @@ export default class ImportComponents {
       // @todo: optimize this maybe. currently, it imports twice.
       // try to make the previous `importComponentsObjectsHarmony` import the same component once from the original
       // scope and once from the lane-scope.
-      await this.consumer.importComponentsObjectsHarmony(
-        mainIdsLatest,
-        false,
-        this.options.allHistory,
-        undefined,
-        true
-      );
+      await this.consumer.importComponentsObjects(mainIdsLatest, {
+        allHistory: this.options.allHistory,
+        ignoreMissingHead: true,
+      });
     }
 
     // merge the lane objects
@@ -362,11 +357,10 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       if (!this.options.objectsOnly) {
         throw new Error(`bit import with no ids and --merge flag was not implemented yet`);
       }
-      componentsAndDependencies = await this.consumer.importComponentsObjectsHarmony(
-        componentsIdsToImport,
-        this.options.fromOriginalScope,
-        this.options.allHistory
-      );
+      componentsAndDependencies = await this.consumer.importComponentsObjects(componentsIdsToImport, {
+        fromOriginalScope: this.options.fromOriginalScope,
+        allHistory: this.options.allHistory,
+      });
       await this._writeToFileSystem(componentsAndDependencies);
     }
     const importDetails = await this._getImportDetails(beforeImportVersions, componentsAndDependencies);

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -178,8 +178,8 @@ export default class ComponentsList {
         const headOnMain = modelComponent.head;
         const headOnLane = modelComponent.laneHeadLocal;
         if (!headOnMain || !headOnLane) return undefined;
-        const divergeData = await getDivergeData(this.scope.objects, modelComponent, headOnMain, headOnLane);
-        if (!divergeData.snapsOnRemoteOnly) return undefined;
+        const divergeData = await getDivergeData(this.scope.objects, modelComponent, headOnMain, headOnLane, false);
+        if (!divergeData.snapsOnRemoteOnly.length && !divergeData.err) return undefined;
         return { id: modelComponent.toBitId(), divergeData };
       })
     );

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -347,12 +347,19 @@ export default class Consumer {
     return componentWithDependencies;
   }
 
-  async importComponentsObjectsHarmony(
+  async importComponentsObjects(
     ids: BitIds,
-    fromOriginalScope = false,
-    allHistory = false,
-    lane?: Lane,
-    ignoreMissingHead = false
+    {
+      fromOriginalScope = false,
+      allHistory = false,
+      lane,
+      ignoreMissingHead = false,
+    }: {
+      fromOriginalScope?: boolean;
+      allHistory?: boolean;
+      lane?: Lane;
+      ignoreMissingHead?: boolean;
+    }
   ): Promise<ComponentWithDependencies[]> {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
     await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory, lane, ignoreMissingHead);

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -351,10 +351,11 @@ export default class Consumer {
     ids: BitIds,
     fromOriginalScope = false,
     allHistory = false,
-    lane?: Lane
+    lane?: Lane,
+    ignoreMissingHead = false
   ): Promise<ComponentWithDependencies[]> {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
-    await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory, lane);
+    await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory, lane, ignoreMissingHead);
     loader.start(`import ${ids.length} components with their dependencies (if missing)`);
     const versionDependenciesArr: VersionDependencies[] = fromOriginalScope
       ? await scopeComponentsImporter.importManyFromOriginalScopes(ids)

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -372,6 +372,9 @@ export default class CommandHelper {
   import(value = '') {
     return this.runCmd(`bit import ${value}`);
   }
+  importLane(laneName: string, flags = '') {
+    return this.runCmd(`bit lane import ${this.scopes.remote}/${laneName} ${flags}`);
+  }
   fetchLane(id: string) {
     return this.runCmd(`bit fetch ${id} --lanes`);
   }

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -477,6 +477,11 @@ export default class CommandHelper {
     return JSON.parse(status);
   }
 
+  getStagedIdsFromStatus(): string[] {
+    const status = this.statusJson();
+    return status.stagedComponents.map((s) => s.id);
+  }
+
   expectStatusToBeClean(exclude: string[] = []) {
     const statusJson = this.statusJson();
     Object.keys(statusJson).forEach((key) => {

--- a/src/scope/component-ops/diverge-data.ts
+++ b/src/scope/component-ops/diverge-data.ts
@@ -4,10 +4,12 @@ export class DivergeData {
   snapsOnLocalOnly: Ref[];
   snapsOnRemoteOnly: Ref[];
   commonSnapBeforeDiverge: Ref | null;
-  constructor(snapsOnLocalOnly?: Ref[], snapsOnRemoteOnly?: Ref[], commonSnapBeforeDiverge?: Ref | null) {
+  err: Error | undefined;
+  constructor(snapsOnLocalOnly?: Ref[], snapsOnRemoteOnly?: Ref[], commonSnapBeforeDiverge?: Ref | null, err?: Error) {
     this.snapsOnLocalOnly = snapsOnLocalOnly || [];
     this.snapsOnRemoteOnly = snapsOnRemoteOnly || [];
     this.commonSnapBeforeDiverge = commonSnapBeforeDiverge || null;
+    this.err = err;
   }
   /**
    * when a local and remote history have diverged, a true merge is needed.

--- a/src/scope/exceptions/no-common-snap.ts
+++ b/src/scope/exceptions/no-common-snap.ts
@@ -2,11 +2,11 @@ import { BitError } from '@teambit/bit-error';
 
 export class NoCommonSnap extends BitError {
   constructor(id: string) {
-    super(`fatal: local and remote of "${id}" could not be diverged as they don't have any snap in common.
-In other words, traversing the hashes of these components indicating that they are not related.
+    super(`fatal: local and remote of "${id}" don't have any snap in common, which means, they're not related.
 If this component was exported before, it might happen when the objects were missing locally.
-In this case, the suggested solution is to untag the local tags, run "bit import" to fetch all objects and then tag and export.
+In this case, the suggested solution is to reset the local tags, run "bit import" to fetch all objects and then tag and export.
 Another case of this error is when locally this component was created for the first time and the remote already has a component with the same name.
-In this case, you might want to remove the local component and import the remote`);
+In this case, you might want to remove the local component and import the remote.
+Another case of this error is when a lane has a component and the remote of that component has also a component with the same name. (suggestion: TBD)`);
   }
 }

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -69,7 +69,8 @@ export default class SourceRepository {
   async getMany(ids: BitId[] | BitIds, versionShouldBeBuilt = false): Promise<ComponentDef[]> {
     if (!ids.length) return [];
     const concurrency = concurrentComponentsLimit();
-    logger.debug(`sources.getMany, Ids: ${ids.join(', ')}`);
+    logger.trace(`sources.getMany, Ids: ${ids.join(', ')}`);
+    logger.debug(`sources.getMany, ${ids.length} Ids`);
     return pMap(
       ids,
       async (id) => {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -663,6 +663,18 @@ export default class Scope {
     return BitId.parse(id, false);
   }
 
+  /**
+   * returns the main ids of the given lane
+   */
+  async getDefaultLaneIdsFromLane(lane: Lane): Promise<BitId[]> {
+    const laneIds = lane.toBitIds();
+    const modelComponents = await Promise.all(laneIds.map((id) => this.getModelComponent(id)));
+    return modelComponents.map((c) => {
+      if (!c.head) throw new Error(`component ${c.id.toString()} has no head`);
+      return c.toBitId().changeVersion(c.head.toString());
+    });
+  }
+
   async writeObjectsToPendingDir(objectList: ObjectList, clientId: string): Promise<void> {
     const pendingDir = pathLib.join(this.path, PENDING_OBJECTS_DIR, clientId);
     if (fs.pathExistsSync(pendingDir)) {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -1,6 +1,7 @@
 import fs from 'fs-extra';
 import * as pathLib from 'path';
 import R from 'ramda';
+import { compact } from 'lodash';
 import { LaneId } from '@teambit/lane-id';
 import semver from 'semver';
 import { Analytics } from '../analytics/analytics';
@@ -669,10 +670,12 @@ export default class Scope {
   async getDefaultLaneIdsFromLane(lane: Lane): Promise<BitId[]> {
     const laneIds = lane.toBitIds();
     const modelComponents = await Promise.all(laneIds.map((id) => this.getModelComponent(id)));
-    return modelComponents.map((c) => {
-      if (!c.head) throw new Error(`component ${c.id.toString()} has no head`);
-      return c.toBitId().changeVersion(c.head.toString());
-    });
+    return compact(
+      modelComponents.map((c) => {
+        if (!c.head) return null; // probably the component was never merged to main
+        return c.toBitId().changeVersion(c.head.toString());
+      })
+    );
   }
 
   async writeObjectsToPendingDir(objectList: ObjectList, clientId: string): Promise<void> {


### PR DESCRIPTION
## Proposed Changes

- when running `bit import`, fetch lane-components not only from lane-scope but also from original scope.
- when running `bit status`, show how many snaps the main is ahead. 
- when running `bit status` and there are issues getting the diverge-data, show them to the user.
- improve `bit status --json` to show the staged versions.
- fix components with multiple parents in the history to show the staged versions correctly.