### PR TITLE
fix(bit-sign): fetch dists of dependencies aspects from the lane-scope

### DIFF
--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -41,12 +41,24 @@ export class SignMain {
     private lanes: LanesMain
   ) {}
 
+  /**
+   * complete the build process of a component.
+   * `isMultiple` indicates that this is running on a new bare-scope and not on the original scope.
+   * it's recommended to always use it, even when it's a single component and not multiple.
+   * (the reason for this name is that for multiple components from multiple scopes, it must be done on a new bare-scope).
+   *
+   * important! this method mutates the legacyScope. it assigns the currentLaneId according to the `bit sign --lane` flag.
+   * if for some reason you're using this API in a long-running-process, make sure to revert it.
+   */
   async sign(ids: ComponentID[], isMultiple?: boolean, push?: boolean, laneIdStr?: string): Promise<SignResult | null> {
     let lane: Lane | undefined;
     if (isMultiple) {
       if (laneIdStr) {
         const laneId = LaneId.parse(laneIdStr);
         lane = await this.lanes.importLaneObject(laneId);
+        // this is critical. otherwise, later on, when loading aspects and isolating capsules, we'll try to fetch dists
+        // from the original scope instead of the lane-scope.
+        this.scope.legacyScope.setCurrentLaneId(laneId);
       }
       await this.scope.import(ids, { lane });
     }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -170,7 +170,7 @@ export default class Consumer {
 
   setCurrentLane(laneId: LaneId, exported = true) {
     this.bitMap.setCurrentLane(laneId, exported);
-    this.scope.currentLaneId = laneId.isDefault() ? undefined : laneId;
+    this.scope.setCurrentLaneId(laneId);
   }
 
   async cleanTmpFolder() {
@@ -712,7 +712,7 @@ export default class Consumer {
       scope,
     });
     await consumer.setBitMap();
-    scope.currentLaneId = consumer.bitMap.laneId;
+    scope.setCurrentLaneId(consumer.bitMap.laneId);
     return consumer;
   }
 

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -123,6 +123,11 @@ export default class Scope {
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   _dependencyGraph: DependencyGraph; // cache DependencyGraph instance
   lanes: Lanes;
+  /**
+   * normally, the data about the current-lane is saved in .bitmap. the reason for having this prop here is that we
+   * need this data when loading model-component, which gets called in multiple places where the consumer is not passed.
+   * another instance this is needed is for bit-sign, this way when loading aspects and fetching dists, it'll go to lane-scope.
+   */
   currentLaneId?: LaneId;
   constructor(scopeProps: ScopeProps) {
     this.path = scopeProps.path;
@@ -177,6 +182,12 @@ export default class Scope {
   get isLegacy(): boolean {
     const harmonyScopeJsonPath = getHarmonyPath(this.path);
     return !fs.existsSync(harmonyScopeJsonPath);
+  }
+
+  setCurrentLaneId(laneId?: LaneId) {
+    if (!laneId) return;
+    if (laneId.isDefault()) return;
+    this.currentLaneId = laneId;
   }
 
   getPath() {


### PR DESCRIPTION
Also, improve the debug-log when artifacts were not found in the scope. Previously, it was throwing ENOENT from the remote. Now, it prints to the log for each object its origin component-id.