### PR TITLE
fix(import): fix the output when a component is deprecated and removed

### DIFF
--- a/scopes/preview/preview/index.ts
+++ b/scopes/preview/preview/index.ts
@@ -8,6 +8,7 @@ export type {
   ComponentPreviewSize,
   PreviewStrategyName,
   PreviewFiles,
+  ComponentPreviewMetaData
 } from './preview.main.runtime';
 export type { PreviewPreview, RenderingContextOptions, RenderingContextProvider } from './preview.preview.runtime';
 export { PreviewDefinition } from './preview-definition';

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -167,11 +167,7 @@ ${WILDCARD_HELP('import')}`;
       return chalk.yellow(importResults.cancellationMessage || 'nothing to import');
     }
 
-    const titlePrefix =
-      importedIds.length === 1
-        ? 'successfully imported one component'
-        : `successfully imported ${importedIds.length} components`;
-
+    const summaryPrefix = `successfully imported ${importedIds.length} component(s)`;
     let upToDateCount = 0;
     const importedComponents = importedIds.map((bitId) => {
       const details = importDetails.find((c) => c.id === bitId.toStringWithoutVersion());
@@ -182,8 +178,8 @@ ${WILDCARD_HELP('import')}`;
       return formatPlainComponentItemWithVersions(bitId, details);
     });
     const upToDateStr = upToDateCount === 0 ? '' : `, ${upToDateCount} components are up to date`;
-    const title = `${titlePrefix}${upToDateStr}`;
-    const componentDependenciesOutput = [chalk.green(title), ...compact(importedComponents)].join('\n');
+    const summary = `${summaryPrefix}${upToDateStr}`;
+    const componentDependenciesOutput = [...compact(importedComponents), chalk.green(summary)].join('\n');
     const importedDepsOutput =
       displayDependencies && importedDeps.length
         ? immutableUnshift(
@@ -221,15 +217,17 @@ function formatPlainComponentItemWithVersions(bitId: BitId, importDetails: Impor
       .join(', ')}) `;
   };
   const conflictMessage = getConflictMessage();
-  const deprecated = importDetails.deprecated ? chalk.yellow('deprecated') : '';
+  const deprecated = importDetails.deprecated && !importDetails.removed ? chalk.yellow('deprecated') : '';
   const removed = importDetails.removed ? chalk.red('removed') : '';
   const missingDeps = importDetails.missingDeps.length
     ? chalk.red(`missing dependencies: ${importDetails.missingDeps.map((d) => d.toString()).join(', ')}`)
     : '';
-  if (status === 'up to date' && !missingDeps && !deprecated && !conflictMessage) {
+  if (status === 'up to date' && !missingDeps && !deprecated && !conflictMessage && !removed) {
     return undefined;
   }
-  return `- ${chalk.green(status)} ${chalk.cyan(
-    id
-  )} ${versions}${usedVersion} ${conflictMessage}${deprecated}${removed} ${missingDeps}`;
+  return chalk.dim(
+    `- ${chalk.green(status)} ${chalk.cyan(
+      id
+    )} ${versions}${usedVersion} ${conflictMessage}${deprecated}${removed} ${missingDeps}`
+  );
 }

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -167,7 +167,11 @@ ${WILDCARD_HELP('import')}`;
       return chalk.yellow(importResults.cancellationMessage || 'nothing to import');
     }
 
-    const summaryPrefix = `successfully imported ${importedIds.length} component(s)`;
+    const summaryPrefix =
+      importedIds.length === 1
+        ? 'successfully imported one component'
+        : `successfully imported ${importedIds.length} components`;
+
     let upToDateCount = 0;
     const importedComponents = importedIds.map((bitId) => {
       const details = importDetails.find((c) => c.id === bitId.toStringWithoutVersion());


### PR DESCRIPTION
In this case, just shows it as `removed`. the deprecation is less relevant. 
Also, make the output of `bit import` without args more clear by dimming the details of individual component and placing the summary at the end. 