### PR TITLE
avoid mutating Component object for capsules

### DIFF
--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -45,11 +45,7 @@ export interface ComponentFactory {
   /**
    * returns a component by ID.
    */
-  get(
-    id: ComponentID | string,
-    withState?: boolean,
-    consumerComponent?: ConsumerComponent
-  ): Promise<Component | undefined>;
+  get(id: ComponentID): Promise<Component | undefined>;
 
   /**
    * returns many components by ids.

--- a/scopes/component/dev-files/dev-files.main.runtime.ts
+++ b/scopes/component/dev-files/dev-files.main.runtime.ts
@@ -152,7 +152,7 @@ export class DevFilesMain {
       DependencyResolver.getDevFiles = async (consumerComponent: LegacyComponent): Promise<string[]> => {
         const componentId = await workspace.resolveComponentId(consumerComponent.id);
         // Do not change the storeInCache=false arg. if you think you need to change it, please talk to Gilad first
-        const component = await workspace.get(componentId, false, consumerComponent, true, false);
+        const component = await workspace.get(componentId, consumerComponent, true, false);
         if (!component) throw Error(`failed to transform component ${consumerComponent.id.toString()} in harmony`);
         const computedDevFiles = devFiles.computeDevFiles(component);
         return computedDevFiles.list();

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -448,8 +448,8 @@ export class IsolatorMain {
           delete params.scope;
         }
         const componentWriter = new ComponentWriter(params);
-        await componentWriter.populateComponentsFilesToWrite();
-        await component.state._consumer.dataToPersist.persistAllToCapsule(capsule, { keepExistingCapsule: true });
+        const dataToPersist = await componentWriter.populateComponentsFilesToWriteForCapsule();
+        await dataToPersist.persistAllToCapsule(capsule, { keepExistingCapsule: true });
       })
     );
   }

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -581,7 +581,6 @@ export class IsolatorMain {
   private async getCurrentPackageJson(capsule: Capsule, capsules: CapsuleList): Promise<PackageJsonFile> {
     const component: Component = capsule.component;
     const currentVersion = await this.getComponentPackageVersionWithCache(component);
-    // const newVersion = '0.0.1-new';
     const getComponentDepsManifest = async (dependencies: DependencyList) => {
       const manifest = {
         dependencies: {},
@@ -608,8 +607,7 @@ export class IsolatorMain {
     const deps = await this.dependencyResolver.getDependencies(component);
     const manifest = await getComponentDepsManifest(deps);
 
-    // unfortunately, component.packageJsonFile is not available here.
-    // the reason is that `writeComponentsToCapsules` clones the component before writing them
+    // component.packageJsonFile is not available here. we don't mutate the component object for capsules.
     // also, don't use `PackageJsonFile.createFromComponent`, as it looses the intermediate changes
     // such as postInstall scripts for custom-module-resolution.
     const packageJson = PackageJsonFile.loadFromCapsuleSync(capsule.path);

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -149,7 +149,7 @@ export class GraphFromFsBuilder {
     const componentMap = this.consumer.bitMap.getComponentIfExist(componentId);
     const isOnWorkspace = Boolean(componentMap);
     if (isOnWorkspace) {
-      return this.consumer.loadComponentForCapsule(componentId);
+      return this.consumer.loadComponent(componentId);
     }
     // a dependency might have been installed as a package in the workspace, and as such doesn't
     // have a componentMap.

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -148,7 +148,7 @@ export default async function provideWorkspace(
   LegacyComponentLoader.registerOnComponentLoadSubscriber(
     async (legacyComponent: ConsumerComponent, opts?: { loadDocs?: boolean }) => {
       const id = await workspace.resolveComponentId(legacyComponent.id);
-      const newComponent = await workspace.get(id, false, legacyComponent, true, true, opts);
+      const newComponent = await workspace.get(id, legacyComponent, true, true, opts);
       return newComponent.state._consumer;
     }
   );

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -497,21 +497,13 @@ export class Workspace implements ComponentFactory {
    */
   async get(
     componentId: ComponentID,
-    forCapsule = false,
     legacyComponent?: ConsumerComponent,
     useCache = true,
     storeInCache = true,
     loadOpts?: ComponentLoadOptions
   ): Promise<Component> {
     this.logger.debug(`get ${componentId.toString()}`);
-    const component = await this.componentLoader.get(
-      componentId,
-      forCapsule,
-      legacyComponent,
-      useCache,
-      storeInCache,
-      loadOpts
-    );
+    const component = await this.componentLoader.get(componentId, legacyComponent, useCache, storeInCache, loadOpts);
     // When loading a component if it's an env make sure to load it as aspect as well
     // We only want to try load it as aspect if it's the first time we load the component
     const tryLoadAsAspect = this.componentLoadedSelfAsAspects.get(component.id.toString()) === undefined;
@@ -802,14 +794,14 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return foundEnv?.components || [];
   }
 
-  async getMany(ids: Array<ComponentID>, forCapsule = false): Promise<Component[]> {
-    return this.componentLoader.getMany(ids, forCapsule);
+  async getMany(ids: Array<ComponentID>): Promise<Component[]> {
+    return this.componentLoader.getMany(ids);
   }
 
   getManyByLegacy(components: ConsumerComponent[], loadOpts?: ComponentLoadOptions): Promise<Component[]> {
     return mapSeries(components, async (component) => {
       const id = await this.resolveComponentId(component.id);
-      return this.get(id, undefined, component, true, true, loadOpts);
+      return this.get(id, component, true, true, loadOpts);
     });
   }
 
@@ -833,12 +825,11 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
    * It will influence the performance
    * currently it used only for get many of aspects
    * @param ids
-   * @param forCapsule
    */
-  async importAndGetMany(ids: Array<ComponentID>, forCapsule = false): Promise<Component[]> {
+  async importAndGetMany(ids: Array<ComponentID>): Promise<Component[]> {
     await this.importCurrentLaneIfMissing();
     await this.scope.import(ids, { reFetchUnBuiltVersion: shouldReFetchUnBuiltVersion() });
-    return this.componentLoader.getMany(ids, forCapsule);
+    return this.componentLoader.getMany(ids);
   }
 
   async importCurrentLaneIfMissing() {

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -353,6 +353,9 @@ export default class ComponentMap {
     if (this.rootDir && !isValidPath(this.rootDir)) {
       throw new ValidationError(`${errorMessage} rootDir attribute ${this.rootDir} is invalid`);
     }
+    if (this.rootDir && this.rootDir === '.') {
+      throw new ValidationError(`${errorMessage} rootDir attribute ${this.rootDir} is invalid`);
+    }
     if (this.nextVersion && !this.nextVersion.version) {
       throw new ValidationError(`${errorMessage} version attribute should be set when nextVersion prop is set`);
     }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -335,10 +335,6 @@ export default class Consumer {
     return components[0];
   }
 
-  loadComponentForCapsule(id: BitId): Promise<Component> {
-    return this.componentLoader.loadForCapsule(id);
-  }
-
   async loadComponents(
     ids: BitIds,
     throwOnFailure = true,


### PR DESCRIPTION
This is a long overdue task.
When writing a component to the capsule, until now, the component-writer used to mutate the `Component` object and replace its rootDir (to `.` via the component-map prop). In order to avoid changing the instance of the normal Component object, the component-loader used to have two caches, one for the capsule and one for the normal loading. 
Besides the complexity it creates where `get()` method has the `forCapsule` boolean, it also caused some issues where in one instance it didn't ask for the capsule, got the normal one and mutated it. 
This PR fixes it by not mutating the component object for capsules. Instead, it gather all the data it needs to write the component in the capsule in one place and writes it. 