### PR TITLE
fix(dependencies-resolution): consider variants/bitmap-config policy

### DIFF
--- a/e2e/harmony/installing-component-dependency.e2e.ts
+++ b/e2e/harmony/installing-component-dependency.e2e.ts
@@ -44,7 +44,7 @@ import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
       helper.fs.exists(path.join(helper.scopes.remoteWithoutOwner, `comp1/node_modules/${scope}comp2/package.json`))
     ).to.eq(false);
   });
-  it.only('should not install the version of the component dependency from the model, when the component dependency is in the workspace policies', () => {
+  it('should not install the version of the component dependency from the model, when the component dependency is in the bitmap config', () => {
     helper.command.dependenciesSet('comp1', `${scope}comp2@0.0.2`);
     helper.command.install();
     expect(helper.fs.readJsonFile(`node_modules/${scope}comp2/package.json`).version).to.eq('0.0.2');

--- a/e2e/harmony/installing-component-dependency.e2e.ts
+++ b/e2e/harmony/installing-component-dependency.e2e.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import path from 'path';
+import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 
@@ -42,6 +43,15 @@ import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
     expect(
       helper.fs.exists(path.join(helper.scopes.remoteWithoutOwner, `comp1/node_modules/${scope}comp2/package.json`))
     ).to.eq(false);
+  });
+  it.only('should not install the version of the component dependency from the model, when the component dependency is in the workspace policies', () => {
+    helper.command.dependenciesSet('comp1', `${scope}comp2@0.0.2`);
+    helper.command.install();
+    expect(helper.fs.readJsonFile(`node_modules/${scope}comp2/package.json`).version).to.eq('0.0.2');
+    const show = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+    const ids: string[] = show.data.dependencies.map((dep) => dep.id);
+    const comp2 = ids.find((id) => id.includes('comp2'));
+    expect(comp2).to.endsWith('0.0.2');
   });
   after(() => {
     npmCiRegistry.destroy();

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -229,8 +229,7 @@ export default class ComponentLoader {
 
   private async _handleOutOfSyncScenarios(component: Component) {
     const { componentFromModel, componentMap } = component;
-    // $FlowFixMe componentMap is set here
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+    // @ts-ignore componentMap is set here
     const currentId: BitId = componentMap.id;
     let newId: BitId | null | undefined;
     if (componentFromModel && !currentId.hasVersion()) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -699,9 +699,11 @@ either, use the ignore file syntax or change the require statement to have a mod
         // (it's there without a version when it's in the workspace and it's linked)
         if (!version) return getExistingIdFromBitMapOrModel();
 
-        // In case it's resolved from the node_modules, and it's also in the ws policy,
+        // In case it's resolved from the node_modules, and it's also in the ws policy or variants,
         // use the resolved version from the node_modules / package folder
-        if (this.isPkgInWorkspacePolicies(compDep.name)) return componentId;
+        if (this.isPkgInWorkspacePolicies(compDep.name) || this.isPkgInVariants(compDep.name)) {
+          return componentId;
+        }
 
         // If there is a version in the node_modules/package folder, but it's not in the ws policy,
         // prefer the version from the bitmap/model over the version from the node_modules
@@ -725,6 +727,14 @@ either, use the ignore file syntax or change the require statement to have a mod
 
   private isPkgInWorkspacePolicies(pkgName: string) {
     return DependencyResolver.getWorkspacePolicy().dependencies?.[pkgName];
+  }
+  private isPkgInVariants(pkgName: string): boolean {
+    const dependencies = this.overridesDependencies.getDependenciesToAddManually(undefined, this.allDependencies);
+    if (!dependencies) return false;
+    const { components } = dependencies;
+    return DEPENDENCIES_FIELDS.some(
+      (depField) => components[depField] && components[depField].some((depData) => depData.packageName === pkgName)
+    );
   }
 
   private addImportNonMainIssueIfNeeded(filePath: PathLinuxRelative, dependencyPkgData: ResolvedPackageData) {


### PR DESCRIPTION
This is a regression caused by https://github.com/teambit/bit/pull/6281.
When a component-dependency is not part of the workspace and it's not in the workspace.jsonc, then, the version is resolved from the model. 
This PR fixes it to take into account "overrides", which are the bitmap-config / component.json / workspace.jsonc-overrides.
If the component is specified there, it uses the package.json in the node_modules to resolve the version from.
