### PR TITLE
fix(lane-list), avoid checking for soft-remove when using --remote

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -141,7 +141,8 @@ export class LanesMain {
     if (remote) {
       const remoteObj = await getRemoteByName(remote, consumer);
       const lanes = await remoteObj.listLanes(name, showMergeData);
-      return this.filterSoftRemovedLaneComps(lanes);
+      // no need to filter soft-removed here. it was filtered already in the remote
+      return lanes;
     }
 
     if (name === DEFAULT_LANE) {


### PR DESCRIPTION
No need to filter those as they were filtered already in the remote.
Also, if the model-component exists locally but not the version on the lane, it throws ComponentNotFound error.