### PR TITLE
fix(bit-export): send only objects needed when exporting on lane and do not rely on the cache

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1297,4 +1297,22 @@ describe('bit lane command', function () {
       expect(() => helper.command.importComponent('*')).to.not.throw();
     });
   });
+  describe('export on lane with tiny cache', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.runCmd('bit config set cache.max.objects 1');
+    });
+    after(() => {
+      helper.command.runCmd('bit config del cache.max.objects');
+    });
+    // previously, it was throwing "HeadNotFound"/"ComponentNotFound" when there were many objects in the cache
+    it('should not throw', () => {
+      expect(() => helper.command.export()).not.to.throw();
+    });
+  });
 });

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -327,7 +327,7 @@ export class MergingMain {
     };
     const currentId = getCurrentId();
     if (!currentId) {
-      const divergeData = await getDivergeData(repo, modelComponent, otherLaneHead, null, false);
+      const divergeData = await getDivergeData({ repo, modelComponent, remoteHead: otherLaneHead, throws: false });
       return { currentComponent: null, componentFromModel: componentOnLane, id, mergeResults: null, divergeData };
     }
     const getCurrentComponent = () => {
@@ -360,12 +360,24 @@ export class MergingMain {
     if (!otherLaneHead) {
       throw new Error(`merging: unable finding a hash for the version ${version} of ${id.toString()}`);
     }
-    const divergeData = await getDivergeData(repo, modelComponent, otherLaneHead, localHead, false);
+    const divergeData = await getDivergeData({
+      repo,
+      modelComponent,
+      remoteHead: otherLaneHead,
+      checkedOutLocalHead: localHead,
+      throws: false,
+    });
     if (divergeData.err) {
       const mainHead = modelComponent.head;
       if (divergeData.err instanceof NoCommonSnap && options?.resolveUnrelated && mainHead) {
         const hasResolvedFromMain = async (hashToCompare: Ref | null) => {
-          const divergeDataFromMain = await getDivergeData(repo, modelComponent, mainHead, hashToCompare, false);
+          const divergeDataFromMain = await getDivergeData({
+            repo,
+            modelComponent,
+            remoteHead: mainHead,
+            checkedOutLocalHead: hashToCompare,
+            throws: false,
+          });
           if (!divergeDataFromMain.err) return true;
           return !(divergeDataFromMain.err instanceof NoCommonSnap);
         };

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -266,7 +266,12 @@ export class MergeLanesMain {
         mergedPreviously.push(id);
         return undefined;
       }
-      const divergeData = await getDivergeData(repo, modelComponent, laneHead, mainHead);
+      const divergeData = await getDivergeData({
+        repo,
+        modelComponent,
+        remoteHead: laneHead,
+        checkedOutLocalHead: mainHead,
+      });
       const modifiedVersion = squashOneComp(DEFAULT_LANE, laneId, id, divergeData, versionObj);
       modelComponent.setHead(laneHead);
       const objects = [modelComponent, modifiedVersion];

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -172,7 +172,13 @@ export default class ComponentsList {
         const headOnMain = modelComponent.head;
         const headOnLane = modelComponent.laneHeadLocal;
         if (!headOnMain || !headOnLane) return undefined;
-        const divergeData = await getDivergeData(this.scope.objects, modelComponent, headOnMain, headOnLane, false);
+        const divergeData = await getDivergeData({
+          repo: this.scope.objects,
+          modelComponent,
+          remoteHead: headOnMain,
+          checkedOutLocalHead: headOnLane,
+          throws: false,
+        });
         if (!divergeData.snapsOnRemoteOnly.length && !divergeData.err) return undefined;
         return { id: modelComponent.toBitId(), divergeData };
       })

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -154,14 +154,19 @@ async function throwForMissingLocalDependencies(
       await Promise.all(
         depsIds.map(async (depId) => {
           if (depId.scope !== scope.name) return;
-          const existingModelComponent = await scope.getModelComponentIfExist(depId);
+          const existingModelComponent =
+            (await scope.getModelComponentIfExist(depId)) ||
+            components.find((c) => c.toBitId().isEqualWithoutVersion(depId));
           if (!existingModelComponent) {
             scope.objects.clearCache(); // just in case this error is caught. we don't want to persist anything by mistake.
             throw new ComponentNotFound(depId.toString(), getOriginCompWithVer().toString());
           }
           const versionRef = existingModelComponent.getRef(depId.version as string);
           if (!versionRef) throw new Error(`unable to find Ref/Hash of ${depId.toString()}`);
-          const objectExist = scope.objects.getCache(versionRef) || (await scope.objects.has(versionRef));
+          const objectExist =
+            scope.objects.getCache(versionRef) ||
+            (await scope.objects.has(versionRef)) ||
+            versions.find((v) => v.hash().isEqual(versionRef));
           if (!objectExist) {
             scope.objects.clearCache(); // just in case this error is caught. we don't want to persist anything by mistake.
             throw new ComponentNotFound(depId.toString(), getOriginCompWithVer().toString());

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -84,12 +84,8 @@ export async function mergeObjects(
     ? { mergeResults: [], errors: [] } // for lanes, no need to merge component objects, the lane is merged later.
     : await scope.sources.mergeComponents(components, versions);
 
-  // add all objects to the cache, it is needed for lanes later on. also it might be
-  // good regardless to update the cache with the new data.
-  [...components, ...versions].forEach((bitObject) => scope.objects.setCache(bitObject));
-
   const mergeAllLanesResults = await mapSeries(lanesObjects, (laneObject) =>
-    scope.sources.mergeLane(laneObject, false)
+    scope.sources.mergeLane(laneObject, false, versions, components)
   );
   const lanesErrors = mergeAllLanesResults.map((r) => r.mergeErrors).flat();
   const componentsNeedUpdate = [

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -114,7 +114,8 @@ bit import ${modelComponent.id()} --objects`);
   if (remoteHeadExistsLocally && !hasMultipleParents) {
     return new DivergeData(snapsOnLocal, [], remoteHead, error);
   }
-  const remoteVersion = (await repo.load(remoteHead)) as Version | undefined;
+  const remoteVersion =
+    ((await repo.load(remoteHead)) as Version | undefined) || versionObjects?.find((v) => v.hash().isEqual(remoteHead));
   if (!remoteVersion) {
     const err = new VersionNotFoundOnFS(remoteHead.toString(), modelComponent.id());
     if (throws) throw err;

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -205,7 +205,7 @@ export default class Component extends BitObject {
     if (isTag(version)) {
       return includeOrphaned ? this.hasTagIncludeOrphaned(version) : this.hasTag(version);
     }
-    const allHashes = await getAllVersionHashes(this, repo, false);
+    const allHashes = await getAllVersionHashes({ modelComponent: this, repo, throws: false });
     return allHashes.some((hash) => hash.toString() === version);
   }
 
@@ -248,7 +248,7 @@ export default class Component extends BitObject {
   async setDivergeData(repo: Repository, throws = true, fromCache = true): Promise<void> {
     if (!this.divergeData || !fromCache) {
       const remoteHead = this.laneHeadRemote || this.remoteHead || null;
-      this.divergeData = await getDivergeData(repo, this, remoteHead, undefined, throws);
+      this.divergeData = await getDivergeData({ repo, modelComponent: this, remoteHead, throws });
     }
   }
 

--- a/src/scope/objects/objects-readable-generator.ts
+++ b/src/scope/objects/objects-readable-generator.ts
@@ -107,13 +107,12 @@ export class ObjectsReadableGenerator {
       };
       if (collectParents) {
         const parentsObjects: ObjectItem[] = [];
-        const allParentsHashes = await getAllVersionHashes(
-          component,
-          this.repo,
-          true,
-          version.hash(),
-          collectParentsUntil
-        );
+        const allParentsHashes = await getAllVersionHashes({
+          modelComponent: component,
+          repo: this.repo,
+          startFrom: version.hash(),
+          stopAt: collectParentsUntil,
+        });
         const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
         await Promise.all(
           missingParentsHashes.map(async (parentHash) => {

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -599,7 +599,9 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
    */
   async mergeLane(
     lane: Lane,
-    isImport: boolean // otherwise, it's coming from export
+    isImport: boolean, // otherwise, it's coming from export
+    versionObjects?: Version[], // for export, some versions don't exist locally yet.
+    componentObjects?: ModelComponent[] // for export, some model-components don't exist locally yet.
   ): Promise<{ mergeResults: MergeResult[]; mergeErrors: ComponentNeedsUpdate[]; mergeLane: Lane }> {
     logger.debug(`sources.mergeLane, lane: ${lane.toLaneId()}`);
     const repo = this.objects();
@@ -622,14 +624,20 @@ otherwise, to collaborate on the same lane as the remote, you'll need to remove 
     const mergeErrors: ComponentNeedsUpdate[] = [];
     await Promise.all(
       lane.components.map(async (component) => {
-        const modelComponent = await this.get(component.id);
+        const modelComponent =
+          (await this.get(component.id)) ||
+          componentObjects?.find((c) => c.toBitId().isEqualWithoutVersion(component.id));
         if (!modelComponent) {
           throw new Error(`unable to merge lane ${lane.name}, the component ${component.id.toString()} was not found`);
         }
         const existingComponent = existingLane ? existingLane.components.find((c) => c.id.isEqual(component.id)) : null;
         if (!existingComponent) {
-          // modelComponent.laneHeadLocal = component.head;
-          const allVersions = await getAllVersionHashes(modelComponent, repo, undefined, component.head);
+          const allVersions = await getAllVersionHashes({
+            modelComponent,
+            repo,
+            startFrom: component.head,
+            versionObjects,
+          });
           if (existingLane) existingLane.addComponent(component);
           mergeResults.push({ mergedComponent: modelComponent, mergedVersions: allVersions.map((h) => h.toString()) });
           return;
@@ -638,7 +646,13 @@ otherwise, to collaborate on the same lane as the remote, you'll need to remove 
           mergeResults.push({ mergedComponent: modelComponent, mergedVersions: [] });
           return;
         }
-        const divergeResults = await getDivergeData(repo, modelComponent, component.head, existingComponent.head);
+        const divergeResults = await getDivergeData({
+          repo,
+          modelComponent,
+          remoteHead: component.head,
+          checkedOutLocalHead: existingComponent.head,
+          versionObjects,
+        });
         if (divergeResults.isDiverged()) {
           if (isImport) {
             // do not update the local lane. later, suggest to snap-merge.

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -376,12 +376,12 @@ once done, to continue working, please run "bit cc"`
     if (!component.head) return true; // it's not on main. must be on a lane. (even if it was forked from another lane, current lane must have all objects)
     if (component.head.toString() === id.version) return false; // it's on main
     // get the diverge between main and the lane. (in this context, main is "remote", lane is "local").
-    const divergeData = await getDivergeData(
-      this.objects,
-      component,
-      component.head,
-      Ref.from(laneIdWithDifferentVersion.version as string)
-    );
+    const divergeData = await getDivergeData({
+      repo: this.objects,
+      modelComponent: component,
+      remoteHead: component.head,
+      checkedOutLocalHead: Ref.from(laneIdWithDifferentVersion.version as string),
+    });
     // if the snap found "locally", then it's on the lane.
     return Boolean(divergeData.snapsOnLocalOnly.find((snap) => snap.toString() === id.version));
   }


### PR DESCRIPTION
## Proposed Changes

- improve bit-export performance when on a lane by checking the head on the remote and sending only the missing objects.
- when merging lane objects, do not rely on the local cache to get Version/Component objects. in case many objects were exported, the cache won't have them all. instead, check the object received during export.

