### PR TITLE
fix(status): avoid showing multiple-env error when the env was not exported yet

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -306,23 +306,34 @@ describe('custom env', function () {
       expect(() => helper.command.setEnv('comp1', envId));
     });
   });
-  describe('custom-env is 0.0.2 on the workspace, but comp1 is using it with 0.0.1', () => {
+  describe('custom-env is 0.0.2 on the workspace, but comp1 is using it in the model with 0.0.1', () => {
+    let envId: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(1);
       const envName = helper.env.setCustomEnv();
-      const envId = `${helper.scopes.remote}/${envName}`;
+      envId = `${helper.scopes.remote}/${envName}`;
       helper.command.setEnv('comp1', envId);
       helper.command.tagAllWithoutBuild();
       helper.command.tagWithoutBuild(envName, '--skip-auto-tag --unmodified'); // 0.0.2
     });
-    // @gilad todo: currently, this is failing with ComponentNotFound error.
+    // previously, this was failing with ComponentNotFound error.
     // it's happening during the load of comp1, we have the onLoad, where the workspace calculate extensions.
     // Once it has all extensions it's loading them. in this case, comp1 has the custom-env with 0.0.1 in the envs/envs
     // it's unable to find it in the workspace and asks the scope, which can't find it because it's the full-id include
     // scope-name.
-    it.skip('any bit command should not throw', () => {
+    // now, during the extension calculation, it checks whether the component is in the workspace, and if so, it sets
+    // the version according to the workspace.
+    it('any bit command should not throw', () => {
       expect(() => helper.command.status()).to.not.throw();
+    });
+    it('bit show should show the correct env', () => {
+      const env = helper.env.getComponentEnv('comp1');
+      expect(env).to.equal(`${envId}@0.0.2`);
+    });
+    it('bit show should not show the previous version of the env', () => {
+      const show = helper.command.showComponent('comp1');
+      expect(show).to.not.have.string(`${envId}@0.0.1`);
     });
   });
   describe('rename custom env', () => {

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -350,6 +350,21 @@ describe('custom env', function () {
       expect(env).to.include('new-env');
     });
   });
+  describe('tag custom env then env-set the comp uses it to another non-core env', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      const envName = helper.env.setCustomEnv();
+      const envId = `${helper.scopes.remote}/${envName}`;
+      helper.command.setEnv('comp1', envId);
+      helper.command.tagAllWithoutBuild();
+      helper.command.setEnv('comp1', 'teambit.react/react-env@0.0.56');
+    });
+    // previously, it didn't remove the custom-env due to mismatch between the legacy-id and harmony-id.
+    it('bit status should not show it as an issue because the previous env was removed', () => {
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MultipleEnvs.name);
+    });
+  });
 });
 
 function getEnvIdFromModel(compModel: any): string {

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -292,11 +292,11 @@ export class AspectsMerger {
     if (envWasFoundPreviously && (envAspect || aspectsRegisteredAsEnvs.length)) {
       const nonEnvs = extensionDataList.filter((e) => {
         // normally the env-id inside the envs aspect doesn't have a version, but the aspect itself has a version.
+        // also, the env-id inside the envs aspect includes the default-scope, but the aspect itself doesn't.
         if (
           (envFromEnvsAspect && e.stringId === envFromEnvsAspect) ||
           (envFromEnvsAspect && e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect) ||
           (envFromEnvsAspect && e.newExtensionId?.toStringWithoutVersion() === envFromEnvsAspect) ||
-          (e.newExtensionId && aspectsRegisteredAsEnvs.includes(e.newExtensionId.toString())) ||
           aspectsRegisteredAsEnvs.includes(e.stringId)
         ) {
           return false;

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -136,8 +136,14 @@ export class AspectsMerger {
       const extsWithoutSelf = selfInMergedExtensions?.extensionId
         ? extsWithoutRemoved.remove(selfInMergedExtensions.extensionId)
         : extsWithoutRemoved;
+      const preferWorkspaceVersion = origin !== 'BitmapFile' && origin !== 'ComponentJsonFile';
+      // it's important to do this resolution before the merge, otherwise we have issues with extensions
+      // coming from scope with local scope name, as opposed to the same extension comes from the workspace with default scope name
+      // also, it's important to do it before filtering the env, because when the env was not exported, it's saved with scope-name
+      // inside the "env" prop of teambit.envs/env, but without scope-name in the root.
+      const extsWithUpdatedIds = await this.resolveExtensionListIds(extsWithoutSelf, preferWorkspaceVersion);
       const { extensionDataListFiltered, envIsCurrentlySet } = await this.filterEnvsFromExtensionsIfNeeded(
-        extsWithoutSelf,
+        extsWithUpdatedIds,
         envWasFoundPreviously,
         origin
       );
@@ -189,9 +195,6 @@ export class AspectsMerger {
       await addExtensionsToMerge(scopeExtensionsNonSpecific, 'ModelNonSpecific');
     }
 
-    // It's important to do this resolution before the merge, otherwise we have issues with extensions
-    // coming from scope with local scope name, as opposed to the same extension comes from the workspace with default scope name
-    await Promise.all(extensionsToMerge.map((list) => this.resolveExtensionListIds(list.extensions)));
     const afterMerge = ExtensionDataList.mergeConfigs(extensionsToMerge.map((ext) => ext.extensions));
     await this.loadExtensions(afterMerge, componentId);
     const withoutRemoved = afterMerge.filter((extData) => !removedExtensionIds.includes(extData.stringId));
@@ -331,11 +334,15 @@ export class AspectsMerger {
    * This should be worked on the extension data list not the new aspect list
    * @param extensionList
    */
-  private async resolveExtensionListIds(extensionList: ExtensionDataList): Promise<ExtensionDataList> {
+  private async resolveExtensionListIds(
+    extensionList: ExtensionDataList,
+    preferWorkspaceVersion = false
+  ): Promise<ExtensionDataList> {
     const promises = extensionList.map(async (entry) => {
       if (entry.extensionId) {
         const id = await this.workspace.resolveComponentId(entry.extensionId);
-        entry.extensionId = id._legacy;
+        const idFromWorkspace = preferWorkspaceVersion ? this.workspace.getIdIfExist(id) : undefined;
+        entry.extensionId = (idFromWorkspace || id)._legacy;
       }
 
       return entry;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -869,6 +869,12 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return Boolean(this.consumer.bitmapIdsFromCurrentLane.find((_) => _.isEqualWithoutVersion(componentId._legacy)));
   }
 
+  getIdIfExist(componentId: ComponentID): ComponentID | undefined {
+    const id = this.consumer.bitmapIdsFromCurrentLane.find((_) => _.isEqualWithoutVersion(componentId._legacy));
+    if (!id) return undefined;
+    return componentId.changeVersion(id.version);
+  }
+
   /**
    * This will make sure to fetch the objects prior to load them
    * do not use it if you are not sure you need it.


### PR DESCRIPTION
currently, when changing the env from one local env to another non-core env, the local env wasn't removed because of a mismatch between the legacy-id and component-id.
This PR adds ComponentID to the aspects during the extensions calculation so it's possible to use it for the comparison.