### PR TITLE
Lanes: Lane Compare + SnapsDistance GQL API

### DIFF
--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -13,6 +13,12 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         diffOutput: String
       }
 
+      type SnapDistance {
+        onSource: [String!]!
+        onTarget: [String!]!
+        common: String
+      }
+
       type FieldsDiff {
         fieldName: String!
         diffOutput: String
@@ -60,6 +66,7 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         """
         changes: [String!]
         upToDate: Boolean
+        snapsDistance: SnapDistance
       }
 
       type LaneDiffStatus {

--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -67,6 +67,7 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         changes: [String!]
         upToDate: Boolean
         snapsDistance: SnapDistance
+        unrelated: Boolean
       }
 
       type LaneDiffStatus {

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -52,6 +52,12 @@ import { LanesDeleteRoute } from './lanes.delete.route';
 
 export { Lane };
 
+export type SnapsDistanceObj = {
+  onSource: string[];
+  onTarget: string[];
+  common?: string;
+};
+
 export type LaneResults = {
   lanes: LaneData[];
   currentLane?: string | null;
@@ -82,6 +88,7 @@ export type LaneComponentDiffStatus = {
   changeType?: ChangeType;
   changes?: ChangeType[];
   upToDate?: boolean;
+  snapsDistance?: SnapsDistanceObj;
 };
 
 export type LaneDiffStatusOptions = {
@@ -695,7 +702,19 @@ export class LanesMain {
     const changes = !options?.skipChanges ? await getChanges() : undefined;
     const changeType = changes ? changes[0] : undefined;
 
-    return { componentId, changeType, changes, sourceHead, targetHead, upToDate: snapsDistance?.isUpToDate() };
+    return {
+      componentId,
+      changeType,
+      changes,
+      sourceHead,
+      targetHead,
+      upToDate: snapsDistance?.isUpToDate(),
+      snapsDistance: {
+        onSource: snapsDistance?.snapsOnSourceOnly.map((s) => s.hash) ?? [],
+        onTarget: snapsDistance?.snapsOnTargetOnly.map((s) => s.hash) ?? [],
+        common: snapsDistance?.commonSnapBeforeDiverge?.hash,
+      },
+    };
   }
 
   async addLaneReadme(readmeComponentIdStr: string, laneName?: string): Promise<{ result: boolean; message?: string }> {

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -155,7 +155,7 @@ export class LanesUI {
   }
 
   getLanesComparePage() {
-    return <LaneComparePage getLaneCompare={this.getLaneCompare} />;
+    return <LaneComparePage getLaneCompare={this.getLaneCompare} groupByScope={this.lanesHost === 'workspace'} />;
   }
 
   getMenuRoutes() {
@@ -216,7 +216,7 @@ export class LanesUI {
         order: 2,
         hide: () => {
           const { lanesModel } = useLanes();
-          return !lanesModel?.viewedLane || lanesModel.viewedLane.id.isDefault();
+          return !lanesModel?.viewedLane;
         },
       },
     ]);

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -80,7 +80,7 @@ export class LanesUI {
             <Route path={LanesModel.lanePath}>
               <Route index element={this.getLaneOverview()} />
               <Route path="~component/*" element={this.getLaneComponent()} />
-              {/* <Route path="~compare/*" element={this.getLanesComparePage()} /> */}
+              <Route path="~compare/*" element={this.getLanesComparePage()} />
               <Route path="*" element={<NotFoundPage />} />
             </Route>
             <Route path="*" element={<NotFoundPage />} />
@@ -211,10 +211,13 @@ export class LanesUI {
       {
         props: {
           href: '~compare',
-          children: 'Lane Compare',
+          children: 'Compare',
         },
         order: 2,
-        hide: () => true,
+        hide: () => {
+          const { lanesModel } = useLanes();
+          return !lanesModel?.viewedLane || lanesModel.viewedLane.id.isDefault();
+        },
       },
     ]);
   }

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -216,7 +216,7 @@ export class LanesUI {
         order: 2,
         hide: () => {
           const { lanesModel } = useLanes();
-          return !lanesModel?.viewedLane;
+          return !lanesModel?.viewedLane || lanesModel?.lanes.length < 2;
         },
       },
     ]);

--- a/scopes/lanes/ui/compare/lane-compare-hooks/use-lane-diff-status/use-lane-diff-status.ts
+++ b/scopes/lanes/ui/compare/lane-compare-hooks/use-lane-diff-status/use-lane-diff-status.ts
@@ -46,6 +46,7 @@ export const QUERY_LANE_DIFF_STATUS = gql`
           targetHead
           changes
           upToDate
+          unrelated
         }
       }
     }
@@ -80,6 +81,7 @@ export const useLaneDiffStatus: UseLaneDiffStatus = ({ baseId, compareId, option
     targetLane: LaneId.from(data.lanes.diffStatus.target.name, data.lanes.diffStatus.target.scope).toString(),
     diff: data.lanes.diffStatus.componentsStatus.map((c) => ({
       ...c,
+      changes: c.changes || [],
       componentId: ComponentID.fromObject(c.componentId).toString(),
     })),
   };

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
@@ -8,4 +8,29 @@
 .top {
   display: flex;
   padding: 32px;
+  align-items: center;
+  width: 60%;
+
+  > div {
+    display: flex;
+  }
+}
+
+.compareLane {
+  padding: 8px;
+  background: var(--surface-neutral-focus-color);
+  border-radius: 6px;
+  margin: 0px 2px;
+  width: fit-content;
+}
+
+.baseSelectorContainer {
+  padding: 0px 4px;
+  flex: 2;
+  width: 100%;
+  min-width: 100px;
+  max-width: 200px;
+  > div:first-of-type {
+    width: 100%;
+  }
 }

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
@@ -7,7 +7,8 @@
 }
 .top {
   display: flex;
-  padding: 32px;
+  padding: 24px;
+  padding-bottom: 8px;
   align-items: center;
   width: 60%;
 
@@ -20,8 +21,13 @@
   padding: 8px;
   background: var(--surface-neutral-focus-color);
   border-radius: 6px;
-  margin: 0px 2px;
+  margin: 0px 4px;
   width: fit-content;
+  // same height as the lane selector
+  height: 34px;
+  box-sizing: border-box;
+  font-size: var(--bit-p-xs, 14px);
+  align-items: center;
 }
 
 .baseSelectorContainer {
@@ -33,4 +39,10 @@
   > div:first-of-type {
     width: 100%;
   }
+}
+
+.laneIcon {
+  padding-right: 4px;
+  height: 16px;
+  font-size: var(--bit-p-sm, 16px);
 }

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
@@ -3,7 +3,6 @@
   flex-direction: column;
   height: 100%;
   width: 100%;
-  // overflow: scroll;
 }
 .top {
   display: flex;
@@ -15,6 +14,11 @@
   > div {
     display: flex;
   }
+}
+
+.bottom {
+  display: flex;
+  overflow: scroll;
 }
 
 .compareLane {

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.module.scss
@@ -32,7 +32,6 @@
 
 .baseSelectorContainer {
   padding: 0px 4px;
-  flex: 2;
   width: 100%;
   min-width: 100px;
   max-width: 200px;

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
@@ -65,7 +65,7 @@ export function LaneComparePage({ getLaneCompare, groupByScope, ...rest }: LaneC
           />
         </div>
       </div>
-      <div className={styles.bottom}> {LaneCompareComponent}</div>
+      {LaneCompareComponent}
     </div>
   );
 }

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
@@ -65,7 +65,7 @@ export function LaneComparePage({ getLaneCompare, groupByScope, ...rest }: LaneC
           />
         </div>
       </div>
-      {LaneCompareComponent}
+      <div className={styles.bottom}>{LaneCompareComponent}</div>
     </div>
   );
 }

--- a/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
+++ b/scopes/lanes/ui/compare/lane-compare-page/lane-compare-page.tsx
@@ -1,27 +1,69 @@
-import React, { HTMLAttributes } from 'react';
+import React, { HTMLAttributes, useState, useEffect, useMemo } from 'react';
 import { LaneCompareProps } from '@teambit/lanes';
 import { useLanes } from '@teambit/lanes.hooks.use-lanes';
+import { LaneSelector } from '@teambit/lanes.ui.inputs.lane-selector';
+import { LaneModel } from '@teambit/lanes.ui.models.lanes-model';
+import { LaneId } from '@teambit/lane-id';
+import { LaneIcon } from '@teambit/lanes.ui.icons.lane-icon';
 
 import styles from './lane-compare-page.module.scss';
 
 export type LaneComparePageProps = {
   getLaneCompare: (props: LaneCompareProps) => React.ReactNode;
+  groupByScope?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
-export function LaneComparePage({ getLaneCompare, ...rest }: LaneComparePageProps) {
+export function LaneComparePage({ getLaneCompare, groupByScope, ...rest }: LaneComparePageProps) {
   const { lanesModel } = useLanes();
+  const [base, setBase] = useState<LaneModel | undefined>();
+  const defaultLane = lanesModel?.getDefaultLane();
+  const compare = lanesModel?.viewedLane;
+
+  useEffect(() => {
+    if (!base && defaultLane) {
+      setBase(defaultLane);
+    }
+  }, [defaultLane]);
+
+  const LaneCompareComponent = useMemo(() => {
+    return getLaneCompare({ base, compare });
+  }, [base?.id.toString(), compare?.id.toString()]);
+
+  const lanes: Array<LaneId> = useMemo(() => {
+    const mainLaneId = defaultLane?.id;
+    const nonMainLaneIds = lanesModel?.getNonMainLanes().map((lane) => lane.id) || [];
+    const allLanes = (mainLaneId && [mainLaneId, ...nonMainLaneIds]) || nonMainLaneIds;
+    return allLanes.filter((l) => l.toString() !== compare?.id.toString());
+  }, [defaultLane?.id?.toString(), lanesModel?.lanes.length]);
 
   if (!lanesModel) return null;
-
-  const base = lanesModel.lanes[0];
-  const compare = lanesModel.lanes[1];
-
-  const LaneCompareComponent = getLaneCompare({ base, compare });
+  if (!lanesModel.viewedLane) return null;
+  if (lanesModel.viewedLane?.id.isDefault()) return null;
+  if (!base) return null;
 
   return (
     <div {...rest} className={styles.laneComparePage}>
-      <div className={styles.top}>{`Comparing Lane ${compare?.id.toString()} with ${base?.id.toString()}`}</div>
-      {LaneCompareComponent}
+      <div className={styles.top}>
+        <div>Compare</div>
+        <div className={styles.compareLane}>
+          <LaneIcon />
+          {compare?.id.name}
+        </div>
+        <div>with</div>
+        <div className={styles.baseSelectorContainer}>
+          <LaneSelector
+            selectedLaneId={base.id}
+            className={styles.baseSelector}
+            lanes={lanes}
+            groupByScope={groupByScope}
+            getHref={() => ''}
+            onLaneSelected={(laneId) => {
+              setBase(lanesModel?.lanes.find((l) => l.id.toString() === laneId.toString()));
+            }}
+          />
+        </div>
+      </div>
+      <div className={styles.bottom}> {LaneCompareComponent}</div>
     </div>
   );
 }

--- a/scopes/lanes/ui/compare/lane-compare/lane-compare.module.scss
+++ b/scopes/lanes/ui/compare/lane-compare/lane-compare.module.scss
@@ -1,5 +1,3 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
-
 .rootLaneCompare {
   position: relative;
   height: 100%;
@@ -42,7 +40,7 @@
     top: 0;
     left: 0;
     background-color: var(--background-color);
-    z-index: $modal-z-index;
+    z-index: 1;
     padding: 0;
   }
 

--- a/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
+++ b/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
@@ -118,7 +118,7 @@ export function LaneCompare({
     return value;
   }, []);
 
-  const [state, setState] = useState<LaneCompareState>(
+  const [laneCompareState, setLaneCompareState] = useState<LaneCompareState>(
     new Map(
       allComponents.map(([_base, _compare]) => {
         const key = computeStateKey(_base, _compare);
@@ -128,9 +128,12 @@ export function LaneCompare({
     )
   );
 
+  const [openDrawerList, setOpenDrawerList] = useState<string[]>([]);
+  const [fullScreenDrawerKey, setFullScreen] = useState<string | undefined>(undefined);
+
   useEffect(() => {
     if (allComponents.length > 0) {
-      setState(
+      setLaneCompareState(
         new Map(
           allComponents.map(([_base, _compare]) => {
             const key = computeStateKey(_base, _compare);
@@ -139,22 +142,21 @@ export function LaneCompare({
           })
         )
       );
+      setFullScreen(undefined);
+      setOpenDrawerList([]);
     }
   }, [loadingLaneDiff, allComponents.length, base.id.toString(), compare.id.toString()]);
-
-  const [openDrawerList, onToggleDrawer] = useState<string[]>([]);
-  const [fullScreenDrawerKey, setFullScreen] = useState<string | undefined>(undefined);
 
   const handleDrawerToggle = (id: string) => {
     const isDrawerOpen = openDrawerList.includes(id);
     if (isDrawerOpen) {
-      onToggleDrawer((list) => list.filter((drawer) => drawer !== id));
+      setOpenDrawerList((list) => list.filter((drawer) => drawer !== id));
       if (id === fullScreenDrawerKey) {
         setFullScreen(undefined);
       }
       return;
     }
-    onToggleDrawer((list) => list.concat(id));
+    setOpenDrawerList((list) => list.concat(id));
   };
 
   const onFullScreenClicked = useCallback(
@@ -162,7 +164,7 @@ export function LaneCompare({
       e.stopPropagation();
       setFullScreen((fullScreenState) => {
         if (fullScreenState === key) return undefined;
-        onToggleDrawer((drawers) => {
+        setOpenDrawerList((drawers) => {
           if (!drawers.includes(key)) return [...drawers, key];
           return drawers;
         });
@@ -177,7 +179,7 @@ export function LaneCompare({
     const _tabs = extractLazyLoadedData(tabs);
 
     const onClicked = (prop: ComponentCompareStateKey) => (id) =>
-      setState((value) => {
+      setLaneCompareState((value) => {
         let existingState = value.get(key);
         const propState = existingState?.[prop];
         if (propState) {
@@ -292,7 +294,7 @@ export function LaneCompare({
                     compareId,
                     changes,
                     className: classnames(styles.componentCompareContainer, isFullScreen && styles.fullScreen),
-                    state: state.get(compKey),
+                    state: laneCompareState.get(compKey),
                     hooks: hooks(baseId, compareId),
                     customUseComponent,
                     Loader: ComponentCompareLoader,

--- a/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
+++ b/scopes/lanes/ui/compare/lane-compare/lane-compare.tsx
@@ -93,7 +93,7 @@ export function LaneCompare({
           componentDiff.componentId.changeVersion(componentDiff.sourceHead),
         ])) ||
       [],
-    [loadingLaneDiff]
+    [loadingLaneDiff, base.id.toString(), compare.id.toString()]
   );
 
   const defaultState = useCallback(() => {
@@ -140,7 +140,7 @@ export function LaneCompare({
         )
       );
     }
-  }, [allComponents.length]);
+  }, [loadingLaneDiff, allComponents.length, base.id.toString(), compare.id.toString()]);
 
   const [openDrawerList, onToggleDrawer] = useState<string[]>([]);
 
@@ -191,7 +191,7 @@ export function LaneCompare({
       accum.set(next.componentId.toStringWithoutVersion(), next);
       return accum;
     }, new Map<string, LaneComponentDiff>());
-  }, [loadingLaneDiff]);
+  }, [base.id.toString(), compare.id.toString(), loadingLaneDiff]);
 
   const groupedComponents = useMemo(() => {
     if (laneComponentDiffByCompId.size === 0) return null;
@@ -211,12 +211,12 @@ export function LaneCompare({
       accum.set(changeType, existing.concat([[baseId, compareId]]));
       return accum;
     }, new Map<ChangeType, Array<[ComponentID | undefined, ComponentID | undefined]>>());
-  }, [base.id.toString(), compare.id.toString(), laneComponentDiffByCompId.size]);
+  }, [base.id.toString(), compare.id.toString(), laneComponentDiffByCompId.size, loadingLaneDiff, laneDiff]);
 
   const Loading = useMemo(() => {
     if (!loadingLaneDiff) return null;
     return <LaneCompareLoader />;
-  }, [loadingLaneDiff]);
+  }, [base.id.toString(), compare.id.toString(), loadingLaneDiff]);
 
   const ComponentCompares = useMemo(() => {
     if (!groupedComponents?.size) return [];
@@ -273,7 +273,7 @@ export function LaneCompare({
         </div>
       );
     });
-  }, [base.id.toString(), compare.id.toString(), openDrawerList.length, groupedComponents?.size]);
+  }, [base.id.toString(), compare.id.toString(), openDrawerList.length, groupedComponents?.size, laneDiff]);
 
   return (
     <div {...rest} className={classnames(styles.laneCompareContainer, className)}>

--- a/scopes/lanes/ui/inputs/lane-selector/lane-grouped-menu-item.tsx
+++ b/scopes/lanes/ui/inputs/lane-selector/lane-grouped-menu-item.tsx
@@ -9,14 +9,32 @@ export type LaneGroupedMenuItemProps = {
   selected?: LaneId;
   current: LaneId[];
   scope: string;
+  getHref?: (laneId: LaneId) => string;
+  onLaneSelected?: (laneId: LaneId) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
-export function LaneGroupedMenuItem({ selected, current, className, scope, ...rest }: LaneGroupedMenuItemProps) {
+export function LaneGroupedMenuItem({
+  selected,
+  current,
+  className,
+  scope,
+  getHref,
+  onLaneSelected,
+  ...rest
+}: LaneGroupedMenuItemProps) {
   if (current.length === 0) return null;
 
-  if (current[0].isDefault()) {
+  if (current.length === 1 && current[0].isDefault()) {
     const defaultLane = current[0] as LaneId;
-    return <LaneMenuItem key={defaultLane.toString()} selected={selected} current={defaultLane} />;
+    return (
+      <LaneMenuItem
+        key={defaultLane.toString()}
+        onLaneSelected={onLaneSelected}
+        getHref={getHref}
+        selected={selected}
+        current={defaultLane}
+      />
+    );
   }
 
   const onClickStopPropagation = (e) => e.stopPropagation();
@@ -27,7 +45,13 @@ export function LaneGroupedMenuItem({ selected, current, className, scope, ...re
         {scope}
       </div>
       {current.map((lane) => (
-        <LaneMenuItem key={lane.toString()} selected={selected} current={lane} />
+        <LaneMenuItem
+          key={lane.toString()}
+          onLaneSelected={onLaneSelected}
+          getHref={getHref}
+          selected={selected}
+          current={lane}
+        />
       ))}
     </div>
   );

--- a/scopes/lanes/ui/inputs/lane-selector/lane-menu-item.tsx
+++ b/scopes/lanes/ui/inputs/lane-selector/lane-menu-item.tsx
@@ -9,9 +9,18 @@ import styles from './lane-menu-item.module.scss';
 export type LaneMenuItemProps = {
   selected?: LaneId;
   current: LaneId;
+  getHref?: (laneId: LaneId) => string;
+  onLaneSelected?: (laneId: LaneId) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
-export function LaneMenuItem({ selected, current, className, ...rest }: LaneMenuItemProps) {
+export function LaneMenuItem({
+  selected,
+  current,
+  className,
+  onLaneSelected,
+  getHref = LanesModel.getLaneUrl,
+  ...rest
+}: LaneMenuItemProps) {
   const isCurrent = selected?.toString() === current.toString();
 
   const currentVersionRef = useRef<HTMLDivElement>(null);
@@ -21,11 +30,16 @@ export function LaneMenuItem({ selected, current, className, ...rest }: LaneMenu
     }
   }, [isCurrent]);
 
-  const href = LanesModel.getLaneUrl(current);
+  const href = getHref(current);
 
   return (
     <div {...rest} className={className} ref={currentVersionRef}>
-      <MenuLinkItem active={isCurrent} href={href} className={styles.menuItem}>
+      <MenuLinkItem
+        active={isCurrent}
+        href={href}
+        className={styles.menuItem}
+        onClick={onLaneSelected && (() => onLaneSelected(current))}
+      >
         <div className={styles.laneName}>{current.name}</div>
         {current.isDefault() && (
           <PillLabel className={styles.defaultLanePill}>

--- a/scopes/lanes/ui/inputs/lane-selector/lane-selector.module.scss
+++ b/scopes/lanes/ui/inputs/lane-selector/lane-selector.module.scss
@@ -5,8 +5,6 @@
   // (this is bizarre, the tree has no position absolute)
   z-index: $nav-z-index;
   border-radius: 8px;
-  // override dropdown default width: 100%
-  width: calc(100% - 40px) !important;
 
   &.disabled {
     > div {
@@ -28,7 +26,7 @@
 }
 
 .menu {
-  width: calc(100% - 24px);
+  width: 100%;
   border-radius: 8px;
   padding: 0;
   padding-top: 8px;

--- a/scopes/lanes/ui/inputs/lane-selector/lane-selector.tsx
+++ b/scopes/lanes/ui/inputs/lane-selector/lane-selector.tsx
@@ -15,17 +15,27 @@ export type LaneSelectorProps = {
   lanes: Array<LaneId>;
   selectedLaneId?: LaneId;
   groupByScope?: boolean;
+  getHref?: (laneId: LaneId) => string;
+  onLaneSelected?: (laneId: LaneId) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
 type LaneDropdownItems = Array<LaneId> | Array<[scope: string, lanes: LaneId[]]>;
 
-export function LaneSelector({ className, lanes, selectedLaneId, groupByScope = true, ...rest }: LaneSelectorProps) {
+export function LaneSelector({
+  className,
+  lanes,
+  selectedLaneId,
+  groupByScope = true,
+  getHref,
+  onLaneSelected,
+  ...rest
+}: LaneSelectorProps) {
   const [filteredLanes, setFilteredLanes] = useState<LaneId[]>(lanes);
   const [focus, setFocus] = useState<boolean>(false);
 
   useEffect(() => {
     setFilteredLanes(lanes);
-  }, [lanes]);
+  }, [lanes.length]);
 
   const multipleLanes = lanes.length > 1;
   const laneDropdownItems: LaneDropdownItems = groupByScope
@@ -51,7 +61,7 @@ export function LaneSelector({ className, lanes, selectedLaneId, groupByScope = 
       {...rest}
       open={!multipleLanes ? false : undefined}
       dropClass={styles.menu}
-      elevation='none'
+      elevation="none"
       onChange={multipleLanes ? onDropdownToggled : undefined}
       // @ts-ignore - mismatch between @types/react
       placeholder={
@@ -68,12 +78,25 @@ export function LaneSelector({ className, lanes, selectedLaneId, groupByScope = 
       {multipleLanes &&
         groupByScope &&
         (laneDropdownItems as Array<[scope: string, lanes: LaneId[]]>).map(([scope, lanesByScope]) => (
-          <LaneGroupedMenuItem key={scope} scope={scope} selected={selectedLaneId} current={lanesByScope} />
+          <LaneGroupedMenuItem
+            key={scope}
+            onLaneSelected={onLaneSelected}
+            getHref={getHref}
+            scope={scope}
+            selected={selectedLaneId}
+            current={lanesByScope}
+          />
         ))}
       {multipleLanes &&
         !groupByScope &&
         (laneDropdownItems as LaneId[]).map((lane) => (
-          <LaneMenuItem key={lane.toString()} selected={selectedLaneId} current={lane}></LaneMenuItem>
+          <LaneMenuItem
+            onLaneSelected={onLaneSelected}
+            key={lane.toString()}
+            getHref={getHref}
+            selected={selectedLaneId}
+            current={lane}
+          ></LaneMenuItem>
         ))}
     </Dropdown>
   );

--- a/scopes/lanes/ui/navigation/lane-switcher/lane-switcher.module.scss
+++ b/scopes/lanes/ui/navigation/lane-switcher/lane-switcher.module.scss
@@ -22,6 +22,7 @@
 
 .laneSelector {
   flex: 1;
-  width: 100%;
   padding-right: 8px;
+  // override dropdown default width: 100%
+  width: calc(100% - 40px) !important;
 }

--- a/src/logger/pino-logger.ts
+++ b/src/logger/pino-logger.ts
@@ -1,5 +1,5 @@
 import prettifier from 'pino-pretty';
-import type { PrettyOptions } from 'pino-pretty';
+import type {PrettyOptions} from 'pino-pretty';
 import pino, { Logger as PinoLogger, LoggerOptions } from 'pino';
 import { DEBUG_LOG } from '../constants';
 
@@ -91,11 +91,11 @@ export function getPinoLoggerWithWorkers(
 
   const pinoConsoleOpts = {
     ...loggerOptions,
-    transport: transportConsole,
+    transport: transportConsole
     // transport: jsonFormat
-    // ? { targets: [{...transportFile, level: logLevel}, {...transportConsole, level: logLevel}] }
-    // ? { targets: [transportFile, transportConsole] }
-    // : transportConsole,
+      // ? { targets: [{...transportFile, level: logLevel}, {...transportConsole, level: logLevel}] }
+      // ? { targets: [transportFile, transportConsole] }
+      // : transportConsole,
   };
 
   const pinoLogger = pino(pinoFileOpts);
@@ -103,6 +103,8 @@ export function getPinoLoggerWithWorkers(
 
   return { pinoLogger, pinoLoggerConsole };
 }
+
+
 
 export function getPinoLoggerWithoutWorkers(
   jsonFormat: string,
@@ -134,6 +136,7 @@ export function getPinoLoggerWithoutWorkers(
   });
 
   const consoleStream = jsonFormat ? destConsole : prettyConsoleStream;
+
 
   const pinoLogger = pino(loggerOptions, fileStream);
 


### PR DESCRIPTION
## Proposed Changes

- Add `Compare` tab to the Lane Page
  - Allows comparing a lane with another lane
  - default to main for non main lanes, and the first non main lane for main
  - hidden if the scope has only (1) lane
- Fix `diffStatus` API on `lanes.main.runtime`. 
  - Allow diffing when source lane is `main`
  - When comparing two lanes, diff the `sourceHead` with the last `commonSnap` instead of head on `target`
- Add `snapDistance` to `LaneComponentDiffStatus` result
  - query common snaps, sourceOnly or targetOnly snaps between components in `source` and `target` lane
  

https://user-images.githubusercontent.com/8999604/217300164-1019dd2f-b4ac-4085-b3bc-f6318ac7805d.mov


  