### PR TITLE
Fixing merge issue for depenency override for react-native html and n…

### DIFF
--- a/scopes/harmony/node/node.main.runtime.ts
+++ b/scopes/harmony/node/node.main.runtime.ts
@@ -1,5 +1,5 @@
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { EnvPolicyConfigObject } from '@teambit/dependency-resolver';
-import { merge } from 'lodash';
 import { TsConfigSourceFile } from 'typescript';
 import { TsCompilerOptionsWithoutTsConfig, TypescriptAspect, TypescriptMain } from '@teambit/typescript';
 import { ApplicationAspect, ApplicationMain } from '@teambit/application';
@@ -136,7 +136,7 @@ export class NodeMain {
    */
   overrideDependencies(dependencyPolicy: EnvPolicyConfigObject) {
     return this.envs.override({
-      getDependencies: () => merge(dependencyPolicy, this.nodeEnv.getDependencies()),
+      getDependencies: () => mergeDeepLeft(dependencyPolicy, this.nodeEnv.getDependencies()),
     });
   }
 

--- a/scopes/html/html/html.main.runtime.ts
+++ b/scopes/html/html/html.main.runtime.ts
@@ -1,5 +1,5 @@
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { TsConfigSourceFile } from 'typescript';
-import { merge } from 'lodash';
 import type { TsCompilerOptionsWithoutTsConfig } from '@teambit/typescript';
 import { BuildTask } from '@teambit/builder';
 import { Compiler } from '@teambit/compiler';
@@ -99,7 +99,7 @@ export class HtmlMain {
    */
   overrideDependencies(dependencyPolicy: EnvPolicyConfigObject) {
     return this.envs.override({
-      getDependencies: () => merge(dependencyPolicy, this.htmlEnv.getDependencies()),
+      getDependencies: () => mergeDeepLeft(dependencyPolicy, this.htmlEnv.getDependencies()),
     });
   }
 

--- a/scopes/react/react-native/react-native.main.runtime.ts
+++ b/scopes/react/react-native/react-native.main.runtime.ts
@@ -1,8 +1,8 @@
+import mergeDeepLeft from 'ramda/src/mergeDeepLeft';
 import { EnvPolicyConfigObject } from '@teambit/dependency-resolver';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 import { TsConfigSourceFile } from 'typescript';
 import type { TsCompilerOptionsWithoutTsConfig } from '@teambit/typescript';
-import { merge } from 'lodash';
 import { MainRuntime } from '@teambit/cli';
 import { BuildTask } from '@teambit/builder';
 import { Aspect } from '@teambit/harmony';
@@ -99,7 +99,7 @@ export class ReactNativeMain {
    */
   overrideDependencies(dependencyPolicy: EnvPolicyConfigObject) {
     return this.envs.override({
-      getDependencies: () => merge(dependencyPolicy, this.reactNativeEnv.getDependencies()),
+      getDependencies: () => mergeDeepLeft(dependencyPolicy, this.reactNativeEnv.getDependencies()),
     });
   }
 


### PR DESCRIPTION
Adding override dependency for some custom environments (react-native, node, HTML) is broken when trying to override a library that already exists in default config of the env. Here is an example.

Let`s say we try to override the react-native-web version for a custom react-native environment.

Doing something like this you expect the `react-native-web` in components that use this custom env to be set to version 0.17.5 but we will end up with whatever the default version of `react-native-web` is set to in `react-native` environment.
```
reactNative.overrideDependencies({
  peerDependencies: {
    'react-native-web': '0.17.5',
  },
}),
```

This is because inside the `overrideDependencies` function, merge was performed like this

`getDependencies: () => merge(dependencyPolicy, this.reactNativeEnv.getDependencies()),`

And this will end up overriding the dependencies provided in `dependencyPolicy` with whatever was in `this.reactNativeEnv.getDependencies()` in case if the values existed in both objects.

In this push, I mimiced what `react` was doing by switching from `merge` to `mergeDeepLeft`. Not sure if there is any benefit to using `mergeDeepLeft` since we could also just switch the arguments inside the `merge` but I chose to do it with `mergeDeepLeft` since the react library was already using that approach.