### PR TITLE
fix(sign): run snap-pipeline when signing snaps

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -175,6 +175,8 @@ describe('sign command', function () {
         signRemote.scopePath
       );
       expect(signOutput).to.include('the following 1 component(s) were signed with build-status "succeed"');
+      expect(signOutput).to.not.include('running tag pipe');
+      expect(signOutput).to.include('running snap pipe');
     });
     it('should be able to sign previous snaps on this lane successfully', () => {
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, signRemote.scopePath);

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -4,6 +4,7 @@ import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { LoggerAspect, LoggerMain, Logger } from '@teambit/logger';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
+import { isSnap } from '@teambit/component-version';
 import { Component, ComponentID } from '@teambit/component';
 import { SnappingAspect, SnappingMain } from '@teambit/snapping';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
@@ -84,9 +85,11 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     this.logger.setStatusLine(`loading ${componentsToSign.length} components and their aspects...`);
     const components = await this.scope.loadMany(componentsToSign, lane);
     this.logger.clearStatusLine();
+    // it's enough to check the first component whether it's a snap or tag, because it can't be a mix of both
+    const shouldRunSnapPipeline = isSnap(components[0].id.version);
     const { builderDataMap, pipeResults } = await this.builder.tagListener(
       components,
-      { throwOnError: false },
+      { throwOnError: false, isSnap: shouldRunSnapPipeline },
       { seedersOnly: true, installOptions: { copyPeerToRuntimeOnComponents: true, installPeersFromEnvs: true } }
     );
     const legacyBuildResults = this.scope.builderDataMapToLegacyOnTagResults(builderDataMap);


### PR DESCRIPTION
currently, it's always running the tag-pipeline, which it should not.