### PR TITLE
load aspects error handling

### DIFF
--- a/e2e/harmony/load-extensions.e2e.4.ts
+++ b/e2e/harmony/load-extensions.e2e.4.ts
@@ -1,3 +1,4 @@
+import stripAnsi from 'strip-ansi';
 import chai, { expect } from 'chai';
 import path from 'path';
 
@@ -100,7 +101,13 @@ describe('load extensions', function () {
         });
         it('should show a warning about the problematic extension', () => {
           expect(output).to.have.string(
-            UNABLE_TO_LOAD_EXTENSION_FROM_LIST(['my-scope/extension-provider-error'], 'error in provider')
+            stripAnsi(
+              UNABLE_TO_LOAD_EXTENSION_FROM_LIST(
+                ['my-scope/extension-provider-error'],
+                'error in provider',
+                'teambit.workspace/workspace (cli.registerOnStart)'
+              )
+            )
           );
         });
       });

--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -16,6 +16,23 @@ export type ResolveAspectsOptions = FilterAspectsOptions & {
 };
 
 export type LoadAspectsOptions = {
+  /* `throwOnError` is an optional parameter that can be passed to the loadAspects method in the `ComponentFactory` interface. If
+  set to `true`, it will cause the method to throw an error if an error occurs during its execution. If set to `false`
+  or not provided, the method will print a warning instead of throwing it. */
+  throwOnError?: boolean;
+  /* `hideMissingModuleError` is an optional parameter that can be passed to the `loadAspects` method in the
+  `ComponentFactory` interface. If set to `true`, it will prevent the method from throwing/printing an error if a required module
+  is missing during the loading of an aspect. Instead, it will continue loading the other
+  aspects. If set to `false` or not provided, the method will print/throw an error if a required module is missing.
+  (considering throwOnError as well) */
+  hideMissingModuleError?: boolean;
+
+  /* The `ignoreErrors` property is an optional boolean parameter that can be passed to the `LoadAspectsOptions` object in
+  the `ComponentFactory` interface. If set to `true`, it will cause the `loadAspects` method to ignore any errors that
+  occur during the loading of aspects and continue loading the other aspects. If set to `false` or not provided, the
+  method will print/throw an error if a required module is missing or if any other error occurs during the loading of
+  aspects. */
+  ignoreErrors?: boolean;
   [key: string]: any;
 };
 

--- a/scopes/component/component/index.ts
+++ b/scopes/component/component/index.ts
@@ -7,7 +7,12 @@ export { Component, InvalidComponent } from './component';
 export { ComponentID } from '@teambit/component-id';
 export { default as ComponentFS } from './component-fs';
 export type { default as ComponentConfig } from './config';
-export type { ComponentFactory, ResolveAspectsOptions, FilterAspectsOptions } from './component-factory';
+export type {
+  ComponentFactory,
+  ResolveAspectsOptions,
+  FilterAspectsOptions,
+  LoadAspectsOptions,
+} from './component-factory';
 export type { AspectList } from './aspect-list';
 export { AspectEntry, AspectData, ResolveComponentIdFunc } from './aspect-entry';
 // TODO: check why it's not working when using the index in snap dir like this:

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -415,7 +415,7 @@ export class IsolatorMain {
       longProcessLogger.end();
       // this.logger.consoleSuccess();
       const capsuleListOutput = allCapsuleList.map((capsule) => capsule.component.id.toString()).join(', ');
-      this.logger.consoleSuccess(`following capsule(s) ensured ${chalk.cyan(capsuleListOutput)}`);
+      this.logger.consoleSuccess(`resolved aspect(s): ${chalk.cyan(capsuleListOutput)}`);
     }
 
     return allCapsuleList;

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -39,7 +39,7 @@ export class PnpmPackageManager implements PackageManager {
     if (!installOptions.hidePackageManagerOutput) {
       // this.logger.setStatusLine('installing dependencies using pnpm');
       // turn off the logger because it interrupts the pnpm output
-      this.logger.console('-------------------------PNPM OUTPUT-------------------------');
+      // this.logger.console('-------------------------PNPM OUTPUT-------------------------');
       this.logger.off();
     }
     const registries = await this.depResolver.getRegistries();
@@ -82,7 +82,7 @@ export class PnpmPackageManager implements PackageManager {
     if (!installOptions.hidePackageManagerOutput) {
       this.logger.on();
       // Make a divider row to improve output
-      this.logger.console('-------------------------END PNPM OUTPUT-------------------------');
+      // this.logger.console('-------------------------END PNPM OUTPUT-------------------------');
       // this.logger.consoleSuccess('installing dependencies using pnpm');
     }
   }

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -68,6 +68,8 @@ export type Descriptor = RegularCompDescriptor | EnvCompDescriptor;
 export const DEFAULT_ENV = 'teambit.harmony/node';
 
 export class EnvsMain {
+  private failedToLoadExt = new Set<string>();
+
   static runtime = MainRuntime;
 
   private alreadyShownWarning = {};
@@ -113,6 +115,22 @@ export class EnvsMain {
    */
   async createEnvironment(components: Component[]): Promise<Runtime> {
     return this.createRuntime(components);
+  }
+
+  /**
+   *
+   * @param id
+   */
+  /**
+   * This function adds an extension ID to a set of failed to load extensions.
+   * This mostly used by the aspect loader to add such issues
+   * Then it is used to hide different errors that are caused by the same issue.
+   * @param {string} id - string - represents the unique identifier of an extension that failed to load.
+   */
+  addFailedToLoadExtension(id: string) {
+    if (!this.failedToLoadExt.has(id)) {
+      this.failedToLoadExt.add(id);
+    }
   }
 
   /**
@@ -617,7 +635,7 @@ export class EnvsMain {
   }
 
   private printWarningIfFirstTime(envId: string, message: string) {
-    if (!this.alreadyShownWarning[envId]) {
+    if (!this.alreadyShownWarning[envId] && !this.failedToLoadExt.has(envId)) {
       this.alreadyShownWarning[envId] = true;
       this.logger.consoleWarning(message);
     }

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -638,7 +638,7 @@ export class AspectLoaderMain {
       const ids = extensionsManifests.map((manifest) => manifest.id || 'unknown');
       // TODO: improve texts
       const errorMsg = e.message.split('\n')[0];
-      const warning = UNABLE_TO_LOAD_EXTENSION_FROM_LIST(ids, errorMsg, neededFor, e);
+      const warning = UNABLE_TO_LOAD_EXTENSION_FROM_LIST(ids, errorMsg, neededFor);
       this.logger.error(warning, e);
       if (mergedOptions.ignoreErrors) return;
       if (e.code === 'MODULE_NOT_FOUND' && mergedOptions.hideMissingModuleError) return;

--- a/scopes/harmony/aspect-loader/constants.ts
+++ b/scopes/harmony/aspect-loader/constants.ts
@@ -1,8 +1,15 @@
+import chalk from 'chalk';
+
 export const UNABLE_TO_LOAD_EXTENSION = (id: string, errMsg?: string) =>
-  `error: unable to load the extension "${id}", due to an error "${
+  `error: Bit received an error loading "${id}", due to the error "${
     errMsg || '<unknown-error>'
   }", please use the '--log=error' flag for the full error.`;
-export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[], errMsg?: string) =>
-  `couldn't load one of the following extensions ${ids.join(', ')}, due to an error "${
-    errMsg || '<unknown-error>'
-  }", please use the '--log=error' flag for the full error.`;
+export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[], errMsg?: string, neededFor?: string, err?: any) => {
+  // const installOutput = err?.code === 'MODULE_NOT_FOUND' ? `try running "bit install" to install the missing dependencies` : '';
+  const installOutput = `try running ${chalk.cyan('"bit install"')} to fix this issue`;
+  return `Bit received an error loading ${chalk.cyan(ids.join(', '))}, due to the error:
+"${errMsg || '<unknown-error>'}".
+This is required for the component: ${chalk.cyan(neededFor || 'unknown')}
+Please use the ${chalk.cyan("'--log=error'")} flag for the full error.
+${installOutput}`;
+};

--- a/scopes/harmony/aspect-loader/constants.ts
+++ b/scopes/harmony/aspect-loader/constants.ts
@@ -11,5 +11,6 @@ export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[], errMsg?: strin
 "${errMsg || '<unknown-error>'}".
 This is required for the component: ${chalk.cyan(neededFor || 'unknown')}
 Please use the ${chalk.cyan("'--log=error'")} flag for the full error.
-${installOutput}`;
+${installOutput}
+`;
 };

--- a/scopes/harmony/aspect-loader/constants.ts
+++ b/scopes/harmony/aspect-loader/constants.ts
@@ -4,7 +4,7 @@ export const UNABLE_TO_LOAD_EXTENSION = (id: string, errMsg?: string) =>
   `error: Bit received an error loading "${id}", due to the error "${
     errMsg || '<unknown-error>'
   }", please use the '--log=error' flag for the full error.`;
-export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[], errMsg?: string, neededFor?: string, err?: any) => {
+export const UNABLE_TO_LOAD_EXTENSION_FROM_LIST = (ids: string[], errMsg?: string, neededFor?: string) => {
   // const installOutput = err?.code === 'MODULE_NOT_FOUND' ? `try running "bit install" to install the missing dependencies` : '';
   const installOutput = `try running ${chalk.cyan('"bit install"')} to fix this issue`;
   return `Bit received an error loading ${chalk.cyan(ids.join(', '))}, due to the error:

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -17,7 +17,7 @@ import { CliCmd, CliGenerateCmd } from './cli.cmd';
 import { HelpCmd } from './help.cmd';
 
 export type CommandList = Array<Command>;
-export type OnStart = (hasWorkspace: boolean) => Promise<void>;
+export type OnStart = (hasWorkspace: boolean, currentCommand: string) => Promise<void>;
 
 export type OnStartSlot = SlotRegistry<OnStart>;
 export type CommandsSlot = SlotRegistry<CommandList>;
@@ -100,7 +100,8 @@ export class CLIMain {
 
   private async invokeOnStart(hasWorkspace: boolean) {
     const onStartFns = this.onStartSlot.values();
-    await pMapSeries(onStartFns, (onStart) => onStart(hasWorkspace));
+    const currentCommand = process.argv[2];
+    await pMapSeries(onStartFns, (onStart) => onStart(hasWorkspace, currentCommand));
   }
 
   private setDefaults(command: Command) {

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -65,7 +65,7 @@ export class ScopeAspectsLoader {
       return module.default || module;
     });
 
-    await this.aspectLoader.loadExtensionsByManifests(manifests, true);
+    await this.aspectLoader.loadExtensionsByManifests(manifests, undefined, { throwOnError: true });
   }
 
   private localAspects: string[] = [];

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -10,16 +10,17 @@ import { compact, uniq, difference, groupBy } from 'lodash';
 import { MainRuntime } from '@teambit/cli';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
 import { ExtensionManifest, Aspect } from '@teambit/harmony';
-import { Component, ComponentID, ResolveAspectsOptions } from '@teambit/component';
+import { Component, ComponentID, LoadAspectsOptions, ResolveAspectsOptions } from '@teambit/component';
 import { ScopeMain } from '@teambit/scope';
 import { Logger } from '@teambit/logger';
 import { EnvsMain } from '@teambit/envs';
 
 type ManifestOrAspect = ExtensionManifest | Aspect;
 
-export type ScopeLoadAspectsOptions = {
+export type ScopeLoadAspectsOptions = LoadAspectsOptions & {
   useScopeAspectsCapsule?: boolean;
   packageManagerConfigRootDir?: string;
+  workspaceName?: string;
 };
 
 export class ScopeAspectsLoader {
@@ -145,6 +146,7 @@ needed-for: ${neededFor || '<unknown>'}`);
     lane?: Lane,
     opts: {
       packageManagerConfigRootDir?: string;
+      workspaceName?: string;
     } = {}
   ): Promise<{ manifests: ManifestOrAspect[]; potentialPluginsIds: string[] }> {
     ids = uniq(ids);
@@ -229,7 +231,7 @@ needed-for: ${neededFor || '<unknown>'}`);
 
   async getResolvedAspects(
     components: Component[],
-    opts?: { skipIfExists?: boolean; packageManagerConfigRootDir?: string }
+    opts?: { skipIfExists?: boolean; packageManagerConfigRootDir?: string; workspaceName?: string }
   ): Promise<RequireableComponent[]> {
     if (!components || !components.length) return [];
     const network = await this.isolator.isolateComponents(
@@ -249,6 +251,7 @@ needed-for: ${neededFor || '<unknown>'}`);
         },
         context: {
           aspects: true,
+          workspaceName: opts?.workspaceName,
         },
       },
       this.scope.legacyScope
@@ -324,7 +327,7 @@ needed-for: ${neededFor || '<unknown>'}`);
   async requireAspects(
     components: Component[],
     throwOnError = false,
-    opts: { packageManagerConfigRootDir?: string } = {}
+    opts: { packageManagerConfigRootDir?: string; workspaceName?: string } = {}
   ): Promise<Array<ExtensionManifest | Aspect>> {
     const requireableExtensions = await this.getResolvedAspects(components, opts);
     if (!requireableExtensions) {

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -83,8 +83,7 @@ export default class InstallCmd implements Command {
     const executionTime = calculateTime(startTime, endTime);
     return `Successfully installed dependencies and compiled ${chalk.cyan(
       components.toArray().length.toString()
-    )} component(s) in ${chalk.cyan(executionTime.toString())} seconds
-Your workspace is ready to use 😃`;
+    )} component(s) in ${chalk.cyan(executionTime.toString())} seconds`;
   }
 }
 

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -107,6 +107,8 @@ export class InstallMain {
    * @memberof Workspace
    */
   async install(packages?: string[], options?: WorkspaceInstallOptions): Promise<ComponentMap<string>> {
+    // set workspace in install context
+    this.workspace.inInstallContext = true;
     if (packages && packages.length) {
       await this._addPackages(packages, options);
     }
@@ -136,7 +138,9 @@ export class InstallMain {
       }
     }
     await pMapSeries(this.preInstallSlot.values(), (fn) => fn(options)); // import objects if not disabled in options
-    return this._installModules(options);
+    const res = await this._installModules(options);
+    this.workspace.inInstallContext = false;
+    return res;
   }
 
   registerPreLink(fn: PreLink) {

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -10,6 +10,7 @@ import { partition, mergeWith, merge } from 'lodash';
 import { MergeConfigConflict } from './exceptions/merge-config-conflict';
 import { AspectSpecificField, ExtensionsOrigin, Workspace } from './workspace';
 import { MergeConflictFile } from './merge-conflict-file';
+import { WorkspaceLoadAspectsOptions } from './workspace-aspects-loader';
 
 export class AspectsMerger {
   private consumer: Consumer;
@@ -319,10 +320,10 @@ export class AspectsMerger {
   private async loadExtensions(
     extensions: ExtensionDataList,
     originatedFrom?: ComponentID,
-    throwOnError = false
+    opts: WorkspaceLoadAspectsOptions = {}
   ): Promise<void> {
     const workspaceAspectsLoader = this.workspace.getWorkspaceAspectsLoader();
-    return workspaceAspectsLoader.loadComponentsExtensions(extensions, originatedFrom, throwOnError);
+    return workspaceAspectsLoader.loadComponentsExtensions(extensions, originatedFrom, opts);
   }
 
   /**

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -238,7 +238,7 @@ export default async function provideWorkspace(
     const aspects = await workspace.loadAspects(
       aspectLoader.getNotLoadedConfiguredExtensions(),
       undefined,
-      'workspace.cli.registerOnStart'
+      'teambit.workspace/workspace (cli.registerOnStart)'
     );
     // clear aspect cache.
     const componentIds = await workspace.resolveMultipleComponentIds(aspects);

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -230,7 +230,10 @@ export default async function provideWorkspace(
   cli.register(...commands);
   component.registerHost(workspace);
 
-  cli.registerOnStart(async () => {
+  cli.registerOnStart(async (_hasWorkspace: boolean, currentCommand: string) => {
+    if (currentCommand === 'install') {
+      workspace.inInstallContext = true;
+    }
     await workspace.importCurrentLaneIfMissing();
     const aspects = await workspace.loadAspects(
       aspectLoader.getNotLoadedConfiguredExtensions(),

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -131,6 +131,11 @@ export class Workspace implements ComponentFactory {
   componentsScopeDirsMap: ComponentScopeDirMap;
   componentLoader: WorkspaceComponentLoader;
   bitMap: BitMap;
+  /**
+   * Indicate that we are now running installaion process
+   * This is important to know to ignore missing modules across different places
+   */
+  inInstallContext = false;
   private _cachedListIds?: ComponentID[];
   private componentLoadedSelfAsAspects: InMemoryCache<boolean>; // cache loaded components
   private aspectsMerger: AspectsMerger;
@@ -568,7 +573,10 @@ export class Workspace implements ComponentFactory {
       try {
         this.componentLoadedSelfAsAspects.set(component.id.toString(), true);
         this.logger.debug(`trying to load self as aspect with id ${component.id.toString()}`);
-        await this.loadAspects([component.id.toString()], undefined, component.id.toString());
+        // ignore missing modules when loading self
+        await this.loadAspects([component.id.toString()], undefined, component.id.toString(), {
+          hideMissingModuleError: true,
+        });
         // In most cases if the load self as aspect failed we don't care about it.
         // we only need it in specific cases to work, but this workspace.get runs on different
         // cases where it might fail (like when importing aspect, after the import objects


### PR DESCRIPTION
## Proposed Changes

- improve aspects loading errors
- getting workspace name for different scope aspects funcs
- remove pnpm output divider
- remove your workspace is ready to use from the install output
- change ensured capsule success message
- improve LoadAspectsOptions type and expose it
- add currentCommand name to cli onStartFn
- add "addFailedToLoadExtension" API to envs aspect
- add break line to output
- add "inInstallContext" to workspace aspect

