### PR TITLE
add component id to preview query

### DIFF
--- a/scopes/preview/ui/component-preview/urls.ts
+++ b/scopes/preview/ui/component-preview/urls.ts
@@ -49,7 +49,11 @@ function toComponentPreviewUrl(component: ComponentModel) {
  */
 function toEnvTemplatePreviewUrl(component: ComponentModel, previewName?: string) {
   const envId = component.environment?.id;
-  const envBasedUrl = `/api/${envId}/~aspect/env-template/${previewName}/`;
+  // add component id for cache busting,
+  // otherwise might have leftovers when switching between components of the same env.
+  // This query param is currently not used yet.
+  const search = `compId=${component.id.toString()}`;
+  const envBasedUrl = `/api/${envId}/~aspect/env-template/${previewName}/?${search}`;
   return envBasedUrl;
 }
 


### PR DESCRIPTION
## Proposed Changes

- added the component id the query of the preview iframe

This will fix rare errors happening when moving between components of the same env. The iframe might not  reload, and have some left overs from older components.
