### PR TITLE
improvement(status/checkout): pendingUpdates only shows current-lane/main

### DIFF
--- a/e2e/harmony/lanes/diverged-from-forked.e2e.ts
+++ b/e2e/harmony/lanes/diverged-from-forked.e2e.ts
@@ -22,7 +22,7 @@ describe('lane-b was forked from lane-a and they are now diverged', function () 
     helper.command.switchLocalLane('lane-b');
   });
   it('bit status should have the diverged component in the updatesFromForked section', () => {
-    const status = helper.command.statusJson();
+    const status = helper.command.statusJson(undefined, '--lanes');
     expect(status.updatesFromForked).to.have.lengthOf(1);
   });
   after(() => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -363,7 +363,7 @@ describe('merge lanes', function () {
       expect(head).to.equal(comp2HeadOnMain);
     });
     it('bit status should indicate that the main is ahead', () => {
-      const status = helper.command.status();
+      const status = helper.command.status('--lanes');
       expect(status).to.have.string(`${helper.scopes.remote}/comp1 ... main is ahead by 1 snaps`);
     });
     let afterMergeToMain: string;
@@ -502,7 +502,7 @@ describe('merge lanes', function () {
       helper.command.import();
     });
     it('bit status should have the component as pendingUpdatesFromMain with an noCommonSnap error', () => {
-      const status = helper.command.statusJson();
+      const status = helper.command.statusJson(undefined, '--lanes');
       expect(status.pendingUpdatesFromMain).to.have.lengthOf(1);
       expect(status.pendingUpdatesFromMain[0].divergeData.err.name).to.equal('NoCommonSnap');
     });

--- a/e2e/harmony/updates-from-main-and-lane.e2e.ts
+++ b/e2e/harmony/updates-from-main-and-lane.e2e.ts
@@ -1,0 +1,67 @@
+import chai, { expect } from 'chai';
+import Helper from '../../src/e2e-helper/e2e-helper';
+
+chai.use(require('chai-fs'));
+chai.use(require('chai-string'));
+
+describe('updates from main and lane', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('updates are available from both main and lane', () => {
+    let scopeBeforeUpdate: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
+      helper.command.export();
+      scopeBeforeUpdate = helper.scopeHelper.cloneLocalScope();
+
+      helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
+      helper.command.export();
+      helper.command.switchLocalLane('main');
+      helper.command.tagWithoutBuild('comp2', '--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.getClonedLocalScope(scopeBeforeUpdate);
+      helper.command.import();
+    });
+    it('by default should only show updates from the current lane', () => {
+      const status = helper.command.statusJson();
+      expect(status.outdatedComponents).to.have.lengthOf(1);
+      expect(status.outdatedComponents[0].id).to.have.string('comp1');
+
+      expect(status.pendingUpdatesFromMain).to.have.lengthOf(0);
+    });
+    it('with --lanes flag, should show updates from main', () => {
+      const status = helper.command.statusJson(undefined, '--lanes');
+      expect(status.outdatedComponents).to.have.lengthOf(1);
+      expect(status.outdatedComponents[0].id).to.have.string('comp1');
+
+      expect(status.pendingUpdatesFromMain).to.have.lengthOf(2);
+    });
+    it('should show only one snap pending for comp2', () => {
+      const status = helper.command.statusJson(undefined, '--lanes');
+      const comp2 = status.pendingUpdatesFromMain.find((c) => c.id.includes('comp2'));
+      expect(comp2.divergeData.snapsOnTargetOnly).to.have.lengthOf(1);
+    });
+    describe('bit checkout', () => {
+      let checkoutOutput: string;
+      before(() => {
+        checkoutOutput = helper.command.checkoutHead('--skip-dependency-installation');
+      });
+      it('should update only components from the current lane', () => {
+        expect(checkoutOutput).to.have.string('comp1');
+        expect(checkoutOutput).not.to.have.string('comp2');
+      });
+    });
+  });
+});

--- a/e2e/harmony/updates-from-main-and-lane.e2e.ts
+++ b/e2e/harmony/updates-from-main-and-lane.e2e.ts
@@ -53,7 +53,7 @@ describe('updates from main and lane', function () {
       const comp2 = status.pendingUpdatesFromMain.find((c) => c.id.includes('comp2'));
       expect(comp2.divergeData.snapsOnTargetOnly).to.have.lengthOf(1);
     });
-    describe('bit checkout', () => {
+    describe('bit checkout head', () => {
       let checkoutOutput: string;
       before(() => {
         checkoutOutput = helper.command.checkoutHead('--skip-dependency-installation');
@@ -61,6 +61,19 @@ describe('updates from main and lane', function () {
       it('should update only components from the current lane', () => {
         expect(checkoutOutput).to.have.string('comp1');
         expect(checkoutOutput).not.to.have.string('comp2');
+      });
+    });
+    describe('bit lane merge main', () => {
+      let mergeOutput: string;
+      before(() => {
+        mergeOutput = helper.command.mergeLane('main', '--skip-dependency-installation --no-snap');
+      });
+      it('should update not only components belong to the main but also components that are available on the workspace and have updates from main', () => {
+        expect(mergeOutput).to.have.string('comp1');
+        expect(mergeOutput).to.have.string('comp2');
+
+        const status = helper.command.statusJson(undefined, '--lanes');
+        expect(status.pendingUpdatesFromMain).to.have.lengthOf(0);
       });
     });
   });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -234,7 +234,14 @@ export class CheckoutMain {
     if (checkoutProps.entireLane && !checkoutProps.head) {
       throw new BitError(`--entire-lane flag can only be used with "head" (bit checkout head --entire-lane)`);
     }
-    const ids = componentPattern ? await this.workspace.idsByPattern(componentPattern) : await this.workspace.listIds();
+    const idsOnWorkspace = componentPattern
+      ? await this.workspace.idsByPattern(componentPattern)
+      : await this.workspace.listIds();
+    const currentLane = await this.workspace.consumer.getCurrentLaneObject();
+    const currentLaneIds = currentLane?.toBitIds();
+    const ids = currentLaneIds
+      ? idsOnWorkspace.filter((id) => currentLaneIds.hasWithoutVersion(id._legacy))
+      : idsOnWorkspace;
     checkoutProps.ids = ids.map((id) => (checkoutProps.head || checkoutProps.latest ? id.changeVersion(LATEST) : id));
   }
 

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -35,6 +35,7 @@ export class StatusCmd implements Command {
       'verbose',
       'show extra data: full snap hashes for staged, divergence point for lanes and updates-from-main for forked lanes',
     ],
+    ['l', 'lanes', 'when on a lane, show updates from main and updates from forked lanes'],
     ['', 'strict', 'in case issues found, exit with code 1'],
   ] as CommandOptions;
   loader = true;
@@ -42,7 +43,7 @@ export class StatusCmd implements Command {
 
   constructor(private status: StatusMain) {}
 
-  async json() {
+  async json(_args, { lanes }: { lanes?: boolean }) {
     const {
       newComponents,
       modifiedComponents,
@@ -62,7 +63,7 @@ export class StatusCmd implements Command {
       updatesFromForked,
       currentLaneId,
       forkedLaneId,
-    }: StatusResult = await this.status.status();
+    }: StatusResult = await this.status.status({ lanes });
     return {
       newComponents: newComponents.map((c) => c.toStringWithoutVersion()),
       modifiedComponents: modifiedComponents.map((c) => c.toString()),
@@ -92,7 +93,7 @@ export class StatusCmd implements Command {
   }
 
   // eslint-disable-next-line complexity
-  async report(_args, { strict, verbose }: { strict?: boolean; verbose?: boolean }) {
+  async report(_args, { strict, verbose, lanes }: { strict?: boolean; verbose?: boolean; lanes?: boolean }) {
     const {
       newComponents,
       modifiedComponents,
@@ -112,7 +113,7 @@ export class StatusCmd implements Command {
       updatesFromForked,
       currentLaneId,
       forkedLaneId,
-    }: StatusResult = await this.status.status();
+    }: StatusResult = await this.status.status({ lanes });
     // If there is problem with at least one component we want to show a link to the
     // troubleshooting doc
     let showTroubleshootingLink = false;

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -50,7 +50,7 @@ export class StatusMain {
     private remove: RemoveMain
   ) {}
 
-  async status(): Promise<StatusResult> {
+  async status({ lanes }: { lanes?: boolean }): Promise<StatusResult> {
     if (!this.workspace) throw new OutsideWorkspaceError();
     loader.start(BEFORE_STATUS);
     const consumer = this.workspace.consumer;
@@ -111,8 +111,8 @@ export class StatusMain {
 
     const softTaggedComponents = componentsList.listSoftTaggedComponents();
     const snappedComponents = (await componentsList.listSnappedComponentsOnMain()).map((c) => c.toBitId());
-    const pendingUpdatesFromMain = await componentsList.listUpdatesFromMainPending();
-    const updatesFromForked = await componentsList.listUpdatesFromForked();
+    const pendingUpdatesFromMain = lanes ? await componentsList.listUpdatesFromMainPending() : [];
+    const updatesFromForked = lanes ? await componentsList.listUpdatesFromForked() : [];
     const currentLaneId = consumer.getCurrentLaneId();
     const currentLane = await consumer.getCurrentLaneObject();
     const forkedLaneId = currentLane?.forkedFrom;

--- a/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
@@ -1,29 +1,39 @@
 import chalk from 'chalk';
+import { DEFAULT_LANE } from '@teambit/lane-id';
 import { Command, CommandOptions } from '@teambit/cli';
 import { BitError } from '@teambit/bit-error';
 import { MergeLanesMain } from './merge-lanes.main.runtime';
+
+type Flags = {
+  pattern?: string;
+  push?: boolean;
+  keepReadme?: boolean;
+  noSquash: boolean;
+  includeDeps?: boolean;
+};
 
 /**
  * private command. the underscore prefix is intended.
  */
 export class MergeLaneFromScopeCmd implements Command {
-  name = '_merge-lane <lane> [pattern]';
-  description = `merge a remote lane into main via a bare-scope (not workspace)`;
+  name = '_merge-lane <from-lane> [to-lane]';
+  description = `merge a remote lane into another lane or main via a bare-scope (not workspace)`;
   extendedDescription = `to merge from a workspace, use "bit lane merge" command.
-this is intended to use from the UI, which will have a button to merge an existing lane into main.
-the lane must be up-to-date with main, otherwise, conflicts might occur which are not handled in this command`;
+this is intended to use from the UI, which will have a button to merge an existing lane.
+the lane must be up-to-date with the other lane, otherwise, conflicts might occur which are not handled in this command`;
   arguments = [
     {
-      name: 'lane',
-      description: 'lane-id to merge to main',
+      name: 'from-lane',
+      description: 'lane-id to merge from',
     },
     {
-      name: 'pattern',
-      description: 'EXPERIMENTAL. partially merge the lane with the specified component-pattern',
+      name: 'to-lane',
+      description: `lane-id to merge to. default is "${DEFAULT_LANE}"`,
     },
   ];
   alias = '';
   options = [
+    ['', 'pattern <string>', 'partially merge the lane with the specified component-pattern'],
     ['', 'push', 'export the updated objects to the original scopes once done'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
     ['', 'no-squash', 'EXPERIMENTAL. relevant for merging lanes into main, which by default squash.'],
@@ -38,31 +48,28 @@ the lane must be up-to-date with main, otherwise, conflicts might occur which ar
   constructor(private mergeLanes: MergeLanesMain) {}
 
   async report(
-    [name, pattern]: [string, string],
-    {
-      push = false,
-      keepReadme = false,
-      noSquash = false,
-      includeDeps = false,
-    }: {
-      push?: boolean;
-      keepReadme?: boolean;
-      noSquash: boolean;
-      includeDeps?: boolean;
-    }
+    [fromLane, toLane]: [string, string],
+    { pattern, push = false, keepReadme = false, noSquash = false, includeDeps = false }: Flags
   ): Promise<string> {
     if (includeDeps && !pattern) {
       throw new BitError(`"--include-deps" flag is relevant only for --pattern flag`);
     }
-    const { mergedNow, mergedPreviously, exportedIds } = await this.mergeLanes.mergeFromScope(name, {
-      push,
-      keepReadme,
-      noSquash,
-      pattern,
-      includeDeps,
-    });
 
-    const mergedTitle = chalk.green(`successfully merged ${mergedNow.length} components from ${name} to main`);
+    const { mergedNow, mergedPreviously, exportedIds } = await this.mergeLanes.mergeFromScope(
+      fromLane,
+      toLane || DEFAULT_LANE,
+      {
+        push,
+        keepReadme,
+        noSquash,
+        pattern,
+        includeDeps,
+      }
+    );
+
+    const mergedTitle = chalk.green(
+      `successfully merged ${mergedNow.length} components from ${fromLane} to ${toLane || DEFAULT_LANE}`
+    );
     const mergedOutput = mergedNow.length ? `${mergedTitle}\n${mergedNow.join('\n')}` : '';
 
     const nonMergedTitle = chalk.bold(
@@ -76,25 +83,15 @@ the lane must be up-to-date with main, otherwise, conflicts might occur which ar
     return mergedOutput + nonMergedOutput + exportedOutput;
   }
   async json(
-    [name, pattern]: [string, string],
-    {
-      push = false,
-      keepReadme = false,
-      noSquash = false,
-      includeDeps = false,
-    }: {
-      push?: boolean;
-      keepReadme?: boolean;
-      noSquash: boolean;
-      includeDeps?: boolean;
-    }
+    [fromLane, toLane]: [string, string],
+    { pattern, push = false, keepReadme = false, noSquash = false, includeDeps = false }: Flags
   ) {
     if (includeDeps && !pattern) {
       throw new BitError(`"--include-deps" flag is relevant only for --pattern flag`);
     }
     let results: any;
     try {
-      results = await this.mergeLanes.mergeFromScope(name, {
+      results = await this.mergeLanes.mergeFromScope(fromLane, toLane || DEFAULT_LANE, {
         push,
         keepReadme,
         noSquash,

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -226,7 +226,7 @@ export class MergeLanesMain {
     }
     const workspaceIds = (await this.workspace.listIds()).map((id) => id._legacy);
     const mainNotOnLane = workspaceIds.filter((id) => !laneIds.find((laneId) => laneId.isEqualWithoutVersion(id)));
-    const ids = [...laneIds, ...mainNotOnLane];
+    const ids = [...laneIds, ...mainNotOnLane].filter((id) => id.hasScope());
     const modelComponents = await Promise.all(ids.map((id) => this.scope.legacyScope.getModelComponent(id)));
     return compact(
       modelComponents.map((c) => {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -492,8 +492,8 @@ export default class CommandHelper {
     return this.runCmd(`bit status ${flags}`);
   }
 
-  statusJson(cwd = this.scopes.localPath): Record<string, any> {
-    const status = this.runCmd('bit status --json', cwd);
+  statusJson(cwd = this.scopes.localPath, flags = ''): Record<string, any> {
+    const status = this.runCmd(`bit status --json ${flags}`, cwd);
     return JSON.parse(status);
   }
 

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -371,6 +371,8 @@ export default class Component extends BitObject {
   }
 
   /**
+   * get the recent head. if locally is ahead, return the local head. otherwise, return the remote head.
+   *
    * a user can be checked out to a lane, in which case, `this.laneHeadLocal` and `this.laneHeadRemote`
    * may be populated.
    * `this.head` may not be populated, e.g. when a component was created on
@@ -383,7 +385,7 @@ export default class Component extends BitObject {
     const remoteHead = this.laneHeadRemote || this.remoteHead;
     if (!remoteHead) return latestLocally;
     if (!this.getHeadRegardlessOfLane()) {
-      return remoteHead.toString(); // user never merged the remote version, so remote is the latest
+      return remoteHead.toString(); // in case a snap was created on another lane
     }
 
     // either a user is on main or a lane, check whether the remote is ahead of the local

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -1,7 +1,6 @@
 import fs from 'fs-extra';
 import * as pathLib from 'path';
 import R from 'ramda';
-import { compact } from 'lodash';
 import { LaneId } from '@teambit/lane-id';
 import semver from 'semver';
 import { Analytics } from '../analytics/analytics';
@@ -696,20 +695,6 @@ once done, to continue working, please run "bit cc"`
     }
     // it's probably new, we assume it doesn't have scope.
     return BitId.parse(id, false);
-  }
-
-  /**
-   * returns the main ids of the given lane
-   */
-  async getDefaultLaneIdsFromLane(lane: Lane): Promise<BitId[]> {
-    const laneIds = lane.toBitIds();
-    const modelComponents = await Promise.all(laneIds.map((id) => this.getModelComponent(id)));
-    return compact(
-      modelComponents.map((c) => {
-        if (!c.head) return null; // probably the component was never merged to main
-        return c.toBitId().changeVersion(c.head.toString());
-      })
-    );
   }
 
   async writeObjectsToPendingDir(objectList: ObjectList, clientId: string): Promise<void> {


### PR DESCRIPTION
Here is a scenario to help explaining the confusion this PR aims to solve.
A workspace is checked out to a lane "dev", and  has two components: comp1 -> comp2 (comp1 is using comp2). comp2 is part of the lane (was snapped on the lane), but comp1 was just imported to the workspace and belong to main.
Assuming comp1 is ahead on main and comp2 is ahead in the remote-lane, until now, `bit status` was showing them both in "pending updates" section, and `bit checkout head` was updating them both.
It might seem logical, because these two components are available in the workspace, however, what if on main a feature was implemented (e.g. an API breaking change) and during the change on comp2, comp1 was changed as well to accommodate these changes. Merging only comp1 from main could break the app because the changes from comp2 won't be merged. 
It also can be confusing for users who expect to get updates from their remote lane, and end up getting updates from main as well.
This PR clears the confusion. `checkout head` only merges components from the current lane. To merge from main, you can run `bit lane merge main`, which will update all components available in the workspace that have updates from main.

## Proposed Changes

- when on a lane, `bit status` shows in `pending updates` section only the components from this lane that are out of date against the remote lane. (previously it showed also components that are available in the workspace from main).
- update from main and from forked lanes are now shown only when using `--lanes` flag.
- when on a lane, `bit checkout head` now checks out only components belong to the lane. (previously it would check out also components from main that are available in the workspace, leading to confusion and possibly broken state where these components from main has dependencies inside the lane).
