### PR TITLE
perf, improve resolveComponentId performance when BitID is passed with a scope-name

### DIFF
--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -344,7 +344,11 @@ export class AspectsMerger {
   ): Promise<ExtensionDataList> {
     const promises = extensionList.map(async (entry) => {
       if (entry.extensionId) {
-        const componentId = await this.workspace.resolveComponentId(entry.extensionId);
+        // don't pass `entry.extensionId` (as BitId) to `resolveComponentId` because then it'll use the optimization
+        // of parsing it to ComponentID without checking the workspace. Normally, this optimization is good, but here
+        // in case the extension wasn't exported, the BitId is wrong, it has the scope-name due to incorrect BitId.parse
+        // in configEntryToDataEntry() function. It'd be ideal to fix it from there but it's not easy.
+        const componentId = await this.workspace.resolveComponentId(entry.extensionId.toString());
         const idFromWorkspace = preferWorkspaceVersion ? this.workspace.getIdIfExist(componentId) : undefined;
         const id = idFromWorkspace || componentId;
         entry.extensionId = id._legacy;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1360,7 +1360,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
    * @memberof Workspace
    */
   async resolveComponentId(id: string | ComponentID | BitId): Promise<ComponentID> {
-    if (id instanceof BitId && id.hasScope()) {
+    if (id instanceof BitId && id.hasScope() && id.hasVersion()) {
       // an optimization to make it faster when BitId is passed
       return ComponentID.fromLegacy(id);
     }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1360,6 +1360,10 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
    * @memberof Workspace
    */
   async resolveComponentId(id: string | ComponentID | BitId): Promise<ComponentID> {
+    if (id instanceof BitId && id.hasScope()) {
+      // an optimization to make it faster when BitId is passed
+      return ComponentID.fromLegacy(id);
+    }
     const getDefaultScope = async (bitId: BitId, bitMapOptions?: GetBitMapComponentOptions) => {
       if (bitId.scope) {
         return bitId.scope;


### PR DESCRIPTION
Previously, in the workspace this was tested on and on the ids matching the criteria, `workspace.resolveComponentId` took 41ms in average. After this optimization it took 0.2ms. 