### PR TITLE
app build - add hash to mainfile

### DIFF
--- a/scopes/react/react/apps/web/react.application.ts
+++ b/scopes/react/react/apps/web/react.application.ts
@@ -112,7 +112,11 @@ export class ReactApp implements Application {
     });
 
     const defaultTransformer: WebpackConfigTransformer = (configMutator) => {
-      const config = configMutator.addTopLevel('output', { path: staticDir, publicPath: `/` });
+      const config = configMutator.addTopLevel('output', {
+        path: staticDir,
+        publicPath: `/`,
+        filename: '[name].[chunkhash].js',
+      });
       if (this.prerender) config.addPlugin(prerenderPlugin(this.prerender));
       if (config.raw.optimization?.minimizer) {
         remove(config.raw.optimization?.minimizer, (minimizer) => {


### PR DESCRIPTION
## Proposed Changes

- include content hash in t he webpack output file, when building app 

This should fix some cache busting problems where an older version of `main.js` got stuck in the cdn.
