### PR TITLE
fix(bit-switch): set "exported" prop in bitmap-lane-key correctly

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1230,6 +1230,15 @@ describe('bit lane command', function () {
         expect(lane.forkedFrom.name).to.equal('lane-a');
       });
     });
+    describe('switching back to lane-a', () => {
+      before(() => {
+        helper.command.switchLocalLane('lane-a');
+      });
+      it('bitmap should show the lane as exported', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap[LANE_KEY].exported).to.be.true;
+      });
+    });
   });
   // @todo: fix!
   describe.skip('head on the lane is not in the filesystem', () => {

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -177,11 +177,6 @@ export class LaneSwitcher {
   }
 
   private async saveLanesData() {
-    const saveRemoteLaneToBitmap = () => {
-      if (this.switchProps.remoteLane) {
-        this.consumer.setCurrentLane(this.switchProps.remoteLane.toLaneId());
-      }
-    };
     const throwIfLaneExists = async () => {
       const allLanes = await this.consumer.scope.listLanes();
       if (allLanes.find((l) => l.toLaneId().isEqual(this.laneIdToSwitch))) {
@@ -203,8 +198,7 @@ export class LaneSwitcher {
       }
     }
 
-    saveRemoteLaneToBitmap();
-    this.consumer.setCurrentLane(this.laneIdToSwitch, Boolean(this.switchProps.remoteLane));
+    this.consumer.setCurrentLane(this.laneIdToSwitch, !this.laneToSwitchTo?.isNew);
     this.consumer.bitMap.syncWithLanes(this.laneToSwitchTo);
   }
 }


### PR DESCRIPTION
Currently when switching between local lanes and they're all exported, the prop in bitmap shows "exported: false". this PR fixes it by verifying against the scope.json