### PR TITLE
support new opts for creating jest tester - patterns, roots, resolveSpecPaths

### DIFF
--- a/e2e/fixtures/extensions/custom-jest-resolve-env/custom-jest-resolve-env.aspect.ts
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/custom-jest-resolve-env.aspect.ts
@@ -1,0 +1,5 @@
+import { Aspect } from '@teambit/harmony';
+
+export const CustomJestResolveEnv = Aspect.create({
+  id: 'my-scope/custom-jest-resolve-env',
+});

--- a/e2e/fixtures/extensions/custom-jest-resolve-env/custom-jest-resolve-env.main.runtime.ts
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/custom-jest-resolve-env.main.runtime.ts
@@ -1,0 +1,40 @@
+import { MainRuntime } from '@teambit/cli';
+import { ReactAspect, ReactMain } from '@teambit/react';
+import { JestAspect, JestMain } from '@teambit/jest';
+import { EnvsAspect, EnvsMain } from '@teambit/envs';
+import { CustomJestResolveEnv } from './custom-jest-resolve-env.aspect';
+import { join, resolve } from 'path';
+import { Component } from '@teambit/component';
+import { TesterContext } from '@teambit/tester';
+
+export class CustomJestResolveEnvMain {
+  static slots = [];
+
+  static dependencies = [ReactAspect, EnvsAspect, JestAspect];
+
+  static runtime = MainRuntime;
+
+  static async provider([react, envs, jestAspect]: [ReactMain, EnvsMain, JestMain]) {
+    const templatesReactEnv = envs.compose(react.reactEnv, [
+      envs.override({
+        getTester: () => {
+          const pathToSource = __dirname.replace('/dist', '');
+          const configPath = join(pathToSource, './jest/jest.config.js');
+          const opts = {
+            resolveSpecPaths: (component: Component, context: TesterContext) => {
+              const componentPatternValue = context.patterns.get(component);
+              if (!componentPatternValue) return [] as string[];
+              const [, patternEntry] = componentPatternValue;
+              return [resolve(patternEntry.componentDir, '**/*.custom-pattern.spec.+(js|ts|jsx|tsx)')]
+            }
+          }
+          return jestAspect.createTester(configPath, undefined, opts);
+        }
+      }),
+    ]);
+    envs.registerEnv(templatesReactEnv);
+    return new CustomJestResolveEnvMain();
+  }
+}
+
+CustomJestResolveEnv.addRuntime(CustomJestResolveEnvMain);

--- a/e2e/fixtures/extensions/custom-jest-resolve-env/index.ts
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/index.ts
@@ -1,0 +1,5 @@
+import { CustomJestResolveEnv } from './custom-jest-resolve-env.aspect';
+
+export type { CustomJestResolveEnvMain } from './custom-jest-resolve-env.main.runtime';
+export default CustomJestResolveEnv;
+export { CustomJestResolveEnv };

--- a/e2e/fixtures/extensions/custom-jest-resolve-env/jest/jest.config.js
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/jest/jest.config.js
@@ -1,0 +1,10 @@
+const reactJestConfig = require('@teambit/react/jest/jest.cjs.config');
+// uncomment the line below and install the package if you want to use this function
+// const {
+//   generateNodeModulesPattern,
+// } = require('@teambit/dependencies.modules.packages-excluder');
+// const packagesToExclude = ['@my-org', 'my-package-name'];
+
+module.exports = {
+  ...reactJestConfig
+};

--- a/e2e/fixtures/extensions/custom-jest-resolve-env/typescript/tsconfig.json
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  // add your compiler options here
+
+  "compilerOptions": {
+    // "target": "es2017",
+    // "module": "es2015",
+    // "moduleResolution": "node",
+    // "lib": ["es2017", "dom"],
+    // "experimentalDecorators": true,
+    // "esModuleInterop": true,
+    // "outDir": "dist",
+    // "sourceMap": true,
+    // "emitDecoratorMetadata": true,
+    // "allowJs": true,
+    // "baseUrl": ".",
+    // "jsx": "react"
+  }
+}

--- a/e2e/fixtures/extensions/custom-jest-resolve-env/webpack/webpack-transformers.ts
+++ b/e2e/fixtures/extensions/custom-jest-resolve-env/webpack/webpack-transformers.ts
@@ -1,0 +1,45 @@
+
+  import { WebpackConfigTransformer, WebpackConfigMutator, WebpackConfigTransformContext } from '@teambit/webpack';
+
+  /**
+   * Transformation to apply for both preview and dev server
+   * @param config
+   * @param _context
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  function commonTransformation(config: WebpackConfigMutator, _context: WebpackConfigTransformContext) {
+    // Merge config with the webpack.config.js file if you choose to import a module export format config.
+    // config.merge([webpackConfig]);
+    // config.addAliases({});
+    // config.addModuleRule(youRuleHere);
+    return config;
+  }
+
+  /**
+   * Transformation for the preview only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const previewConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+
+  /**
+   * Transformation for the dev server only
+   * @param config
+   * @param context
+   * @returns
+   */
+  export const devServerConfigTransformer: WebpackConfigTransformer = (
+    config: WebpackConfigMutator,
+    context: WebpackConfigTransformContext
+  ) => {
+    const newConfig = commonTransformation(config, context);
+    return newConfig;
+  };
+

--- a/e2e/harmony/jest.e2e.ts
+++ b/e2e/harmony/jest.e2e.ts
@@ -109,11 +109,62 @@ describe('Jest Tester', function () {
       expect(output).to.have.string('someUndefinedFunc is not defined');
     });
   });
+
+  describe('env with custom spec resolver', () => {
+    let compName;
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      compName = helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/comp1.spec.ts', specFilePassingFixture());
+      helper.fs.outputFile('comp1/comp1.custom-pattern.spec.ts', specFilePassingFixture('custom pattern describe text', 'custom pattern it text'));
+      helper.env.setCustomEnv('custom-jest-resolve-env');
+      helper.command.compile();
+      helper.command.install();
+      helper.command.setEnv('comp1', 'custom-jest-resolve-env');
+    });
+    describe('bit test command', () => {
+      let output;
+      before(() => {
+        output = helper.command.test('', true);
+      });
+      it('bit test should mentions the custom resolved spec file', () => {
+        expect(output).to.have.string('comp1.custom-pattern.spec');
+      });
+      it('bit test should show the passing component for resolved specs via Jest output', () => {
+        expect(output).to.have.string('✓ custom pattern it text');
+      });
+      it('bit test should not mentions the default spec file', () => {
+        expect(output).to.not.have.string('comp1.spec');
+      });
+      it('bit test should NOT show the passing component for default specs via Jest output', () => {
+        expect(output).to.not.have.string('should pass');
+      });
+    });
+    describe('bit build command', () => {
+      let output;
+      before(() => {
+        output = helper.command.build(compName, true);
+      });
+      it('bit build should mentions the custom resolved spec file', () => {
+        expect(output).to.have.string('comp1.custom-pattern.spec');
+      });
+      it('bit build should show the passing component for resolved specs via Jest output', () => {
+        expect(output).to.have.string('✓ custom pattern it text');
+      });
+      it('bit build should not mentions the default spec file', () => {
+        expect(output).to.not.have.string('comp1.spec');
+      });
+      it('bit build should NOT show the passing component for default specs via Jest output', () => {
+        expect(output).to.not.have.string('should pass');
+      });
+    });
+  });
+
 });
 
-function specFilePassingFixture() {
-  return `describe('test', () => {
-  it('should pass', () => {
+function specFilePassingFixture(describeText = 'test', itText = 'should pass') {
+  return `describe('${describeText}', () => {
+  it('${itText}', () => {
     expect(true).toBeTruthy();
   });
 });

--- a/scopes/defender/jest/jest.main.runtime.ts
+++ b/scopes/defender/jest/jest.main.runtime.ts
@@ -2,7 +2,7 @@ import { MainRuntime } from '@teambit/cli';
 import { LoggerAspect, LoggerMain, Logger } from '@teambit/logger';
 import { WorkerAspect, WorkerMain, HarmonyWorker } from '@teambit/worker';
 import { JestAspect } from './jest.aspect';
-import { JestTester } from './jest.tester';
+import { JestTester, JestTesterOptions } from './jest.tester';
 import type { JestWorker } from './jest.worker';
 
 export const WORKER_NAME = 'jest';
@@ -10,8 +10,8 @@ export const WORKER_NAME = 'jest';
 export class JestMain {
   constructor(private jestWorker: HarmonyWorker<JestWorker>, private logger: Logger) {}
 
-  createTester(jestConfig: any, jestModulePath = require.resolve('jest')) {
-    return new JestTester(JestAspect.id, jestConfig, jestModulePath, this.jestWorker, this.logger);
+  createTester(jestConfig: any, jestModulePath = require.resolve('jest'), opts?: JestTesterOptions) {
+    return new JestTester(JestAspect.id, jestConfig, jestModulePath, this.jestWorker, this.logger, opts);
   }
 
   static runtime = MainRuntime;

--- a/scopes/defender/tester/index.ts
+++ b/scopes/defender/tester/index.ts
@@ -1,7 +1,7 @@
 import { TesterAspect } from './tester.aspect';
 
 export { Tests } from './tester';
-export type { Tester, TesterContext, CallbackFn, SpecFiles, ComponentPatternsMap, ComponentsResults } from './tester';
+export type { Tester, TesterContext, CallbackFn, SpecFiles, ComponentPatternsMap, ComponentsResults, ComponentPatternsEntry } from './tester';
 export type { TesterMain } from './tester.main.runtime';
 export type { TesterUI, EmptyStateSlot } from './tester.ui.runtime';
 

--- a/scopes/defender/tester/tester.service.tsx
+++ b/scopes/defender/tester/tester.service.tsx
@@ -116,9 +116,15 @@ export class TesterService implements EnvService<Tests, TesterDescriptor> {
       this.logger.console(`testing ${componentWithTests} components with environment ${chalk.cyan(context.id)}\n`);
 
     const patterns = ComponentMap.as(context.components, (component) => {
-      const dir = this.workspace.componentDir(component.id);
+      const componentDir = this.workspace.componentDir(component.id);
       const componentPatterns = this.devFiles.getDevPatterns(component, TesterAspect.id);
-      return componentPatterns.map((pattern: string) => ({ path: resolve(dir, pattern), relative: pattern }));
+      return {
+        componentDir,
+        paths: componentPatterns.map((pattern: string) => ({
+          path: resolve(componentDir, pattern),
+          relative: pattern,
+        })) || [],
+      }
     });
 
     let additionalHostDependencies = [];

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -30,7 +30,7 @@ export class TesterTask implements BuildTask {
         componentsResults: [],
       };
 
-    const specFilesWithCapsule = ComponentMap.as(components, (component) => {
+    const patternsWithCapsule = ComponentMap.as(components, (component) => {
       const componentSpecFiles = componentsSpecFiles.get(component);
       if (!componentSpecFiles) throw new Error('capsule not found');
       const [, specs] = componentSpecFiles;
@@ -52,11 +52,18 @@ export class TesterTask implements BuildTask {
       }
     });
 
+    const specFilesWithCapsule = ComponentMap.as(components, (component) => {
+      const patternEntry = patternsWithCapsule.get(component);
+      // @ts-ignore
+      const [, val] = patternEntry;
+      return val.paths;
+    });
+
     const testerContext = Object.assign(context, {
       release: true,
       specFiles: specFilesWithCapsule,
       rootPath: context.capsuleNetwork.capsulesRootDir,
-      patterns: specFilesWithCapsule,
+      patterns: patternsWithCapsule,
     });
 
     // TODO: remove after fix AbstractVinyl on capsule

--- a/scopes/defender/tester/tester.ts
+++ b/scopes/defender/tester/tester.ts
@@ -31,7 +31,8 @@ export type ComponentsResults = {
 };
 
 export type SpecFiles = ComponentMap<AbstractVinyl[]>;
-export type ComponentPatternsMap = ComponentMap<{ path: string; relative: string }[]>;
+export type ComponentPatternsEntry = { componentDir: string, paths: {path: string; relative: string}[]};
+export type ComponentPatternsMap = ComponentMap<ComponentPatternsEntry>;
 
 export interface TesterContext extends ExecutionContext {
   /**


### PR DESCRIPTION
## Proposed Changes

- change tester's ComponentPatternsMap API - add component dir, and move the paths into paths prop
- support new opts for creating jest tester - patterns, roots, resolveSpecPaths
