### PR TITLE
Move pipeline tab to widgets and hide it for the moment

### DIFF
--- a/scopes/component/component-compare/component-compare-widget.tsx
+++ b/scopes/component/component-compare/component-compare-widget.tsx
@@ -9,7 +9,7 @@ export function ComponentCompareMenuWidget({ className, ...rest }: MenuWidgetIco
   return (
     <Tooltip placement="bottom" offset={[0, 15]} content={'Compare'}>
       <div {...rest} className={classNames(styles.widgetMenuIcon, className)}>
-        <img src={'https://static.bit.dev/bit-icons/compare.svg'} />
+        <img src={'https://static.bit.dev/bit-icons/compare.svg?v=0.1'} />
       </div>
     </Tooltip>
   );

--- a/scopes/pipelines/builder-ui/builder.section.tsx
+++ b/scopes/pipelines/builder-ui/builder.section.tsx
@@ -1,6 +1,7 @@
 import { Section } from '@teambit/component';
 import React from 'react';
 import { ComponentPipelinePage } from '@teambit/component.ui.pipelines.component-pipeline';
+import { ComponentPipelineWidget } from './component-pipeline-widget';
 import { BuilderUI } from './builder.ui.runtime';
 
 export class BuilderSection implements Section {
@@ -13,7 +14,7 @@ export class BuilderSection implements Section {
 
   navigationLink = {
     href: '~component-pipeline',
-    children: 'Pipeline',
+    children: <ComponentPipelineWidget />,
   };
 
   order = 50;

--- a/scopes/pipelines/builder-ui/builder.ui.runtime.tsx
+++ b/scopes/pipelines/builder-ui/builder.ui.runtime.tsx
@@ -46,7 +46,7 @@ export class BuilderUI {
     const section = new BuilderSection(host, ui);
 
     component.registerRoute(section.route);
-    component.registerNavigation(section.navigationLink, section.order);
+    // component.registerWidget(section.navigationLink, section.order);
 
     return ui;
   }

--- a/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.module.scss
+++ b/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.module.scss
@@ -1,0 +1,10 @@
+.widgetMenuIcon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  img {
+    height: 16px;
+    width: 16px;
+  }
+}

--- a/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.tsx
+++ b/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.tsx
@@ -9,7 +9,7 @@ export function ComponentPipelineWidget({ className, ...rest }: ComponentPipelin
   return (
     <Tooltip placement="bottom" offset={[0, 15]} content={'Pipeline'}>
       <div {...rest} className={classNames(styles.widgetMenuIcon, className)}>
-        <img src={'https://static.bit.dev/bit-icons/pipe.svg'} />
+        <img src={'https://static.bit.dev/bit-icons/pipe.svg?v=0.1'} />
       </div>
     </Tooltip>
   );

--- a/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.tsx
+++ b/scopes/pipelines/builder-ui/component-pipeline-widget/component-pipeline-widget.tsx
@@ -1,0 +1,16 @@
+import React, { HTMLAttributes } from 'react';
+import classNames from 'classnames';
+import { Tooltip } from '@teambit/design.ui.tooltip';
+import styles from './component-pipeline-widget.module.scss';
+
+export type ComponentPipelineWidgetProps = {} & HTMLAttributes<HTMLDivElement>;
+
+export function ComponentPipelineWidget({ className, ...rest }: ComponentPipelineWidgetProps) {
+  return (
+    <Tooltip placement="bottom" offset={[0, 15]} content={'Pipeline'}>
+      <div {...rest} className={classNames(styles.widgetMenuIcon, className)}>
+        <img src={'https://static.bit.dev/bit-icons/pipe.svg'} />
+      </div>
+    </Tooltip>
+  );
+}

--- a/scopes/pipelines/builder-ui/component-pipeline-widget/index.ts
+++ b/scopes/pipelines/builder-ui/component-pipeline-widget/index.ts
@@ -1,0 +1,2 @@
+export { ComponentPipelineWidget } from './component-pipeline-widget';
+export type { ComponentPipelineWidgetProps } from './component-pipeline-widget';


### PR DESCRIPTION
## Proposed Changes

- Move Pipeline tab to widgets tabs instead of the main tabs.
- Not register the widget for the moment. (Still available via the route)

