### PR TITLE
fix(new), log the error before removing the new dir

### DIFF
--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -61,6 +61,7 @@ export class WorkspaceGenerator {
       });
       // await this.buildUI(); // disabled for now. it takes too long
     } catch (err: any) {
+      this.logger.error(`failed generating a new workspace, will delete the dir ${this.workspacePath}`, err);
       await fs.remove(this.workspacePath);
       throw err;
     }


### PR DESCRIPTION
Otherwise, if the `fs.remove` fails, we won't know what was the reason