### PR TITLE
fix: show a descriptive error when workspace has workspace.jsonc but not .bitmap nor .bit

### DIFF
--- a/e2e/harmony/init-harmony.e2e.ts
+++ b/e2e/harmony/init-harmony.e2e.ts
@@ -54,4 +54,15 @@ describe('init command on Harmony', function () {
       expect(() => helper.command.status()).to.not.throw();
     });
   });
+  describe('when workspace.jsonc exist, but not .bitmap nor .bit', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.fs.deletePath('.bit');
+      helper.fs.deletePath('.bitmap');
+    });
+    // previously, it was throwing command-not-found
+    it('should show a descriptive error', () => {
+      expect(() => helper.command.install()).to.throw(`fatal: unable to load the workspace`);
+    });
+  });
 });

--- a/src/consumer/consumer-locator.ts
+++ b/src/consumer/consumer-locator.ts
@@ -53,7 +53,7 @@ export async function getConsumerInfo(absPath: string): Promise<ConsumerInfo | u
     const hasScope = await pathHasScopeDir(path); // eslint-disable-line no-await-in-loop
     const hasConsumerConfig = await pathHasConsumerConfig(path); // eslint-disable-line no-await-in-loop
     const hasBitMap = await pathHasBitMap(path); // eslint-disable-line no-await-in-loop
-    const consumerExists = (hasScope && hasConsumerConfig) || hasBitMap;
+    const consumerExists = hasConsumerConfig || hasBitMap;
     if (consumerExists) {
       return {
         path,

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -661,6 +661,11 @@ export default class Consumer {
     if (!consumerInfo) {
       return Promise.reject(new ConsumerNotFound());
     }
+    if (!consumerInfo.hasBitMap && !consumerInfo.hasScope && consumerInfo.hasConsumerConfig) {
+      throw new Error(
+        `fatal: unable to load the workspace. workspace.jsonc exists, but the .bitmap and local-scope are missing. run "bit init" to generate the missing files`
+      );
+    }
     let consumer: Consumer | undefined;
 
     if ((!consumerInfo.hasConsumerConfig || !consumerInfo.hasScope) && consumerInfo.hasBitMap) {


### PR DESCRIPTION
currently, it shows command-not-found unexpectedly.