### PR TITLE
log(merge): add snaps details into the debug.log

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -519,8 +519,11 @@ export class MergingMain {
     if (!currentComponent) throw new Error(`getDivergedMergeStatus, currentComponent is missing for ${id.toString()}`);
 
     const baseSnap = divergeData.commonSnapBeforeDiverge as Ref; // must be set when isTrueMerge
-    // uncomment for debugging
-    // console.log('id', id.toStringWithoutVersion(), 'baseSnap', baseSnap.toString(), 'current', currentId.version, 'other', otherLaneHead.toString());
+    this.logger.debug(`merging snaps details:
+id:      ${id.toStringWithoutVersion()}
+base:    ${baseSnap.toString()}
+current: ${currentId.version}
+other:   ${otherLaneHead.toString()}`);
     const baseComponent: Version = await modelComponent.loadVersion(baseSnap.toString(), repo);
     const otherComponent: Version = await modelComponent.loadVersion(otherLaneHead.toString(), repo);
 


### PR DESCRIPTION
Helpful to get the base-snap when merging lanes.