### PR TITLE
better support for dev file registration by a component env

### DIFF
--- a/e2e/fixtures/components/custom-dev-files/comp.custom-composition-suffix.tsx
+++ b/e2e/fixtures/components/custom-dev-files/comp.custom-composition-suffix.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export const BasicComposition = () => {
+  return (
+    <div>hello world!</div>
+  );
+}

--- a/e2e/fixtures/components/custom-dev-files/comp.custom-docs-suffix.mdx
+++ b/e2e/fixtures/components/custom-dev-files/comp.custom-docs-suffix.mdx
@@ -1,0 +1,1 @@
+My docs file

--- a/e2e/fixtures/components/custom-dev-files/custom-dev-files.js
+++ b/e2e/fixtures/components/custom-dev-files/custom-dev-files.js
@@ -1,0 +1,3 @@
+export default function isString(val) {
+  return typeof val === 'string';
+}

--- a/e2e/fixtures/components/custom-dev-files/custom-dev-files.registered-test.spec.js
+++ b/e2e/fixtures/components/custom-dev-files/custom-dev-files.registered-test.spec.js
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import isString from './custom-dev-files';
+
+describe('#isString()', () => {
+  it('should return false if undefined is passed', () => {
+    expect(isString()).to.equal(false);
+  });
+});

--- a/e2e/fixtures/components/custom-dev-files/custom-dev-files.spec.js
+++ b/e2e/fixtures/components/custom-dev-files/custom-dev-files.spec.js
@@ -1,0 +1,8 @@
+import { expect } from 'chai';
+import isString from './custom-dev-files';
+
+describe('#isString()', () => {
+  it('should return false if undefined is passed', () => {
+    expect(isString()).to.equal(false);
+  });
+});

--- a/e2e/fixtures/components/custom-dev-files/file.custom-dev-file.js
+++ b/e2e/fixtures/components/custom-dev-files/file.custom-dev-file.js
@@ -1,0 +1,1 @@
+console.log('custom-dev-file');

--- a/e2e/fixtures/components/custom-dev-files/index.js
+++ b/e2e/fixtures/components/custom-dev-files/index.js
@@ -1,0 +1,1 @@
+export { default } from './custom-dev-files';

--- a/e2e/fixtures/extensions/dev-files-env/dev-files-env.extension.ts
+++ b/e2e/fixtures/extensions/dev-files-env/dev-files-env.extension.ts
@@ -1,0 +1,23 @@
+import { EnvsMain, EnvsAspect } from '@teambit/envs';
+import { NodeMain, NodeAspect } from '@teambit/node';
+
+export class DevFilesEnv {
+  constructor(private node: NodeMain) {}
+
+  static dependencies: any = [EnvsAspect, NodeAspect];
+
+  static async provider([envs, node]: [EnvsMain, NodeMain]) {
+
+    const devFilesEnv = node.compose([
+      envs.override({
+        getTestsDevPatterns: () => ['**/*.registered-test.spec.+(js|ts|jsx|tsx)', '**/*.registered-test.test.+(js|ts|jsx|tsx)'],
+        getDocsDevPatterns: () => ['**/*.custom-docs-suffix.*'],
+        getCompositionsDevPatterns: () => ['**/*.custom-composition?(s)-suffix.*'],
+        getDevPatterns: () => ['**/*.custom-dev-file.*']
+      }),
+    ]);
+
+    envs.registerEnv(devFilesEnv);
+    return new DevFilesEnv(node);
+  }
+}

--- a/e2e/fixtures/extensions/dev-files-env/index.ts
+++ b/e2e/fixtures/extensions/dev-files-env/index.ts
@@ -1,0 +1,4 @@
+import { DevFilesEnv } from './dev-files-env.extension';
+
+export default DevFilesEnv;
+export { DevFilesEnv };

--- a/e2e/harmony/dev-files.e2e.ts
+++ b/e2e/harmony/dev-files.e2e.ts
@@ -1,0 +1,62 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('dev files', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('custom env that changes dev files patterns', () => {
+    let envId;
+    let envName;
+    let showOutput;
+    let devFiles;
+    const ENV_NAME = 'dev-files-env';
+    const COMP_NAME = 'custom-dev-files';
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.bitJsonc.setPackageManager();
+      envName = helper.env.setCustomEnv(ENV_NAME);
+      envId = `${helper.scopes.remote}/${envName}`;
+      // helper.fixtures.createComponentBarFoo();
+      helper.fixtures.copyFixtureComponents(COMP_NAME);
+      helper.command.addComponent(COMP_NAME);
+
+      helper.extensions.addExtensionToVariant('*', envId);
+      helper.command.compile();
+      showOutput = helper.command.showComponentParsedHarmony(COMP_NAME);
+      devFiles = showOutput.find(item => item.title === 'dev files').json;
+    });
+    it('should show registered custom dev file as dev file', () => {
+      const fullEnvName = `${helper.scopes.remote}/${envName}`;
+      const envDevFiles = devFiles[fullEnvName];
+      expect(envDevFiles).to.include('file.custom-dev-file.js');
+    });
+    describe('test files', () => {
+      it('should show registered custom test file as dev file', () => {
+        const testFiles = devFiles['teambit.defender/tester'];
+        expect(testFiles).to.include('custom-dev-files.registered-test.spec.js');
+      });
+      it('should not show default test file as dev file', () => {
+        const testFiles = devFiles['teambit.defender/tester'];
+        expect(testFiles).to.not.include('custom-dev-files.spec.js');
+      });
+    });
+    it('should show registered custom docs file as dev file', () => {
+      const docsFiles = devFiles['teambit.docs/docs'];
+      expect(docsFiles).to.include('comp.custom-docs-suffix.mdx');
+    });
+    it('should show registered custom composition file as dev file', () => {
+      const compositionsFiles = devFiles['teambit.compositions/compositions'];
+      expect(compositionsFiles).to.include('comp.custom-composition-suffix.tsx');
+    });
+  });
+});

--- a/scopes/component/dev-files/dev-files.main.runtime.ts
+++ b/scopes/component/dev-files/dev-files.main.runtime.ts
@@ -47,7 +47,7 @@ export class DevFilesMain {
     const entry = component.state.aspects.get(DevFilesAspect.id);
     const configuredPatterns = entry?.config.devFilePatterns || [];
     const envDef = this.envs.calculateEnv(component);
-    const envPatterns: DevPatterns[] = envDef.env?.getDevPatterns ? envDef.env.getDevPatterns(component) : [];
+    const envPatterns: string[] = envDef.env?.getDevPatterns ? envDef.env.getDevPatterns(component) : [];
 
     const getPatterns = (devPatterns: DevPatterns) => {
       if (isFunction(devPatterns)) {

--- a/scopes/compositions/compositions/compositions.main.runtime.ts
+++ b/scopes/compositions/compositions/compositions.main.runtime.ts
@@ -1,5 +1,5 @@
 import { MainRuntime } from '@teambit/cli';
-import { AspectData, Component, ComponentAspect, ComponentMap, IComponent } from '@teambit/component';
+import { AspectData, Component, ComponentMap, IComponent } from '@teambit/component';
 import { DevFilesAspect, DevFilesMain } from '@teambit/dev-files';
 import EnvsAspect, { EnvsMain } from '@teambit/envs';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -46,10 +46,6 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
 
   constructor(
     readonly workspace: Workspace,
-    /**
-     * regex used to identify which files to test.
-     */
-    readonly patterns: string[],
 
     private logger: Logger,
 

--- a/scopes/envs/envs/environment.ts
+++ b/scopes/envs/envs/environment.ts
@@ -209,6 +209,11 @@ export interface TesterEnv extends Environment {
    * Required for `bit start` & `bit test`
    */
   getTester?: (path: string, tester: any) => Tester;
+
+  /**
+   * Returns the dev patterns to match test files
+   */
+  getTestsDevPatterns?: (component: Component) => string[];
 }
 
 export interface CompilerEnv {
@@ -217,11 +222,6 @@ export interface CompilerEnv {
    * Required for making and reading dists, especially for `bit compile`
    */
   getCompiler: () => Compiler;
-
-  /**
-   * Returns the dev patterns to match test files
-   */
-  getTestsDevPatterns?: (component: Component) => string[];
 }
 
 export function hasCompiler(obj: Environment): obj is CompilerEnv {

--- a/scopes/envs/envs/environment.ts
+++ b/scopes/envs/envs/environment.ts
@@ -51,9 +51,20 @@ export interface Environment {
   getSchemaExtractor?: (config?: any) => SchemaExtractor;
 
   /**
-   * Returns the dev patterns to match doc file
+   * Returns the dev patterns to match doc files
    */
   getDocsDevPatterns?: (component: Component) => string[];
+
+  /**
+   * Returns the dev patterns to match composition files
+   */
+  getCompositionsDevPatterns?: (component: Component) => string[];
+
+  /**
+   * Returns additional dev patterns for the component.
+   * Patterns that were provided by getDocsDevPatterns, getTestsDevPatterns will be considered as dev files as well, without need to add them here.
+   */
+  getDevPatterns?: (component: Component) => string[];
 }
 
 export interface DependenciesEnv extends Environment {
@@ -206,6 +217,11 @@ export interface CompilerEnv {
    * Required for making and reading dists, especially for `bit compile`
    */
   getCompiler: () => Compiler;
+
+  /**
+   * Returns the dev patterns to match test files
+   */
+  getTestsDevPatterns?: (component: Component) => string[];
 }
 
 export function hasCompiler(obj: Environment): obj is CompilerEnv {

--- a/src/e2e-helper/e2e-env-helper.ts
+++ b/src/e2e-helper/e2e-env-helper.ts
@@ -228,7 +228,7 @@ export default class EnvHelper {
   setCustomEnv(extensionsBaseFolder = 'node-env'): string {
     this.fixtures.copyFixtureExtensions(extensionsBaseFolder);
     this.command.addComponent(extensionsBaseFolder);
-    this.extensions.addExtensionToVariant(extensionsBaseFolder, 'teambit.harmony/aspect');
+    this.extensions.addExtensionToVariant(extensionsBaseFolder, 'teambit.envs/env');
     this.command.link();
     this.command.install();
     this.command.compile();

--- a/src/e2e-helper/e2e-fixtures-helper.ts
+++ b/src/e2e-helper/e2e-fixtures-helper.ts
@@ -91,9 +91,9 @@ export default class FixtureHelper {
     fs.copySync(sourceDir, dest);
   }
 
-  copyFixtureComponents(dir = '', cwd: string = this.scopes.localPath) {
+  copyFixtureComponents(dir = '', dest: string = path.join(this.scopes.localPath, dir)) {
     const sourceDir = path.join(this.getFixturesDir(), 'components', dir);
-    fs.copySync(sourceDir, cwd);
+    fs.copySync(sourceDir, dest);
   }
 
   copyFixtureExtensions(dir = '', cwd: string = this.scopes.localPath) {


### PR DESCRIPTION
## Proposed Changes

- new envs API:
  - `getCompositionsDevPatterns?: (component: Component) => string[];`
  - `getDevPatterns?: (component: Component) => string[];`
  - `getTestsDevPatterns?: (component: Component) => string[];`
  
An example of a custom env that uses it looks something like this:
```js
envs.override({
  getTestsDevPatterns: () => ['**/*.registered-test.spec.+(js|ts|jsx|tsx)', '**/*.registered-test.test.+(js|ts|jsx|tsx)'],
  getDocsDevPatterns: () => ['**/*.custom-docs-suffix.*'],
  getCompositionsDevPatterns: () => ['**/*.custom-composition?(s)-suffix.*'],
  getDevPatterns: () => ['**/*.custom-dev-file.*']
}),
```
