### PR TITLE
fix(bit-status): avoid throwing when modified and a dependency is deleted from the filesystem

### DIFF
--- a/e2e/harmony/status-harmony.e2e.ts
+++ b/e2e/harmony/status-harmony.e2e.ts
@@ -89,4 +89,18 @@ describe('status command on Harmony', function () {
       expect(show.dependencies).to.have.lengthOf(0);
     });
   });
+  describe('deleting a dependency from the filesystem when the record is still in bitmap', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.fs.deletePath('comp2');
+      helper.fs.appendFile('comp1/index.js');
+    });
+    it('bit status should not throw', () => {
+      expect(() => helper.command.status()).not.to.throw();
+    });
+  });
 });

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -146,14 +146,8 @@ export class GraphFromFsBuilder {
     return components;
   }
   private async loadComponent(componentId: BitId): Promise<Component> {
-    const componentMap = this.consumer.bitMap.getComponentIfExist(componentId);
-    const isOnWorkspace = Boolean(componentMap);
-    if (isOnWorkspace) {
-      return this.consumer.loadComponent(componentId);
-    }
-    // a dependency might have been installed as a package in the workspace, and as such doesn't
-    // have a componentMap.
-    const componentFromModel = await this.consumer.loadComponentFromModel(componentId);
-    return componentFromModel.clone();
+    const compId = await this.workspace.resolveComponentId(componentId);
+    const comp = await this.workspace.get(compId);
+    return comp.state._consumer;
   }
 }

--- a/src/scope/component-ops/auto-tag.ts
+++ b/src/scope/component-ops/auto-tag.ts
@@ -18,7 +18,7 @@ export async function getAutoTagInfo(consumer: Consumer, changedComponents: BitI
   if (!changedComponents.length) return [];
   const potentialComponents = potentialComponentsForAutoTagging(consumer, changedComponents);
   const idsToLoad = new BitIds(...potentialComponents, ...changedComponents);
-  const { components } = await consumer.loadComponents(idsToLoad);
+  const { components } = await consumer.loadComponents(idsToLoad, false);
   const graph = buildGraph(components);
 
   const autoTagResults: AutoTagResult[] = [];


### PR DESCRIPTION
Currently, if a component is deleted from the filesystem, we know to show it as an "invalid component" in bit-status.
However, if this deleted component is a dependency of another component, and that dependent is modified, Bit thrown an error ComponentNotFondInPath. This PR fixes it to not throw.