### PR TITLE
fix(lane-merge): avoid merging when current component is soft-removed

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -639,6 +639,19 @@ describe('merge lanes', function () {
         });
       });
     });
+    describe('bit lane merge after soft-removed the unrelated component', () => {
+      before(() => {
+        helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
+        helper.scopeHelper.getClonedLocalScope(afterLaneExport);
+        helper.command.import();
+        helper.command.removeComponent('comp1', '--soft');
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+      });
+      it('should not throw', () => {
+        expect(() => helper.command.mergeLane('main')).to.not.throw();
+      });
+    });
   });
   describe('merge lanes when local-lane has soft-removed components and the other lane is behind', () => {
     before(() => {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -389,9 +389,6 @@ export class MergingMain {
       return consumer.scope.getConsumerComponent(currentId);
     };
     const currentComponent = await getCurrentComponent();
-    if (currentComponent.removed) {
-      return returnUnmerged(`component has been removed`, true);
-    }
     const isModified = async () => {
       const componentModificationStatus = await consumer.getComponentStatusById(currentComponent.id);
       if (!componentModificationStatus.modified) return false;
@@ -420,6 +417,11 @@ export class MergingMain {
       throws: false,
     });
     if (divergeData.err) {
+      if (currentComponent.removed) {
+        // if current component is removed and there is no divergeData errors, it's ok to merge, because on the other
+        // lane it might be re-imported and might be needed.
+        return returnUnmerged(`component has been removed`, true);
+      }
       const mainHead = modelComponent.head;
       if (divergeData.err instanceof NoCommonSnap && options?.resolveUnrelated && mainHead) {
         const hasResolvedFromMain = async (hashToCompare: Ref | null) => {


### PR DESCRIPTION
Until this fix it wasn't merging only if the other lane has it as removed. This PR also checks the current lane/main.