### PR TITLE
aspects loading fixes

### DIFF
--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -285,7 +285,9 @@ export class WorkspaceComponentLoader {
       Object.assign(existingExtension.data, data);
       return;
     }
-    component.state.config.extensions.push(await this.getDataEntry(extension, data));
+    if (data){
+      component.state.config.extensions.push(await this.getDataEntry(extension, data));
+    }
   }
 
   private async getDataEntry(extension: string, data: { [key: string]: any }): Promise<ExtensionDataEntry> {

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -290,9 +290,10 @@ export class WorkspaceComponentLoader {
     }
   }
 
-  private async getDataEntry(extension: string, data: { [key: string]: any }): Promise<ExtensionDataEntry> {
+  private async getDataEntry(extensionId: string, data: { [key: string]: any }): Promise<ExtensionDataEntry> {
     // TODO: @gilad we need to refactor the extension data entry api.
-    return new ExtensionDataEntry(undefined, undefined, extension, undefined, data);
+    const entry = ExtensionDataEntry.create(extensionId, undefined, data);
+    return entry;
   }
 }
 

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -99,6 +99,16 @@ export class ExtensionDataEntry {
       R.clone(this.data)
     );
   }
+
+  static create(extensionId: string, config?: any, data?: any): ExtensionDataEntry {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define
+    const isCore = ExtensionDataList.coreExtensionsNames.has(extensionId);
+    if (!isCore) {
+      const parsedId = BitId.parse(extensionId, true);
+      return new ExtensionDataEntry(undefined, parsedId, undefined, config, data);
+    }
+    return new ExtensionDataEntry(undefined, undefined, extensionId, config, data);
+  }
 }
 
 export class ExtensionDataList extends Array<ExtensionDataEntry> {


### PR DESCRIPTION
- do not add extension with empty data and config to the component extension list on load
- add non core aspects with id rather than name when they only register data on load (and has no component's config)

## Proposed Changes

-
-
-
