### PR TITLE
feat(Schema): allow querying explicitly tagged exports

### DIFF
--- a/scopes/semantics/entities/semantic-schema/api-schema.ts
+++ b/scopes/semantics/entities/semantic-schema/api-schema.ts
@@ -38,7 +38,8 @@ export class APISchema extends SchemaNode {
     this.taggedModuleExports = this.listTaggedExports(module);
   }
 
-  listTaggedExports(module: ModuleSchema) {
+  listTaggedExports(module?: ModuleSchema) {
+    if (!module) return [];
     return module.exports.filter((e) => e.doc?.hasTag(TagName.exports));
   }
 

--- a/scopes/semantics/entities/semantic-schema/api-schema.ts
+++ b/scopes/semantics/entities/semantic-schema/api-schema.ts
@@ -15,6 +15,7 @@ import {
 import { Location, SchemaNode } from './schema-node';
 import { schemaObjArrayToInstances, schemaObjToInstance } from './class-transformers';
 import { componentIdTransformer } from './class-transformers/comp-id-transformer';
+import { TagName } from './schemas/docs/tag';
 
 export class APISchema extends SchemaNode {
   @Transform(schemaObjToInstance)
@@ -26,11 +27,19 @@ export class APISchema extends SchemaNode {
   @Transform(componentIdTransformer)
   readonly componentId: ComponentID;
 
+  @Transform(schemaObjArrayToInstances)
+  readonly taggedModuleExports: SchemaNode[];
+
   constructor(readonly location: Location, module: ModuleSchema, internals: ModuleSchema[], componentId: ComponentID) {
     super();
     this.module = module;
     this.internals = internals;
     this.componentId = componentId;
+    this.taggedModuleExports = this.listTaggedExports(module);
+  }
+
+  listTaggedExports(module: ModuleSchema) {
+    return module.exports.filter((e) => e.doc?.hasTag(TagName.exports));
   }
 
   toString() {

--- a/scopes/semantics/entities/semantic-schema/schemas/docs/tag.ts
+++ b/scopes/semantics/entities/semantic-schema/schemas/docs/tag.ts
@@ -35,4 +35,5 @@ export enum TagName {
   implements = 'implements',
   return = 'return',
   deprecated = 'deprecated',
+  exports = 'exports',
 }

--- a/scopes/semantics/schema/mock/button-schemas.json
+++ b/scopes/semantics/schema/mock/button-schemas.json
@@ -2628,5 +2628,6 @@
   "componentId": {
     "name": "button",
     "scope": "org.scope"
-  }
+  },
+  "taggedModuleExports": []
 }


### PR DESCRIPTION
## Proposed Changes

This is in preparation to render a subset of the component schema in the preview. 

- `taggedModuleExports` contains list of all explicitly tagged exports using jsdocs `@exports` tag
