### PR TITLE
fix(bit-export): fix parent-not-found error when sending multiple snaps to a remote

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1314,4 +1314,21 @@ describe('bit lane command', function () {
       expect(() => helper.command.export()).not.to.throw();
     });
   });
+  describe('export multiple snaps on lane when the remote has it already', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopesHarmony();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      // the second snap is mandatory, don't skip it.
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // previously, it was throwing ParentNotFound
+    it('bit export should not throw ParentNotFound', () => {
+      expect(() => helper.command.export()).not.to.throw();
+    });
+  });
 });

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -59,7 +59,7 @@ export async function getDivergeData({
     return new DivergeData([], allRemoteHashes);
   }
 
-  const getVersion = async (ref: Ref): Promise<Version | undefined> => {
+  const getVersionObj = async (ref: Ref): Promise<Version | undefined> => {
     return versionObjects?.find((v) => v.hash().isEqual(ref)) || ((await repo.load(ref)) as Version | undefined);
   };
 
@@ -104,7 +104,7 @@ export async function getDivergeData({
     if (version.parents.length > 1) hasMultipleParents = true;
     await Promise.all(
       version.parents.map(async (parent) => {
-        const parentVersion = await getVersion(parent);
+        const parentVersion = await getVersionObj(parent);
         if (parentVersion) {
           await addParentsRecursively(parentVersion, snaps, isLocal);
         } else {
@@ -128,7 +128,7 @@ bit import ${modelComponent.id()} --objects`);
   if (remoteHeadExistsLocally && !hasMultipleParents) {
     return new DivergeData(snapsOnLocal, [], remoteHead, error);
   }
-  const remoteVersion = await getVersion(remoteHead);
+  const remoteVersion = await getVersionObj(remoteHead);
   if (!remoteVersion) {
     const err = new VersionNotFoundOnFS(remoteHead.toString(), modelComponent.id());
     if (throws) throw err;

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -59,6 +59,10 @@ export async function getDivergeData({
     return new DivergeData([], allRemoteHashes);
   }
 
+  const getVersion = async (ref: Ref): Promise<Version | undefined> => {
+    return versionObjects?.find((v) => v.hash().isEqual(ref)) || ((await repo.load(ref)) as Version | undefined);
+  };
+
   if (remoteHead.isEqual(localHead)) {
     // no diverge they're the same
     return new DivergeData();
@@ -100,7 +104,7 @@ export async function getDivergeData({
     if (version.parents.length > 1) hasMultipleParents = true;
     await Promise.all(
       version.parents.map(async (parent) => {
-        const parentVersion = (await parent.load(repo)) as Version;
+        const parentVersion = await getVersion(parent);
         if (parentVersion) {
           await addParentsRecursively(parentVersion, snaps, isLocal);
         } else {
@@ -124,8 +128,7 @@ bit import ${modelComponent.id()} --objects`);
   if (remoteHeadExistsLocally && !hasMultipleParents) {
     return new DivergeData(snapsOnLocal, [], remoteHead, error);
   }
-  const remoteVersion =
-    ((await repo.load(remoteHead)) as Version | undefined) || versionObjects?.find((v) => v.hash().isEqual(remoteHead));
+  const remoteVersion = await getVersion(remoteHead);
   if (!remoteVersion) {
     const err = new VersionNotFoundOnFS(remoteHead.toString(), modelComponent.id());
     if (throws) throw err;


### PR DESCRIPTION
This is a regression caused by https://github.com/teambit/bit/pull/6504. 