### PR TITLE
fix(bit-checkout): avoid running package installation and compilation when files left with conflicts

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -317,6 +317,15 @@ describe('bit checkout command', function () {
         const statusOutput = helper.command.runCmd('bit status');
         expect(statusOutput).to.have.string('modified components');
       });
+      it('should not try to compile the files', () => {
+        expect(output).not.to.have.string('compilation failed');
+        expect(output).not.to.have.string('Merge conflict marker encountered');
+      });
+      it('should not run the package installation', () => {
+        expect(output).not.to.have.string('installing dependencies');
+        expect(output).not.to.have.string('pnpm');
+        expect(output).not.to.have.string('yarn');
+      });
     });
     describe('using theirs strategy', () => {
       let output;

--- a/src/cli/commands/public-cmds/checkout-cmd.ts
+++ b/src/cli/commands/public-cmds/checkout-cmd.ts
@@ -7,6 +7,7 @@ import {
   ApplyVersionResults,
   getMergeStrategy,
   applyVersionReport,
+  conflictSummaryReport,
 } from '../../../consumer/versions-ops/merge-version';
 import { Group } from '../../command-groups';
 import { CommandOptions, LegacyCommand } from '../../legacy-command';
@@ -103,7 +104,7 @@ export default class Checkout implements LegacyCommand {
   }
 
   report(
-    { components, version, failedComponents }: ApplyVersionResults,
+    { components, version, failedComponents, leftUnresolvedConflicts }: ApplyVersionResults,
     _,
     { verbose, all }: { verbose: boolean; all: boolean }
   ): string {
@@ -140,6 +141,14 @@ export default class Checkout implements LegacyCommand {
         .join('\n');
       return `${title}\n${body}\n\n`;
     };
+    const getConflictSummary = () => {
+      if (!components || !components.length || !leftUnresolvedConflicts) return '';
+      const title = `\n\nfiles with conflicts summary\n`;
+      const suggestion = `\n\nfix the conflicts above manually and then run "bit install" and "bit compile".
+once ready, snap/tag the components to persist the changes`;
+      return chalk.underline(title) + conflictSummaryReport(components) + chalk.yellow(suggestion);
+    };
+
     const getSuccessfulOutput = () => {
       if (!components || !components.length) return '';
       if (components.length === 1) {
@@ -167,6 +176,6 @@ export default class Checkout implements LegacyCommand {
       return title + componentsStr;
     };
 
-    return getFailureOutput() + getNeutralOutput() + getSuccessfulOutput();
+    return getFailureOutput() + getNeutralOutput() + getSuccessfulOutput() + getConflictSummary();
   }
 }

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -93,12 +93,12 @@ export default async function checkoutVersion(
   const componentsWithDependencies = componentsResults
     .map((c) => c.component)
     .filter((c) => c) as ComponentWithDependencies[];
-
+  const leftUnresolvedConflicts = componentWithConflict && checkoutProps.mergeStrategy === 'manual';
   if (componentsWithDependencies.length) {
     const manyComponentsWriter = new ManyComponentsWriter({
       consumer,
       componentsWithDependencies,
-      installNpmPackages: !checkoutProps.skipNpmInstall,
+      installNpmPackages: !checkoutProps.skipNpmInstall && !leftUnresolvedConflicts,
       override: true,
       verbose: checkoutProps.verbose,
       writeDists: !checkoutProps.ignoreDist,
@@ -112,7 +112,7 @@ export default async function checkoutVersion(
 
   const appliedVersionComponents = componentsResults.map((c) => c.applyVersionResult);
 
-  return { components: appliedVersionComponents, version, failedComponents };
+  return { components: appliedVersionComponents, version, failedComponents, leftUnresolvedConflicts };
 
   async function getAllComponentsStatus(): Promise<ComponentStatus[]> {
     const tmp = new Tmp(consumer.scope);

--- a/src/consumer/versions-ops/merge-version/merge-version.ts
+++ b/src/consumer/versions-ops/merge-version/merge-version.ts
@@ -251,7 +251,9 @@ export const applyVersionReport = (components: ApplyVersionResult[], addName = t
         .map((file) => {
           const note =
             component.filesStatus[file] === FileStatus.manual
-              ? chalk.white('automatic merge failed. please fix conflicts manually and then tag the results.')
+              ? chalk.white(
+                  'automatic merge failed. please fix conflicts manually and then run "bit install" and "bit compile"'
+                )
               : '';
           return `${tab}${component.filesStatus[file]} ${chalk.bold(file)} ${note}`;
         })


### PR DESCRIPTION
Currently, when files left with conflicts after the checkout process, Bit runs the package installation ("bit install") and compile the components. It leads to two issues:
1. since it unable to parse the files with the conflicts, it doesn't know which packages are imported in those files, so the manifest created for the package-manager is missing these packages. It leads to confusion, because users don't expect packages to be removed. 
2. since the files have conflicts, the compilation will always fail. The failure output is verbose and makes it difficult to understand the checkout results.

This PR disable these two (installation and compilation) and instead, it shows a summary of all files with conflicts and suggests to run `bit install` and `bit compile` once they're resolved. 