### PR TITLE
suggest running --verbose when it shows no diff

### DIFF
--- a/src/consumer/component-ops/components-diff.ts
+++ b/src/consumer/component-ops/components-diff.ts
@@ -252,7 +252,7 @@ export function outputDiffResults(diffResults: DiffResults[]): string {
         const fields = diffResult.fieldsDiff ? diffResult.fieldsDiff.map((field) => field.diffOutput).join('\n') : '';
         return `${title}\n${files}\n${fields}`;
       }
-      return `no diff for ${chalk.bold(diffResult.id.toString())}`;
+      return `no diff for ${chalk.bold(diffResult.id.toString())} (consider running with --verbose)`;
     })
     .join('\n\n');
 }


### PR DESCRIPTION
It's possible that a component is shown as modified, but `bit diff` doesn't show any diff because it's override diffs that are shown only when `--verbose` flag is used. 
This flag suggests using this flag when it has no diff.