### PR TITLE
Aspects Page: Expand/Collapse nested objects + Copy JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,6 @@ package-lock.json
 !.yarn/plugins
 !.yarn/sdks
 !.yarn/versions
+
+# component issues
+scopes/component/component-issues/dist/

--- a/scopes/harmony/ui/aspect-box/aspect-box.module.scss
+++ b/scopes/harmony/ui/aspect-box/aspect-box.module.scss
@@ -52,6 +52,31 @@
     }
   }
 }
+.copyMessage {
+  position: unset;
+  transform: unset;
+  display: flex;
+}
+
+.toolbar {
+  align-items: center;
+}
+.toolbar {
+  flex-direction: row;
+  display: flex;
+}
+.copyIcon {
+  display: flex;
+  font-size: var(--bit-p-xs);
+}
+.copyButton {
+  cursor: pointer;
+  box-sizing: border-box;
+  border: none;
+  background-color: var(--bit-bg-color-highlight);
+  color: var(--bit-accent-color);
+  outline: none;
+}
 .sectionTitle {
   display: flex;
   margin-bottom: 16px;

--- a/scopes/harmony/ui/aspect-box/aspect-box.module.scss
+++ b/scopes/harmony/ui/aspect-box/aspect-box.module.scss
@@ -59,11 +59,9 @@
 }
 
 .toolbar {
-  align-items: center;
-}
-.toolbar {
   flex-direction: row;
   display: flex;
+  align-items: flex-start;
 }
 .copyIcon {
   display: flex;

--- a/scopes/harmony/ui/aspect-box/aspect-box.module.scss
+++ b/scopes/harmony/ui/aspect-box/aspect-box.module.scss
@@ -34,7 +34,26 @@
   cursor: pointer;
   color: var(--bit-text-color-light, #6c707c);
 }
+.sectionTitleContainer {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}
+.expandCollapse {
+  display: flex;
+  align-items: flex-start;
+  cursor: pointer;
+
+  img {
+    border-radius: 8px;
+    width: 16px;
+    &:hover {
+      background-color: var(--bit-border-color-lightest, #ededed);
+    }
+  }
+}
 .sectionTitle {
+  display: flex;
   margin-bottom: 16px;
   font-weight: bold;
   font-size: var(--bit-p-xs);

--- a/scopes/harmony/ui/aspect-box/aspect-box.tsx
+++ b/scopes/harmony/ui/aspect-box/aspect-box.tsx
@@ -30,7 +30,7 @@ export function AspectBox({ icon, name, config, data, className, ...rest }: Aspe
     setTimeout(() => {
       if (dataOrConfig === 'data') setIsCopiedData(false);
       else setIsCopiedConfig(false);
-    }, 20000);
+    }, 2000);
     copy(JSON.stringify(dataToCopy, null, 2));
   };
 

--- a/scopes/harmony/ui/aspect-box/aspect-box.tsx
+++ b/scopes/harmony/ui/aspect-box/aspect-box.tsx
@@ -1,7 +1,8 @@
 import classNames from 'classnames';
-import React from 'react';
+import React, { useState } from 'react';
 import JSONFormatter from 'json-formatter-js';
 import styles from './aspect-box.module.scss';
+import { isObject } from 'lodash';
 
 export type AspectBoxProps = {
   icon?: string;
@@ -11,12 +12,28 @@ export type AspectBoxProps = {
   data: any;
 } & React.HTMLAttributes<HTMLDivElement>;
 
+const collapsedIcon = 'https://static.bit.dev/bit-icons/collapse.svg';
+const expandIcon = 'https://static.bit.dev/bit-icons/expand.svg';
 export function AspectBox({ icon, name, config, data, className, ...rest }: AspectBoxProps) {
-  const configContent = new JSONFormatter(config, 1, {
+  const [configCollapseState, setConfigCollapseState] = useState<number>(1);
+  const [dataCollapseState, setDataCollapseState] = useState<number>(1);
+  const configCollapseExpandIcon = configCollapseState === 1 ? expandIcon : collapsedIcon;
+  const dataCollapseExpandIcon = dataCollapseState === 1 ? expandIcon : collapsedIcon;
+  const isDataDepthGreaterThanOne = Object.keys(data).some((key) => isObject(data[key]));
+  const isConfigDepthGreaterThanOne = Object.keys(config).some((key) => isObject(data[key]));
+
+  const toggleCollapseState = (state: number) => {
+    if (state === 1) return Infinity;
+    return 1;
+  };
+
+  const configContent = new JSONFormatter(config, configCollapseState, {
     theme: 'dark',
     hoverPreviewEnabled: true,
   });
-  const dataContent = new JSONFormatter(data, 1, { theme: 'dark' });
+
+  const dataContent = new JSONFormatter(data, dataCollapseState, { theme: 'dark' });
+
   return (
     <div {...rest} className={classNames(styles.aspectBox, className)}>
       <div className={styles.titleLine}>
@@ -30,19 +47,39 @@ export function AspectBox({ icon, name, config, data, className, ...rest }: Aspe
           <Icon of="open-tab" />
         </a> */}
       </div>
-      <div className={styles.sectionTitle}>Configuration</div>
+      <div className={styles.sectionTitleContainer}>
+        <div className={styles.sectionTitle}>Configuration</div>
+        {isConfigDepthGreaterThanOne && (
+          <div className={styles.expandCollapse}>
+            <img
+              src={configCollapseExpandIcon}
+              onClick={() => setConfigCollapseState((value) => toggleCollapseState(value))}
+            />
+          </div>
+        )}
+      </div>
       <div className={classNames(styles.log, styles.config)}>
         <div
           ref={(nodeElement) => {
-            nodeElement && nodeElement.appendChild(configContent.render());
+            nodeElement && nodeElement.replaceChildren(configContent.render());
           }}
         />
       </div>
-      <div className={styles.sectionTitle}>Calculated data</div>
+      <div className={styles.sectionTitleContainer}>
+        <div className={styles.sectionTitle}>Calculated Data</div>
+        {isDataDepthGreaterThanOne && (
+          <div className={styles.expandCollapse}>
+            <img
+              src={dataCollapseExpandIcon}
+              onClick={() => setDataCollapseState((value) => toggleCollapseState(value))}
+            />
+          </div>
+        )}
+      </div>
       <div className={styles.log}>
         <div
           ref={(nodeElement) => {
-            nodeElement && nodeElement.appendChild(dataContent.render());
+            nodeElement && nodeElement.replaceChildren(dataContent.render());
           }}
         />
       </div>

--- a/scopes/harmony/ui/aspect-box/aspect-box.tsx
+++ b/scopes/harmony/ui/aspect-box/aspect-box.tsx
@@ -1,8 +1,12 @@
 import classNames from 'classnames';
 import React, { useState } from 'react';
 import JSONFormatter from 'json-formatter-js';
-import styles from './aspect-box.module.scss';
 import { isObject } from 'lodash';
+import { CopiedMessage } from '@teambit/documenter.ui.copied-message';
+import { Icon } from '@teambit/evangelist.elements.icon';
+import copy from 'copy-to-clipboard';
+
+import styles from './aspect-box.module.scss';
 
 export type AspectBoxProps = {
   icon?: string;
@@ -17,6 +21,19 @@ const expandIcon = 'https://static.bit.dev/bit-icons/expand.svg';
 export function AspectBox({ icon, name, config, data, className, ...rest }: AspectBoxProps) {
   const [configCollapseState, setConfigCollapseState] = useState<number>(1);
   const [dataCollapseState, setDataCollapseState] = useState<number>(1);
+  const [isCopiedData, setIsCopiedData] = useState(false);
+  const [isCopiedConfig, setIsCopiedConfig] = useState(false);
+
+  const handleClick = (dataToCopy, dataOrConfig: 'data' | 'config') => () => {
+    if (dataOrConfig === 'data') setIsCopiedData(true);
+    else setIsCopiedConfig(true);
+    setTimeout(() => {
+      if (dataOrConfig === 'data') setIsCopiedData(false);
+      else setIsCopiedConfig(false);
+    }, 20000);
+    copy(JSON.stringify(dataToCopy, null, 2));
+  };
+
   const configCollapseExpandIcon = configCollapseState === 1 ? expandIcon : collapsedIcon;
   const dataCollapseExpandIcon = dataCollapseState === 1 ? expandIcon : collapsedIcon;
   const isDataDepthGreaterThanOne = Object.keys(data).some((key) => isObject(data[key]));
@@ -49,14 +66,23 @@ export function AspectBox({ icon, name, config, data, className, ...rest }: Aspe
       </div>
       <div className={styles.sectionTitleContainer}>
         <div className={styles.sectionTitle}>Configuration</div>
-        {isConfigDepthGreaterThanOne && (
-          <div className={styles.expandCollapse}>
-            <img
-              src={configCollapseExpandIcon}
-              onClick={() => setConfigCollapseState((value) => toggleCollapseState(value))}
-            />
+        <div className={styles.toolbar}>
+          <CopiedMessage className={styles.copyMessage} show={isCopiedConfig} />
+          <div className={styles.copy}>
+            <button className={styles.copyButton} onClick={handleClick(configContent.json, 'config')}>
+              <Icon className={styles.copyIcon} of="copy-cmp" />
+            </button>
           </div>
-        )}
+
+          {isConfigDepthGreaterThanOne && (
+            <div className={styles.expandCollapse}>
+              <img
+                src={configCollapseExpandIcon}
+                onClick={() => setConfigCollapseState((value) => toggleCollapseState(value))}
+              />
+            </div>
+          )}
+        </div>
       </div>
       <div className={classNames(styles.log, styles.config)}>
         <div
@@ -67,14 +93,22 @@ export function AspectBox({ icon, name, config, data, className, ...rest }: Aspe
       </div>
       <div className={styles.sectionTitleContainer}>
         <div className={styles.sectionTitle}>Calculated Data</div>
-        {isDataDepthGreaterThanOne && (
-          <div className={styles.expandCollapse}>
-            <img
-              src={dataCollapseExpandIcon}
-              onClick={() => setDataCollapseState((value) => toggleCollapseState(value))}
-            />
+        <div className={styles.toolbar}>
+          <CopiedMessage className={styles.copyMessage} show={isCopiedData} />
+          <div className={styles.copy}>
+            <button className={styles.copyButton} onClick={handleClick(dataContent.json, 'data')}>
+              <Icon className={styles.copyIcon} of="copy-cmp" />
+            </button>
           </div>
-        )}
+          {isDataDepthGreaterThanOne && (
+            <div className={styles.expandCollapse}>
+              <img
+                src={dataCollapseExpandIcon}
+                onClick={() => setDataCollapseState((value) => toggleCollapseState(value))}
+              />
+            </div>
+          )}
+        </div>
       </div>
       <div className={styles.log}>
         <div

--- a/scopes/react/ui/docs-app/index.tsx
+++ b/scopes/react/ui/docs-app/index.tsx
@@ -5,4 +5,6 @@ export { default } from './docs.app-root';
 
 export type { ReactDocsAppProps } from './docs-app';
 
+export { DocsApp } from './docs-app';
+
 export { default as docsStyles } from './docs-app.module.scss';


### PR DESCRIPTION
## Proposed Changes

- Allow expanding/collapsing config/data for nested objects in aspects page
- Allow copying config/data json