### PR TITLE
fix finding local-versions when on a lane

### DIFF
--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -51,4 +51,37 @@ describe('bit reset when on lane', function () {
       expect(() => helper.command.untagAll()).to.not.throw();
     });
   });
+  describe('reset on lane after fork from another lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      // helper.command.export(); // todo: try with and without export
+      helper.command.createLane('dev2');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit reset should not throw', () => {
+      expect(() => helper.command.untagAll()).to.not.throw();
+    });
+  });
+  describe('reset on lane after merging from another lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.reInitLocalScopeHarmony();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane('dev2');
+      helper.command.mergeLane(`${helper.scopes.remote}/dev`);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit reset should not throw', () => {
+      expect(() => helper.command.untagAll()).to.not.throw();
+    });
+  });
 });

--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -51,16 +51,40 @@ describe('bit reset when on lane', function () {
       expect(() => helper.command.untagAll()).to.not.throw();
     });
   });
-  describe('reset on lane after fork from another lane', () => {
+  describe('reset on lane after fork from another non-exported lane', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1, false);
       helper.command.createLane();
       helper.command.snapAllComponentsWithoutBuild();
-      // helper.command.export(); // todo: try with and without export
       helper.command.createLane('dev2');
       helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit status should show two snaps as staged', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents[0].versions).to.have.lengthOf(2);
+    });
+    it('bit reset should reset the component to new', () => {
+      expect(() => helper.command.untagAll()).to.not.throw();
+      const status = helper.command.statusJson();
+      expect(status.newComponents).to.have.lengthOf(1);
+    });
+  });
+  describe('reset on lane after fork from another exported lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('dev2');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit status should show only one version as staged, not two', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents[0].versions).to.have.lengthOf(1);
     });
     it('bit reset should not throw', () => {
       expect(() => helper.command.untagAll()).to.not.throw();
@@ -79,6 +103,11 @@ describe('bit reset when on lane', function () {
       helper.command.createLane('dev2');
       helper.command.mergeLane(`${helper.scopes.remote}/dev`);
       helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // a previous buy showed two staged snaps, because the remote-head was empty.
+    it('bit status should show only one version as staged, not two', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents[0].versions).to.have.lengthOf(1);
     });
     it('bit reset should not throw', () => {
       expect(() => helper.command.untagAll()).to.not.throw();

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -339,10 +339,9 @@ describe('merge lanes', function () {
         status = helper.command.statusJson();
         afterMergeToMain = helper.scopeHelper.cloneLocalScope();
       });
-      it('bit status should show two staging versions, the main-head and merge-snap', () => {
+      it('bit status should show one staging versions, the merge-snap', () => {
         const stagedVersions = status.stagedComponents.find((c) => c.id === `${helper.scopes.remote}/comp2`);
-        expect(stagedVersions.versions).to.have.lengthOf(2);
-        expect(stagedVersions.versions).to.include(comp2HeadOnMain);
+        expect(stagedVersions.versions).to.have.lengthOf(1);
         expect(stagedVersions.versions).to.include(helper.command.getHeadOfLane('dev', 'comp2'));
       });
       it('bit status should not show the components in pending-merge', () => {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -254,11 +254,13 @@ export class ExportMain {
       await modelComponent.setDivergeData(scope.objects);
       const localTagsOrHashes = modelComponent.getLocalTagsOrHashes();
       if (!allVersions && !lane) {
-        // if lane is exported, components from other remotes may be exported to this remote. we need their history.
         return localTagsOrHashes;
       }
       let stopAt: Ref[] | undefined;
-      if (lane) {
+      if (lane && !allVersions) {
+        // if lane is exported, components from other remotes may be part of this lane. we need their history.
+        // because their history could already exist on the remote from previous exports, we search this id in all
+        // remote-refs files of this lane-scope. while traversing the local history, stop when finding one of the remotes.
         stopAt = await scope.objects.remoteLanes.getRefsFromAllLanesOnScope(lane.scope, modelComponent.toBitId());
         if (modelComponent.laneHeadRemote) stopAt.push(modelComponent.laneHeadRemote);
       }

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -38,7 +38,6 @@ import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { Remote, Remotes } from '@teambit/legacy/dist/remotes';
 import { getScopeRemotes } from '@teambit/legacy/dist/scope/scope-remotes';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
-import ScopeComponentsImporter from '@teambit/legacy/dist/scope/component-ops/scope-components-importer';
 import { ExportVersions } from '@teambit/legacy/dist/scope/models/export-metadata';
 import {
   persistRemotes,
@@ -258,13 +257,10 @@ export class ExportMain {
         // if lane is exported, components from other remotes may be exported to this remote. we need their history.
         return localTagsOrHashes;
       }
-      let stopAt: Ref | undefined;
-      if (lane && !lane.isNew) {
-        const scopeComponentImporter = new ScopeComponentsImporter(scope);
-        const remoteLanes = await scopeComponentImporter.importLanes([lane.toLaneId()]);
-        const remoteLane = remoteLanes[0];
-        const headOnRemote = remoteLane?.getComponentByName(modelComponent.toBitId())?.head;
-        stopAt = headOnRemote;
+      let stopAt: Ref[] | undefined;
+      if (lane) {
+        stopAt = await scope.objects.remoteLanes.getRefsFromAllLanesOnScope(lane.scope, modelComponent.toBitId());
+        if (modelComponent.laneHeadRemote) stopAt.push(modelComponent.laneHeadRemote);
       }
       const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects, stopAt });
       await addMainHeadIfPossible(allHashes, modelComponent);

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -20,6 +20,7 @@ export async function getDivergeData({
   repo,
   modelComponent,
   remoteHead,
+  otherRemoteHeads, // when remoteHead empty, instead of returning all local snaps, stop if found one of these snaps
   checkedOutLocalHead, // in case locally on the workspace it has a different version
   throws = true, // otherwise, save the error instance in the `DivergeData` object,
   versionObjects, // relevant for remote-scope where during export the data is not in the repo yet.
@@ -27,6 +28,7 @@ export async function getDivergeData({
   repo: Repository;
   modelComponent: ModelComponent;
   remoteHead: Ref | null;
+  otherRemoteHeads?: Ref[];
   checkedOutLocalHead?: Ref | null;
   throws?: boolean;
   versionObjects?: Version[];
@@ -35,7 +37,13 @@ export async function getDivergeData({
   const localHead = checkedOutLocalHead || (isOnLane ? modelComponent.laneHeadLocal : modelComponent.getHead());
   if (!remoteHead) {
     if (localHead) {
-      const allLocalHashes = await getAllVersionHashes({ modelComponent, repo, throws: false, versionObjects });
+      const allLocalHashes = await getAllVersionHashes({
+        modelComponent,
+        repo,
+        throws: false,
+        versionObjects,
+        stopAt: otherRemoteHeads,
+      });
       return new DivergeData(allLocalHashes);
     }
     return new DivergeData();

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -64,6 +64,8 @@ export async function getDivergeData({
     return new DivergeData();
   }
 
+  const existOnRemote = (ref: Ref) => [remoteHead, ...(otherRemoteHeads || [])].find((r) => r.isEqual(ref));
+
   const snapsOnLocal: Ref[] = [];
   const snapsOnRemote: Ref[] = [];
   let remoteHeadExistsLocally = false;
@@ -72,7 +74,7 @@ export async function getDivergeData({
   let hasMultipleParents = false;
   let error: Error | undefined;
   const addParentsRecursively = async (version: Version, snaps: Ref[], isLocal: boolean) => {
-    if (isLocal && version.hash().isEqual(remoteHead)) {
+    if (isLocal && existOnRemote(version.hash())) {
       remoteHeadExistsLocally = true;
       return;
     }

--- a/src/scope/lanes/remote-lanes.ts
+++ b/src/scope/lanes/remote-lanes.ts
@@ -116,9 +116,7 @@ export default class RemoteLanes {
 
   async getAllRemoteLaneIdsOfScope(scopeName: string): Promise<LaneId[]> {
     const matches = await glob(path.join('*'), { cwd: path.join(this.basePath, scopeName) });
-    // in the future, lane-name might have slashes, so until the first slash is the scope.
-    // the rest are the name
-    return matches.map((match) => LaneId.from(scopeName, match));
+    return matches.map((match) => LaneId.from(match, scopeName));
   }
 
   async syncWithLaneObject(remoteName: string, lane: Lane) {

--- a/src/scope/lanes/remote-lanes.ts
+++ b/src/scope/lanes/remote-lanes.ts
@@ -1,6 +1,8 @@
 import fs from 'fs-extra';
 import path from 'path';
+import pMapSeries from 'p-map-series';
 import { LaneId } from '@teambit/lane-id';
+import { compact } from 'lodash';
 import { Mutex } from 'async-mutex';
 import { BitId } from '../../bit-id';
 import { PREVIOUS_DEFAULT_LANE, REMOTE_REFS_DIR } from '../../constants';
@@ -64,6 +66,18 @@ export default class RemoteLanes {
     return this.remotes[remoteLaneId.scope][remoteLaneId.name];
   }
 
+  async getRefsFromAllLanesOnScope(scopeName: string, bitId: BitId): Promise<Ref[]> {
+    const allLaneIdOfScope = await this.getAllRemoteLaneIdsOfScope(scopeName);
+    const results = await pMapSeries(allLaneIdOfScope, (laneId) => this.getRef(laneId, bitId));
+    return compact(results);
+  }
+
+  async getRefsFromAllLanes(bitId: BitId): Promise<Ref[]> {
+    const allLaneIds = await this.getAllRemoteLaneIds();
+    const results = await pMapSeries(allLaneIds, (laneId) => this.getRef(laneId, bitId));
+    return compact(results);
+  }
+
   async getRemoteBitIds(remoteLaneId: LaneId): Promise<BitId[]> {
     const remoteLane = await this.getRemoteLane(remoteLaneId);
     return remoteLane.map((item) => item.id.changeVersion(item.head.toString()));
@@ -98,6 +112,13 @@ export default class RemoteLanes {
       .map((match) => match.split(path.sep))
       .map(([head, ...tail]) => LaneId.from(tail.join('/'), head))
       .filter((remoteLaneId) => !remoteLaneId.isDefault() && remoteLaneId.name !== PREVIOUS_DEFAULT_LANE);
+  }
+
+  async getAllRemoteLaneIdsOfScope(scopeName: string): Promise<LaneId[]> {
+    const matches = await glob(path.join('*'), { cwd: path.join(this.basePath, scopeName) });
+    // in the future, lane-name might have slashes, so until the first slash is the scope.
+    // the rest are the name
+    return matches.map((match) => LaneId.from(scopeName, match));
   }
 
   async syncWithLaneObject(remoteName: string, lane: Lane) {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -253,7 +253,7 @@ export default class Component extends BitObject {
     if (!this.divergeData || !fromCache) {
       const remoteHead = (this.laneId ? this.laneHeadRemote : this.remoteHead) || null;
       let otherRemoteHeads: Ref[] | undefined;
-      if (this.laneId && !this.laneHeadRemote) {
+      if (this.laneId) {
         otherRemoteHeads = await repo.remoteLanes.getRefsFromAllLanes(this.toBitId());
         if (this.remoteHead) otherRemoteHeads.push(this.remoteHead);
       }

--- a/src/scope/objects/objects-readable-generator.ts
+++ b/src/scope/objects/objects-readable-generator.ts
@@ -111,7 +111,7 @@ export class ObjectsReadableGenerator {
           modelComponent: component,
           repo: this.repo,
           startFrom: version.hash(),
-          stopAt: collectParentsUntil,
+          stopAt: collectParentsUntil ? [collectParentsUntil] : undefined,
         });
         const missingParentsHashes = allParentsHashes.filter((h) => !h.isEqual(version.hash()));
         await Promise.all(

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -532,7 +532,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       modelComponent: incomingComp,
       throws: false,
       versionObjects,
-      stopAt: existingHead,
+      stopAt: existingHead ? [existingHead] : undefined,
     });
     const hashesOnly = allIncomingVersionsInfoUntilExistingHead
       .filter((v) => !v.tag) // only non-tag, the tagged are already part of the mergedVersion


### PR DESCRIPTION
Until now, it was done by traversing the local and remote snaps. The “remote-head” was the head on the remote-lane, and if not-exist (the component is new on this lane), it’s the remote-head of main.
The issue with this is that sometimes we get incorrect results. In case of merging lane-a into lane-b, and a new component introduced as part of the merge to lane-b, all the history of this component of lane-a is considered local. Because this history is considered local, bit-reset removes it unexpectedly.
Another issue is the export performance. We send way too many objects unnecessarily. Especially when lane-a is merged into lane-b, both on the same scope and lane-a has tons of snaps that were already exported. 

This PR fixes it by searching all remote-refs files (of lanes only, not main) for a component and during the local history traversal, if a hash is found there, it'll stop the traversal and not mark it as local.

For export, if exporting a lane to a new scope, then, we need all history from original component-scope. however, the history might already been there from previous snaps. to check this, we find all remote-refs of the same scope as the current lane and search for the hashes to stop the traversal. 