### PR TITLE
fix(lane-create): fix lane.forkedFrom to point to the last exported lane

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1836,5 +1836,5 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/yarn"
     },
-    "$schema-version": "14.9.0"
+    "$schema-version": "15.0.0"
 }

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1202,5 +1202,14 @@ describe('bit lane command', function () {
     it('bit status should be clean', () => {
       helper.command.expectStatusToBeClean();
     });
+    describe('lane-a (exported) => lane-b (not-exported) => lane-c', () => {
+      before(() => {
+        helper.command.createLane('lane-c');
+      });
+      it('forkedFrom should be of lane-a and not lane-b because this is the last exported one', () => {
+        const lane = helper.command.catLane('lane-c');
+        expect(lane.forkedFrom.name).to.equal('lane-a');
+      });
+    });
   });
 });


### PR DESCRIPTION
currently, it points to the current lane even when it's new.