### PR TITLE
fix: don't fail when error from pnpm doesn't have a code

### DIFF
--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
@@ -15,3 +15,8 @@ dsffsdf is not in the npm registry, or you have no permission to fetch it.
 
 An authorization header was used: Bearer df96[hidden]`);
 });
+
+test('a regular error object is reported', () => {
+  const bitError = pnpmErrorToBitError(new Error('some error') as any);
+  expect(bitError.report()).toEqual('some error');
+});

--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.ts
@@ -17,7 +17,7 @@ export function pnpmErrorToBitError(err: PnpmError): BitError {
 }
 
 function renderErrorMessage(err: PnpmError): string {
-  if (err.code.startsWith('ERR_PNPM_FETCH_')) {
+  if (err.code?.startsWith('ERR_PNPM_FETCH_')) {
     // On fetching errors, pnpm adds information to the error object about the used auth headers.
     // This information is safe to print as the tokens are obfuscated.
     return `${err.message}


### PR DESCRIPTION
## Proposed Changes

-
-
-
