### PR TITLE
fix: auto install auto-detected from overrides

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -15,7 +15,6 @@ import { Logger, LoggerAspect } from '@teambit/logger';
 import { CFG_PACKAGE_MANAGER_CACHE, CFG_REGISTRY_URL_KEY, CFG_USER_TOKEN_KEY } from '@teambit/legacy/dist/constants';
 // TODO: it's weird we take it from here.. think about it../workspace/utils
 import { DependencyResolver } from '@teambit/legacy/dist/consumer/component/dependencies/dependency-resolver';
-import type { EnvPolicyForComponent as LegacyEnvPolicyForComponent } from '@teambit/legacy/dist/consumer/component/dependencies/dependency-resolver';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
 import { DetectorHook } from '@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detector-hook';
@@ -1440,10 +1439,13 @@ export class DependencyResolverMain {
       const workspacePolicy = dependencyResolver.getWorkspacePolicy();
       return workspacePolicy.toManifest();
     });
-    DependencyResolver.registerHarmonyEnvPolicyForComponentGetter(async (configuredExtensions: ExtensionDataList) => {
-      const envPolicy = await dependencyResolver.getComponentEnvPolicyFromExtension(configuredExtensions);
-      return envPolicy.toLegacyAutoDetectOverrides() as LegacyEnvPolicyForComponent;
-    });
+    DependencyResolver.registerOnComponentAutoDetectOverridesGetter(
+      async (configuredExtensions: ExtensionDataList, id: BitId, legacyFiles: SourceFile[]) => {
+        const policy = await dependencyResolver.mergeVariantPolicies(configuredExtensions, id, legacyFiles);
+        return policy.toLegacyAutoDetectOverrides();
+      }
+    );
+
     DependencyResolver.registerHarmonyEnvPeersPolicyForEnvItselfGetter(async (id: BitId, files: SourceFile[]) => {
       const envPolicy = await dependencyResolver.getEnvPolicyFromEnvLegacyId(id, files);
       if (!envPolicy) return undefined;

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -26,6 +26,7 @@ import { packageToDefinetlyTyped } from './package-to-definetly-typed';
 import { ExtensionDataList } from '../../../config';
 import PackageJsonFile from '../../../../consumer/component/package-json-file';
 import { SourceFile } from '../../sources';
+import { DependenciesOverridesData } from '../../../config/component-overrides';
 
 export type AllDependencies = {
   dependencies: Dependency[];
@@ -70,18 +71,22 @@ export type EnvPolicyForComponent = {
   peerDependencies: { [name: string]: string };
 };
 
-type HarmonyEnvPolicyForComponentGetter = (configuredExtensions: ExtensionDataList) => Promise<EnvPolicyForComponent>;
-
 type HarmonyEnvPeersPolicyForEnvItselfGetter = (
   componentId: BitId,
   files: SourceFile[]
 ) => Promise<{ [name: string]: string } | undefined>;
 
+type OnComponentAutoDetectOverrides = (
+  configuredExtensions: ExtensionDataList,
+  componentId: BitId,
+  files: SourceFile[]
+) => Promise<DependenciesOverridesData>;
+
 const DepsKeysToAllPackagesDepsKeys = {
   dependencies: 'packageDependencies',
   devDependencies: 'devPackageDependencies',
   peerDependencies: 'peerPackageDependencies',
-}
+};
 
 export default class DependencyResolver {
   component: Component;
@@ -104,12 +109,9 @@ export default class DependencyResolver {
     this.getWorkspacePolicy = func;
   }
 
-  /**
-   * This will get the peers policy provided by the env of the component
-   */
-  static getHarmonyEnvPolicyForComponent: HarmonyEnvPolicyForComponentGetter;
-  static registerHarmonyEnvPolicyForComponentGetter(func: HarmonyEnvPolicyForComponentGetter) {
-    this.getHarmonyEnvPolicyForComponent = func;
+  static getOnComponentAutoDetectOverrides: OnComponentAutoDetectOverrides;
+  static registerOnComponentAutoDetectOverridesGetter(func: OnComponentAutoDetectOverrides) {
+    this.getOnComponentAutoDetectOverrides = func;
   }
 
   /**
@@ -248,7 +250,7 @@ export default class DependencyResolver {
     this.applyPackageJson();
     this.applyWorkspacePolicy();
     this.makeLegacyAsPeer();
-    await this.applyEnvPolicyOnComponent();
+    await this.applyAutoDetectOverridesOnComponent();
     this.manuallyAddDependencies();
     // Doing this here (after manuallyAddDependencies) because usually the env of the env is adding dependencies as peer of the env
     // which will make this not work if it come before
@@ -1169,35 +1171,39 @@ either, use the ignore file syntax or change the require statement to have a mod
    */
   makeLegacyAsPeer(): void {
     let version;
-    if (this.allPackagesDependencies.packageDependencies['@teambit/legacy']){
+    if (this.allPackagesDependencies.packageDependencies['@teambit/legacy']) {
       version = this.allPackagesDependencies.packageDependencies['@teambit/legacy'];
       delete this.allPackagesDependencies.packageDependencies['@teambit/legacy'];
     }
-    if (this.allPackagesDependencies.devPackageDependencies['@teambit/legacy']){
+    if (this.allPackagesDependencies.devPackageDependencies['@teambit/legacy']) {
       if (!version) version = this.allPackagesDependencies.devPackageDependencies['@teambit/legacy'];
       delete this.allPackagesDependencies.devPackageDependencies['@teambit/legacy'];
     }
-    if (version){
+    if (version) {
       if (!Number.isNaN(version[0])) version = `^${version}`;
       this.allPackagesDependencies.peerPackageDependencies['@teambit/legacy'] = version;
     }
   }
 
-  async applyEnvPolicyOnComponent(): Promise<void> {
-    const envPolicy = await DependencyResolver.getHarmonyEnvPolicyForComponent(this.component.extensions);
-    if (!envPolicy || !Object.keys(envPolicy).length) {
+  async applyAutoDetectOverridesOnComponent(): Promise<void> {
+    const autoDetectOverrides = await DependencyResolver.getOnComponentAutoDetectOverrides(
+      this.component.extensions,
+      this.component.id,
+      this.component.files
+    );
+    if (!autoDetectOverrides || !Object.keys(autoDetectOverrides).length) {
       return;
     }
     const originallyExists: string[] = [];
     let missingPackages: string[] = [];
     // We want to also add missing packages to the peer list as we know to resolve the version from the env anyway
     // @ts-ignore
-    const missingsData = this.issues.getIssueByName<IssuesClasses.MissingPackagesDependenciesOnFs>(
+    const missingData = this.issues.getIssueByName<IssuesClasses.MissingPackagesDependenciesOnFs>(
       'MissingPackagesDependenciesOnFs'
     )?.data;
-    if (missingsData) {
+    if (missingData) {
       // @ts-ignore
-      missingPackages = union(...(Object.values(missingsData) || []));
+      missingPackages = union(...(Object.values(missingData) || []));
     }
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach((field) => {
       R.forEachObjIndexed((pkgVal, pkgName) => {
@@ -1239,7 +1245,7 @@ either, use the ignore file syntax or change the require statement to have a mod
         if (pkgVal !== MANUALLY_REMOVE_DEPENDENCY) {
           this.allPackagesDependencies[key][pkgName] = pkgVal;
         }
-      }, envPolicy[field]);
+      }, autoDetectOverrides[field]);
     });
   }
 


### PR DESCRIPTION
Currently, when dependencyResolver.data.policy has auto-detected dependencies and they're missing from node-modules, `bit install` doesn't install them. 
This PR adds them to the dependencies list during the dependency resolution, so then `bit install` will install them successfully.

(implemented according to @GiladShoham 's instructions)