### PR TITLE
fix(artifacts), fix missing component error after tag

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-extractor.ts
+++ b/scopes/pipelines/builder/artifact/artifact-extractor.ts
@@ -43,7 +43,7 @@ export class ArtifactExtractor {
 
   async list(): Promise<ExtractorResult[]> {
     const ids = await this.scope.idsByPattern(this.pattern);
-    const components = await this.scope.loadMany(ids);
+    const components = await this.scope.getMany(ids);
     const artifactListPerId: ArtifactListPerId[] = components.map((component) => {
       return {
         id: component.id,

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -615,7 +615,8 @@ export class ScopeMain implements ComponentFactory {
   }
 
   /**
-   * load components from a scope and load their aspects
+   * important! you probably want to use `getMany`, which returns the components from the scope.
+   * this method loads all aspects of the loaded components. (which hurts performance)
    */
   async loadMany(ids: ComponentID[], lane?: Lane): Promise<Component[]> {
     const components = await mapSeries(ids, (id) => this.load(id, lane));


### PR DESCRIPTION
In some cases, the first run of `bit artifact` after `bit tag` was throwing an error of ComponentNotFound. 
This PR uses `scope.getMany` instead of `scope.loadMany` because there is no need to load all aspects. This change also improves this command performance dramatically.