### PR TITLE
feat: support configure default tsconfig

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -127,11 +127,15 @@ export class ReactEnv
   ) {}
 
   getTsConfig(targetTsConfig?: TsConfigSourceFile): TsConfigSourceFile {
-    return targetTsConfig ? merge({}, defaultTsConfig, targetTsConfig) : defaultTsConfig;
+    return targetTsConfig
+      ? merge({ compilerOptions: this.config.tsCompilerOptions || {} }, defaultTsConfig, targetTsConfig)
+      : defaultTsConfig;
   }
 
   getBuildTsConfig(targetTsConfig?: TsConfigSourceFile): TsConfigSourceFile {
-    return targetTsConfig ? merge({}, buildTsConfig, targetTsConfig) : buildTsConfig;
+    return targetTsConfig
+      ? merge({ compilerOptions: this.config.tsCompilerOptions || {} }, buildTsConfig, targetTsConfig)
+      : buildTsConfig;
   }
 
   /**
@@ -188,7 +192,7 @@ export class ReactEnv
     const compileJs = true;
     const compileJsx = true;
     return {
-      tsconfig,
+      tsconfig: merge({}, tsconfig, { compilerOptions: this.config.tsCompilerOptions || {} }),
       // TODO: @david please remove this line and refactor to be something that makes sense.
       types: [resolve(pathToSource, './typescript/style.d.ts'), resolve(pathToSource, './typescript/asset.d.ts')],
       compileJs,

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -71,6 +71,11 @@ export type ReactMainConfig = {
    * version of React to configure.
    */
   reactVersion: string;
+
+  /**
+   * configure default typescript compiler options(for all modes)
+   */
+  tsCompilerOptions?: ts.CompilerOptions;
 };
 
 export type UseWebpackModifiers = {


### PR DESCRIPTION
## Proposed Changes

- Support directly configure default typescript compiler options through workspace.jsonc, like:
```
{
  "$schema": "https://static.bit.dev/teambit/schemas/schema.json",
  "teambit.react/react": {
    "tsCompilerOptions": {
      "jsx": "react-jsx"
    }
  }
}
``` 

