### PR TITLE
fix(patterns): support patterns that have only exclude syntax

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -972,6 +972,9 @@ needed-for: ${neededFor || '<unknown>'}`);
   // todo: move this to somewhere else (where?)
   filterIdsFromPoolIdsByPattern(pattern: string, ids: ComponentID[], throwForNoMatch = true) {
     const patterns = pattern.split(',').map((p) => p.trim());
+    if (patterns.every((p) => p.startsWith('!'))) {
+      patterns.push('**'); // otherwise it'll never match anything
+    }
     // check also as legacyId.toString, as it doesn't have the defaultScope
     const idsToCheck = (id: ComponentID) => [id.toStringWithoutVersion(), id._legacy.toStringWithoutVersion()];
     const idsFiltered = ids.filter((id) => multimatch(idsToCheck(id), patterns).length);


### PR DESCRIPTION
e.g. a workspace with two components: "foo", "bar". currently, running `bit pattern "!foo"` yield zero results. 
This PR include `**` in this case and returns "bar".