### PR TITLE
fix, handle soft-remove on a new lane and import soft-removed components

### DIFF
--- a/e2e/commands/remove.e2e.1.ts
+++ b/e2e/commands/remove.e2e.1.ts
@@ -221,7 +221,7 @@ describe('bit remove command', function () {
       helper.command.tagWithoutBuild();
       helper.command.export();
 
-      helper.command.removeComponent('comp2', '--soft');
+      helper.command.softRemoveComponent('comp2');
       afterRemove = helper.scopeHelper.cloneLocalScope();
     });
     it('bit status should show a section of removed components', () => {
@@ -390,6 +390,31 @@ describe('bit remove command', function () {
       const removeAspect = helper.command.showAspectConfig('comp1', 'teambit.component/remove');
       expect(removeAspect).to.be.an('Object');
       expect(removeAspect.config.removed).to.be.true;
+    });
+  });
+  describe('soft-remove when a lane is new', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('should throw an error suggesting to remove without --soft', () => {
+      expect(() => helper.command.softRemoveComponent('comp1')).to.throw();
+    });
+  });
+
+  describe('soft-remove then import', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(2);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.softRemoveComponent('comp2');
+    });
+    it('should not throwing an error upon import', () => {
+      expect(() => helper.command.importComponent('comp2')).to.not.throw();
     });
   });
 });

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -61,6 +61,12 @@ export class RemoveMain {
 
   async softRemove(componentsPattern: string): Promise<ComponentID[]> {
     if (!this.workspace) throw new ConsumerNotFound();
+    const currentLane = await this.workspace.getCurrentLaneObject();
+    if (currentLane?.isNew) {
+      throw new BitError(
+        `unable to soft-remove on a new (not-exported) lane "${currentLane.name}". please remove without --soft`
+      );
+    }
     const componentIds = await this.workspace.idsByPattern(componentsPattern);
     const components = await this.workspace.getMany(componentIds);
     const newComps = components.filter((c) => !c.id.hasVersion());

--- a/src/consumer/component-ops/component-status-loader.ts
+++ b/src/consumer/component-ops/component-status-loader.ts
@@ -1,6 +1,6 @@
 import mapSeries from 'p-map-series';
 import { Consumer } from '..';
-import { BitId } from '../../bit-id';
+import { BitId, BitIds } from '../../bit-id';
 import { LATEST } from '../../constants';
 import ShowDoctorError from '../../error/show-doctor-error';
 import { ModelComponent } from '../../scope/models';
@@ -64,7 +64,14 @@ export class ComponentStatusLoader {
       // loadOne to not find model component as it assumes there is no version
       // also, don't leave the id as is, otherwise, it'll cause issues with import --merge, when
       // imported version is bigger than .bitmap, it won't find it and will consider as deleted
-      componentFromFileSystem = await this.consumer.loadComponent(id.changeVersion(LATEST));
+      const { components, removedComponents } = await this.consumer.loadComponents(
+        new BitIds(id.changeVersion(LATEST))
+      );
+      if (removedComponents.length) {
+        status.deleted = true;
+        return status;
+      }
+      componentFromFileSystem = components[0];
     } catch (err: any) {
       if (
         err instanceof MissingFilesFromComponent ||

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -201,6 +201,9 @@ export default class CommandHelper {
   removeComponent(id: string, flags = '') {
     return this.runCmd(`bit remove ${id} --silent ${flags}`);
   }
+  softRemoveComponent(id: string, flags = '') {
+    return this.runCmd(`bit remove ${id} --silent --soft ${flags}`);
+  }
   deprecateComponent(id: string, flags = '') {
     return this.runCmd(`bit deprecate ${id} ${flags}`);
   }


### PR DESCRIPTION
## Proposed Changes

- when a lane is new (not exported yet), don't allow soft-remove. suggest to "bit remove" instead. we already do the same when components are new.
- fix obscure error `"Cannot read properties of undefined (reading 'id')` when importing locally soft-removed component.
