### PR TITLE
feat: add a new "FetchMissingHistory" action

### DIFF
--- a/src/api/scope/lib/action.ts
+++ b/src/api/scope/lib/action.ts
@@ -6,6 +6,7 @@ import {
   RemovePendingDir,
   FetchMissingDeps,
   PostSign,
+  FetchMissingHistory,
 } from '../../../scope/actions';
 import ActionNotFound from '../../../scope/exceptions/action-not-found';
 import { AuthData } from '../../../scope/network/http/http';
@@ -28,7 +29,14 @@ export async function action(
     return externalAction.execute(options);
   }
   const scope: Scope = await loadScope(scopePath);
-  const actionList: ActionClassesList[] = [ExportValidate, ExportPersist, RemovePendingDir, FetchMissingDeps, PostSign];
+  const actionList: ActionClassesList[] = [
+    ExportValidate,
+    ExportPersist,
+    RemovePendingDir,
+    FetchMissingDeps,
+    PostSign,
+    FetchMissingHistory,
+  ];
   const ActionClass = actionList.find((a) => a.name === name);
   if (!ActionClass) {
     throw new ActionNotFound(name);

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -626,8 +626,8 @@ export default class CommandHelper {
   runTask(taskName: string) {
     return this.runCmd(`bit run ${taskName}`);
   }
-  create(templateName: string, componentName: string, flags = '') {
-    return this.runCmd(`bit create ${templateName} ${componentName} ${flags}`);
+  create(templateName: string, componentName: string, flags = '', cwd = this.scopes.localPath) {
+    return this.runCmd(`bit create ${templateName} ${componentName} ${flags}`, cwd);
   }
   new(templateName: string, flags = '', workspaceName = 'my-workspace', cwd = this.scopes.localPath) {
     return this.runCmd(`bit new ${templateName} ${workspaceName} ${flags}`, cwd);
@@ -711,7 +711,9 @@ export default class CommandHelper {
     const parsedOpts = this.parseOptions(options);
     return this.runCmd(`bit eject-conf ${id} ${parsedOpts}`);
   }
-
+  runAction(actionName: string, remote: string, options: Record<string, any>) {
+    return this.runCmd(`bit run-action ${actionName} ${remote} '${JSON.stringify(options)}'`);
+  }
   compile(id = '', options?: Record<string, any>) {
     const parsedOpts = this.parseOptions(options);
     return this.runCmd(`bit compile ${id} ${parsedOpts}`);

--- a/src/scope/actions/fetch-missing-history.ts
+++ b/src/scope/actions/fetch-missing-history.ts
@@ -1,0 +1,23 @@
+import { Scope } from '..';
+import { BitIds } from '../../bit-id';
+import logger from '../../logger/logger';
+import ScopeComponentsImporter from '../component-ops/scope-components-importer';
+import { Action } from './action';
+
+type Options = { ids: string[] };
+
+/**
+ * for lanes, when components from other scopes are exported to this scope, some history might be missing.
+ */
+export class FetchMissingHistory implements Action<Options> {
+  async execute(scope: Scope, options: Options): Promise<void> {
+    logger.debugAndAddBreadCrumb(
+      'FetchMissingHistory',
+      'check if history is missing and fetch it from original scopes'
+    );
+    const scopeComponentsImporter = ScopeComponentsImporter.getInstance(scope);
+    const bitIds: BitIds = BitIds.deserialize(options.ids);
+    await scopeComponentsImporter.importMissingHistory(bitIds);
+    logger.debugAndAddBreadCrumb('FetchMissingHistory', 'completed successfully');
+  }
+}

--- a/src/scope/actions/index.ts
+++ b/src/scope/actions/index.ts
@@ -1,6 +1,7 @@
 export { Action } from './action';
 export { ExportPersist } from './export-persist';
 export { ExportValidate } from './export-validate';
+export { FetchMissingHistory } from './fetch-missing-history';
 export { RemovePendingDir } from './remove-pending-dir';
 export { FetchMissingDeps } from './fetch-missing-deps';
 export { PostSign } from './post-sign';


### PR DESCRIPTION
This is useful for a remote when exporting a lane with components from another scope to get the history of those components.
