### PR TITLE
fix(mocha): handle failures inside hooks

### DIFF
--- a/e2e/harmony/mocha-tester.e2e.ts
+++ b/e2e/harmony/mocha-tester.e2e.ts
@@ -51,11 +51,11 @@ describe('Mocha Tester', function () {
       it('bit test should exit with non-zero code', () => {
         expect(() => helper.command.test()).to.throw();
       });
-      it('bit test should show the failing component via Jest output', () => {
+      it('bit test should show the failing component via Mocha output', () => {
         const output = helper.general.runWithTryCatch('bit test');
         expect(output).to.have.string('1 failing');
       });
-      it('bit build should show the failing component via Jest output', () => {
+      it('bit build should show the failing component via Mocha output', () => {
         const output = helper.general.runWithTryCatch('bit build');
         expect(output).to.have.string('1 failing');
       });
@@ -63,6 +63,22 @@ describe('Mocha Tester', function () {
     describe('component with an errored test', () => {
       before(() => {
         helper.fs.outputFile('comp1/comp1.spec.ts', specFileErroringFixture());
+      });
+      it('bit test should exit with non-zero code', () => {
+        expect(() => helper.command.test()).to.throw();
+      });
+      it('bit test should show the error', () => {
+        const output = helper.general.runWithTryCatch('bit test');
+        expect(output).to.have.string('SomeError');
+      });
+      it('bit build should show the error', () => {
+        const output = helper.general.runWithTryCatch('bit build');
+        expect(output).to.have.string('SomeError');
+      });
+    });
+    describe('component with an errored before hook', () => {
+      before(() => {
+        helper.fs.outputFile('comp1/comp1.spec.ts', specFileWithErrorInBeforeHook());
       });
       it('bit test should exit with non-zero code', () => {
         expect(() => helper.command.test()).to.throw();
@@ -138,6 +154,21 @@ function specFileErroringFixture() {
   return `import { expect } from 'chai';
 describe('test', () => {
     throw new Error('SomeError');
+  it('should not reach here', () => {
+    expect(true).to.be.true;
+  });
+});
+`;
+}
+
+function specFileWithErrorInBeforeHook() {
+  return `import { expect } from 'chai';
+
+describe('test', () => {
+  // @ts-ignore
+  before(() => {
+    throw new Error('SomeError');
+  });
   it('should not reach here', () => {
     expect(true).to.be.true;
   });

--- a/scopes/component/component-issues/issues-list.ts
+++ b/scopes/component/component-issues/issues-list.ts
@@ -69,7 +69,7 @@ export class IssuesList {
   }
 
   delete(IssueClass: typeof ComponentIssue) {
-    this.issues = this.issues.filter((issue) => !(issue instanceof IssueClass));
+    this.issues = this.issues.filter((issue) => issue.constructor.name !== IssueClass.name);
   }
 
   getIssue<T extends ComponentIssue>(IssueClass: { new (): T }): T | undefined {

--- a/scopes/component/issues/issues.main.runtime.ts
+++ b/scopes/component/issues/issues.main.runtime.ts
@@ -54,11 +54,11 @@ export class IssuesMain {
     });
   }
 
-  removeIgnoredIssuesFromComponents(components: Component[]) {
+  removeIgnoredIssuesFromComponents(components: Component[], extraIssuesToIgnore: string[] = []) {
     const issuesToIgnoreGlobally = this.getIssuesToIgnoreGlobally();
     components.forEach((component) => {
       const issuesToIgnoreForThisComp = this.getIssuesToIgnorePerComponent(component);
-      const issuesToIgnore = [...issuesToIgnoreGlobally, ...issuesToIgnoreForThisComp];
+      const issuesToIgnore = [...issuesToIgnoreGlobally, ...issuesToIgnoreForThisComp, ...extraIssuesToIgnore];
       issuesToIgnore.forEach((issueToIgnore) => {
         component.state.issues.delete(IssuesClasses[issueToIgnore]);
       });

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -732,7 +732,7 @@ there are matching among unmodified components thought. consider using --unmodif
     const issuesToIgnore = [...issuesToIgnoreFromFlag, ...issuesToIgnoreFromConfig];
     const components = await this.workspace.getManyByLegacy(legacyComponents);
     await this.issues.triggerAddComponentIssues(components, issuesToIgnore);
-    this.issues.removeIgnoredIssuesFromComponents(components);
+    this.issues.removeIgnoredIssuesFromComponents(components, issuesToIgnore);
 
     const componentsWithBlockingIssues = legacyComponents.filter((component) => component.issues?.shouldBlockTagging());
     if (!R.isEmpty(componentsWithBlockingIssues)) {

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -38,7 +38,7 @@ describe('LanesAspect', function () {
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
       snapping = await loadAspect(SnappingAspect, workspacePath);
-      await snapping.tag({ ids: ['comp1'], build: false });
+      await snapping.tag({ ids: ['comp1'], build: false, ignoreIssues: 'MissingManuallyConfiguredPackages' });
       lanes = await loadAspect(LanesAspect, workspacePath);
       await lanes.createLane('stage');
       await modifyMockedComponents(workspacePath, 'v2');

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -42,7 +42,11 @@ describe('LanesAspect', function () {
       lanes = await loadAspect(LanesAspect, workspacePath);
       await lanes.createLane('stage');
       await modifyMockedComponents(workspacePath, 'v2');
-      const result = await snapping.snap({ pattern: 'comp1', build: false });
+      const result = await snapping.snap({
+        pattern: 'comp1',
+        build: false,
+        ignoreIssues: 'MissingManuallyConfiguredPackages',
+      });
       // intermediate step, make sure it is snapped
       expect(result?.snappedComponents.length).to.equal(1);
     });
@@ -59,7 +63,12 @@ describe('LanesAspect', function () {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
-      await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
+      await snapping.snap({
+        pattern: 'comp1',
+        build: false,
+        unmodified: true,
+        ignoreIssues: 'MissingManuallyConfiguredPackages',
+      });
       const isUpToDate = await lanes.isLaneUpToDate(currentLane);
       expect(isUpToDate).to.be.false;
     });


### PR DESCRIPTION
Until now, failure during hooks, such as `before()` was ending with code 0 (success). 
This PR registers to an event on Mocha that catches these errors and report them correctly to the tester.