### PR TITLE
fix: only resolve dependency versions from dependencies (not policies) when installing in capsules

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -378,6 +378,7 @@ export class IsolatorMain {
     const installOptions: InstallOptions = {
       installTeambitBit: !!isolateInstallOptions.installTeambitBit,
       packageManagerConfigRootDir: isolateInstallOptions.packageManagerConfigRootDir,
+      resolveVersionsFromDependenciesOnly: true,
     };
 
     const packageManagerInstallOptions: PackageManagerInstallOptions = {

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -34,12 +34,14 @@ export type InstallArgs = {
 export type InstallOptions = {
   installTeambitBit: boolean;
   packageManagerConfigRootDir?: string;
+  resolveVersionsFromDependenciesOnly?: boolean;
 };
 
 export type GetComponentManifestsOptions = {
   componentDirectoryMap: ComponentMap<string>;
   rootPolicy: WorkspacePolicy;
   rootDir: string;
+  resolveVersionsFromDependenciesOnly?: boolean;
 } & Pick<
   PackageManagerInstallOptions,
   'dedupe' | 'dependencyFilterFn' | 'copyPeerToRuntimeOnComponents' | 'copyPeerToRuntimeOnRoot' | 'installPeersFromEnvs'
@@ -101,6 +103,7 @@ export class DependencyInstaller {
       componentDirectoryMap,
       rootPolicy,
       rootDir: finalRootDir,
+      resolveVersionsFromDependenciesOnly: options.resolveVersionsFromDependenciesOnly,
     });
     return this.installComponents(
       finalRootDir,
@@ -195,12 +198,14 @@ export class DependencyInstaller {
     copyPeerToRuntimeOnComponents,
     copyPeerToRuntimeOnRoot,
     installPeersFromEnvs,
+    resolveVersionsFromDependenciesOnly,
   }: GetComponentManifestsOptions) {
     const options: CreateFromComponentsOptions = {
       filterComponentsFromManifests: true,
       createManifestForComponentsWithoutDependencies: true,
       dedupe,
       dependencyFilterFn,
+      resolveVersionsFromDependenciesOnly,
     };
     const workspaceManifest = await this.dependencyResolver.getWorkspaceManifest(
       undefined,
@@ -217,9 +222,7 @@ export class DependencyInstaller {
         const manifest = workspaceManifest.componentsManifestsMap.get(packageName);
         if (manifest) {
           acc[dir] = manifest.toJson({ copyPeerToRuntime: copyPeerToRuntimeOnComponents });
-          acc[dir].defaultPeerDependencies = fromPairs(
-            manifest.envPolicy.selfPolicy.toNameVersionTuple()
-          );
+          acc[dir].defaultPeerDependencies = fromPairs(manifest.envPolicy.selfPolicy.toNameVersionTuple());
         }
         return acc;
       }, {});

--- a/scopes/dependencies/dependency-resolver/manifest/update-dependency-version.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/update-dependency-version.ts
@@ -26,16 +26,16 @@ import { VariantPolicy, WorkspacePolicy } from '../policy';
  */
 export function updateDependencyVersion(
   dependency: Dependency,
-  rootPolicy: WorkspacePolicy,
-  variantPolicy: VariantPolicy
+  rootPolicy?: WorkspacePolicy,
+  variantPolicy?: VariantPolicy
 ): void {
   if (dependency.getPackageName) {
     const packageName = dependency.getPackageName();
-    const variantVersion = variantPolicy.getDepVersion(packageName, dependency.lifecycle);
+    const variantVersion = variantPolicy?.getDepVersion(packageName, dependency.lifecycle);
     const variantVersionWithoutMinus = variantVersion && variantVersion !== '-' ? variantVersion : undefined;
     const version =
       variantVersionWithoutMinus ||
-      rootPolicy.getValidSemverDepVersion(packageName, dependency.lifecycle === 'peer' ? 'peer' : 'runtime') ||
+      rootPolicy?.getValidSemverDepVersion(packageName, dependency.lifecycle === 'peer' ? 'peer' : 'runtime') ||
       snapToSemver(dependency.version) ||
       '0.0.1-new';
 


### PR DESCRIPTION
## Proposed Changes

-
-
-
