### PR TITLE
fix(checkout), fetch current lane object first to find new comps

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1357,7 +1357,6 @@ describe('bit lane command', function () {
       helper.command.export();
       firstWorkspaceAfterExport = helper.scopeHelper.cloneLocalScope();
       helper.scopeHelper.getClonedLocalScope(secondWorkspace);
-      helper.command.import();
     });
     it('bit checkout with --workspace-only flag should not add the component and should suggest omitting --workspace-only flag', () => {
       const output = helper.command.checkoutHead('--skip-dependency-installation --workspace-only');

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -684,7 +684,7 @@ export class Workspace implements ComponentFactory {
 
   /**
    * if checked out to a lane and the lane exists in the remote,
-   * return the remote lane id (name+scope). otherwise, return null.
+   * return the remote lane. otherwise, return null.
    */
   async getCurrentRemoteLane(): Promise<Lane | null> {
     const currentLaneId = this.getCurrentLaneId();

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -304,16 +304,13 @@ export default class Consumer {
     return Promise.all(componentsP);
   }
 
-  /**
-   * For legacy, it loads all the dependencies. For Harmony, it's not needed.
-   */
   async loadComponentFromModelImportIfNeeded(id: BitId, throwIfNotExist = true): Promise<Component> {
     const scopeComponentsImporter = this.scope.scopeImporter;
     const getModelComponent = async (): Promise<ModelComponent> => {
       if (throwIfNotExist) return this.scope.getModelComponent(id);
       const modelComponent = await this.scope.getModelComponentIfExist(id);
       if (modelComponent) return modelComponent;
-      await scopeComponentsImporter.importMany({ ids: new BitIds(id) });
+      await scopeComponentsImporter.importMany({ ids: new BitIds(id), preferDependencyGraph: true });
       return this.scope.getModelComponent(id);
     };
     const modelComponent = await getModelComponent();


### PR DESCRIPTION
Currently, this is working only when `bit import` was running first, which updates the local lane object with the remote.
Otherwise, it wouldn't bring the new components because the local lane doesn't have them. 
