### PR TITLE
fix: exclude `ui-bundle` folder from `.npmignore` for core aspect

### DIFF
--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -68,7 +68,11 @@ export class AspectEnv implements DependenciesEnv, PackageEnv, PreviewEnv {
     // ignores only .ts files in the root directory, so d.ts files inside dists are unaffected.
     // without this change, the package has "index.ts" file in the root, causing typescript to parse it instead of the
     // d.ts files. (changing the "types" prop in the package.json file doesn't help).
-    const patterns = ['/*.ts', `${CAPSULE_ARTIFACTS_DIR}/`];
+
+    // Ignores all the contents inside the artifacts directory.
+    // Asterisk (*) is needed in order to ignore all other contents of the artifacts directory,
+    // especially when specific folders are excluded from the ignore e.g. in combination with `!artifacts/ui-bundle`.
+    const patterns = ['/*.ts', `${CAPSULE_ARTIFACTS_DIR}/*`];
 
     // In order to load the env preview template from core aspects we need it to be in the package of the core envs
     // This is because we don't have the core envs in the local scope so we load it from the package itself in the bvm installation

--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -76,6 +76,8 @@ export class AspectEnv implements DependenciesEnv, PackageEnv, PreviewEnv {
     // we want to make sure to add it for the core envs
     if (context && this.aspectLoader.isCoreEnv(context.component.id.toStringWithoutVersion())) {
       patterns.push(`!${CAPSULE_ARTIFACTS_DIR}/env-template`);
+    }
+    if (context && this.aspectLoader.isCoreAspect(context.component.id.toStringWithoutVersion())) {
       patterns.push(`!${CAPSULE_ARTIFACTS_DIR}/${BUNDLE_UI_DIR}`);
     }
     return patterns;


### PR DESCRIPTION
## Proposed Changes

Exclude `ui-bundle` artifact folder in `.npmignore` for `@teambit/ui` 

### Before
#### **`.npmignore`**
```
dist/tsconfig.tsbuildinfo

/*.ts
artifacts/
```

### After
#### **`.npmignore`**
```
dist/tsconfig.tsbuildinfo

/*.ts
artifacts/
!artifacts/ui-bundle
```
