### PR TITLE
feat(deps-unset): introduce a new sub-command "bit deps unset"

### DIFF
--- a/e2e/harmony/dependencies-cmd.e2e.ts
+++ b/e2e/harmony/dependencies-cmd.e2e.ts
@@ -188,4 +188,38 @@ describe('bit dependencies command', function () {
       expect(showConfig.config.policy.dependencies).to.deep.equal({ lodash: '3.3.1' });
     });
   });
+  describe('bit deps unset', () => {
+    describe('one dep was specifically set and one dep was auto-detected', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.fixtures.populateComponents(1);
+        helper.fs.writeFile('comp1/index.js', `import lodash from 'lodash';`);
+        helper.npm.addFakeNpmPackage('lodash', '3.3.1');
+        helper.command.dependenciesSet('comp1', 'ramda@0.20.0');
+        helper.command.tagWithoutBuild();
+      });
+      describe('unset the auto-detected', () => {
+        before(() => {
+          helper.command.dependenciesUnset('comp1', 'lodash');
+        });
+        it('should not remove the dependency', () => {
+          const deps = helper.command.showComponentParsedHarmonyByTitle('comp1', 'dependencies');
+          const ids = deps.map((d) => d.id);
+          expect(ids).to.include('lodash');
+          expect(ids).to.include('ramda'); // just to make sure it didn't touch this as well.
+        });
+      });
+      describe('unset the previously deps-set', () => {
+        before(() => {
+          helper.command.dependenciesUnset('comp1', 'ramda');
+        });
+        it('should remove the dependency', () => {
+          const deps = helper.command.showComponentParsedHarmonyByTitle('comp1', 'dependencies');
+          const ids = deps.map((d) => d.id);
+          expect(ids).to.not.include('ramda');
+          expect(ids).to.include('lodash'); // just to make sure it didn't change this
+        });
+      });
+    });
+  });
 });

--- a/scopes/dependencies/dependencies/dependencies-cmd.ts
+++ b/scopes/dependencies/dependencies/dependencies-cmd.ts
@@ -158,6 +158,40 @@ export class DependenciesRemoveCmd implements Command {
   }
 }
 
+export class DependenciesUnsetCmd implements Command {
+  name = 'unset <component-pattern> <package...>';
+  arguments = [
+    { name: 'component-pattern', description: COMPONENT_PATTERN_HELP },
+    {
+      name: 'package...',
+      description:
+        'package name with or without a version, e.g. "lodash@1.0.0" or just "lodash" which will remove all lodash instances of any version',
+    },
+  ];
+  group = 'info';
+  description = 'unset a dependency to component(s) that was previously set by "bit deps set"';
+  alias = '';
+  options = [
+    ['d', 'dev', 'unset from devDependencies'],
+    ['p', 'peer', 'unset from peerDependencies'],
+  ] as CommandOptions;
+
+  constructor(private deps: DependenciesMain) {}
+
+  async report([pattern, packages]: [string, string[]], removeDepsFlags: RemoveDependenciesFlags) {
+    const results = await this.deps.removeDependency(pattern, packages, removeDepsFlags, true);
+    if (!results.length) {
+      return chalk.yellow('the specified component-pattern do not use the entered packages. nothing to unset');
+    }
+
+    const output = results
+      .map(({ id, removedPackages }) => `${chalk.underline(id.toString())}\n${removedPackages.join('\n')}`)
+      .join('\n\n');
+
+    return `${chalk.green('successfully unset dependencies')}\n${output}`;
+  }
+}
+
 export class DependenciesResetCmd implements Command {
   name = 'reset <component-pattern>';
   arguments = [{ name: 'component-pattern', description: COMPONENT_PATTERN_HELP }];

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -18,6 +18,7 @@ import {
   DependenciesRemoveCmd,
   DependenciesResetCmd,
   DependenciesSetCmd,
+  DependenciesUnsetCmd,
   RemoveDependenciesFlags,
   SetDependenciesFlags,
 } from './dependencies-cmd';
@@ -77,7 +78,8 @@ export class DependenciesMain {
   async removeDependency(
     componentPattern: string,
     packages: string[],
-    options: RemoveDependenciesFlags = {}
+    options: RemoveDependenciesFlags = {},
+    removeOnlyIfExists = false // unset
   ): Promise<RemoveDependencyResult[]> {
     const compIds = await this.workspace.idsByPattern(componentPattern);
     const results = await Promise.all(
@@ -111,6 +113,7 @@ export class DependenciesMain {
             if (existsInSpecificConfig === '-') return null;
             delete newDepResolverConfig.policy[depField][depName];
           } else {
+            if (removeOnlyIfExists) return null;
             set(newDepResolverConfig, ['policy', depField, depName], '-');
           }
           return `${depName}@${dependency.version}`;
@@ -217,6 +220,7 @@ export class DependenciesMain {
     depsCmd.commands = [
       new DependenciesGetCmd(),
       new DependenciesRemoveCmd(depsMain),
+      new DependenciesUnsetCmd(depsMain),
       new DependenciesDebugCmd(),
       new DependenciesSetCmd(depsMain),
       new DependenciesResetCmd(depsMain),

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -228,6 +228,9 @@ export default class CommandHelper {
   dependenciesSet(pattern: string, pkg: string, flags = '') {
     return this.runCmd(`bit dependencies set ${pattern} ${pkg} ${flags}`);
   }
+  dependenciesUnset(pattern: string, pkg: string, flags = '') {
+    return this.runCmd(`bit dependencies unset ${pattern} ${pkg} ${flags}`);
+  }
   dependenciesRemove(pattern: string, pkg: string, flags = '') {
     return this.runCmd(`bit dependencies remove ${pattern} ${pkg} ${flags}`);
   }


### PR DESCRIPTION
To unset only deps that were set by `bit deps set`. 
Dependencies that were auto-detected won't be affected.