### PR TITLE
feat: add raw property to the HTML Injector

### DIFF
--- a/scopes/webpack/config-mutator/config-mutator.ts
+++ b/scopes/webpack/config-mutator/config-mutator.ts
@@ -3,7 +3,7 @@ import { Configuration, ResolveOptions, RuleSetRule } from 'webpack';
 import { merge, mergeWithCustomize, mergeWithRules, CustomizeRule } from 'webpack-merge';
 import { ICustomizeOptions } from 'webpack-merge/dist/types';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
-import { inject } from '@teambit/html.modules.inject-html-element';
+import { inject, InjectedHtmlElement as CustomHtmlElement } from '@teambit/html.modules.inject-html-element';
 
 export * from 'webpack-merge';
 
@@ -24,14 +24,6 @@ type MergeOpts = {
 
 type Rules = {
   [s: string]: CustomizeRule | Rules;
-};
-
-type CustomHtmlElement = {
-  parent: 'head' | 'body';
-  position: 'prepend' | 'append';
-  tag: string;
-  content?: string;
-  attributes?: { [key: string]: string };
 };
 
 const defaultAddToArrayOpts: AddToArrayOpts = {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -196,7 +196,7 @@
         "@teambit/graph.cleargraph": "0.0.1",
         "@teambit/graphql.hooks.use-query-light": "1.0.0",
         "@teambit/harmony": "0.4.6",
-        "@teambit/html.modules.inject-html-element": "^0.0.2",
+        "@teambit/html.modules.inject-html-element": "^0.0.3",
         "@teambit/html.modules.render-template": "0.0.104",
         "@teambit/lanes.ui.compare.lane-compare": "^0.0.69",
         "@teambit/lanes.ui.compare.lane-compare-drawer": "^0.0.51",


### PR DESCRIPTION
## Proposed Changes

- Bump version for `@teambit/html.modules.inject-html-element` and use same types (The new version allows the use of `raw` property instead of using attributes and element tags)
