### PR TITLE
fix(snap-from-scope): export only the current snap, ignore the history

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -390,6 +390,10 @@ export class SnappingMain {
         idsWithFutureScope: legacyIds,
         allVersions: false,
         laneObject: updatedLane || undefined,
+        // no need other snaps. only the latest one. without this option, when snapping on lane from another-scope, it
+        // may throw an error saying the previous snaps don't exist on the filesystem.
+        // (see the e2e - "snap on a lane when the component is new to the lane and the scope")
+        exportHeadsOnly: true,
       });
       exportedIds = exported.map((e) => e.toString());
     }

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -266,7 +266,7 @@ export class ExportMain {
 
     const getVersionsToExport = async (modelComponent: ModelComponent): Promise<Ref[]> => {
       if (exportHeadsOnly) {
-        const head = modelComponent.head;
+        const head = laneObject?.getComponent(modelComponent.toBitId())?.head || modelComponent.head;
         if (!head)
           throw new Error(
             `getVersionsToExport should export the head only, but the head of ${modelComponent.id()} is missing`


### PR DESCRIPTION
No need for the history. The usage of this command is for creating a new lane from main (not forking) and snapping on that new lane. The history, if needed, can be obtained by FetchMissingHistory action.