### PR TITLE
fix(sign), avoid running clear-cache when --multiple is used

### DIFF
--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -103,8 +103,8 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
         await this.exportExtensionsDataIntoScopes(legacyComponents, buildStatus, lane);
       } else {
         await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+        await this.clearScopesCaches(legacyComponents);
       }
-      await this.clearScopesCaches(legacyComponents);
     }
     await this.triggerOnPostSign(components);
 


### PR DESCRIPTION
It's not needed for `--multiple`, only when the sign is done on the same scope of the components.