### PR TITLE
Make sure to load envs first when loading a list of aspects

### DIFF
--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -2,7 +2,7 @@ import findRoot from 'find-root';
 import { resolveFrom } from '@teambit/toolbox.modules.module-resolver';
 import { Graph } from '@teambit/graph.cleargraph';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
-import { Harmony } from '@teambit/harmony';
+import { ExtensionManifest, Harmony, Aspect } from '@teambit/harmony';
 import {
   AspectDefinition,
   AspectLoaderMain,
@@ -131,18 +131,19 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
       throwOnError,
       ...mergedOpts,
     });
-    const requireableComponents = this.aspectDefsToRequireableComponents(aspectsDefs);
-    const manifests = await this.aspectLoader.getManifestsFromRequireableExtensions(
-      requireableComponents,
+
+    const { manifests, requireableComponents } = await this.loadAspectDefsByOrder(
+      aspectsDefs,
+      idsWithoutCore,
       throwOnError
     );
+
     const potentialPluginsIndexes = compact(
       manifests.map((manifest, index) => {
         if (this.aspectLoader.isValidAspect(manifest)) return undefined;
         return index;
       })
     );
-    await this.aspectLoader.loadExtensionsByManifests(manifests, throwOnError, idsWithoutCore);
 
     // Try require components for potential plugins
     const pluginsRequireableComponents = potentialPluginsIndexes.map((index) => {
@@ -157,6 +158,30 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     this.logger.debug(`${loggerPrefix} finish loading aspects`);
     const manifestIds = manifests.map((manifest) => manifest.id);
     return compact(manifestIds.concat(scopeAspectIds));
+  }
+
+  private async loadAspectDefsByOrder(
+    aspectsDefs: AspectDefinition[],
+    seeders: string[],
+    throwOnError: boolean
+  ): Promise<{ manifests: Array<Aspect | ExtensionManifest>; requireableComponents: RequireableComponent[] }> {
+    const { nonWorkspaceDefs } = await this.groupAspectDefsByWorkspaceExistence(aspectsDefs);
+    const scopeAspectsLoader = this.scope.getScopeAspectsLoader();
+    const scopeIds: string[] = compact(nonWorkspaceDefs.map((aspectDef) => aspectDef.getId));
+    const scopeIdsGrouped = await scopeAspectsLoader.groupAspectIdsByEnvOfTheList(scopeIds);
+
+    // Make sure to first load envs from the list otherwise it will fail when trying to load other aspects
+    // as their envs might not be loaded yet
+    if (scopeIdsGrouped.envs && scopeIdsGrouped.envs.length) {
+      await this.scope.loadAspects(scopeIdsGrouped.envs, throwOnError, 'workspace.loadAspects loading scope aspects');
+    }
+    const requireableComponents = this.aspectDefsToRequireableComponents(aspectsDefs);
+    const manifests = await this.aspectLoader.getManifestsFromRequireableExtensions(
+      requireableComponents,
+      throwOnError
+    );
+    await this.aspectLoader.loadExtensionsByManifests(manifests, throwOnError, seeders);
+    return { manifests, requireableComponents };
   }
 
   async resolveAspects(
@@ -627,6 +652,26 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
       })
     );
     return { workspaceComps, nonWorkspaceComps };
+  }
+
+  /**
+   * split the provided components into 2 groups, one which are workspace components and the other which are not.
+   * @param components
+   * @returns
+   */
+  private async groupAspectDefsByWorkspaceExistence(
+    aspectDefs: AspectDefinition[]
+  ): Promise<{ workspaceDefs: AspectDefinition[]; nonWorkspaceDefs: AspectDefinition[] }> {
+    const workspaceDefs: AspectDefinition[] = [];
+    const nonWorkspaceDefs: AspectDefinition[] = [];
+    await Promise.all(
+      aspectDefs.map(async (aspectDef) => {
+        const id = aspectDef.component?.id;
+        const existOnWorkspace = id ? await this.workspace.hasId(id) : true;
+        existOnWorkspace ? workspaceDefs.push(aspectDef) : nonWorkspaceDefs.push(aspectDef);
+      })
+    );
+    return { workspaceDefs, nonWorkspaceDefs };
   }
 
   private async groupIdsByWorkspaceExistence(


### PR DESCRIPTION
## Proposed Changes

- when loading a list of aspects and the list contains envs of other aspects of the list, make sure to first load the envs into harmony before loading the rest of the aspects.

