### PR TITLE
Component/Lane Compare: Style Fixes

### DIFF
--- a/scopes/code/ui/code-compare/code-compare-view/code-compare-view.tsx
+++ b/scopes/code/ui/code-compare/code-compare-view/code-compare-view.tsx
@@ -31,7 +31,6 @@ export function CodeCompareView({ className, fileName }: CodeCompareViewProps) {
 
   // const [ignoreWhitespace, setIgnoreWhitespace] = useState(true);
   const monacoRef = useRef<any>();
-
   const title = useMemo(() => fileName?.split('/').pop(), [fileName]);
 
   const language = useMemo(() => {
@@ -68,6 +67,15 @@ export function CodeCompareView({ className, fileName }: CodeCompareViewProps) {
         noSyntaxValidation: true,
       });
     }
+    monaco.editor.defineTheme('bit', {
+      base: 'vs-dark',
+      inherit: true,
+      rules: [],
+      colors: {
+        'scrollbar.shadow': '#222222',
+      },
+    });
+    monaco.editor.setTheme('bit');
   };
 
   /**
@@ -96,6 +104,18 @@ export function CodeCompareView({ className, fileName }: CodeCompareViewProps) {
         options={{
           // ignoreTrimWhitespace: ignoreWhitespace,
           readOnly: true,
+          minimap: { enabled: false },
+          scrollbar: { alwaysConsumeMouseWheel: false },
+          scrollBeyondLastLine: false,
+          folding: false,
+          overviewRulerLanes: 0,
+          overviewRulerBorder: false,
+          wordWrap: 'on',
+          wrappingStrategy: 'advanced',
+          fixedOverflowWidgets: true,
+          renderLineHighlight: 'none',
+          lineHeight: 18,
+          padding: { top: 8 },
         }}
         loading={<CodeCompareViewLoader />}
       />

--- a/scopes/lanes/ui/compare/lane-compare-drawer/lane-compare-drawer-name.tsx
+++ b/scopes/lanes/ui/compare/lane-compare-drawer/lane-compare-drawer-name.tsx
@@ -24,7 +24,7 @@ export function LaneCompareDrawerName({ baseId, compareId, open }: LaneCompareDr
       <div className={styles.versionContainer}>
         {baseId && (
           <Tooltip content={baseId.version} placement={'bottom'}>
-            <div className={styles.version}>{baseId?.version}</div>
+            <div className={styles.version}>{baseId?.version?.substring(0, 6)}</div>
           </Tooltip>
         )}
         {baseId && (
@@ -34,7 +34,7 @@ export function LaneCompareDrawerName({ baseId, compareId, open }: LaneCompareDr
         )}
         {compareId && (
           <Tooltip content={compareId.version} placement={'bottom'}>
-            <div className={styles.version}>{compareId.version}</div>
+            <div className={styles.version}>{compareId?.version?.substring(0, 6)}</div>
           </Tooltip>
         )}
       </div>

--- a/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
+++ b/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
@@ -197,10 +197,9 @@ export function LaneCompare({
     if (laneComponentDiffByCompId.size === 0) return null;
     return allComponents.reduce((accum, [baseId, compareId]) => {
       const compareIdStrWithoutVersion = compareId?.toStringWithoutVersion();
-      const laneCompDiff =
-        !compareIdStrWithoutVersion || loadingLaneDiff === undefined
-          ? undefined
-          : laneComponentDiffByCompId.get(compareIdStrWithoutVersion);
+      const laneCompDiff = !compareIdStrWithoutVersion
+        ? undefined
+        : laneComponentDiffByCompId.get(compareIdStrWithoutVersion);
 
       const changeType = laneCompDiff?.changeType;
 


### PR DESCRIPTION
## Proposed Changes

- Add Custom Bit theme to Monaco. Remove box shadow from scrollbar
- Display shortHash (6 char) in Lane Compare Drawer Name
- Remove loading: undefined check when constructing lane component lookup
