### PR TITLE
fix(bit-new): refactor forked components

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -95,7 +95,7 @@ export class ForkingMain {
       const { targetCompId, component } = await this.forkRemoteComponent(sourceIdWithScope, targetId, { scope, path });
       return { targetCompId, sourceId, component };
     });
-    await this.refactorMultipleAndInstall(results);
+    await this.refactorMultipleAndInstall(results, options);
   }
 
   private async refactorMultipleAndInstall(results: MultipleForkInfo[], options: MultipleForkOptions = {}) {


### PR DESCRIPTION
When forking components via `bit new`, search & replace old package names with new names. 
It used to work in the past, but for some reason the "refactor: true" option wasn't passed to `refactorMultipleAndInstall` method.