### PR TITLE
improvement(ws-config) - Add new API for extending config files to replace extending file name with its abs/relative path

### DIFF
--- a/scopes/defender/eslint/eslint-config-writer.ts
+++ b/scopes/defender/eslint/eslint-config-writer.ts
@@ -7,6 +7,7 @@ import type {
   WrittenConfigFile,
   ExtendingConfigFile,
   ConfigFile,
+  GenerateExtendingConfigFilesArgs,
 } from '@teambit/workspace-config-files';
 import { expandIncludeExclude } from '@teambit/typescript';
 import { set } from 'lodash';
@@ -72,14 +73,16 @@ export class EslintConfigWriter implements ConfigWriterEntry {
     return Promise.resolve();
   }
 
-  generateExtendingFile(writtenConfigFiles: WrittenConfigFile[]): ExtendingConfigFile | undefined {
+  generateExtendingFile(args: GenerateExtendingConfigFilesArgs): ExtendingConfigFile | undefined {
+    const { writtenConfigFiles } = args;
     const eslintConfigFile = writtenConfigFiles.find((file) => file.name.includes('.eslintrc.bit'));
     if (!eslintConfigFile) return undefined;
     const config = {
-      extends: [eslintConfigFile.filePath],
+      // Using DSL to make sure it will be replaced with relative path
+      extends: [`{${eslintConfigFile.name}}`],
     };
     const content = `${BIT_GENERATED_ESLINT_CONFIG_COMMENT}\n${JSON.stringify(config, null, 2)}`;
-    return { content, name: '.eslintrc.json', extendingTarget: eslintConfigFile.filePath };
+    return { content, name: '.eslintrc.json', extendingTarget: eslintConfigFile, useAbsPaths: false };
   }
 
   isBitGenerated(filePath: string): boolean {

--- a/scopes/defender/prettier/prettier-config-writer.ts
+++ b/scopes/defender/prettier/prettier-config-writer.ts
@@ -2,9 +2,9 @@ import fs from 'fs-extra';
 import { ExecutionContext } from '@teambit/envs';
 import type {
   ConfigWriterEntry,
-  WrittenConfigFile,
   ExtendingConfigFile,
   ConfigFile,
+  GenerateExtendingConfigFilesArgs,
 } from '@teambit/workspace-config-files';
 import { FormatterMain } from '@teambit/formatter';
 import { PrettierFormatterInterface } from './prettier-formatter-interface';
@@ -33,13 +33,15 @@ export class PrettierConfigWriter implements ConfigWriterEntry {
     return [prettierConfigFile];
   }
 
-  generateExtendingFile(writtenConfigFiles: WrittenConfigFile[]): ExtendingConfigFile | undefined {
+  generateExtendingFile(args: GenerateExtendingConfigFilesArgs): ExtendingConfigFile | undefined {
+    const { writtenConfigFiles } = args;
     const prettierConfigFile = writtenConfigFiles[0];
+    // Using DSL to make sure it will be replaced with relative path
     const configContent = `module.exports = {
-  ...require('${prettierConfigFile.filePath}')
+  ...require('{${prettierConfigFile.name}}')
 }`;
     const content = `${BIT_GENERATED_PRETTIER_CONFIG_COMMENT}\n${configContent}`;
-    return { content, name: CONFIG_NAME, extendingTarget: prettierConfigFile.filePath };
+    return { content, name: CONFIG_NAME, extendingTarget: prettierConfigFile, useAbsPaths: false };
   }
   calcName(hash: string): string {
     return `.prettierrc.bit.${hash}.cjs`;

--- a/scopes/typescript/typescript/ts-config-writer.ts
+++ b/scopes/typescript/typescript/ts-config-writer.ts
@@ -10,6 +10,7 @@ import type {
   ConfigFile,
   EnvMapValue,
   PostProcessExtendingConfigFilesArgs,
+  GenerateExtendingConfigFilesArgs,
 } from '@teambit/workspace-config-files';
 import { uniq } from 'lodash';
 import { CompilerMain } from '@teambit/compiler';
@@ -85,14 +86,16 @@ export class TypescriptConfigWriter implements ConfigWriterEntry {
     return Promise.resolve();
   }
 
-  generateExtendingFile(writtenConfigFiles: WrittenConfigFile[]): ExtendingConfigFile | undefined {
+  generateExtendingFile(args: GenerateExtendingConfigFilesArgs): ExtendingConfigFile | undefined {
+    const { writtenConfigFiles } = args;
     const tsconfigFile = writtenConfigFiles.find((file) => file.name.includes('tsconfig.bit'));
     if (!tsconfigFile) return undefined;
     const config = {
-      extends: tsconfigFile.filePath,
+      // Using DSL to make sure it will be replaced with relative path
+      extends: `{${tsconfigFile.name}}`,
     };
     const content = `${BIT_GENERATED_TS_CONFIG_COMMENT}\n\n${JSON.stringify(config, null, 2)}`;
-    return { content, name: 'tsconfig.json', extendingTarget: tsconfigFile.filePath };
+    return { content, name: 'tsconfig.json', extendingTarget: tsconfigFile, useAbsPaths: false };
   }
 
   async postProcessExtendingConfigFiles?(args: PostProcessExtendingConfigFilesArgs): Promise<void> {

--- a/scopes/workspace/workspace-config-files/config-writer-entry.ts
+++ b/scopes/workspace/workspace-config-files/config-writer-entry.ts
@@ -25,15 +25,28 @@ export type ConfigFile = {
 
 export type ExtendingConfigFile = ConfigFile & {
   /**
-   * Name of the config file that this config file extends.
+   * the config file that this config file extends.
    */
-  extendingTarget: string;
+  extendingTarget: WrittenConfigFile;
+
+  /**
+   * When replacing the config file name with the actual path of the config file, use absolute paths.
+   */
+  useAbsPaths?: boolean;
 };
 
 export type PostProcessExtendingConfigFilesArgs = {
   workspaceDir: string;
   configsRootDir: string;
   writtenExtendingConfigFiles: EnvsWrittenExtendingConfigFiles;
+  envCompsDirsMap: EnvCompsDirsMap;
+  dryRun: boolean;
+};
+
+export type GenerateExtendingConfigFilesArgs = {
+  workspaceDir: string;
+  configsRootDir: string;
+  writtenConfigFiles: WrittenConfigFile[];
   envCompsDirsMap: EnvCompsDirsMap;
   dryRun: boolean;
 };
@@ -90,8 +103,13 @@ export interface ConfigWriterEntry {
    * For example, the tsconfig.json file will extend the real tsconfig.{hash}.json file (that were coming from the env).
    * That way we can avoid writing the same config file multiple times.
    * It also reduces the risk of the user manually change the config file and then the changes will be lost.
+   * This function support returning a file with content with a dsl using `{}` to replace the config file name.
+   * for example:
+   * content = `{
+   *   "extends": {configFile.name},
+   * }`
    */
-  generateExtendingFile(writtenConfigFiles: WrittenConfigFile[]): ExtendingConfigFile | undefined;
+  generateExtendingFile(args: GenerateExtendingConfigFilesArgs): ExtendingConfigFile | undefined;
 
   /**
    * This enables the writer to do some post processing after the extending config files were written.

--- a/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
+++ b/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
@@ -67,6 +67,7 @@ const envCompsDirsMap = {
 const tsExtendingConfigFilesMap: ExtendingConfigFilesMap = {
   '816b7f584991ff21a7682ef8a4229ebf312c457f': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-typescript-config\n' +
         '\n' +
@@ -74,14 +75,21 @@ const tsExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  "extends": "/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.4957ea3122e57ea3302aadd885eed84127d9c54b.json"\n' +
         '}',
       name: 'tsconfig.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.4957ea3122e57ea3302aadd885eed84127d9c54b.json',
+      extendingTarget: {
+        hash: '4957ea3122e57ea3302aadd885eed84127d9c54b',
+        content: 'does not matter',
+        name: 'tsconfig.bit.4957ea3122e57ea3302aadd885eed84127d9c54b.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.4957ea3122e57ea3302aadd885eed84127d9c54b.json',
+      },
+
       hash: '816b7f584991ff21a7682ef8a4229ebf312c457f',
     },
     envIds: ['teambit.harmony/node', 'teambit.react/react'],
   },
   '00330a9c547353867d519c34f47e17ddc9f161d1': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-typescript-config\n' +
         '\n' +
@@ -89,14 +97,20 @@ const tsExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  "extends": "/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.17b99a1071b1d2d86ed04ebce68903b82403f278.json"\n' +
         '}',
       name: 'tsconfig.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.17b99a1071b1d2d86ed04ebce68903b82403f278.json',
+      extendingTarget: {
+        hash: '17b99a1071b1d2d86ed04ebce68903b82403f278',
+        content: 'does not matter',
+        name: 'tsconfig.bit.17b99a1071b1d2d86ed04ebce68903b82403f278.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.17b99a1071b1d2d86ed04ebce68903b82403f278.json',
+      },
       hash: '00330a9c547353867d519c34f47e17ddc9f161d1',
     },
     envIds: ['teambit.react/react-env@0.0.44', 'teambit.react/examples/my-react-env@0.0.39'],
   },
   '3c5960bcad98570b98834a5c37f47dd4729dbef0': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-typescript-config\n' +
         '\n' +
@@ -104,8 +118,13 @@ const tsExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  "extends": "/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.dab521d0914afe64de248743e05a169cf9b4b50c.json"\n' +
         '}',
       name: 'tsconfig.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.dab521d0914afe64de248743e05a169cf9b4b50c.json',
+      extendingTarget: {
+        hash: 'dab521d0914afe64de248743e05a169cf9b4b50c',
+        content: 'does not matter',
+        name: 'tsconfig.bit.dab521d0914afe64de248743e05a169cf9b4b50c.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/tsconfig.bit.dab521d0914afe64de248743e05a169cf9b4b50c.json',
+      },
       hash: '3c5960bcad98570b98834a5c37f47dd4729dbef0',
     },
     envIds: ['teambit.node/node@0.0.16'],
@@ -130,6 +149,7 @@ const tsExpectedDedupedPaths: DedupedPaths = [
 const eslintExtendingConfigFilesMap: ExtendingConfigFilesMap = {
   '8810839e74a9c41694bb5a2a8587dcae71dc389d': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-eslint-config\n' +
         '{\n' +
@@ -138,14 +158,20 @@ const eslintExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  ]\n' +
         '}',
       name: '.eslintrc.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.be8facfbdcf1db685d5020f8612d8c2c3ac2eb7c.json',
+      extendingTarget: {
+        hash: 'be8facfbdcf1db685d5020f8612d8c2c3ac2eb7c',
+        content: 'does not matter',
+        name: '.eslintrc.bit.be8facfbdcf1db685d5020f8612d8c2c3ac2eb7c.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.be8facfbdcf1db685d5020f8612d8c2c3ac2eb7c.json',
+      },
       hash: '8810839e74a9c41694bb5a2a8587dcae71dc389d',
     },
     envIds: ['teambit.harmony/node', 'teambit.react/react', 'teambit.envs/env'],
   },
   ff6ea265e6f21ce25f7985570beef37dd957d0dc: {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-eslint-config\n' +
         '{\n' +
@@ -154,14 +180,20 @@ const eslintExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  ]\n' +
         '}',
       name: '.eslintrc.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.e5ca5528c64e0442b05b949fea42cdda4243d840.json',
+      extendingTarget: {
+        hash: 'e5ca5528c64e0442b05b949fea42cdda4243d840',
+        content: 'does not matter',
+        name: '.eslintrc.bit.e5ca5528c64e0442b05b949fea42cdda4243d840.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.e5ca5528c64e0442b05b949fea42cdda4243d840.json',
+      },
       hash: 'ff6ea265e6f21ce25f7985570beef37dd957d0dc',
     },
     envIds: ['teambit.react/react-env@0.0.44'],
   },
   '91021f2c973a2940c70b75447639e4ea2a799955': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-eslint-config\n' +
         '{\n' +
@@ -170,14 +202,20 @@ const eslintExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  ]\n' +
         '}',
       name: '.eslintrc.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.7f229bf5ab41e8bfe61916de6c68f9c14c76f23e.json',
+      extendingTarget: {
+        hash: '7f229bf5ab41e8bfe61916de6c68f9c14c76f23e',
+        content: 'does not matter',
+        name: '.eslintrc.bit.7f229bf5ab41e8bfe61916de6c68f9c14c76f23e.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.7f229bf5ab41e8bfe61916de6c68f9c14c76f23e.json',
+      },
       hash: '91021f2c973a2940c70b75447639e4ea2a799955',
     },
     envIds: ['teambit.mdx/mdx-env@0.0.6', 'teambit.react/examples/my-react-env@0.0.39'],
   },
   f1743b227e588db0c59d4a43171653e6c4262816: {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-eslint-config\n' +
         '{\n' +
@@ -186,8 +224,13 @@ const eslintExtendingConfigFilesMap: ExtendingConfigFilesMap = {
         '  ]\n' +
         '}',
       name: '.eslintrc.json',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.c503f7386e2a637d91c74f7df90d8fafe79c4378.json',
+      extendingTarget: {
+        hash: 'c503f7386e2a637d91c74f7df90d8fafe79c4378',
+        content: 'does not matter',
+        name: '.eslintrc.bit.c503f7386e2a637d91c74f7df90d8fafe79c4378.json',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.eslintrc.bit.c503f7386e2a637d91c74f7df90d8fafe79c4378.json',
+      },
       hash: 'f1743b227e588db0c59d4a43171653e6c4262816',
     },
     envIds: ['teambit.node/node@0.0.16'],
@@ -216,14 +259,20 @@ const eslintExpectedDedupedPaths: DedupedPaths = [
 const prettierExtendingConfigFilesMap: ExtendingConfigFilesMap = {
   '082f546b2555ea89e7063b20de47c039d387fc74': {
     extendingConfigFile: {
+      useAbsPaths: false,
       content:
         '// bit-generated-prettier-config\n' +
         'module.exports = {\n' +
         "  ...require('/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.prettierrc.bit.e4882af8861bcf5b0147891d8b70b40a10428881.cjs')\n" +
         '}',
       name: '.prettierrc.cjs',
-      extendingTarget:
-        '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.prettierrc.bit.e4882af8861bcf5b0147891d8b70b40a10428881.cjs',
+      extendingTarget: {
+        hash: 'e4882af8861bcf5b0147891d8b70b40a10428881',
+        content: 'does not matter',
+        name: '.prettierrc.bit.e4882af8861bcf5b0147891d8b70b40a10428881.cjs',
+        filePath:
+          '/Users/giladshoham/dev/temp/new-react-18-config-files/node_modules/.cache/.prettierrc.bit.e4882af8861bcf5b0147891d8b70b40a10428881.cjs',
+      },
       hash: '082f546b2555ea89e7063b20de47c039d387fc74',
     },
     envIds: [

--- a/scopes/workspace/workspace-config-files/format-outputs.ts
+++ b/scopes/workspace/workspace-config-files/format-outputs.ts
@@ -107,7 +107,7 @@ function getEnvGroupExtendingConfigFilesOutput(
   )}`;
   const extendingConfigFile = envsWrittenExtendingConfigFile.extendingConfigFile;
   const paths = extendingConfigFile.filePaths
-    .map((p) => `  ${relative(wsDir, p)} --> ${relative(wsDir, extendingConfigFile.extendingTarget)}`)
+    .map((p) => `  ${relative(wsDir, p)} --> ${relative(wsDir, extendingConfigFile.extendingTarget.filePath)}`)
     .join('\n    ');
   return `${title}\n    ${paths}`;
 }

--- a/scopes/workspace/workspace-config-files/index.ts
+++ b/scopes/workspace/workspace-config-files/index.ts
@@ -11,6 +11,7 @@ export type {
   ExtendingConfigFile,
   ConfigFile,
   PostProcessExtendingConfigFilesArgs,
+  GenerateExtendingConfigFilesArgs,
 } from './config-writer-entry';
 export default WorkspaceConfigFilesAspect;
 export { WorkspaceConfigFilesAspect };


### PR DESCRIPTION
## Proposed Changes

- Add new API for extending config files to replace extending file name with its abs/relative path
- Use relative paths in extending files for ts-config-writer, eslint-config-writer, and prettier-config-writer
- Add more context to the `generateExtendingFile` function
