### PR TITLE
fix: allow removing components with dependents from the workspace without --force

### DIFF
--- a/e2e/commands/remove.e2e.1.ts
+++ b/e2e/commands/remove.e2e.1.ts
@@ -110,13 +110,13 @@ describe('bit remove command', function () {
       helper.command.export();
     });
     it('should not remove component with dependencies when -f flag is false', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`);
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`, '--remote');
       expect(output).to.have.string(
         `error: unable to delete ${helper.scopes.remote}/${componentName}, because the following components depend on it:`
       );
     });
     it('should remove component with dependencies when -f flag is true', () => {
-      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`, '-f');
+      const output = helper.command.removeComponent(`${helper.scopes.remote}/${componentName}`, '--remote -f');
       expect(output).to.have.string('removed components');
       expect(output).to.have.string(`${helper.scopes.remote}/${componentName}`);
     });

--- a/e2e/commands/remove.e2e.1.ts
+++ b/e2e/commands/remove.e2e.1.ts
@@ -299,4 +299,20 @@ describe('bit remove command', function () {
       });
     });
   });
+  describe('removing from workspace when it had dependents previously in old tags', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.fs.writeFile('comp1/index.js', ''); // remove the dependency of comp2
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.command.removeComponent('comp2');
+    });
+    // only removing from scope needs the --force. from workspace it's not an irreversible action.
+    it('should remove successfully without the need for --force flag', () => {
+      helper.bitMap.expectNotToHaveId('comp2');
+    });
+  });
 });

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -302,7 +302,7 @@ describe('components that are not synced between the scope and the consumer', fu
         });
         it('should sync .bitmap according to the latest version of the scope', () => {
           helper.command.expectStatusToBeClean();
-          helper.bitMap.expectToHaveIdHarmony('bar/foo', '0.0.1', helper.scopes.remote);
+          helper.bitMap.expectToHaveId('bar/foo', '0.0.1', helper.scopes.remote);
         });
       });
       describe('bit tag', () => {

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -68,7 +68,7 @@ describe('import functionality on Harmony', function () {
           helper.command.importComponent('comp1');
         });
         it('should not save the dependencies as components', () => {
-          helper.bitMap.expectToHaveIdHarmony('comp1', '0.0.1', helper.scopes.remote);
+          helper.bitMap.expectToHaveId('comp1', '0.0.1', helper.scopes.remote);
           const bitMap = helper.bitMap.readComponentsMapOnly();
           expect(bitMap).not.to.have.property(`comp2`);
           expect(bitMap).not.to.have.property(`comp3`);
@@ -245,7 +245,7 @@ describe('import functionality on Harmony', function () {
           helper.command.importComponent('comp1');
         });
         it('should import the component with the pre-release correctly', () => {
-          helper.bitMap.expectToHaveIdHarmony('comp1', '0.0.1-beta.0', helper.scopes.remote);
+          helper.bitMap.expectToHaveId('comp1', '0.0.1-beta.0', helper.scopes.remote);
         });
         // previously, it threw an error: "error: version 0.0.1.0 is not a valid semantic version. learn more: https://semver.org"
         it('bit status should be clean with no errors', () => {

--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -30,15 +30,6 @@ describe('bit lane command', function () {
       const lane = helper.command.showOneLaneParsed('dev');
       expect(lane.components).to.have.lengthOf(3);
     });
-    describe('removing a component that has dependents', () => {
-      let output;
-      before(() => {
-        output = helper.command.removeComponent('comp3');
-      });
-      it('should stop the process and indicate that a component has dependents', () => {
-        expect(output).to.have.string('error: unable to delete');
-      });
-    });
     describe('removing a component that has no dependents with --from-lane', () => {
       let output;
       before(() => {

--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -55,7 +55,7 @@ describe('bit lane command', function () {
       });
       it('should not remove the component from .bitmap', () => {
         const head = helper.command.getHead('comp1');
-        helper.bitMap.expectToHaveIdHarmony('comp1', head, helper.scopes.remote);
+        helper.bitMap.expectToHaveId('comp1', head, helper.scopes.remote);
       });
       it('should not delete the files from the filesystem', () => {
         expect(path.join(helper.scopes.localPath, 'comp1/index.js')).to.be.a.file();

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -459,14 +459,14 @@ describe('bit lane command', function () {
       helper.command.switchLocalLane('main');
     });
     it('should checkout to the head of the origin branch', () => {
-      helper.bitMap.expectToHaveIdHarmony('bar/foo', '0.0.2');
+      helper.bitMap.expectToHaveId('bar/foo', '0.0.2');
     });
     it('bit status should be clean', () => {
       helper.command.expectStatusToBeClean();
     });
     // previously, the behavior was to checkout to the same version it had before
     it.skip('should checkout to the same version the origin branch had before the switch', () => {
-      helper.bitMap.expectToHaveIdHarmony('bar/foo', '0.0.1');
+      helper.bitMap.expectToHaveId('bar/foo', '0.0.1');
     });
     // previously, the behavior was to checkout to the same version it had before
     it.skip('bit status should not show the component as modified only as pending update', () => {

--- a/e2e/harmony/out-of-sync-components-harmony.e2e.ts
+++ b/e2e/harmony/out-of-sync-components-harmony.e2e.ts
@@ -41,7 +41,7 @@ describe('components that are not synced between the scope and the consumer', fu
       });
       it('should sync .bitmap according to the scope', () => {
         helper.command.expectStatusToBeClean();
-        helper.bitMap.expectToHaveIdHarmony('bar/foo', '0.0.1', helper.scopes.remote);
+        helper.bitMap.expectToHaveId('bar/foo', '0.0.1', helper.scopes.remote);
       });
     });
   });

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -38,7 +38,7 @@ describe('bit snap command', function () {
     it('should save the snap hash as a version in .bitmap file', () => {
       const listScope = helper.command.listLocalScopeParsed();
       const hash = listScope[0].localVersion;
-      helper.bitMap.expectToHaveIdHarmony('bar/foo', hash);
+      helper.bitMap.expectToHaveId('bar/foo', hash);
     });
     it('bit status should show the snap as staged', () => {
       const status = helper.command.status();
@@ -165,7 +165,7 @@ describe('bit snap command', function () {
           });
         });
         it('should not change the version/snap in .bitmap', () => {
-          helper.bitMap.expectToHaveIdHarmony('bar/foo', firstSnap, helper.scopes.remote);
+          helper.bitMap.expectToHaveId('bar/foo', firstSnap, helper.scopes.remote);
         });
         it('bit status should show pending updates', () => {
           const status = helper.command.status();
@@ -189,7 +189,7 @@ describe('bit snap command', function () {
           });
         });
         it('should change the version/snap in .bitmap', () => {
-          helper.bitMap.expectToHaveIdHarmony('bar/foo', secondSnap, helper.scopes.remote);
+          helper.bitMap.expectToHaveId('bar/foo', secondSnap, helper.scopes.remote);
         });
         it('bit status should be clean', () => {
           helper.command.expectStatusToBeClean(['snappedComponents']);
@@ -288,7 +288,7 @@ describe('bit snap command', function () {
           });
           it('should update bitmap snap', () => {
             const head = helper.command.getHead('bar/foo');
-            helper.bitMap.expectToHaveIdHarmony('bar/foo', head, helper.scopes.remote);
+            helper.bitMap.expectToHaveId('bar/foo', head, helper.scopes.remote);
           });
         });
         describe('with --no-snap flag', () => {
@@ -318,7 +318,7 @@ describe('bit snap command', function () {
             expect(status.mergePendingComponents).to.have.lengthOf(0);
           });
           it('should not update bitmap', () => {
-            helper.bitMap.expectToHaveIdHarmony('bar/foo', beforeMergeHead, helper.scopes.remote);
+            helper.bitMap.expectToHaveId('bar/foo', beforeMergeHead, helper.scopes.remote);
           });
           describe('generating merge-snap by merge --resolve flag', () => {
             let resolveOutput;
@@ -342,7 +342,7 @@ describe('bit snap command', function () {
             });
             it('should update bitmap snap', () => {
               const head = helper.command.getHead('bar/foo');
-              helper.bitMap.expectToHaveIdHarmony('bar/foo', head, helper.scopes.remote);
+              helper.bitMap.expectToHaveId('bar/foo', head, helper.scopes.remote);
             });
           });
         });
@@ -374,7 +374,7 @@ describe('bit snap command', function () {
         });
         it('should update bitmap snap', () => {
           const head = helper.command.getHead('bar/foo');
-          helper.bitMap.expectToHaveIdHarmony('bar/foo', head, helper.scopes.remote);
+          helper.bitMap.expectToHaveId('bar/foo', head, helper.scopes.remote);
         });
       });
       describe('merge with merge=manual flag', () => {
@@ -398,7 +398,7 @@ describe('bit snap command', function () {
           expect(content).to.have.string(`>>>>>>> ${secondSnap} (incoming)`);
         });
         it('should not change bitmap version', () => {
-          helper.bitMap.expectToHaveIdHarmony('bar/foo', localHead, helper.scopes.remote);
+          helper.bitMap.expectToHaveId('bar/foo', localHead, helper.scopes.remote);
         });
         it('should not generate a new merge-snap', () => {
           const head = helper.command.getHead('bar/foo');
@@ -504,7 +504,7 @@ describe('bit snap command', function () {
           });
           it('should update bitmap snap', () => {
             const head = helper.command.getHead('bar/foo');
-            helper.bitMap.expectToHaveIdHarmony('bar/foo', head, helper.scopes.remote);
+            helper.bitMap.expectToHaveId('bar/foo', head, helper.scopes.remote);
           });
         });
         describe('aborting the merge', () => {
@@ -525,7 +525,7 @@ describe('bit snap command', function () {
             expect(status.stagedComponents).to.have.lengthOf(1);
           });
           it('should not change the version in .bitmap', () => {
-            helper.bitMap.expectToHaveIdHarmony('bar/foo', localHead, helper.scopes.remote);
+            helper.bitMap.expectToHaveId('bar/foo', localHead, helper.scopes.remote);
           });
           it('should reset the changes the merge done on the filesystem', () => {
             const content = helper.fs.readFile('bar/foo.js');

--- a/e2e/harmony/track-directories-harmony.e2e.ts
+++ b/e2e/harmony/track-directories-harmony.e2e.ts
@@ -160,7 +160,7 @@ describe('track directories functionality', function () {
       });
       it('should not change the rootDir', () => {
         const bitMap = helper.bitMap.read();
-        helper.bitMap.expectToHaveIdHarmony('utils/bar', '0.0.1', helper.scopes.remote);
+        helper.bitMap.expectToHaveId('utils/bar', '0.0.1', helper.scopes.remote);
         expect(bitMap['utils/bar'].rootDir).to.equal('utils/bar');
       });
     });

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -3,7 +3,6 @@ import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { BitId } from '@teambit/legacy-bit-id';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
-import removeComponents from '@teambit/legacy/dist/consumer/component-ops/remove-components';
 import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import hasWildcard from '@teambit/legacy/dist/utils/string/has-wildcard';
 import { getRemoteBitIdsByWildcards } from '@teambit/legacy/dist/api/consumer/lib/list-scope';
@@ -13,6 +12,7 @@ import deleteComponentsFiles from '@teambit/legacy/dist/consumer/component-ops/d
 import ComponentAspect, { Component, ComponentMain } from '@teambit/component';
 import { removeComponentsFromNodeModules } from '@teambit/legacy/dist/consumer/component/package-json-utils';
 import { RemoveCmd } from './remove-cmd';
+import { removeComponents } from './remove-components';
 import { RemoveAspect } from './remove.aspect';
 import { RemoveFragment } from './remove.fragment';
 

--- a/src/e2e-helper/e2e-bitmap-helper.ts
+++ b/src/e2e-helper/e2e-bitmap-helper.ts
@@ -87,10 +87,14 @@ export default class BitMapHelper {
     return `Files in bitmap file: ${filesStr}`;
   }
 
-  expectToHaveIdHarmony(name: string, version?: string, scope?: string) {
+  expectToHaveId(name: string, version?: string, scope?: string) {
     const bitMap = this.read();
     expect(bitMap).to.have.property(name);
     if (scope) expect(bitMap[name].scope).to.equal(scope);
     if (version) expect(bitMap[name].version).to.equal(version);
+  }
+  expectNotToHaveId(name: string) {
+    const bitMap = this.read();
+    expect(bitMap).to.not.have.property(name);
   }
 }

--- a/src/scope/graph/graph.ts
+++ b/src/scope/graph/graph.ts
@@ -3,8 +3,6 @@ import R from 'ramda';
 
 import { BitId } from '../../bit-id';
 import Component from '../../consumer/component';
-import ComponentsList from '../../consumer/component/components-list';
-import Consumer from '../../consumer/consumer';
 import { loadScope } from '../index';
 import { ModelComponent, Version } from '../models';
 import Scope from '../scope';
@@ -124,31 +122,6 @@ export default class Graph extends GraphLib {
         await Promise.all(buildVersionP);
       })
     );
-  }
-
-  static async buildGraphFromWorkspace(consumer: Consumer, onlyLatest = false): Promise<Graph> {
-    const componentsList = new ComponentsList(consumer);
-    const allModelComponents: ModelComponent[] = await consumer.scope.list();
-    const workspaceComponents: Component[] = await componentsList.getFromFileSystem();
-    const graph = new Graph();
-    workspaceComponents.forEach((component: Component) => {
-      const id = component.id.toString();
-      graph.setNode(id, component);
-    });
-    await this.addScopeComponentsAsNodes(allModelComponents, graph, workspaceComponents, onlyLatest);
-    R.forEach((componentId: string) => {
-      const component: Component = graph.node(componentId);
-      Object.entries(component.depsIdsGroupedByType).forEach(([depType, depIds]) => {
-        depIds.forEach((dependencyId) => {
-          const depIdStr = dependencyId.toString();
-          if (graph.hasNode(depIdStr)) {
-            graph.setEdge(componentId, depIdStr, depType);
-          }
-        });
-      });
-    }, graph.nodes());
-
-    return graph;
   }
 
   findCycles(): string[][] {


### PR DESCRIPTION
From the workspace, it's ok to remove components that other components are using them, because the user can always install the component as a package or re-import it.
From the scope, this action is irreversible, so it makes sense to require the `--force` flag.
