### PR TITLE
fix(templates) - load envs' templates correctly from ws.jsonc

### DIFF
--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -104,7 +104,7 @@ export interface ComponentFactory {
    * load aspects.
    * returns the loaded aspect ids including the loaded versions.
    */
-  loadAspects: (ids: string[], throwOnError?: boolean, neededFor?: string) => Promise<string[]>;
+  loadAspects: (ids: string[], throwOnError?: boolean, neededFor?: string, opts?: any) => Promise<string[]>;
 
   /**
    * Resolve dirs for aspects

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -90,6 +90,12 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     let idsToLoadFromWs = componentIds;
     let scopeAspectIds: string[] = [];
 
+    // TODO: hard coded use the old approach and loading from the scope capsules
+    // This is because right now loading from the ws node_modules causes issues in some cases
+    // like for the cloud app
+    // it should be removed once we fix the issues
+    mergedOpts.useScopeAspectsCapsule = true;
+
     if (mergedOpts.useScopeAspectsCapsule) {
       idsToLoadFromWs = workspaceIds;
       const currentLane = await this.consumer.getCurrentLaneObject();
@@ -233,7 +239,7 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     const scopeAspectsDefs: AspectDefinition[] = scopeIds.length
       ? await this.scope.resolveAspects(runtimeName, scopeIds, mergedOpts)
       : [];
-    
+
     this.logger.debug(
       `${loggerPrefix} ${
         componentsToResolveFromInstalled.length

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -92,6 +92,7 @@ import {
   AspectPackage,
   GetConfiguredUserAspectsPackagesOptions,
   WorkspaceAspectsLoader,
+  WorkspaceLoadAspectsOptions,
 } from './workspace-aspects-loader';
 import { MergeConflictFile } from './merge-conflict-file';
 
@@ -1189,9 +1190,14 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
    * load aspects from the workspace and if not exists in the workspace, load from the scope.
    * keep in mind that the graph may have circles.
    */
-  async loadAspects(ids: string[] = [], throwOnError = false, neededFor?: string): Promise<string[]> {
+  async loadAspects(
+    ids: string[] = [],
+    throwOnError = false,
+    neededFor?: string,
+    opts: WorkspaceLoadAspectsOptions = {}
+  ): Promise<string[]> {
     const workspaceAspectsLoader = this.getWorkspaceAspectsLoader();
-    return workspaceAspectsLoader.loadAspects(ids, throwOnError, neededFor);
+    return workspaceAspectsLoader.loadAspects(ids, throwOnError, neededFor, opts);
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes
This fixes an issue when an env without a version is set in the generator like this:
```
"teambit.generator/generator": {
  "envs": [
    "teambit.web-components/stencil"
  ]
}
```
It wasn't able to correctly load the env to get the templates

### internal changes
- allow pass options to load aspects
- temporarily set useScopeAspectsCapsule in load aspects to true

