### PR TITLE
fix(export): provide a clear error when local snaps are missing

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -722,8 +722,10 @@ export default class Component extends BitObject {
     );
     const versionsRefs = versions.map((version) => this.getRef(version) as Ref);
     refsWithoutArtifacts.push(...versionsRefs);
-    // @ts-ignore
-    const versionsObjects: Version[] = await Promise.all(versionsRefs.map((versionRef) => versionRef.load(repo)));
+
+    const versionsObjects: Version[] = await Promise.all(
+      versionsRefs.map((versionRef) => this.loadVersion(versionRef.toString(), repo))
+    );
     versionsObjects.forEach((versionObject) => {
       const refs = versionObject.refsWithOptions(false, false);
       refsWithoutArtifacts.push(...refs);


### PR DESCRIPTION
Currently, in this case it shows an obscure error: `TypeError: Cannot read properties of null (reading 'refsWithOptions')`. 
With this PR, it shows the standard VersionNotFound error, which outlines the component name and the missing snap.