### PR TITLE
revert legacy detective entries

### DIFF
--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-css/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/styling.deps-detectors.detective-css';

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-es6/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-es6/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/node.deps-detectors.detective-es6';

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-less/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-less/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/styling.deps-detectors.detective-less';

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/styling.deps-detectors.detective-sass';

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-scss/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-scss/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/styling.deps-detectors.detective-scss';

--- a/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-typescript/index.ts
+++ b/src/consumer/component/dependencies/files-dependency-builder/detectives/detective-typescript/index.ts
@@ -1,0 +1,1 @@
+export * from '@teambit/typescript.deps-detectors.detective-typescript';


### PR DESCRIPTION
## Proposed Changes

Reverted files to make sure those packages below could be properly imported.

- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-es6`
- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-typescript`
- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-css`
- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-sass`
- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-scss`
- `@teambit/legacy/dist/consumer/component/dependencies/files-dependency-builder/detectives/detective-less`

Since I have no existing test cases. I just _manually and locally_ tried some commands which were mentioned in the slack channel for a better review process and effect:

```bash
# successful
bit-dev new react my-workspace --env teambit.react/react-env --default-scope my-org.my-scope
```

```bash
# failed
bit-dev new bit-dev new-angular-doc --aspect teambit.community/starters/bit-dev --log=error
```

<details>

<summary>Error output</summary>

```bash
  -------------------------
✔ installing dependencies using pnpm
✔ running post install subscribers
✔ installed packages in capsules
failed to backup bitmap
    err: {
      "type": "Error",
      "message": "ENOENT: no such file or directory, copyfile '/Users/jinjiang/Developer/teambit/new-angular-doc/.bitmap' -> '/Users/jinjiang/Developer/teambit/new-angular-doc/.git/bit/bitmap-history/.bitmap-2023-4-3-10-53-38'",
      "stack":
          Error: ENOENT: no such file or directory, copyfile '/Users/jinjiang/Developer/teambit/new-angular-doc/.bitmap' -> '/Users/jinjiang/Developer/teambit/new-angular-doc/.git/bit/bitmap-history/.bitmap-2023-4-3-10-53-38'
      "errno": -2,
      "code": "ENOENT",
      "syscall": "copyfile",
      "path": "/Users/jinjiang/Developer/teambit/new-angular-doc/.bitmap",
      "dest": "/Users/jinjiang/Developer/teambit/new-angular-doc/.git/bit/bitmap-history/.bitmap-2023-4-3-10-53-38"
    }
✔ linking components
✔ deduping dependencies for installation
✔ running pre install subscribers
...community_envs_community-react@2.1.14 |  WARN  deprecated subscriptions-transport-ws@0.11.0
...community_envs_community-react@2.1.14 |  +96 ++++++++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/jinjiang/Library/pnpm/store/v3
  Virtual store is at:             ../../../Library/Caches/Bit/capsules/8990969992d184e21d6c36674dd559f02fe00511/teambit.community_envs_community-react@2.1.14/node_modules/.pnpm
...community_envs_community-react@2.1.14 | Progress: resolved 96, reused 96, downloaded 0, added 96, done
  -------------------------
✔ installing dependencies using pnpm
✔ running post install subscribers
✔ installed packages in capsules
✔ linking components
✔ deduping dependencies for installation
✔ running pre install subscribers
...ud-providers_deployers_netlify@0.1.12 |  +36 ++++
Packages are hard linked from the content-addressable store to the virtual store.
  Content-addressable store is at: /Users/jinjiang/Library/pnpm/store/v3
  Virtual store is at:             ../../../Library/Caches/Bit/capsules/8990969992d184e21d6c36674dd559f02fe00511/teambit.cloud-providers_deployers_netlify@0.1.12/node_modules/.pnpm
...ud-providers_deployers_netlify@0.1.12 | Progress: resolved 36, reused 36, downloaded 0, added 36, done
  -------------------------
✔ installing dependencies using pnpm
✔ running post install subscribers
✔ installed packages in capsules
  installing dependencies in workspace using teambit.dependencies/pnpm
✔ deduping dependencies for installation
✔ linking components
✔ running pre install subscribers
 WARN  deprecated subscriptions-transport-ws@0.11.0: The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md
Progress: resolved 44, reused 43, downloaded 0, added 0
got an error from command new: BitErrorWithRichMessage: No matching version found for @teambit/cloud-providers.docs.aws-lambda@0.0.2
BitErrorWithRichMessage: No matching version found for @teambit/cloud-providers.docs.aws-lambda@0.0.2
    at pnpmErrorToBitError (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/pnpm/dist/pnpm-error-to-bit-error.js:35:10)
    at install (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/pnpm/dist/lynx.js:328:58)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async PnpmPackageManager.install (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/pnpm/dist/pnpm.package-manager.js:85:5)
    at async DependencyInstaller.installComponents (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/dependency-resolver/dist/dependency-installer.js:167:5)
    at async InstallMain._installModules (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/install/dist/install.main.runtime.js:374:7)
    at async WorkspaceGenerator.generate (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/generator/dist/workspace-generator.js:157:7)
    at async GeneratorMain.generateWorkspaceTemplate (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/generator/dist/generator.main.runtime.js:443:27)
    at async NewCmd.report (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/generator/dist/new.cmd.js:48:9)
    at async CommandRunner.runReportHandler (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/cli/dist/command-runner.js:163:20)
    at async CommandRunner.runCommand (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/cli/dist/command-runner.js:104:16)
No matching version found for @teambit/cloud-providers.docs.aws-lambda@0.0.2
[*] the command "new" has been terminated with an error code 1
```

</details>

```bash
# failed
bit-dev new angular my-workspace --aspect teambit.angular/angular --default-scope test.my-scope --log=error
```

<details>

<summary>Error output</summary>

```bash
  -------------------------
✔ installing dependencies using pnpm
✔ running post install subscribers
✔ installed packages in capsules
teambit.harmony/aspect-loader, couldn't load one of the following extensions teambit.angular/angular@3.0.5, due to an error "failed loading extension teambit.workspace/workspace", please use the '--log=error' flag for the full error.
    err: {
      "type": "Error",
      "message": "failed loading extension teambit.workspace/workspace",
      "stack":
          Error: failed loading extension teambit.workspace/workspace
              at Harmony.get (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/harmony/dist/harmony.js:118:19)
              at ServiceHandlerContext.getAspect (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/services/service-handler-context.js:31:25)
              at /Users/jinjiang/Library/Caches/Bit/capsules/aeb8200bea78464a26a9c3bbfd0211e572f49364/node_modules/.pnpm/@teambit+angular-apps@1.0.2_y2pcjlu4okbqnojx6zvn6rzzla/node_modules/@teambit/angular-apps/dist/angular.app-type.js:23:39
              at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/app-type-list.js:14:41
              at Array.map (<anonymous>)
              at AppTypeList.compute (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/app-type-list.js:14:26)
              at AppService.transform (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/application.service.js:32:35)
              at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:66:39
              at Array.reduce (<anonymous>)
              at EnvPlugin.transformToLegacyEnv (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:64:38)
              at EnvPlugin.register (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:83:22)
              at Plugin.register (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugin.js:30:14)
              at Plugins.registerPluginWithTryCatch (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:67:21)
              at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:53:23
              at Array.map (<anonymous>)
              at Object.provider (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:52:35)
    }
teambit.harmony/aspect-loader, couldn't load one of the following extensions teambit.angular/angular@3.0.5, due to an error "failed loading extension teambit.workspace/workspace", please use the '--log=error' flag for the full error.
✖ couldn't load one of the following extensions teambit.angular/angular@3.0.5, due to an error "failed loading extension teambit.workspace/workspace", please use the '--log=error' flag for the full error.
got an error from command new: Error: failed loading extension teambit.workspace/workspace
Error: failed loading extension teambit.workspace/workspace
    at Harmony.get (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/harmony/dist/harmony.js:118:19)
    at ServiceHandlerContext.getAspect (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/services/service-handler-context.js:31:25)
    at /Users/jinjiang/Library/Caches/Bit/capsules/aeb8200bea78464a26a9c3bbfd0211e572f49364/node_modules/.pnpm/@teambit+angular-apps@1.0.2_y2pcjlu4okbqnojx6zvn6rzzla/node_modules/@teambit/angular-apps/dist/angular.app-type.js:23:39
    at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/app-type-list.js:14:41
    at Array.map (<anonymous>)
    at AppTypeList.compute (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/app-type-list.js:14:26)
    at AppService.transform (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/application/dist/application.service.js:32:35)
    at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:66:39
    at Array.reduce (<anonymous>)
    at EnvPlugin.transformToLegacyEnv (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:64:38)
    at EnvPlugin.register (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/envs/dist/env.plugin.js:83:22)
    at Plugin.register (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugin.js:30:14)
    at Plugins.registerPluginWithTryCatch (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:67:21)
    at /Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:53:23
    at Array.map (<anonymous>)
    at Object.provider (/Users/jinjiang/Developer/teambit/bit/node_modules/@teambit/aspect-loader/dist/plugins.js:52:35)
failed loading extension teambit.workspace/workspace
[*] the command "new" has been terminated with an error code 1
```

</details>

Thanks.