### PR TITLE
fix(artifacts): fix objects corruption during artifacts import by importing them one by one

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-list.ts
+++ b/scopes/pipelines/builder/artifact/artifact-list.ts
@@ -1,4 +1,5 @@
 import { Component } from '@teambit/component';
+import pMapSeries from 'p-map-series';
 import type { ArtifactObject } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { BitId } from '@teambit/legacy/dist/bit-id';
 import { Scope } from '@teambit/legacy/dist/scope';
@@ -81,7 +82,7 @@ export class ArtifactList<T extends Artifact> extends Array<T> {
 
   async getVinylsAndImportIfMissing(id: BitId, scope: Scope): Promise<ArtifactVinyl[]> {
     if (this.isEmpty()) return [];
-    const vinyls = await Promise.all(this.map((artifact) => artifact.files.getVinylsAndImportIfMissing(id, scope)));
+    const vinyls = await pMapSeries(this, (artifact) => artifact.files.getVinylsAndImportIfMissing(id, scope));
     return vinyls.flat();
   }
 


### PR DESCRIPTION
Currently, multiple artifacts are imported concurrently. As a result, it's possible that the same file being written to the filesystem from multiple remotes at the same time, causing them to be corrupted. 