### PR TITLE
fix(bit-lane-merge): add files that were introduced in the other lane

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -368,4 +368,34 @@ describe('merge lanes', function () {
       });
     });
   });
+  describe('getting new files when lane is diverge from another lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false, 'v2');
+      helper.command.snapComponentWithoutBuild('comp1');
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.fixtures.populateComponents(1, false, 'v3');
+      helper.command.snapComponentWithoutBuild('comp1');
+      helper.command.export();
+      helper.command.switchLocalLane('lane-a');
+      helper.fs.outputFile('comp1/new-file.ts');
+      helper.command.snapComponentWithoutBuild('comp1');
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importLane('lane-b');
+      helper.command.fetchLane(`${helper.scopes.remote}/lane-a`);
+      helper.command.mergeLane(`${helper.scopes.remote}/lane-a`);
+    });
+    it('should add the newly added file', () => {
+      expect(path.join(helper.scopes.localPath, helper.scopes.remote, 'comp1/new-file.ts')).to.be.a.file();
+    });
+  });
 });

--- a/scopes/lanes/lanes/merge-lanes.ts
+++ b/scopes/lanes/lanes/merge-lanes.ts
@@ -148,7 +148,7 @@ export async function mergeLanes({
       deleteFiles: true,
     });
   } else if (otherLane && !otherLane.readmeComponent) {
-    deleteResults = { readmeResult: `lane ${otherLane.name} doesn't have a readme component` };
+    deleteResults = { readmeResult: `\nlane ${otherLane.name} doesn't have a readme component` };
   }
 
   return { mergeResults, deleteResults };

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -315,8 +315,10 @@ export function applyModifiedVersion(
       throw new GeneralError(`file ${filePath} does not have output nor conflict`);
     }
   });
+
   mergeResults.addFiles.forEach((file) => {
-    if (modifiedFiles.find((m) => m.relative === file.filePath)) return;
+    const filePath: PathOsBased = path.normalize(file.filePath);
+    if (modifiedFiles.find((m) => m.relative === filePath)) return;
     modifiedFiles.push(file.fsFile);
     filesStatus[file.filePath] = FileStatus.added;
   });

--- a/src/consumer/versions-ops/merge-version/three-way-merge.ts
+++ b/src/consumer/versions-ops/merge-version/three-way-merge.ts
@@ -158,7 +158,17 @@ export default async function threeWayMergeVersions({
   const deletedFromFs = otherFiles.filter(
     (otherFile) => !fsFilesPaths.includes(otherFile.relativePath) && baseFilesPaths.includes(otherFile.relativePath)
   );
+  const addedOnOther = otherFiles.filter(
+    (otherFile) => !fsFilesPaths.includes(otherFile.relativePath) && !baseFilesPaths.includes(otherFile.relativePath)
+  );
   deletedFromFs.forEach((file) => results.remainDeletedFiles.push({ filePath: file.relativePath }));
+
+  await Promise.all(
+    addedOnOther.map(async (file) => {
+      const fsFile = await SourceFile.loadFromSourceFileModel(file, consumer.scope.objects);
+      results.addFiles.push({ filePath: file.relativePath, fsFile });
+    })
+  );
   if (R.isEmpty(results.modifiedFiles)) return results;
 
   const conflictResults = await getMergeResults(consumer, results.modifiedFiles);


### PR DESCRIPTION
currently, when the lane is diverged and the other lane introduced new files, they don't get created during merge.