### PR TITLE
fix: avoid loading cli aspect twice by removing it from ConfigAspect dependencies

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -214,13 +214,13 @@ export async function loadBit(path = process.cwd()) {
   logger.info(`*** Loading Bit *** argv:\n${process.argv.join('\n')}`);
   const config = await getConfig(path);
   registerCoreExtensions();
-  // await loadLegacyConfig(config);
+  await loadLegacyConfig(config);
   const configMap = config.toObject();
   configMap[BitAspect.id] ||= {};
   configMap[BitAspect.id].cwd = path;
   verifyEngine(configMap[BitAspect.id]);
 
-  const aspectsToLoad = [CLIAspect, ConfigAspect];
+  const aspectsToLoad = [CLIAspect];
   const loadCLIOnly = shouldLoadInSafeMode();
   if (!loadCLIOnly) {
     aspectsToLoad.push(BitAspect);

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -214,13 +214,13 @@ export async function loadBit(path = process.cwd()) {
   logger.info(`*** Loading Bit *** argv:\n${process.argv.join('\n')}`);
   const config = await getConfig(path);
   registerCoreExtensions();
-  await loadLegacyConfig(config);
+  // await loadLegacyConfig(config);
   const configMap = config.toObject();
   configMap[BitAspect.id] ||= {};
   configMap[BitAspect.id].cwd = path;
   verifyEngine(configMap[BitAspect.id]);
 
-  const aspectsToLoad = [CLIAspect];
+  const aspectsToLoad = [CLIAspect, ConfigAspect];
   const loadCLIOnly = shouldLoadInSafeMode();
   if (!loadCLIOnly) {
     aspectsToLoad.push(BitAspect);

--- a/scopes/harmony/config/config.main.runtime.ts
+++ b/scopes/harmony/config/config.main.runtime.ts
@@ -11,7 +11,7 @@ import LegacyWorkspaceConfig, {
   WorkspaceConfigLoadFunction,
 } from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { PathOsBased, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
-import { CLIAspect, MainRuntime } from '@teambit/cli';
+import { MainRuntime } from '@teambit/cli';
 import { GlobalConfig } from '@teambit/harmony';
 import path from 'path';
 import { transformLegacyPropsToExtensions, WorkspaceConfig, WorkspaceConfigFileProps } from './workspace-config';
@@ -90,7 +90,7 @@ export class ConfigMain {
 
   static runtime = MainRuntime;
   static slots = [];
-  static dependencies = [CLIAspect];
+  static dependencies = [];
   static config = {};
   static async provider() {
     LegacyWorkspaceConfig.registerOnWorkspaceConfigIsExist(onLegacyWorkspaceConfigIsExist());


### PR DESCRIPTION
Looks like Config aspect doesn't use it, so it should be safe to remove. (currently, `loadLegacyConfig()` function loads Config aspect before anything else and it causes the CLI aspect to be loaded. as well). 