### PR TITLE
test, use an older version of the angular aspect for bit-new

### DIFF
--- a/e2e/harmony/install-angular.e2e.ts
+++ b/e2e/harmony/install-angular.e2e.ts
@@ -7,7 +7,7 @@ describe('installing in an angular workspace', function () {
   let workspaceDir: string;
   function prepare() {
     helper = new Helper();
-    helper.command.new('ng-workspace', '--aspect=teambit.angular/angular');
+    helper.command.new('ng-workspace', '--aspect=teambit.angular/angular@2.0.8');
     workspaceDir = path.join(helper.scopes.localPath, 'my-workspace');
     helper.command.create('ng-module', 'ui/my-button', undefined, workspaceDir);
   }


### PR DESCRIPTION
with the newly released one, the e2e-test fails with `template "ng-workspace" was not found` error.