### PR TITLE
fix: Yarn should write the global cache to the folder that Bit specifies

### DIFF
--- a/scopes/dependencies/yarn/yarn.package-manager.ts
+++ b/scopes/dependencies/yarn/yarn.package-manager.ts
@@ -400,7 +400,7 @@ export class YarnPackageManager implements PackageManager {
       data[defaultAuthProp.keyName] = defaultAuthProp.value;
     }
     // TODO: node-modules is hardcoded now until adding support for pnp.
-    config.use('<bit>', data, rootDirPath, {});
+    config.use('<bit>', data, rootDirPath, { overwrite: true });
 
     return config;
   }


### PR DESCRIPTION
## Proposed Changes

- settings provided by Bit should have higher priority than internal Yarn settings.

