### PR TITLE
fix(merge-from-scope), push artifacts to original scopes

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -725,6 +725,23 @@ describe('bit lane command', function () {
         helper.command.expectStatusToBeClean();
       });
     });
+    describe('merging from scope', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(localScope);
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        helper.command.export();
+        const bareMerge = helper.scopeHelper.getNewBareScope('-bare-merge');
+        helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareMerge.scopePath);
+        helper.scopeHelper.addRemoteScope(anotherRemotePath, bareMerge.scopePath);
+        helper.command.mergeLaneFromScope(bareMerge.scopePath, `${helper.scopes.remote}/dev`, '--push');
+      });
+      it('should push the artifacts to the original-scope', () => {
+        const artifacts = helper.command.getArtifacts(`${anotherRemote}/bar2@latest`, anotherRemotePath);
+        const pkgArtifacts = artifacts.find((a) => a.generatedBy === 'teambit.pkg/pkg');
+        const hash = pkgArtifacts.files[0].file;
+        expect(() => helper.command.catObject(hash, false, anotherRemotePath)).to.not.throw();
+      });
+    });
   });
   describe('multiple scopes when the components are new', () => {
     let anotherRemote: string;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -203,6 +203,7 @@ export class ExportMain {
     idsWithFutureScope,
     resumeExportId,
     ignoreMissingArtifacts,
+    ignoreMissingExternalArtifacts = true,
     isOnMain = true,
     exportHeadsOnly, // relevant when exporting from bare-scope, especially when re-exporting existing versions, the normal calculation based on getDivergeData won't work
     filterOutExistingVersions, // go to the remote and check whether the version exists there. if so, don't export it
@@ -215,6 +216,7 @@ export class ExportMain {
     idsWithFutureScope: BitIds;
     resumeExportId?: string | undefined;
     ignoreMissingArtifacts?: boolean;
+    ignoreMissingExternalArtifacts?: boolean;
     isOnMain?: boolean;
     exportHeadsOnly?: boolean;
     filterOutExistingVersions?: boolean;
@@ -351,7 +353,8 @@ export class ExportMain {
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,
           refs.map((ref) => ref.toString()),
-          ignoreMissingArtifacts
+          ignoreMissingArtifacts,
+          ignoreMissingExternalArtifacts
         );
         const objectsList = await new ObjectList(objectItems).toBitObjects();
         const componentAndObject = { component: modelComponent, objects: objectsList.getAll() };

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -362,8 +362,8 @@ export default class CommandHelper {
     const component = lane.components.find((c) => c.id.name === componentName);
     return component.head;
   }
-  getArtifacts(id: string) {
-    const comp = this.catComponent(`${id}@latest`);
+  getArtifacts(id: string, cwd?: string) {
+    const comp = this.catComponent(`${id}@latest`, cwd);
     const builderExt = comp.extensions.find((ext) => ext.name === 'teambit.pipelines/builder');
     if (!builderExt) throw new Error(`unable to find builder data for ${id}`);
     const artifacts = builderExt.data.artifacts;

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -720,7 +720,8 @@ export default class Component extends BitObject {
   async collectVersionsObjects(
     repo: Repository,
     versions: string[],
-    ignoreMissingArtifacts?: boolean
+    ignoreMissingLocalArtifacts = false,
+    ignoreMissingExternalArtifacts = true
   ): Promise<ObjectItem[]> {
     const refsWithoutArtifacts: Ref[] = [];
     const artifactsRefs: Ref[] = [];
@@ -739,7 +740,7 @@ export default class Component extends BitObject {
       const refs = versionObject.refsWithOptions(false, false);
       refsWithoutArtifacts.push(...refs);
       const refsFromExtensions = getRefsFromExtensions(versionObject.extensions);
-      locallyChangedHashes.includes(versionObject.hash.toString())
+      locallyChangedHashes.includes(versionObject.hash.toString()) || !ignoreMissingExternalArtifacts
         ? artifactsRefs.push(...refsFromExtensions)
         : artifactsRefsFromExportedVersions.push(...refsFromExtensions);
     });
@@ -755,7 +756,7 @@ for a component "${this.id()}", versions: ${versions.join(', ')}`);
       throw err;
     }
     try {
-      const loaded = ignoreMissingArtifacts
+      const loaded = ignoreMissingLocalArtifacts
         ? await repo.loadManyRawIgnoreMissing(artifactsRefs)
         : await repo.loadManyRaw(artifactsRefs);
       loadedRefs.push(...loaded);


### PR DESCRIPTION
Currently, when merging lanes from a bare-scope, it doesn't import the artifacts. As a result, when it pushes the components after the merge to main or to another lane, the artifacts are missing from that scope. 
It wasn't throwing an error during the export about missing artifacts because it assumed they're all external and exist in the scope.
This PR imports the missing artifacts and also throw an error during the export if they're missing.
