### PR TITLE
refactor: remove old dependencies to community aspects

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -11,25 +11,25 @@
 {
     "api-reference": {
         "scope": "teambit.api-reference",
-        "version": "0.0.148",
+        "version": "0.0.149",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/api-reference"
     },
     "api-server": {
         "scope": "teambit.harmony",
-        "version": "0.0.54",
+        "version": "0.0.55",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/api-server"
     },
     "application": {
         "scope": "teambit.harmony",
-        "version": "0.0.684",
+        "version": "0.0.685",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/application"
     },
     "aspect": {
         "scope": "teambit.harmony",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect"
     },
@@ -161,13 +161,13 @@
     },
     "aspect-loader": {
         "scope": "teambit.harmony",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-loader"
     },
     "babel": {
         "scope": "teambit.compilation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/babel"
     },
@@ -179,13 +179,13 @@
     },
     "bit": {
         "scope": "teambit.harmony",
-        "version": "0.1.29",
+        "version": "0.1.30",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit"
     },
     "bit-custom-aspect": {
         "scope": "teambit.harmony",
-        "version": "0.0.379",
+        "version": "0.0.380",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit-custom-aspect"
     },
@@ -197,55 +197,55 @@
     },
     "bit-roots": {
         "scope": "teambit.workspace",
-        "version": "0.0.39",
+        "version": "0.0.40",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/bit-roots"
     },
     "builder": {
         "scope": "teambit.pipelines",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/builder"
     },
     "builder-data": {
         "scope": "teambit.pipelines",
-        "version": "0.0.254",
+        "version": "0.0.255",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/modules/builder-data"
     },
     "bundler": {
         "scope": "teambit.compilation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/bundler"
     },
     "cache": {
         "scope": "teambit.harmony",
-        "version": "0.0.795",
+        "version": "0.0.796",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cache"
     },
     "changelog": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/changelog"
     },
     "checkout": {
         "scope": "teambit.component",
-        "version": "0.0.211",
+        "version": "0.0.212",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/checkout"
     },
     "clear-cache": {
         "scope": "teambit.workspace",
-        "version": "0.0.261",
+        "version": "0.0.262",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/clear-cache"
     },
     "cli": {
         "scope": "teambit.harmony",
-        "version": "0.0.702",
+        "version": "0.0.703",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli"
     },
@@ -287,49 +287,49 @@
     },
     "cloud": {
         "scope": "teambit.cloud",
-        "version": "0.0.250",
+        "version": "0.0.251",
         "mainFile": "index.ts",
         "rootDir": "scopes/cloud/cloud"
     },
     "code": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/code"
     },
     "command-bar": {
         "scope": "teambit.explorer",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/command-bar"
     },
     "community": {
         "scope": "teambit.community",
-        "version": "0.0.250",
+        "version": "0.0.251",
         "mainFile": "index.ts",
         "rootDir": "scopes/community/community"
     },
     "compiler": {
         "scope": "teambit.compilation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/compiler"
     },
     "component": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component"
     },
     "component-compare": {
         "scope": "teambit.component",
-        "version": "0.0.290",
+        "version": "0.0.291",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-compare"
     },
     "component-descriptor": {
         "scope": "teambit.component",
-        "version": "0.0.271",
+        "version": "0.0.272",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-descriptor"
     },
@@ -341,7 +341,7 @@
     },
     "component-log": {
         "scope": "teambit.component",
-        "version": "0.0.419",
+        "version": "0.0.420",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-log"
     },
@@ -353,13 +353,13 @@
     },
     "component-sizer": {
         "scope": "teambit.component",
-        "version": "0.0.415",
+        "version": "0.0.416",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-sizer"
     },
     "component-tree": {
         "scope": "teambit.component",
-        "version": "0.0.830",
+        "version": "0.0.831",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-tree"
     },
@@ -371,85 +371,85 @@
     },
     "component-writer": {
         "scope": "teambit.component",
-        "version": "0.0.78",
+        "version": "0.0.79",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-writer"
     },
     "composition-card": {
         "scope": "teambit.compositions",
-        "version": "0.0.64",
+        "version": "0.0.65",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/composition-card"
     },
     "compositions": {
         "scope": "teambit.compositions",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/compositions"
     },
     "config": {
         "scope": "teambit.harmony",
-        "version": "0.0.715",
+        "version": "0.0.716",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/config"
     },
     "content/cli-reference": {
         "scope": "teambit.harmony",
-        "version": "1.95.138",
+        "version": "1.95.139",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli-reference"
     },
     "dependencies": {
         "scope": "teambit.dependencies",
-        "version": "0.0.235",
+        "version": "0.0.236",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependencies"
     },
     "dependency-resolver": {
         "scope": "teambit.dependencies",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver"
     },
     "deprecation": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/deprecation"
     },
     "dev-files": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/dev-files"
     },
     "diagnostic": {
         "scope": "teambit.harmony",
-        "version": "0.0.335",
+        "version": "0.0.336",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/diagnostic"
     },
     "docs": {
         "scope": "teambit.docs",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/docs"
     },
     "eject": {
         "scope": "teambit.workspace",
-        "version": "0.0.513",
+        "version": "0.0.514",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/eject"
     },
     "elements": {
         "scope": "teambit.web-components",
-        "version": "0.0.495",
+        "version": "0.0.496",
         "mainFile": "index.ts",
         "rootDir": "scopes/web-components/elements"
     },
     "entities/lane-diff": {
         "scope": "teambit.lanes",
-        "version": "0.0.64",
+        "version": "0.0.65",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/entities/lane-diff"
     },
@@ -461,25 +461,25 @@
     },
     "env": {
         "scope": "teambit.envs",
-        "version": "0.0.415",
+        "version": "0.0.416",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/env"
     },
     "envs": {
         "scope": "teambit.envs",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/envs"
     },
     "eslint": {
         "scope": "teambit.defender",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/eslint"
     },
     "eslint-config-bit-react": {
         "scope": "teambit.react",
-        "version": "0.0.774",
+        "version": "0.0.775",
         "mainFile": "index.js",
         "rootDir": "scopes/react/eslint-config-bit-react"
     },
@@ -497,25 +497,25 @@
     },
     "export": {
         "scope": "teambit.scope",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/export"
     },
     "express": {
         "scope": "teambit.harmony",
-        "version": "0.0.800",
+        "version": "0.0.801",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/express"
     },
     "forking": {
         "scope": "teambit.component",
-        "version": "0.0.446",
+        "version": "0.0.447",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/forking"
     },
     "formatter": {
         "scope": "teambit.defender",
-        "version": "0.0.593",
+        "version": "0.0.594",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/formatter"
     },
@@ -527,31 +527,31 @@
     },
     "generator": {
         "scope": "teambit.generator",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/generator/generator"
     },
     "global-config": {
         "scope": "teambit.harmony",
-        "version": "0.0.704",
+        "version": "0.0.705",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/global-config"
     },
     "graph": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/graph"
     },
     "graphql": {
         "scope": "teambit.harmony",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/graphql"
     },
     "harmony-ui-app": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.684",
+        "version": "0.0.685",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
     },
@@ -569,19 +569,19 @@
     },
     "hooks/use-lane-components": {
         "scope": "teambit.lanes",
-        "version": "0.0.164",
+        "version": "0.0.165",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/hooks/use-lane-components"
     },
     "hooks/use-lane-readme": {
         "scope": "teambit.lanes",
-        "version": "0.0.164",
+        "version": "0.0.165",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/hooks/use-lane-readme"
     },
     "hooks/use-lanes": {
         "scope": "teambit.lanes",
-        "version": "0.0.165",
+        "version": "0.0.166",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/hooks/use-lanes"
     },
@@ -593,61 +593,61 @@
     },
     "hooks/use-viewed-lane-from-url": {
         "scope": "teambit.lanes",
-        "version": "0.0.127",
+        "version": "0.0.128",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/hooks/use-viewed-lane-from-url"
     },
     "html": {
         "scope": "teambit.html",
-        "version": "0.0.610",
+        "version": "0.0.611",
         "mainFile": "index.ts",
         "rootDir": "scopes/html/html"
     },
     "importer": {
         "scope": "teambit.scope",
-        "version": "0.0.471",
+        "version": "0.0.472",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/importer"
     },
     "insights": {
         "scope": "teambit.explorer",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/insights"
     },
     "install": {
         "scope": "teambit.workspace",
-        "version": "0.0.153",
+        "version": "0.0.154",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/install"
     },
     "isolator": {
         "scope": "teambit.component",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/isolator"
     },
     "issues": {
         "scope": "teambit.component",
-        "version": "0.0.350",
+        "version": "0.0.351",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/issues"
     },
     "jest": {
         "scope": "teambit.defender",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/jest"
     },
     "lane-id": {
         "scope": "teambit.lanes",
-        "version": "0.0.219",
+        "version": "0.0.220",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lane-id"
     },
     "lanes": {
         "scope": "teambit.lanes",
-        "version": "0.0.614",
+        "version": "0.0.615",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lanes"
     },
@@ -659,43 +659,43 @@
     },
     "linter": {
         "scope": "teambit.defender",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/linter"
     },
     "lister": {
         "scope": "teambit.component",
-        "version": "0.0.278",
+        "version": "0.0.279",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/lister"
     },
     "logger": {
         "scope": "teambit.harmony",
-        "version": "0.0.795",
+        "version": "0.0.796",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/logger"
     },
     "mdx": {
         "scope": "teambit.mdx",
-        "version": "0.0.1022",
+        "version": "0.0.1023",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/mdx"
     },
     "merge-lanes": {
         "scope": "teambit.lanes",
-        "version": "0.0.219",
+        "version": "0.0.220",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/merge-lanes"
     },
     "merging": {
         "scope": "teambit.component",
-        "version": "0.0.357",
+        "version": "0.0.358",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/merging"
     },
     "mocha": {
         "scope": "teambit.defender",
-        "version": "0.0.379",
+        "version": "0.0.380",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/mocha"
     },
@@ -725,7 +725,7 @@
     },
     "models/scope-model": {
         "scope": "teambit.scope",
-        "version": "0.0.360",
+        "version": "0.0.361",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/models/scope-model"
     },
@@ -755,7 +755,7 @@
     },
     "modules/diff": {
         "scope": "teambit.lanes",
-        "version": "0.0.337",
+        "version": "0.0.338",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/diff"
     },
@@ -815,7 +815,7 @@
     },
     "modules/node-modules-linker": {
         "scope": "teambit.workspace",
-        "version": "0.0.46",
+        "version": "0.0.47",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/modules/node-modules-linker"
     },
@@ -857,19 +857,19 @@
     },
     "mover": {
         "scope": "teambit.component",
-        "version": "0.0.73",
+        "version": "0.0.74",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/mover"
     },
     "multi-compiler": {
         "scope": "teambit.compilation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/multi-compiler"
     },
     "multi-tester": {
         "scope": "teambit.defender",
-        "version": "0.0.211",
+        "version": "0.0.212",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/multi-tester"
     },
@@ -887,31 +887,31 @@
     },
     "new-component-helper": {
         "scope": "teambit.component",
-        "version": "0.0.446",
+        "version": "0.0.447",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/new-component-helper"
     },
     "node": {
         "scope": "teambit.harmony",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/node"
     },
     "notifications": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/notifications/aspect"
     },
     "panels": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.703",
+        "version": "0.0.704",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/panels"
     },
     "panels/composition-gallery": {
         "scope": "teambit.compositions",
-        "version": "0.0.64",
+        "version": "0.0.65",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/panels/composition-gallery"
     },
@@ -941,7 +941,7 @@
     },
     "pkg": {
         "scope": "teambit.pkg",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/pkg/pkg"
     },
@@ -953,13 +953,13 @@
     },
     "pnpm": {
         "scope": "teambit.dependencies",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/pnpm"
     },
     "prettier": {
         "scope": "teambit.defender",
-        "version": "0.0.593",
+        "version": "0.0.594",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/prettier"
     },
@@ -971,61 +971,61 @@
     },
     "preview": {
         "scope": "teambit.preview",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/preview"
     },
     "pubsub": {
         "scope": "teambit.harmony",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/pubsub"
     },
     "react": {
         "scope": "teambit.react",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react"
     },
     "react-elements": {
         "scope": "teambit.react",
-        "version": "0.0.495",
+        "version": "0.0.496",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react-elements"
     },
     "react-native": {
         "scope": "teambit.react",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react-native"
     },
     "react-router": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/react-router/react-router"
     },
     "readme": {
         "scope": "teambit.mdx",
-        "version": "0.0.326",
+        "version": "0.0.327",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/readme"
     },
     "refactoring": {
         "scope": "teambit.component",
-        "version": "0.0.339",
+        "version": "0.0.340",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/refactoring"
     },
     "remove": {
         "scope": "teambit.component",
-        "version": "0.0.219",
+        "version": "0.0.220",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/remove"
     },
     "renaming": {
         "scope": "teambit.component",
-        "version": "0.0.446",
+        "version": "0.0.447",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/renaming"
     },
@@ -1139,13 +1139,13 @@
     },
     "schema": {
         "scope": "teambit.semantics",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/semantics/schema"
     },
     "scope": {
         "scope": "teambit.scope",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/scope"
     },
@@ -1163,25 +1163,25 @@
     },
     "sidebar": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/sidebar"
     },
     "sign": {
         "scope": "teambit.scope",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/sign"
     },
     "snapping": {
         "scope": "teambit.component",
-        "version": "0.0.357",
+        "version": "0.0.358",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/snapping"
     },
     "status": {
         "scope": "teambit.component",
-        "version": "0.0.354",
+        "version": "0.0.355",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/status"
     },
@@ -1211,19 +1211,19 @@
     },
     "tester": {
         "scope": "teambit.defender",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/tester"
     },
     "testing/load-aspect": {
         "scope": "teambit.harmony",
-        "version": "0.0.65",
+        "version": "0.0.66",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/testing/load-aspect"
     },
     "testing/mock-components": {
         "scope": "teambit.component",
-        "version": "0.0.66",
+        "version": "0.0.67",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/testing/mock-components"
     },
@@ -1247,7 +1247,7 @@
     },
     "tracker": {
         "scope": "teambit.component",
-        "version": "0.0.73",
+        "version": "0.0.74",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/tracker"
     },
@@ -1265,13 +1265,13 @@
     },
     "typescript": {
         "scope": "teambit.typescript",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/typescript"
     },
     "ui": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/ui"
     },
@@ -1313,7 +1313,7 @@
     },
     "ui/code-compare": {
         "scope": "teambit.code",
-        "version": "0.0.189",
+        "version": "0.0.190",
         "mainFile": "index.ts",
         "rootDir": "scopes/code/ui/code-compare"
     },
@@ -1331,19 +1331,19 @@
     },
     "ui/compare/lane-compare": {
         "scope": "teambit.lanes",
-        "version": "0.0.75",
+        "version": "0.0.76",
         "mainFile": "index.ts",
         "rootDir": "components/ui/compare/lane-compare"
     },
     "ui/compare/lane-compare-drawer": {
         "scope": "teambit.lanes",
-        "version": "0.0.54",
+        "version": "0.0.55",
         "mainFile": "index.ts",
         "rootDir": "components/ui/compare/lane-compare-drawer"
     },
     "ui/compare/lane-compare-hooks/use-lane-diff-status": {
         "scope": "teambit.lanes",
-        "version": "0.0.55",
+        "version": "0.0.56",
         "mainFile": "index.ts",
         "rootDir": "components/ui/compare/lane-compare-hooks/use-lane-diff-status"
     },
@@ -1355,7 +1355,7 @@
     },
     "ui/compare/lane-compare-page": {
         "scope": "teambit.lanes",
-        "version": "0.0.59",
+        "version": "0.0.60",
         "mainFile": "index.ts",
         "rootDir": "components/ui/compare/lane-compare-page"
     },
@@ -1373,7 +1373,7 @@
     },
     "ui/component-compare/changelog": {
         "scope": "teambit.component",
-        "version": "0.0.75",
+        "version": "0.0.76",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/changelog"
     },
@@ -1385,7 +1385,7 @@
     },
     "ui/component-compare/compare-aspects/compare-aspects": {
         "scope": "teambit.component",
-        "version": "0.0.52",
+        "version": "0.0.53",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/compare-aspects/compare-aspects"
     },
@@ -1397,7 +1397,7 @@
     },
     "ui/component-compare/compare-aspects/hooks/use-compare-aspects": {
         "scope": "teambit.component",
-        "version": "0.0.25",
+        "version": "0.0.26",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/compare-aspects/hooks/use-compare-aspects"
     },
@@ -1409,19 +1409,19 @@
     },
     "ui/component-compare/component-compare": {
         "scope": "teambit.component",
-        "version": "0.0.75",
+        "version": "0.0.76",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/component-compare"
     },
     "ui/component-compare/context": {
         "scope": "teambit.component",
-        "version": "0.0.25",
+        "version": "0.0.26",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/context"
     },
     "ui/component-compare/hooks/use-component-compare": {
         "scope": "teambit.component",
-        "version": "0.0.23",
+        "version": "0.0.24",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/hooks/use-component-compare"
     },
@@ -1451,13 +1451,13 @@
     },
     "ui/component-compare/models/component-compare-model": {
         "scope": "teambit.component",
-        "version": "0.0.21",
+        "version": "0.0.22",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/models/component-compare-model"
     },
     "ui/component-compare/models/component-compare-props": {
         "scope": "teambit.component",
-        "version": "0.0.10",
+        "version": "0.0.11",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/models/component-compare-props"
     },
@@ -1493,13 +1493,13 @@
     },
     "ui/component-compare/utils/sort-tabs": {
         "scope": "teambit.component",
-        "version": "0.0.10",
+        "version": "0.0.11",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/utils/sort-tabs"
     },
     "ui/component-compare/version-picker": {
         "scope": "teambit.component",
-        "version": "0.0.75",
+        "version": "0.0.76",
         "mainFile": "index.ts",
         "rootDir": "components/ui/component-compare/version-picker"
     },
@@ -1511,37 +1511,37 @@
     },
     "ui/component-drawer": {
         "scope": "teambit.component",
-        "version": "0.0.260",
+        "version": "0.0.261",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-drawer"
     },
     "ui/component-filters/component-filter-context": {
         "scope": "teambit.component",
-        "version": "0.0.125",
+        "version": "0.0.126",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-filters/component-filter-context"
     },
     "ui/component-filters/deprecate-filter": {
         "scope": "teambit.component",
-        "version": "0.0.125",
+        "version": "0.0.126",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-filters/deprecate-filter"
     },
     "ui/component-filters/env-filter": {
         "scope": "teambit.component",
-        "version": "0.0.131",
+        "version": "0.0.132",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-filters/env-filter"
     },
     "ui/component-filters/show-main-filter": {
         "scope": "teambit.component",
-        "version": "0.0.118",
+        "version": "0.0.119",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-filters/show-main-filter"
     },
     "ui/component-meta": {
         "scope": "teambit.component",
-        "version": "0.0.269",
+        "version": "0.0.270",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/ui/component-meta"
     },
@@ -1583,13 +1583,13 @@
     },
     "ui/composition-compare": {
         "scope": "teambit.compositions",
-        "version": "0.0.164",
+        "version": "0.0.165",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/ui/composition-compare"
     },
     "ui/composition-compare-section": {
         "scope": "teambit.compositions",
-        "version": "0.0.9",
+        "version": "0.0.10",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/ui/composition-compare-section"
     },
@@ -1703,7 +1703,7 @@
     },
     "ui/gallery": {
         "scope": "teambit.lanes",
-        "version": "0.0.43",
+        "version": "0.0.44",
         "mainFile": "index.ts",
         "rootDir": "components/ui/gallery"
     },
@@ -1739,7 +1739,7 @@
     },
     "ui/hooks/scope-context": {
         "scope": "teambit.scope",
-        "version": "0.0.360",
+        "version": "0.0.361",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/ui/hooks/scope-context"
     },
@@ -1781,7 +1781,7 @@
     },
     "ui/hooks/use-scope": {
         "scope": "teambit.scope",
-        "version": "0.0.365",
+        "version": "0.0.366",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/ui/hooks/use-scope"
     },
@@ -1805,7 +1805,7 @@
     },
     "ui/inputs/lane-selector": {
         "scope": "teambit.lanes",
-        "version": "0.0.119",
+        "version": "0.0.120",
         "mainFile": "index.ts",
         "rootDir": "components/ui/inputs/lane-selector"
     },
@@ -1823,13 +1823,13 @@
     },
     "ui/lane-details": {
         "scope": "teambit.lanes",
-        "version": "0.0.115",
+        "version": "0.0.116",
         "mainFile": "index.ts",
         "rootDir": "components/ui/lane-details"
     },
     "ui/lane-overview": {
         "scope": "teambit.lanes",
-        "version": "0.0.119",
+        "version": "0.0.120",
         "mainFile": "index.ts",
         "rootDir": "components/ui/lane-overview"
     },
@@ -1883,25 +1883,25 @@
     },
     "ui/menus/use-lanes-menu": {
         "scope": "teambit.lanes",
-        "version": "0.0.118",
+        "version": "0.0.119",
         "mainFile": "index.ts",
         "rootDir": "components/ui/menus/use-lanes-menu"
     },
     "ui/models": {
         "scope": "teambit.lanes",
-        "version": "0.0.42",
+        "version": "0.0.43",
         "mainFile": "index.ts",
         "rootDir": "components/ui/models_1"
     },
     "ui/models/lanes-model": {
         "scope": "teambit.lanes",
-        "version": "0.0.118",
+        "version": "0.0.119",
         "mainFile": "index.ts",
         "rootDir": "components/ui/models/lanes-model"
     },
     "ui/navigation/lane-switcher": {
         "scope": "teambit.lanes",
-        "version": "0.0.120",
+        "version": "0.0.121",
         "mainFile": "index.ts",
         "rootDir": "components/ui/navigation/lane-switcher"
     },
@@ -1931,13 +1931,13 @@
     },
     "ui/overview-compare": {
         "scope": "teambit.docs",
-        "version": "0.0.221",
+        "version": "0.0.222",
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/ui/overview-compare"
     },
     "ui/overview-compare-section": {
         "scope": "teambit.docs",
-        "version": "0.0.9",
+        "version": "0.0.10",
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/ui/overview-compare-section"
     },
@@ -1979,7 +1979,7 @@
     },
     "ui/readme": {
         "scope": "teambit.lanes",
-        "version": "0.0.44",
+        "version": "0.0.45",
         "mainFile": "index.ts",
         "rootDir": "components/ui/readme"
     },
@@ -2009,7 +2009,7 @@
     },
     "ui/side-bar": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.777",
+        "version": "0.0.778",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/uis/side-bar"
     },
@@ -2021,13 +2021,13 @@
     },
     "ui/test-compare": {
         "scope": "teambit.defender",
-        "version": "0.0.162",
+        "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/ui/test-compare"
     },
     "ui/test-compare-section": {
         "scope": "teambit.defender",
-        "version": "0.0.9",
+        "version": "0.0.10",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/ui/test-compare-section"
     },
@@ -2135,13 +2135,13 @@
     },
     "ui/version-block": {
         "scope": "teambit.component",
-        "version": "0.0.785",
+        "version": "0.0.786",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/ui/version-block"
     },
     "ui/version-dropdown": {
         "scope": "teambit.component",
-        "version": "0.0.759",
+        "version": "0.0.760",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/ui/version-dropdown"
     },
@@ -2159,7 +2159,7 @@
     },
     "update-dependencies": {
         "scope": "teambit.scope",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/update-dependencies"
     },
@@ -2177,7 +2177,7 @@
     },
     "user-agent": {
         "scope": "teambit.ui-foundation",
-        "version": "0.0.728",
+        "version": "0.0.729",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent"
     },
@@ -2213,43 +2213,43 @@
     },
     "variants": {
         "scope": "teambit.workspace",
-        "version": "0.0.807",
+        "version": "0.0.808",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/variants"
     },
     "watcher": {
         "scope": "teambit.workspace",
-        "version": "0.0.54",
+        "version": "0.0.55",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/watcher"
     },
     "webpack": {
         "scope": "teambit.webpack",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/webpack"
     },
     "worker": {
         "scope": "teambit.harmony",
-        "version": "0.0.1006",
+        "version": "0.0.1007",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/worker"
     },
     "workspace": {
         "scope": "teambit.workspace",
-        "version": "0.0.1042",
+        "version": "0.0.1043",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace"
     },
     "workspace-config-files": {
         "scope": "teambit.workspace",
-        "version": "0.0.22",
+        "version": "0.0.23",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace-config-files"
     },
     "yarn": {
         "scope": "teambit.dependencies",
-        "version": "0.0.1043",
+        "version": "0.0.1044",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/yarn"
     },

--- a/scopes/component/component-log/component-log.main.runtime.ts
+++ b/scopes/component/component-log/component-log.main.runtime.ts
@@ -3,10 +3,8 @@ import { BitId } from '@teambit/legacy-bit-id';
 import moment from 'moment';
 import WorkspaceAspect, { OutsideWorkspaceError, Workspace } from '@teambit/workspace';
 import pMapSeries from 'p-map-series';
-import { CommunityAspect } from '@teambit/community';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils/path';
 import { getFilesDiff } from '@teambit/legacy/dist/consumer/component-ops/components-diff';
-import type { CommunityMain } from '@teambit/community';
 import chalk from 'chalk';
 import getRemoteByName from '@teambit/legacy/dist/remotes/get-remote-by-name';
 import { ComponentLogAspect } from './component-log.aspect';
@@ -109,11 +107,11 @@ export class ComponentLogMain {
   }
 
   static slots = [];
-  static dependencies = [CLIAspect, WorkspaceAspect, CommunityAspect];
+  static dependencies = [CLIAspect, WorkspaceAspect];
   static runtime = MainRuntime;
-  static async provider([cli, workspace, community]: [CLIMain, Workspace, CommunityMain]) {
+  static async provider([cli, workspace]: [CLIMain, Workspace]) {
     const componentLog = new ComponentLogMain(workspace);
-    cli.register(new LogCmd(componentLog, community.getDocsDomain()), new LogFileCmd(componentLog));
+    cli.register(new LogCmd(componentLog), new LogFileCmd(componentLog));
     return componentLog;
   }
 }

--- a/scopes/component/component-log/log-cmd.ts
+++ b/scopes/component/component-log/log-cmd.ts
@@ -22,9 +22,7 @@ export default class LogCmd implements Command {
   skipWorkspace = true;
   arguments = [{ name: 'id', description: 'component-id or component-name' }];
 
-  constructor(private componentLog: ComponentLogMain, docsDomain: string) {
-    this.extendedDescription = `https://${docsDomain}/reference/cli-reference#log`;
-  }
+  constructor(private componentLog: ComponentLogMain) {}
 
   async report(
     [id]: [string],

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -4,12 +4,7 @@ import ConsumerComponent from '@teambit/legacy/dist/consumer/component/consumer-
 import { IssuesClasses } from '@teambit/component-issues';
 import { Command, CommandOptions } from '@teambit/cli';
 import { isFeatureEnabled, BUILD_ON_CI } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
-import {
-  WILDCARD_HELP,
-  NOTHING_TO_SNAP_MSG,
-  AUTO_SNAPPED_MSG,
-  COMPONENT_PATTERN_HELP,
-} from '@teambit/legacy/dist/constants';
+import { NOTHING_TO_SNAP_MSG, AUTO_SNAPPED_MSG, COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import { BitError } from '@teambit/bit-error';
 import { Logger } from '@teambit/logger';
 import { SnappingMain, SnapResults } from './snapping.main.runtime';
@@ -25,6 +20,7 @@ export class SnapCmd implements Command {
       description: `${COMPONENT_PATTERN_HELP}. By default, all new and modified components are snapped.`,
     },
   ];
+  helpUrl = 'docs/components/snaps';
   alias = '';
   options = [
     ['m', 'message <message>', 'log message describing the latest changes'],
@@ -61,10 +57,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
   loader = true;
   migration = true;
 
-  constructor(docsDomain: string, private snapping: SnappingMain, private logger: Logger) {
-    this.extendedDescription = `https://${docsDomain}/components/snaps
-${WILDCARD_HELP('snap')}`;
-  }
+  constructor(private snapping: SnappingMain, private logger: Logger) {}
 
   async report(
     [pattern]: string[],

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -2,7 +2,6 @@ import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
 import { LegacyOnTagResult } from '@teambit/legacy/dist/scope/scope';
 import { FlattenedDependenciesGetter } from '@teambit/legacy/dist/scope/component-ops/get-flattened-dependencies';
-import CommunityAspect, { CommunityMain } from '@teambit/community';
 import WorkspaceAspect, { OutsideWorkspaceError, Workspace } from '@teambit/workspace';
 import R from 'ramda';
 import semver, { ReleaseType } from 'semver';
@@ -958,7 +957,6 @@ there are matching among unmodified components thought. consider using --unmodif
   static dependencies = [
     WorkspaceAspect,
     CLIAspect,
-    CommunityAspect,
     LoggerAspect,
     IssuesAspect,
     InsightsAspect,
@@ -972,7 +970,6 @@ there are matching among unmodified components thought. consider using --unmodif
   static async provider([
     workspace,
     cli,
-    community,
     loggerMain,
     issues,
     insights,
@@ -984,7 +981,6 @@ there are matching among unmodified components thought. consider using --unmodif
   ]: [
     Workspace,
     CLIMain,
-    CommunityMain,
     LoggerMain,
     IssuesMain,
     InsightsMain,
@@ -1006,7 +1002,7 @@ there are matching among unmodified components thought. consider using --unmodif
       builder,
       importer
     );
-    const snapCmd = new SnapCmd(community.getBaseDomain(), snapping, logger);
+    const snapCmd = new SnapCmd(snapping, logger);
     const tagCmd = new TagCmd(snapping, logger);
     const tagFromScopeCmd = new TagFromScopeCmd(snapping, logger);
     const snapFromScopeCmd = new SnapFromScopeCmd(snapping, logger);

--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -13,12 +13,8 @@ import { GLOBAL_GROUP, STANDARD_GROUP, YargsAdapter } from './yargs-adapter';
 import { CommandNotFound } from './exceptions/command-not-found';
 
 export class CLIParser {
-  constructor(
-    private commands: Command[],
-    private groups: GroupsType,
-    public parser = yargs,
-    private docsDomain: string
-  ) {}
+  public parser = yargs;
+  constructor(private commands: Command[], private groups: GroupsType, private docsDomain: string) {}
 
   async parse(args = process.argv.slice(2)) {
     this.throwForNonExistsCommand(args[0]);

--- a/scopes/harmony/cli/cli.cmd.ts
+++ b/scopes/harmony/cli/cli.cmd.ts
@@ -54,7 +54,7 @@ export class CliCmd implements Command {
       completer: (line, cb) => completer(line, cb, this.cliMain),
     });
 
-    const cliParser = new CLIParser(this.cliMain.commands, this.cliMain.groups, undefined, this.docsDomain);
+    const cliParser = new CLIParser(this.cliMain.commands, this.cliMain.groups, this.docsDomain);
 
     rl.prompt();
 

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -94,7 +94,7 @@ export class CLIMain {
    */
   async run(hasWorkspace: boolean) {
     await this.invokeOnStart(hasWorkspace);
-    const CliParser = new CLIParser(this.commands, this.groups, undefined, this.community.getBaseDomain());
+    const CliParser = new CLIParser(this.commands, this.groups, this.community.getBaseDomain());
     await CliParser.parse();
   }
 

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -73,10 +73,7 @@ export class ImportCmd implements Command {
   remoteOp = true;
   _packageManagerArgs: string[]; // gets populated by yargs-adapter.handler().
 
-  constructor(private importer: ImporterMain, private docsDomain: string) {
-    this.extendedDescription = `https://${docsDomain}/components/importing-components
-${WILDCARD_HELP('import')}`;
-  }
+  constructor(private importer: ImporterMain) {}
 
   async report(
     [ids = []]: [string[]],

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -3,7 +3,6 @@ import chalk from 'chalk';
 import { compact } from 'lodash';
 import R from 'ramda';
 import { installationErrorOutput, compilationErrorOutput } from '@teambit/merging';
-import { WILDCARD_HELP } from '@teambit/legacy/dist/constants';
 import {
   FileStatus,
   MergeOptions,

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -1,8 +1,6 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import WorkspaceAspect, { OutsideWorkspaceError, Workspace } from '@teambit/workspace';
-import { CommunityAspect } from '@teambit/community';
-import type { CommunityMain } from '@teambit/community';
 import { Analytics } from '@teambit/legacy/dist/analytics/analytics';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
@@ -256,7 +254,6 @@ export class ImporterMain {
     CLIAspect,
     WorkspaceAspect,
     DependencyResolverAspect,
-    CommunityAspect,
     GraphAspect,
     ScopeAspect,
     ComponentWriterAspect,
@@ -264,11 +261,10 @@ export class ImporterMain {
     LoggerAspect,
   ];
   static runtime = MainRuntime;
-  static async provider([cli, workspace, depResolver, community, graph, scope, componentWriter, install, loggerMain]: [
+  static async provider([cli, workspace, depResolver, graph, scope, componentWriter, install, loggerMain]: [
     CLIMain,
     Workspace,
     DependencyResolverMain,
-    CommunityMain,
     GraphMain,
     ScopeMain,
     ComponentWriterMain,
@@ -286,7 +282,7 @@ export class ImporterMain {
     install.registerPreLink(async (opts) => {
       if (opts?.fetchObject) await importerMain.importCurrentObjects();
     });
-    cli.register(new ImportCmd(importerMain, community.getDocsDomain()), new FetchCmd(importerMain));
+    cli.register(new ImportCmd(importerMain), new FetchCmd(importerMain));
     return importerMain;
   }
 }

--- a/scopes/workspace/clear-cache/clear-cache-cmd.ts
+++ b/scopes/workspace/clear-cache/clear-cache-cmd.ts
@@ -13,7 +13,7 @@ export default class ClearCacheCmd implements Command {
   skipWorkspace = true;
   helpUrl = 'reference/workspace/clearing-cache';
 
-  constructor(private clearCache: ClearCacheMain, private docsDomain: string) {
+  constructor(private clearCache: ClearCacheMain) {
     this.extendedDescription = `The following gets removed by this command:
 1) V8 compiled code (generated the first time Bit is loaded by v8-compile-cache package)
 2) components cache on the filesystem (mainly the dependencies graph and docs)

--- a/scopes/workspace/clear-cache/clear-cache.main.runtime.ts
+++ b/scopes/workspace/clear-cache/clear-cache.main.runtime.ts
@@ -3,9 +3,6 @@ import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import ScopeAspect, { ScopeMain } from '@teambit/scope';
 import { clearCache } from '@teambit/legacy/dist/api/consumer';
 import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
-import { CommunityAspect } from '@teambit/community';
-import type { CommunityMain } from '@teambit/community';
-
 import getRemoteByName from '@teambit/legacy/dist/remotes/get-remote-by-name';
 import ClearCacheCmd from './clear-cache-cmd';
 import { ClearCacheAspect } from './clear-cache.aspect';
@@ -25,11 +22,11 @@ export class ClearCacheMain {
   }
 
   static slots = [];
-  static dependencies = [WorkspaceAspect, CLIAspect, ScopeAspect, CommunityAspect];
+  static dependencies = [WorkspaceAspect, CLIAspect, ScopeAspect];
   static runtime = MainRuntime;
-  static async provider([workspace, cli, scope, community]: [Workspace, CLIMain, ScopeMain, CommunityMain]) {
+  static async provider([workspace, cli, scope]: [Workspace, CLIMain, ScopeMain]) {
     const clearCacheMain = new ClearCacheMain(workspace);
-    cli.register(new ClearCacheCmd(clearCacheMain, community.getDocsDomain()));
+    cli.register(new ClearCacheCmd(clearCacheMain));
     ExternalActions.externalActions.push(new ClearCacheAction(scope));
 
     return clearCacheMain;

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1,7 +1,6 @@
 import fs, { pathExists } from 'fs-extra';
 import path from 'path';
 import { getRootComponentDir, getBitRootsDir, linkPkgsToBitRoots } from '@teambit/bit-roots';
-import { CommunityMain, CommunityAspect } from '@teambit/community';
 import { CompilerMain, CompilerAspect, CompilationInitiator } from '@teambit/compiler';
 import { CLIMain, CommandList, CLIAspect, MainRuntime } from '@teambit/cli';
 import chalk from 'chalk';
@@ -675,7 +674,6 @@ export class InstallMain {
     LoggerAspect,
     VariantsAspect,
     CLIAspect,
-    CommunityAspect,
     CompilerAspect,
     IssuesAspect,
     EnvsAspect,
@@ -685,13 +683,12 @@ export class InstallMain {
   static runtime = MainRuntime;
 
   static async provider(
-    [dependencyResolver, workspace, loggerExt, variants, cli, community, compiler, issues, envs, app]: [
+    [dependencyResolver, workspace, loggerExt, variants, cli, compiler, issues, envs, app]: [
       DependencyResolverMain,
       Workspace,
       LoggerMain,
       VariantsMain,
       CLIMain,
-      CommunityMain,
       CompilerMain,
       IssuesMain,
       EnvsMain,
@@ -719,7 +716,7 @@ export class InstallMain {
       new InstallCmd(installExt, workspace, logger),
       new UninstallCmd(installExt),
       new UpdateCmd(installExt),
-      new LinkCommand(installExt, workspace, logger, community.getDocsDomain()),
+      new LinkCommand(installExt, workspace, logger),
     ];
     // For now do not automate installation during aspect resolving
     // workspace.registerOnAspectsResolve(installExt.onAspectsResolveSubscriber.bind(installExt));

--- a/scopes/workspace/install/link/link.cmd.ts
+++ b/scopes/workspace/install/link/link.cmd.ts
@@ -47,12 +47,8 @@ export class LinkCommand implements Command {
     /**
      * logger extension.
      */
-    private logger: Logger,
-
-    private docsDomain: string
-  ) {
-    this.extendedDescription = `https://${this.docsDomain}/workspace/component-links`;
-  }
+    private logger: Logger
+  ) {}
 
   async report([ids]: [string[]], opts: LinkCommandOpts) {
     const startTime = Date.now();


### PR DESCRIPTION
They are not needed since the `helpUrl` was introduced a while ago.