### PR TITLE
fix: resolve @types packages from model if not exists in workspace.jsonc

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -286,7 +286,7 @@ describe('import functionality on Harmony', function () {
       expect(() => helper.command.importComponent('comp1')).to.throw();
     });
   });
-  describe.only('importing a component with @types dependency when current workspace does not have it', () => {
+  describe('importing a component with @types dependency when current workspace does not have it', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();


### PR DESCRIPTION
this fixes an issue of bit-status shows an imported component as modified due to missing "types" package.