### PR TITLE
improvement(lanes): allow resolving unmerged via bit-tag and bit-snap

### DIFF
--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -115,7 +115,7 @@ export function mergeReport({
     if (!components || !components.length || !leftUnresolvedConflicts) return '';
     const title = `files with conflicts summary\n`;
     const suggestion = `\n\nthe merge process wasn't completed due to the conflicts above. fix them manually and then run "bit install".
-once ready, run "bit merge --resolve" to complete the merge.`;
+once ready, snap/tag the components to complete the merge.`;
     return chalk.underline(title) + conflictSummaryReport(components) + chalk.yellow(suggestion);
   };
 

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -437,7 +437,6 @@ export class MergingMain {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const { snappedComponents } = await this.snapping.snap({
       legacyBitIds: BitIds.fromArray(ids),
-      resolveUnmerged: true,
       build,
       message: snapMessage,
     });

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -27,6 +27,7 @@ export class SnapCmd implements Command {
   options = [
     ['m', 'message <message>', 'log message describing the latest changes'],
     ['', 'unmodified', 'include unmodified components (by default, only new and modified components are snapped)'],
+    ['', 'unmerged', 'EXPERIMENTAL. complete a merge process by snapping the unmerged components'],
     ['', 'build', 'Harmony only. run the pipeline build and complete the tag'],
     ['', 'skip-tests', 'skip running component tests during snap process'],
     ['', 'skip-auto-snap', 'skip auto snapping dependents'],
@@ -61,6 +62,7 @@ ${WILDCARD_HELP('snap')}`;
       message = '',
       all = false,
       force = false,
+      unmerged = false,
       ignoreIssues,
       build,
       skipTests = false,
@@ -72,6 +74,7 @@ ${WILDCARD_HELP('snap')}`;
       message?: string;
       all?: boolean;
       force?: boolean;
+      unmerged?: boolean;
       ignoreIssues?: string;
       build?: boolean;
       skipTests?: boolean;
@@ -107,6 +110,7 @@ ${WILDCARD_HELP('snap')}`;
     const results = await this.snapping.snap({
       pattern,
       message,
+      unmerged,
       ignoreIssues,
       build,
       skipTests,

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -47,6 +47,7 @@ if patterns are entered, you can specify a version per pattern using "@" sign, e
     ['', 'major', 'syntactic sugar for "--increment major"'],
     ['', 'pre-release [identifier]', 'syntactic sugar for "--increment prerelease" and `--prerelease-id <identifier>`'],
     ['', 'snapped', 'EXPERIMENTAL. tag components that their head is a snap (not a tag)'],
+    ['', 'unmerged', 'EXPERIMENTAL. complete a merge process by tagging the unmerged components'],
     ['', 'skip-tests', 'skip running component tests during tag process'],
     ['', 'skip-auto-tag', 'skip auto tagging dependents'],
     ['', 'soft', 'do not persist. only keep note of the changes to be made'],
@@ -95,6 +96,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       all = false,
       editor = '',
       snapped = false,
+      unmerged = false,
       patch,
       minor,
       major,
@@ -119,6 +121,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     }: {
       all?: boolean | string;
       snapped?: boolean;
+      unmerged?: boolean;
       ver?: string;
       force?: boolean;
       patch?: boolean;
@@ -205,6 +208,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     const params = {
       ids: patterns,
       snapped,
+      unmerged,
       editor,
       message,
       releaseType: getReleaseType(),

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -179,7 +179,7 @@ alternatively, to keep local tags/snaps history, use "bit merge <remote-name>/<l
       : '';
 
     const compWithConflictsTitle = chalk.underline.white('components during merge state');
-    const compWithConflictsDesc = `(use "bit merge [component-id] --resolve" to mark them as resolved and snap the changes
+    const compWithConflictsDesc = `(use "bit snap/tag [--unmerged]" to complete the merge process
 or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
     const compWithConflictsComps = componentsDuringMergeState
       .map((id) => {
@@ -226,7 +226,7 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
         : ''
     ).join('\n');
 
-    const stagedDesc = '\n(use "bit export to push these components to a remote scope")\n';
+    const stagedDesc = '\n(use "bit export" to push these components to a remote scope)\n';
     const stagedComponentsOutput = immutableUnshift(
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       stagedComponents.map((c) => format(c, true)),

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -299,9 +299,9 @@ export default class ComponentsList {
       this.listNewComponents(),
       this.listModifiedComponents(),
     ]);
+    const duringMergeIds = this.listDuringMergeStateComponents();
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return BitIds.fromArray([...newComponents, ...modifiedComponents]);
+    return BitIds.fromArray([...(newComponents as BitId[]), ...(modifiedComponents as BitId[]), ...duringMergeIds]);
   }
 
   async listExportPendingComponentsIds(lane?: Lane | null): Promise<BitIds> {

--- a/src/scope/component-ops/tag-model-component.ts
+++ b/src/scope/component-ops/tag-model-component.ts
@@ -138,7 +138,6 @@ export default async function tagModelComponent({
   soft,
   build,
   persist,
-  resolveUnmerged,
   isSnap = false,
   disableTagAndSnapPipelines,
   forceDeploy,
@@ -152,7 +151,6 @@ export default async function tagModelComponent({
   releaseType?: ReleaseType;
   incrementBy?: number;
   consumer: Consumer;
-  resolveUnmerged?: boolean;
   isSnap?: boolean;
   packageManagerConfigRootDir?: string;
 } & BasicTagParams): Promise<{
@@ -238,7 +236,7 @@ export default async function tagModelComponent({
     await addFlattenedDependenciesToComponents(consumer.scope, allComponentsToTag);
     emptyBuilderData(allComponentsToTag);
     addBuildStatus(allComponentsToTag, BuildStatus.Pending);
-    await addComponentsToScope(consumer, allComponentsToTag, Boolean(resolveUnmerged), build);
+    await addComponentsToScope(consumer, allComponentsToTag, build);
     await consumer.updateComponentsVersions(allComponentsToTag);
   }
 
@@ -262,19 +260,13 @@ export default async function tagModelComponent({
   return { taggedComponents: componentsToTag, autoTaggedResults: autoTagData, publishedPackages };
 }
 
-async function addComponentsToScope(
-  consumer: Consumer,
-  components: Component[],
-  resolveUnmerged: boolean,
-  shouldValidateVersion: boolean
-) {
+async function addComponentsToScope(consumer: Consumer, components: Component[], shouldValidateVersion: boolean) {
   const lane = await consumer.getCurrentLaneObject();
   await mapSeries(components, async (component) => {
     await consumer.scope.sources.addSource({
       source: component,
       consumer,
       lane,
-      resolveUnmerged,
       shouldValidateVersion,
     });
   });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -266,25 +266,18 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     source,
     consumer,
     lane,
-    resolveUnmerged = false,
     shouldValidateVersion = false,
   }: {
     source: ConsumerComponent;
     consumer: Consumer;
     lane: Lane | null;
-    resolveUnmerged?: boolean;
     shouldValidateVersion?: boolean;
   }): Promise<ModelComponent> {
     const objectRepo = this.objects();
     // if a component exists in the model, add a new version. Otherwise, create a new component on the model
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     const component = await this.findOrAddComponent(source);
-    const unmergedComponent = consumer.scope.objects.unmergedComponents.getEntry(component.name);
-    if (unmergedComponent && !unmergedComponent.resolved && !resolveUnmerged) {
-      throw new GeneralError(
-        `unable to snap/tag "${component.name}", it is unmerged with conflicts. please run "bit merge <id> --resolve"`
-      );
-    }
+
     const artifactFiles = getArtifactsFiles(source.extensions);
     const artifacts = this.transformArtifactsFromVinylToSource(artifactFiles);
     const { version, files } = await this.consumerComponentToVersion(source);
@@ -292,14 +285,13 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
     if (!source.version) throw new Error(`addSource expects source.version to be set`);
     component.addVersion(version, source.version, lane, objectRepo);
 
+    const unmergedComponent = consumer.scope.objects.unmergedComponents.getEntry(component.name);
     if (unmergedComponent) {
       version.addParent(unmergedComponent.head);
       logger.debug(
         `sources.addSource, unmerged component "${component.name}". adding a parent ${unmergedComponent.head.hash}`
       );
-      version.log.message = version.log.message
-        ? version.log.message
-        : UnmergedComponents.buildSnapMessage(unmergedComponent);
+      version.log.message = version.log.message || UnmergedComponents.buildSnapMessage(unmergedComponent);
       consumer.scope.objects.unmergedComponents.removeComponent(component.name);
     }
     objectRepo.add(component);

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -6,7 +6,6 @@ import { BuildStatus } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { ArtifactFiles, ArtifactSource, getArtifactsFiles } from '../../consumer/component/sources/artifact-files';
 import Consumer from '../../consumer/consumer';
-import GeneralError from '../../error/general-error';
 import logger from '../../logger/logger';
 import ComponentObjects from '../component-objects';
 import { getAllVersionHashes, getAllVersionsInfo, VersionInfo } from '../component-ops/traverse-versions';


### PR DESCRIPTION
After merging lanes, instead of requiring the users to run `bit merge --resolve`, allow using `bit snap` and `bit tag` to complete the merge process.
This is relevant only when the `bit lane merge` was used with `--no-snap` or it has unresolved conflicts. Otherwise, this command already auto-snap. 

Also, introduce `--unmerged` flag for `bit tag` and `bit snap` to tag/snap only the component-during-merge.