### PR TITLE
improvement: cache staged-snaps hashes to avoid fetching them from a remote

### DIFF
--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -172,6 +172,7 @@ export class ExportMain {
     // re-generate the package.json, this way, it has the correct data in the componentId prop.
     await linkToNodeModules(this.workspace, updatedIds, true);
     await this.removeFromStagedConfig(exported);
+    await this.workspace.scope.legacyScope.stagedSnaps.deleteFile();
     Analytics.setExtraData('num_components', exported.length);
     // it is important to have consumer.onDestroy() before running the eject operation, we want the
     // export and eject operations to function independently. we don't want to lose the changes to

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -172,6 +172,8 @@ export class ExportMain {
     // re-generate the package.json, this way, it has the correct data in the componentId prop.
     await linkToNodeModules(this.workspace, updatedIds, true);
     await this.removeFromStagedConfig(exported);
+    // ideally we should delete the staged-snaps only for the exported snaps. however, it's not easy, and it's ok to
+    // delete them all because this file is mainly an optimization for the import process.
     await this.workspace.scope.legacyScope.stagedSnaps.deleteFile();
     Analytics.setExtraData('num_components', exported.length);
     // it is important to have consumer.onDestroy() before running the eject operation, we want the

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -105,9 +105,11 @@ export default class SourceRepository {
       if (bitId.isLocal(this.scope.name) || version.buildStatus === BuildStatus.Succeed || !versionShouldBeBuilt) {
         return component;
       }
-      const hasLocalVersion = await component.hasLocalVersion(this.scope.objects, bitId.version as string);
+      const hash = component.getRef(bitId.version as string);
+      if (!hash) throw new Error(`sources.get: unable to get has for ${bitId.toString()}`);
+      const hasLocalVersion = this.scope.stagedSnaps.has(hash.toString());
       if (hasLocalVersion) {
-        // e.g. during tag
+        // no point to go to the remote, it's local.
         return component;
       }
       const bitIdStr = bitId.toString();

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -51,6 +51,7 @@ import { ObjectItem, ObjectList } from './objects/object-list';
 import ClientIdInUse from './exceptions/client-id-in-use';
 import { UnexpectedPackageName } from '../consumer/exceptions/unexpected-package-name';
 import { getDivergeData } from './component-ops/get-diverge-data';
+import { StagedSnaps } from './staged-snaps';
 
 const removeNils = R.reject(R.isNil);
 const pathHasScope = pathHasAll([OBJECTS_DIR, SCOPE_JSON]);
@@ -118,6 +119,7 @@ export default class Scope {
    * another instance this is needed is for bit-sign, this way when loading aspects and fetching dists, it'll go to lane-scope.
    */
   currentLaneId?: LaneId;
+  stagedSnaps: StagedSnaps;
   constructor(scopeProps: ScopeProps) {
     this.path = scopeProps.path;
     this.scopeJson = scopeProps.scopeJson;
@@ -128,6 +130,7 @@ export default class Scope {
     this.lanes = new Lanes(this.objects, this.scopeJson);
     this.isBare = scopeProps.isBare ?? false;
     this.scopeImporter = ScopeComponentsImporter.getInstance(this);
+    this.stagedSnaps = StagedSnaps.load(this.path);
   }
 
   static onPostExport: (ids: BitId[], lanes: Lane[]) => Promise<void>; // enable extensions to hook after the export process

--- a/src/scope/staged-snaps.ts
+++ b/src/scope/staged-snaps.ts
@@ -1,0 +1,39 @@
+import path from 'path';
+import fs from 'fs-extra';
+
+const STAGED_SNAPS = 'staged-snaps';
+
+export class StagedSnaps {
+  private hasChanged = false;
+  constructor(private scopePath: string, private snaps: string[]) {}
+
+  async write() {
+    if (this.hasChanged) {
+      await fs.writeFile(StagedSnaps.getPath(this.scopePath), this.snaps.join('\n'));
+    }
+  }
+
+  addSnap(snap: string) {
+    this.snaps.push(snap);
+    this.hasChanged = true;
+  }
+
+  has(snap: string) {
+    return this.snaps.includes(snap);
+  }
+
+  async deleteFile() {
+    await fs.remove(StagedSnaps.getPath(this.scopePath));
+  }
+
+  static getPath(scopePath: string) {
+    return path.join(scopePath, STAGED_SNAPS);
+  }
+
+  static load(scopePath: string) {
+    const stagedSnapsPath = StagedSnaps.getPath(scopePath);
+    if (!fs.existsSync(stagedSnapsPath)) return new StagedSnaps(scopePath, []);
+    const stagedSnapsStr = fs.readFileSync(stagedSnapsPath).toString();
+    return new StagedSnaps(scopePath, stagedSnapsStr.split('\n'));
+  }
+}

--- a/src/scope/staged-snaps.ts
+++ b/src/scope/staged-snaps.ts
@@ -3,6 +3,14 @@ import fs from 'fs-extra';
 
 const STAGED_SNAPS = 'staged-snaps';
 
+/**
+ * keeps track of the local snaps/tags.
+ * during tag/snap, the hash is saved into `STAGED_SNAPS` file. during export, it gets deleted.
+ * the purpose of this file is to easily get an answer whether a hash is local, without making the expensive
+ * calculation of `getDivergeData` for `sources.get()` method.
+ * It's not 100% accurate (during export, we delete the entire file, even when the user entered ids to export),
+ * but because it is only used for optimization of the import process, it's good enough.
+ */
 export class StagedSnaps {
   private hasChanged = false;
   constructor(private scopePath: string, private snaps: string[]) {}


### PR DESCRIPTION
Currently, to get this info whether or not a version is local, we have to run the expensive `getDivergeData` call.
Not only this is not good for performance reasons, but this is also throw errors in some cases when the version we search for is coming from another lane, not the currently checked out one. 
Also, in these cases, it's unable to determine whether it's local, because the `setDivergeData` only checks the currently checked out lane against the remote.