### PR TITLE
fix(bit-reset): avoid deleting Version objects

### DIFF
--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -1,0 +1,40 @@
+import chai, { expect } from 'chai';
+import Helper from '../../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('bit reset when on lane', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('snapping on a lane, switching to main, snapping and running "bit reset"', () => {
+    let headOnLane: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, false, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      headOnLane = helper.command.getHeadOfLane('dev', 'comp1');
+      helper.command.switchLocalLane('main');
+      helper.command.mergeLane('dev');
+      helper.command.untagAll();
+    });
+    it('should not delete the head of the lane', () => {
+      expect(() => helper.command.catObject(headOnLane)).to.not.throw();
+    });
+    it('bit status should not throw after switching to the lane', () => {
+      helper.command.switchLocalLane('dev');
+      expect(() => helper.command.status()).not.to.throw();
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1211,4 +1211,21 @@ describe('bit lane command', function () {
       });
     });
   });
+  // @todo: fix!
+  describe.skip('head on the lane is not in the filesystem', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.fs.deletePath('.bit');
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('bit status should not throw', () => {
+      expect(() => helper.command.status()).not.to.throw();
+    });
+  });
 });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -355,7 +355,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       const versionObject = allVersionsObjects.find((v) => v.hash().isEqual(ref));
       const refStr = ref.toString();
       if (!versionObject) throw new Error(`removeComponentVersions failed finding a version object of ${refStr}`);
-      objectRepo.removeObject(ref);
+      // avoid deleting the Version object from the filesystem. see the e2e-case: "'snapping on a lane, switching to main, snapping and running "bit reset"'"
+      // objectRepo.removeObject(ref);
       return ref;
     });
 


### PR DESCRIPTION
In some scenarios deleting the Version objects can be an issue. See the e2e-test in this PR for such a case.
It's ok to leave them as they lightweight and their hash is unique (v4). If needed, we'll develop a GC mechanism to remove them later.