### PR TITLE
fix(isolator): write the package.json inside capsules with valid version when it is a snap

### DIFF
--- a/src/consumer/component/package-json-utils.ts
+++ b/src/consumer/component/package-json-utils.ts
@@ -1,17 +1,15 @@
 import fs from 'fs-extra';
 import R from 'ramda';
 import { compact } from 'lodash';
-import { BitId, BitIds } from '../../bit-id';
+import { BitId } from '../../bit-id';
 import logger from '../../logger/logger';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
 import getNodeModulesPathOfComponent from '../../utils/bit/component-node-modules-path';
-import { PathLinux, pathNormalizeToLinux, PathOsBasedAbsolute } from '../../utils/path';
+import { PathOsBasedAbsolute } from '../../utils/path';
 import Component from '../component/consumer-component';
 import Consumer from '../consumer';
 import PackageJson from './package-json';
 import PackageJsonFile from './package-json-file';
-import BitMap from '../bit-map';
-import ComponentMap from '../bit-map/component-map';
 
 export async function addComponentsWithVersionToRoot(consumer: Consumer, components: Component[]) {
   const componentsToAdd = R.fromPairs(
@@ -45,48 +43,6 @@ export async function removeComponentsFromWorkspacesAndDependencies(
   await removeComponentsFromNodeModules(consumer, components);
 }
 
-export function preparePackageJsonToWrite(
-  bitMap: BitMap,
-  component: Component,
-  bitDir: string,
-  override = true,
-  ignoreBitDependencies: BitIds | boolean = true,
-  isIsolated?: boolean
-): { packageJson: PackageJsonFile; distPackageJson: PackageJsonFile | null | undefined } {
-  logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}. override ${override.toString()}`);
-  const getBitDependencies = (dependencies: BitIds) => {
-    if (ignoreBitDependencies === true) return {};
-    return dependencies.reduce((acc, depId: BitId) => {
-      if (Array.isArray(ignoreBitDependencies) && ignoreBitDependencies.searchWithoutVersion(depId)) return acc;
-      const packageDependency = getPackageDependency(bitMap, depId);
-      const packageName = componentIdToPackageName({
-        ...component,
-        id: depId,
-        isDependency: true,
-      });
-      acc[packageName] = packageDependency;
-      return acc;
-    }, {});
-  };
-  const bitDependencies = getBitDependencies(component.dependencies.getAllIds());
-  const bitDevDependencies = getBitDependencies(component.devDependencies.getAllIds());
-  const bitExtensionDependencies = getBitDependencies(component.extensions.extensionsBitIds);
-  const packageJson = PackageJsonFile.createFromComponent(bitDir, component, isIsolated);
-  const main = pathNormalizeToLinux(component.mainFile);
-  packageJson.addOrUpdateProperty('main', main);
-  const addDependencies = (packageJsonFile: PackageJsonFile) => {
-    packageJsonFile.addDependencies(bitDependencies);
-    packageJsonFile.addDevDependencies({
-      ...bitDevDependencies,
-      ...bitExtensionDependencies,
-    });
-  };
-  addDependencies(packageJson);
-  let distPackageJson;
-
-  return { packageJson, distPackageJson };
-}
-
 async function _addDependenciesPackagesIntoPackageJson(dir: PathOsBasedAbsolute, dependencies: Record<string, any>) {
   const packageJsonFile = await PackageJsonFile.load(dir);
   packageJsonFile.addDependencies(dependencies);
@@ -101,30 +57,4 @@ export async function removeComponentsFromNodeModules(consumer: Consumer, compon
   const pathsToRemove = compact(pathsToRemoveWithNulls);
   logger.debug(`deleting the following paths: ${pathsToRemove.join('\n')}`);
   return Promise.all(pathsToRemove.map((componentPath) => fs.remove(consumer.toAbsolutePath(componentPath))));
-}
-
-export function convertToValidPathForPackageManager(pathStr: PathLinux): string {
-  const prefix = 'file:'; // it works for both, Yarn and NPM
-  return prefix + (pathStr.startsWith('.') ? pathStr : `./${pathStr}`);
-}
-
-/**
- * Only imported components should be saved with relative path in package.json
- * If a component is nested or imported as a package dependency, it should be saved with the version
- * If a component is authored, no need to save it as a dependency of the imported component because
- * the root package.json takes care of it already.
- */
-function getPackageDependencyValue(
-  dependencyId: BitId,
-  dependencyComponentMap?: ComponentMap | null | undefined
-): string | null | undefined {
-  if (!dependencyComponentMap) {
-    return dependencyId.version;
-  }
-  return null;
-}
-
-function getPackageDependency(bitMap: BitMap, dependencyId: BitId): string | null | undefined {
-  const dependencyComponentMap = bitMap.getComponentIfExist(dependencyId);
-  return getPackageDependencyValue(dependencyId, dependencyComponentMap);
 }


### PR DESCRIPTION
currently, in some occurrences (during bit-sign), when a component version is a hash (snap) its package.json inside the capsule has the hash as the version.