### PR TITLE
fix(export): save newly introduced components on a lane from previous merge

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1060,4 +1060,26 @@ describe('merge lanes', function () {
       });
     });
   });
+  describe('merge introduces a new component to a lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.fixtures.populateComponents(2);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('lane-a', '-x');
+      helper.command.mergeLane('lane-b', '-x');
+      helper.command.export();
+    });
+    // previous bug was ignoring the new component on the remote during export because the snap was already on the remote.
+    // as a result, the lane-object on the remote didn't have this comp2 component.
+    it('should update the remote lane with the newly merged component', () => {
+      const lane = helper.command.catLane('lane-a', helper.scopes.remotePath);
+      expect(lane.components).to.have.lengthOf(2);
+    });
+  });
 });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -566,13 +566,13 @@ otherwise, to collaborate on the same lane as the remote, you'll need to remove 
         const existingComponent = existingLane ? existingLane.components.find((c) => c.id.isEqual(component.id)) : null;
         if (!existingComponent) {
           if (isExport) {
+            if (existingLane) existingLane.addComponent(component);
             if (!sentVersionHashes?.includes(component.head.toString())) {
               // during export, the remote might got a lane when some components were not sent from the client. ignore them.
               return;
             }
             if (!versionParents) throw new Error('mergeLane, versionParents must be set during export');
             const subsetOfVersionParents = getSubsetOfVersionParents(versionParents, component.head);
-            if (existingLane) existingLane.addComponent(component);
             mergeResults.push({
               mergedComponent: modelComponent,
               mergedVersions: subsetOfVersionParents.map((h) => h.hash.toString()),


### PR DESCRIPTION
The use-case this PR fixes is when merging one lane to another and during this merge a new component is introduced to this lane, after export, the remote-lane wasn't saving this newly introduced component.