### PR TITLE
fix(install): import objects according to the current lane/main

### DIFF
--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -131,20 +131,6 @@ export default class ImportComponents {
       lane,
     });
 
-    // import lane components from their original scope, this way, it's possible to run diff/merge on them.
-    // don't use `scope.getDefaultLaneIdsFromLane()`. we need all components, because it's possible that a component
-    // does't have "head" locally although it exits in the origin-scope. it happens when the component was created on
-    // the origin-scope after a component with the same-name was created on the lane
-    // if (lane) {
-    //   // @todo: optimize this maybe. currently, it imports twice.
-    //   // try to make the previous `importComponentsObjectsHarmony` import the same component once from the original
-    //   // scope and once from the lane-scope.
-    //   const mainIdsLatest = BitIds.fromArray(lane.toBitIds().map((m) => m.changeVersion(undefined)));
-    //   await this._importComponentsObjects(mainIdsLatest, {
-    //     ignoreMissingHead: true,
-    //   });
-    // }
-
     // merge the lane objects
     const mergeAllLanesResults = await pMapSeries(this.laneObjects, (laneObject) =>
       this.scope.sources.mergeLane(laneObject, true)

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -65,6 +65,10 @@ export class ImporterMain {
     return results;
   }
 
+  /**
+   * fetch objects according to the criteria set by `options` param.
+   * to fetch current objects according to the current lane or main, use `this.importCurrentObjects()`.
+   */
   async importObjects(options: Partial<ImportOptions> = {}): Promise<ImportResult> {
     const importOptions: ImportOptions = {
       ...options,
@@ -72,6 +76,23 @@ export class ImporterMain {
       ids: options.ids || [],
       installNpmPackages: false,
     };
+    const importComponents = new ImportComponents(this.workspace, this.graph, this.componentWriter, importOptions);
+    return importComponents.importComponents();
+  }
+
+  /**
+   * if on main, fetch main objects, if on lane, fetch lane objects.
+   */
+  async importCurrentObjects(): Promise<ImportResult> {
+    if (!this.workspace) throw new OutsideWorkspaceError();
+    const importOptions: ImportOptions = {
+      ids: [],
+      installNpmPackages: false,
+    };
+    const currentRemoteLane = await this.workspace.getCurrentRemoteLane();
+    if (currentRemoteLane) {
+      importOptions.lanes = { laneIds: [currentRemoteLane.toLaneId()], lanes: [currentRemoteLane] };
+    }
     const importComponents = new ImportComponents(this.workspace, this.graph, this.componentWriter, importOptions);
     return importComponents.importComponents();
   }
@@ -162,11 +183,6 @@ export class ImporterMain {
     shouldFetchFromMain?: boolean,
     options: Partial<ImportOptions> = {}
   ): Promise<ImportResult> {
-    // workaround for an issue where we have the current-lane object at hand but not its components, the sources.get
-    // throws an error about missing the Version object in the filesystem. to reproduce, comment the following line and
-    // run the e2e-test "import objects for multiple lanes".
-    await this.importObjects();
-
     const resultFromMain = shouldFetchFromMain
       ? await this.importObjects(options)
       : { importedIds: [], importDetails: [], importedDeps: [] };
@@ -247,11 +263,11 @@ export class ImporterMain {
     install.registerPreInstall(async (opts) => {
       if (!opts?.import) return;
       logger.setStatusLine('importing missing objects');
-      await importerMain.importObjects();
+      await importerMain.importCurrentObjects();
       logger.consoleSuccess();
     });
     install.registerPreLink(async (opts) => {
-      if (opts?.fetchObject) await importerMain.importObjects();
+      if (opts?.fetchObject) await importerMain.importCurrentObjects();
     });
     cli.register(new ImportCmd(importerMain, community.getDocsDomain()), new FetchCmd(importerMain));
     return importerMain;

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -87,6 +87,7 @@ export class ImporterMain {
     if (!this.workspace) throw new OutsideWorkspaceError();
     const importOptions: ImportOptions = {
       ids: [],
+      objectsOnly: true,
       installNpmPackages: false,
     };
     const currentRemoteLane = await this.workspace.getCurrentRemoteLane();


### PR DESCRIPTION
Currently, the import during install only fetches from main. This PR fetches from a lane if checked out to a lane.