### PR TITLE
fix: clean node_modules only after all iteration of installation were completed

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -235,7 +235,7 @@ export class DependencyInstaller {
     if (!this.packageManager.pruneModules) {
       return;
     }
-    return this.packageManager.pruneModules(rootDir);
+    await this.packageManager.pruneModules(rootDir);
   }
 
   /**

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -40,7 +40,6 @@ export type InstallOptions = {
   packageManagerConfigRootDir?: string;
   resolveVersionsFromDependenciesOnly?: boolean;
   linkedDependencies?: Record<string, Record<string, string>>;
-  pruneNodeModules?: boolean;
 };
 
 export type GetComponentManifestsOptions = {
@@ -180,7 +179,6 @@ export class DependencyInstaller {
       engineStrict: this.engineStrict,
       packageManagerConfigRootDir: options.packageManagerConfigRootDir,
       peerDependencyRules: this.peerDependencyRules,
-      pruneNodeModules: options.pruneNodeModules,
       hidePackageManagerOutput,
       ...packageManagerOptions,
     };

--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -233,6 +233,13 @@ export class DependencyInstaller {
     return installResult;
   }
 
+  public async pruneModules(rootDir: string): Promise<void> {
+    if (!this.packageManager.pruneModules) {
+      return;
+    }
+    return this.packageManager.pruneModules(rootDir);
+  }
+
   /**
    * Compute all the component manifests (a.k.a. package.json files) that should be passed to the package manager
    * in order to install the dependencies.

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -53,8 +53,6 @@ export type PackageManagerInstallOptions = {
   updateAll?: boolean;
 
   hidePackageManagerOutput?: boolean;
-
-  pruneNodeModules?: boolean;
 };
 
 export type PackageManagerGetPeerDependencyIssuesOptions = PackageManagerInstallOptions;

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -93,7 +93,7 @@ export interface PackageManager {
     options: PackageManagerInstallOptions
   ): Promise<{ dependenciesChanged: boolean }>;
 
-  pruneModules(rootDir: string): Promise<void>;
+  pruneModules?(rootDir: string): Promise<void>;
 
   resolveRemoteVersion(
     packageName: string,

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -95,6 +95,8 @@ export interface PackageManager {
     options: PackageManagerInstallOptions
   ): Promise<{ dependenciesChanged: boolean }>;
 
+  pruneModules(rootDir: string): Promise<void>;
+
   resolveRemoteVersion(
     packageName: string,
     options: PackageManagerResolveRemoteVersionOptions

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -226,7 +226,7 @@ export async function install(
     workspacePackages,
     preferFrozenLockfile: true,
     pruneLockfileImporters: true,
-    modulesCacheMaxAge: options.pruneNodeModules ? 0 : undefined,
+    modulesCacheMaxAge: options.pruneNodeModules ? 0 : Infinity,
     neverBuiltDependencies: ['core-js'],
     registries: registriesMap,
     resolutionMode: 'highest',

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -166,7 +166,6 @@ export async function install(
     updateAll?: boolean;
     nodeLinker?: 'hoisted' | 'isolated';
     overrides?: Record<string, string>;
-    pruneNodeModules?: boolean;
     rootComponents?: boolean;
     rootComponentsForCapsules?: boolean;
     includeOptionalDeps?: boolean;
@@ -226,7 +225,7 @@ export async function install(
     workspacePackages,
     preferFrozenLockfile: true,
     pruneLockfileImporters: true,
-    modulesCacheMaxAge: options.pruneNodeModules ? 0 : Infinity,
+    modulesCacheMaxAge: Infinity, // pnpm should never prune the virtual store. Bit does it on its own.
     neverBuiltDependencies: ['core-js'],
     registries: registriesMap,
     resolutionMode: 'highest',

--- a/scopes/dependencies/pnpm/pnpm-prune-modules.ts
+++ b/scopes/dependencies/pnpm/pnpm-prune-modules.ts
@@ -1,0 +1,23 @@
+import fs from 'fs-extra';
+import path from 'path';
+import { difference } from 'lodash';
+import { readCurrentLockfile } from '@pnpm/lockfile-file';
+import { depPathToFilename } from '@pnpm/dependency-path';
+
+/**
+ * Reads the private lockfile at node_modules/.pnpm/lock.yaml
+ * and removes any directories from node_modules/.pnpm that are not listed in the lockfile.
+ */
+export async function pnpmPruneModules(rootDir: string): Promise<void> {
+  const virtualStoreDir = path.join(rootDir, 'node_modules/.pnpm');
+  const pkgDirs = await readPackageDirsFromVirtualStore(virtualStoreDir);
+  if (pkgDirs.length === 0) return;
+  const lockfile = await readCurrentLockfile(virtualStoreDir, { ignoreIncompatible: false });
+  const dirsShouldBePresent = Object.keys(lockfile?.packages ?? {}).map(depPathToFilename);
+  await Promise.all(difference(pkgDirs, dirsShouldBePresent).map((dir) => fs.remove(path.join(virtualStoreDir, dir))));
+}
+
+async function readPackageDirsFromVirtualStore(virtualStoreDir: string): Promise<string[]> {
+  const allDirs = await fs.readdir(virtualStoreDir);
+  return allDirs.filter((dir) => dir !== 'lock.yaml' && dir !== 'node_modules');
+}

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -75,7 +75,6 @@ export class PnpmPackageManager implements PackageManager {
         sideEffectsCacheRead: installOptions.sideEffectsCache ?? true,
         sideEffectsCacheWrite: installOptions.sideEffectsCache ?? true,
         pnpmHomeDir: config.pnpmHomeDir,
-        pruneNodeModules: installOptions.pruneNodeModules,
         updateAll: installOptions.updateAll,
         hidePackageManagerOutput: installOptions.hidePackageManagerOutput,
       },

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -19,6 +19,7 @@ import { readModulesManifest } from '@pnpm/modules-yaml';
 import { ProjectManifest } from '@pnpm/types';
 import { join } from 'path';
 import { readConfig } from './read-config';
+import { pnpmPruneModules } from './pnpm-prune-modules';
 
 export class PnpmPackageManager implements PackageManager {
   readonly name = 'pnpm';
@@ -197,5 +198,9 @@ export class PnpmPackageManager implements PackageManager {
 
   getWorkspaceDepsOfBitRoots(manifests: ProjectManifest[]): Record<string, string> {
     return Object.fromEntries(manifests.map((manifest) => [manifest.name, 'workspace:*']));
+  }
+
+  async pruneModules(rootDir: string): Promise<void> {
+    return pnpmPruneModules(rootDir);
   }
 }

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -248,9 +248,6 @@ export class InstallMain {
         current.componentDirectoryMap,
         {
           installTeambitBit: false,
-          // We clean node_modules only on the first install.
-          // Otherwise, we might load an env from a location that we later remove.
-          pruneNodeModules: installCycle === 0,
         },
         pmInstallOptions
       );
@@ -277,6 +274,7 @@ export class InstallMain {
       current = await this._getComponentsManifests(installer, mergedRootPolicy, pmInstallOptions);
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
+    await installer.pruneModules(this.workspace.path);
     await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */
     return current.componentDirectoryMap;

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -274,6 +274,8 @@ export class InstallMain {
       current = await this._getComponentsManifests(installer, mergedRootPolicy, pmInstallOptions);
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
+    // We clean node_modules only after the last install.
+    // Otherwise, we might load an env from a location that we later remove.
     await installer.pruneModules(this.workspace.path);
     await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */


### PR DESCRIPTION
Looks like the fix in https://github.com/teambit/bit/pull/7310 was not enough, we need to clean node_modules only after all installation iterations were complete.

## Proposed Changes

-
-
-
