### PR TITLE
fix(bit-sign): fetch all history of components that their dists are missing

### DIFF
--- a/src/consumer/component/sources/artifact-files.ts
+++ b/src/consumer/component/sources/artifact-files.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import R from 'ramda';
-import { BitId } from '../../../bit-id';
+import { BitId, BitIds } from '../../../bit-id';
 import ShowDoctorError from '../../../error/show-doctor-error';
 import logger from '../../../logger/logger';
 import { Scope } from '../../../scope';
@@ -139,6 +139,15 @@ export async function importMultipleDistsArtifacts(scope: Scope, components: Com
   );
   const extensionsNamesForDistArtifacts = 'teambit.compilation/compiler';
   const lane = await scope.getCurrentLaneObject();
+  const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
+  if (lane) {
+    // when on lane, locally, it's possible that not all components have their entire history (e.g. during "bit sign").
+    // as a result, the following "scope.isIdOnLane" fails to traverse the history.
+    // in terms of performance it's not ideal. once we have the lane-history, it'll be faster to get this data.
+    const compsIds = BitIds.fromArray(components.map((c) => c.id));
+    const compsToImport = BitIds.uniqFromArray(lane?.toBitIds().filter((id) => compsIds.hasWithoutVersion(id)) || []);
+    await scopeComponentsImporter.importManyDeltaWithoutDeps(compsToImport, true, lane, true);
+  }
   const groupedHashes: { [scopeName: string]: string[] } = {};
   const debugHashesOrigin = {};
   await Promise.all(
@@ -161,7 +170,6 @@ export async function importMultipleDistsArtifacts(scope: Scope, components: Com
       });
     })
   );
-  const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
   try {
     await scopeComponentsImporter.importManyObjects(groupedHashes);
   } catch (err) {


### PR DESCRIPTION
Currently, in some cases it throws `ParentNotFound` during `bit sign`. With this PR, before we check whether an id is on the lane, we fetch all history of that component.