### PR TITLE
fix(snap), avoid importing-delta when isolating non-modified comps

### DIFF
--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -343,6 +343,7 @@ once done, to continue working, please run "bit cc"`
 
   /**
    * returns null if we can't determine whether it's on the lane or not.
+   * if throwForDivergeDataErr is false, it also returns null when divergeData wasn't able to get Version objects or failed for whatever reason.
    *
    * sadly, there are not good tests for this. it pretty complex to create them as it involves multiple scopes and
    * packages installations. be careful when changing this.
@@ -350,7 +351,7 @@ once done, to continue working, please run "bit cc"`
    * it's needed for importing artifacts to know whether the artifact could be found on the origin scope or on the
    * lane-scope
    */
-  async isIdOnLane(id: BitId, lane?: Lane | null): Promise<boolean | null> {
+  async isIdOnLane(id: BitId, lane?: Lane | null, throwForDivergeDataErr = true): Promise<boolean | null> {
     if (!lane) return false;
 
     // it's possible that main was merged to the lane, so the ref in the lane object is actually a tag.
@@ -373,6 +374,7 @@ once done, to continue working, please run "bit cc"`
     const divergeData = await getDivergeData({
       repo: this.objects,
       modelComponent: component,
+      throws: throwForDivergeDataErr,
       targetHead: component.head, // target is main
       sourceHead: Ref.from(laneIdWithDifferentVersion.version as string), // source is lane
     });


### PR DESCRIPTION
When isolating non-modified components into capsules, the dists are written from the artifacts saved in the scope.
If checked out to a lane, sometimes we don't know whether the requested id is on the lane and therefore the artifacts should be fetched from the lane-scope or it's on main and the import should go to the original scope. 
To determine this better we fetch delta from both main and lane so then we could traverse the history and find out whether it's on main or lane.
Thing is that in most cases, this import is not needed and we're able to easily determine whether a component is on a lane, especially because we have the VersionHistory object.
This PR skips the import, and in case we're unable to determine the origin due to missing Version object, it tries to find the dists on both, the lane and main.