### PR TITLE
fix(bit-reset): enable reset a local merge of lanes before export

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -351,6 +351,21 @@ describe('merge lanes', function () {
       it('bit status should not show the components in pending-merge', () => {
         expect(status.mergePendingComponents).to.have.lengthOf(0);
       });
+      describe('switching to main and merging the lane to main', () => {
+        before(() => {
+          helper.command.switchLocalLane('main');
+          helper.command.mergeLane('dev');
+        });
+        it('head should have two parents', () => {
+          const cat = helper.command.catComponent('comp1@latest');
+          expect(cat.parents).to.have.lengthOf(2);
+        });
+        // previously it was throwing:
+        // removeComponentVersions found multiple parents for a local (un-exported) version 368fb583865af40a8823d2ac1d556f4b65582ba2 of iw4j2eko-remote/comp1
+        it('bit reset should not throw', () => {
+          expect(() => helper.command.untagAll()).to.not.throw();
+        });
+      });
     });
   });
 });

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -722,16 +722,37 @@ describe('bit snap command', function () {
       expect(output).to.have.string('bit merge');
     });
     describe('bit reset a diverge component', () => {
+      let beforeUntag: string;
+      let localHeadV3: string;
       before(() => {
-        helper.command.untagAll();
+        localHeadV3 = helper.command.getHead('comp1');
+        helper.command.tagAllWithoutBuild('-s 0.0.4');
+        beforeUntag = helper.scopeHelper.cloneLocalScope();
       });
-      it('should change the head to point to the remote head and not to the parent of the untagged version', () => {
-        const head = helper.command.getHead('comp1');
-        const remoteHead = helper.general.getRemoteHead('comp1');
-        expect(head).to.be.equal(remoteHead);
+      describe('reset all local versions', () => {
+        before(() => {
+          helper.command.untagAll();
+        });
+        it('should change the head to point to the remote head and not to the parent of the untagged version', () => {
+          const head = helper.command.getHead('comp1');
+          const remoteHead = helper.general.getRemoteHead('comp1');
+          expect(head).to.be.equal(remoteHead);
+        });
+        it('bit status after untag should show the component as modified only', () => {
+          helper.command.expectStatusToBeClean(['modifiedComponent']);
+        });
       });
-      it('bit status after untag should show the component as modified only', () => {
-        helper.command.expectStatusToBeClean(['modifiedComponent']);
+      describe('reset only head', () => {
+        before(() => {
+          helper.scopeHelper.getClonedLocalScope(beforeUntag);
+          helper.command.untagAll('--head');
+        });
+        it('should change the head to point to the parent of the head and not to the remote head', () => {
+          const head = helper.command.getHead('comp1');
+          const remoteHead = helper.general.getRemoteHead('comp1');
+          expect(head).to.not.be.equal(remoteHead);
+          expect(head).to.be.equal(localHeadV3);
+        });
       });
     });
   });

--- a/src/scope/component-ops/untag-component.ts
+++ b/src/scope/component-ops/untag-component.ts
@@ -54,7 +54,7 @@ export async function removeLocalVersion(
   const allVersionsObjects = await Promise.all(
     versionsToRemoveStr.map((localVer) => component.loadVersion(localVer, scope.objects))
   );
-  scope.sources.removeComponentVersions(component, versionsToRemoveStr, allVersionsObjects, lane);
+  scope.sources.removeComponentVersions(component, versionsToRemoveStr, allVersionsObjects, lane, head);
 
   return { id, versions: versionsToRemoveStr, component };
 }


### PR DESCRIPTION
Currently, an error is thrown when running `bit reset` after lanes merge: 
```
removeComponentVersions found multiple parents for a local (un-exported) version snapX of comp-name
```
with this PR it's possible to revert the merge by `bit reset`.