### PR TITLE
fix(ws-config) - various fixes for ws-config write generated config files

### DIFF
--- a/scopes/defender/eslint/eslint-config-writer.ts
+++ b/scopes/defender/eslint/eslint-config-writer.ts
@@ -9,7 +9,7 @@ import type {
   ConfigFile,
   GenerateExtendingConfigFilesArgs,
 } from '@teambit/workspace-config-files';
-import { expandIncludeExclude } from '@teambit/typescript';
+import { GLOBAL_TYPES_DIR, expandIncludeExclude } from '@teambit/typescript';
 import { set } from 'lodash';
 import { Logger } from '@teambit/logger';
 import { LinterMain } from '@teambit/linter';
@@ -67,7 +67,7 @@ export class EslintConfigWriter implements ConfigWriterEntry {
     }
     const tsConfig = await fs.readJson(tsConfigPath);
     const compDirs: string[] = envMapValue.paths;
-    const newTsConfig = expandIncludeExclude(tsConfigPath, tsConfig, compDirs);
+    const newTsConfig = expandIncludeExclude(tsConfigPath, tsConfig, compDirs, GLOBAL_TYPES_DIR);
 
     fs.outputJSONSync(tsConfigPath, newTsConfig, { spaces: 2 });
     return Promise.resolve();

--- a/scopes/typescript/typescript/expand-include-exclude.ts
+++ b/scopes/typescript/typescript/expand-include-exclude.ts
@@ -11,7 +11,12 @@ import { dirname, relative } from 'path';
  * @returns the tsConfig object.
  */
 
-export function expandIncludeExclude(tsConfigPath: string, tsConfig: TsConfigJson, compDirs: string[]) {
+export function expandIncludeExclude(
+  tsConfigPath: string,
+  tsConfig: TsConfigJson,
+  compDirs: string[],
+  globalTypesDir?: string
+) {
   const tsConfigDir = dirname(tsConfigPath);
 
   if (tsConfig.include) {
@@ -23,6 +28,10 @@ export function expandIncludeExclude(tsConfigPath: string, tsConfig: TsConfigJso
         });
       })
     );
+  }
+  if (globalTypesDir) {
+    tsConfig.include = tsConfig.include || [];
+    tsConfig.include.push(`./${globalTypesDir}/**/*`);
   }
   if (tsConfig.exclude) {
     tsConfig.exclude = flatten(

--- a/scopes/typescript/typescript/index.ts
+++ b/scopes/typescript/typescript/index.ts
@@ -6,3 +6,4 @@ export type { TypeScriptCompilerOptions, TsCompilerOptionsWithoutTsConfig } from
 export { TypescriptAspect } from './typescript.aspect';
 export type { TypescriptCompilerInterface } from './typescript-compiler-interface';
 export { expandIncludeExclude } from './expand-include-exclude';
+export { GLOBAL_TYPES_DIR } from './ts-config-writer';

--- a/scopes/typescript/typescript/ts-config-writer.ts
+++ b/scopes/typescript/typescript/ts-config-writer.ts
@@ -20,7 +20,7 @@ import { expandIncludeExclude } from './expand-include-exclude';
 
 const CONFIG_NAME = 'tsconfig.json';
 const BIT_GENERATED_TS_CONFIG_COMMENT = '// bit-generated-typescript-config';
-const GLOBAL_TYPES_DIR = 'global-types';
+export const GLOBAL_TYPES_DIR = 'global-types';
 
 export class TypescriptConfigWriter implements ConfigWriterEntry {
   name = 'TypescriptConfigWriter';
@@ -80,7 +80,7 @@ export class TypescriptConfigWriter implements ConfigWriterEntry {
     const tsConfig = await fs.readJson(tsConfigPath);
     const compDirs: string[] = envMapValue.paths;
 
-    const newTsConfig = expandIncludeExclude(tsConfigPath, tsConfig, compDirs);
+    const newTsConfig = expandIncludeExclude(tsConfigPath, tsConfig, compDirs, GLOBAL_TYPES_DIR);
 
     fs.outputJSONSync(tsConfigPath, newTsConfig, { spaces: 2 });
     return Promise.resolve();
@@ -112,8 +112,9 @@ export class TypescriptConfigWriter implements ConfigWriterEntry {
     const compilerOptions = tsConfig.compilerOptions || {};
     const typeRoots = compilerOptions.typeRoots || [];
     const globalTypesDir = join(configsRootDir, GLOBAL_TYPES_DIR);
-    const relativeGlobalTypesDir = relative(workspaceDir, globalTypesDir);
+    const relativeGlobalTypesDir = `./${relative(workspaceDir, globalTypesDir)}`;
     typeRoots.push(relativeGlobalTypesDir);
+    typeRoots.push('./node_modules/@types');
     assign(compilerOptions, { typeRoots: uniq(typeRoots) });
     assign(tsConfig, { compilerOptions });
     await fs.outputFile(rootTsConfigPath, stringify(tsConfig, null, 2));

--- a/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
+++ b/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
@@ -351,7 +351,7 @@ export class WorkspaceConfigFilesMain {
             const filePath = join(this.workspace.path, path, name);
             const targetPath = configFile.useAbsPaths
               ? configFile.extendingTarget.filePath
-              : relative(dirname(filePath), configFile.extendingTarget.filePath);
+              : `./${relative(dirname(filePath), configFile.extendingTarget.filePath)}`;
             const content = configFile.content.replace(`{${configFile.extendingTarget.name}}`, targetPath);
             if (!opts.dryRun) {
               await fs.outputFile(filePath, content);


### PR DESCRIPTION
## Proposed Changes

- add include to the generated global types folder from the generated tsconfig files
- add `node_modules/@types` to the `typeRoots` in the generated root tsconfig file
- reference relative config files with `./` at the beginning (some tools like TS don't know to use relative path correctly when not start with `.` or `..`) 
