### PR TITLE
fix(switch): compile gracefully during import/switch/checkout

### DIFF
--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -6,6 +6,7 @@ import {
   applyVersionReport,
   conflictSummaryReport,
   installationErrorOutput,
+  compilationErrorOutput,
 } from '@teambit/merging';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { getMergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
@@ -107,6 +108,7 @@ export class CheckoutCmd implements Command {
       newFromLane,
       newFromLaneAdded,
       installationError,
+      compilationError,
     }: ApplyVersionResults = await this.checkout.checkoutByCLIValues(to, componentPattern || '', checkoutProps);
     const isHead = to === 'head';
     const isReset = to === 'reset';
@@ -211,7 +213,8 @@ once ready, snap/tag the components to persist the changes`;
       getNewOnLaneOutput() +
       getConflictSummary() +
       getSummary() +
-      installationErrorOutput(installationError)
+      installationErrorOutput(installationError) +
+      compilationErrorOutput(compilationError)
     );
   }
 }

--- a/scopes/component/merging/index.ts
+++ b/scopes/component/merging/index.ts
@@ -1,6 +1,12 @@
 import { MergingAspect } from './merging.aspect';
 
-export { mergeReport, applyVersionReport, conflictSummaryReport, installationErrorOutput } from './merge-cmd';
+export {
+  mergeReport,
+  applyVersionReport,
+  conflictSummaryReport,
+  installationErrorOutput,
+  compilationErrorOutput,
+} from './merge-cmd';
 export type { MergingMain, ComponentMergeStatus, ApplyVersionResults } from './merging.main.runtime';
 export { ConfigMergeResult } from './config-merge-result';
 export default MergingAspect;

--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -267,3 +267,11 @@ export function installationErrorOutput(installationError?: Error) {
   const body = chalk.red(installationError.message);
   return `\n\n${title}\n${subTitle}\n${body}`;
 }
+
+export function compilationErrorOutput(compilationError?: Error) {
+  if (!compilationError) return '';
+  const title = chalk.underline('Compilation Error');
+  const subTitle = 'The following error had been caught from the compiler, please fix the issue and run "bit compile"';
+  const body = chalk.red(compilationError.message);
+  return `\n\n${title}\n${subTitle}\n${body}`;
+}

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -85,6 +85,7 @@ export type ApplyVersionResults = {
   newFromLane?: string[];
   newFromLaneAdded?: boolean;
   installationError?: Error; // in case the package manager failed, it won't throw, instead, it'll return error here
+  compilationError?: Error; // in case the compiler failed, it won't throw, instead, it'll return error here
 };
 
 export class MergingMain {

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -97,14 +97,16 @@ export class LaneSwitcher {
       verbose: this.checkoutProps.verbose,
       writeConfig: this.checkoutProps.writeConfig,
     };
-    const { installationError } = await this.Lanes.componentWriter.writeMany(manyComponentsWriterOpts);
+    const { installationError, compilationError } = await this.Lanes.componentWriter.writeMany(
+      manyComponentsWriterOpts
+    );
     await deleteFilesIfNeeded(componentsResults, this.consumer);
 
     const appliedVersionComponents = componentsResults.map((c) => c.applyVersionResult);
 
     await this.consumer.onDestroy();
 
-    return { components: appliedVersionComponents, failedComponents, installationError };
+    return { components: appliedVersionComponents, failedComponents, installationError, compilationError };
   }
 
   private async populateSwitchProps() {

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -1,5 +1,5 @@
 import chalk from 'chalk';
-import { applyVersionReport, installationErrorOutput } from '@teambit/merging';
+import { applyVersionReport, installationErrorOutput, compilationErrorOutput } from '@teambit/merging';
 import { Command, CommandOptions } from '@teambit/cli';
 import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
 import { LanesMain } from './lanes.main.runtime';
@@ -45,7 +45,7 @@ export class SwitchCmd implements Command {
       json?: boolean;
     }
   ) {
-    const { components, failedComponents, installationError } = await this.lanes.switchLanes(lane, {
+    const { components, failedComponents, installationError, compilationError } = await this.lanes.switchLanes(lane, {
       alias,
       merge,
       getAll,
@@ -82,6 +82,11 @@ export class SwitchCmd implements Command {
     };
     const failedOutput = getFailureOutput();
     const successOutput = getSuccessfulOutput();
-    return failedOutput + successOutput + installationErrorOutput(installationError);
+    return (
+      failedOutput +
+      successOutput +
+      installationErrorOutput(installationError) +
+      compilationErrorOutput(compilationError)
+    );
   }
 }

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -83,6 +83,7 @@ export type ImportResult = {
   importDetails: ImportDetails[];
   cancellationMessage?: string;
   installationError?: Error;
+  compilationError?: Error;
 };
 
 export default class ImportComponents {
@@ -197,6 +198,7 @@ export default class ImportComponents {
       writtenComponents,
       importDetails,
       installationError: componentWriterResults?.installationError,
+      compilationError: componentWriterResults?.compilationError,
     };
   }
 
@@ -427,6 +429,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       writtenComponents,
       importDetails,
       installationError: componentWriterResults?.installationError,
+      compilationError: componentWriterResults?.compilationError,
     };
   }
 

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -2,7 +2,7 @@ import { Command, CommandOptions } from '@teambit/cli';
 import chalk from 'chalk';
 import { compact } from 'lodash';
 import R from 'ramda';
-import { installationErrorOutput } from '@teambit/merging';
+import { installationErrorOutput, compilationErrorOutput } from '@teambit/merging';
 import { WILDCARD_HELP } from '@teambit/legacy/dist/constants';
 import {
   FileStatus,
@@ -158,7 +158,7 @@ ${WILDCARD_HELP('import')}`;
       fetchDeps,
     };
     const importResults = await this.importer.import(importOptions, this._packageManagerArgs);
-    const { importDetails, importedIds, importedDeps, installationError } = importResults;
+    const { importDetails, importedIds, importedDeps, installationError, compilationError } = importResults;
 
     if (json) {
       return JSON.stringify({ importDetails, installationError }, null, 4);
@@ -193,7 +193,11 @@ ${WILDCARD_HELP('import')}`;
           ).join('\n')
         : '';
 
-    const output = importOutput + importedDepsOutput + installationErrorOutput(installationError);
+    const output =
+      importOutput +
+      importedDepsOutput +
+      installationErrorOutput(installationError) +
+      compilationErrorOutput(compilationError);
 
     return output;
   }


### PR DESCRIPTION
Avoid stopping the process if the compilation failed. Instead, catch the error, complete the process and show it at the end of the command. This way, it won't leave the workspace in a bad shape, where the files are already written but the .bitmap wasn't updated.