### PR TITLE
feat, better handling of types components

### DIFF
--- a/scopes/typescript/typescript/typescript.compiler.ts
+++ b/scopes/typescript/typescript/typescript.compiler.ts
@@ -124,7 +124,8 @@ export class TypescriptCompiler implements Compiler, TypescriptCompilerInterface
         const packageJson = PackageJsonFile.loadFromCapsuleSync(capsule.path);
         // the types['index.ts'] is needed only during the build to avoid errors when tsc finds the
         // same type once in the d.ts and once in the ts file.
-        if (packageJson.packageJsonObject.types) {
+        // the reason for `packageJson.packageJsonObject.main` is that .d.ts components don't have a main file and they do need the types prop
+        if (packageJson.packageJsonObject.types && packageJson.packageJsonObject.main) {
           delete packageJson.packageJsonObject.types;
           await packageJson.write();
         }

--- a/src/utils/bit/component-placeholders.ts
+++ b/src/utils/bit/component-placeholders.ts
@@ -17,6 +17,11 @@ export function replacePlaceHolderForPackageValue(
 ): string {
   if (typeof template !== 'string') return template;
 
+  // kind of a hack, but couldn't find a better way to do it. for types components, seems like the mainFile is empty
+  if (template.includes('{main}.js') && mainFile?.endsWith('.d.ts')) {
+    return '';
+  }
+
   const values = {
     main: () => (mainFile ? getMainFileWithoutExtension(mainFile) : mainFile),
     name: () => replaceSlashesWithDots(name),


### PR DESCRIPTION
## Components with `*.d.ts` as main-file

- fix the `main` prop of package.json to be empty. currently it's `dist/<file-name>.d.js` (which doesn't exist, as d.ts files are not compiled into d.js, they're just copied).
- fix the `types` prop during build to not get deleted.
