### PR TITLE
fix(tag/snap): show the error message when "npm pack" fails

### DIFF
--- a/src/pack/packer.ts
+++ b/src/pack/packer.ts
@@ -116,9 +116,9 @@ export class Packer {
       return { metadata, warnings, errors, startTime, endTime: Date.now() };
     } catch (err: any) {
       const errorMsg = `failed running ${packageManager} ${args} at ${cwd}`;
-      logger.error(`${errorMsg}`);
+      logger.error(`${errorMsg}`, err);
       if (err.stderr) logger.error(`${err.stderr}`);
-      errors.push(`${errorMsg}\n${err.stderr}`);
+      errors.push(`${errorMsg}\n${err.stderr || err.message}`);
       return { errors, startTime, endTime: Date.now() };
     }
   }


### PR DESCRIPTION
Currently, in case of failure it shows:
```
failed running npm pack at /Users/davidfirst/Library/Caches/Bit/capsules/c8faea78513ab52bfd30032f9fa81289c5628e6c/my-scope_bar@0.0.1
undefined
```
This PR fixes it to show the original error-message and log the error instance. 