### PR TITLE
feat(doctor): introduce "--archive" to archive the workspace as well

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,6 +211,7 @@
     "stringify-package": "1.0.1",
     "stylus-lookup": "3.0.2",
     "table": "5.4.6",
+    "tar-fs": "2.1.1",
     "tar-stream": "2.2.0",
     "cli-table": "0.3.6",
     "uid-number": "0.0.6",

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -2,7 +2,9 @@ import fs from 'fs-extra';
 import os from 'os';
 // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
 import Stream from 'stream';
+import path from 'path';
 import tar from 'tar-stream';
+import tarFS from 'tar-fs';
 import { getHarmonyVersion } from '../../../bootstrap';
 
 import { CFG_USER_EMAIL_KEY, CFG_USER_NAME_KEY, DEBUG_LOG } from '../../../constants';
@@ -42,7 +44,13 @@ export type DoctorRunOneResult = {
 
 let runningTimeStamp;
 
-export default async function runAll({ filePath }: { filePath?: string }): Promise<DoctorRunAllResults> {
+export default async function runAll({
+  filePath,
+  archiveWorkspace,
+}: {
+  filePath?: string;
+  archiveWorkspace?: boolean;
+}): Promise<DoctorRunAllResults> {
   registerCoreAndExtensionsDiagnoses();
   runningTimeStamp = _getTimeStamp();
   const doctorRegistrar = DoctorRegistrar.getInstance();
@@ -56,9 +64,11 @@ export default async function runAll({ filePath }: { filePath?: string }): Promi
 export async function runOne({
   diagnosisName,
   filePath,
+  archiveWorkspace = false,
 }: {
   diagnosisName: string;
   filePath?: string;
+  archiveWorkspace?: boolean;
 }): Promise<DoctorRunOneResult> {
   if (!diagnosisName) {
     throw new MissingDiagnosisName();
@@ -72,7 +82,7 @@ export async function runOne({
   }
   const examineResult = await diagnosis.examine();
   const envMeta = await _getEnvMeta();
-  const savedFilePath = await _saveExamineResultsToFile([examineResult], envMeta, filePath);
+  const savedFilePath = await _saveExamineResultsToFile([examineResult], envMeta, filePath, archiveWorkspace);
   return { examineResult, savedFilePath, metaData: envMeta };
 }
 
@@ -85,13 +95,14 @@ export async function listDiagnoses(): Promise<Diagnosis[]> {
 async function _saveExamineResultsToFile(
   examineResults: ExamineResult[],
   envMeta: DoctorMetaData,
-  filePath: string | null | undefined
+  filePath: string | null | undefined,
+  archiveWorkspace = false
 ): Promise<string | null | undefined> {
   if (!filePath) {
     return Promise.resolve(undefined);
   }
   const finalFilePath = _calculateFinalFileName(filePath);
-  const packStream = await _generateExamineResultsTarFile(examineResults, envMeta);
+  const packStream = await _generateExamineResultsTarFile(examineResults, envMeta, archiveWorkspace, finalFilePath);
 
   const yourTarball = fs.createWriteStream(finalFilePath);
 
@@ -135,35 +146,54 @@ function _getTimeStamp() {
 
 async function _generateExamineResultsTarFile(
   examineResults: ExamineResult[],
-  envMeta: DoctorMetaData
+  envMeta: DoctorMetaData,
+  archiveWorkspace = false,
+  tarFilePath: string
 ): Promise<Stream.Readable> {
-  const pack = tar.pack(); // pack is a streams2 stream
   const debugLog = await _getDebugLogAsBuffer();
   const consumerInfo = await _getConsumerInfo();
   let bitmap;
   if (consumerInfo && consumerInfo.path) {
     bitmap = _getBitMap(consumerInfo.path);
   }
-  pack.entry({ name: 'env-meta.json' }, JSON.stringify(envMeta, null, 2));
-  pack.entry({ name: 'doc-results.json' }, JSON.stringify(examineResults, null, 2));
-  if (debugLog) {
-    pack.entry({ name: 'debug.log' }, debugLog);
-  }
-  if (bitmap) {
-    pack.entry({ name: '.bitmap' }, bitmap);
-  }
-  if (consumerInfo && consumerInfo.hasConsumerConfig) {
-    // TODO: support new config as well
-    const config = await WorkspaceConfig.loadIfExist(consumerInfo.path);
-    const legacyPlainConfig = config?._legacyPlainObject();
-    if (legacyPlainConfig) {
-      pack.entry({ name: 'config.json' }, JSON.stringify(legacyPlainConfig, null, 4));
+
+  const packExamineResults = async (pack) => {
+    pack.entry({ name: 'env-meta.json' }, JSON.stringify(envMeta, null, 2));
+    pack.entry({ name: 'doc-results.json' }, JSON.stringify(examineResults, null, 2));
+    if (debugLog) {
+      pack.entry({ name: 'debug.log' }, debugLog);
     }
+    if (!archiveWorkspace && bitmap) {
+      pack.entry({ name: '.bitmap' }, bitmap);
+    }
+    if (consumerInfo && consumerInfo.hasConsumerConfig) {
+      // TODO: support new config as well
+      const config = await WorkspaceConfig.loadIfExist(consumerInfo.path);
+      const legacyPlainConfig = config?._legacyPlainObject();
+      if (legacyPlainConfig) {
+        pack.entry({ name: 'config.json' }, JSON.stringify(legacyPlainConfig, null, 4));
+      }
+    }
+
+    pack.finalize();
+
+    return pack;
+  };
+
+  if (!archiveWorkspace) {
+    const pack = tar.pack(); // pack is a streams2 stream
+    return packExamineResults(pack);
   }
 
-  pack.finalize();
+  const myPack = tarFS.pack('.', {
+    ignore: (name) => {
+      return name.startsWith(`node_modules${path.sep}`) || name === tarFilePath;
+    },
+    finalize: false,
+    finish: packExamineResults,
+  });
 
-  return pack;
+  return myPack;
 }
 
 async function _getEnvMeta(): Promise<DoctorMetaData> {

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -57,7 +57,7 @@ export default async function runAll({
   const examineP = doctorRegistrar.diagnoses.map((diagnosis) => diagnosis.examine());
   const examineResults = await Promise.all(examineP);
   const envMeta = await _getEnvMeta();
-  const savedFilePath = await _saveExamineResultsToFile(examineResults, envMeta, filePath);
+  const savedFilePath = await _saveExamineResultsToFile(examineResults, envMeta, filePath, archiveWorkspace);
   return { examineResults, savedFilePath, metaData: envMeta };
 }
 

--- a/src/cache/in-memory-cache.ts
+++ b/src/cache/in-memory-cache.ts
@@ -20,5 +20,5 @@ export function getMaxSizeForComponents(): number {
 }
 
 export function getMaxSizeForObjects(): number {
-  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_OBJECTS) || 10000;
+  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_OBJECTS) || 5000;
 }

--- a/src/cli/commands/public-cmds/doctor-cmd.ts
+++ b/src/cli/commands/public-cmds/doctor-cmd.ts
@@ -41,13 +41,16 @@ export default class Doctor implements LegacyCommand {
     let filePath = save;
     // Happen when used --save without specify the location
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    if (save === true) {
+    if (save === true || archive === true) {
       filePath = '.';
     }
-    if (diagnosisName) {
-      return runOne({ diagnosisName, filePath });
+    if (typeof archive === 'string') {
+      filePath = archive;
     }
-    return runAll({ filePath });
+    if (diagnosisName) {
+      return runOne({ diagnosisName, filePath, archiveWorkspace: Boolean(archive) });
+    }
+    return runAll({ filePath, archiveWorkspace: Boolean(archive) });
   }
 
   report(res: DoctorRunAllResults | Diagnosis[], args: any, flags: Record<string, any>): string {

--- a/src/cli/commands/public-cmds/doctor-cmd.ts
+++ b/src/cli/commands/public-cmds/doctor-cmd.ts
@@ -19,6 +19,7 @@ export default class Doctor implements LegacyCommand {
     ['j', 'json', 'return diagnoses in json format'],
     ['', 'list', 'list all available diagnoses'],
     ['s', 'save [filePath]', 'save diagnoses to a file'],
+    ['a', 'archive [filePath]', 'archive the workspace including diagnosis info'],
   ] as CommandOptions;
   migration = false;
 
@@ -27,9 +28,11 @@ export default class Doctor implements LegacyCommand {
     {
       list = false,
       save,
+      archive,
     }: {
       list?: boolean;
       save?: string;
+      archive?: string;
     }
   ): Promise<DoctorRunAllResults | Diagnosis[] | DoctorRunOneResult> {
     if (list) {


### PR DESCRIPTION
For now, it includes the local scope, but ignores the node-modules. Later we'll have this configurable.