### PR TITLE
fix(lane-change-scope), block when lane is exported, throw when scope-name is invalid

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import fs from 'fs-extra';
 import { LANE_REMOTE_DELIMITER } from '@teambit/lane-id';
+import { InvalidScopeName } from '@teambit/legacy-bit-id';
 import path from 'path';
 import { statusWorkspaceIsCleanMsg, AUTO_SNAPPED_MSG, IMPORT_PENDING_MSG } from '../../../src/constants';
 import { LANE_KEY } from '../../../src/consumer/bit-map/bit-map';
@@ -1427,6 +1428,34 @@ describe('bit lane command', function () {
     });
     it('bit export should not throw', () => {
       expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+  describe('change-scope', () => {
+    describe('when the lane is exported', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.command.createLane();
+        helper.fixtures.populateComponents(1, false);
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+      });
+      it('should block the rename', () => {
+        expect(() => helper.command.changeLaneScope('dev', 'new-scope')).to.throw(
+          'changing lane scope-name is allowed for new lanes only'
+        );
+      });
+    });
+    describe('when the scope-name is invalid', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.command.createLane();
+        helper.fixtures.populateComponents(1, false);
+      });
+      it('should throw InvalidScopeName error', () => {
+        const err = new InvalidScopeName('invalid.scope.name');
+        const cmd = () => helper.command.changeLaneScope('dev', 'invalid.scope.name');
+        helper.general.expectToThrow(cmd, err);
+      });
     });
   });
 });

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -19,7 +19,7 @@ import removeLanes from '@teambit/legacy/dist/consumer/lanes/remove-lanes';
 import { Lane, Version } from '@teambit/legacy/dist/scope/models';
 import { getDivergeData } from '@teambit/legacy/dist/scope/component-ops/get-diverge-data';
 import { Scope as LegacyScope } from '@teambit/legacy/dist/scope';
-import { BitId } from '@teambit/legacy-bit-id';
+import { BitId, InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
 import { ExportAspect, ExportMain } from '@teambit/export';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
 import { compact } from 'lodash';
@@ -324,6 +324,13 @@ export class LanesMain {
     const lane = await this.loadLane(laneId);
     if (!lane) {
       throw new BitError(`unable to find a local lane "${laneName}"`);
+    }
+    if (!lane.isNew) {
+      throw new BitError(`changing lane scope-name is allowed for new lanes only. this lane has been exported already.
+please create a new lane instead, which will include all components of this lane`);
+    }
+    if (!isValidScopeName(remoteScope)) {
+      throw new InvalidScopeName(remoteScope);
     }
     const remoteScopeBefore = lane.scope;
     lane.scope = remoteScope;


### PR DESCRIPTION
## Proposed Changes

- block `bit lane change-scope` when the lane is not new, because then, whole history of the current lane needs to be exported, otherwise, on the next export, the remote will throw about missing objects. It's much easier to just create a new lane with the new scope-name.
- in case the scope-name is invalid, throw an error about it. Currently, it lets you use an invalid scope-name and saves it in the lane-object incorrectly.
