### PR TITLE
fix(aspects): return an empty object from a plugin auto generated provider

### DIFF
--- a/scopes/harmony/aspect-loader/plugins.ts
+++ b/scopes/harmony/aspect-loader/plugins.ts
@@ -41,6 +41,9 @@ export class Plugins {
             return this.registerPluginWithTryCatch(plugin, aspect);
           })
         );
+        // Return an empty object so haromny will have something in the extension instance
+        // otherwise it will throw an error when trying to access the extension instance (harmony.get)
+        return {};
       },
       runtime,
       // dependencies: this.computeDependencies(runtime)


### PR DESCRIPTION
## Proposed Changes

- This prevents harmony from throwing an error when trying to `harmony.get(pluginComponentId)`
- This will fix an issue with forking a component that uses the new env format (env plugin with *.bit-env.* file)

