### PR TITLE
fix(bit-install): avoid installation of a component that exists in the workspace, regardless the version

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
@@ -158,8 +158,8 @@ function filterComponents(dependencyList: DependencyList, componentsToFilterOut:
       // while the component.state._consumer.id has the upcoming version (the version that will be after the tag)
       // The dependency in some cases is already updated to the upcoming version
       return (
-        component.id._legacy.isEqual(dep.componentId._legacy) ||
-        component.state._consumer.id.isEqual(dep.componentId._legacy)
+        component.id._legacy.isEqualWithoutVersion(dep.componentId._legacy) ||
+        component.state._consumer.id.isEqualWithoutVersion(dep.componentId._legacy)
       );
     });
     if (existingComponent) return false;


### PR DESCRIPTION
Currently, the filter that removes workspace-components from package-installation is considering the version. As a result, if a dependency exists in the workspace but with a different version, it's installed as package.
This PR filters out components that exist in the workspace regardless of their version. 