### PR TITLE
refactor: remove onTag slot, call builder directory during tag/snap

### DIFF
--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -8,10 +8,9 @@ import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import { LoggerAspect, LoggerMain } from '@teambit/logger';
-import { ScopeAspect, ScopeMain, OnTagResults } from '@teambit/scope';
+import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { IsolateComponentsOptions, IsolatorAspect, IsolatorMain } from '@teambit/isolator';
-import { OnTagOpts } from '@teambit/legacy/dist/scope/scope';
 import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import findDuplications from '@teambit/legacy/dist/utils/array/find-duplications';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
@@ -32,6 +31,14 @@ import { buildTaskTemplate } from './templates/build-task';
 import { BuilderRoute } from './builder.route';
 
 export type TaskSlot = SlotRegistry<BuildTask[]>;
+export type OnTagResults = { builderDataMap: ComponentMap<RawBuilderData>; pipeResults: TaskResultsList[] };
+export type OnTagOpts = {
+  disableTagAndSnapPipelines?: boolean;
+  throwOnError?: boolean; // on the CI it helps to save the results on failure so this is set to false
+  forceDeploy?: boolean; // whether run the deploy-pipeline although the build-pipeline has failed
+  skipTests?: boolean;
+  isSnap?: boolean;
+};
 export const FILE_PATH_PARAM_DELIM = '~';
 
 /**
@@ -387,8 +394,6 @@ export class BuilderMain {
     component.registerRoute([new BuilderRoute(builder, scope, logger)]);
     graphql.register(builderSchema(builder));
     generator.registerComponentTemplate([buildTaskTemplate]);
-    const func = builder.tagListener.bind(builder);
-    if (scope) scope.onTag(func);
     const commands = [new BuilderCmd(builder, workspace, logger), new ArtifactsCmd(builder, scope)];
     cli.register(...commands);
 

--- a/scopes/scope/scope/index.ts
+++ b/scopes/scope/scope/index.ts
@@ -2,7 +2,7 @@ import { ScopeAspect } from './scope.aspect';
 
 export { ComponentNotFound, NoIdMatchPattern } from './exceptions';
 export { ScopeComponentCard } from './ui/scope-overview/scope-overview';
-export type { ScopeMain, OnTag, OnTagResults } from './scope.main.runtime';
+export type { ScopeMain } from './scope.main.runtime';
 export type { ScopeModel } from '@teambit/scope.models.scope-model';
 export { ScopeContext } from '@teambit/scope.ui.hooks.scope-context';
 export type { ScopeUI, ScopeBadgeSlot, ScopeOverview, ScopeOverviewSlot, OverviewLineSlot } from './scope.ui.runtime';

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -2,7 +2,7 @@ import mapSeries from 'p-map-series';
 import semver from 'semver';
 import multimatch from 'multimatch';
 import type { AspectLoaderMain } from '@teambit/aspect-loader';
-import { TaskResultsList, RawBuilderData, BuilderAspect } from '@teambit/builder';
+import { RawBuilderData, BuilderAspect } from '@teambit/builder';
 import { readdirSync, existsSync } from 'fs-extra';
 import { resolve, join } from 'path';
 import { AspectLoaderAspect, AspectDefinition } from '@teambit/aspect-loader';
@@ -12,7 +12,7 @@ import { Component, ComponentAspect, ComponentFactory, ComponentID, Snap, State 
 import type { GraphqlMain } from '@teambit/graphql';
 import { GraphqlAspect } from '@teambit/graphql';
 import { Harmony, Slot, SlotRegistry, ExtensionManifest, Aspect } from '@teambit/harmony';
-import { Capsule, IsolatorAspect, IsolatorMain, IsolateComponentsOptions } from '@teambit/isolator';
+import { Capsule, IsolatorAspect, IsolatorMain } from '@teambit/isolator';
 import { LoggerAspect, LoggerMain, Logger } from '@teambit/logger';
 import { ExpressAspect, ExpressMain } from '@teambit/express';
 import type { UiMain } from '@teambit/ui';
@@ -22,7 +22,7 @@ import { BitId } from '@teambit/legacy-bit-id';
 import { BitIds as ComponentsIds } from '@teambit/legacy/dist/bit-id';
 import { ModelComponent, Lane } from '@teambit/legacy/dist/scope/models';
 import { Repository } from '@teambit/legacy/dist/scope/objects';
-import LegacyScope, { LegacyOnTagResult, OnTagFunc, OnTagOpts } from '@teambit/legacy/dist/scope/scope';
+import LegacyScope, { LegacyOnTagResult } from '@teambit/legacy/dist/scope/scope';
 import { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
 import { loadScopeIfExist } from '@teambit/legacy/dist/scope/scope-loader';
 import { PersistOptions } from '@teambit/legacy/dist/scope/types';
@@ -56,16 +56,7 @@ import { ScopeCmd } from './scope-cmd';
 import { StagedConfig } from './staged-config';
 import { NoIdMatchPattern } from './exceptions/no-id-match-pattern';
 
-type TagRegistry = SlotRegistry<OnTag>;
-
 type ManifestOrAspect = ExtensionManifest | Aspect;
-
-export type OnTagResults = { builderDataMap: ComponentMap<RawBuilderData>; pipeResults: TaskResultsList[] };
-export type OnTag = (
-  components: Component[],
-  options: OnTagOpts,
-  isolateOptions?: IsolateComponentsOptions
-) => Promise<OnTagResults>;
 
 type RemoteEventMetadata = { auth?: AuthData; headers?: {} };
 type RemoteEvent<Data> = (data: Data, metadata: RemoteEventMetadata, errors?: Array<string | Error>) => Promise<void>;
@@ -115,8 +106,6 @@ export class ScopeMain implements ComponentFactory {
 
     readonly config: ScopeConfig,
 
-    private tagRegistry: TagRegistry,
-
     private postPutSlot: OnPostPutSlot,
 
     private postDeleteSlot: OnPostDeleteSlot,
@@ -163,26 +152,6 @@ export class ScopeMain implements ComponentFactory {
 
   get isLegacy(): boolean {
     return this.legacyScope.isLegacy;
-  }
-
-  /**
-   * register to the tag slot.
-   */
-  onTag(tagFn: OnTag) {
-    const host = this.componentExtension.getHost();
-    const legacyOnTagFunc: OnTagFunc = async (
-      legacyComponents: ConsumerComponent[],
-      options: OnTagOpts,
-      isolateOptions?: IsolateComponentsOptions
-    ): Promise<LegacyOnTagResult[]> => {
-      // Reload the aspects with their new version
-      await this.reloadAspectsWithNewVersion(legacyComponents);
-      const components = await host.getManyByLegacy(legacyComponents);
-      const { builderDataMap } = await tagFn(components, options, isolateOptions);
-      return this.builderDataMapToLegacyOnTagResults(builderDataMap);
-    };
-    this.legacyScope.onTag.push(legacyOnTagFunc);
-    this.tagRegistry.register(tagFn);
   }
 
   // We need to reload the aspects with their new version since:
@@ -523,7 +492,7 @@ needed-for: ${neededFor || '<unknown>'}`);
           packageManagerConfigRootDir: opts?.packageManagerConfigRootDir,
           useNesting: true,
           copyPeerToRuntimeOnComponents: true,
-          installPeersFromEnvs: true
+          installPeersFromEnvs: true,
         },
       },
       this.legacyScope
@@ -677,7 +646,7 @@ needed-for: ${neededFor || '<unknown>'}`);
           dedupe: false,
           useNesting: true,
           copyPeerToRuntimeOnComponents: true,
-          installPeersFromEnvs: true
+          installPeersFromEnvs: true,
         },
         host: this,
       },
@@ -725,7 +694,7 @@ needed-for: ${neededFor || '<unknown>'}`);
     if (componentIds && componentIds.length) {
       const groupedByIsCore = groupBy(componentIds, (id) => coreAspectsIds.includes(id.toString()));
       userAspectsIds = groupedByIsCore.false || [];
-      requestedCoreStringIds = groupedByIsCore.true?.map(id => id.toStringWithoutVersion()) || [];
+      requestedCoreStringIds = groupedByIsCore.true?.map((id) => id.toStringWithoutVersion()) || [];
     } else {
       userAspectsIds = await this.resolveMultipleComponentIds(this.aspectLoader.getUserAspects());
     }
@@ -745,12 +714,12 @@ needed-for: ${neededFor || '<unknown>'}`);
       const userAspectsIdsWithoutVersion = userAspectsIds.map((aspectId) => aspectId.toStringWithoutVersion());
       const userAspectsIdsWithoutVersionAndCoreRequested = userAspectsIdsWithoutVersion.concat(requestedCoreStringIds);
       afterExclusion = allDefs.filter((def) => {
-          const id = ComponentID.fromString(def.getId || '');
-          const isTarget = userAspectsIdsWithoutVersionAndCoreRequested.includes(id.toStringWithoutVersion());
-          // If it's core, but requested explicitly, keep it
-          if (isTarget) return true;
-          const isCore = coreAspectsDefs.find((coreId) => def.getId === coreId.getId);
-          return !isCore;
+        const id = ComponentID.fromString(def.getId || '');
+        const isTarget = userAspectsIdsWithoutVersionAndCoreRequested.includes(id.toStringWithoutVersion());
+        // If it's core, but requested explicitly, keep it
+        if (isTarget) return true;
+        const isCore = coreAspectsDefs.find((coreId) => def.getId === coreId.getId);
+        return !isCore;
       });
     }
 
@@ -1118,7 +1087,6 @@ needed-for: ${neededFor || '<unknown>'}`);
    * declare the slots of scope extension.
    */
   static slots = [
-    Slot.withType<OnTag>(),
     Slot.withType<OnPostPut>(),
     Slot.withType<OnPostDelete>(),
     Slot.withType<OnPostExport>(),
@@ -1156,8 +1124,7 @@ needed-for: ${neededFor || '<unknown>'}`);
       EnvsMain
     ],
     config: ScopeConfig,
-    [tagSlot, postPutSlot, postDeleteSlot, postExportSlot, postObjectsPersistSlot, preFetchObjectsSlot]: [
-      TagRegistry,
+    [postPutSlot, postDeleteSlot, postExportSlot, postObjectsPersistSlot, preFetchObjectsSlot]: [
       OnPostPutSlot,
       OnPostDeleteSlot,
       OnPostExportSlot,
@@ -1178,7 +1145,6 @@ needed-for: ${neededFor || '<unknown>'}`);
       legacyScope,
       componentExt,
       config,
-      tagSlot,
       postPutSlot,
       postDeleteSlot,
       postExportSlot,

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -96,21 +96,10 @@ export type LegacyOnTagResult = {
   id: BitId;
   builderData: ExtensionDataEntry;
 };
-export type OnTagOpts = {
-  disableTagAndSnapPipelines?: boolean;
-  throwOnError?: boolean; // on the CI it helps to save the results on failure so this is set to false
-  forceDeploy?: boolean; // whether run the deploy-pipeline although the build-pipeline has failed
-  skipTests?: boolean;
-  isSnap?: boolean;
-};
+
 export type IsolateComponentsOptions = {
   packageManagerConfigRootDir?: string;
 };
-export type OnTagFunc = (
-  components: Component[],
-  options: OnTagOpts,
-  isolateOptions: IsolateComponentsOptions
-) => Promise<LegacyOnTagResult[]>;
 
 export default class Scope {
   created = false;
@@ -142,7 +131,6 @@ export default class Scope {
     this.scopeImporter = ScopeComponentsImporter.getInstance(this);
   }
 
-  public onTag: OnTagFunc[] = []; // enable extensions to hook during the tag process
   static onPostExport: (ids: BitId[], lanes: Lane[]) => Promise<void>; // enable extensions to hook after the export process
 
   /**


### PR DESCRIPTION
Previously, the tag was on legacy and to get the builder aspect running during tag, a few indirections was needed. There indirections weren't trivial and confusing. (tag called legacy-scope, which had the harmony-scope register to its onTag. this onTag registered the builder tagListener which eventually got called during tag).
Now it's easier to just call the builder directly from the Snapping aspect.