### PR TITLE
remove R.merge

### DIFF
--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "pino-pretty": "4.5.0",
     "prettier": "2.3.2",
     "prompt": "1.1.0",
-    "ramda": "0.27.1",
+    "ramda": "0.28.0",
     "react-docgen": "5.3.1",
     "read-pkg-up": "7.0.1",
     "regenerator-runtime": "0.13.7",

--- a/package.json
+++ b/package.json
@@ -188,7 +188,7 @@
     "pino-pretty": "4.5.0",
     "prettier": "2.3.2",
     "prompt": "1.1.0",
-    "ramda": "0.28.0",
+    "ramda": "0.27.1",
     "react-docgen": "5.3.1",
     "read-pkg-up": "7.0.1",
     "regenerator-runtime": "0.13.7",

--- a/src/consumer/config/component-config.ts
+++ b/src/consumer/config/component-config.ts
@@ -57,9 +57,7 @@ export default class ComponentConfig extends AbstractConfig {
 
   toPlainObject() {
     const superObject = super.toPlainObject();
-    const componentObject = R.merge(superObject, {
-      overrides: this.overrides,
-    });
+    const componentObject = { ...superObject, overrides: this.overrides };
     const isPropDefaultOrEmpty = (val, key) => {
       if (key === 'overrides') return !R.isEmpty(val);
       return true;

--- a/src/consumer/config/workspace-config.ts
+++ b/src/consumer/config/workspace-config.ts
@@ -125,7 +125,8 @@ export default class WorkspaceConfig extends AbstractConfig {
 
   toPlainObject() {
     const superObject = super.toPlainObject();
-    const consumerObject = R.merge(superObject, {
+    const consumerObject = {
+      ...superObject,
       componentsDefaultDirectory: this.componentsDefaultDirectory,
       dependenciesDirectory: this.dependenciesDirectory,
       saveDependenciesAsComponents: this.saveDependenciesAsComponents,
@@ -137,7 +138,7 @@ export default class WorkspaceConfig extends AbstractConfig {
       resolveModules: this.resolveModules,
       defaultScope: this.defaultScope,
       overrides: this.overrides.overrides,
-    });
+    };
 
     const isPropDefault = (val, key) => {
       if (key === 'dependenciesDirectory') return val !== DEFAULT_DEPENDENCIES_DIR_PATH;

--- a/src/npm-client/npm-client.ts
+++ b/src/npm-client/npm-client.ts
@@ -4,7 +4,7 @@ import execa from 'execa';
 import fs from 'fs-extra';
 import mapSeries from 'p-map-series';
 import * as path from 'path';
-import R, { is, isNil, join, map, merge, toPairs } from 'ramda';
+import R, { is, isNil, join, map, toPairs } from 'ramda';
 import semver from 'semver';
 
 import { Analytics } from '../analytics/analytics';

--- a/src/npm-client/npm-client.ts
+++ b/src/npm-client/npm-client.ts
@@ -97,10 +97,10 @@ const _installInOneDirectory = ({
 }): Promise<PackageManagerResults> => {
   // Handle process options
   const allowedPackageManagerProcessOptions = getAllowdPackageManagerProcessOptions(packageManagerProcessOptions);
-  const concretePackageManagerProcessOptions = merge(
-    defaultPackageManagerProcessOptions,
-    allowedPackageManagerProcessOptions
-  );
+  const concretePackageManagerProcessOptions = {
+    ...defaultPackageManagerProcessOptions,
+    ...allowedPackageManagerProcessOptions,
+  };
   concretePackageManagerProcessOptions.cwd = dir || concretePackageManagerProcessOptions.cwd;
   const cwd = concretePackageManagerProcessOptions.cwd;
 

--- a/src/scope/scope-remotes.ts
+++ b/src/scope/scope-remotes.ts
@@ -1,5 +1,3 @@
-import R from 'ramda';
-
 import { BitId } from '../bit-id';
 import GlobalRemotes from '../global-config/global-remotes';
 import { Remotes } from '../remotes';
@@ -8,7 +6,7 @@ import { Scope } from '.';
 export async function getScopeRemotes(scope: Scope): Promise<Remotes> {
   const globalRemotes = await GlobalRemotes.load();
   const globalObj = globalRemotes.toPlainObject();
-  return Remotes.load(R.merge(globalObj, scope.scopeJson.remotes), scope);
+  return Remotes.load({ ...globalObj, ...scope.scopeJson.remotes }, scope);
 }
 
 export async function fetchRemoteVersions(scope: Scope, componentIds: BitId[]): Promise<BitId[]> {


### PR DESCRIPTION
removed all R.merge occurrences. seems like this function was removed from the latest (0.28.0) version. although we don't use this version, other packages are using it and it causes issues when `babel-plugin-ramda` finds it in the code.