### PR TITLE
fix, avoid compiling scope components

### DIFF
--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -365,7 +365,8 @@ export class WorkspaceCompiler {
     changed = false
   ): Promise<ComponentID[]> {
     if (componentsIds.length) {
-      return this.workspace.resolveMultipleComponentIds(componentsIds);
+      const componentIds = await this.workspace.resolveMultipleComponentIds(componentsIds);
+      return this.workspace.filterIds(componentIds);
     }
     if (changed) {
       return this.workspace.getNewAndModifiedIds();

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -359,6 +359,14 @@ export class Workspace implements ComponentFactory {
   }
 
   /**
+   * given component-ids, return the ones that are part of the workspace
+   */
+  async filterIds(ids: ComponentID[]): Promise<ComponentID[]> {
+    const workspaceIds = await this.listIds();
+    return ids.filter((id) => workspaceIds.find((wsId) => wsId.isEqual(id)));
+  }
+
+  /**
    * whether or not a workspace has a component with the given name
    */
   async hasName(name: string): Promise<boolean> {


### PR DESCRIPTION
This is a regression caused by https://github.com/teambit/bit/pull/7183. 
When a component is coming from the scope (happens when loadAspects from scope fails, which is register to `onAspectLoadErrorSlot`), don't try to compile it, otherwise, it throws ComponentNotFound.