### PR TITLE
fix: avoid loading the same components at the same time

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -565,17 +565,18 @@ export class IsolatorMain {
     capsulesWithPackagesData: CapsulePackageJsonData[],
     capsules: CapsuleList
   ) {
-    // ci seems to have some inconsistencies behavior (regards to the package.json) when using Promise.all.
-    return pMapSeries(capsules, async (capsule) => {
-      const packageJson = await this.getCurrentPackageJson(capsule, capsules);
-      const found = capsulesWithPackagesData.filter((c) => c.capsule.component.id.isEqual(capsule.component.id));
-      if (!found.length) throw new Error(`updateWithCurrentPackageJsonData unable to find ${capsule.component.id}`);
-      if (found.length > 1)
-        throw new Error(
-          `updateWithCurrentPackageJsonData found duplicate capsules: ${capsule.component.id.toString()}""`
-        );
-      found[0].currentPackageJson = packageJson.packageJsonObject;
-    });
+    return Promise.all(
+      capsules.map(async (capsule) => {
+        const packageJson = await this.getCurrentPackageJson(capsule, capsules);
+        const found = capsulesWithPackagesData.filter((c) => c.capsule.component.id.isEqual(capsule.component.id));
+        if (!found.length) throw new Error(`updateWithCurrentPackageJsonData unable to find ${capsule.component.id}`);
+        if (found.length > 1)
+          throw new Error(
+            `updateWithCurrentPackageJsonData found duplicate capsules: ${capsule.component.id.toString()}""`
+          );
+        found[0].currentPackageJson = packageJson.packageJsonObject;
+      })
+    );
   }
 
   private async getCurrentPackageJson(capsule: Capsule, capsules: CapsuleList): Promise<PackageJsonFile> {

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -18,7 +18,6 @@ import {
   PackageManagerInstallOptions,
 } from '@teambit/dependency-resolver';
 import legacyLogger from '@teambit/legacy/dist/logger/logger';
-import pMapSeries from 'p-map-series';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
 import LegacyScope from '@teambit/legacy/dist/scope/scope';

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -268,11 +268,9 @@ export default class ComponentsList {
    * @return {Promise<string[]>}
    */
   async listTagPendingComponents(): Promise<BitIds> {
-    const [newComponents, modifiedComponents, removedComponents] = await Promise.all([
-      this.listNewComponents(),
-      this.listModifiedComponents(),
-      this.listRemovedComponents(),
-    ]);
+    const newComponents = await this.listNewComponents();
+    const modifiedComponents = await this.listModifiedComponents();
+    const removedComponents = await this.listRemovedComponents();
     const duringMergeIds = this.listDuringMergeStateComponents();
 
     return BitIds.fromArray([


### PR DESCRIPTION
it causes some race-condition when these components need external aspect to be loaded. the same aspects are isolated at the same time in the same capsule, as a result, some files are deleted by one call while they're being read by another call.