### PR TITLE
fix(lane-fork), push all snaps from the original lane to the forked lane scope

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -320,7 +320,9 @@ export default class Component extends BitObject {
 
     const calculateRemote = async () => {
       if (this.laneHeadRemote) return this.laneHeadRemote;
-      if (lane.isNew && lane.forkedFrom) {
+      if (lane.isNew && lane.forkedFrom && lane.forkedFrom.scope === lane.scope) {
+        // the last check is to make sure that if this lane will be exported to a different scope than the original
+        // lane, all snaps of the original lane will be considered as local and will be exported later on.
         const headFromFork = await repo.remoteLanes.getRef(lane.forkedFrom, this.toBitId());
         if (headFromFork) return headFromFork;
       }


### PR DESCRIPTION
when their scope is not the same.
