### PR TITLE
improvement(bit-export): improve lane-export performance

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -618,7 +618,7 @@ describe('bit lane command', function () {
       // another bug was that it had all versions included exported.
       const status = helper.command.status('--verbose');
       const hash = helper.command.getHeadOfLane('dev', 'comp1');
-      expect(status).to.have.string(`versions: ${hash} ...`);
+      expect(status).to.have.string(`versions: 0.0.1, ${hash} ...`);
     });
     describe('export the lane, then switch back to main', () => {
       let afterSwitchingLocal: string;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -47,7 +47,6 @@ import {
 import { BitObject, Ref } from '@teambit/legacy/dist/scope/objects';
 import { PersistFailed } from '@teambit/legacy/dist/scope/exceptions/persist-failed';
 import { getAllVersionHashes } from '@teambit/legacy/dist/scope/component-ops/traverse-versions';
-import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/scope-components-importer';
 import { ExportAspect } from './export.aspect';
 import { ExportCmd } from './export-cmd';
 import { ResumeExportCmd } from './resume-export-cmd';
@@ -251,22 +250,14 @@ export class ExportMain {
       allHashes.push(head);
     };
 
-    const getVersionsToExport = async (modelComponent: ModelComponent, lane?: Lane): Promise<string[]> => {
+    const getVersionsToExport = async (modelComponent: ModelComponent): Promise<string[]> => {
       await modelComponent.setDivergeData(scope.objects);
       const localTagsOrHashes = modelComponent.getLocalTagsOrHashes();
-      if (!allVersions && !lane) {
+      if (!allVersions) {
         // if lane is exported, components from other remotes may be exported to this remote. we need their history.
         return localTagsOrHashes;
       }
-      let stopAt: Ref | undefined;
-      if (lane && !lane.isNew) {
-        const scopeComponentImporter = new ScopeComponentsImporter(scope);
-        const remoteLanes = await scopeComponentImporter.importLanes([lane.toLaneId()]);
-        const remoteLane = remoteLanes[0];
-        const headOnRemote = remoteLane?.getComponentByName(modelComponent.toBitId())?.head;
-        stopAt = headOnRemote;
-      }
-      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects, stopAt });
+      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects });
       await addMainHeadIfPossible(allHashes, modelComponent);
       return modelComponent.switchHashesWithTagsIfExist(allHashes);
     };
@@ -303,7 +294,7 @@ export class ExportMain {
       const objectList = new ObjectList();
       const objectListPerName: ObjectListPerName = {};
       const processModelComponent = async (modelComponent: ModelComponent) => {
-        const versionToExport = await getVersionsToExport(modelComponent, lane);
+        const versionToExport = await getVersionsToExport(modelComponent);
         modelComponent.clearStateData();
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -101,11 +101,14 @@ export default class Component extends BitObject {
   remoteHead?: Ref | null; // doesn't get saved in the scope, used to easier access the remote main head
   /**
    * doesn't get saved in the scope, used to easier access the local snap head data
-   * when checked out to a lane, this prop is either Ref or null. otherwise (when on main), this
-   * prop is undefined.
+   * when checked out to a lane, this prop is either Ref or null. otherwise (when on main), this prop is undefined.
    */
   laneHeadLocal?: Ref | null;
-  laneHeadRemote?: Ref | null; // doesn't get saved in the scope, used to easier access the remote snap head data
+  /**
+   * doesn't get saved in the scope, used to easier access the remote snap head data
+   * when checked out to a lane, this prop is either Ref or null. otherwise (when on main), this prop is undefined.
+   */
+  laneHeadRemote?: Ref | null;
   laneDataIsPopulated = false; // doesn't get saved in the scope, used to improve performance of loading the lane data
   schema: string | undefined;
   private divergeData?: DivergeData;
@@ -247,7 +250,8 @@ export default class Component extends BitObject {
 
   async setDivergeData(repo: Repository, throws = true, fromCache = true): Promise<void> {
     if (!this.divergeData || !fromCache) {
-      const remoteHead = this.laneHeadRemote || this.remoteHead || null;
+      const isOnLane = this.laneHeadRemote || this.laneHeadRemote === null;
+      const remoteHead = (isOnLane ? this.laneHeadRemote : this.remoteHead) || null;
       this.divergeData = await getDivergeData({ repo, modelComponent: this, remoteHead, throws });
     }
   }


### PR DESCRIPTION
by sending only the snapped versions to the remote. the algorithm to find them on a lane is the same one used in `bit status`.
Also, fixed the "getDivergeData" for a new lane, to compare the local-lane vs remote-lane and not versus the main.