### PR TITLE
fix(reset): change the head to be the common-before-diverge instead of the remote-head

### DIFF
--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -691,12 +691,14 @@ describe('bit snap command', function () {
   });
   describe('merge tags', () => {
     let authorFirstTag;
+    let headBeforeDiverge;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.bitJsonc.setupDefault();
       helper.fixtures.populateComponents(1);
       helper.command.tagAllWithoutBuild();
       helper.command.export();
+      headBeforeDiverge = helper.command.getHead('comp1');
       authorFirstTag = helper.scopeHelper.cloneLocalScope();
       helper.fixtures.populateComponents(1, undefined, ' v2');
       helper.command.tagAllWithoutBuild();
@@ -730,17 +732,21 @@ describe('bit snap command', function () {
         helper.command.tagAllWithoutBuild('-s 0.0.4');
         beforeUntag = helper.scopeHelper.cloneLocalScope();
       });
-      describe('reset all local versions', () => {
+      describe.only('reset all local versions', () => {
         before(() => {
           helper.command.untagAll();
         });
-        it('should change the head to point to the remote head and not to the parent of the untagged version', () => {
+        it('should change the head to point to the parent of the untagged version not to the remote head', () => {
           const head = helper.command.getHead('comp1');
           const remoteHead = helper.general.getRemoteHead('comp1');
-          expect(head).to.be.equal(remoteHead);
+          expect(head).to.not.be.equal(remoteHead);
+          expect(head).to.be.equal(headBeforeDiverge);
         });
-        it('bit status after untag should show the component as modified only', () => {
-          helper.command.expectStatusToBeClean(['modifiedComponents']);
+        it('bit status after untag should show the component not only as modified but also as outdated', () => {
+          const status = helper.command.statusJson();
+          expect(status.modifiedComponents).to.have.lengthOf(1);
+          expect(status.outdatedComponents).to.have.lengthOf(1);
+          helper.command.expectStatusToBeClean(['modifiedComponents', 'outdatedComponents']);
         });
       });
       describe('reset only head', () => {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -374,7 +374,7 @@ export default class Component extends BitObject {
    */
   async headIncludeRemote(repo: Repository): Promise<string> {
     const latestLocally = this.latest();
-    const remoteHead = this.laneHeadRemote;
+    const remoteHead = this.laneHeadRemote || this.remoteHead;
     if (!remoteHead) return latestLocally;
     if (!this.getHeadRegardlessOfLane()) {
       return remoteHead.toString(); // user never merged the remote version, so remote is the latest

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -275,17 +275,9 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       return ref;
     });
 
-    const getNewHead = (isLane = false) => {
+    const getNewHead = () => {
       if (!removeOnlyHead) {
         const divergeData = component.getDivergeData();
-        if (divergeData.isDiverged()) {
-          // if it's diverged, the Component object might have versions from the remote as part of the last import.
-          // run snap.e2e - 'bit reset a diverge component' case to understand why it's better to pick the remoteHead
-          // than the commonSnapBeforeDiverge.
-          const remoteHead = isLane ? component.laneHeadRemote : component.remoteHead;
-          if (!remoteHead) throw new Error(`remoteHead must be set when component is diverged (id: ${component.id()})`);
-          return remoteHead;
-        }
         if (divergeData.commonSnapBeforeDiverge) {
           return divergeData.commonSnapBeforeDiverge;
         }
@@ -304,7 +296,7 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       component.setHead(newHead);
     }
     if (laneItem && refWasDeleted(laneItem.head)) {
-      const newHead = getNewHead(true);
+      const newHead = getNewHead();
       if (newHead) {
         laneItem.head = newHead;
       } else {


### PR DESCRIPTION
Currently, in case of diverge, during reset, the head (of the component or inside the lane) is set to the remote-head. Inside the .bitmap the version is set to be the same as the head. 
This PR fixes it to set the head back to what it was before the local snaps as expected.