### PR TITLE
remove support of "latest" for bit-checkout

### DIFF
--- a/src/api/consumer/lib/checkout.ts
+++ b/src/api/consumer/lib/checkout.ts
@@ -1,3 +1,4 @@
+import { BitError } from '@teambit/bit-error';
 import R from 'ramda';
 
 import { BitId } from '../../../bit-id';
@@ -33,7 +34,7 @@ async function parseValues(consumer: Consumer, values: string[], checkoutProps: 
     checkoutProps.version && (checkoutProps.version === LATEST || checkoutProps.version === HEAD)
   );
   if (checkoutProps.latestVersion && checkoutProps.version === LATEST) {
-    logger.console(`"latest" is deprecated. please use "${HEAD}" instead`);
+    throw new BitError(`"latest" is not supported. please use "${HEAD}" instead`);
   }
   if (checkoutProps.latestVersion && !ids.length) {
     if (checkoutProps.all) {


### PR DESCRIPTION
It has been deprecated for a while now, it's time to remove it. 
Later, we'll support `latest` in the semver context, which won't be the same as "head".