### PR TITLE
fix sort + limit logs entries on components

### DIFF
--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -128,13 +128,13 @@ export class Component implements IComponent {
     };
 
     let filteredLogs = (type && allLogs.filter(typeFilter)) || allLogs;
+    if (sort !== 'asc') filteredLogs = filteredLogs.reverse();
+
     if (limit) {
       filteredLogs = slice(filteredLogs, offset, limit + (offset || 0));
     }
 
-    if (sort && sort === 'asc') return filteredLogs;
-
-    return filteredLogs.reverse();
+    return filteredLogs;
   }
 
   stringify(): string {


### PR DESCRIPTION
When running sort and limit on components' logs, make sure to run sort before the limit