### PR TITLE
remove duplications from getAllVersionsInfo and fix bit-checkout of empty files

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -249,9 +249,9 @@ describe('merge lanes', function () {
       const log = helper.command.logParsed('comp1');
       expect(log).to.have.lengthOf(2);
 
-      expect(log[0].hash).to.equal(headOnLane);
-      expect(log[0].parents[0]).to.equal(headOnMain);
-      expect(log[1].hash).to.equal(headOnMain);
+      expect(log[0].hash).to.equal(headOnMain);
+      expect(log[1].hash).to.equal(headOnLane);
+      expect(log[1].parents[0]).to.equal(headOnMain);
     });
   });
   describe('partial merge', () => {

--- a/scopes/component/component-log/log-cmd.ts
+++ b/scopes/component/component-log/log-cmd.ts
@@ -28,6 +28,7 @@ export default class LogCmd implements Command {
       return logs.join('\n');
     }
     const logs = await this.componentLog.getLogs(id, remote);
+    // reverse to show from the latest to earliest
     return logs.reverse().map(paintLog).join('\n');
   }
 

--- a/src/consumer/versions-ops/checkout-version.ts
+++ b/src/consumer/versions-ops/checkout-version.ts
@@ -128,7 +128,7 @@ export function applyModifiedVersion(
     if (file.conflict) {
       foundFile.contents = Buffer.from(file.conflict);
       filesStatus[file.filePath] = FileStatus.manual;
-    } else if (file.output) {
+    } else if (typeof file.output === 'string') {
       foundFile.contents = Buffer.from(file.output);
       filesStatus[file.filePath] = FileStatus.merged;
     } else if (file.isBinaryConflict) {

--- a/src/consumer/versions-ops/merge-version/merge-version.ts
+++ b/src/consumer/versions-ops/merge-version/merge-version.ts
@@ -203,7 +203,7 @@ function applyModifiedVersion(
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       foundFile.contents = Buffer.from(file.conflict);
       filesStatus[file.filePath] = FileStatus.manual;
-    } else if (file.output) {
+    } else if (typeof file.output === 'string') {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       foundFile.contents = Buffer.from(file.output);
       filesStatus[file.filePath] = FileStatus.merged;

--- a/src/scope/component-ops/traverse-versions.ts
+++ b/src/scope/component-ops/traverse-versions.ts
@@ -10,6 +10,7 @@
  * methods here.
  */
 
+import pMapSeries from 'p-map-series';
 import { HeadNotFound, ParentNotFound, VersionNotFound } from '../exceptions';
 import { ModelComponent, Version } from '../models';
 import { Ref, Repository } from '../objects';
@@ -49,6 +50,9 @@ export async function getAllVersionsInfo({
   stopAt?: Ref | null; // by default, stop when the parents is empty
 }): Promise<VersionInfo[]> {
   const results: VersionInfo[] = [];
+  const isAlreadyProcessed = (ref: Ref): boolean => {
+    return Boolean(results.find((result) => result.ref.isEqual(ref)));
+  };
   const getVersionObj = async (ref: Ref): Promise<Version | undefined> => {
     if (versionObjects) return versionObjects.find((v) => v.hash().isEqual(ref));
     if (repo) return (await ref.load(repo)) as Version;
@@ -60,63 +64,60 @@ export async function getAllVersionsInfo({
   };
 
   const laneHead = getRefToStartFrom();
-  let stopped = false;
   const headOnMain = modelComponent.getHead()?.toString();
   let foundOnMain = laneHead?.toString() === headOnMain;
-  if (laneHead) {
-    const headInfo: VersionInfo = {
-      ref: laneHead,
-      tag: modelComponent.getTagOfRefIfExists(laneHead),
-      parents: [],
-      onLane: !foundOnMain,
-    };
-    const head = await getVersionObj(laneHead);
-    if (head) {
-      if (stopAt && stopAt.isEqual(head.hash())) {
-        return [];
-      }
-      headInfo.version = head;
-      headInfo.parents = head.parents;
-    } else {
-      headInfo.error = new HeadNotFound(modelComponent.id(), laneHead.toString());
-      if (throws) throw headInfo.error;
-    }
-    results.push(headInfo);
-    const addParentsRecursively = async (version: Version) => {
-      await Promise.all(
-        version.parents.map(async (parent) => {
-          if (stopAt && stopAt.isEqual(parent)) {
-            stopped = true;
-            return;
-          }
-          const parentVersion = await getVersionObj(parent);
-          if (!foundOnMain) foundOnMain = parentVersion?._hash === headOnMain;
-          const versionInfo: VersionInfo = {
-            ref: parent,
-            tag: modelComponent.getTagOfRefIfExists(parent),
-            isPartOfHistory: true,
-            parents: parentVersion?.parents || [],
-            onLane: !foundOnMain,
-          };
-          if (parentVersion) {
-            versionInfo.version = parentVersion;
-          } else {
-            versionInfo.error = versionInfo.tag
-              ? new VersionNotFound(versionInfo.tag, modelComponent.id())
-              : new ParentNotFound(modelComponent.id(), version.hash().toString(), parent.toString());
-            if (throws) throw versionInfo.error;
-          }
-          results.push(versionInfo);
-          if (parentVersion) await addParentsRecursively(parentVersion);
-        })
-      );
-    };
-    if (head) await addParentsRecursively(head);
+  if (!laneHead) {
+    return results;
   }
-  // @todo: make sure the "stopped" is working. seems like it doesn't do anything now.
-  // previously, this function was longer and continued traversing all tags to find legacy Version objects that didn't
-  // have parents.
-  if (stopped) return results;
+  const headInfo: VersionInfo = {
+    ref: laneHead,
+    tag: modelComponent.getTagOfRefIfExists(laneHead),
+    parents: [],
+    onLane: !foundOnMain,
+  };
+  const head = await getVersionObj(laneHead);
+  if (head) {
+    if (stopAt && stopAt.isEqual(head.hash())) {
+      return [];
+    }
+    headInfo.version = head;
+    headInfo.parents = head.parents;
+  } else {
+    headInfo.error = new HeadNotFound(modelComponent.id(), laneHead.toString());
+    if (throws) throw headInfo.error;
+  }
+  results.push(headInfo);
+  const addParentsRecursively = async (version: Version) => {
+    await pMapSeries(version.parents, async (parent) => {
+      if (stopAt && stopAt.isEqual(parent)) {
+        return;
+      }
+      if (isAlreadyProcessed(parent)) {
+        // happens when there are two parents at some point, and then they merged
+        return;
+      }
+      const parentVersion = await getVersionObj(parent);
+      if (!foundOnMain) foundOnMain = parentVersion?._hash === headOnMain;
+      const versionInfo: VersionInfo = {
+        ref: parent,
+        tag: modelComponent.getTagOfRefIfExists(parent),
+        isPartOfHistory: true,
+        parents: parentVersion?.parents || [],
+        onLane: !foundOnMain,
+      };
+      if (parentVersion) {
+        versionInfo.version = parentVersion;
+      } else {
+        versionInfo.error = versionInfo.tag
+          ? new VersionNotFound(versionInfo.tag, modelComponent.id())
+          : new ParentNotFound(modelComponent.id(), version.hash().toString(), parent.toString());
+        if (throws) throw versionInfo.error;
+      }
+      results.push(versionInfo);
+      if (parentVersion) await addParentsRecursively(parentVersion);
+    });
+  };
+  if (head) await addParentsRecursively(head);
   return results;
 }
 

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -397,10 +397,13 @@ export default class Component extends BitObject {
     return versionStr || VERSION_ZERO;
   }
 
+  /**
+   * get component log and sort by the timestamp in ascending order (from the earliest to the latest)
+   */
   async collectLogs(repo: Repository, shortHash = false, startFrom?: Ref): Promise<ComponentLog[]> {
     const versionsInfo = await getAllVersionsInfo({ modelComponent: this, repo, throws: false, startFrom });
     const getRef = (ref: Ref) => (shortHash ? ref.toShortString() : ref.toString());
-    return versionsInfo.map((versionInfo) => {
+    const results = versionsInfo.map((versionInfo) => {
       const log = versionInfo.version ? versionInfo.version.log : { message: '<no-data-available>' };
       return {
         ...log, // @ts-ignore
@@ -413,6 +416,13 @@ export default class Component extends BitObject {
         onLane: versionInfo.onLane,
       };
     });
+    // sort from earliest to latest
+    const sorted = results.sort((a: ComponentLog, b: ComponentLog) => {
+      // @ts-ignore
+      if (a.date && b.date) return a.date - b.date;
+      return 0;
+    });
+    return sorted;
   }
 
   collectVersions(repo: Repository): Promise<ConsumerComponent[]> {


### PR DESCRIPTION
## Proposed Changes

- fix bit-log to not show duplicate entries when history is split by having two parents.
- fix bit-checkout to not throw an error when one of the file versions removes the content from the file.
- add e2e-tests for merge-lanes when the local lane has soft-removed components.
