### PR TITLE
feat: introduce a new command "bit scope rename-owner"

### DIFF
--- a/e2e/harmony/scope-cmd.e2e.ts
+++ b/e2e/harmony/scope-cmd.e2e.ts
@@ -54,4 +54,22 @@ describe('bit scope command', function () {
       expect(workspaceJsonc).not.to.have.property(`my-scope/comp2`);
     });
   });
+  describe('bit scope rename-owner', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.bitJsonc.addDefaultScope('old-org.my-scope');
+      helper.fixtures.populateComponents(2);
+      helper.command.setScope('old-org.my-scope1', 'comp1');
+      helper.command.setScope('old-org.my-scope2', 'comp2');
+      helper.command.renameScopeOwner('old-org', 'new-org');
+    });
+    it('should rename the default-scope in workspace.jsonc', () => {
+      expect(helper.bitJsonc.getDefaultScope()).to.equal('new-org.my-scope');
+    });
+    it('should rename the scope of the components', () => {
+      const list = helper.command.listParsed();
+      const ids = list.map((c) => c.id);
+      expect(ids).to.have.members(['new-org.my-scope1/comp1', 'new-org.my-scope2/comp2']);
+    });
+  });
 });

--- a/scopes/component/renaming/exceptions/old-scope-exported.ts
+++ b/scopes/component/renaming/exceptions/old-scope-exported.ts
@@ -1,0 +1,10 @@
+import { BitError } from '@teambit/bit-error';
+
+export class OldScopeExported extends BitError {
+  constructor(idsStr: string[]) {
+    super(`unable to rename the scope for the following exported components:\n${idsStr.join(', ')}
+because these components were exported already, other components may use them and they'll break upon rename.
+instead, deprecate the above components (using "bit deprecate"), tag, export and then eject them.
+once they are not in the workspace, you can fork them ("bit fork") with the new scope-name`);
+  }
+}

--- a/scopes/component/renaming/exceptions/old-scope-not-found.ts
+++ b/scopes/component/renaming/exceptions/old-scope-not-found.ts
@@ -1,0 +1,7 @@
+import { BitError } from '@teambit/bit-error';
+
+export class OldScopeNotFound extends BitError {
+  constructor(oldScope: string) {
+    super(`none of the components is using "${oldScope}". also, the workspace is not configured with "${oldScope}"`);
+  }
+}

--- a/scopes/component/renaming/exceptions/old-scope-tagged.ts
+++ b/scopes/component/renaming/exceptions/old-scope-tagged.ts
@@ -1,0 +1,9 @@
+import { BitError } from '@teambit/bit-error';
+
+export class OldScopeTagged extends BitError {
+  constructor(idsStr: string[]) {
+    super(`unable to rename the scope for the following tagged components:\n${idsStr.join(', ')}
+because these components were tagged, the objects have the dependencies data of the old-scope.
+to be able to rename the scope, please untag the components first (using "bit reset" command)`);
+  }
+}

--- a/scopes/component/renaming/scope-rename-owner.cmd.ts
+++ b/scopes/component/renaming/scope-rename-owner.cmd.ts
@@ -1,0 +1,36 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import chalk from 'chalk';
+import { RenamingMain } from './renaming.main.runtime';
+
+export class ScopeRenameOwnerCmd implements Command {
+  name = 'rename <current-owner-name> <new-owner-name>';
+  description = "Renames the owner part of the scope-name for all components with the specified 'current owner name'";
+  arguments = [
+    { name: 'current-owner-name', description: 'the owner name to be replaced by another owner name' },
+    { name: 'new-owner-name', description: 'a new owner name to replace the current owner name' },
+  ];
+  options = [
+    [
+      'r',
+      'refactor',
+      'update the import statements in all dependent components to the new package name (that contains the new owner name)',
+    ],
+  ] as CommandOptions;
+  group = 'development';
+
+  constructor(private renaming: RenamingMain) {}
+
+  async report([oldName, newName]: [string, string], { refactor }: { refactor?: boolean }) {
+    const { scopeRenamedComponentIds, refactoredIds } = await this.renaming.renameScope(oldName, newName, { refactor });
+    const title = chalk.green(`successfully replaced "${oldName}" scope with "${newName}"`);
+    const renamedIdsStr = scopeRenamedComponentIds.length
+      ? `\n${chalk.bold(
+          'the following components were affected by this scope-name change:'
+        )}\n${scopeRenamedComponentIds.map((c) => c.changeScope(newName)).join('\n')}`
+      : '';
+    const refactoredStr = refactoredIds.length
+      ? `\n\n${chalk.bold('the following components have been refactored:')}\n${refactoredIds.join('\n')}`
+      : '';
+    return `${title}\n${renamedIdsStr}${refactoredStr}`;
+  }
+}

--- a/scopes/component/renaming/scope-rename-owner.cmd.ts
+++ b/scopes/component/renaming/scope-rename-owner.cmd.ts
@@ -21,8 +21,8 @@ export class ScopeRenameOwnerCmd implements Command {
   constructor(private renaming: RenamingMain) {}
 
   async report([oldName, newName]: [string, string], { refactor }: { refactor?: boolean }) {
-    const { scopeRenamedComponentIds, refactoredIds } = await this.renaming.renameScope(oldName, newName, { refactor });
-    const title = chalk.green(`successfully replaced "${oldName}" scope with "${newName}"`);
+    const { scopeRenamedComponentIds, refactoredIds } = await this.renaming.renameOwner(oldName, newName, { refactor });
+    const title = chalk.green(`successfully replaced "${oldName}" owner with "${newName}"`);
     const renamedIdsStr = scopeRenamedComponentIds.length
       ? `\n${chalk.bold(
           'the following components were affected by this scope-name change:'

--- a/scopes/component/renaming/scope-rename-owner.cmd.ts
+++ b/scopes/component/renaming/scope-rename-owner.cmd.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import { RenamingMain } from './renaming.main.runtime';
 
 export class ScopeRenameOwnerCmd implements Command {
-  name = 'rename <current-owner-name> <new-owner-name>';
+  name = 'rename-owner <current-owner-name> <new-owner-name>';
   description = "Renames the owner part of the scope-name for all components with the specified 'current owner name'";
   arguments = [
     { name: 'current-owner-name', description: 'the owner name to be replaced by another owner name' },

--- a/src/e2e-helper/e2e-bit-jsonc-helper.ts
+++ b/src/e2e-helper/e2e-bit-jsonc-helper.ts
@@ -101,6 +101,11 @@ export default class BitJsoncHelper {
   addDefaultScope(scope = this.scopes.remote) {
     this.addKeyValToWorkspace('defaultScope', scope);
   }
+  getDefaultScope() {
+    const bitJsonc = this.read();
+    const workspace = bitJsonc['teambit.workspace/workspace'];
+    return workspace.defaultScope;
+  }
 
   setComponentsDir(compDir: string) {
     this.addKeyValToWorkspace('defaultDirectory', compDir);

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -172,6 +172,9 @@ export default class CommandHelper {
   renameScope(oldScope: string, newScope: string, flags = '') {
     return this.runCmd(`bit scope rename ${oldScope} ${newScope} ${flags}`);
   }
+  renameScopeOwner(oldScope: string, newScope: string, flags = '') {
+    return this.runCmd(`bit scope rename-owner ${oldScope} ${newScope} ${flags}`);
+  }
   setEnv(compId: string, envId: string) {
     return this.runCmd(`bit envs set ${compId} ${envId}`);
   }


### PR DESCRIPTION
To only rename the owner part of the scope. (helpful when multiple different scopes need to be aligned with a new owner-name)