### PR TITLE
fix(bit-log): import all history in case they are missing

### DIFF
--- a/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
@@ -186,6 +186,7 @@ describe('bit lane command', function () {
       });
     });
     describe('when the components on the lane have history other than head on main', () => {
+      let localScope: string;
       before(() => {
         helper.scopeHelper.setNewLocalAndRemoteScopes();
         helper.bitJsonc.setupDefault();
@@ -203,11 +204,14 @@ describe('bit lane command', function () {
         helper.fs.deletePath('.bit');
         helper.scopeHelper.addRemoteScope();
         helper.command.import();
+        localScope = helper.scopeHelper.cloneLocalScope();
       });
       it('should not bring all history of main only the head', () => {
         const comp = helper.command.catComponent(`${helper.scopes.remote}/comp1`);
+        const v1Hash = comp.versions['0.0.1'];
         const v2Hash = comp.versions['0.0.2'];
         const v3Hash = comp.versions['0.0.3'];
+        expect(() => helper.command.catObject(v1Hash)).to.throw();
         expect(() => helper.command.catObject(v2Hash)).to.throw();
         expect(() => helper.command.catObject(v3Hash)).to.not.throw(); // coz it's the head
       });
@@ -216,6 +220,13 @@ describe('bit lane command', function () {
         const comp = helper.command.catComponent(`${helper.scopes.remote}/comp1`);
         const v2Hash = comp.versions['0.0.2'];
         expect(() => helper.command.catObject(v2Hash)).to.not.throw();
+      });
+      it('should import the history if "bit log" was running', () => {
+        helper.scopeHelper.getClonedLocalScope(localScope);
+        helper.command.log(`${helper.scopes.remote}/comp1`);
+        const comp = helper.command.catComponent(`${helper.scopes.remote}/comp1`);
+        const v1Hash = comp.versions['0.0.1'];
+        expect(() => helper.command.catObject(v1Hash)).to.not.throw();
       });
     });
   });

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -288,7 +288,7 @@ export default class ScopeComponentsImporter {
   }: {
     ids: BitIds;
     fromHead?: boolean; // previously, this was named "allHistory". now with versionHistory, it only instructs fetch to start from head
-    lane?: Lane;
+    lane?: Lane | null;
     ignoreMissingHead?: boolean;
     collectParents?: boolean;
   }): Promise<void> {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -455,9 +455,12 @@ export default class Component extends BitObject {
     ) {
       logger.info(`collectLogs is unable to find some objects for ${this.id()}. will try to import them`);
       try {
+        const lane = await scope.getCurrentLaneObject();
         await scope.scopeImporter.importManyDeltaWithoutDeps({
           ids: BitIds.fromArray([this.toBitId()]),
           collectParents: true,
+          fromHead: true,
+          lane,
         });
         versionsInfo = await getAllVersionsInfo({ modelComponent: this, repo, throws: false, startFrom });
       } catch (err) {


### PR DESCRIPTION
Although it was implemented in the original performance improvement PR (https://github.com/teambit/bit/pull/6639), it wasn't working properly because it was trying to import only delta. (delta is not really useful with the new optimization). Fixed by asking the component-delta to get all history from head.