### PR TITLE
fix(lane-merge): avoid loading multiple components in parallel

### DIFF
--- a/scopes/component/merging/config-merger.ts
+++ b/scopes/component/merging/config-merger.ts
@@ -105,7 +105,6 @@ export class ConfigMerger {
       if (this.handledExtIds.includes(id)) return null;
       this.handledExtIds.push(id);
       if (otherExt.extensionId && otherExt.extensionId.hasVersion()) {
-        // if (this.compIdStr === 'teambit.dot-cloud/community-cloud') console.log('current', this.currentAspects);
         // avoid using the id from the other lane if it exits in the workspace. prefer the id from the workspace.
         const idFromWorkspace = this.getIdFromWorkspace(otherExt.extensionId.toStringWithoutVersion());
         if (idFromWorkspace) {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -321,8 +321,8 @@ export class MergingMain {
     if (!currentLane && otherLane) {
       await this.importer.importObjectsFromMainIfExist(otherLane.toBitIds().toVersionLatest());
     }
-    const componentStatusBeforeMergeAttempt = await Promise.all(
-      bitIds.map((id) => this.getComponentStatusBeforeMergeAttempt(id, currentLane, options))
+    const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
+      this.getComponentStatusBeforeMergeAttempt(id, currentLane, options)
     );
     const toImport = componentStatusBeforeMergeAttempt
       .map((compStatus) => {


### PR DESCRIPTION
Otherwise, along the line, it runs some hooks that calls scope.get(), which runs loadAspects, which imports aspects if they are missing. This could easily import the same missing aspect multiple time in parallel and throw timeout errors and corrupt the objects.