### PR TITLE
fix(deps-remove): avoid removing deps that were set before tag/snap

### DIFF
--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -175,4 +175,17 @@ describe('bit dependencies command', function () {
       });
     });
   });
+  describe('bit deps remove - when other deps were set previously before tag', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.dependenciesSet('comp1', 'ramda@0.20.0 lodash@3.3.1');
+      helper.command.tagWithoutBuild();
+    });
+    it('should remove only the dependency specified and leave the rest', () => {
+      helper.command.dependenciesRemove('comp1', 'ramda');
+      const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+      expect(showConfig.config.policy.dependencies).to.deep.equal({ lodash: '3.3.1' });
+    });
+  });
 });

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -71,10 +71,16 @@ export class DependenciesMain {
       compIds.map(async (compId) => {
         const component = await this.workspace.get(compId);
         const depList = await this.dependencyResolver.getDependencies(component);
-        const currentDepResolverConfig = await this.workspace.getSpecificComponentConfig(
-          compId,
-          DependencyResolverAspect.id
-        );
+        const getCurrentConfig = async () => {
+          const currentConfigFromWorkspace = await this.workspace.getSpecificComponentConfig(
+            compId,
+            DependencyResolverAspect.id
+          );
+          if (currentConfigFromWorkspace) return currentConfigFromWorkspace;
+          const extFromScope = await this.workspace.getSpecificExtensionsFromScope(compId);
+          return extFromScope?.toConfigObject()[DependencyResolverAspect.id];
+        };
+        const currentDepResolverConfig = await getCurrentConfig();
         const newDepResolverConfig = cloneDeep(currentDepResolverConfig || {});
         const removedPackagesWithNulls = await pMapSeries(packages, async (pkg) => {
           const [name, version] = this.splitPkgToNameAndVer(pkg);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -728,7 +728,7 @@ export class Workspace implements ComponentFactory {
     };
   }
 
-  private async getSpecificExtensionsFromScope(id: ComponentID): Promise<ExtensionDataList> {
+  async getSpecificExtensionsFromScope(id: ComponentID): Promise<ExtensionDataList> {
     const componentFromScope = await this.scope.get(id);
     const { extensions } = await this.componentExtensions(id, componentFromScope, [
       'WorkspaceDefault',


### PR DESCRIPTION
currently, `bit deps remove` adds a new entry to .bitmap in case it doesn't have any. as a result, this entry overrides any other deps setting created previously. 
This PR fixes it by retrieving the current deps data from the scope and apply the removal on this data. 