### PR TITLE
fix(merge): avoid changing .bitmap version when using --theirs strategy

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -644,7 +644,7 @@ other:   ${otherLaneHead.toString()}`);
     const remoteId = id.changeVersion(remoteHead.toString());
     const idToLoad = !mergeResults || mergeStrategy === MergeOptions.theirs ? remoteId : id;
     const legacyComponent = await consumer.loadComponentFromModelImportIfNeeded(idToLoad);
-    legacyComponent.version = id.version;
+    if (mergeResults && mergeStrategy === MergeOptions.theirs) legacyComponent.version = id.version;
     const files = legacyComponent.files;
     files.forEach((file) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -644,6 +644,7 @@ other:   ${otherLaneHead.toString()}`);
     const remoteId = id.changeVersion(remoteHead.toString());
     const idToLoad = !mergeResults || mergeStrategy === MergeOptions.theirs ? remoteId : id;
     const legacyComponent = await consumer.loadComponentFromModelImportIfNeeded(idToLoad);
+    legacyComponent.version = id.version;
     const files = legacyComponent.files;
     files.forEach((file) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -644,7 +644,10 @@ other:   ${otherLaneHead.toString()}`);
     const remoteId = id.changeVersion(remoteHead.toString());
     const idToLoad = !mergeResults || mergeStrategy === MergeOptions.theirs ? remoteId : id;
     const legacyComponent = await consumer.loadComponentFromModelImportIfNeeded(idToLoad);
-    if (mergeResults && mergeStrategy === MergeOptions.theirs) legacyComponent.version = id.version;
+    if (mergeResults && mergeStrategy === MergeOptions.theirs) {
+      // in this case, we don't want to update .bitmap with the version of the remote. we want to keep the same version
+      legacyComponent.version = id.version;
+    }
     const files = legacyComponent.files;
     files.forEach((file) => {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!


### PR DESCRIPTION
currently, when running `bit lane merge --theirs` it changes the version in the .bitmap file according to the other lane. This PR fixes it to keep the version and only change the files.