### PR TITLE
fix, change the ServerIsBusy error message to not suggest using export --persist

### DIFF
--- a/src/scope/exceptions/server-is-busy.ts
+++ b/src/scope/exceptions/server-is-busy.ts
@@ -4,11 +4,10 @@ export default class ServerIsBusy extends BitError {
   code: number;
   constructor(public queueSize: number, public currentExportId: string) {
     super(
-      `fatal: the server is busy exporting from other clients. total clients (including yours) in the queue: ${queueSize},
+      `fatal: the server is busy by other exports. total exports (including yours) in the queue: ${queueSize},
 the current export-id in queue is "${currentExportId}".
-if the last export was failed during the persist stage and left the remotes locked, you have the following options:
-1. if the failure occurred on your local, just re-run the export command with "--resume <id>".
-2. run "bit persist <id> <remotes...>", you will need to list all the remote scopes you want the persist to take place.
+in a few minutes, bit.cloud will try to complete the export for you.
+if the remote scopes are not updated, please contact support.
 `
     );
     this.code = 137;


### PR DESCRIPTION
Otherwise, the components won't be indexed by bit.cloud.