### PR TITLE
add flattened dependencies as a graph to the model

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -591,7 +591,9 @@ there are matching among unmodified components thought. consider using --unmodif
       const flattenedEdges = component.flattenedDependencies.map((dep) => graph.outEdges(dep.toString())).flat();
       const allEdges = [...edges, ...flattenedEdges];
       const edgesWithBitIds: DepEdge[] = allEdges.map((edge) => ({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         source: graph.node(edge.source)!.attr,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         target: graph.node(edge.target)!.attr,
         type: edge.attr as DepEdgeType,
       }));

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -1,4 +1,5 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
+import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
 import { LegacyOnTagResult } from '@teambit/legacy/dist/scope/scope';
 import { FlattenedDependenciesGetter } from '@teambit/legacy/dist/scope/component-ops/get-flattened-dependencies';
 import { Scope as LegacyScope } from '@teambit/legacy/dist/scope';
@@ -49,6 +50,7 @@ import {
   getArtifactsFiles,
 } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { AutoTagResult } from '@teambit/legacy/dist/scope/component-ops/auto-tag';
+import { DepEdge, DepEdgeType } from '@teambit/legacy/dist/scope/models/version';
 import { SnapCmd } from './snap-cmd';
 import { SnappingAspect } from './snapping.aspect';
 import { TagCmd } from './tag-cmd';
@@ -554,6 +556,47 @@ there are matching among unmodified components thought. consider using --unmodif
     const flattenedDependenciesGetter = new FlattenedDependenciesGetter(scope, components);
     await flattenedDependenciesGetter.populateFlattenedDependencies();
     loader.stop();
+    await this._addFlattenedDepsGraphToComponents(components);
+  }
+
+  async _addFlattenedDepsGraphToComponents(components: ConsumerComponent[]) {
+    const graph = new Graph<BitId, string>();
+    const addEdges = (compId: BitId, dependencies: ConsumerComponent['dependencies'], label: DepEdgeType) => {
+      dependencies.get().forEach((dep) => {
+        graph.setNode(new Node(dep.id.toString(), dep.id));
+        graph.setEdge(new Edge(compId.toString(), dep.id.toString(), label));
+      });
+    };
+    components.forEach((comp) => {
+      graph.setNode(new Node(comp.id.toString(), comp.id));
+      addEdges(comp.id, comp.dependencies, 'prod');
+      addEdges(comp.id, comp.devDependencies, 'dev');
+      addEdges(comp.id, comp.extensionDependencies, 'ext');
+    });
+    const allFlattened = components.map((comp) => comp.flattenedDependencies);
+    const allFlattenedUniq = BitIds.uniqFromArray(allFlattened.flat());
+    const allFlattenedWithoutCurrent = allFlattenedUniq.filter((id) => !components.find((c) => c.id.isEqual(id)));
+    const componentsAndVersions = await this.scope.legacyScope.getComponentsAndVersions(
+      BitIds.fromArray(allFlattenedWithoutCurrent)
+    );
+    componentsAndVersions.forEach(({ component, version, versionStr }) => {
+      const compId = component.toBitId().changeVersion(versionStr);
+      graph.setNode(new Node(compId.toString(), compId));
+      addEdges(compId, version.dependencies, 'prod');
+      addEdges(compId, version.devDependencies, 'dev');
+      addEdges(compId, version.extensionDependencies, 'ext');
+    });
+    components.forEach((component) => {
+      const edges = graph.outEdges(component.id.toString());
+      const flattenedEdges = component.flattenedDependencies.map((dep) => graph.outEdges(dep.toString())).flat();
+      const allEdges = [...edges, ...flattenedEdges];
+      const edgesWithBitIds: DepEdge[] = allEdges.map((edge) => ({
+        source: graph.node(edge.source)!.attr,
+        target: graph.node(edge.target)!.attr,
+        type: edge.attr as DepEdgeType,
+      }));
+      component.flattenedEdges = edgesWithBitIds;
+    });
   }
 
   _updateComponentsByTagResult(components: ConsumerComponent[], tagResult: LegacyOnTagResult[]) {

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -591,6 +591,11 @@ export class ExportMain {
       const needsChange = ids.some((id) => id.scope !== remoteScope);
       if (needsChange) {
         version.flattenedDependencies = getBitIdsWithUpdatedScope(ids);
+        version.flattenedEdges = version.flattenedEdges.map((edge) => ({
+          ...edge,
+          source: getIdWithUpdatedScope(edge.source),
+          target: getIdWithUpdatedScope(edge.target),
+        }));
         hasChanged = true;
       }
       return hasChanged;

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -17,7 +17,7 @@ import { Doclet } from '../../jsdoc/types';
 import logger from '../../logger/logger';
 import ComponentWithDependencies from '../../scope/component-dependencies';
 import { ScopeListItem } from '../../scope/models/model-component';
-import Version, { Log } from '../../scope/models/version';
+import Version, { DepEdge, Log } from '../../scope/models/version';
 import { pathNormalizeToLinux } from '../../utils';
 import { PathLinux, PathOsBased, PathOsBasedRelative } from '../../utils/path';
 import ComponentMap from '../bit-map/component-map';
@@ -56,6 +56,7 @@ export type ComponentProps = {
   dependencies?: Dependency[];
   devDependencies?: Dependency[];
   flattenedDependencies?: BitIds;
+  flattenedEdges?: DepEdge[];
   packageDependencies?: Record<string, string>;
   devPackageDependencies?: Record<string, string>;
   peerPackageDependencies?: Record<string, string>;
@@ -105,6 +106,7 @@ export default class Component {
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   devDependencies: Dependencies;
   flattenedDependencies: BitIds;
+  flattenedEdges: DepEdge[];
   packageDependencies: Record<string, string>;
   devPackageDependencies: Record<string, string>;
   peerPackageDependencies: Record<string, string>;
@@ -160,6 +162,7 @@ export default class Component {
     dependencies,
     devDependencies,
     flattenedDependencies,
+    flattenedEdges,
     packageDependencies,
     devPackageDependencies,
     peerPackageDependencies,
@@ -190,6 +193,7 @@ export default class Component {
     this.setDependencies(dependencies);
     this.setDevDependencies(devDependencies);
     this.flattenedDependencies = flattenedDependencies || new BitIds();
+    this.flattenedEdges = flattenedEdges || [];
     this.packageDependencies = packageDependencies || {};
     this.devPackageDependencies = devPackageDependencies || {};
     this.peerPackageDependencies = peerPackageDependencies || {};


### PR DESCRIPTION
This is a preparation for a future improvement of not importing all flattened dependencies. 