### PR TITLE
fix(bit-tag): avoid relying on the repo.cache when tagging components

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -406,4 +406,21 @@ describe('tag components on Harmony', function () {
       expect(bitMap.comp1.nextVersion.version).equal('patch');
     });
   });
+  describe('with tiny cache', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.fixtures.populateComponents(1, false, 'v2');
+      helper.command.runCmd('bit config set cache.max.objects 1');
+    });
+    after(() => {
+      helper.command.runCmd('bit config del cache.max.objects');
+    });
+    // previously, it was throwing "VersionNotFound" and "VersionNotFoundOnFS".
+    it('should not throw', () => {
+      // don't skip the build here. otherwise, you won't be able to reproduce.
+      expect(() => helper.command.tagAllComponents()).not.to.throw();
+    });
+  });
 });

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -39,6 +39,7 @@ import MissingFilesFromComponent from './exceptions/missing-files-from-component
 import { NoComponentDir } from './exceptions/no-component-dir';
 import PackageJsonFile from './package-json-file';
 import DataToPersist from './sources/data-to-persist';
+import { ModelComponent } from '../../scope/models';
 
 export type CustomResolvedPath = { destinationPath: PathLinux; importSource: string };
 
@@ -74,6 +75,7 @@ export type ComponentProps = {
   scopesList?: ScopeListItem[];
   extensions: ExtensionDataList;
   componentFromModel?: Component;
+  modelComponent?: ModelComponent;
   buildStatus?: BuildStatus;
 };
 
@@ -119,6 +121,7 @@ export default class Component {
   schema?: string;
   componentMap: ComponentMap | undefined; // always populated when the loadedFromFileSystem is true
   componentFromModel: Component | undefined; // populated when loadedFromFileSystem is true and it exists in the model
+  modelComponent?: ModelComponent; // populated when loadedFromFileSystem is true and it exists in the model
   issues: IssuesList;
   deprecated: boolean;
   removed?: boolean; // was it soft-removed
@@ -161,6 +164,7 @@ export default class Component {
     devPackageDependencies,
     peerPackageDependencies,
     componentFromModel,
+    modelComponent,
     overrides,
     schema,
     defaultScope,
@@ -201,6 +205,7 @@ export default class Component {
     this.scopesList = scopesList;
     this.extensions = extensions || [];
     this.componentFromModel = componentFromModel;
+    this.modelComponent = modelComponent;
     this.schema = schema;
     this.buildStatus = buildStatus;
     this.issues = new IssuesList();
@@ -505,6 +510,7 @@ export default class Component {
   }): Promise<Component> {
     const consumerPath = consumer.getPath();
     const workspaceConfig: ILegacyWorkspaceConfig = consumer.config;
+    const modelComponent = await consumer.scope.getModelComponentIfExist(id);
     const componentFromModel = await consumer.loadComponentFromModelIfExist(id);
     if (!componentFromModel && id.scope) {
       const inScopeWithAnyVersion = await consumer.scope.getModelComponentIfExist(id.changeVersion(undefined));
@@ -572,6 +578,7 @@ export default class Component {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       loadedFromFileSystem: true,
       componentFromModel,
+      modelComponent,
       componentMap,
       docs: flattenedDocs,
       deprecated,

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -596,10 +596,15 @@ export default class Component extends BitObject {
     return componentObject;
   }
 
-  async loadVersion(versionStr: string, repository: Repository, throws = true): Promise<Version> {
+  async loadVersion(
+    versionStr: string,
+    repository: Repository,
+    throws = true,
+    preferInMemoryObjects = false
+  ): Promise<Version> {
     const versionRef = this.getRef(versionStr);
     if (!versionRef) throw new VersionNotFound(versionStr, this.id());
-    const version = await versionRef.load(repository);
+    const version = await repository.load(versionRef, false, preferInMemoryObjects);
     if (!version && throws) throw new VersionNotFoundOnFS(versionStr, this.id());
     return version as Version;
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -110,7 +110,14 @@ export default class Repository {
     return fs.pathExists(objectPath);
   }
 
-  async load(ref: Ref, throws = false): Promise<BitObject> {
+  async load(ref: Ref, throws = false, preferInMemoryObjects = false): Promise<BitObject> {
+    if (preferInMemoryObjects) {
+      // during tag, the updated objects are in `this.objects`.
+      // `this.cache` is less reliable, because if it reaches its max, then it loads from the filesystem, which may not
+      // be there yet (in case of "version" object), or may be out-of-date (in case of "component" object).
+      const inMemoryObjects = this.objects[ref.hash.toString()];
+      if (inMemoryObjects) return inMemoryObjects;
+    }
     const cached = this.getCache(ref);
     if (cached) {
       return cached;

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -196,6 +196,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   }
 
   findOrAddComponent(props: ComponentProps): Promise<ModelComponent> {
+    // @ts-ignore normally "props" is a consumerComponent, and when loaded from FS, it has modelComponent
+    if (props.modelComponent) return props.modelComponent;
     const comp = ModelComponent.from(props);
     return this._findComponent(comp).then((component) => {
       if (!component) return comp;
@@ -252,8 +254,8 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
   }
 
   async getObjectsToEnrichSource(consumerComponent: ConsumerComponent): Promise<BitObject[]> {
-    const component = await this.findOrAddComponent(consumerComponent);
-    const version = await component.loadVersion(consumerComponent.id.version as string, this.objects());
+    const component = consumerComponent.modelComponent || (await this.findOrAddComponent(consumerComponent));
+    const version = await component.loadVersion(consumerComponent.id.version as string, this.objects(), true, true);
     const artifactFiles = getArtifactsFiles(consumerComponent.extensions);
     const artifacts = this.transformArtifactsFromVinylToSource(artifactFiles);
     version.extensions = consumerComponent.extensions;


### PR DESCRIPTION
In case `bit tag` reaches the default `cache.max.objects`, it throws VersionNotFound error because the Version object got removed from the cache.
This PR fixes it by grabbing the object from `repo.objects` first.