### PR TITLE
fix(bit-reset): make local-versions on lane be aware of main to not reset it

### DIFF
--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -37,4 +37,18 @@ describe('bit reset when on lane', function () {
       expect(() => helper.command.status()).not.to.throw();
     });
   });
+  describe('reset on lane after export from main', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit reset should not throw', () => {
+      expect(() => helper.command.untagAll()).to.not.throw();
+    });
+  });
 });

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -618,7 +618,7 @@ describe('bit lane command', function () {
       // another bug was that it had all versions included exported.
       const status = helper.command.status('--verbose');
       const hash = helper.command.getHeadOfLane('dev', 'comp1');
-      expect(status).to.have.string(`versions: 0.0.1, ${hash} ...`);
+      expect(status).to.have.string(`versions: ${hash} ...`);
     });
     describe('export the lane, then switch back to main', () => {
       let afterSwitchingLocal: string;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -303,7 +303,7 @@ export class ExportMain {
       const objectList = new ObjectList();
       const objectListPerName: ObjectListPerName = {};
       const processModelComponent = async (modelComponent: ModelComponent) => {
-        const versionToExport = await getVersionsToExport(modelComponent);
+        const versionToExport = await getVersionsToExport(modelComponent, lane);
         modelComponent.clearStateData();
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -38,6 +38,7 @@ import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { Remote, Remotes } from '@teambit/legacy/dist/remotes';
 import { getScopeRemotes } from '@teambit/legacy/dist/scope/scope-remotes';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
+import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/scope-components-importer';
 import { ExportVersions } from '@teambit/legacy/dist/scope/models/export-metadata';
 import {
   persistRemotes,
@@ -250,14 +251,22 @@ export class ExportMain {
       allHashes.push(head);
     };
 
-    const getVersionsToExport = async (modelComponent: ModelComponent): Promise<string[]> => {
+    const getVersionsToExport = async (modelComponent: ModelComponent, lane?: Lane): Promise<string[]> => {
       await modelComponent.setDivergeData(scope.objects);
       const localTagsOrHashes = modelComponent.getLocalTagsOrHashes();
-      if (!allVersions) {
+      if (!allVersions && !lane) {
         // if lane is exported, components from other remotes may be exported to this remote. we need their history.
         return localTagsOrHashes;
       }
-      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects });
+      let stopAt: Ref | undefined;
+      if (lane && !lane.isNew) {
+        const scopeComponentImporter = new ScopeComponentsImporter(scope);
+        const remoteLanes = await scopeComponentImporter.importLanes([lane.toLaneId()]);
+        const remoteLane = remoteLanes[0];
+        const headOnRemote = remoteLane?.getComponentByName(modelComponent.toBitId())?.head;
+        stopAt = headOnRemote;
+      }
+      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects, stopAt });
       await addMainHeadIfPossible(allHashes, modelComponent);
       return modelComponent.switchHashesWithTagsIfExist(allHashes);
     };

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -250,8 +250,11 @@ export default class Component extends BitObject {
 
   async setDivergeData(repo: Repository, throws = true, fromCache = true): Promise<void> {
     if (!this.divergeData || !fromCache) {
-      const isOnLane = this.laneHeadRemote || this.laneHeadRemote === null;
-      const remoteHead = (isOnLane ? this.laneHeadRemote : this.remoteHead) || null;
+      // const isOnLane = this.laneHeadRemote || this.laneHeadRemote === null;
+      // const remoteHead = (isOnLane ? this.laneHeadRemote : this.remoteHead) || null;
+      // this is tricky. in case the remote-lane doesn't exist, we can't just use the remote-head.
+      // maybe it should check forkedFrom, and if not exists, then use remote-head. or just leave it as null.
+      const remoteHead = this.laneHeadRemote || this.remoteHead || null;
       this.divergeData = await getDivergeData({ repo, modelComponent: this, remoteHead, throws });
     }
   }


### PR DESCRIPTION
In some cases, due to a recent change (https://github.com/teambit/bit/pull/6507), `bit reset` throws errors while trying to remove exported-versions. 
For now, the code mostly reverts what was done in that PR. Later, a new PR will be created to calculate the local versions more accurately. 