### PR TITLE
improvement: print install and import duration, suppress object-count on ci

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -325,6 +325,7 @@ export class IsolatorMain {
     if (installOptions.installPackages) {
       const cachePackagesOnCapsulesRoot = opts.cachePackagesOnCapsulesRoot ?? false;
       const linkingOptions = opts.linkingOptions ?? {};
+      const longProcessLogger = this.logger.createLongProcessLogger('install packages');
       if (installOptions.useNesting) {
         await Promise.all(
           capsuleList.map(async (capsule) => {
@@ -341,6 +342,8 @@ export class IsolatorMain {
         await this.installInCapsules(rootDir, capsuleList, installOptions, cachePackagesOnCapsulesRoot);
         await this.linkInCapsules(capsulesDir, capsuleList, capsulesWithPackagesData, linkingOptions);
       }
+      longProcessLogger.end();
+      this.logger.consoleSuccess();
     }
 
     // rewrite the package-json with the component dependencies in it. the original package.json

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -51,6 +51,7 @@ export class SignMain {
   async sign(ids: ComponentID[], isMultiple?: boolean, push?: boolean, laneIdStr?: string): Promise<SignResult | null> {
     let lane: Lane | undefined;
     if (isMultiple) {
+      const longProcessLogger = this.logger.createLongProcessLogger('import objects');
       if (laneIdStr) {
         const laneId = LaneId.parse(laneIdStr);
         lane = await this.lanes.importLaneObject(laneId);
@@ -59,6 +60,8 @@ export class SignMain {
         this.scope.legacyScope.setCurrentLaneId(laneId);
       }
       await this.scope.import(ids, { lane });
+      longProcessLogger.end();
+      this.logger.consoleSuccess();
     }
     const { componentsToSkip, componentsToSign } = await this.getComponentIdsToSign(ids);
     if (ids.length && componentsToSkip.length) {
@@ -169,7 +172,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     const componentsToSkip: ComponentID[] = [];
     components.forEach((component) => {
       if (component.state._consumer.buildStatus === BuildStatus.Succeed) {
-        componentsToSkip.push(component.id);
+        componentsToSign.push(component.id);
       } else {
         componentsToSign.push(component.id);
       }

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -144,6 +144,9 @@ the remote scope "${scopeName}" was not found`);
   }
 
   private showProgress(objectsQueue: WriteObjectsQueue, componentsQueue: WriteComponentsQueue) {
+    if (process.env.CI) {
+      return; // don't show progress on CI.
+    }
     let objectsAdded = 0;
     let objectsCompleted = 0;
     let componentsAdded = 0;


### PR DESCRIPTION
## Proposed Changes

- print to the console how long took installation on capsules
- print to the console how long took import on `bit sign`
- don't show the objects count during import if is running on a CI. (`process.env.CI` is `true`).
