### PR TITLE
resolve webpack-dev-server version for bit envs get <component>

### DIFF
--- a/scopes/compilation/bundler/dev-server.service.tsx
+++ b/scopes/compilation/bundler/dev-server.service.tsx
@@ -32,12 +32,12 @@ type DevServiceTransformationMap = ServiceTransformationMap  & {
 
 export type DevServerDescriptor = {
   /**
-   * id of the dev server (e.g. jest/mocha)
+   * id of the dev server (e.g. webpack)
    */
   id: string;
 
   /**
-   * display name of the dev server (e.g. Jest / Mocha)
+   * display name of the dev server (e.g. Webpack dev server)
    */
   displayName: string;
 

--- a/scopes/webpack/webpack/webpack.main.runtime.ts
+++ b/scopes/webpack/webpack/webpack.main.runtime.ts
@@ -13,6 +13,8 @@ import { MainRuntime } from '@teambit/cli';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { merge } from 'webpack-merge';
+// We want to import it to make sure bit recognizes it as a dependency
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import WsDevServer from 'webpack-dev-server';
 import { WebpackConfigMutator } from '@teambit/webpack.modules.config-mutator';
 

--- a/scopes/webpack/webpack/webpack.main.runtime.ts
+++ b/scopes/webpack/webpack/webpack.main.runtime.ts
@@ -96,7 +96,7 @@ export class WebpackMain {
       transformerContext
     );
     // @ts-ignore - fix this
-    return new WebpackDevServer(afterMutation.raw, webpack, WsDevServer);
+    return new WebpackDevServer(afterMutation.raw, webpack, require.resolve('webpack-dev-server'));
   }
 
   mergeConfig(target: any, source: any): any {


### PR DESCRIPTION
## Proposed Changes

- pass a resolved path of `webpack-dev-server` instead of its instance to `WebpackDevServer` class
- resolve `webpack-dev-server` version from its package.json
