### PR TITLE
fix: filter teambit/legacy from root policy

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/workspace-manifest-factory.ts
@@ -55,6 +55,7 @@ export class WorkspaceManifestFactory {
       hasRootComponents
     );
     let dedupedDependencies = getEmptyDedupedDependencies();
+    rootPolicy = rootPolicy.filter((dep) => dep.dependencyId !== '@teambit/legacy');
     if (hasRootComponents) {
       dedupedDependencies.rootDependencies = rootPolicy.toManifest();
       const { peerDependencies } = dedupeDependencies(rootPolicy, componentDependenciesMap, [


### PR DESCRIPTION
Currently, when running `bit build` on bit repo, the `node_modules/@teambit/legacy` in the capsules is a package, not symlink. As a result, PRs fail with errors about mismatch types between the last version of teambit/legacy package and the current code of the legacy.
(this change was done with @GiladShoham ). 