### PR TITLE
fix: fix errors about legacy-bit-id during bit-build of bit

### DIFF
--- a/scopes/component/component-version/version.ts
+++ b/scopes/component/component-version/version.ts
@@ -12,11 +12,14 @@ export class Version {
     this.latest = latest;
   }
 
-  resolve(availableVersion: string[]) {
+  /**
+   * @deprecated this is super old method, which is not relevant anymore.
+   */
+  resolve(availableVersion: string[]): string {
     const getLatest = () => semver.maxSatisfying(availableVersion, '*', { includePrerelease: true });
 
-    if (this.latest) return getLatest();
-    return this.versionNum;
+    if (this.latest) return getLatest() as string;
+    return this.versionNum as string;
   }
 
   toString() {


### PR DESCRIPTION
for some reason, bit-build get new errors related to this file. on master `resolve()` method returns `string | null | undefined`, which makes sense. but inside the d.ts of the package it shows `string` for some reason.
this PR casts it to `string`. we really should not use this version-parser. it doesn't make sense anymore. 