### PR TITLE
add sqlite3 & sqlite as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,6 +196,8 @@
     "sass-lookup": "3.0.0",
     "semver": "7.3.4",
     "serialize-error": "5.0.0",
+    "sqlite": "^4.1.2",
+    "sqlite3": "^5.1.6",
     "ssh2": "1.4.0",
     "ssri": "10.0.1",
     "string-format": "0.5.0",


### PR DESCRIPTION
This is a preparation for replacing the index.json with a proper db. This PR only installs these packages to make sure there are no binding/building issues on the various OSs.  