### PR TITLE
improvement(scope-rename), remove old links, create new links and compile

### DIFF
--- a/e2e/harmony/scope-cmd.e2e.ts
+++ b/e2e/harmony/scope-cmd.e2e.ts
@@ -86,6 +86,7 @@ describe('bit scope command', function () {
       helper.fixtures.populateComponents(2);
       helper.command.setScope('old-org.my-scope1', 'comp1');
       helper.command.setScope('old-org.my-scope2', 'comp2');
+
       helper.command.renameScopeOwner('old-org', 'new-org');
     });
     it('should rename the default-scope in workspace.jsonc', () => {
@@ -95,6 +96,22 @@ describe('bit scope command', function () {
       const list = helper.command.listParsed();
       const ids = list.map((c) => c.id);
       expect(ids).to.have.members(['new-org.my-scope1/comp1', 'new-org.my-scope2/comp2']);
+    });
+    it('should delete the old link to node_modules', () => {
+      const linkPath1 = path.join(helper.scopes.localPath, 'node_modules', '@old-org/my-scope1.comp1');
+      expect(linkPath1).to.not.be.a.path();
+      const linkPath2 = path.join(helper.scopes.localPath, 'node_modules', '@old-org/my-scope2.comp2');
+      expect(linkPath2).to.not.be.a.path();
+    });
+    it('should create a new link to node_modules', () => {
+      const linkPath1 = path.join(helper.scopes.localPath, 'node_modules', '@new-org/my-scope1.comp1');
+      expect(linkPath1).to.be.a.directory();
+      const linkPath2 = path.join(helper.scopes.localPath, 'node_modules', '@new-org/my-scope2.comp2');
+      expect(linkPath2).to.be.a.directory();
+    });
+    it('should compile the renamed components', () => {
+      const linkPath = path.join(helper.scopes.localPath, 'node_modules', '@new-org/my-scope1.comp1/dist');
+      expect(linkPath).to.be.a.directory();
     });
   });
 });

--- a/e2e/harmony/scope-cmd.e2e.ts
+++ b/e2e/harmony/scope-cmd.e2e.ts
@@ -1,4 +1,5 @@
 import chai, { expect } from 'chai';
+import path from 'path';
 import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
 
@@ -34,6 +35,30 @@ describe('bit scope command', function () {
       expect(showFork.config).to.have.property('forkedFrom');
       expect(showFork.config.forkedFrom.scope).to.equal(helper.scopes.remote);
       expect(showFork.config.forkedFrom.name).to.equal('comp1');
+    });
+  });
+  describe('bit scope rename', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.renameScope(helper.scopes.remote, 'new-scope');
+    });
+    it('should rename the scope', () => {
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(1);
+      expect(list[0].id).to.equal('new-scope/comp1');
+    });
+    it('should delete the old link to node_modules', () => {
+      const linkPath = path.join(helper.scopes.localPath, 'node_modules', `@${helper.scopes.remote}`, 'comp1');
+      expect(linkPath).to.not.be.a.path();
+    });
+    it('should create a new link to node_modules', () => {
+      const linkPath = path.join(helper.scopes.localPath, 'node_modules', '@new-scope', 'comp1');
+      expect(linkPath).to.be.a.directory();
+    });
+    it('should compile the renamed components', () => {
+      const linkPath = path.join(helper.scopes.localPath, 'node_modules', '@new-scope', 'comp1', 'dist');
+      expect(linkPath).to.be.a.directory();
     });
   });
   describe('bit scope rename --refactor', () => {

--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -112,7 +112,7 @@ export default class NodeModuleLinker {
       bindingPrefix: legacyComponent.bindingPrefix,
       id: componentId,
       allowNonScope: true,
-      defaultScope: this._getDefaultScope(legacyComponent),
+      defaultScope: component.id.scope,
       extensions: legacyComponent.extensions,
     });
 


### PR DESCRIPTION
Remove old links to node_modules once `bit scope rename` renamed the components. Then, re-link and compile.
Same for `bit scope rename-owner`.