### PR TITLE
fix high memory consumption of fetchWithDeps

### DIFF
--- a/src/api/scope/lib/fetch.ts
+++ b/src/api/scope/lib/fetch.ts
@@ -56,7 +56,10 @@ export default async function fetch(
       const bitIds: BitIds = BitIds.deserialize(ids);
       const { withoutDependencies, includeArtifacts, allowExternal, onlyIfBuilt } = fetchOptions;
       const collectParents = !withoutDependencies;
-      const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
+
+      // important! don't create a new instance of ScopeComponentImporter. Otherwise, the Mutex will be created
+      // every request, and won't do anything.
+      const scopeComponentsImporter = scope.scopeImporter;
 
       const laneId = fetchOptions.laneId ? LaneId.parse(fetchOptions.laneId) : null;
       const lane = laneId ? await scope.loadLane(laneId) : null;

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -358,6 +358,7 @@ export default class ScopeComponentsImporter {
   async fetchWithDeps(ids: BitIds, allowExternal: boolean, onlyIfBuild = false): Promise<VersionDependencies[]> {
     logger.debugAndAddBreadCrumb('fetchWithDeps', `ids: {ids}`, { ids: ids.toString() });
     if (!allowExternal) this.throwIfExternalFound(ids);
+    logger.debug(`fetchWithDeps, is locked? ${this.fetchWithDepsMutex.isLocked()}`);
     // avoid race condition of getting multiple "fetch" requests, which later translates into
     // multiple getExternalMany calls, which saves objects and write refs files at the same time
     return this.fetchWithDepsMutex.runExclusive(async () => {


### PR DESCRIPTION
Originally, a Mutex was used to make sure only one process is running `fetchWithDeps`, however, instead of re-using the same mutex for all requests, a new instance was created each time.
This PR fixes it by using the ScopeComponentImporter instance of the Scope instead of creating it every fetch. 