### PR TITLE
fix(lane-switch): block switching a lane when on main and there are staging components

### DIFF
--- a/e2e/harmony/lanes/lane-from-lane.e2e.ts
+++ b/e2e/harmony/lanes/lane-from-lane.e2e.ts
@@ -160,9 +160,7 @@ describe('bit lane command', function () {
     });
     it('bit create should throw an error suggesting to export or reset first', () => {
       const output = helper.general.runWithTryCatch('bit lane create lane-b');
-      expect(output).to.have.string(
-        'unable to create a new lane, please export or reset the following components first'
-      );
+      expect(output).to.have.string('please export or reset the following components first');
     });
   });
 });

--- a/e2e/harmony/lanes/switch-lanes.e2e.ts
+++ b/e2e/harmony/lanes/switch-lanes.e2e.ts
@@ -249,4 +249,22 @@ describe('bit lane command', function () {
       expect(list).to.have.lengthOf(1);
     });
   });
+  describe('switch from main to a lane when main has staged components', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.command.switchLocalLane('main');
+      helper.command.tagAllWithoutBuild('--unmodified');
+    });
+    it('should block the switch and suggest to export or reset', () => {
+      expect(() => helper.command.switchLocalLane('dev')).to.throw(
+        'please export or reset the following components first'
+      );
+    });
+  });
 });

--- a/scopes/lanes/lanes/create-lane.ts
+++ b/scopes/lanes/lanes/create-lane.ts
@@ -86,12 +86,12 @@ export function throwForInvalidLaneName(laneName: string) {
   }
 }
 
-async function throwForStagedComponents(consumer: Consumer) {
+export async function throwForStagedComponents(consumer: Consumer) {
   const componentList = new ComponentsList(consumer);
   const stagedComponents = await componentList.listExportPendingComponentsIds();
   if (stagedComponents.length) {
     throw new BitError(
-      `unable to create a new lane, please export or reset the following components first: ${stagedComponents.join(
+      `unable to switch/create a new lane, please export or reset the following components first: ${stagedComponents.join(
         ', '
       )}`
     );

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -25,6 +25,7 @@ import { Workspace } from '@teambit/workspace';
 import { Logger } from '@teambit/logger';
 import { BitError } from '@teambit/bit-error';
 import { LanesMain } from './lanes.main.runtime';
+import { throwForStagedComponents } from './create-lane';
 
 export type SwitchProps = {
   laneName: string;
@@ -51,6 +52,9 @@ export class LaneSwitcher {
 
   async switch(): Promise<ApplyVersionResults> {
     this.logger.setStatusLine(`switching lanes`);
+    if (this.workspace.isOnMain()) {
+      await throwForStagedComponents(this.consumer);
+    }
     await this.populateSwitchProps();
     const allComponentsStatus: ComponentStatus[] = await this.getAllComponentsStatus();
     const componentWithConflict = allComponentsStatus.find(

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -674,6 +674,10 @@ export class Workspace implements ComponentFactory {
     return this.consumer.getCurrentLaneId();
   }
 
+  isOnMain(): boolean {
+    return this.consumer.isOnMain();
+  }
+
   /**
    * if checked out to a lane and the lane exists in the remote,
    * return the remote lane id (name+scope). otherwise, return null.


### PR DESCRIPTION
This fixes a bug found in the following scenario:
A component has a different scope than the lane. It was snapped on main, as a result, the `head` prop of the Component model has changed locally. Later, the lane was switched to a local lane, running `bit export` threw the following error:

> unexpected network error has occurred.
> server responded with: "scope "teambit.webpack". error: head snap a4197234768854dea33ff782e4de7196b4d0d496 was not found for a component learnbit-react.module-federation/apps/remote-app"
> 

It happened because the remote-scope of the lane got the component object with a head that only exists locally.
It's not easy to fix this issue and it could happen only when switching from main to another lane. not from one lane to another. so for now, we just block it. Later, we might support it somehow.