### PR TITLE
docs: Fix a few typos

### DIFF
--- a/e2e/fixtures/components/is-string/is-string.js
+++ b/e2e/fixtures/components/is-string/is-string.js
@@ -1,5 +1,5 @@
 /**
- * detemines whether `str` is a string.
+ * determines whether `str` is a string.
  * @name isString
  * @param {*} val
  * @returns {boolean}

--- a/scopes/react/bit-react-transformer/bit-react-tranformer.docs.md
+++ b/scopes/react/bit-react-transformer/bit-react-tranformer.docs.md
@@ -3,7 +3,7 @@ description: A Babel plugin that adds metadata to React components.
 labels: ['babel', 'react', 'component-id']
 ---
 
-The Bit React transformer is a Babel plugin thar adds the component id (as it determined by Bit) as a static property of the React component (both classes and functions).
+The Bit React transformer is a Babel plugin that adds the component id (as it determined by Bit) as a static property of the React component (both classes and functions).
 
 Having the added metadata is useful for debbuging and [showcasing](/ui/component-highlighter).
 

--- a/scopes/webpack/config-mutator/config-mutator.docs.md
+++ b/scopes/webpack/config-mutator/config-mutator.docs.md
@@ -5,7 +5,7 @@ description: 'webpack config mutator.'
 
 A small wrapper around webpack config object.
 This wrapper help you to mutate the webpack config in a chainable way.
-In general it is a sugar syntax to do commong operation on the config like add a plugin or and entry.
+In general it is a sugar syntax to do common operation on the config like add a plugin or and entry.
 It also give you different options like append and prepend for arrays and override, ignore, throw (for conflict) for objects;
 
 You can also mutate the raw config itself by accessing `mutator.raw`.

--- a/todo.md
+++ b/todo.md
@@ -1,12 +1,12 @@
 refactoring to do in Bit:
 
-- config api is far too concete and causes coupling, we need to delegate configuration to harmony.
-  - start by standardizing seralization and deserialization of types.
+- config api is far too concrete and causes coupling, we need to delegate configuration to harmony.
+  - start by standardizing serialization and deserialization of types.
 - refactor all implmentations of the api file to or Bit extensions for now.
-- chanage the name of the debug environment variable from BLUEBIRD_DEBUG to DEBUG.
-- refactor filesystem to be given to Bit so it could be reaplced from the outside.
+- change the name of the debug environment variable from BLUEBIRD_DEBUG to DEBUG.
+- refactor filesystem to be given to Bit so it could be replaced from the outside.
 - consolidate and refactor file system and path selection outside of Bit through workspace.
-- rewrite and replace cli infraturcture
+- rewrite and replace cli infrastructure
   - React components for UI using Ink or anything else.
   - support stdout streaming through extensions.
   - extensions 


### PR DESCRIPTION
There are small typos in:
- e2e/fixtures/components/is-string/is-string.js
- scopes/react/bit-react-transformer/bit-react-tranformer.docs.md
- scopes/webpack/config-mutator/config-mutator.docs.md
- todo.md

Fixes:
- Should read `serialization` rather than `seralization`.
- Should read `replaced` rather than `reaplced`.
- Should read `infrastructure` rather than `infraturcture`.
- Should read `determines` rather than `detemines`.
- Should read `concrete` rather than `concete`.
- Should read `common` rather than `commong`.
- Should read `change` rather than `chanage`.
- Should read `that` rather than `thar`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md