### PR TITLE
fix(import): import components from main even when they do not have head

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -960,6 +960,26 @@ describe('bit lane command', function () {
       expect(() => helper.command.export()).to.throw('cannot find scope');
     });
   });
+  describe('multiple scopes when the origin-scope exits but does not have the component. only lane-scope has it', () => {
+    let anotherRemote: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope(anotherRemote, 'comp1');
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    // should not throw an error "the component {component-name} has no versions and the head is empty."
+    it('bit import should not throw an error', () => {
+      expect(() => helper.command.import()).to.not.throw();
+    });
+  });
   describe('snapping and un-tagging on a lane', () => {
     let afterFirstSnap: string;
     before(() => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -467,7 +467,6 @@ describe('merge lanes', function () {
 
       helper.scopeHelper.getClonedLocalScope(afterLaneExport);
       helper.command.import();
-      helper.command.fetchAllComponents(); // todo: this should not be needed. "bit import" should do that
     });
     it('bit status should have the component as pendingUpdatesFromMain with an noCommonSnap error', () => {
       const status = helper.command.statusJson();
@@ -513,7 +512,6 @@ describe('merge lanes', function () {
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
         helper.scopeHelper.getClonedLocalScope(afterLaneExport);
-        helper.command.fetchAllComponents(); // todo: this should not be needed. "bit import" should do that
         helper.command.mergeLane('main', '--resolve-unrelated --no-snap');
       });
       it('bit status should show the component as during-merge and staged and not everywhere else', () => {
@@ -545,7 +543,6 @@ describe('merge lanes', function () {
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
         helper.scopeHelper.getClonedLocalScope(afterLaneExport);
-        helper.command.fetchAllComponents(); // todo: this should not be needed. "bit import" should do that
         helper.command.mergeLane('main', '--resolve-unrelated theirs --no-snap');
       });
       it('bit status should show the component as during-merge and staged and not everywhere else', () => {
@@ -569,7 +566,6 @@ describe('merge lanes', function () {
         helper.command.snapAllComponentsWithoutBuild('--unmodified');
         helper.command.export();
         helper.command.switchLocalLane('dev');
-        helper.command.fetchAllComponents(); // todo: this should not be needed. "bit import" should do that
         helper.command.mergeLane('main', '--resolve-unrelated');
         laneHeadAfterMerge = helper.command.getHeadOfLane('dev', 'comp1');
         helper.command.export();

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -436,6 +436,7 @@ describe('merge lanes', function () {
   });
   describe('multiple scopes when a component in the origin is different than on the lane', () => {
     let originRemote: string;
+    let originPath: string;
     let afterLaneExport: string;
     let mainHead: string;
     let laneScopeHead: string;
@@ -445,6 +446,7 @@ describe('merge lanes', function () {
       helper.bitJsonc.setupDefault();
       const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
       originRemote = scopeName;
+      originPath = scopePath;
       helper.scopeHelper.addRemoteScope(scopePath);
       helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
@@ -512,6 +514,7 @@ describe('merge lanes', function () {
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
         helper.scopeHelper.getClonedLocalScope(afterLaneExport);
+        helper.command.import();
         helper.command.mergeLane('main', '--resolve-unrelated --no-snap');
       });
       it('bit status should show the component as during-merge and staged and not everywhere else', () => {
@@ -543,6 +546,7 @@ describe('merge lanes', function () {
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
         helper.scopeHelper.getClonedLocalScope(afterLaneExport);
+        helper.command.import();
         helper.command.mergeLane('main', '--resolve-unrelated theirs --no-snap');
       });
       it('bit status should show the component as during-merge and staged and not everywhere else', () => {
@@ -559,6 +563,7 @@ describe('merge lanes', function () {
     });
     describe('bit lane merge of another lane that was not resolved yet', () => {
       let laneHeadAfterMerge: string;
+      let beforeMergingSecondLane: string;
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
         helper.scopeHelper.getClonedLocalScope(afterLaneExport);
@@ -566,9 +571,11 @@ describe('merge lanes', function () {
         helper.command.snapAllComponentsWithoutBuild('--unmodified');
         helper.command.export();
         helper.command.switchLocalLane('dev');
+        helper.command.import();
         helper.command.mergeLane('main', '--resolve-unrelated');
         laneHeadAfterMerge = helper.command.getHeadOfLane('dev', 'comp1');
         helper.command.export();
+        beforeMergingSecondLane = helper.scopeHelper.cloneLocalScope();
         helper.command.mergeLane('dev2', '--resolve-unrelated');
       });
       it('should keep the local history and not the dev2 history because the current history has been already resolved', () => {
@@ -580,6 +587,25 @@ describe('merge lanes', function () {
       it('bit status should not show components as pendingUpdatesFromMain', () => {
         const status = helper.command.statusJson();
         expect(status.pendingUpdatesFromMain).to.have.lengthOf(0);
+      });
+      // it's a complex scenario. in short:
+      // main has 0.0.1 and 0.0.2
+      // dev lane resolved unrelated when main was on 0.0.1
+      // now when merging dev to dev2, the component-head (0.0.2) can't be found in the local-snaps of dev
+      describe('when main got another tag meanwhile', () => {
+        before(() => {
+          helper.scopeHelper.reInitLocalScopeHarmony();
+          helper.scopeHelper.addRemoteScope(originPath);
+          helper.command.import(`${originRemote}/comp1`);
+          helper.command.tagAllWithoutBuild('--unmodified');
+          helper.command.export();
+
+          helper.scopeHelper.getClonedLocalScope(beforeMergingSecondLane);
+          helper.command.import();
+        });
+        it('should be able to merge with no errors', () => {
+          expect(() => helper.command.mergeLane('dev2', '--resolve-unrelated')).to.not.throw();
+        });
       });
     });
   });

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -124,13 +124,15 @@ export default class ImportComponents {
       lane,
     });
 
-    // import lane components from their original scope, this way, it's possible to run diff/merge on them
+    // import lane components from their original scope, this way, it's possible to run diff/merge on them.
+    // don't use `scope.getDefaultLaneIdsFromLane()`. we need all components, because it's possible that a component
+    // does't have "head" locally although it exits in the origin-scope. it happens when the component was created on
+    // the origin-scope after a component with the same-name was created on the lane
     if (lane) {
-      const mainIds = await this.scope.getDefaultLaneIdsFromLane(lane);
-      const mainIdsLatest = BitIds.fromArray(mainIds.map((m) => m.changeVersion(undefined)));
       // @todo: optimize this maybe. currently, it imports twice.
       // try to make the previous `importComponentsObjectsHarmony` import the same component once from the original
       // scope and once from the lane-scope.
+      const mainIdsLatest = BitIds.fromArray(lane.toBitIds().map((m) => m.changeVersion(undefined)));
       await this.consumer.importComponentsObjects(mainIdsLatest, {
         allHistory: this.options.allHistory,
         ignoreMissingHead: true,

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -377,7 +377,7 @@ export default class Consumer {
     loader.start(`import ${ids.length} components with their dependencies (if missing)`);
     const versionDependenciesArr: VersionDependencies[] = fromOriginalScope
       ? await scopeComponentsImporter.importManyFromOriginalScopes(ids)
-      : await scopeComponentsImporter.importMany({ ids, lanes: lane ? [lane] : undefined });
+      : await scopeComponentsImporter.importMany({ ids, ignoreMissingHead, lanes: lane ? [lane] : undefined });
     const componentWithDependencies = await multipleVersionDependenciesToConsumer(
       versionDependenciesArr,
       this.scope.objects

--- a/src/scope/exceptions/no-head-no-version.ts
+++ b/src/scope/exceptions/no-head-no-version.ts
@@ -1,0 +1,10 @@
+import { BitError } from '@teambit/bit-error';
+
+export class NoHeadNoVersion extends BitError {
+  constructor(id: string) {
+    super(`the component ${id} has no versions and the head is empty.
+this is probably a component from another lane which should not be loaded in this lane (or main).
+if this component is on a lane, make sure to ask for it with a version.
+if that's not the case, make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`);
+  }
+}

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -38,6 +38,7 @@ import { getLatestVersion } from '../../utils/semver-helper';
 import { ObjectItem } from '../objects/object-list';
 import { getRefsFromExtensions } from '../../consumer/component/sources/artifact-files';
 import { SchemaName } from '../../consumer/component/component-schema';
+import { NoHeadNoVersion } from '../exceptions/no-head-no-version';
 
 type State = {
   versions?: {
@@ -715,10 +716,7 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     const versionNum = versionParsed.latest ? this.latest() : versionParsed.resolve(this.listVersionsIncludeOrphaned());
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (versionNum === VERSION_ZERO) {
-      throw new Error(`the component ${this.id()} has no versions and the head is empty.
-this is probably a component from another lane which should not be loaded in this lane (or main).
-if this component is on a lane, make sure to ask for it with a version.
-if that's not the case, make sure to call "getAllIdsAvailableOnLane" and not "getAllBitIdsFromAllLanes"`);
+      throw new NoHeadNoVersion(this.id());
     }
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     if (isTag(versionNum) && !this.hasTagIncludeOrphaned(versionNum!)) {


### PR DESCRIPTION
- when on a lane, import components from main even when they do not have head because it's possible that a component was created later on the origin-scope.
- fix resolve-unrelated case of bit-lane-merge when main got more snaps after a lane was resolved and the current lane is merging that lane. 