### PR TITLE
fix(import): fetch versions that are shown in .bitmap but not in the lane object

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1458,7 +1458,7 @@ describe('bit lane command', function () {
       });
     });
   });
-  describe.only('checking out to a different version from main', () => {
+  describe('checking out to a different version from main', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(1, false);

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1458,4 +1458,35 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe.only('checking out to a different version from main', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild(); // 0.0.1
+      helper.command.tagAllWithoutBuild('--unmodified'); // 0.0.2
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFooAsDir();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.importComponent('comp1@0.0.1', '--save-in-lane'); // now the lane has it as 0.0.1
+      helper.command.export();
+
+      helper.command.checkoutVersion('0.0.2', 'comp1', '-x');
+
+      // deleting the local scope
+      helper.command.init('--reset-scope');
+
+      helper.command.import();
+    });
+    it('bit import should bring the version in the bitmap', () => {
+      expect(() => helper.command.catComponent(`${helper.scopes.remote}/comp1@0.0.2`)).to.not.throw();
+    });
+    it('bit status should not throw ComponentsPendingImport', () => {
+      expect(() => helper.command.status()).to.not.throw();
+    });
+  });
 });

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -268,9 +268,10 @@ export default class ImportComponents {
     const bitIdsFromLane = BitIds.fromArray(this.laneObjects.flatMap((lane) => lane.toBitIds()));
 
     if (!this.options.ids.length) {
-      const mainIds = this.consumer.bitMap.getAuthoredAndImportedBitIdsOfDefaultLane();
-      const mainIdsToImport = mainIds.filter((id) => id.hasScope() && !bitIdsFromLane.hasWithoutVersion(id));
-      bitIdsFromLane.push(...mainIdsToImport);
+      const bitMapIds = this.consumer.bitMap.getAllBitIds();
+      const bitMapIdsToImport = bitMapIds.filter((id) => id.hasScope() && !bitIdsFromLane.has(id));
+      bitIdsFromLane.push(...bitMapIdsToImport);
+
       return bitIdsFromLane;
     }
 


### PR DESCRIPTION
currently, when checked out to a lane, `bit import` fetches main components from main and lane components according to the versions in the lane. 
In some scenarios, the .bitmap can be out-of-sync and a version in .bitmap is different than a version in the lane object. Or maybe `bit checkout` was running to a different version. In such cases, if the local scope is deleted, bit was throwing `ComponentsPendingImport` error. 
This PR fixes the import process to fetch these versions as well.