### PR TITLE
feat(pkg): allow custom-package-name without publishing to NPM

### DIFF
--- a/e2e/harmony/publish.e2e.4.ts
+++ b/e2e/harmony/publish.e2e.4.ts
@@ -151,4 +151,22 @@ describe('publish functionality', function () {
       });
     });
   });
+  describe('prevent publishing to npm when custom-package-name is needed', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      const pkg = {
+        packageJson: {
+          name: 'no', // custom-name so it will try to publish to npm
+        },
+        avoidPublishToNPM: true,
+      };
+      helper.bitJsonc.addToVariant('*', 'teambit.pkg/pkg', pkg);
+    });
+    it('should not publish to npm', () => {
+      // if it was publishing, it would failed with an error:
+      // "failed running npm publish at /Users/davidfirst/Library/Caches/Bit/capsules/d7865720a5a6eb77903fb2536ba6e34efcaa0344/ci.w4hrkz2p-remote_comp1@0.0.1"
+      expect(() => helper.command.tagAllComponents()).to.not.throw();
+    });
+  });
 });

--- a/scopes/pkg/aspect-docs/pkg/pkg.mdx
+++ b/scopes/pkg/aspect-docs/pkg/pkg.mdx
@@ -74,6 +74,8 @@ For example:
 }
 ```
 
+- By default, when specifying `name` or `publishConfig`, it'll publish to NPM. In some rare cases, this is not desired, to cancel it, add the config `"avoidPublishToNPM": true`
+
 #### Private registry
 
 Use the `scope` and `registry` properties to configure the publishing process to your own private registry (and scope).

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -43,7 +43,11 @@ export interface PackageJsonProps {
 
 export type PackageJsonPropsRegistry = SlotRegistry<PackageJsonProps>;
 
-export type PkgExtensionConfig = {};
+export type PkgExtensionConfig = {
+  packageManagerPublishArgs?: string[];
+  packageJson?: Record<string, any>;
+  avoidPublishToNPM?: boolean; // by default, if packageJson.name or packageJson.publishConfig are set, it publish to npm.
+};
 
 type GetModulePathOptions = { absPath?: boolean };
 

--- a/scopes/pkg/pkg/publisher.ts
+++ b/scopes/pkg/pkg/publisher.ts
@@ -10,6 +10,7 @@ import { Scope } from '@teambit/legacy/dist/scope';
 import mapSeries from 'p-map-series';
 import execa from 'execa';
 import { PkgAspect } from './pkg.aspect';
+import { PkgExtensionConfig } from './pkg.main.runtime';
 
 export type PublisherOptions = {
   dryRun?: boolean;
@@ -113,7 +114,9 @@ export class Publisher {
   public shouldPublish(extensions: ExtensionDataList): boolean {
     const pkgExt = extensions.findExtension(PkgAspect.id);
     if (!pkgExt) return false;
-    return pkgExt.config?.packageJson?.name || pkgExt.config?.packageJson?.publishConfig;
+    const config = pkgExt.config as PkgExtensionConfig;
+    if (config?.avoidPublishToNPM) return false;
+    return config?.packageJson?.name || config?.packageJson?.publishConfig;
   }
 
   private getExtraArgsFromConfig(component: Component): string | undefined {


### PR DESCRIPTION
Currently, if the `packageJson.name` prop is set in the pkg aspect, the tag pipeline publishes the component to npm. There are cases, when the custom-name is needed without publishing, e.g. when a component is a VSCode extension. For these scenarios, a new config-prop is introduced `avoidPublishToNPM` to stop publishing. 