### PR TITLE
fix: load extensions only once after merging from different sources

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1140,29 +1140,22 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     // in the case the same extension pushed twice, the former takes precedence (opposite of Object.assign)
     const extensionsToMerge: Array<{ origin: ExtensionsOrigin; extensions: ExtensionDataList; extraData: any }> = [];
     let envWasFoundPreviously = false;
-    const loadedExtensionIds: string[] = [];
     const removedExtensionIds: string[] = [];
 
-    const addAndLoadExtensions = async (extensions: ExtensionDataList, origin: ExtensionsOrigin, extraData?: any) => {
+    const addExtensionsToMerge = async (extensions: ExtensionDataList, origin: ExtensionsOrigin, extraData?: any) => {
       if (!extensions.length) {
         return;
       }
       removedExtensionIds.push(...extensions.filter((extData) => extData.isRemoved).map((extData) => extData.stringId));
       const extsWithoutRemoved = extensions.filterRemovedExtensions();
-      const extsWithoutLoaded = ExtensionDataList.fromArray(
-        extsWithoutRemoved.filter(
-          (ext) => !loadedExtensionIds.includes(ext.extensionId?.toStringWithoutVersion() || '')
-        )
-      );
-      const selfInMergedExtensions = extsWithoutLoaded.findExtension(
+      const selfInMergedExtensions = extsWithoutRemoved.findExtension(
         componentId._legacy.toStringWithoutScopeAndVersion(),
         true,
         true
       );
       const extsWithoutSelf = selfInMergedExtensions?.extensionId
-        ? extsWithoutLoaded.remove(selfInMergedExtensions.extensionId)
-        : extsWithoutLoaded;
-      // await this.loadExtensions(extsWithoutSelf, componentId);
+        ? extsWithoutRemoved.remove(selfInMergedExtensions.extensionId)
+        : extsWithoutRemoved;
       const { extensionDataListFiltered, envIsCurrentlySet } = this.filterEnvsFromExtensionsIfNeeded(
         extsWithoutSelf,
         envWasFoundPreviously
@@ -1173,10 +1166,6 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       }
 
       extensionsToMerge.push({ origin, extensions: extensionDataListFiltered, extraData });
-
-      // loadedExtensionIds.push(
-      //   ...compact(extensionDataListFiltered.map((e) => e.extensionId?.toStringWithoutVersion()))
-      // );
     };
     const setDataListAsSpecific = (extensions: ExtensionDataList) => {
       extensions.forEach((dataEntry) => (dataEntry.config[AspectSpecificField] = true));
@@ -1184,22 +1173,22 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     if (bitMapExtensions && !excludeOrigins.includes('BitmapFile')) {
       const extensionDataList = ExtensionDataList.fromConfigObject(bitMapExtensions);
       setDataListAsSpecific(extensionDataList);
-      await addAndLoadExtensions(extensionDataList, 'BitmapFile');
+      await addExtensionsToMerge(extensionDataList, 'BitmapFile');
     }
     if (configFileExtensions && !excludeOrigins.includes('ComponentJsonFile')) {
       setDataListAsSpecific(configFileExtensions);
-      await addAndLoadExtensions(configFileExtensions, 'ComponentJsonFile');
+      await addExtensionsToMerge(configFileExtensions, 'ComponentJsonFile');
     }
     if (unmergedExtensionsSpecific && !excludeOrigins.includes('UnmergedSpecific')) {
-      await addAndLoadExtensions(ExtensionDataList.fromArray(unmergedExtensionsSpecific), 'UnmergedSpecific');
+      await addExtensionsToMerge(ExtensionDataList.fromArray(unmergedExtensionsSpecific), 'UnmergedSpecific');
     }
     if (!excludeOrigins.includes('ModelSpecific')) {
-      await addAndLoadExtensions(ExtensionDataList.fromArray(scopeExtensionsSpecific), 'ModelSpecific');
+      await addExtensionsToMerge(ExtensionDataList.fromArray(scopeExtensionsSpecific), 'ModelSpecific');
     }
     let continuePropagating = componentConfigFile?.propagate ?? true;
     if (variantsExtensions && continuePropagating && !excludeOrigins.includes('WorkspaceVariants')) {
       const appliedRules = variantConfig?.sortedMatches.map(({ pattern, specificity }) => ({ pattern, specificity }));
-      await addAndLoadExtensions(variantsExtensions, 'WorkspaceVariants', { appliedRules });
+      await addExtensionsToMerge(variantsExtensions, 'WorkspaceVariants', { appliedRules });
     }
     continuePropagating = continuePropagating && (variantConfig?.propagate ?? true);
     // Do not apply default extensions on the default extensions (it will create infinite loop when loading them)
@@ -1210,7 +1199,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       !isDefaultExtension &&
       !excludeOrigins.includes('WorkspaceDefault')
     ) {
-      await addAndLoadExtensions(wsDefaultExtensions, 'WorkspaceDefault');
+      await addExtensionsToMerge(wsDefaultExtensions, 'WorkspaceDefault');
     }
     if (
       unmergedExtensionsNonSpecific &&
@@ -1218,10 +1207,10 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       continuePropagating &&
       !excludeOrigins.includes('UnmergedNonSpecific')
     ) {
-      await addAndLoadExtensions(unmergedExtensionsNonSpecific, 'UnmergedNonSpecific');
+      await addExtensionsToMerge(unmergedExtensionsNonSpecific, 'UnmergedNonSpecific');
     }
     if (mergeFromScope && continuePropagating && !excludeOrigins.includes('ModelNonSpecific')) {
-      await addAndLoadExtensions(scopeExtensionsNonSpecific, 'ModelNonSpecific');
+      await addExtensionsToMerge(scopeExtensionsNonSpecific, 'ModelNonSpecific');
     }
 
     // It's important to do this resolution before the merge, otherwise we have issues with extensions
@@ -1290,9 +1279,6 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
     const envFromEnvsAspect = envAspect?.config.env;
     const nonEnvs = extensionDataList.filter((e) => e.id !== envFromEnvsAspect);
-    // const [envsNotFromEnvsAspect, nonEnvs] = partition(extensionDataList, (ext) =>
-    //   this.envs.isEnvRegistered(ext.stringId)
-    // );
     const extensionDataListFiltered = new ExtensionDataList(...nonEnvs);
     const envIsCurrentlySet = Boolean(envFromEnvsAspect); // || envsNotFromEnvsAspect.length;
     const shouldIgnoreCurrentEnv = envIsCurrentlySet && envWasFoundPreviously;
@@ -1305,7 +1291,6 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     } else if (envAspect) {
       // add the envs
       extensionDataListFiltered.push(envAspect);
-      // extensionDataListFiltered.push(...envsNotFromEnvsAspect);
     }
     return { extensionDataListFiltered, envIsCurrentlySet };
   }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1278,21 +1278,13 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
     const envFromEnvsAspect: string | undefined = envAspect?.config.env;
-    const nonEnvs = extensionDataList.filter((e) => e.stringId !== envFromEnvsAspect);
-    const extensionDataListFiltered = new ExtensionDataList(...nonEnvs);
-    const envIsCurrentlySet = Boolean(envFromEnvsAspect); // || envsNotFromEnvsAspect.length;
-    const shouldIgnoreCurrentEnv = envIsCurrentlySet && envWasFoundPreviously;
-    if (shouldIgnoreCurrentEnv) {
+    if (envWasFoundPreviously && envAspect) {
+      const nonEnvs = extensionDataList.filter((e) => e.stringId !== envFromEnvsAspect);
       // still, aspect env may have other data other then config.env.
-      if (envAspect) {
-        delete envAspect.config.env;
-        extensionDataListFiltered.push(envAspect);
-      }
-    } else if (envAspect) {
-      // add the envs
-      extensionDataListFiltered.push(envAspect);
+      delete envAspect.config.env;
+      return { extensionDataListFiltered: new ExtensionDataList(...nonEnvs), envIsCurrentlySet: true };
     }
-    return { extensionDataListFiltered, envIsCurrentlySet };
+    return { extensionDataListFiltered: extensionDataList, envIsCurrentlySet: Boolean(envFromEnvsAspect) };
   }
 
   async triggerOnPreWatch(componentIds: ComponentID[], watchOpts: WatchOptions) {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1277,8 +1277,8 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
 
   private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
-    const envFromEnvsAspect = envAspect?.config.env;
-    const nonEnvs = extensionDataList.filter((e) => e.id !== envFromEnvsAspect);
+    const envFromEnvsAspect: string | undefined = envAspect?.config.env;
+    const nonEnvs = extensionDataList.filter((e) => e.stringId !== envFromEnvsAspect);
     const extensionDataListFiltered = new ExtensionDataList(...nonEnvs);
     const envIsCurrentlySet = Boolean(envFromEnvsAspect); // || envsNotFromEnvsAspect.length;
     const shouldIgnoreCurrentEnv = envIsCurrentlySet && envWasFoundPreviously;


### PR DESCRIPTION
Bit calculates the aspect based on different sources, such as, model, workspace.json, bitmap. At each source, the aspects are loaded. The reason was to get the envs registered so then we know whether we have already an env configured, and then ignore other envs from different sources.
This is now not needed, because all envs are registered via `teambit.envs/envs`, so it's possible to get the env from there and no need to load the aspect to check whether it's an env.
The load is done at the end, once all aspects from different sources are merged. 