### PR TITLE
fix(tag): use pre-release for auto-tag as well instead of patch

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -346,6 +346,18 @@ describe('tag components on Harmony', function () {
       });
     });
   });
+  describe('auto-tag with pre-release', () => {
+    let tagOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      tagOutput = helper.command.tagWithoutBuild('comp3', '--unmodified --increment prerelease --prerelease-id dev');
+    });
+    it('should auto-tag dependents according to the pre-release version', () => {
+      expect(tagOutput).to.have.string('comp1@0.0.2-dev.0');
+    });
+  });
   describe('soft-tag pre-release', () => {
     let tagOutput: string;
     before(() => {


### PR DESCRIPTION
currently, for auto-tag it always bump by patch. for pre-release, it makes sense to use the same pre-release for the auto-tag.