### PR TITLE
fix, avoid overriding mutated Version objects

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1023,6 +1023,39 @@ describe('merge lanes', function () {
       });
     });
   });
+  describe('merging from a lane to main when it has a long history which does not exist locally - with multiple scopes', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapComponentWithoutBuild(
+        `"${helper.scopes.remote}/comp1, ${helper.scopes.remote}/comp2"`,
+        '--unmodified'
+      );
+      helper.command.snapComponentWithoutBuild(
+        `"${helper.scopes.remote}/comp1, ${helper.scopes.remote}/comp2"`,
+        '--unmodified'
+      );
+      helper.command.snapComponentWithoutBuild(
+        `"${helper.scopes.remote}/comp1, ${helper.scopes.remote}/comp2"`,
+        '--unmodified'
+      );
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.mergeLane(`${helper.scopes.remote}/dev`, `-x`);
+      const head = helper.command.getHead(`${helper.scopes.remote}/comp1`);
+      // because comp3 is missing, this will re-fetch comp1 with all its dependencies, which could potentially override the version objects
+      helper.command.import(`${helper.scopes.remote}/comp1@${head} --objects --fetch-deps`);
+    });
+    // previously it was throwing "error: component "X" was exported without the following version(s): Y"
+    it('bit export should not throw', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
   describe('merging from a lane to main when it has a long history which does not exist locally', () => {
     let beforeMerge: string;
     before(() => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1023,7 +1023,7 @@ describe('merge lanes', function () {
       });
     });
   });
-  describe('merging from a lane to main when it has a long history which does not exist locally - with multiple scopes', () => {
+  describe('merging from a lane to main when it changed Version object with squashed property and then re-imported it', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(3);
@@ -1051,7 +1051,11 @@ describe('merge lanes', function () {
       // because comp3 is missing, this will re-fetch comp1 with all its dependencies, which could potentially override the version objects
       helper.command.import(`${helper.scopes.remote}/comp1@${head} --objects --fetch-deps`);
     });
-    // previously it was throwing "error: component "X" was exported without the following version(s): Y"
+    it('should not override the squashed property', () => {
+      const comp = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`);
+      expect(comp).to.have.property('squashed');
+      expect(comp.modified).to.have.lengthOf(1);
+    });
     it('bit export should not throw', () => {
       expect(() => helper.command.export()).to.not.throw();
     });

--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -39,6 +39,7 @@ describe('sign command', function () {
     it('should save updated versions on the remotes', () => {
       const comp1 = helper.command.catComponent(`${helper.scopes.remote}/comp1@latest`, helper.scopes.remotePath);
       expect(comp1.buildStatus).to.equal('succeed');
+      expect(comp1.modified).to.have.lengthOf(1);
     });
     describe('running bit import on the workspace', () => {
       before(() => {

--- a/scopes/component/snapping/index.ts
+++ b/scopes/component/snapping/index.ts
@@ -1,6 +1,6 @@
 import { SnappingAspect } from './snapping.aspect';
 
-export { getBitCloudUsername, getBitCloudUser, BitCloudUser } from './tag-model-component';
+export { getBitCloudUsername, getBitCloudUser, BitCloudUser, getBasicLog } from './tag-model-component';
 export type { SnappingMain, TagResults, SnapResults } from './snapping.main.runtime';
 export default SnappingAspect;
 export { SnappingAspect };

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -50,7 +50,7 @@ import {
   getArtifactsFiles,
 } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { AutoTagResult } from '@teambit/legacy/dist/scope/component-ops/auto-tag';
-import Version, { DepEdge, DepEdgeType } from '@teambit/legacy/dist/scope/models/version';
+import Version, { DepEdge, DepEdgeType, Log } from '@teambit/legacy/dist/scope/models/version';
 import { SnapCmd } from './snap-cmd';
 import { SnappingAspect } from './snapping.aspect';
 import { TagCmd } from './tag-cmd';
@@ -745,16 +745,17 @@ there are matching among unmodified components thought. consider using --unmodif
     return { component, version };
   }
 
-  async _enrichComp(consumerComponent: ConsumerComponent) {
-    const objects = await this._getObjectsToEnrichComp(consumerComponent);
+  async _enrichComp(consumerComponent: ConsumerComponent, modifiedLog?: Log) {
+    const objects = await this._getObjectsToEnrichComp(consumerComponent, modifiedLog);
     objects.forEach((obj) => this.objectsRepo.add(obj));
     return consumerComponent;
   }
 
-  async _getObjectsToEnrichComp(consumerComponent: ConsumerComponent): Promise<BitObject[]> {
+  async _getObjectsToEnrichComp(consumerComponent: ConsumerComponent, modifiedLog?: Log): Promise<BitObject[]> {
     const component =
       consumerComponent.modelComponent || (await this.scope.legacyScope.sources.findOrAddComponent(consumerComponent));
     const version = await component.loadVersion(consumerComponent.id.version as string, this.objectsRepo, true, true);
+    if (modifiedLog) version.addModifiedLog(modifiedLog);
     const artifactFiles = getArtifactsFiles(consumerComponent.extensions);
     const artifacts = this.transformArtifactsFromVinylToSource(artifactFiles);
     version.extensions = consumerComponent.extensions;

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -437,9 +437,7 @@ async function addLogToComponents(
   messagePerComponent: MessagePerComponent[],
   copyLogFromPreviousSnap = false
 ) {
-  const username = await globalConfig.get(CFG_USER_NAME_KEY);
-  const bitCloudUsername = await getBitCloudUsername();
-  const email = await globalConfig.get(CFG_USER_EMAIL_KEY);
+  const basicLog = await getBasicLog();
   const getLog = (component: ConsumerComponent): Log => {
     const nextVersion = persist ? component.componentMap?.nextVersion : null;
     const msgFromEditor = messagePerComponent.find((item) => item.id.isEqualWithoutVersion(component.id))?.msg;
@@ -451,15 +449,15 @@ async function addLogToComponents(
         );
       }
       currentLog.message = msgFromEditor || message || currentLog.message;
-      currentLog.date = Date.now().toString();
+      currentLog.date = basicLog.date;
       return currentLog;
     }
 
     return {
-      username: nextVersion?.username || bitCloudUsername || username,
-      email: nextVersion?.email || email,
+      username: nextVersion?.username || basicLog.username,
+      email: nextVersion?.email || basicLog.email,
       message: nextVersion?.message || msgFromEditor || message,
-      date: Date.now().toString(),
+      date: basicLog.date,
     };
   };
 
@@ -475,6 +473,17 @@ async function addLogToComponents(
       autoTagComp.log.message = defaultMsg;
     }
   });
+}
+
+export async function getBasicLog(): Promise<Log> {
+  const username = (await getBitCloudUsername()) || (await globalConfig.get(CFG_USER_NAME_KEY));
+  const email = await globalConfig.get(CFG_USER_EMAIL_KEY);
+  return {
+    username,
+    email,
+    message: '',
+    date: Date.now().toString(),
+  };
 }
 
 export async function getBitCloudUsername(): Promise<string | undefined> {

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -6,7 +6,7 @@ import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
 import { isSnap } from '@teambit/component-version';
 import { Component, ComponentID } from '@teambit/component';
-import { SnappingAspect, SnappingMain } from '@teambit/snapping';
+import { getBasicLog, SnappingAspect, SnappingMain } from '@teambit/snapping';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { BuildStatus, CENTRAL_BIT_HUB_URL, CENTRAL_BIT_HUB_NAME } from '@teambit/legacy/dist/constants';
 import { getScopeRemotes } from '@teambit/legacy/dist/scope/scope-remotes';
@@ -14,6 +14,7 @@ import { PostSign } from '@teambit/legacy/dist/scope/actions';
 import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';
 import { Remotes } from '@teambit/legacy/dist/remotes';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
+import { Log } from '@teambit/legacy/dist/scope/models/version';
 import { Http } from '@teambit/legacy/dist/scope/network/http';
 import LanesAspect, { LanesMain } from '@teambit/lanes';
 import { LaneId } from '@teambit/lane-id';
@@ -138,18 +139,25 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
   }
 
   private async saveExtensionsDataIntoScope(components: ConsumerComponent[], buildStatus: BuildStatus) {
+    const modifiedLog = await this.getModifiedLog(buildStatus);
     await mapSeries(components, async (component) => {
       component.buildStatus = buildStatus;
-      await this.snapping._enrichComp(component);
+      await this.snapping._enrichComp(component, modifiedLog);
     });
     await this.scope.legacyScope.objects.persist();
   }
 
+  private async getModifiedLog(buildStatus: BuildStatus): Promise<Log> {
+    const log = await getBasicLog();
+    return { ...log, message: `sign. buildStatus: ${buildStatus}` };
+  }
+
   private async exportExtensionsDataIntoScopes(components: ConsumerComponent[], buildStatus: BuildStatus, lane?: Lane) {
     const objectList = new ObjectList();
+    const modifiedLog = await this.getModifiedLog(buildStatus);
     const signComponents = await mapSeries(components, async (component) => {
       component.buildStatus = buildStatus;
-      const objects = await this.snapping._getObjectsToEnrichComp(component);
+      const objects = await this.snapping._getObjectsToEnrichComp(component, modifiedLog);
       const scopeName = component.scope as string;
       const objectToMerge = await ObjectList.fromBitObjects(objects);
       objectToMerge.addScopeName(scopeName);

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -125,7 +125,7 @@ export default class Version extends BitObject {
   buildStatus?: BuildStatus;
   componentId?: BitId; // can help debugging errors when validating Version object
   bitVersion?: string;
-  modified: Log[] = [];
+  modified: Log[] = []; // currently mutation could happen as a result of either "squash" or "sign".
 
   constructor(props: VersionProps) {
     super();
@@ -691,6 +691,10 @@ export default class Version extends BitObject {
 
   setSquashed(squashData: SquashData, log: Log) {
     this.squashed = squashData;
+    this.addModifiedLog(log);
+  }
+
+  addModifiedLog(log: Log) {
     this.modified.push(log);
   }
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -79,6 +79,7 @@ export type VersionProps = {
   buildStatus?: BuildStatus;
   componentId?: BitId;
   bitVersion?: string;
+  modified?: Log[];
 };
 
 /**
@@ -124,6 +125,7 @@ export default class Version extends BitObject {
   buildStatus?: BuildStatus;
   componentId?: BitId; // can help debugging errors when validating Version object
   bitVersion?: string;
+  modified: Log[] = [];
 
   constructor(props: VersionProps) {
     super();
@@ -152,6 +154,7 @@ export default class Version extends BitObject {
     this.buildStatus = props.buildStatus;
     this.componentId = props.componentId;
     this.bitVersion = props.bitVersion;
+    this.modified = props.modified || [];
     this.validateVersion();
   }
 
@@ -272,6 +275,11 @@ export default class Version extends BitObject {
 
   get extensionDependencies() {
     return new Dependencies(this.extensions.extensionsBitIds.map((id) => new Dependency(id, [])));
+  }
+
+  lastModified(): string {
+    if (!this.modified || !this.modified.length) return this.log.date;
+    return this.modified[this.modified.length - 1].date;
   }
 
   getAllFlattenedDependencies(): BitIds {
@@ -423,6 +431,7 @@ export default class Version extends BitObject {
           ? { head: this.unrelated.head.toString(), laneId: this.unrelated.laneId.toObject() }
           : undefined,
         bitVersion: this.bitVersion,
+        modified: this.modified,
       },
       (val) => !!val
     );
@@ -470,6 +479,7 @@ export default class Version extends BitObject {
       squashed,
       unrelated,
       bitVersion,
+      modified,
     } = contentParsed;
 
     const _getDependencies = (deps = []): Dependency[] => {
@@ -576,6 +586,7 @@ export default class Version extends BitObject {
       extensions: _getExtensions(extensions),
       buildStatus,
       bitVersion,
+      modified,
     });
   }
 
@@ -678,8 +689,9 @@ export default class Version extends BitObject {
     this.parents.push(ref);
   }
 
-  setSquashed(squashData: SquashData) {
+  setSquashed(squashData: SquashData, log: Log) {
     this.squashed = squashData;
+    this.modified.push(log);
   }
 
   addAsOnlyParent(ref: Ref) {


### PR DESCRIPTION
In some cases, the `Version` object is mutated. For example when merging with squash or when building on CI. 
Currently, the object-writer is not aware of that and treat this object as immutable. As a result, it's possible that locally a `Version` object has changed and has the `squashed` prop and `parents` modified, but an import process that fetched this Version as a dependency of another component, overrode it. 
This PR fixes it by adding a new `modified` property to the `Version` object and it allows overriding only in case the incoming object is newer. 