### PR TITLE
fix: avoid loading envs aspects from various sources once an env is determined either by config or data

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1328,6 +1328,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const envFromEnvsAspect: string | undefined = envAspect?.config.env || envAspect?.data.id;
     if (envWasFoundPreviously && envAspect) {
       const nonEnvs = extensionDataList.filter((e) => {
+        // normally the env-id inside the envs aspect doesn't have a version, but the aspect itself has a version.
         if (e.stringId === envFromEnvsAspect || e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect)
           return false;
         return true;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1328,8 +1328,9 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const envFromEnvsAspect: string | undefined = envAspect?.config.env || envAspect?.data.id;
     if (envWasFoundPreviously && envAspect) {
       const nonEnvs = extensionDataList.filter((e) => {
-        if (e.extensionId) return e.extensionId.toStringWithoutVersion() !== envFromEnvsAspect;
-        return e.stringId !== envFromEnvsAspect;
+        if (e.stringId === envFromEnvsAspect || e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect)
+          return false;
+        return true;
       });
       // still, aspect env may have other data other then config.env.
       delete envAspect.config.env;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1325,9 +1325,12 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
 
   private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
-    const envFromEnvsAspect: string | undefined = envAspect?.config.env;
+    const envFromEnvsAspect: string | undefined = envAspect?.config.env || envAspect?.data.id;
     if (envWasFoundPreviously && envAspect) {
-      const nonEnvs = extensionDataList.filter((e) => e.stringId !== envFromEnvsAspect);
+      const nonEnvs = extensionDataList.filter((e) => {
+        if (e.extensionId) return e.extensionId.toStringWithoutVersion() !== envFromEnvsAspect;
+        return e.stringId !== envFromEnvsAspect;
+      });
       // still, aspect env may have other data other then config.env.
       delete envAspect.config.env;
       return { extensionDataListFiltered: new ExtensionDataList(...nonEnvs), envIsCurrentlySet: true };


### PR DESCRIPTION
## Proposed Changes

- check whether a source (model/bitmap/workspace.jsonc, etc) has an env configured not only by the config but also by the data
- ignore the version when searching for duplicate envs aspects because that's how they're stored in envs/envs.
