### PR TITLE
revert #7296 change

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -877,12 +877,11 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
    * @param ids
    */
   async importAndGetMany(ids: Array<ComponentID>): Promise<Component[]> {
+    if (!ids.length) return [];
     await this.importCurrentLaneIfMissing();
     await this.scope.import(ids, {
       reFetchUnBuiltVersion: shouldReFetchUnBuiltVersion(),
-      // @todo: when this is set to true, in some cases, "bit lane merge" tries to fetch older versions of
-      // lane-components from main for some reason. it needs to be debugged further to understand why.
-      preferDependencyGraph: false,
+      preferDependencyGraph: true,
     });
     return this.componentLoader.getMany(ids);
   }


### PR DESCRIPTION
See https://github.com/teambit/bit/pull/7296.
After investigating the issue, the reason for the ComponentNotFound in that case is due to another bug.
A component from laneX was depend on another component from laneY, which is invalid. (this [PR](https://github.com/teambit/bit/pull/7275) started the work to block it.) When it was set to fetch all deps, this dep was successfully fetched during importAndGetAspects because these two lanes belong to the same scope. 
However, when it was set to not fetch deps, this dependency was missing during the build-graph of load-aspect, which doesn't go automatically to the scope-lane but checks whether a component is belong to a lane. In this case, the dep wasn't part of the lane, and as such, it tried to fetch it from main and failed.