### PR TITLE
improvement(testing): support non-core aspect loading

### DIFF
--- a/scopes/component/testing/mock-components/index.ts
+++ b/scopes/component/testing/mock-components/index.ts
@@ -1,1 +1,1 @@
-export { mockComponents } from './mock-components';
+export { mockComponents, modifyMockedComponents } from './mock-components';

--- a/scopes/component/testing/mock-components/mock-components.ts
+++ b/scopes/component/testing/mock-components/mock-components.ts
@@ -8,22 +8,12 @@ import path from 'path';
 
 /**
  * create dummy components, add, link and compile them.
- * if `numOfComponents` is more than one, the components will depend on each other.
+ * if `numOfComponents` is more than one, the components will depend on each other. by default, it's one.
  */
 export async function mockComponents(workspacePath: string, { numOfComponents = 1, additionalStr = '' } = {}) {
-  const getImp = (index) => {
-    if (index === numOfComponents) return `module.exports = () => 'comp${index}${additionalStr}';`;
-    const nextComp = `comp${index + 1}`;
-    return `const ${nextComp} = require('../${nextComp}');
-module.exports = () => 'comp${index}${additionalStr} and ' + ${nextComp}();`;
-  };
-
+  const compsDirs = await createComponents(workspacePath, { numOfComponents, additionalStr });
   const workspace: Workspace = await loadAspect(WorkspaceAspect, workspacePath);
-  const numOfComponentsArr = Array(numOfComponents).fill(null);
-  await pMapSeries(numOfComponentsArr, async (val, key) => {
-    const i = key + 1;
-    const compDir = path.join(workspacePath, `comp${i}`);
-    await fs.outputFile(path.join(compDir, `index.js`), getImp(i));
+  await pMapSeries(compsDirs, async (compDir) => {
     await workspace.track({ rootDir: compDir });
   });
   await workspace.bitMap.write();
@@ -32,4 +22,31 @@ module.exports = () => 'comp${index}${additionalStr} and ' + ${nextComp}();`;
 
   const compiler: CompilerMain = await loadAspect(CompilerAspect, workspacePath);
   await compiler.compileOnWorkspace();
+}
+
+/**
+ * make the mocked components modified by appending the `additionalStr` to the component files
+ */
+export async function modifyMockedComponents(workspacePath: string, additionalStr = ' ', { numOfComponents = 1 } = {}) {
+  await createComponents(workspacePath, { numOfComponents, additionalStr });
+}
+
+async function createComponents(
+  workspacePath: string,
+  { numOfComponents = 1, additionalStr = '' } = {}
+): Promise<string[]> {
+  const getImp = (index) => {
+    if (index === numOfComponents) return `module.exports = () => 'comp${index}${additionalStr}';`;
+    const nextComp = `comp${index + 1}`;
+    return `const ${nextComp} = require('../${nextComp}');
+module.exports = () => 'comp${index}${additionalStr} and ' + ${nextComp}();`;
+  };
+
+  const numOfComponentsArr = Array(numOfComponents).fill(null);
+  return pMapSeries(numOfComponentsArr, async (val, key) => {
+    const i = key + 1;
+    const compDir = path.join(workspacePath, `comp${i}`);
+    await fs.outputFile(path.join(compDir, `index.js`), getImp(i));
+    return compDir;
+  });
 }

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -41,8 +41,7 @@ export async function loadAspect<T>(targetAspect: Aspect, cwd = process.cwd(), r
 
   await harmony.run(async (aspect, runtimeDef) => {
     const id = ComponentID.fromString(aspect.id);
-    const packageName = getPackageName(aspect, id);
-    const mainFilePath = require.resolve(packageName);
+    const mainFilePath = getMainFilePath(aspect, id);
     const packagePath = resolve(join(mainFilePath, '..'));
     const files = readdirSync(packagePath);
     const runtimePath = files.find((path) => path.includes(`.${runtimeDef.name}.runtime.js`));
@@ -61,6 +60,18 @@ go to the aspect-main file and add a new line with "export default YourAspectMai
   });
 
   return harmony.get(targetAspect.id);
+}
+
+function getMainFilePath(aspect: any, id: ComponentID) {
+  let packageName = getPackageName(aspect, id);
+  try {
+    // try core aspects
+    return require.resolve(packageName);
+  } catch (err) {
+    // fallback to a naive way of converting componentId to pkg-name. (it won't work when the component has special pkg name settings)
+    packageName = `@${id.scope.replace('.', '/')}.${id.fullName.replaceAll('/', '.')}`;
+    return require.resolve(packageName);
+  }
 }
 
 export async function getConfig(cwd = process.cwd()) {

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { loadAspect } from '@teambit/harmony.testing.load-aspect';
 import SnappingAspect, { SnappingMain } from '@teambit/snapping';
 import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
-import { mockComponents } from '@teambit/component.testing.mock-components';
+import { mockComponents, modifyMockedComponents } from '@teambit/component.testing.mock-components';
 import { LanesAspect } from './lanes.aspect';
 import { LanesMain } from './lanes.main.runtime';
 
@@ -41,7 +41,8 @@ describe('LanesAspect', function () {
       await snapping.tag({ ids: ['comp1'], build: false });
       lanes = await loadAspect(LanesAspect, workspacePath);
       await lanes.createLane('stage');
-      const result = await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
+      await modifyMockedComponents(workspacePath, 'v2');
+      const result = await snapping.snap({ pattern: 'comp1', build: false });
       // intermediate step, make sure it is snapped
       expect(result?.snappedComponents.length).to.equal(1);
     });


### PR DESCRIPTION
## Proposed Changes

- `loadAspect()` of the testing framework supports non-core aspects.
- add a new API to modified mocked components.
