### PR TITLE
improvement: show missing packages when manually added with versions

### DIFF
--- a/e2e/commands/list.e2e.1.ts
+++ b/e2e/commands/list.e2e.1.ts
@@ -23,8 +23,7 @@ describe('bit list command', function () {
   });
   describe('when a component is created but not tagged', () => {
     before(() => {
-      helper.scopeHelper.clean();
-      helper.scopeHelper.initWorkspace();
+      helper.scopeHelper.reInitLocalScope();
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
     });
@@ -35,8 +34,7 @@ describe('bit list command', function () {
   });
   describe('when a component is created and tagged', () => {
     before(() => {
-      helper.scopeHelper.clean();
-      helper.scopeHelper.initWorkspace();
+      helper.scopeHelper.reInitLocalScope();
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       helper.fixtures.tagComponentBarFoo();

--- a/e2e/functionalities/workspace-config.e2e.3.ts
+++ b/e2e/functionalities/workspace-config.e2e.3.ts
@@ -1,7 +1,6 @@
 import chai, { expect } from 'chai';
 import * as path from 'path';
 import { IssuesClasses } from '@teambit/component-issues';
-import { MISSING_PACKAGES_FROM_OVERRIDES_LABEL } from '../../src/cli/templates/component-issues-template';
 import { OVERRIDE_COMPONENT_PREFIX, statusFailureMsg } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
@@ -396,7 +395,6 @@ describe('workspace config', function () {
           const output = helper.command.status().replace(/\n/g, '');
           helper.command.expectStatusToHaveIssue(IssuesClasses.MissingPackagesDependenciesOnFs.name);
           expect(output).to.have.string('foo.js -> chai');
-          expect(output).to.have.string(`${MISSING_PACKAGES_FROM_OVERRIDES_LABEL} -> chai`);
         });
       });
       // skipped for now. see the first test for more details.

--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -141,7 +141,7 @@ describe('bit dependencies command', function () {
           helper.command.dependenciesSet('comp1', `${helper.general.getPackageNameByCompName('bar/foo')}@0.0.1`);
         });
         it('bit status should show it as missing', () => {
-          helper.command.expectStatusToHaveIssue(IssuesClasses.MissingPackagesDependenciesOnFs.name);
+          helper.command.expectStatusToHaveIssue(IssuesClasses.MissingManuallyConfiguredPackages.name);
         });
         it('bit install should fix it', () => {
           helper.command.install();

--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -135,7 +135,7 @@ describe('bit dependencies command', function () {
       });
       describe('adding a component dependency when it is not installed locally', () => {
         before(() => {
-          helper.scopeHelper.reInitLocalScope();
+          helper.scopeHelper.reInitLocalScope({ disableMissingManuallyConfiguredPackagesIssue: false });
           helper.scopeHelper.addRemoteScope();
           helper.command.importComponent('comp1');
           helper.command.dependenciesSet('comp1', `${helper.general.getPackageNameByCompName('bar/foo')}@0.0.1`);

--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -1,6 +1,8 @@
+import { IssuesClasses } from '@teambit/component-issues';
 import { expect } from 'chai';
 import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
+import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
 
 describe('bit dependencies command', function () {
   let helper: Helper;
@@ -108,6 +110,47 @@ describe('bit dependencies command', function () {
       it('should not remove the previously added dependencies', () => {
         const show = helper.command.showComponent('comp1');
         expect(show).to.have.string('lodash');
+      });
+    });
+    (supportNpmCiRegistryTesting ? describe : describe.skip)('adding component dependency', () => {
+      let npmCiRegistry: NpmCiRegistry;
+      before(async () => {
+        helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.bitJsonc.setupDefault();
+        npmCiRegistry = new NpmCiRegistry(helper);
+        await npmCiRegistry.init();
+        npmCiRegistry.configureCiInPackageJsonHarmony();
+        helper.fixtures.populateComponents(1, false);
+        helper.fixtures.createComponentBarFoo();
+        helper.fixtures.addComponentBarFooAsDir();
+        helper.command.compile();
+        helper.command.install();
+        helper.command.tagAllComponents();
+        helper.command.export();
+      });
+      after(() => {
+        npmCiRegistry.destroy();
+        helper = new Helper();
+      });
+      describe('adding a component dependency when it is not installed locally', () => {
+        before(() => {
+          helper.scopeHelper.reInitLocalScope();
+          helper.scopeHelper.addRemoteScope();
+          helper.command.importComponent('comp1');
+          helper.command.dependenciesSet('comp1', `${helper.general.getPackageNameByCompName('bar/foo')}@0.0.1`);
+        });
+        it('bit status should show it as missing', () => {
+          helper.command.expectStatusToHaveIssue(IssuesClasses.MissingPackagesDependenciesOnFs.name);
+        });
+        it('bit install should fix it', () => {
+          helper.command.install();
+          helper.command.expectStatusToNotHaveIssues();
+        });
+        it('should recognize it as a component after the installation', () => {
+          const deps = helper.command.dependenciesGet('comp1');
+          expect(deps).to.include('bar/foo@0.0.1');
+        });
       });
     });
   });

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -5,6 +5,7 @@ import { MissingComponents } from './missing-components';
 import { MissingDependenciesOnFs } from './missing-dependencies-on-fs';
 import { MissingDists } from './missing-dists';
 import { MissingPackagesDependenciesOnFs } from './missing-packages-dependencies-on-fs';
+import { MissingManuallyConfiguredPackages } from './missing-manually-configured-packages';
 import { ParseErrors } from './parse-errors';
 import { RelativeComponents } from './relative-components';
 import { RelativeComponentsAuthored } from './relative-components-authored';
@@ -18,6 +19,7 @@ import { DuplicateComponentAndPackage } from './duplicate-component-and-package'
 
 export const IssuesClasses = {
   MissingPackagesDependenciesOnFs,
+  MissingManuallyConfiguredPackages,
   MissingComponents,
   UntrackedDependencies,
   ResolveErrors,

--- a/scopes/component/component-issues/missing-manually-configured-packages.ts
+++ b/scopes/component/component-issues/missing-manually-configured-packages.ts
@@ -1,0 +1,10 @@
+import { ComponentIssue, ISSUE_FORMAT_SPACE } from './component-issue';
+
+export class MissingManuallyConfiguredPackages extends ComponentIssue {
+  description = `missing packages that were manually set`;
+  solution = `run "bit install"`;
+  data: string[] = []; // package names
+  dataToString() {
+    return ISSUE_FORMAT_SPACE + this.data.join(', ');
+  }
+}

--- a/src/cli/templates/component-issues-template.ts
+++ b/src/cli/templates/component-issues-template.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import ConsumerComponent from '../../consumer/component/consumer-component';
 
-export const MISSING_PACKAGES_FROM_OVERRIDES_LABEL = 'from overrides configuration';
+export const MISSING_PACKAGES_FROM_OVERRIDES_LABEL = 'manually configured';
 
 export function getInvalidComponentLabel(error: Error) {
   switch (error.name) {

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-loader.ts
@@ -9,7 +9,6 @@ import Component from '../../consumer-component';
 import { DependenciesData } from './dependencies-data';
 import DependencyResolver from './dependencies-resolver';
 import { COMPONENT_CONFIG_FILE_NAME } from '../../../../constants';
-import { MISSING_PACKAGES_FROM_OVERRIDES_LABEL } from '../../../../cli/templates/component-issues-template';
 
 type Opts = {
   cacheResolvedDependencies: Record<string, any>;
@@ -84,9 +83,7 @@ export class DependenciesLoader {
     this.component.peerPackageDependencies = dependenciesData.allPackagesDependencies.peerPackageDependencies ?? {};
     const missingFromOverrides = dependenciesData.overridesDependencies.missingPackageDependencies;
     if (!R.isEmpty(missingFromOverrides)) {
-      dependenciesData.issues.getOrCreate(IssuesClasses.MissingPackagesDependenciesOnFs).data[
-        MISSING_PACKAGES_FROM_OVERRIDES_LABEL
-      ] = missingFromOverrides;
+      dependenciesData.issues.getOrCreate(IssuesClasses.MissingManuallyConfiguredPackages).data = missingFromOverrides;
     }
     if (!dependenciesData.issues.isEmpty()) this.component.issues = dependenciesData.issues;
     this.component.manuallyRemovedDependencies = dependenciesData.overridesDependencies.manuallyRemovedDependencies;

--- a/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
@@ -109,7 +109,7 @@ export default class OverridesDependencies {
         const dependencyValue = overrides[depField][dependency];
         if (dependencyValue === MANUALLY_REMOVE_DEPENDENCY) return;
         const componentData = this._getComponentIdToAdd(depField, dependency);
-        if (componentData && componentData.componentId) {
+        if (componentData?.componentId) {
           const dependencyExist = existingDependencies[depField].find((d) =>
             d.id.isEqualWithoutScopeAndVersion(componentData.componentId)
           );
@@ -122,6 +122,9 @@ export default class OverridesDependencies {
         const addedPkg = this._manuallyAddPackage(depField, dependency, dependencyValue, packageJson);
         if (addedPkg) {
           packages[depField] = Object.assign(packages[depField] || {}, addedPkg);
+          if (!componentData?.packageName) {
+            this.missingPackageDependencies.push(dependency);
+          }
         }
       });
     });

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -117,12 +117,20 @@ export default class BitJsoncHelper {
     const bitJsoncPath = composePath(this.scopes.localPath);
     fs.writeFileSync(bitJsoncPath, '"corrupted');
   }
+  disableMissingManuallyConfiguredPackagesIssue() {
+    this.addKeyVal('teambit.component/issues', {
+      ignoreIssues: ['MissingManuallyConfiguredPackages'],
+    });
+  }
   disablePreview() {
     this.addKeyVal('teambit.preview/preview', { disabled: true });
   }
   setupDefault() {
     this.disablePreview();
     this.addDefaultScope();
+    // otherwise, "bit tag" and "bit status" will always fail with "MissingManuallyConfiguredPackages" for jest/babel
+    // until "bit install" is running, because they're coming from the default env.
+    this.disableMissingManuallyConfiguredPackagesIssue();
   }
 }
 

--- a/src/e2e-helper/e2e-general-helper.ts
+++ b/src/e2e-helper/e2e-general-helper.ts
@@ -129,6 +129,6 @@ export default class GeneralHelper {
   }
 
   getPackageNameByCompName(compName: string) {
-    return `@${DEFAULT_OWNER}/${this.scopes.remoteWithoutOwner}.${compName}`;
+    return `@${DEFAULT_OWNER}/${this.scopes.remoteWithoutOwner}.${compName.replaceAll('/', '.')}`;
   }
 }

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -90,6 +90,7 @@ export default class ScopeHelper {
     const disablePreview = opts?.disablePreview || opts?.disablePreview === undefined;
     if (addRemoteScopeAsDefaultScope) this.bitJsonc.addDefaultScope();
     if (disablePreview) this.bitJsonc.disablePreview();
+    this.bitJsonc.disableMissingManuallyConfiguredPackagesIssue();
 
     if (opts?.registry) {
       this._writeNpmrc({

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -17,6 +17,7 @@ import BitJsoncHelper from './e2e-bit-jsonc-helper';
 type SetupWorkspaceOpts = {
   addRemoteScopeAsDefaultScope?: boolean; // default to true, otherwise, the scope is "my-scope"
   disablePreview?: boolean; // default to true to speed up the tag
+  disableMissingManuallyConfiguredPackagesIssue?: boolean; // default to true. otherwise, it'll always show missing babel/jest from react-env
   registry?: string;
   initGit?: boolean;
   yarnRCConfig?: any;
@@ -85,12 +86,10 @@ export default class ScopeHelper {
     if (opts?.initGit) this.command.runCmd('git init');
     this.initWorkspace();
 
-    const addRemoteScopeAsDefaultScope =
-      opts?.addRemoteScopeAsDefaultScope || opts?.addRemoteScopeAsDefaultScope === undefined;
-    const disablePreview = opts?.disablePreview || opts?.disablePreview === undefined;
-    if (addRemoteScopeAsDefaultScope) this.bitJsonc.addDefaultScope();
-    if (disablePreview) this.bitJsonc.disablePreview();
-    this.bitJsonc.disableMissingManuallyConfiguredPackagesIssue();
+    if (opts?.addRemoteScopeAsDefaultScope ?? true) this.bitJsonc.addDefaultScope();
+    if (opts?.disablePreview ?? true) this.bitJsonc.disablePreview();
+    if (opts?.disableMissingManuallyConfiguredPackagesIssue ?? true)
+      this.bitJsonc.disableMissingManuallyConfiguredPackagesIssue();
 
     if (opts?.registry) {
       this._writeNpmrc({


### PR DESCRIPTION
currently, when running `bit deps set` and the component dependency is not imported nor installed and is added with a specific version, it is added as package instead of a component.
It's happening because Bit doesn't have the package.json to know that it's a componnet.
This PR shows the component/package as missing until it's installed. Once installed, it's recognized correctly.