### PR TITLE
fix workspace preview for components with no compositions

### DIFF
--- a/scopes/compositions/compositions/compositions.preview-definition.ts
+++ b/scopes/compositions/compositions/compositions.preview-definition.ts
@@ -21,6 +21,6 @@ export class CompositionPreviewDefinition implements PreviewDefinition {
 
   async getModuleMap(components: Component[]): Promise<ComponentMap<AbstractVinyl[]>> {
     const map = this.compositions.getPreviewFiles(components);
-    return map.filter((value) => value.length !== 0);
+    return map;
   }
 }


### PR DESCRIPTION
## Proposed Changes

- fix the preview link file compositions.

link file was missing components without compositions. examples:

correct:
![Screen Shot 2022-07-31 at 13 07 06](https://user-images.githubusercontent.com/5400361/182022163-55fe891c-1262-4d54-b084-f2150832af5a.png)

incorrect:
![Screen Shot 2022-07-31 at 13 07 35](https://user-images.githubusercontent.com/5400361/182022171-adf6050a-113c-4605-9fa9-9364071f8837.png)

fixed to be:
![Screen Shot 2022-07-31 at 13 35 16](https://user-images.githubusercontent.com/5400361/182022183-549dbde4-34bd-4d72-bca6-138b1b21621e.png)

