### PR TITLE
fix(lane-merge), avoid showing workspace conflicts when it Semver satisfied

### DIFF
--- a/scopes/component/merging/config-merger.ts
+++ b/scopes/component/merging/config-merger.ts
@@ -4,7 +4,6 @@ import { Logger } from '@teambit/logger';
 import { isHash } from '@teambit/component-version';
 import {
   DependencyResolverAspect,
-  isRange,
   SerializedDependency,
   VariantPolicy,
   VariantPolicyEntry,
@@ -479,12 +478,7 @@ export class ConfigMerger {
         return;
       }
 
-      if (
-        currentDep.policy &&
-        otherDep.policy &&
-        isRange(currentDep.policy, currentDep.id) &&
-        isRange(otherDep.policy, otherDep.id)
-      ) {
+      if (currentDep.policy && otherDep.policy) {
         if (semver.satisfies(currentDep.version, otherDep.policy)) {
           return;
         }


### PR DESCRIPTION
## Proposed Changes

- Currently, `semver.satisfies` was checked only when the current-policy and other-policy were a range, which never happened, because saving the policy upon tag wasn't implemented yet. This PR removes this condition and always check whether it satisfies, and if it is, it won't be shown as a conflict.
- Fixes a bug where other-lane had the same version as workspace.jsonc, but different version than current-component. It was showing the same version from current/other as a conflict. 
