### PR TITLE
feat: allow making components to be available on main

### DIFF
--- a/e2e/harmony/lanes/switch-lanes.e2e.ts
+++ b/e2e/harmony/lanes/switch-lanes.e2e.ts
@@ -216,4 +216,35 @@ describe('bit lane command', function () {
       expect(list[0].currentVersion).to.equal('0.0.1');
     });
   });
+  describe('switch to main after merging the lane somewhere else', () => {
+    let originalWorkspace: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      originalWorkspace = helper.scopeHelper.cloneLocalScope();
+      helper.command.switchLocalLane('main');
+      helper.command.mergeLane('dev');
+      helper.command.export();
+
+      helper.scopeHelper.getClonedLocalScope(originalWorkspace);
+      helper.command.switchLocalLane('main');
+      helper.command.import();
+    });
+    it('should not make the component available on main', () => {
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(0);
+    });
+    it('bit status should show a section of unavailable components on main', () => {
+      const status = helper.command.statusJson();
+      expect(status.unavailableOnMain).to.have.lengthOf(1);
+    });
+    it('bit checkout should make it available', () => {
+      helper.command.checkoutHead();
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(1);
+    });
+  });
 });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -183,6 +183,7 @@ export class CheckoutMain {
     this.logger.setStatusLine(BEFORE_CHECKOUT);
     if (!this.workspace) throw new OutsideWorkspaceError();
     const consumer = this.workspace.consumer;
+    if (to === 'head') await this.makeLaneComponentsAvailableOnMain();
     await this.parseValues(to, componentPattern, checkoutProps);
     const checkoutResults = await this.checkout(checkoutProps);
     await consumer.onDestroy();
@@ -202,6 +203,12 @@ export class CheckoutMain {
       // don't stop the process. it's possible that the scope doesn't exist yet because these are new components
       this.logger.error(`unable to sync new components due to an error`, err);
     }
+  }
+
+  private async makeLaneComponentsAvailableOnMain() {
+    const unavailableOnMain = await this.workspace.getUnavailableOnMainComponents();
+    if (!unavailableOnMain.length) return;
+    this.workspace.bitMap.makeComponentsAvailableOnMain(unavailableOnMain);
   }
 
   private async parseValues(to: CheckoutTo, componentPattern: string, checkoutProps: CheckoutProps) {

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -55,6 +55,7 @@ export class StatusCmd implements Command {
       componentsDuringMergeState,
       softTaggedComponents,
       snappedComponents,
+      unavailableOnMain,
       pendingUpdatesFromMain,
       updatesFromForked,
       currentLaneId,
@@ -64,6 +65,7 @@ export class StatusCmd implements Command {
       newComponents: newComponents.map((c) => c.toStringWithoutVersion()),
       modifiedComponents: modifiedComponents.map((c) => c.toString()),
       stagedComponents: stagedComponents.map((c) => ({ id: c.id.toStringWithoutVersion(), versions: c.versions })),
+      unavailableOnMain: unavailableOnMain.map((c) => c.toString()),
       componentsWithIssues: componentsWithIssues.map((c) => ({
         id: c.id.toString(),
         issues: c.issues?.toObject(),
@@ -107,6 +109,7 @@ export class StatusCmd implements Command {
       snappedComponents,
       pendingUpdatesFromMain,
       updatesFromForked,
+      unavailableOnMain,
       currentLaneId,
       forkedLaneId,
     }: StatusResult = await this.status.status({ lanes });
@@ -246,6 +249,12 @@ or use "bit merge [component-id] --abort" to cancel the merge operation)\n`;
       snappedComponents.length ? chalk.underline.white('snapped components') + snappedDesc : ''
     ).join('\n');
 
+    const unavailableOnMainDesc = '\n(use "bit checkout head" to make it available)\n';
+    const unavailableOnMainOutput = immutableUnshift(
+      unavailableOnMain.map((c) => format(c)),
+      unavailableOnMain.length ? chalk.underline.white('unavailable on main components') + unavailableOnMainDesc : ''
+    ).join('\n');
+
     const getUpdateFromMsg = (divergeData: SnapsDistance, from = 'main'): string => {
       if (divergeData.err) return divergeData.err.message;
       let msg = `${from} is ahead by ${divergeData.snapsOnTargetOnly.length || 0} snaps`;
@@ -302,6 +311,7 @@ use "bit fetch ${forkedLaneId.toString()} --lanes" to update ${forkedLaneId.name
         modifiedComponentOutput,
         snappedComponentsOutput,
         stagedComponentsOutput,
+        unavailableOnMainOutput,
         autoTagPendingOutput,
         invalidComponentOutput,
         locallySoftRemovedOutput,

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -38,6 +38,7 @@ export type StatusResult = {
   snappedComponents: ComponentID[];
   pendingUpdatesFromMain: DivergeDataPerId[];
   updatesFromForked: DivergeDataPerId[];
+  unavailableOnMain: ComponentID[];
   currentLaneId: LaneId;
   forkedLaneId?: LaneId;
 };
@@ -75,6 +76,7 @@ export class StatusMain {
       };
     });
 
+    const unavailableOnMain = await this.workspace.getUnavailableOnMainComponents();
     const autoTagPendingComponents = await componentsList.listAutoTagPendingComponents();
     const autoTagPendingComponentsIds = autoTagPendingComponents.map((component) => component.id);
     const allInvalidComponents = await componentsList.listInvalidComponents();
@@ -170,6 +172,7 @@ export class StatusMain {
       snappedComponents: await convertBitIdToComponentIdsAndSort(snappedComponents),
       pendingUpdatesFromMain: await convertObjToComponentIdsAndSort(pendingUpdatesFromMain),
       updatesFromForked: await convertObjToComponentIdsAndSort(updatesFromForked),
+      unavailableOnMain,
       currentLaneId,
       forkedLaneId,
     };

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -421,8 +421,8 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
   }
 
   private getIdsToImportFromBitmap() {
-    const authoredExportedComponents = this.consumer.bitMap.getExportedComponents();
-    return BitIds.fromArray(authoredExportedComponents);
+    const allIds = this.consumer.bitMap.getAllBitIdsFromAllLanes();
+    return BitIds.fromArray(allIds.filter((id) => id.hasScope()));
   }
 
   async _getCurrentVersions(ids: BitIds): Promise<ImportedVersions> {

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -174,6 +174,15 @@ export class BitMap {
     return this.legacyBitMap.isLaneExported ? this.legacyBitMap.laneId : undefined;
   }
 
+  makeComponentsAvailableOnMain(ids: ComponentID[]) {
+    ids.forEach((id) => {
+      const componentMap = this.getBitmapEntry(id);
+      delete componentMap.onLanesOnly;
+      delete componentMap.isAvailableOnCurrentLane;
+    });
+    this.legacyBitMap.markAsChanged();
+  }
+
   /**
    * whether .bitmap file has changed in-memory
    */

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -12,7 +12,7 @@ import { BIT_MAP, OLD_BIT_MAP, VERSION_DELIMITER, BITMAP_PREFIX_MESSAGE } from '
 import ShowDoctorError from '../../error/show-doctor-error';
 import logger from '../../logger/logger';
 import { isDir, outputFile, pathJoinLinux, pathNormalizeToLinux, sortObject } from '../../utils';
-import { PathLinux, PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative, PathRelative } from '../../utils/path';
+import { PathLinux, PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative } from '../../utils/path';
 import { getFilesByDir, getGitIgnoreHarmony } from '../component-ops/add-components/add-components';
 import ComponentMap, { ComponentMapFile, Config, PathChange } from './component-map';
 import { InvalidBitMap, MissingBitMapComponent, MultipleMatches } from './exceptions';
@@ -449,20 +449,6 @@ export default class BitMap {
       return componentMap.id;
     });
     return BitIds.fromArray(compact(filteredWithDefaultVersion));
-  }
-
-  getExportedComponents(): BitId[] {
-    const authoredIds = this.getAllIdsAvailableOnLane();
-    return authoredIds.filter((id) => id.hasScope());
-  }
-  getAuthoredNonExportedComponents(): BitId[] {
-    const authoredIds = this.getAllIdsAvailableOnLane();
-    return authoredIds.filter((id) => !id.hasScope());
-  }
-
-  _makePathRelativeToProjectRoot(pathToChange: PathRelative): PathOsBasedRelative {
-    const absolutePath = path.resolve(pathToChange);
-    return path.relative(this.projectRoot, absolutePath);
   }
 
   /**


### PR DESCRIPTION
A popular use-case when this is needed is when creating new components on a lane then this lane was merged by someone else or by the cloud to main. Now, when switching to main, all these components are unavailable.
This PR handle it in two places:
1. `bit status` shows a new section of such components.
2. `bit checkout head` makes them available.