### PR TITLE
fix, write objects atomically

### DIFF
--- a/package.json
+++ b/package.json
@@ -212,6 +212,7 @@
     "vinyl": "2.2.1",
     "vinyl-file": "3.0.0",
     "winston": "3.3.3",
+    "write-file-atomic": "5.0.0",
     "yargs": "17.0.1",
     "yn": "2.0.0"
   },

--- a/src/utils/fs-write-file.ts
+++ b/src/utils/fs-write-file.ts
@@ -1,4 +1,6 @@
 import fs from 'fs-extra';
+import pathLib from 'path';
+import writeFileAtomic from 'write-file-atomic';
 import { userInfo } from 'os';
 
 export type ChownOptions = {
@@ -11,9 +13,11 @@ export default async function writeFile(
   contents: string | Buffer,
   options: ChownOptions = {}
 ): Promise<void> {
-  await fs.outputFile(path, contents);
+  let chown;
   if (options.gid || options.uid) {
     const user = userInfo();
-    await fs.chown(path, options.uid || user.uid, options.gid || user.gid);
+    chown = { uid: options.uid || user.uid, gid: options.gid || user.gid };
   }
+  await fs.mkdir(pathLib.dirname(path));
+  await writeFileAtomic(path, contents, { chown });
 }

--- a/src/utils/fs-write-file.ts
+++ b/src/utils/fs-write-file.ts
@@ -18,6 +18,6 @@ export default async function writeFile(
     const user = userInfo();
     chown = { uid: options.uid || user.uid, gid: options.gid || user.gid };
   }
-  await fs.mkdir(pathLib.dirname(path));
+  await fs.ensureDir(pathLib.dirname(path));
   await writeFileAtomic(path, contents, { chown });
 }


### PR DESCRIPTION
This will help with the error users get about corrupted objects in case the process interrupted during the import. 
With this PR the objects are written to a tmp file first, and once done successfully, they’re renamed.

