### PR TITLE
feat(bit-lane-merge): introduce "--ignore-config-changes" to merge modified components 

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -243,7 +243,7 @@ export class MergingMain {
     id: BitId, // the id.version is the version we want to merge to the current component
     localLane: Lane | null, // currently checked out lane. if on main, then it's null.
     otherLaneName: string, // the lane name we want to merged to our lane. (can be also "main").
-    options?: { resolveUnrelated?: MergeStrategy }
+    options?: { resolveUnrelated?: MergeStrategy; ignoreConfigChanges?: boolean }
   ): Promise<ComponentMergeStatus> {
     const consumer = this.workspace.consumer;
     const componentStatus: ComponentMergeStatus = { id };
@@ -296,11 +296,23 @@ export class MergingMain {
       return consumer.scope.getConsumerComponent(currentId);
     };
     const currentComponent = await getCurrentComponent();
-    const componentModificationStatus = await consumer.getComponentStatusById(currentComponent.id);
-    if (componentModificationStatus.modified) {
-      return returnUnmerged(
-        `unable to merge ${id.toStringWithoutVersion()}, the component is modified, please snap/tag it first`
+    const isModified = async () => {
+      const componentModificationStatus = await consumer.getComponentStatusById(currentComponent.id);
+      if (!componentModificationStatus.modified) return false;
+      if (!existingBitMapId) return false;
+      const baseComponent = await modelComponent.loadVersion(
+        existingBitMapId.version as string,
+        consumer.scope.objects
       );
+      return options?.ignoreConfigChanges
+        ? consumer.isComponentSourceCodeModified(baseComponent, currentComponent)
+        : true;
+    };
+
+    const isComponentModified = await isModified();
+
+    if (isComponentModified) {
+      return returnUnmerged(`component is modified, please snap/tag it first`);
     }
     const laneHeadIsDifferentThanCheckedOut =
       localLane && existingBitMapId?.version && modelComponent.laneHeadLocal?.toString() !== existingBitMapId?.version;

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -34,6 +34,11 @@ in case the <lane> exists locally but you want to merge the remote version of it
     ['m', 'message <message>', 'override the default message for the auto snap'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
     ['', 'no-squash', 'EXPERIMENTAL. relevant for merging lanes into main, which by default squash.'],
+    [
+      '',
+      'ignore-config-changes',
+      'allow merging when component are modified due to config changes (such as dependencies) only and not files',
+    ],
     ['', 'verbose', 'show details of components that were not merged legitimately'],
     ['', 'skip-dependency-installation', 'do not install packages of the imported components'],
     ['', 'remote', 'relevant when the target-lane locally is differ than the remote and you want the remote'],
@@ -71,6 +76,7 @@ in case the <lane> exists locally but you want to merge the remote version of it
       remote = false,
       includeDeps = false,
       resolveUnrelated,
+      ignoreConfigChanges,
       verbose = false,
     }: {
       ours: boolean;
@@ -86,6 +92,7 @@ in case the <lane> exists locally but you want to merge the remote version of it
       remote: boolean;
       includeDeps?: boolean;
       resolveUnrelated?: string | boolean;
+      ignoreConfigChanges?: boolean;
       verbose?: boolean;
     }
   ): Promise<string> {
@@ -119,6 +126,7 @@ in case the <lane> exists locally but you want to merge the remote version of it
       skipDependencyInstallation,
       remote,
       resolveUnrelated: getResolveUnrelated(),
+      ignoreConfigChanges,
       includeDeps,
     });
 

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -30,6 +30,7 @@ export type MergeLaneOptions = {
   includeDeps?: boolean;
   skipDependencyInstallation?: boolean;
   resolveUnrelated?: MergeStrategy;
+  ignoreConfigChanges?: boolean;
   remote?: boolean;
 };
 
@@ -63,6 +64,7 @@ export class MergeLanesMain {
       includeDeps,
       skipDependencyInstallation,
       resolveUnrelated,
+      ignoreConfigChanges,
       remote,
     } = options;
 
@@ -103,7 +105,10 @@ export class MergeLanesMain {
       try {
         const componentsStatus = await Promise.all(
           bitIds.map((bitId) =>
-            this.merging.getComponentMergeStatus(bitId, currentLane, otherLaneName, { resolveUnrelated })
+            this.merging.getComponentMergeStatus(bitId, currentLane, otherLaneName, {
+              resolveUnrelated,
+              ignoreConfigChanges,
+            })
           )
         );
         await tmp.clear();


### PR DESCRIPTION
when the modification is config only (such as dependencies changes), not files.