### PR TITLE
improvement: introduce helpUrl prop for commands

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -462,7 +462,7 @@ there are matching among unmodified components thought. consider using --unmodif
     const logger = loggerMain.createLogger(SnappingAspect.id);
     const snapping = new SnappingMain(workspace, logger, issues, insights);
     const snapCmd = new SnapCmd(community.getBaseDomain(), snapping, logger);
-    const tagCmd = new TagCmd(community.getBaseDomain(), snapping, logger);
+    const tagCmd = new TagCmd(snapping, logger);
     const resetCmd = new ResetCmd(snapping);
     cli.register(tagCmd, snapCmd, resetCmd);
     return snapping;

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -19,6 +19,8 @@ export class TagCmd implements Command {
   name = 'tag [component-patterns...]';
   group = 'development';
   description = 'create an immutable and exportable component snapshot, tagged with a release version.';
+  extendedDescription = `if no patterns are provided, it will tag all new and modified components.
+if patterns are entered, you can specify a version per pattern using "@" sign, e.g. bit tag foo@1.0.0 bar@minor baz@major`;
   arguments = [
     {
       name: 'component-patterns...',
@@ -26,7 +28,7 @@ export class TagCmd implements Command {
         'a list of component names, IDs or patterns (separated by space). run "bit pattern --help" to get more data about patterns. By default, all modified are tagged.',
     },
   ];
-  extendedDescription: string;
+  helpUrl = 'components/tags';
   alias = 't';
   loader = true;
   options = [
@@ -82,11 +84,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
   remoteOp = true; // In case a compiler / tester is not installed
   examples = [{ cmd: 'tag --ver 1.0.0', description: 'tag all components to version 1.0.0' }];
 
-  constructor(docsDomain: string, private snapping: SnappingMain, private logger: Logger) {
-    this.extendedDescription = `if no patterns are provided, it will tag all new and modified components.
-if patterns are entered, you can specify a version per pattern using "@" sign, e.g. bit tag foo@1.0.0 bar@minor baz@major
-https://${docsDomain}/components/tags`;
-  }
+  constructor(private snapping: SnappingMain, private logger: Logger) {}
 
   // eslint-disable-next-line complexity
   async report(

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -248,6 +248,9 @@ export class CLIParser {
     if (command?.extendedDescription) {
       descriptionColored.push(command?.extendedDescription);
     }
+    if (command?.helpUrl) {
+      descriptionColored.push(`for more info, visit: ${chalk.underline(command.helpUrl)}`);
+    }
     const descriptionStr = descriptionColored.join('\n');
     const globalOptionsStr = globalOptions.join('\n');
 

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -114,6 +114,9 @@ export class CLIMain {
         command.loader = true;
       }
     }
+    if (command.helpUrl && !isFullUrl(command.helpUrl)) {
+      command.helpUrl = `https://${this.community.getDocsDomain()}/${command.helpUrl}`;
+    }
   }
 
   static dependencies = [CommunityAspect];
@@ -153,4 +156,8 @@ async function ensureWorkspaceAndScope() {
   } catch (err) {
     // do nothing. it could fail for example with ScopeNotFound error, which is taken care of in "bit init".
   }
+}
+
+function isFullUrl(url: string) {
+  return url.startsWith('http://') || url.startsWith('https://');
 }

--- a/scopes/harmony/cli/legacy-command-adapter.ts
+++ b/scopes/harmony/cli/legacy-command-adapter.ts
@@ -15,10 +15,12 @@ export class LegacyCommandAdapter implements Command {
   migration?: boolean;
   internal?: boolean;
   skipWorkspace?: boolean;
+  helpUrl?: string;
   _packageManagerArgs?: string[];
   constructor(private cmd: LegacyCommand, cliExtension: CLIMain) {
     this.name = cmd.name;
     this.description = cmd.description;
+    this.helpUrl = cmd.helpUrl;
     this.options = cmd.opts || [];
     this.alias = cmd.alias;
     this.extendedDescription = cmd.extendedDescription;

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -27,6 +27,12 @@ export interface Command {
   extendedDescription?: string;
 
   /**
+   * url to a doc page explaining the command. shown in the command help just after the extendedDescription.
+   * if a relative url is entered, the base url will be retrieved from `teambit.community/community` aspect.
+   */
+  helpUrl?: string;
+
+  /**
    * allow grouping of commands to hint summery renderer
    * Places in default automatic help
    */

--- a/src/cli/legacy-command.ts
+++ b/src/cli/legacy-command.ts
@@ -7,6 +7,7 @@ export interface LegacyCommand {
   name: string;
   description: string; // for "bit help"
   extendedDescription?: string; // for the command itself
+  helpUrl?: string;
   alias: string;
   opts?: CommandOptions;
   commands?: LegacyCommand[];


### PR DESCRIPTION
The current mechanism of adding a URL to the command output is cumbersome. The command aspect needs to add the community aspect as a dependency, get the base-url from it and then move the extendedDescription to the constructor and concatenate it there.
With this PR, a new prop `helpUrl` was added to the `Command` class. The CLI aspect is the one that responsible to concatenate the base-url from the community aspect to the relative-url provides by the `helpUrl` of the command. 
Since the output provided by `yargs` is already parsed and manipulated heavily, it was easy to let it render the URL as well (and with an underline style). 
Users can always override the base-url. Or override specific commands with full-url. In case the `helpUrl` has full-url, then, it won't concatenate from the community aspect.

In this PR, only `bit tag` was changed to use the new format. Other commands will be changed as well gradually. 