### PR TITLE
fix(export): avoid sending historical Version objects during export on lane

### DIFF
--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -252,7 +252,7 @@ export class ExportMain {
       allHashes.push(head);
     };
 
-    const getVersionsToExport = async (modelComponent: ModelComponent, lane?: Lane): Promise<string[]> => {
+    const getVersionsToExport = async (modelComponent: ModelComponent): Promise<string[]> => {
       if (exportHeadsOnly) {
         const head = modelComponent.head;
         if (!head)
@@ -262,18 +262,11 @@ export class ExportMain {
         return modelComponent.switchHashesWithTagsIfExist([head]);
       }
       const localTagsOrHashes = await modelComponent.getLocalTagsOrHashes(scope.objects);
-      if (!allVersions && !lane) {
+      if (!allVersions) {
         return localTagsOrHashes;
       }
-      let stopAt: Ref[] | undefined;
-      if (lane && !allVersions) {
-        // if lane is exported, components from other remotes may be part of this lane. we need their history.
-        // because their history could already exist on the remote from previous exports, we search this id in all
-        // remote-refs files of this lane-scope. while traversing the local history, stop when finding one of the remotes.
-        stopAt = await scope.objects.remoteLanes.getRefsFromAllLanesOnScope(lane.scope, modelComponent.toBitId());
-        if (modelComponent.laneHeadRemote) stopAt.push(modelComponent.laneHeadRemote);
-      }
-      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects, stopAt });
+
+      const allHashes = await getAllVersionHashes({ modelComponent, repo: scope.objects });
       await addMainHeadIfPossible(allHashes, modelComponent);
       return modelComponent.switchHashesWithTagsIfExist(allHashes);
     };
@@ -310,7 +303,7 @@ export class ExportMain {
       const objectList = new ObjectList();
       const objectListPerName: ObjectListPerName = {};
       const processModelComponent = async (modelComponent: ModelComponent) => {
-        const versionToExport = await getVersionsToExport(modelComponent, lane);
+        const versionToExport = await getVersionsToExport(modelComponent);
         modelComponent.clearStateData();
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,

--- a/src/scope/actions/export-validate.ts
+++ b/src/scope/actions/export-validate.ts
@@ -14,9 +14,11 @@ const NUM_OF_RETRIES = 60;
 const WAIT_BEFORE_RETRY_IN_MS = 1000;
 
 /**
- * do not save anything. just make sure the objects can be merged and there are no conflicts.
+ * do not save the exported objects. just make sure the objects can be merged and there are no conflicts.
  * once done, clear the objects from the memory so then they won't be used by mistake later on.
  * this also makes sure that non-external dependencies are not missing.
+ * also, in case the lane is exported and there are non-local components coming from the lane, it imports them from
+ * their original scopes and throw if they're missing from there.
  */
 export class ExportValidate implements Action<Options> {
   scope: Scope;

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -14,6 +14,7 @@ import loader from '../../cli/loader';
 import { PersistFailed } from '../exceptions/persist-failed';
 import { MergeResult } from '../repositories/sources';
 import { Ref } from '../objects';
+import { BitObjectList } from '../objects/bit-object-list';
 
 /**
  * ** Legacy and "bit sign" Only **
@@ -46,7 +47,7 @@ export async function saveObjects(scope: Scope, objectList: ObjectList): Promise
   const bitObjectList = await objectList.toBitObjects();
   const objectsNotRequireMerge = bitObjectList.getObjectsNotRequireMerge();
   // components and lanes can't be just added, they need to be carefully merged.
-  const { mergedIds, mergedComponentsResults, mergedLanes } = await mergeObjects(scope, objectList);
+  const { mergedIds, mergedComponentsResults, mergedLanes } = await mergeObjects(scope, bitObjectList);
 
   const mergedComponents = mergedComponentsResults.map((_) => _.mergedComponent);
   const allObjects = [...mergedComponents, ...mergedLanes, ...objectsNotRequireMerge];
@@ -68,10 +69,9 @@ type MergeObjectsResult = { mergedIds: BitIds; mergedComponentsResults: MergeRes
  */
 export async function mergeObjects(
   scope: Scope,
-  objectList: ObjectList,
+  bitObjectList: BitObjectList,
   throwForMissingDeps = false
 ): Promise<MergeObjectsResult> {
-  const bitObjectList = await objectList.toBitObjects();
   const components = bitObjectList.getComponents();
   const lanesObjects = bitObjectList.getLanes();
   const versions = bitObjectList.getVersions();

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -206,10 +206,14 @@ export default class ScopeComponentsImporter {
   }
 
   /**
-   * checks whether the given components has all history graph to it is able to traverse the history.
-   * if not, it fetches the history from their remotes without deps.
+   * this is relevant when a lane has components from other scopes, otherwise, the scope always have the entire history
+   * of its own components.
+   * checks whether the given components has all history graph so then it's possible to traverse the history.
+   * if missing, go to their origin-scope and fetch their version-history. (currently, it also fetches the head
+   * Version object, but it can be optimized to not fetch it)
    */
   async importMissingVersionHistory(externalComponents: ModelComponent[]) {
+    // profiler is here temporarily to make sure this doesn't cost too much for some reason
     logger.profile(`importMissingVersionHistory, ${externalComponents.length} externalComponents`);
     const [compsWithHead, compsWithoutHead] = partition(externalComponents, (comp) => comp.hasHead());
     try {


### PR DESCRIPTION
currently, when exporting a lane with external components (components on a lane that belong to other scopes), there is a calculation of additional objects needed to be sent to the lane-scope in case it's missing from there. 
This PR takes a different approach. It only sends the local-snapped objects. Other missing objects on the lane-scope, will be fetched directly by the lane-scope during the validation phase. 