### PR TITLE
fix: skip broken symlinks when copying components to .bit_roots

### DIFF
--- a/scopes/toolbox/fs/hard-link-directory/hard-link-directory.spec.ts
+++ b/scopes/toolbox/fs/hard-link-directory/hard-link-directory.spec.ts
@@ -74,3 +74,25 @@ test('copy symlinked files', async () => {
   expect(fs.readFileSync(path.join(dest2Dir, 'file.txt'), 'utf8')).toBe('Hello World');
   expect(fs.lstatSync(path.join(dest2Dir, 'file.txt')).isSymbolicLink()).toBeFalsy();
 });
+
+test('skip broken symlink', async () => {
+  const tempDir = globalBitTempDir();
+  const symlinkTargetDir = path.join(tempDir, 'symlink-target');
+  const srcDir = path.join(tempDir, 'source');
+  const dest1Dir = path.join(tempDir, 'dest1');
+  const dest2Dir = path.join(tempDir, 'dest2');
+
+  fs.mkdirpSync(symlinkTargetDir);
+  fs.mkdirpSync(srcDir);
+  fs.mkdirpSync(dest1Dir);
+  fs.mkdirpSync(dest2Dir);
+  const symlinkTargetFile = path.join(symlinkTargetDir, 'file.txt');
+  fs.writeFileSync(symlinkTargetFile, 'Hello World');
+  await symlinkDir(symlinkTargetFile, path.join(srcDir, 'file.txt'));
+  fs.unlinkSync(symlinkTargetFile);
+
+  await hardLinkDirectory(srcDir, [dest1Dir, dest2Dir]);
+
+  expect(fs.readdirSync(dest1Dir)).toEqual([]);
+  expect(fs.readdirSync(dest2Dir)).toEqual([]);
+});

--- a/scopes/toolbox/fs/hard-link-directory/hard-link-directory.ts
+++ b/scopes/toolbox/fs/hard-link-directory/hard-link-directory.ts
@@ -33,7 +33,15 @@ export async function hardLinkDirectory(src: string, destDirs: string[]) {
       }
       if (file.isSymbolicLink()) {
         srcFile = await resolveLinkTarget(srcFile);
-        if ((await fs.stat(srcFile)).isDirectory()) {
+        let srcStats: fs.Stats;
+        try {
+          srcStats = await fs.stat(srcFile);
+        } catch (err: any) {
+          // if the link is broken, ignore it
+          if (err.code === 'ENOENT') return;
+          throw err;
+        }
+        if (srcStats.isDirectory()) {
           await Promise.all(
             destDirs.map(async (destDir) => {
               const destSubdir = path.join(destDir, file.name);


### PR DESCRIPTION
## Proposed Changes

-
-
-
