### PR TITLE
fix(bit-reset): revert the config in .bitmap

### DIFF
--- a/e2e/commands/untag.e2e.2.ts
+++ b/e2e/commands/untag.e2e.2.ts
@@ -291,4 +291,27 @@ describe('bit reset command', function () {
       });
     });
   });
+  describe('components with config in the .bitmap file', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagWithoutBuild();
+      helper.command.deprecateComponent('comp1');
+      helper.command.tagWithoutBuild();
+      const isDeprecated = helper.command.isDeprecated('comp1');
+      expect(isDeprecated).to.be.true; // intermediate step.
+      helper.command.untagAll();
+    });
+    it('bit reset should leave the config as they were before the tag', () => {
+      const isDeprecated = helper.command.isDeprecated('comp1');
+      expect(isDeprecated).to.be.true;
+    });
+    it('bit export should remove the entries form the staged-config file', () => {
+      helper.command.tagWithoutBuild('--unmodified');
+      helper.command.export();
+      const stagedConfig = helper.general.getStagedConfig();
+      expect(stagedConfig).to.have.lengthOf(0);
+    });
+  });
 });

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -41,7 +41,7 @@ import { SnappingAspect } from './snapping.aspect';
 import { TagCmd } from './tag-cmd';
 import { ComponentsHaveIssues } from './components-have-issues';
 import ResetCmd from './reset-cmd';
-import { tagModelComponent } from './tag-model-component';
+import { tagModelComponent, updateComponentsVersions } from './tag-model-component';
 
 const HooksManagerInstance = HooksManager.getInstance();
 
@@ -139,15 +139,14 @@ export class SnappingMain {
     }
 
     const { taggedComponents, autoTaggedResults, publishedPackages } = await tagModelComponent({
+      workspace: this.workspace,
       consumerComponents: components,
       ids: legacyBitIds,
-      scope: this.workspace.scope.legacyScope,
       message,
       editor,
       exactVersion: validExactVersion,
       releaseType,
       preReleaseId,
-      consumer: this.workspace.consumer,
       ignoreNewestVersion,
       skipTests,
       skipAutoTag,
@@ -226,12 +225,11 @@ export class SnappingMain {
     }
 
     const { taggedComponents, autoTaggedResults } = await tagModelComponent({
+      workspace: this.workspace,
       consumerComponents: components,
       ids,
       ignoreNewestVersion: false,
-      scope: this.workspace.scope.legacyScope,
       message,
-      consumer: this.workspace.consumer,
       skipTests,
       skipAutoTag: skipAutoSnap,
       persist: true,
@@ -340,7 +338,7 @@ there are matching among unmodified components thought. consider using --unmodif
       results = await untag();
       await consumer.scope.objects.persist();
       const components = results.map((result) => result.component);
-      await consumer.updateComponentsVersions(components as ModelComponent[]);
+      await updateComponentsVersions(this.workspace, components as ModelComponent[], false);
     } else {
       results = await softUntag();
       consumer.bitMap.markAsChanged();

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -113,6 +113,7 @@ export class ExportMain {
     });
     if (laneObject) await updateLanesAfterExport(consumer, laneObject);
     const { updatedIds, nonExistOnBitMap } = _updateIdsOnBitMap(consumer.bitMap, updatedLocally);
+    await this.removeFromStagedConfig(updatedIds);
     await linkComponents(updatedIds, consumer);
     Analytics.setExtraData('num_components', exported.length);
     // it is important to have consumer.onDestroy() before running the eject operation, we want the
@@ -127,6 +128,13 @@ export class ExportMain {
       newIdsOnRemote,
       exportedLanes: laneObject ? [laneObject] : [],
     };
+  }
+
+  private async removeFromStagedConfig(ids: BitId[]) {
+    const componentIds = await this.workspace.resolveMultipleComponentIds(ids);
+    const stagedConfig = await this.workspace.scope.getStagedConfig();
+    componentIds.map((compId) => stagedConfig.removeComponentConfig(compId));
+    await stagedConfig.write();
   }
 
   private async getComponentsToExport(

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -53,6 +53,7 @@ import { ScopeUIRoot } from './scope.ui-root';
 import { PutRoute, FetchRoute, ActionRoute, DeleteRoute } from './routes';
 import { ScopeComponentLoader } from './scope-component-loader';
 import { ScopeCmd } from './scope-cmd';
+import { StagedConfig } from './staged-config';
 
 type TagRegistry = SlotRegistry<OnTag>;
 
@@ -922,6 +923,11 @@ needed-for: ${neededFor || '<unknown>'}`);
 
   async getLogs(id: ComponentID, shortHash = false, startsFrom?: string): Promise<ComponentLog[]> {
     return this.legacyScope.loadComponentLogs(id._legacy, shortHash, startsFrom);
+  }
+
+  async getStagedConfig() {
+    const currentLaneId = this.legacyScope.currentLaneId;
+    return StagedConfig.load(this.path, currentLaneId);
   }
 
   /**

--- a/scopes/scope/scope/staged-config.ts
+++ b/scopes/scope/scope/staged-config.ts
@@ -1,0 +1,59 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { ComponentID } from '@teambit/component-id';
+import { DEFAULT_LANE, LaneId } from '@teambit/lane-id';
+
+const STAGED_CONFIG_DIR = 'staged-config';
+
+type Config = Record<string, any> | undefined;
+type ComponentConfig = { id: ComponentID; config: Config };
+
+export class StagedConfig {
+  hasChanged = false;
+  constructor(private filePath: string, private componentsConfig: ComponentConfig[]) {}
+
+  static async load(scopePath: string, laneId?: LaneId): Promise<StagedConfig> {
+    const lanePath = laneId ? path.join(laneId.scope, laneId.name) : DEFAULT_LANE;
+    const filePath = path.join(scopePath, STAGED_CONFIG_DIR, `${lanePath}.json`);
+    let componentsConfig: ComponentConfig[] = [];
+    try {
+      const fileContent = await fs.readJson(filePath);
+      componentsConfig = fileContent.map((item) => ({ id: ComponentID.fromObject(item.id), config: item.config }));
+    } catch (err: any) {
+      if (err.code === 'ENOENT') {
+        componentsConfig = [];
+      } else {
+        throw err;
+      }
+    }
+    return new StagedConfig(filePath, componentsConfig);
+  }
+
+  toObject() {
+    return this.componentsConfig.map(({ id, config }) => ({ id: id.toObject(), config }));
+  }
+
+  async write() {
+    if (!this.hasChanged) return;
+    await fs.outputFile(this.filePath, JSON.stringify(this.toObject(), null, 2));
+  }
+
+  getConfigPerId(id: ComponentID): Config {
+    return this.componentsConfig.find((c) => c.id.isEqual(id, { ignoreVersion: true }))?.config;
+  }
+
+  addComponentConfig(id: ComponentID, config: Config) {
+    const exists = this.componentsConfig.find((c) => c.id.isEqual(id, { ignoreVersion: true }));
+    if (exists) {
+      exists.config = config;
+    } else {
+      this.componentsConfig.push({ id, config });
+    }
+    this.hasChanged = true;
+  }
+
+  removeComponentConfig(id: ComponentID) {
+    this.componentsConfig = this.componentsConfig.filter((c) => !c.id.isEqual(id, { ignoreVersion: true }));
+    this.hasChanged = true;
+  }
+}

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -8,7 +8,7 @@ import tar from 'tar';
 import { LANE_REMOTE_DELIMITER } from '@teambit/lane-id';
 import { BUILD_ON_CI, ENV_VAR_FEATURE_TOGGLE } from '../api/consumer/lib/feature-toggle';
 import { NOTHING_TO_TAG_MSG } from '../api/consumer/lib/tag';
-import { NOTHING_TO_SNAP_MSG } from '../constants';
+import { Extensions, NOTHING_TO_SNAP_MSG } from '../constants';
 import runInteractive, { InteractiveInputs } from '../interactive/utils/run-interactive-cmd';
 import { removeChalkCharacters } from '../utils';
 import ScopesData from './e2e-scopes';
@@ -481,6 +481,11 @@ export default class CommandHelper {
   statusJson(cwd = this.scopes.localPath) {
     const status = this.runCmd('bit status --json', cwd);
     return JSON.parse(status);
+  }
+
+  isDeprecated(compName: string): boolean {
+    const deprecationData = this.showAspectConfig(compName, Extensions.deprecation);
+    return deprecationData.config.deprecate;
   }
 
   getStagedIdsFromStatus(): string[] {

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -122,4 +122,8 @@ export default class GeneralHelper {
   getExtension(component, extName: string) {
     return component.extensions.find((e) => e.name === extName);
   }
+
+  getStagedConfig(laneName = 'main') {
+    return fs.readJSONSync(path.join(this.scopes.localPath, '.bit', 'staged-config', `${laneName}.json`));
+  }
 }


### PR DESCRIPTION
Currently, if a config was added to the .bitmap file, it gets deleted during `bit tag`. as a result, when running `bit reset`, there is no way to get it back, and the workspace is left without the config changes unexpectedly. 
This PR implements a new mechanism of storing this config between the tag and the export, so then, `bit reset` can copy the config from this file and put it back in the .bitmap file.
See https://github.com/teambit/bit/discussions/5074#discussioncomment-1787197 for more info about this topic.