### PR TITLE
feat(snap): introdue --editor flag, similar to what bit-tag has

### DIFF
--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -32,6 +32,11 @@ export class SnapCmd implements Command {
       'build',
       'EXPERIMENTAL. not needed for now. run the build pipeline in case the feature-flag build-on-ci is enabled',
     ],
+    [
+      '',
+      'editor [editor]',
+      'EXPERIMENTAL. open an editor to write a tag message for each component. optionally, specify the editor-name (defaults to vim).',
+    ],
     ['', 'skip-tests', 'skip running component tests during snap process'],
     ['', 'skip-auto-snap', 'skip auto snapping dependents'],
     ['', 'disable-snap-pipeline', 'skip the snap pipeline'],
@@ -66,6 +71,7 @@ ${WILDCARD_HELP('snap')}`;
       all = false,
       force = false,
       unmerged = false,
+      editor = '',
       ignoreIssues,
       build,
       skipTests = false,
@@ -78,6 +84,7 @@ ${WILDCARD_HELP('snap')}`;
       all?: boolean;
       force?: boolean;
       unmerged?: boolean;
+      editor?: string;
       ignoreIssues?: string;
       build?: boolean;
       skipTests?: boolean;
@@ -104,7 +111,7 @@ ${WILDCARD_HELP('snap')}`;
       );
       if (pattern) unmodified = true;
     }
-    if (!message) {
+    if (!message && !editor) {
       this.logger.consoleWarning(
         `--message will be mandatory in the next few releases. make sure to add a message with your snap`
       );
@@ -114,6 +121,7 @@ ${WILDCARD_HELP('snap')}`;
       pattern,
       message,
       unmerged,
+      editor,
       ignoreIssues,
       build,
       skipTests,

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -408,6 +408,7 @@ export class SnappingMain {
     pattern,
     legacyBitIds, // @todo: change to ComponentID[]. pass only if have the ids already parsed.
     unmerged,
+    editor,
     message = '',
     ignoreIssues,
     skipTests = false,
@@ -420,6 +421,7 @@ export class SnappingMain {
     pattern?: string;
     legacyBitIds?: BitIds;
     unmerged?: boolean;
+    editor?: string;
     message?: string;
     ignoreIssues?: string;
     build: boolean;
@@ -448,6 +450,7 @@ export class SnappingMain {
       scope: this.scope,
       snapping: this,
       builder: this.builder,
+      editor,
       consumerComponents: components,
       ids,
       ignoreNewestVersion: false,

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -144,7 +144,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     if (disableDeployPipeline) {
       this.logger.consoleWarning(`--disable-deploy-pipeline is deprecated, please use --disable-tag-pipeline instead`);
     }
-    if (!message && !persist) {
+    if (!message && !persist && !editor) {
       this.logger.consoleWarning(
         `--message will be mandatory in the next few releases. make sure to add a message with your tag`
       );


### PR DESCRIPTION
Also, suppress the warning about adding message when `--editor` is used.