### PR TITLE
fix, change deps-resolver config policy to be saved as an object. always

### DIFF
--- a/e2e/harmony/install-angular.e2e.ts
+++ b/e2e/harmony/install-angular.e2e.ts
@@ -17,5 +17,8 @@ describe('installing in an angular workspace', function () {
       helper.command.install(undefined, undefined, workspaceDir);
     });
   });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
   // TODO: test the same with pnpm
 });

--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -54,6 +54,7 @@ describe('install command', function () {
       helper.command.install('pkg-with-good-optional --no-optional');
     });
     after(() => {
+      helper.command.delConfig('registry');
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });

--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -55,6 +55,7 @@ describe('install command', function () {
     });
     after(() => {
       npmCiRegistry.destroy();
+      helper.scopeHelper.destroy();
     });
     it('should not install optional dependencies', async () => {
       const dirs = fs.readdirSync(path.join(helper.fixtures.scopes.localPath, 'node_modules/.pnpm'));

--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -255,6 +255,74 @@ describe('merge config scenarios', function () {
         const ramdaDep = showConfig.data.dependencies.find((d) => d.id === 'ramda');
         expect(ramdaDep.version).to.equal('0.0.21');
       });
+      it('running bit deps set of another pkg, should work', () => {
+        helper.command.dependenciesSet('comp1', 'lodash@1.0.0', '--dev');
+        const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+        const lodashDep = showConfig.data.dependencies.find((d) => d.id === 'lodash');
+        expect(lodashDep.version).to.equal('1.0.0');
+      });
+    });
+  });
+  describe('diverge with different auto-detected dependencies config', () => {
+    let mainBeforeDiverge: string;
+    let beforeConfigResolved: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/index.js', `import R from 'ramda';`);
+      helper.npm.addFakeNpmPackage('ramda', '0.0.19');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      mainBeforeDiverge = helper.scopeHelper.cloneLocalScope();
+
+      helper.command.createLane();
+      helper.npm.addFakeNpmPackage('ramda', '0.0.20');
+      helper.bitJsonc.addPolicyToDependencyResolver({ dependencies: { ramda: '0.0.20' } });
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.getClonedLocalScope(mainBeforeDiverge);
+      helper.npm.addFakeNpmPackage('ramda', '0.0.21');
+      helper.bitJsonc.addPolicyToDependencyResolver({ dependencies: { ramda: '0.0.21' } });
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importLane('dev', '--skip-dependency-installation');
+      helper.command.mergeLane('main', '--no-snap --skip-dependency-installation --ignore-config-changes');
+      beforeConfigResolved = helper.scopeHelper.cloneLocalScope();
+    });
+    it('bit status should show the component with an issue of MergeConfigHasConflict', () => {
+      helper.command.expectStatusToHaveIssue(IssuesClasses.MergeConfigHasConflict.name);
+    });
+    describe('fixing the conflict with ours', () => {
+      before(() => {
+        helper.general.fixMergeConfigConflict('ours');
+      });
+      it('should show the dev-dependency as it was set on the lane', () => {
+        const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+        const ramdaDep = showConfig.data.dependencies.find((d) => d.id === 'ramda');
+        expect(ramdaDep.version).to.equal('0.0.20');
+        expect(ramdaDep.lifecycle).to.equal('dev');
+      });
+    });
+    describe('fixing the conflict with theirs', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(beforeConfigResolved);
+        helper.general.fixMergeConfigConflict('theirs');
+      });
+      it('should show the dev-dependency as it was set on main', () => {
+        const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+        const ramdaDep = showConfig.data.dependencies.find((d) => d.id === 'ramda');
+        expect(ramdaDep.version).to.equal('0.0.21');
+      });
+      it('running bit deps set of another pkg, should work', () => {
+        helper.command.dependenciesSet('comp1', 'lodash@1.0.0', '--dev');
+        const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
+        const lodashDep = showConfig.data.dependencies.find((d) => d.id === 'lodash');
+        expect(lodashDep.version).to.equal('1.0.0');
+      });
     });
   });
   describe('diverge with envs changes', () => {

--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -304,7 +304,7 @@ describe('merge config scenarios', function () {
         const showConfig = helper.command.showAspectConfig('comp1', Extensions.dependencyResolver);
         const ramdaDep = showConfig.data.dependencies.find((d) => d.id === 'ramda');
         expect(ramdaDep.version).to.equal('0.0.20');
-        expect(ramdaDep.lifecycle).to.equal('dev');
+        expect(ramdaDep.lifecycle).to.equal('runtime');
       });
     });
     describe('fixing the conflict with theirs', () => {

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -1480,13 +1480,6 @@ export class DependencyResolverMain {
       const workspacePolicy = dependencyResolver.getWorkspacePolicy();
       return workspacePolicy.toManifest();
     });
-    DependencyResolver.registerOnComponentAutoDetectOverridesGetter(
-      async (configuredExtensions: ExtensionDataList, id: BitId, legacyFiles: SourceFile[]) => {
-        const policy = await dependencyResolver.mergeVariantPolicies(configuredExtensions, id, legacyFiles);
-        return policy.toLegacyAutoDetectOverrides();
-      }
-    );
-
     DependencyResolver.registerHarmonyEnvPeersPolicyForEnvItselfGetter(async (id: BitId, files: SourceFile[]) => {
       const envPolicy = await dependencyResolver.getEnvPolicyFromEnvLegacyId(id, files);
       if (!envPolicy) return undefined;

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -150,13 +150,16 @@ export class AspectsMerger {
     const setDataListAsSpecific = (extensions: ExtensionDataList) => {
       extensions.forEach((dataEntry) => (dataEntry.config[AspectSpecificField] = true));
     };
-    if (configMergeExtensions && !excludeOrigins.includes('ConfigMerge')) {
-      await addExtensionsToMerge(ExtensionDataList.fromArray(configMergeExtensions), 'ConfigMerge');
-    }
     if (bitMapExtensions && !excludeOrigins.includes('BitmapFile')) {
       const extensionDataList = ExtensionDataList.fromConfigObject(bitMapExtensions);
       setDataListAsSpecific(extensionDataList);
       await addExtensionsToMerge(extensionDataList, 'BitmapFile');
+    }
+    // config-merge is after the .bitmap. because normally if you have config set in .bitmap, you won't
+    // be able to lane-merge. (unless you specify --ignore-config-changes).
+    // so, if there is config in .bitmap, it probably happened after lane-merge.
+    if (configMergeExtensions && !excludeOrigins.includes('ConfigMerge')) {
+      await addExtensionsToMerge(ExtensionDataList.fromArray(configMergeExtensions), 'ConfigMerge');
     }
     if (configFileExtensions && !excludeOrigins.includes('ComponentJsonFile')) {
       setDataListAsSpecific(configFileExtensions);

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -3,7 +3,7 @@ import type { AspectLoaderMain } from '@teambit/aspect-loader';
 import { BundlerMain } from '@teambit/bundler';
 import { CLIMain, CommandList } from '@teambit/cli';
 import type { ComponentMain, Component } from '@teambit/component';
-import { DependencyResolverMain } from '@teambit/dependency-resolver';
+import { DependencyResolverMain, VariantPolicy } from '@teambit/dependency-resolver';
 import { EnvsMain } from '@teambit/envs';
 import { GraphqlMain } from '@teambit/graphql';
 import { Harmony, SlotRegistry } from '@teambit/harmony';
@@ -16,6 +16,9 @@ import { Consumer, loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import LegacyComponentLoader from '@teambit/legacy/dist/consumer/component/component-loader';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
+import { BitId } from '@teambit/legacy-bit-id';
+import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
+import { DependencyResolver as LegacyDependencyResolver } from '@teambit/legacy/dist/consumer/component/dependencies/dependency-resolver';
 import { EXT_NAME } from './constants';
 import EjectConfCmd from './eject-conf.cmd';
 import {
@@ -148,6 +151,18 @@ export default async function provideWorkspace(
     }
   );
 
+  LegacyDependencyResolver.registerOnComponentAutoDetectOverridesGetter(
+    async (configuredExtensions: ExtensionDataList, id: BitId, legacyFiles: SourceFile[]) => {
+      let policy = await dependencyResolver.mergeVariantPolicies(configuredExtensions, id, legacyFiles);
+      const depsDataOfMergeConfig = workspace.getDepsDataOfMergeConfig(id);
+      if (depsDataOfMergeConfig) {
+        const policiesFromMergeConfig = VariantPolicy.fromConfigObject(depsDataOfMergeConfig, 'auto');
+        policy = VariantPolicy.mergePolices([policy, policiesFromMergeConfig]);
+      }
+      return policy.toLegacyAutoDetectOverrides();
+    }
+  );
+
   ConsumerComponent.registerOnComponentConfigLoading(EXT_NAME, async (id) => {
     const componentId = await workspace.resolveComponentId(id);
     // We call here directly workspace.scope.get instead of workspace.get because part of the workspace get is loading consumer component
@@ -207,7 +222,7 @@ export default async function provideWorkspace(
     const componentIds = await workspace.resolveMultipleComponentIds(aspects);
     componentIds.forEach((id) => {
       workspace.clearComponentCache(id);
-    }); 
+    });
   });
 
   // add sub-commands "set" and "unset" to envs command.

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1045,6 +1045,10 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return this.aspectsMerger.mergeConflictFile;
   }
 
+  getDepsDataOfMergeConfig(id: BitId): Record<string, any> | undefined {
+    return this.aspectsMerger.getDepsDataOfMergeConfig(id);
+  }
+
   async listComponentsDuringMerge(): Promise<ComponentID[]> {
     const unmergedComps = this.scope.legacyScope.objects.unmergedComponents.getComponents();
     const bitIds = unmergedComps.map((u) => new BitId(u.id));

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -163,6 +163,10 @@ export default class CommandHelper {
   delConfig(configName: string) {
     return this.runCmd(`bit config del ${configName}`);
   }
+  /**
+   * careful! this changes the config globally and will affect all e2e-tests.
+   * try to avoid. if not possible, make sure to call `delConfig` in the `after` hook
+   */
   setConfig(configName: string, configVal: string) {
     return this.runCmd(`bit config set ${configName} ${configVal}`);
   }


### PR DESCRIPTION
Currently, if data are retrieved from merge-config (when merging lanes), the config is saved as an array in order to support the `force` field.
In this PR, the `force: false` goes to the dependencies.data so then the config can be an object as it was before.
This fixes issues with `bit envs` commands that were running after the data was saved in the model as an array.