### PR TITLE
fix(bit-export): avoid throwing ComponentNotFound when a dependency is missing from non-head

### DIFF
--- a/e2e/harmony/extensions-config.e2e.3.ts
+++ b/e2e/harmony/extensions-config.e2e.3.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 
 import Helper from '../../src/e2e-helper/e2e-helper';
+import { ComponentNotFound } from '../../src/scope/exceptions';
 
 chai.use(require('chai-fs'));
 
@@ -152,8 +153,11 @@ describe('harmony extension config', function () {
             remoteBeforeExport = helper.scopeHelper.cloneRemoteScope();
           });
           it('should block exporting component without exporting the extension', () => {
-            output = helper.general.runWithTryCatch(`bit export bar/foo`);
-            expect(output).to.have.string(`"${helper.scopes.remote}/dummy-extension-without-logs@0.0.1" was not found`);
+            const err = new ComponentNotFound(
+              `${helper.scopes.remote}/dummy-extension-without-logs@0.0.1`,
+              `${helper.scopes.remote}/bar/foo@0.0.1`
+            );
+            helper.general.expectToThrow(() => helper.command.export('bar/foo'), err);
           });
           describe('exporting extension and component together', () => {
             before(() => {

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1257,4 +1257,22 @@ describe('bit lane command', function () {
       expect(() => helper.command.status()).not.to.throw();
     });
   });
+  describe('export when previous versions have deleted dependencies', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.command.removeComponent(`${helper.scopes.remote}/comp3`, '--remote --force');
+      helper.command.removeComponent('comp3', '--force');
+      helper.fs.outputFile('comp2/index.js', ''); // remove the dependency from the code
+      helper.command.tagWithoutBuild();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('should not throw ComponentNotFound on export', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
 });

--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -62,7 +62,7 @@ export interface ComponentFactory {
    */
   getRemoteComponent?: (id: ComponentID) => Promise<Component>;
 
-  getLegacyGraph(ids?: ComponentID[]): Promise<LegacyGraph>;
+  getLegacyGraph(ids?: ComponentID[], shouldThrowOnMissingDep?: boolean): Promise<LegacyGraph>;
 
   getLogs(id: ComponentID, shortHash?: boolean, startsFrom?: string): Promise<ComponentLog[]>;
 

--- a/scopes/component/graph/graph-builder.ts
+++ b/scopes/component/graph/graph-builder.ts
@@ -25,7 +25,7 @@ export class GraphBuilder {
   async getGraph(ids?: ComponentID[], opts: GetGraphOpts = {}): Promise<ComponentGraph> {
     const componentHost = opts.host || this.componentAspect.getHost();
 
-    const legacyGraph = await componentHost.getLegacyGraph(ids);
+    const legacyGraph = await componentHost.getLegacyGraph(ids, false);
     const graph = await this.buildFromLegacy(legacyGraph, { host: opts.host });
     this._graph = graph;
     this._initialized = true;

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -5,10 +5,11 @@ import BitIds from '@teambit/legacy/dist/bit-id/bit-ids';
 import Component from '@teambit/legacy/dist/consumer/component/consumer-component';
 import LegacyGraph from '@teambit/legacy/dist/scope/graph/graph';
 import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/scope-components-importer';
+import { ComponentNotFound } from '@teambit/legacy/dist/scope/exceptions';
+import { ComponentNotFound as ComponentNotFoundInScope } from '@teambit/scope';
 import compact from 'lodash.compact';
 import { BitId } from '@teambit/legacy-bit-id';
 import { Logger } from '@teambit/logger';
-import { ComponentNotFound } from '@teambit/scope';
 import { BitError } from '@teambit/bit-error';
 import { Workspace } from './workspace';
 
@@ -62,7 +63,7 @@ export class GraphFromFsBuilder {
   async buildGraph(ids: BitId[]): Promise<LegacyGraph> {
     this.logger.debug(`GraphFromFsBuilder, buildGraph with ${ids.length} seeders`);
     const start = Date.now();
-    const components = await this.loadManyComponents(ids, '<none>');
+    const components = await this.loadManyComponents(ids);
     await this.processManyComponents(components);
     this.logger.debug(
       `GraphFromFsBuilder, buildGraph with ${ids.length} seeders completed (${(Date.now() - start) / 1000} sec)`
@@ -102,6 +103,7 @@ export class GraphFromFsBuilder {
     await scopeComponentsImporter.importMany({
       ids: BitIds.uniqFromArray(allDepsWithScope),
       throwForDependencyNotFound: this.shouldThrowOnMissingDep,
+      throwForSeederNotFound: this.shouldThrowOnMissingDep,
     });
   }
 
@@ -115,7 +117,11 @@ export class GraphFromFsBuilder {
       depsIds.forEach((depId) => {
         if (this.ignoreIds.has(depId)) return;
         if (!this.graph.hasNode(depId.toString())) {
-          throw new Error(`buildOneComponent: missing node of ${depId.toString()}`);
+          if (this.shouldThrowOnMissingDep) {
+            throw new Error(`buildOneComponent: missing node of ${depId.toString()}`);
+          }
+          this.logger.warn(`ignoring missing ${depId.toString()}`);
+          return;
         }
         this.graph.setEdge(idStr, depId.toString(), depType);
       });
@@ -124,7 +130,7 @@ export class GraphFromFsBuilder {
     return allDependencies;
   }
 
-  private async loadManyComponents(componentsIds: BitId[], dependenciesOf: string): Promise<Component[]> {
+  private async loadManyComponents(componentsIds: BitId[], dependenciesOf?: string): Promise<Component[]> {
     const components = await mapSeries(componentsIds, async (comp: BitId) => {
       const idStr = comp.toString();
       const fromGraph = this.graph.node(idStr);
@@ -134,12 +140,20 @@ export class GraphFromFsBuilder {
         this.graph.setNode(idStr, component);
         return component;
       } catch (err: any) {
-        if (err instanceof ComponentNotFound) {
+        if (err instanceof ComponentNotFound || err instanceof ComponentNotFoundInScope) {
+          if (dependenciesOf && !this.shouldThrowOnMissingDep) {
+            this.logger.warn(
+              `component ${idStr}, dependency of ${dependenciesOf} was not found. continuing without it`
+            );
+            return null;
+          }
           throw new BitError(
-            `error: component "${idStr}" was not found.\nthis component is a dependency of "${dependenciesOf}" and is needed as part of the graph generation`
+            `error: component "${idStr}" was not found.\nthis component is a dependency of "${
+              dependenciesOf || '<none>'
+            }" and is needed as part of the graph generation`
           );
         }
-        this.logger.error(`failed loading dependencies of ${dependenciesOf}`);
+        if (dependenciesOf) this.logger.error(`failed loading dependencies of ${dependenciesOf}`);
         throw err;
       }
     });

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -18,13 +18,13 @@ export class GraphFromFsBuilder {
   private graph = new LegacyGraph();
   private completed: string[] = [];
   private depth = 1;
-  private shouldThrowOnMissingDep = true;
   private consumer: Consumer;
   constructor(
     private workspace: Workspace,
     private logger: Logger,
     private ignoreIds = new BitIds(),
-    private shouldLoadItsDeps?: ShouldLoadFunc
+    private shouldLoadItsDeps?: ShouldLoadFunc,
+    private shouldThrowOnMissingDep = true
   ) {
     this.consumer = this.workspace.consumer;
   }

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -5,7 +5,7 @@ import BitIds from '@teambit/legacy/dist/bit-id/bit-ids';
 import Component from '@teambit/legacy/dist/consumer/component/consumer-component';
 import LegacyGraph from '@teambit/legacy/dist/scope/graph/graph';
 import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/scope-components-importer';
-import { ComponentNotFound } from '@teambit/legacy/dist/scope/exceptions';
+import { ComponentNotFound, ScopeNotFound } from '@teambit/legacy/dist/scope/exceptions';
 import { ComponentNotFound as ComponentNotFoundInScope } from '@teambit/scope';
 import compact from 'lodash.compact';
 import { BitId } from '@teambit/legacy-bit-id';
@@ -140,7 +140,11 @@ export class GraphFromFsBuilder {
         this.graph.setNode(idStr, component);
         return component;
       } catch (err: any) {
-        if (err instanceof ComponentNotFound || err instanceof ComponentNotFoundInScope) {
+        if (
+          err instanceof ComponentNotFound ||
+          err instanceof ComponentNotFoundInScope ||
+          err instanceof ScopeNotFound
+        ) {
           if (dependenciesOf && !this.shouldThrowOnMissingDep) {
             this.logger.warn(
               `component ${idStr}, dependency of ${dependenciesOf} was not found. continuing without it`

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -422,12 +422,12 @@ export class Workspace implements ComponentFactory {
     return this.scope.getLogs(id, shortHash, startsFrom);
   }
 
-  async getLegacyGraph(ids?: ComponentID[]): Promise<LegacyGraph> {
+  async getLegacyGraph(ids?: ComponentID[], shouldThrowOnMissingDep = true): Promise<LegacyGraph> {
     if (!ids || ids.length < 1) ids = await this.listIds();
 
     const legacyIds = ids.map((id) => id._legacy);
 
-    const legacyGraph = await this.buildOneGraphForComponents(legacyIds);
+    const legacyGraph = await this.buildOneGraphForComponents(legacyIds, undefined, undefined, shouldThrowOnMissingDep);
     return legacyGraph;
   }
 
@@ -1535,9 +1535,16 @@ needed-for: ${neededFor || '<unknown>'}`);
   async buildOneGraphForComponents(
     ids: BitId[],
     ignoreIds?: BitIds,
-    shouldLoadFunc?: ShouldLoadFunc
+    shouldLoadFunc?: ShouldLoadFunc,
+    shouldThrowOnMissingDep = true
   ): Promise<LegacyGraph> {
-    const graphFromFsBuilder = new GraphFromFsBuilder(this, this.logger, ignoreIds, shouldLoadFunc);
+    const graphFromFsBuilder = new GraphFromFsBuilder(
+      this,
+      this.logger,
+      ignoreIds,
+      shouldLoadFunc,
+      shouldThrowOnMissingDep
+    );
     return graphFromFsBuilder.buildGraph(ids);
   }
 

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -117,7 +117,7 @@ export default class ScopeComponentsImporter {
     logger.debug('importMany', `total missing externals: ${uniqExternals.length}`);
     const remotes = await getScopeRemotes(this.scope);
     // we don't care about the VersionDeps returned here as it may belong to the dependencies
-    await this.getExternalMany(uniqExternals, remotes, throwForDependencyNotFound, lanes);
+    await this.getExternalMany(uniqExternals, remotes, throwForDependencyNotFound, lanes, throwForSeederNotFound);
     const versionDeps = await this.bitIdsToVersionDeps(idsToImport, throwForSeederNotFound);
     logger.debug('importMany, completed!');
     return versionDeps;
@@ -544,7 +544,8 @@ export default class ScopeComponentsImporter {
     ids: BitId[],
     remotes: Remotes,
     throwForDependencyNotFound = false,
-    lanes: Lane[] = []
+    lanes: Lane[] = [],
+    throwOnUnavailableScope = true
   ): Promise<VersionDependencies[]> {
     if (!ids.length) return [];
     if (lanes.length > 1) throw new Error(`getExternalMany support only one lane`);
@@ -575,7 +576,8 @@ export default class ScopeComponentsImporter {
       },
       ids,
       lanes,
-      context
+      context,
+      throwOnUnavailableScope
     ).fetchFromRemoteAndWrite();
     const componentDefs = await this.sources.getMany(ids);
     const versionDeps = await this.multipleCompsDefsToVersionDeps(componentDefs, lanes);

--- a/src/scope/exceptions/component-not-found.ts
+++ b/src/scope/exceptions/component-not-found.ts
@@ -10,7 +10,7 @@ export default class ComponentNotFound extends BitError {
     const baseMsg = dependentId
       ? `error: the component dependency "${chalk.bold(id)}" required by "${chalk.bold(dependentId)}" was not found`
       : `error: component "${chalk.bold(id)}" was not found`;
-    super(`${baseMsg}\nconsider running "bit dependents ${id}" to understand why this component was needed`);
+    super(baseMsg);
     this.code = 127;
     this.id = id;
     this.dependentId = dependentId;

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -570,6 +570,10 @@ export default class Component extends BitObject {
     return new BitId({ scope: this.scope, name: this.name, version: this.latest() });
   }
 
+  toBitIdWithHead(): BitId {
+    return new BitId({ scope: this.scope, name: this.name, version: this.head?.toString() });
+  }
+
   toBitIdWithLatestVersionAllowNull(): BitId {
     const id = this.toBitIdWithLatestVersion();
     return id.version === VERSION_ZERO ? id.changeVersion(undefined) : id;

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -40,7 +40,8 @@ export class ObjectFetcher {
     private fetchOptions: Partial<FETCH_OPTIONS>,
     private ids: BitId[],
     private lanes: Lane[] = [],
-    private context = {}
+    private context = {},
+    private throwOnUnavailableScope = true
   ) {}
 
   public async fetchFromRemoteAndWrite() {
@@ -88,7 +89,7 @@ ${failedScopesErr.join('\n')}`);
   private async fetchFromSingleRemote(scopeName: string, ids: string[]): Promise<ObjectItemsStream | null> {
     // when importing directly from a remote scope, throw for ScopeNotFound. otherwise, when
     // fetching flattened dependencies (withoutDependencies=true), ignore this error
-    const shouldThrowOnUnavailableScope = !this.fetchOptions.withoutDependencies;
+    const shouldThrowOnUnavailableScope = this.throwOnUnavailableScope && !this.fetchOptions.withoutDependencies;
     let remote: Remote;
     try {
       remote = await this.remotes.resolve(scopeName, this.scope);


### PR DESCRIPTION
## Proposed Changes

- when running `bit status` and components have missing dependencies, do not throw an error.
- when exporting components and dependencies are missing from a non-head version, do not throw an error.
- fix the ComponentNotFound message to not suggest running "bit dependent". in most cases it doesn't help and is only confusing.

