### PR TITLE
fix: avoid caching the component-graph

### DIFF
--- a/scopes/component/graph/graph-builder.ts
+++ b/scopes/component/graph/graph-builder.ts
@@ -18,8 +18,6 @@ type BuildFromLegacyGraphOpts = {
  * which makes the _graph prop and other props unpredictable.
  */
 export class GraphBuilder {
-  _graph?: ComponentGraph;
-  _initialized = false;
   constructor(private componentAspect: ComponentMain) {}
 
   async getGraph(ids?: ComponentID[], opts: GetGraphOpts = {}): Promise<ComponentGraph> {
@@ -27,10 +25,8 @@ export class GraphBuilder {
 
     const legacyGraph = await componentHost.getLegacyGraph(ids, false);
     const graph = await this.buildFromLegacy(legacyGraph, { host: opts.host });
-    this._graph = graph;
-    this._initialized = true;
     graph.seederIds = ids || (await componentHost.listIds());
-    return this._graph;
+    return graph;
   }
 
   private async buildFromLegacy(


### PR DESCRIPTION
This graph was cache for no reason. 