### PR TITLE
fix: avoid fetching main-artifacts from lane-scope

### DIFF
--- a/src/consumer/component/sources/artifact-files.ts
+++ b/src/consumer/component/sources/artifact-files.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import R from 'ramda';
 import { BitId } from '../../../bit-id';
 import ShowDoctorError from '../../../error/show-doctor-error';
+import logger from '../../../logger/logger';
 import { Scope } from '../../../scope';
 import ScopeComponentsImporter from '../../../scope/component-ops/scope-components-importer';
 import { Source } from '../../../scope/models';
@@ -131,27 +132,45 @@ export class ArtifactFiles {
 }
 
 export async function importMultipleDistsArtifacts(scope: Scope, components: Component[]) {
+  logger.debug(
+    `importMultipleDistsArtifacts: ${components.length} components: ${components
+      .map((c) => c.id.toString())
+      .join(', ')}`
+  );
   const extensionsNamesForDistArtifacts = 'teambit.compilation/compiler';
   const lane = await scope.getCurrentLaneObject();
   const laneIds = lane?.toBitIds();
-  const isIdOnLane = (id: BitId) => laneIds?.hasWithoutVersion(id);
+  const isIdOnLane = async (id: BitId): Promise<boolean> => {
+    if (!lane) return false;
+    if (laneIds?.has(id)) return true; // in the lane with the same version
+    if (!laneIds?.hasWithoutVersion(id)) return false; // not in the lane at all
+    // component is in the lane object but with a different version.
+    // we have to figure out whether the current version exists on the lane or not.
+    const component = await scope.getModelComponent(id);
+    await component.setDivergeData(scope.objects, false);
+    const divergeData = component.getDivergeData();
+    return Boolean(divergeData.snapsOnLocalOnly.find((snap) => snap.toString() === id.version));
+  };
   const groupedHashes: { [scopeName: string]: string[] } = {};
-  components.forEach((component) => {
-    const artifactsFiles = getArtifactFilesByExtension(component.extensions, extensionsNamesForDistArtifacts);
-    artifactsFiles.forEach((artifactFiles) => {
-      if (!artifactFiles) return;
-      if (!(artifactFiles instanceof ArtifactFiles)) {
-        artifactFiles = deserializeArtifactFiles(artifactFiles);
-      }
-      if (artifactFiles.isEmpty()) return;
-      if (artifactFiles.vinyls.length) return;
-      const allHashes = artifactFiles.refs.map((artifact) => artifact.ref.hash);
-      const scopeName = isIdOnLane(component.id) ? (lane?.scope as string) : (component.scope as string);
-      (groupedHashes[scopeName] ||= []).push(...allHashes);
-    });
-  });
+  await Promise.all(
+    components.map(async (component) => {
+      const artifactsFiles = getArtifactFilesByExtension(component.extensions, extensionsNamesForDistArtifacts);
+      const scopeName = (await isIdOnLane(component.id)) ? (lane?.scope as string) : (component.scope as string);
+      artifactsFiles.forEach((artifactFiles) => {
+        if (!artifactFiles) return;
+        if (!(artifactFiles instanceof ArtifactFiles)) {
+          artifactFiles = deserializeArtifactFiles(artifactFiles);
+        }
+        if (artifactFiles.isEmpty()) return;
+        if (artifactFiles.vinyls.length) return;
+        const allHashes = artifactFiles.refs.map((artifact) => artifact.ref.hash);
+        (groupedHashes[scopeName] ||= []).push(...allHashes);
+      });
+    })
+  );
   const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
   await scopeComponentsImporter.importManyObjects(groupedHashes);
+  logger.debug(`importMultipleDistsArtifacts: ${components.length} components. completed successfully`);
 }
 
 export function refsToModelObjects(refs: ArtifactRef[]): ArtifactModel[] {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -253,7 +253,9 @@ export default class Component extends BitObject {
 
   getDivergeData(): DivergeData {
     if (!this.divergeData)
-      throw new Error(`getDivergeData() expects divergeData to be populate, please use this.setDivergeData()`);
+      throw new Error(
+        `getDivergeData() expects divergeData to be populate, please use this.setDivergeData() for id: ${this.id()}`
+      );
     return this.divergeData;
   }
 


### PR DESCRIPTION
currently, if checked out to a lane, and the lane has the id with a different version, it'll fetch the dists for the capsule from the lane's scope incorrectly.