### PR TITLE
fix(merge): avoid running package-installation for each one of the components individually

### DIFF
--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -28,6 +28,7 @@ export class MergeCmd implements Command {
     ['', 'resolve', 'EXPERIMENTAL. mark an unresolved merge as resolved and create a new snap with the changes'],
     ['', 'no-snap', 'EXPERIMENTAL. do not auto snap in case the merge completed without conflicts'],
     ['', 'build', 'in case of snap during the merge, run the build-pipeline (similar to bit snap --build)'],
+    ['', 'skip-dependency-installation', 'do not install packages of the imported components'],
     ['m', 'message <message>', 'EXPERIMENTAL. override the default message for the auto snap'],
   ] as CommandOptions;
   loader = true;
@@ -45,6 +46,7 @@ export class MergeCmd implements Command {
       build = false,
       noSnap = false,
       message,
+      skipDependencyInstallation = false,
     }: {
       ours?: boolean;
       theirs?: boolean;
@@ -54,6 +56,7 @@ export class MergeCmd implements Command {
       build?: boolean;
       noSnap?: boolean;
       message: string;
+      skipDependencyInstallation?: boolean;
     }
   ) {
     build = isFeatureEnabled(BUILD_ON_CI) ? Boolean(build) : true;
@@ -74,7 +77,8 @@ export class MergeCmd implements Command {
       resolve,
       noSnap,
       message,
-      build
+      build,
+      skipDependencyInstallation
     );
     if (resolvedComponents) {
       const title = 'successfully resolved component(s)\n';

--- a/scopes/dependencies/dependency-resolver/dependency-linker.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-linker.ts
@@ -1,6 +1,6 @@
 import isBuiltinModule from 'is-builtin-module';
 import path from 'path';
-import { uniq, compact, flatten, head } from 'lodash';
+import { uniq, compact, flatten, head, omit } from 'lodash';
 import { Stats } from 'fs';
 import fs from 'fs-extra';
 import resolveFrom from 'resolve-from';
@@ -139,7 +139,7 @@ export class DependencyLinker {
     options: LinkingOptions = {}
   ): Promise<LinkResults> {
     this.logger.setStatusLine('linking components');
-    this.logger.debug('linking components with options', options);
+    this.logger.debug('linking components with options', omit(options, ['consumer']));
     const result: LinkResults = {};
     const finalRootDir = rootDir || this.rootDir;
     const linkingOpts = Object.assign({}, DEFAULT_LINKING_OPTIONS, this.linkingOptions || {}, options || {});

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -294,6 +294,7 @@ export class LaneMergeCmd implements Command {
     ['m', 'message <message>', 'override the default message for the auto snap'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
     ['', 'squash', 'EXPERIMENTAL. squash multiple snaps. keep the last one only'],
+    ['', 'skip-dependency-installation', 'do not install packages of the imported components'],
     [
       '',
       'include-deps',
@@ -320,6 +321,7 @@ export class LaneMergeCmd implements Command {
       message: snapMessage = '',
       keepReadme = false,
       squash = false,
+      skipDependencyInstallation = false,
       includeDeps = false,
     }: {
       ours: boolean;
@@ -332,6 +334,7 @@ export class LaneMergeCmd implements Command {
       message: string;
       keepReadme?: boolean;
       squash: boolean;
+      skipDependencyInstallation?: boolean;
       includeDeps?: boolean;
     }
   ): Promise<string> {
@@ -353,6 +356,7 @@ export class LaneMergeCmd implements Command {
       keepReadme,
       squash,
       pattern,
+      skipDependencyInstallation,
       includeDeps,
     });
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -65,6 +65,7 @@ export type MergeLaneOptions = {
   squash: boolean;
   pattern?: string;
   includeDeps?: boolean;
+  skipDependencyInstallation?: boolean;
 };
 
 export type CreateLaneOptions = {

--- a/scopes/lanes/lanes/merge-lanes.ts
+++ b/scopes/lanes/lanes/merge-lanes.ts
@@ -28,6 +28,7 @@ export async function mergeLanes({
   squash,
   pattern,
   includeDeps,
+  skipDependencyInstallation,
 }: {
   merging: MergingMain;
   workspace: Workspace;
@@ -122,6 +123,7 @@ export async function mergeLanes({
     noSnap,
     snapMessage,
     build,
+    skipDependencyInstallation,
   });
 
   const mergedSuccessfully =

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -983,7 +983,8 @@ needed-for: ${neededFor || '<unknown>'}`);
   filterIdsFromPoolIdsByPattern(pattern: string, ids: ComponentID[], throwForNoMatch = true) {
     const patterns = pattern.split(',').map((p) => p.trim());
     if (patterns.every((p) => p.startsWith('!'))) {
-      patterns.push('**'); // otherwise it'll never match anything
+      // otherwise it'll never match anything. don't use ".push()". it must be the first item in the array.
+      patterns.unshift('**');
     }
     // check also as legacyId.toString, as it doesn't have the defaultScope
     const idsToCheck = (id: ComponentID) => [id.toStringWithoutVersion(), id._legacy.toStringWithoutVersion()];


### PR DESCRIPTION
This fix is for both `bit merge` and `bit lane merge`. Currently, it was looping throw the components, and running the package-manager on each one of them.
This PR fixes it to run it once and only if `--skip-dependency-installation` was not entered and only if no conflicts were found. 
Also, fixed an issue with pattern containing negation. 