### PR TITLE
improvement(bit-checkout): import components before checkout 

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -431,4 +431,27 @@ describe('bit checkout command', function () {
       });
     });
   });
+  describe('checkout-head when the local head is not up to date', () => {
+    let localHeadScope: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.fixtures.populateComponents(1, false, 'v2');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      localHeadScope = helper.scopeHelper.cloneLocalScope();
+      helper.fixtures.populateComponents(1, false, 'v3');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(localHeadScope);
+      helper.command.checkout('0.0.1 --all');
+      helper.command.checkoutHead();
+    });
+    it('should checkout to the remote head and not to the local head', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap.comp1.version).to.equal('0.0.3');
+    });
+  });
 });

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -58,7 +58,7 @@ export default async function checkoutVersion(
 ): Promise<ApplyVersionResults> {
   const { version, ids, promptMergeOptions } = checkoutProps;
   const bitIds = BitIds.fromArray(ids || []);
-  await consumer.scope.import(bitIds);
+  await consumer.scope.import(bitIds, false);
   const { components } = await consumer.loadComponents(bitIds);
   const allComponentsStatus: ComponentStatus[] = await getAllComponentsStatus();
   const componentWithConflict = allComponentsStatus.find(


### PR DESCRIPTION
so then `bit checkout head` checks out to the remote-head rather than the local-head.
