### PR TITLE
fix(deps-set): avoid overriding dependencies set before tag/snap

### DIFF
--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -97,6 +97,19 @@ describe('bit dependencies command', function () {
         expect(show).to.have.string('@scoped/button@3.3.1');
       });
     });
+    describe('adding prod dep, tagging then adding devDep', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.fixtures.populateComponents(1);
+        helper.command.dependenciesSet('comp1', 'lodash@3.3.1');
+        helper.command.tagAllWithoutBuild();
+        helper.command.dependenciesSet('comp1', 'ramda@0.0.20', '--dev');
+      });
+      it('should not remove the previously added dependencies', () => {
+        const show = helper.command.showComponent('comp1');
+        expect(show).to.have.string('lodash');
+      });
+    });
   });
   describe('bit deps remove - removing components', () => {
     describe('removing a component', () => {

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -49,7 +49,7 @@ export class DependenciesMain {
     };
     await Promise.all(
       compIds.map(async (compId) => {
-        await this.workspace.addSpecificComponentConfig(compId, DependencyResolverAspect.id, config, true);
+        await this.workspace.addSpecificComponentConfig(compId, DependencyResolverAspect.id, config, true, true);
       })
     );
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1292,7 +1292,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
      * relevant only when writing to .bitmap.
      * eject config of the given aspect-id, so then it won't override previous config. (see "adding prod dep, tagging then adding devDep" e2e-test)
      */
-    shouldEjectPrevious = false
+    shouldMergeWithPrevious = false
   ) {
     const componentConfigFile = await this.componentConfigFile(id);
     if (componentConfigFile) {
@@ -1304,7 +1304,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       );
       await componentConfigFile.write({ override: true });
     } else {
-      if (shouldEjectPrevious) {
+      if (shouldMergeWithPrevious) {
         const extensions = await this.getSpecificExtensionsFromScope(id);
         const obj = extensions.toConfigObject();
         config = obj[aspectId] ? merge(obj[aspectId], config) : config;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -57,7 +57,7 @@ import {
   pathNormalizeToLinux,
 } from '@teambit/legacy/dist/utils/path';
 import fs from 'fs-extra';
-import { slice, uniqBy, difference, compact, partition, isEmpty } from 'lodash';
+import { slice, uniqBy, difference, compact, partition, isEmpty, merge } from 'lodash';
 import path from 'path';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import type { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
@@ -648,12 +648,7 @@ export class Workspace implements ComponentFactory {
 
   async ejectConfig(id: ComponentID, options: EjectConfOptions): Promise<EjectConfResult> {
     const componentId = await this.resolveComponentId(id);
-    const component = await this.get(componentId);
-    const componentFromScope = await this.scope.get(id);
-    const { extensions } = await this.componentExtensions(component.id, componentFromScope, [
-      'WorkspaceDefault',
-      'WorkspaceVariants',
-    ]);
+    const extensions = await this.getSpecificExtensionsFromScope(id);
     const aspects = await this.createAspectList(extensions);
     const componentDir = this.componentDir(id, { ignoreVersion: true });
     const componentConfigFile = new ComponentConfigFile(componentId, aspects, componentDir, options.propagate);
@@ -664,6 +659,16 @@ export class Workspace implements ComponentFactory {
     return {
       configPath: ComponentConfigFile.composePath(componentDir),
     };
+  }
+
+  private async getSpecificExtensionsFromScope(id: ComponentID): Promise<ExtensionDataList> {
+    const componentFromScope = await this.scope.get(id);
+    const { extensions } = await this.componentExtensions(id, componentFromScope, [
+      'WorkspaceDefault',
+      'WorkspaceVariants',
+    ]);
+
+    return extensions;
   }
 
   /**
@@ -1282,7 +1287,12 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     id: ComponentID,
     aspectId: string,
     config: Record<string, any> = {},
-    shouldMergeWithExisting = false
+    shouldMergeWithExisting = false,
+    /**
+     * relevant only when writing to .bitmap.
+     * eject config of the given aspect-id, so then it won't override previous config. (see "adding prod dep, tagging then adding devDep" e2e-test)
+     */
+    shouldEjectPrevious = false
   ) {
     const componentConfigFile = await this.componentConfigFile(id);
     if (componentConfigFile) {
@@ -1294,6 +1304,11 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       );
       await componentConfigFile.write({ override: true });
     } else {
+      if (shouldEjectPrevious) {
+        const extensions = await this.getSpecificExtensionsFromScope(id);
+        const obj = extensions.toConfigObject();
+        config = obj[aspectId] ? merge(obj[aspectId], config) : config;
+      }
       this.bitMap.addComponentConfig(id, aspectId, config, shouldMergeWithExisting);
     }
   }


### PR DESCRIPTION
This is happening when running `bit deps set X`, tagging, then `bit deps set Y --dev`, the last one overrides what was set before the tag. This PR fixes it by ejecting the specific dep-resolver config into the .bitmap.