### PR TITLE
allow recovering when objects are corrupted

### DIFF
--- a/e2e/harmony/corrupted-objects.e2e.ts
+++ b/e2e/harmony/corrupted-objects.e2e.ts
@@ -1,0 +1,39 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+
+const assertArrays = require('chai-arrays');
+
+chai.use(assertArrays);
+
+describe('objects in scope are corrupted', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('objects are empty, which are invalid zlib', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.bitJsonc.setupDefault();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      const comp = helper.command.catComponent('comp1@latest');
+      const fileHash = comp.files[0].file;
+      const objectPath = helper.general.getHashPathOfObject(fileHash, true);
+      helper.fs.outputFile(objectPath, '');
+    });
+    it('should throw', () => {
+      expect(() => helper.command.status()).to.throw();
+    });
+    it('bit import --all-history should fix it', () => {
+      helper.command.import('--all-history');
+      expect(() => helper.command.status()).to.not.throw();
+    });
+  });
+});

--- a/e2e/harmony/corrupted-objects.e2e.ts
+++ b/e2e/harmony/corrupted-objects.e2e.ts
@@ -28,8 +28,8 @@ describe('objects in scope are corrupted', function () {
       const objectPath = helper.general.getHashPathOfObject(fileHash, true);
       helper.fs.outputFile(objectPath, '');
     });
-    it('should throw', () => {
-      expect(() => helper.command.status()).to.throw();
+    it('bit status should throw an error with a suggestion how to fix', () => {
+      expect(() => helper.command.status()).to.throw('bit import --all-history');
     });
     it('bit import --all-history should fix it', () => {
       helper.command.import('--all-history');

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -364,8 +364,8 @@ export class LanesMain {
       installNpmPackages: false,
       lanes: { laneIds: [laneId], lanes: [lane] },
     };
-    const { dependencies } = await this.importer.importWithOptions(importOptions);
-    this.logger.debug(`fetching lane ${laneId.toString()} done, fetched ${dependencies.length} components`);
+    const { importedIds } = await this.importer.importWithOptions(importOptions);
+    this.logger.debug(`fetching lane ${laneId.toString()} done, fetched ${importedIds.length} components`);
     return lane;
   }
 

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -1,10 +1,8 @@
 import chalk from 'chalk';
 import R from 'ramda';
-import semver from 'semver';
 import { BitError } from '@teambit/bit-error';
 import { LaneId } from '@teambit/lane-id';
 import pMapSeries from 'p-map-series';
-import { isTag } from '@teambit/component-version';
 import { getRemoteBitIdsByWildcards } from '@teambit/legacy/dist/api/consumer/lib/list-scope';
 import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
 import { Consumer } from '@teambit/legacy/dist/consumer';
@@ -78,8 +76,9 @@ export type ImportDetails = {
   removed?: boolean;
 };
 export type ImportResult = {
-  dependencies: ComponentWithDependencies[];
-  envComponents?: Component[];
+  importedIds: BitId[];
+  importedDeps: BitId[];
+  writtenComponents?: Component[];
   importDetails: ImportDetails[];
   cancellationMessage?: string;
 };
@@ -121,7 +120,7 @@ export default class ImportComponents {
       ? logger.debug(`importObjectsOnLane, Lane: ${lane.id()}, Ids: ${bitIds.toString()}`)
       : logger.debug(`importObjectsOnLane, the lane does not exist on the remote. importing only the main components`);
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
-    const componentsWithDependencies = await this._importComponentsObjects(bitIds, {
+    const versionDependenciesArr = await this._importComponentsObjects(bitIds, {
       allHistory: this.options.allHistory,
       lane,
     });
@@ -148,13 +147,12 @@ export default class ImportComponents {
     const mergedLanes = mergeAllLanesResults.map((result) => result.mergeLane);
     await Promise.all(mergedLanes.map((mergedLane) => this.scope.lanes.saveLane(mergedLane)));
 
-    const componentsWithDependenciesFiltered = this._filterComponentsWithLowerVersions(componentsWithDependencies);
-    await this._fetchDivergeData(componentsWithDependenciesFiltered);
-    this._throwForDivergedHistory();
-    await this._writeToFileSystem(componentsWithDependenciesFiltered);
-    await this._saveLaneDataIfNeeded(componentsWithDependenciesFiltered);
-    const importDetails = await this._getImportDetails(beforeImportVersions, componentsWithDependencies);
-    return { dependencies: componentsWithDependenciesFiltered, importDetails };
+    const importDetails = await this._getImportDetails(beforeImportVersions, versionDependenciesArr);
+    return {
+      importedIds: versionDependenciesArr.map((v) => v.component.id).flat(),
+      importedDeps: versionDependenciesArr.map((v) => v.allDependenciesIds).flat(),
+      importDetails,
+    };
   }
 
   async importSpecificComponents(): Promise<ImportResult> {
@@ -162,7 +160,7 @@ export default class ImportComponents {
     const bitIds: BitIds = await this.getBitIds();
     const beforeImportVersions = await this._getCurrentVersions(bitIds);
     await this._throwForPotentialIssues(bitIds);
-    const componentsWithDependencies = await this._importComponentsObjects(bitIds, {
+    const versionDependenciesArr = await this._importComponentsObjects(bitIds, {
       lane: this.laneObjects?.[0],
     });
     if (this.laneObjects && this.options.objectsOnly) {
@@ -173,13 +171,26 @@ export default class ImportComponents {
       const mergedLanes = mergeAllLanesResults.map((result) => result.mergeLane);
       await Promise.all(mergedLanes.map((mergedLane) => this.scope.lanes.saveLane(mergedLane)));
     }
-    const componentsWithDependenciesFiltered = this._filterComponentsWithLowerVersions(componentsWithDependencies);
-    await this._fetchDivergeData(componentsWithDependenciesFiltered);
-    this._throwForDivergedHistory();
-    await this._writeToFileSystem(componentsWithDependenciesFiltered);
-    await this._saveLaneDataIfNeeded(componentsWithDependenciesFiltered);
-    const importDetails = await this._getImportDetails(beforeImportVersions, componentsWithDependencies);
-    return { dependencies: componentsWithDependenciesFiltered, importDetails };
+    let writtenComponents: Component[] = [];
+    if (!this.options.objectsOnly) {
+      const componentsWithDependencies = await multipleVersionDependenciesToConsumer(
+        versionDependenciesArr,
+        this.scope.objects
+      );
+      await this._fetchDivergeData(componentsWithDependencies);
+      this._throwForDivergedHistory();
+      await this._writeToFileSystem(componentsWithDependencies);
+      await this._saveLaneDataIfNeeded(componentsWithDependencies);
+      writtenComponents = componentsWithDependencies.map((c) => c.component);
+    }
+
+    const importDetails = await this._getImportDetails(beforeImportVersions, versionDependenciesArr);
+    return {
+      importedIds: versionDependenciesArr.map((v) => v.component.id).flat(),
+      importedDeps: versionDependenciesArr.map((v) => v.allDependenciesIds).flat(),
+      writtenComponents,
+      importDetails,
+    };
   }
 
   async _fetchDivergeData(componentsWithDependencies: ComponentWithDependencies[]) {
@@ -212,42 +223,6 @@ export default class ImportComponents {
     }
   }
 
-  /**
-   * it can happen for example when importing a component with `--dependent` flag and the component has
-   * the same dependent with different versions. we only want the one with the higher version
-   */
-  _filterComponentsWithLowerVersions(
-    componentsWithDependencies: ComponentWithDependencies[]
-  ): ComponentWithDependencies[] {
-    return componentsWithDependencies.filter((comp) => {
-      const sameIdHigherVersion = componentsWithDependencies.find(
-        (c) =>
-          !c.component.id.isEqual(comp.component.id) &&
-          c.component.id.isEqualWithoutVersion(comp.component.id) &&
-          isTag(c.component.id.version) &&
-          isTag(comp.component.id.version) &&
-          semver.gt(c.component.id.version as string, comp.component.id.version as string)
-      );
-      return !sameIdHigherVersion;
-    });
-  }
-
-  private async _importObjectsDisregardLocalCache(
-    ids: BitIds,
-    lanes: Lane[] = []
-  ): Promise<ComponentWithDependencies[]> {
-    const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
-    const versionDependenciesArr: VersionDependencies[] = await scopeComponentsImporter.importMany({
-      ids,
-      cache: false,
-      lanes,
-    });
-    const componentWithDependencies = await pMapSeries(versionDependenciesArr, (versionDependencies) =>
-      versionDependencies.toConsumer(this.scope.objects)
-    );
-    return componentWithDependencies;
-  }
-
   private async _importComponentsObjects(
     ids: BitIds,
     {
@@ -261,19 +236,15 @@ export default class ImportComponents {
       lane?: Lane;
       ignoreMissingHead?: boolean;
     }
-  ): Promise<ComponentWithDependencies[]> {
+  ): Promise<VersionDependencies[]> {
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope);
     await scopeComponentsImporter.importManyDeltaWithoutDeps(ids, allHistory, lane, ignoreMissingHead);
     loader.start(`import ${ids.length} components with their dependencies (if missing)`);
-    const versionDependenciesArr: VersionDependencies[] = fromOriginalScope
+    const results = fromOriginalScope
       ? await scopeComponentsImporter.importManyFromOriginalScopes(ids)
       : await scopeComponentsImporter.importMany({ ids, ignoreMissingHead, lanes: lane ? [lane] : undefined });
-    const componentWithDependencies = await multipleVersionDependenciesToConsumer(
-      versionDependenciesArr,
-      this.scope.objects
-    );
 
-    return componentWithDependencies;
+    return results;
   }
 
   /**
@@ -406,23 +377,38 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
     }
     await this._throwForModifiedOrNewComponents(componentsIdsToImport);
     const beforeImportVersions = await this._getCurrentVersions(componentsIdsToImport);
-
-    let componentsAndDependencies: ComponentWithDependencies[] = [];
-    if (componentsIdsToImport.length) {
-      // change all ids version to 'latest'. otherwise, it tries to import local tags/snaps from a remote
-      // const idsWithLatestVersion = componentsIdsToImport.toVersionLatest();
-      if (!this.options.objectsOnly) {
-        throw new Error(`bit import with no ids and --merge flag was not implemented yet`);
-      }
-      componentsAndDependencies = await this._importComponentsObjects(componentsIdsToImport, {
-        fromOriginalScope: this.options.fromOriginalScope,
-        allHistory: this.options.allHistory,
-      });
-      await this._writeToFileSystem(componentsAndDependencies);
+    if (!componentsIdsToImport.length) {
+      return {
+        importedIds: [],
+        importedDeps: [],
+        importDetails: [],
+      };
     }
-    const importDetails = await this._getImportDetails(beforeImportVersions, componentsAndDependencies);
+    if (!this.options.objectsOnly) {
+      throw new Error(`bit import with no ids and --merge flag was not implemented yet`);
+    }
+    const versionDependenciesArr = await this._importComponentsObjects(componentsIdsToImport, {
+      fromOriginalScope: this.options.fromOriginalScope,
+      allHistory: this.options.allHistory,
+    });
+    let writtenComponents: Component[] = [];
+    if (!this.options.objectsOnly) {
+      const componentWithDependencies = await multipleVersionDependenciesToConsumer(
+        versionDependenciesArr,
+        this.scope.objects
+      );
+      await this._writeToFileSystem(componentWithDependencies);
+      writtenComponents = componentWithDependencies.map((c) => c.component);
+    }
 
-    return { dependencies: componentsAndDependencies, importDetails };
+    const importDetails = await this._getImportDetails(beforeImportVersions, versionDependenciesArr);
+
+    return {
+      importedIds: versionDependenciesArr.map((v) => v.component.id).flat(),
+      importedDeps: versionDependenciesArr.map((v) => v.allDependenciesIds).flat(),
+      writtenComponents,
+      importDetails,
+    };
   }
 
   private getIdsToImportFromBitmap() {
@@ -446,7 +432,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
    */
   async _getImportDetails(
     currentVersions: ImportedVersions,
-    components: ComponentWithDependencies[]
+    components: VersionDependencies[]
   ): Promise<ImportDetails[]> {
     const detailsP = components.map(async (component) => {
       const id = component.component.id;
@@ -470,7 +456,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       };
       const filesStatus = this.mergeStatus && this.mergeStatus[idStr] ? this.mergeStatus[idStr] : null;
       const deprecated = await modelComponent.isDeprecated(this.scope.objects);
-      const removed = component.component.removed;
+      const removed = await component.component.component.isRemoved(this.scope.objects);
       const latestVersion = modelComponent.latest();
       return {
         id: idStr,
@@ -478,7 +464,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
         latestVersion: versionDifference.includes(latestVersion) ? latestVersion : null,
         status: getStatus(),
         filesStatus,
-        missingDeps: component.missingDependencies,
+        missingDeps: component.getMissingDependencies(),
         deprecated,
         removed,
       };

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -371,7 +371,6 @@ export class InstallMain {
     return res;
   }
 
-  // TODO: replace with a proper import API on the workspace
   private async importObjects() {
     const importOptions: ImportOptions = {
       ids: [],
@@ -379,13 +378,12 @@ export class InstallMain {
       installNpmPackages: false,
     };
     try {
-      const res = await this.importer.import(importOptions, []);
-      return res;
+      await this.importer.import(importOptions, []);
     } catch (err: any) {
       // TODO: this is a hack since the legacy throw an error, we should provide a way to not throw this error from the legacy
       if (err instanceof NothingToImport) {
         // Do not write nothing to import warning
-        return undefined;
+        return;
       }
       throw err;
     }

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -53,8 +53,9 @@ export default class GeneralHelper {
     const hash = comp3.hash;
     return this.getHashPathOfObject(hash);
   }
-  getHashPathOfObject(hash: string) {
-    return path.join(hash.slice(0, 2), hash.slice(2));
+  getHashPathOfObject(hash: string, relativeToWorkspace = false) {
+    const objectPath = path.join(hash.slice(0, 2), hash.slice(2));
+    return relativeToWorkspace ? path.join('.bit/objects', objectPath) : objectPath;
   }
   installAndGetTypeScriptCompilerDir(): string {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/utils/zlib-inflate.ts
+++ b/src/utils/zlib-inflate.ts
@@ -7,6 +7,7 @@ export default async function inflate(buffer: Buffer, filePath?: string): Promis
     return await inflateP(buffer);
   } catch (err: any) {
     const filePathStr = filePath ? ` of "${filePath}"` : '';
-    throw new Error(`fatal: zlib.inflate${filePathStr} has failed with an error: "${err.message}"`);
+    throw new Error(`fatal: zlib.inflate${filePathStr} has failed with an error: "${err.message}"
+try running bit import --all-history to fix the corrupted objects`);
   }
 }


### PR DESCRIPTION
Currently, if `bit import` is interrupted, the objects might be corrupted and there is no easy way to recover other than deleting the local scope.
With this PR, it's possible to recover by running `bit import --all-history`.