### PR TITLE
improvement(envs-update): in case workspace-envs have versions, remove the versions

### DIFF
--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1597,6 +1597,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const allEnvs = await this.envs.createEnvironment(allWsComps);
     const getEnvWithVersion = async (envId: ComponentID) => {
       if (envId.hasVersion()) return envId;
+      if (isInWs(envId)) return envId;
       try {
         const fromRemote = await this.scope.getRemoteComponent(envId);
         return envId.changeVersion(fromRemote.id.version);
@@ -1607,27 +1608,14 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const getEnvs = async (): Promise<ComponentID[]> => {
       if (envIdStr) {
         const envCompId = await this.resolveComponentId(envIdStr);
-        if (isInWs(envCompId)) {
-          throw new BitError(
-            `error: unable to update the env ${envCompId.toString()}, it's already part of the workspace, as such, it's always using the workspace version`
-          );
-        }
         const envWithVer = await getEnvWithVersion(envCompId);
         return [envWithVer];
       }
-      // get all non-local envs.
       const allEnvsIds = allEnvs.runtimeEnvs.map((env) => env.id);
       const allEnvsCompIds = await this.resolveMultipleComponentIds(allEnvsIds);
-      // also check the envId has version, otherwise, it's a core env.
-      const nonLocalEnvs = allEnvsCompIds.filter((envId) => !isInWs(envId) && envId.hasVersion());
-      if (!nonLocalEnvs.length) {
-        throw new BitError(
-          `error: unable to update envs ${allEnvsIds
-            .map((e) => e.toString())
-            .join(', ')}, they're already part of the workspace`
-        );
-      }
-      const envsWithVersions = await mapSeries(nonLocalEnvs, (envId) =>
+      // check whether the envId has version, otherwise, it's a core env.
+      const nonCoreEnvs = allEnvsCompIds.filter((envId) => envId.hasVersion());
+      const envsWithVersions = await mapSeries(nonCoreEnvs, (envId) =>
         getEnvWithVersion(envId.changeVersion(undefined))
       );
       return envsWithVersions;
@@ -1647,15 +1635,27 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
         const compEnv = compEnvs[0]; // should not be more than one
         const envToUpdate = envsWithVerToUpdate.find((e) => e.isEqual(compEnv.id, { ignoreVersion: true }));
         if (!envToUpdate) throw new Error(`unable to find ${compEnv.id.toString()} in the envs to update`);
-        if (compEnv.id.version === envToUpdate.version) {
+        const envIsInWs = isInWs(envToUpdate);
+
+        if (!envIsInWs && compEnv.id.version === envToUpdate.version) {
           // nothing to update
+          alreadyUpToDate.push(comp.id);
+          return;
+        }
+        if (envIsInWs && !(await this.getSpecificComponentConfig(comp.id, compEnv.id.toString()))) {
+          // compEnv has version. If this id with version doesn't exist in .bitmap, either, it's not saved in .bitmap
+          // (probably it's in the model) or it's in .bitmap without version (as expected). either way, nothing to update.
           alreadyUpToDate.push(comp.id);
           return;
         }
         // don't mark with minus if not exist in .bitmap. it's not needed. when the component is loaded, the
         // merge-operation of the aspects removes duplicate aspect-id with different versions.
         await this.removeSpecificComponentConfig(comp.id, compEnv.id.toString(), false);
-        await this.addSpecificComponentConfig(comp.id, envToUpdate.toString(), compEnv.config);
+        await this.addSpecificComponentConfig(
+          comp.id,
+          envIsInWs ? envToUpdate.toStringWithoutVersion() : envToUpdate.toString(),
+          compEnv.config
+        );
         (updated[envToUpdate.toString()] ||= []).push(comp.id);
       })
     );


### PR DESCRIPTION
This is useful in case the env used by the workspace components was installed as a package and is now imported. 
With this PR, `bit envs updates` updates the component to use the env from the workspace by removing the version.