### PR TITLE
fix(lane-merge), import missing artifacts before starting the merge process

### DIFF
--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -210,7 +210,7 @@ export default class ScopeComponentsImporter {
 
   /**
    * an efficient way to verify that all history exists locally.
-   * instead of all versions objects, load only the VersionHistory, get the graph from head, then only check whether
+   * instead of loading all versions objects, load only the VersionHistory, get the graph from head, then only check whether
    * the objects exist in the filesystem.
    */
   private async importMissingHistoryOne(id: BitId) {


### PR DESCRIPTION
otherwise, in some case, it needs the artifacts later on in the merge process where it doesn't have the lane object at hand and then throw an error about missing objects.