### PR TITLE
fix(out-of-sync): recreate a lane if local scope got deleted and is new

### DIFF
--- a/e2e/harmony/out-of-sync-components-harmony.e2e.ts
+++ b/e2e/harmony/out-of-sync-components-harmony.e2e.ts
@@ -103,4 +103,17 @@ describe('components that are not synced between the scope and the consumer', fu
       expect(bitmap.comp1.version).to.equal('0.0.1');
     });
   });
+  describe('new lane got deleted', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.fs.deletePath('.bit');
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('should recrate the lane', () => {
+      expect(() => helper.command.showOneLane('dev')).to.not.throw();
+    });
+  });
 });

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -792,6 +792,19 @@ please create a new lane instead, which will include all components of this lane
     };
   }
 
+  private async recreateNewLaneIfDeleted() {
+    if (!this.workspace) return;
+    const laneId = this.getCurrentLaneId();
+    if (!laneId || laneId.isDefault() || this.workspace.consumer.bitMap.isLaneExported) {
+      return;
+    }
+    const laneObj = await this.scope.legacyScope.getCurrentLaneObject();
+    if (laneObj) {
+      return;
+    }
+    await this.createLane(laneId.name, { scope: laneId.scope });
+  }
+
   async addLaneReadme(readmeComponentIdStr: string, laneName?: string): Promise<{ result: boolean; message?: string }> {
     if (!this.workspace) {
       throw new BitError(`unable to track a lane readme component outside of Bit workspace`);
@@ -942,6 +955,9 @@ please create a new lane instead, which will include all components of this lane
       new LaneImportCmd(switchCmd),
     ];
     cli.register(laneCmd, switchCmd);
+    cli.registerOnStart(async () => {
+      await lanesMain.recreateNewLaneIfDeleted();
+    });
     graphql.register(lanesSchema(lanesMain));
     express.register([
       new LanesCreateRoute(lanesMain, logger),

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -152,15 +152,8 @@ export default class BitMap {
     let isLaneExported = false;
     let laneId: LaneId | undefined;
     if (componentsJson[LANE_KEY]) {
-      if (componentsJson[LANE_KEY].name) {
-        // backward compatibility
-        throw new Error(
-          `enable to migrate to the new Lane format of .bitmap. change to the previous Bit version, switch to main, then upgrade again`
-        );
-      } else {
-        laneId = new LaneId(componentsJson[LANE_KEY].id);
-        isLaneExported = componentsJson[LANE_KEY].exported;
-      }
+      laneId = new LaneId(componentsJson[LANE_KEY].id);
+      isLaneExported = componentsJson[LANE_KEY].exported;
     }
     BitMap.removeNonComponentFields(componentsJson);
 
@@ -228,7 +221,6 @@ export default class BitMap {
     };
     if (resetHard) {
       deleteBitMapFile();
-      // @todo: delete workspace lanes as well? maybe they're already taken care of within scope.reset
       return;
     }
     try {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -335,19 +335,6 @@ export default class Consumer {
     return this.componentLoader.loadMany(ids, throwOnFailure, loadOpts);
   }
 
-  async shouldDependenciesSavedAsComponents(bitIds: BitId[], saveDependenciesAsComponents?: boolean) {
-    if (saveDependenciesAsComponents === undefined) {
-      saveDependenciesAsComponents = this.config._saveDependenciesAsComponents;
-    }
-    const shouldDependenciesSavedAsComponents = bitIds.map((bitId: BitId) => {
-      return {
-        id: bitId, // if it doesn't go to the hub, it can't import dependencies as packages
-        saveDependenciesAsComponents: false,
-      };
-    });
-    return shouldDependenciesSavedAsComponents;
-  }
-
   async listComponentsForAutoTagging(modifiedComponents: BitIds): Promise<Component[]> {
     return getAutoTagPending(this, modifiedComponents);
   }


### PR DESCRIPTION
Currently, in this case, the .bitmap still has the lane-id but the scope doesn't have the lane object, so the user might be under impression that the workspace is checked out to a lane. Snap command doesn't throw and is snapped on main. Once the user is trying to export, an error is thrown about missing lane object.
This PR re-create the lane in this case. since the .bitmap has the full lane-id, the data to recreate the lane exists and it's possible to do.