### PR TITLE
make sure scope.list() returns only ModelComponent

### DIFF
--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -66,7 +66,7 @@ export default class ComponentsList {
    */
   async getFromObjects(): Promise<BitId[]> {
     if (!this._fromObjectsIds) {
-      const modelComponents: ModelComponent[] = await this.getModelComponents();
+      const modelComponents = await this.getModelComponents();
       this._fromObjectsIds = modelComponents.map((componentObjects) => {
         return new BitId({
           scope: componentObjects.scope,
@@ -249,7 +249,6 @@ export default class ComponentsList {
 
   async idsFromObjects(): Promise<BitIds> {
     const fromObjects = await this.getFromObjects();
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return new BitIds(...fromObjects);
   }
 

--- a/src/scope/objects/components-index.ts
+++ b/src/scope/objects/components-index.ts
@@ -98,11 +98,11 @@ export default class ScopeIndex {
 
   getHashes(indexType: IndexType): string[] {
     // @ts-ignore how to tell TS that all this.index.prop are array?
-    return this.index[indexType].map((indexItem) => indexItem.hash);
+    return this.index[indexType].map((indexItem: IndexItem) => indexItem.hash);
   }
   getHashesByQuery(indexType: IndexType, filter: Function): string[] {
     // @ts-ignore how to tell TS that all this.index.prop are array?
-    return this.index[indexType].filter(filter).map((indexItem) => indexItem.hash);
+    return this.index[indexType].filter(filter).map((indexItem: IndexItem) => indexItem.hash);
   }
   getHashesIncludeSymlinks(): string[] {
     return this.index.components.map((indexItem) => indexItem.hash);

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -234,8 +234,7 @@ export default class Repository {
         return bitObject;
       })
     );
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    return bitObjects.filter((b) => b); // remove nulls;
+    return compact(bitObjects);
   }
 
   async loadOptionallyCreateScopeIndex(): Promise<ScopeIndex> {


### PR DESCRIPTION
a user was getting an error with the following stack trace
```
got an error from command tag: TypeError: component.populateLocalAndRemoteHeads is not a function
TypeError: component.populateLocalAndRemoteHeads is not a function
    at C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\scope\scope.js:587:61
    at Array.map (<anonymous>)
    at Scope.listIncludeRemoteHead (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\scope\scope.js:587:34)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async ComponentsList.getModelComponents (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\consumer\component\components-list.js:183:31)
    at async ComponentsList.getFromObjects (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\consumer\component\components-list.js:195:31)
    at async ComponentsList.idsFromObjects (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\consumer\component\components-list.js:365:25)
    at async ComponentsList.listNewComponents (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\legacy\dist\consumer\component\components-list.js:379:28)
    at async SnappingMain.tag (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\snapping\dist\snapping.main.runtime.js:416:27)
    at async TagCmd.report (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\snapping\dist\tag-cmd.js:229:21)
    at async CommandRunner.runReportHandler (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\cli\dist\command-runner.js:214:20)
    at async CommandRunner.runCommand (C:\Users\user\AppData\Local\.bvm\versions\0.0.809\bit-0.0.809\node_modules\@teambit\cli\dist\command-runner.js:142:16)
component.populateLocalAndRemoteHeads is not a function
[+] CLI-OUTPUT: component.populateLocalAndRemoteHeads is not a function 
```
Which is unclear how the scope.list() returned an object which is not a ModelComponent. This PR throws earlier to make sure it returns the correct type.