### PR TITLE
change(aspects) - do not auto-load aspects' dependencies that are not configured in the workspace.jsonc

### DIFF
--- a/scopes/compilation/bundler/index.ts
+++ b/scopes/compilation/bundler/index.ts
@@ -1,3 +1,5 @@
+import { BundlerAspect } from './bundler.aspect';
+
 export { DevServer } from './dev-server';
 export { DevServerContext } from './dev-server-context';
 export {
@@ -11,7 +13,7 @@ export {
 } from './bundler-context';
 export { Bundler, BundlerResult, BundlerMode, Asset, ChunksAssetsMap, EntriesAssetsMap, EntryAssets } from './bundler';
 export type { BundlerMain } from './bundler.main.runtime';
-export { BundlerAspect } from './bundler.aspect';
 export { ComponentDir } from './get-entry';
 export { ComponentServer } from './component-server';
 export * from './events';
+export { BundlerAspect, BundlerAspect as default };

--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -13,6 +13,7 @@ export type ResolveAspectsOptions = FilterAspectsOptions & {
   throwOnError?: boolean;
   useScopeAspectsCapsule?: boolean;
   workspaceName?: string;
+  skipDeps?: boolean;
 };
 
 export type LoadAspectsOptions = {

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -1,3 +1,5 @@
+import { DependencyResolverAspect } from './dependency-resolver.aspect';
+
 export { RawComponentState, ComponentsManifestsMap, RegistriesMap } from './types';
 export {
   WorkspaceManifest,
@@ -26,7 +28,6 @@ export {
   ProxyConfig as PackageManagerProxyConfig,
   NetworkConfig as PackageManagerNetworkConfig,
 } from './dependency-resolver.main.runtime';
-export { DependencyResolverAspect } from './dependency-resolver.aspect';
 export {
   DependencyLifecycleType,
   WorkspaceDependencyLifecycleType,
@@ -72,3 +73,4 @@ export { OutdatedPkg } from './get-all-policy-pkgs';
 export { extendWithComponentsFromDir } from './extend-with-components-from-dir';
 export { isRange } from './manifest/deduping/hoist-dependencies';
 export { DependencyEnv } from './dependency-env';
+export { DependencyResolverAspect as default, DependencyResolverAspect };

--- a/scopes/harmony/aspect-loader/aspect-definition.ts
+++ b/scopes/harmony/aspect-loader/aspect-definition.ts
@@ -6,6 +6,7 @@ export type AspectDefinitionProps = {
   aspectPath: string;
   runtimePath: string | null;
   aspectFilePath: string | null;
+  local?: boolean;
 };
 
 export class AspectDefinition {
@@ -44,7 +45,7 @@ export class AspectDefinition {
     return null;
   }
 
-  static from({ component, aspectPath, aspectFilePath, runtimePath, id }: AspectDefinitionProps) {
-    return new AspectDefinition(aspectPath, aspectFilePath, runtimePath, component, id);
+  static from({ component, aspectPath, aspectFilePath, runtimePath, id, local }: AspectDefinitionProps) {
+    return new AspectDefinition(aspectPath, aspectFilePath, runtimePath, component, id, local);
   }
 }

--- a/scopes/harmony/cli/index.ts
+++ b/scopes/harmony/cli/index.ts
@@ -1,5 +1,8 @@
+import { CLIAspect, MainRuntime } from './cli.aspect';
+
 export type { CLIMain, CommandList, CommandsSlot } from './cli.main.runtime';
 export { Command, CLIArgs, Flags, GenericObject } from '@teambit/legacy/dist/cli/command';
 export { CommandOptions } from '@teambit/legacy/dist/cli/legacy-command';
 export * from './exceptions';
-export { CLIAspect, MainRuntime } from './cli.aspect';
+
+export { CLIAspect as default, MainRuntime, CLIAspect };

--- a/scopes/pipelines/builder/index.ts
+++ b/scopes/pipelines/builder/index.ts
@@ -1,3 +1,5 @@
+import { BuilderAspect } from './builder.aspect';
+
 export { ArtifactVinyl } from '@teambit/legacy/dist/consumer/component/sources/artifact';
 export { BuildPipe, TaskResults } from './build-pipe';
 export { ComponentResult, TaskMetadata } from './types';
@@ -14,8 +16,8 @@ export type { BuilderMain, RawBuilderData, BuilderData, OnTagOpts } from './buil
 export { Pipeline, TaskHandler } from './pipeline';
 export type { PipelineReport } from './build-pipeline-result-list';
 export type { BuilderEnv } from './builder-env-type';
-export { BuilderAspect } from './builder.aspect';
 export { WholeArtifactStorageResolver, FileStorageResolver, ArtifactStorageResolver } from './storage';
 export { Artifact, ArtifactList, ArtifactFactory, ArtifactDefinition, ArtifactModelDefinition } from './artifact';
 export { Task } from './task';
 export { TaskResultsList } from './task-results-list';
+export { BuilderAspect, BuilderAspect as default };

--- a/scopes/workspace/workspace/types.ts
+++ b/scopes/workspace/workspace/types.ts
@@ -45,4 +45,22 @@ export interface WorkspaceExtConfig {
    * from the scope aspects capsule.
    */
   resolveAspectsFromNodeModules?: boolean;
+
+  /**
+   * If set to `true`, bit will try to load aspects dependencies automatically.
+   * even if the aspects dependencies are not configured in the workspace.jsonc root config.
+   * for example having the aspect
+   * main aspect
+   * export class MainAspectMain {
+   *  ...
+   *   static dependencies = [MyDepAspect];
+   * }
+   * and the in the workspace.jsonc file:
+   * {
+   *  ...
+   *   main-aspect: {}
+   * }
+   * when set to true, bit will try to load MyDepAspect automatically.
+   */
+  autoLoadAspectsDeps?: boolean;
 }

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -238,7 +238,11 @@ export default async function provideWorkspace(
     const aspects = await workspace.loadAspects(
       aspectLoader.getNotLoadedConfiguredExtensions(),
       undefined,
-      'teambit.workspace/workspace (cli.registerOnStart)'
+      'teambit.workspace/workspace (cli.registerOnStart)',
+      {
+        runSubscribers: false,
+        skipDeps: true
+      }
     );
     // clear aspect cache.
     const componentIds = await workspace.resolveMultipleComponentIds(aspects);

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -235,14 +235,15 @@ export default async function provideWorkspace(
       workspace.inInstallContext = true;
     }
     await workspace.importCurrentLaneIfMissing();
+    const loadAspectsOpts = {
+      runSubscribers: false,
+      skipDeps: !config.autoLoadAspectsDeps,
+    };
     const aspects = await workspace.loadAspects(
       aspectLoader.getNotLoadedConfiguredExtensions(),
       undefined,
       'teambit.workspace/workspace (cli.registerOnStart)',
-      {
-        runSubscribers: false,
-        skipDeps: true
-      }
+      loadAspectsOpts
     );
     // clear aspect cache.
     const componentIds = await workspace.resolveMultipleComponentIds(aspects);


### PR DESCRIPTION
## Proposed Changes

- do not auto-load aspects' dependencies that are not configured in the workspace.jsonc
- add a new flag to use the old behavior of auto load aspects' deps
```
/**
   * If set to `true`, bit will try to load aspects dependencies automatically.
   * even if the aspects dependencies are not configured in the workspace.jsonc root config.
   * for example having the aspect
   * main aspect
   * export class MainAspectMain {
   *  ...
   *   static dependencies = [MyDepAspect];
   * }
   * and the in the workspace.jsonc file:
   * {
   *  ...
   *   main-aspect: {}
   * }
   * when set to true, bit will try to load MyDepAspect automatically.
   */
  autoLoadAspectsDeps?: boolean;
```

