### PR TITLE
Lanes: Gql API: diff status

### DIFF
--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -42,6 +42,19 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         scope: String!
       }
 
+      type LaneComponentDiffStatus {
+        componentId: ComponentID!
+        type: String!
+        upToDate: boolean!
+      }
+
+      type LaneDiffStatus {
+        source: LaneId!
+        target: LaneId!
+        upToDate: boolean!
+        componentsStatus: [LaneComponentDiffStatus!]!
+      }
+
       type Lane {
         id: LaneId!
         hash: String
@@ -55,6 +68,7 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         id: String!
         list(ids: [String!], offset: Int, limit: Int): [Lane!]!
         diff(from: String!, to: String!, options: DiffOptions): GetDiffResult
+        diffStatus(source: String!, target: String): LaneDiffStatus!
         current: Lane
       }
 
@@ -99,6 +113,11 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
             ...getDiffResults,
             compsWithDiff: getDiffResults.compsWithDiff.map((item) => ({ ...item, id: item.id.toString() })),
           };
+        },
+        diffStatus: async (lanesMain: LanesMain, { source, target }: { source: string; target?: string }) => {
+          const sourceLaneId = LaneId.parse(source);
+          const targetLaneId = target ? LaneId.parse(target) : undefined;
+          return lanesMain.diffStatus(sourceLaneId, targetLaneId);
         },
       },
       Lane: {

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -44,7 +44,7 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
 
       type LaneComponentDiffStatus {
         componentId: ComponentID!
-        type: String!
+        changeType: String!
         upToDate: Boolean!
       }
 

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -45,13 +45,13 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
       type LaneComponentDiffStatus {
         componentId: ComponentID!
         type: String!
-        upToDate: boolean!
+        upToDate: Boolean!
       }
 
       type LaneDiffStatus {
         source: LaneId!
         target: LaneId!
-        upToDate: boolean!
+        upToDate: Boolean!
         componentsStatus: [LaneComponentDiffStatus!]!
       }
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -77,10 +77,17 @@ export enum ChangeType {
   CONFIG = 'CONFIG',
 }
 
-type LaneComponentDiff = {
+export type LaneComponentDiffStatus = {
   componentId: ComponentID;
   changeType: ChangeType;
   upToDate: boolean;
+};
+
+export type LaneDiffStatus = {
+  upToDate: boolean;
+  source: LaneId;
+  target: LaneId;
+  componentsStatus: LaneComponentDiffStatus[];
 };
 
 export class LanesMain {
@@ -635,7 +642,7 @@ export class LanesMain {
     return { result: true };
   }
 
-  async laneDiff(sourceLaneId: LaneId, targetLaneId?: LaneId): Promise<LaneComponentDiff[]> {
+  async diffStatus(sourceLaneId: LaneId, targetLaneId?: LaneId): Promise<LaneDiffStatus> {
     const sourceLane = await this.loadLane(sourceLaneId);
     if (!sourceLane) throw new Error(`unable to find ${sourceLaneId.toString()} in the scope`);
     const targetLane = targetLaneId ? await this.loadLane(targetLaneId) : undefined;
@@ -667,7 +674,14 @@ export class LanesMain {
       })
     );
 
-    return results;
+    const isLaneUptoDate = results.every((r) => r.upToDate);
+
+    return {
+      source: sourceLaneId,
+      target: targetLaneId || this.getDefaultLaneId(),
+      upToDate: isLaneUptoDate,
+      componentsStatus: results,
+    };
   }
 
   async addLaneReadme(readmeComponentIdStr: string, laneName?: string): Promise<{ result: boolean; message?: string }> {

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -97,18 +97,18 @@ describe('LanesAspect', function () {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
       const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
-      expect(laneDiffResults[0].upToDate).to.be.true;
-      expect(laneDiffResults[0].changeType).to.equal(ChangeType.NONE);
+      expect(laneDiffResults.componentsStatus[0].upToDate).to.be.true;
+      expect(laneDiffResults.componentsStatus[0].changeType).to.equal(ChangeType.NONE);
     });
-    it('should return that the lane is not up to date when main is ahead', async () => {
+    it.only('should return that the lane is not up to date when main is ahead', async () => {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
       await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
 
       const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
-      expect(laneDiffResults[0].upToDate).to.be.false;
-      expect(laneDiffResults[0].changeType).to.equal(ChangeType.NONE);
+      expect(laneDiffResults.componentsStatus[0].upToDate).to.be.false;
+      expect(laneDiffResults.componentsStatus[0].changeType).to.equal(ChangeType.NONE);
     });
   });
 });

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -96,7 +96,7 @@ describe('LanesAspect', function () {
     it('should return that the lane is up to date when the lane is ahead of main', async () => {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
-      const laneDiffResults = await lanes.laneDiff(currentLane.toLaneId());
+      const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
       expect(laneDiffResults[0].upToDate).to.be.true;
       expect(laneDiffResults[0].changeType).to.equal(ChangeType.NONE);
     });
@@ -106,7 +106,7 @@ describe('LanesAspect', function () {
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
       await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
 
-      const laneDiffResults = await lanes.laneDiff(currentLane.toLaneId());
+      const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
       expect(laneDiffResults[0].upToDate).to.be.false;
       expect(laneDiffResults[0].changeType).to.equal(ChangeType.NONE);
     });

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -100,7 +100,7 @@ describe('LanesAspect', function () {
       expect(laneDiffResults.componentsStatus[0].upToDate).to.be.true;
       expect(laneDiffResults.componentsStatus[0].changeType).to.equal(ChangeType.NONE);
     });
-    it.only('should return that the lane is not up to date when main is ahead', async () => {
+    it('should return that the lane is not up to date when main is ahead', async () => {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
       await lanes.switchLanes('main', { skipDependencyInstallation: true });


### PR DESCRIPTION
## Proposed Changes

- Allow querying `diffStatus` for given `source` and `target` LaneIds

**Schema**

      type LaneComponentDiffStatus {
        componentId: ComponentID!
        changeType: String!
        upToDate: Boolean!
      }

      type LaneDiffStatus {
        source: LaneId!
        target: LaneId!
        upToDate: Boolean!
        componentsStatus: [LaneComponentDiffStatus!]!
      }

      type Lanes {
        diffStatus(source: String!, target: String): LaneDiffStatus!
      }