### PR TITLE
fix(remove): delete a component from the local lane even without --from-lane

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -137,4 +137,23 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('remove a new component on a lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.removeComponent('comp1');
+    });
+    it('should remove from the lane object as well', () => {
+      const lane = helper.command.showOneLaneParsed('dev');
+      expect(lane.components).to.have.lengthOf(1);
+      expect(lane.components[0].id.name).to.not.have.string('comp1');
+    });
+    // previously, it was throwing: "Error: unable to merge lane dev, the component 87ql0ef4-remote/comp1 was not found"
+    // because the component was not removed from the lane-object.
+    it('bit export should not throw', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
 });

--- a/scopes/component/remove/remove-components.ts
+++ b/scopes/component/remove/remove-components.ts
@@ -99,7 +99,7 @@ async function removeLocal(
 ): Promise<RemovedLocalObjects> {
   // local remove in case user wants to delete tagged components
   const modifiedComponents = new BitIds();
-  const nonModifiedComponents = new BitIds(); // $FlowFixMe
+  const nonModifiedComponents = new BitIds();
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   if (R.isEmpty(bitIds)) return new RemovedLocalObjects();
   if (!force) {
@@ -149,7 +149,7 @@ async function removeLocal(
       await consumer.cleanFromBitMap(idsToCleanFromWorkspace);
     }
   }
-  if (removedFromLane.length) {
+  if (removedFromLane.length && fromLane) {
     await consumer.cleanOrRevertFromBitMapWhenOnLane(removedFromLane);
   }
   return new RemovedLocalObjects(

--- a/src/scope/component-ops/remove-model-components.ts
+++ b/src/scope/component-ops/remove-model-components.ts
@@ -54,12 +54,12 @@ export default class RemoveModelComponents {
 
     const removedFromLane: BitId[] = [];
     const removalDataWithNulls = await mapSeries(foundComponents, (bitId) => {
-      if (this.currentLane && this.fromLane) {
+      if (this.currentLane) {
         const result = this.currentLane.removeComponent(bitId);
         if (result) {
           // component was found on the lane.
           removedFromLane.push(bitId);
-          return null;
+          if (this.fromLane) return null;
         }
         // component was not found on lane. it's ok, it might be on main. continue with the component removal.
       }


### PR DESCRIPTION
otherwise, when a component is staged (not exported yet) and the lane is exported, the remote throws a ComponentNotFound error.