### PR TITLE
improvement(bit-checkout-head): sync non-exported components with their remote default-scope

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -454,4 +454,27 @@ describe('bit checkout command', function () {
       expect(bitMap.comp1.version).to.equal('0.0.3');
     });
   });
+  describe('sync new components', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(2);
+      const scopeBeforeTag = helper.scopeHelper.cloneLocalScope();
+      helper.command.tagWithoutBuild('comp2');
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(scopeBeforeTag);
+
+      // intermediate step, make sure they're both new.
+      const status = helper.command.statusJson();
+      expect(status.newComponents).to.have.lengthOf(2);
+    });
+    it('bit checkout head should sync the exported components', () => {
+      helper.command.checkoutHead();
+      const status = helper.command.statusJson();
+      expect(status.newComponents).to.have.lengthOf(1);
+
+      const bitMap = helper.bitMap.read();
+      expect(bitMap.comp2.scope).to.equal(helper.scopes.remote);
+    });
+  });
 });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -142,7 +142,12 @@ export class CheckoutMain {
     if (!head) return;
     const notExported = ids?.filter((id) => !id._legacy.hasScope()).map((id) => id._legacy.changeScope(id.scope));
     const scopeComponentsImporter = new ScopeComponentsImporter(this.workspace.consumer.scope);
-    await scopeComponentsImporter.importManyDeltaWithoutDeps(BitIds.fromArray(notExported || []), true);
+    try {
+      await scopeComponentsImporter.importManyDeltaWithoutDeps(BitIds.fromArray(notExported || []), true);
+    } catch (err) {
+      // don't stop the process. it's possible that the scope doesn't exist yet because these are new components
+      this.logger.error(`unable to sync new components due to an error`, err);
+    }
   }
 
   private async parseValues(to: CheckoutTo, componentPattern: string, checkoutProps: CheckoutProps) {


### PR DESCRIPTION
In some cases, the .bitmap is not up to date with exported component. Locally, a component is new, but in fact the component has been exported to the remote.
This could happen for example when the CI tags+exports and for some reason the .bitmap wasn't pushed to Git. 
With this PR, these new components are updated during `bit checkout head` to the latest version on the remote.
(other cases of out-of-sync are already taken care during the component-load. this case involves going to the remote for all new components, so for performance reasons it's done on bit-checkout).