### PR TITLE
fix(bit-status): avoid showing a component as pending-merge when it is in updates-from-main section

### DIFF
--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -164,7 +164,7 @@ once ready, snap/tag the components to complete the merge.`;
       })
     ).join('\n');
     if (!body) {
-      return `${chalk.bold(`the merge has been canceled on ${failedComponents.length} component(s) legitimately`)}
+      return `${chalk.bold(`\nthe merge has been canceled on ${failedComponents.length} component(s) legitimately`)}
 (use --verbose to list them next time)`;
     }
     return `\n${chalk.underline(title)}\n${body}\n\n`;

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -188,11 +188,13 @@ export default class ComponentsList {
       const componentsFromFs = await this.getComponentsFromFS(loadOpts);
       const componentsFromModel = await this.getModelComponents();
       const duringMergeComps = this.listDuringMergeStateComponents();
+      const updatesFromMain = await this.listUpdatesFromMainPending();
       this._mergePendingComponents = (
         await Promise.all(
           componentsFromFs.map(async (component: Component) => {
             const modelComponent = componentsFromModel.find((c) => c.toBitId().isEqualWithoutVersion(component.id));
             if (!modelComponent || duringMergeComps.hasWithoutScopeAndVersion(component.id)) return null;
+            if (updatesFromMain.find((item) => item.id.isEqualWithoutVersion(component.id))) return null;
             await modelComponent.setDivergeData(this.scope.objects);
             const divergedData = modelComponent.getDivergeData();
             if (!modelComponent.getDivergeData().isDiverged()) return null;


### PR DESCRIPTION
It can happen when merging laneA to laneB, and comp1 is newly introduced to laneB, so on laneB remote it doesn't exist. 
This PR removes these entries as they are not needed. Getting updates from main (by "bit lane merge main") helps to resolve these as well.