### PR TITLE
fix(import), avoid throwing ComponentNotFound when .bitmap component was not found

### DIFF
--- a/e2e/harmony/out-of-sync-components-harmony.e2e.ts
+++ b/e2e/harmony/out-of-sync-components-harmony.e2e.ts
@@ -83,4 +83,24 @@ describe('components that are not synced between the scope and the consumer', fu
       });
     });
   });
+  describe('consumer with a tagged exported component and scope with no components', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.tagAllWithoutBuild('--unmodified'); // 0.0.2
+      helper.fs.deletePath('.bit');
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('bit import should not throw', () => {
+      expect(() => helper.command.import()).to.not.throw();
+    });
+    it('bit import followed by bit status should sync .bitmap', () => {
+      helper.command.import();
+      helper.command.status();
+      const bitmap = helper.bitMap.read();
+      expect(bitmap.comp1.version).to.equal('0.0.1');
+    });
+  });
 });

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -165,13 +165,13 @@ ${WILDCARD_HELP('import')}`;
       trackOnly,
     };
     const importResults = await this.importer.import(importOptions, this._packageManagerArgs);
-    const { importDetails, importedIds, importedDeps, installationError, compilationError } = importResults;
+    const { importDetails, importedIds, importedDeps, installationError, compilationError, missingIds } = importResults;
 
     if (json) {
       return JSON.stringify({ importDetails, installationError }, null, 4);
     }
 
-    if (!importedIds.length) {
+    if (!importedIds.length && !missingIds?.length) {
       return chalk.yellow(importResults.cancellationMessage || 'nothing to import');
     }
 
@@ -203,11 +203,21 @@ ${WILDCARD_HELP('import')}`;
     const output =
       importOutput +
       importedDepsOutput +
+      formatMissingComponents(missingIds) +
       installationErrorOutput(installationError) +
       compilationErrorOutput(compilationError);
 
     return output;
   }
+}
+
+function formatMissingComponents(missing?: string[]) {
+  if (!missing?.length) return '';
+  const title = chalk.underline('Missing Components');
+  const subTitle =
+    'The following components are missing from the remote in the requested version, try running "bit status" to re-sync your .bitmap file';
+  const body = chalk.red(missing.join('\n'));
+  return `\n\n${title}\n${subTitle}\n${body}`;
 }
 
 function formatPlainComponentItemWithVersions(bitId: BitId, importDetails: ImportDetails) {


### PR DESCRIPTION
This is an out-of-sync case which apparently we didn't handle.
It happens when a component is exported. One user tagged the exported component locally, committed and pushed, another user clones the repo, gets the .bitmap with the versions according to the tagged one, which only exist on the first-user local but not on the remote.
Until now, in this case, `bit status` was showing the import-pending message, suggesting to import, but `bit import` was throwing `ComponentNotFound` error.
This PR fixes the import to not throw. Instead, in the output it shows the not-found components and suggests running `bit status` to sync the .bitmap back to the remote. 