### PR TITLE
fix(export): do not try to export snaps existing on main

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -306,6 +306,8 @@ export default class Component extends BitObject {
           return LaneId.from(DEFAULT_LANE, this.scope as string);
         };
         const remoteToCheck = getRemoteToCheck();
+        // if no remote-ref was found, because it's checked out to a lane, it's safe to assume that
+        // this.head should be on the original-remote. hence, FetchMissingHistory will retrieve it on lane-remote
         this.laneHeadRemote = (await repo.remoteLanes.getRef(remoteToCheck, this.toBitId())) || this.head;
       }
       // we need also the remote head of main, otherwise, the diverge-data assumes all versions are local

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -306,7 +306,7 @@ export default class Component extends BitObject {
           return LaneId.from(DEFAULT_LANE, this.scope as string);
         };
         const remoteToCheck = getRemoteToCheck();
-        this.laneHeadRemote = await repo.remoteLanes.getRef(remoteToCheck, this.toBitId());
+        this.laneHeadRemote = (await repo.remoteLanes.getRef(remoteToCheck, this.toBitId())) || this.head;
       }
       // we need also the remote head of main, otherwise, the diverge-data assumes all versions are local
       this.remoteHead = await repo.remoteLanes.getRef(LaneId.from(DEFAULT_LANE, this.scope), this.toBitId());


### PR DESCRIPTION
In some scenarios, `bit export` throws an error:
```
error: version "a683008508bf68c6cd48d0c26253e32c11fd9589" of component X was not found on the filesystem.
```
This fixes it by not attempting to export snaps that are already exist in the original scope.
(regression caused by https://github.com/teambit/bit/pull/6992 ).