### PR TITLE
perf, fix writing files performance by disabling fsync

### DIFF
--- a/src/utils/fs-write-file.ts
+++ b/src/utils/fs-write-file.ts
@@ -19,5 +19,5 @@ export default async function writeFile(
     chown = { uid: options.uid || user.uid, gid: options.gid || user.gid };
   }
   await fs.ensureDir(pathLib.dirname(path));
-  await writeFileAtomic(path, contents, { chown });
+  await writeFileAtomic(path, contents, { chown, fsync: false });
 }


### PR DESCRIPTION
Writing object files is 16 times faster with this change. See https://github.com/npm/write-file-atomic/issues/155 for more info.