### PR TITLE
fix: clear workspace cache before calculating component manifests

### DIFF
--- a/e2e/harmony/dependencies/policies-order.e2e.ts
+++ b/e2e/harmony/dependencies/policies-order.e2e.ts
@@ -68,7 +68,6 @@ describe('policies order', function () {
       helper.scopeHelper.destroy();
     });
     it('should install react specified in env itself', () => {
-      helper.command.clearCache();
       helper.command.showComponent('custom-react/env1'); // We need to run bit show twice due to a bug in bit
       const showOutput = helper.command.showComponent('custom-react/env1');
       expect(showOutput).to.have.string('react@16.0.0');

--- a/e2e/harmony/dependencies/policies-order.e2e.ts
+++ b/e2e/harmony/dependencies/policies-order.e2e.ts
@@ -68,6 +68,7 @@ describe('policies order', function () {
       helper.scopeHelper.destroy();
     });
     it('should install react specified in env itself', () => {
+      helper.command.clearCache();
       helper.command.showComponent('custom-react/env1'); // We need to run bit show twice due to a bug in bit
       const showOutput = helper.command.showComponent('custom-react/env1');
       expect(showOutput).to.have.string('react@16.0.0');

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -235,8 +235,6 @@ export class InstallMain {
       // are not added to the manifests.
       // This is an issue when installation is done using root components.
       hasMissingLocalComponents = hasRootComponents && hasComponentsFromWorkspaceInMissingDeps(current);
-      this.workspace.consumer.componentLoader.clearComponentsCache();
-      this.workspace.clearCache();
       await installer.installComponents(
         this.workspace.path,
         current.manifests,
@@ -257,6 +255,9 @@ export class InstallMain {
       }
       await this.link(linkOpts);
       prevManifests.add(hash(current.manifests));
+      // We need to clear cache before creating the new component manifests.
+      this.workspace.consumer.componentLoader.clearComponentsCache();
+      this.workspace.clearCache();
       current = await this._getComponentsManifests(installer, mergedRootPolicy, pmInstallOptions);
       installCycle += 1;
     } while ((!prevManifests.has(hash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -261,6 +261,7 @@ export class InstallMain {
       current = await this._getComponentsManifests(installer, mergedRootPolicy, pmInstallOptions);
       installCycle += 1;
     } while ((!prevManifests.has(hash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
+    await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */
     return current.componentDirectoryMap;
   }
@@ -418,10 +419,6 @@ export class InstallMain {
         )
       )
     );
-  }
-
-  private async _getAllUsedApps(): Promise<Component[]> {
-    return this.app.listAppsFromComponents();
   }
 
   private async _getAllUsedEnvIds(): Promise<string[]> {


### PR DESCRIPTION
This fix reduces the number of repeat installs
