### PR TITLE
fix(status): avoid showing components as pending-update when their remote-lane is empty

### DIFF
--- a/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-import-on-lanes.e2e.ts
@@ -262,4 +262,26 @@ describe('bit lane command', function () {
       expect(helper.command.getHead('comp1')).to.equal(secondSnapMain, 'main was not updated');
     });
   });
+  describe('import previous version from main when on a lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane();
+      helper.command.importComponent('comp1@0.0.1');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // previous bug showed this component in the pending-updates section.
+    // it was because the calculation whether it's up-to-date was based also on the component-head.
+    // it should be based on the remote-lane object only.
+    it('bit status should not show the component as pending-updates because it does not exits on the remote lane', () => {
+      const status = helper.command.statusJson();
+      expect(status.outdatedComponents).to.have.lengthOf(0);
+    });
+  });
 });


### PR DESCRIPTION
currently, if the remote-lane doesn't exist, or it doesn't have this specific component, it falls back to the either the forked-lane or to the `component.head`. For bit-status or bit-checkout-head this is incorrect. The comparison needs to be against the remote-lane, and if it doesn't exist there, it should assume that the local is ahead.

(this regression caused by https://github.com/teambit/bit/pull/7036. but this time, instead of changing the divergeData, we treat bit-status/checkout differently)