### PR TITLE
fix: change env version according to the workspace

### DIFF
--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -283,7 +283,7 @@ describe('merge config scenarios', function () {
       helper.command.export();
 
       helper.scopeHelper.getClonedLocalScope(mainBeforeDiverge);
-      helper.command.setEnv('comp1', `${envId}@0.0.3`);
+      // helper.command.setEnv('comp1', `${envId}@0.0.3`);
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1185,7 +1185,8 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
         : extsWithoutRemoved;
       const { extensionDataListFiltered, envIsCurrentlySet } = await this.filterEnvsFromExtensionsIfNeeded(
         extsWithoutSelf,
-        envWasFoundPreviously
+        envWasFoundPreviously,
+        origin
       );
       if (envIsCurrentlySet) {
         await this.warnAboutMisconfiguredEnv(componentId, extensions);
@@ -1323,7 +1324,11 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return componentStatus.modified === true;
   }
 
-  private async filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
+  private async filterEnvsFromExtensionsIfNeeded(
+    extensionDataList: ExtensionDataList,
+    envWasFoundPreviously: boolean,
+    origin: ExtensionsOrigin
+  ) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
     const envFromEnvsAspect: string | undefined = envAspect?.config.env || envAspect?.data.id;
     if (envWasFoundPreviously && envAspect) {
@@ -1337,7 +1342,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       delete envAspect.config.env;
       return { extensionDataListFiltered: new ExtensionDataList(...nonEnvs), envIsCurrentlySet: true };
     }
-    if (envFromEnvsAspect) {
+    if (envFromEnvsAspect && (origin === 'ModelNonSpecific' || origin === 'ModelSpecific')) {
       // if env was found, search for this env in the workspace and if found, replace the env-id with the one from the workspace
       const envAspectExt = extensionDataList.find((e) => e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect);
       const ids = await this.listIds();

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -2125,8 +2125,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
   async setEnvToComponents(envId: ComponentID, componentIds: ComponentID[]) {
     const envStrWithPossiblyVersion = await this.resolveEnvIdWithPotentialVersionForConfig(envId);
     const envIdStrNoVersion = envId.toStringWithoutVersion();
-    // no need to unset, when loading the component, we load the first one, and ignore the rest.
-    // await this.unsetEnvFromComponents(componentIds);
+    await this.unsetEnvFromComponents(componentIds);
     await Promise.all(
       componentIds.map(async (componentId) => {
         await this.addSpecificComponentConfig(componentId, envStrWithPossiblyVersion);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -2125,7 +2125,8 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
   async setEnvToComponents(envId: ComponentID, componentIds: ComponentID[]) {
     const envStrWithPossiblyVersion = await this.resolveEnvIdWithPotentialVersionForConfig(envId);
     const envIdStrNoVersion = envId.toStringWithoutVersion();
-    await this.unsetEnvFromComponents(componentIds);
+    // no need to unset, when loading the component, we load the first one, and ignore the rest.
+    // await this.unsetEnvFromComponents(componentIds);
     await Promise.all(
       componentIds.map(async (componentId) => {
         await this.addSpecificComponentConfig(componentId, envStrWithPossiblyVersion);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1183,7 +1183,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       const extsWithoutSelf = selfInMergedExtensions?.extensionId
         ? extsWithoutRemoved.remove(selfInMergedExtensions.extensionId)
         : extsWithoutRemoved;
-      const { extensionDataListFiltered, envIsCurrentlySet } = this.filterEnvsFromExtensionsIfNeeded(
+      const { extensionDataListFiltered, envIsCurrentlySet } = await this.filterEnvsFromExtensionsIfNeeded(
         extsWithoutSelf,
         envWasFoundPreviously
       );
@@ -1323,7 +1323,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return componentStatus.modified === true;
   }
 
-  private filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
+  private async filterEnvsFromExtensionsIfNeeded(extensionDataList: ExtensionDataList, envWasFoundPreviously: boolean) {
     const envAspect = extensionDataList.findExtension(EnvsAspect.id);
     const envFromEnvsAspect: string | undefined = envAspect?.config.env || envAspect?.data.id;
     if (envWasFoundPreviously && envAspect) {
@@ -1336,6 +1336,16 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       // still, aspect env may have other data other then config.env.
       delete envAspect.config.env;
       return { extensionDataListFiltered: new ExtensionDataList(...nonEnvs), envIsCurrentlySet: true };
+    }
+    if (envFromEnvsAspect) {
+      // if env was found, search for this env in the workspace and if found, replace the env-id with the one from the workspace
+      const envAspectExt = extensionDataList.find((e) => e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect);
+      const ids = await this.listIds();
+      const envAspectId = envAspectExt?.extensionId;
+      const found = envAspectId && ids.find((id) => id._legacy.isEqualWithoutVersion(envAspectId));
+      if (found) {
+        envAspectExt.extensionId = found._legacy;
+      }
     }
     return { extensionDataListFiltered: extensionDataList, envIsCurrentlySet: Boolean(envFromEnvsAspect) };
   }


### PR DESCRIPTION
In the case the env is received from the model and the workspace has the env component with different version, use the version from the workspace.