### PR TITLE
fix(start), imporove CopmonentNotFound error when a component is missing on a lane

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -29,6 +29,7 @@ import ComponentWriterAspect, { ComponentWriterMain } from '@teambit/component-w
 import { SnapsDistance } from '@teambit/legacy/dist/scope/component-ops/snaps-distance';
 import { MergingMain, MergingAspect } from '@teambit/merging';
 import { ChangeType } from '@teambit/lanes.entities.lane-diff';
+import { ComponentNotFound } from '@teambit/legacy/dist/scope/exceptions';
 import { NoCommonSnap } from '@teambit/legacy/dist/scope/exceptions/no-common-snap';
 import { LanesAspect } from './lanes.aspect';
 import {
@@ -170,7 +171,15 @@ export class LanesMain {
             (
               await this.getLaneComponentIds(lane)
             ).map(async (laneCompId) => {
-              if (await this.scope.isComponentRemoved(laneCompId)) return undefined;
+              try {
+                if (await this.scope.isComponentRemoved(laneCompId)) return undefined;
+              } catch (err) {
+                if (err instanceof ComponentNotFound)
+                  throw new Error(
+                    `component "${laneCompId.toString()}" from the lane "${lane.id.toString()}" not found`
+                  );
+                throw err;
+              }
               return { id: laneCompId._legacy, head: laneCompId.version as string };
             })
           )


### PR DESCRIPTION
to include the lane-id.