### PR TITLE
remove duplicate resolve.extensions causing bugs

### DIFF
--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -139,7 +139,6 @@ export function configFactory(
     },
 
     resolve: {
-      extensions: ['.ts', '.tsx', '.js', '.mdx', '.md'],
       // TODO - check - we shoult not need both fallbacks and alias and provider plugin
       alias: fallbacksAliases,
 


### PR DESCRIPTION
## Proposed Changes

- delete resolve.extensions array coming from webpack aspect, which was placing .js/.ts etc before the more specific extensions in the env's webpack config, causing unexpected behaviour and bugs, e.g. with packages exposing .web.js modules
- resolves #6161
- 
-
