### PR TITLE
feature(react-env) - allow overriding webpack and webpack-dev-server for react env

### DIFF
--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -316,7 +316,12 @@ export class ReactEnv
    * returns and configures the React component dev server.
    * required for `bit start`
    */
-  getDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
+  getDevServer(
+    context: DevServerContext,
+    transformers: WebpackConfigTransformer[] = [],
+    webpack?: any,
+    webpackDevServerPath?: string
+  ): DevServer {
     const baseConfig = basePreviewConfigFactory(false);
     const envDevConfig = envPreviewDevConfigFactory(context.id);
     const componentDevConfig = componentPreviewDevConfigFactory(this.workspace.path, context.id);
@@ -326,16 +331,21 @@ export class ReactEnv
       return merged;
     };
 
-    return this.webpack.createDevServer(context, [defaultTransformer, ...transformers]);
+    return this.webpack.createDevServer(context, [defaultTransformer, ...transformers], webpack, webpackDevServerPath);
   }
 
-  async getBundler(context: BundlerContext, transformers: WebpackConfigTransformer[] = []): Promise<Bundler> {
-    return this.createComponentsWebpackBundler(context, transformers);
+  async getBundler(
+    context: BundlerContext,
+    transformers: WebpackConfigTransformer[] = [],
+    webpack?: any
+  ): Promise<Bundler> {
+    return this.createComponentsWebpackBundler(context, transformers, webpack);
   }
 
   async createComponentsWebpackBundler(
     context: BundlerContext,
-    transformers: WebpackConfigTransformer[] = []
+    transformers: WebpackConfigTransformer[] = [],
+    webpack?: any
   ): Promise<Bundler> {
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(context.development);
@@ -346,12 +356,13 @@ export class ReactEnv
       return merged;
     };
     const mergedTransformers = [defaultTransformer, ...transformers];
-    return this.createWebpackBundler(context, mergedTransformers);
+    return this.createWebpackBundler(context, mergedTransformers, webpack);
   }
 
   async createTemplateWebpackBundler(
     context: BundlerContext,
-    transformers: WebpackConfigTransformer[] = []
+    transformers: WebpackConfigTransformer[] = [],
+    webpack?: any
   ): Promise<Bundler> {
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(context.development);
@@ -362,14 +373,15 @@ export class ReactEnv
       return merged;
     };
     const mergedTransformers = [defaultTransformer, ...transformers];
-    return this.createWebpackBundler(context, mergedTransformers);
+    return this.createWebpackBundler(context, mergedTransformers, webpack);
   }
 
   private async createWebpackBundler(
     context: BundlerContext,
-    transformers: WebpackConfigTransformer[] = []
+    transformers: WebpackConfigTransformer[] = [],
+    webpack?: any
   ): Promise<Bundler> {
-    return this.webpack.createBundler(context, transformers);
+    return this.webpack.createBundler(context, transformers, undefined, webpack);
   }
 
   getAdditionalHostDependencies(): string[] {

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -319,8 +319,8 @@ export class ReactEnv
   getDevServer(
     context: DevServerContext,
     transformers: WebpackConfigTransformer[] = [],
-    webpack?: any,
-    webpackDevServerPath?: string
+    webpackModulePath?: string,
+    webpackDevServerModulePath?: string
   ): DevServer {
     const baseConfig = basePreviewConfigFactory(false);
     const envDevConfig = envPreviewDevConfigFactory(context.id);
@@ -331,21 +331,26 @@ export class ReactEnv
       return merged;
     };
 
-    return this.webpack.createDevServer(context, [defaultTransformer, ...transformers], webpack, webpackDevServerPath);
+    return this.webpack.createDevServer(
+      context,
+      [defaultTransformer, ...transformers],
+      webpackModulePath,
+      webpackDevServerModulePath
+    );
   }
 
   async getBundler(
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = [],
-    webpack?: any
+    webpackModulePath?: string
   ): Promise<Bundler> {
-    return this.createComponentsWebpackBundler(context, transformers, webpack);
+    return this.createComponentsWebpackBundler(context, transformers, webpackModulePath);
   }
 
   async createComponentsWebpackBundler(
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = [],
-    webpack?: any
+    webpackModulePath?: string
   ): Promise<Bundler> {
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(context.development);
@@ -356,13 +361,13 @@ export class ReactEnv
       return merged;
     };
     const mergedTransformers = [defaultTransformer, ...transformers];
-    return this.createWebpackBundler(context, mergedTransformers, webpack);
+    return this.createWebpackBundler(context, mergedTransformers, webpackModulePath);
   }
 
   async createTemplateWebpackBundler(
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = [],
-    webpack?: any
+    webpackModulePath?: string
   ): Promise<Bundler> {
     const baseConfig = basePreviewConfigFactory(!context.development);
     const baseProdConfig = basePreviewProdConfigFactory(context.development);
@@ -373,15 +378,15 @@ export class ReactEnv
       return merged;
     };
     const mergedTransformers = [defaultTransformer, ...transformers];
-    return this.createWebpackBundler(context, mergedTransformers, webpack);
+    return this.createWebpackBundler(context, mergedTransformers, webpackModulePath);
   }
 
   private async createWebpackBundler(
     context: BundlerContext,
     transformers: WebpackConfigTransformer[] = [],
-    webpack?: any
+    webpackModulePath?: string
   ): Promise<Bundler> {
-    return this.webpack.createBundler(context, transformers, undefined, webpack);
+    return this.webpack.createBundler(context, transformers, undefined, webpackModulePath);
   }
 
   getAdditionalHostDependencies(): string[] {

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -76,6 +76,8 @@ export type ReactMainConfig = {
 export type UseWebpackModifiers = {
   previewConfig?: WebpackConfigTransformer[];
   devServerConfig?: WebpackConfigTransformer[];
+  webpack?: any;
+  webpackDevServerPath?: string;
 };
 
 export type UseTypescriptModifiers = {
@@ -214,14 +216,15 @@ export class ReactMain {
   useWebpack(modifiers?: UseWebpackModifiers): EnvTransformer {
     const overrides: any = {};
     const devServerTransformers = modifiers?.devServerConfig;
-    if (devServerTransformers) {
+    if (devServerTransformers || modifiers?.webpack || modifiers?.webpackDevServerPath) {
       overrides.getDevServer = (context: DevServerContext) =>
-        this.reactEnv.getDevServer(context, devServerTransformers);
+        this.reactEnv.getDevServer(context, devServerTransformers, modifiers?.webpack, modifiers?.webpackDevServerPath);
       overrides.getDevEnvId = (context: DevServerContext) => this.reactEnv.getDevEnvId(context.envDefinition.id);
     }
     const previewTransformers = modifiers?.previewConfig;
-    if (previewTransformers) {
-      overrides.getBundler = (context: BundlerContext) => this.reactEnv.getBundler(context, previewTransformers);
+    if (previewTransformers || modifiers?.webpack) {
+      overrides.getBundler = (context: BundlerContext) =>
+        this.reactEnv.getBundler(context, previewTransformers, modifiers?.webpack);
     }
     return this.envs.override(overrides);
   }

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -76,8 +76,8 @@ export type ReactMainConfig = {
 export type UseWebpackModifiers = {
   previewConfig?: WebpackConfigTransformer[];
   devServerConfig?: WebpackConfigTransformer[];
-  webpack?: any;
-  webpackDevServerPath?: string;
+  webpackModulePath?: string;
+  webpackDevServerModulePath?: string;
 };
 
 export type UseTypescriptModifiers = {
@@ -216,15 +216,20 @@ export class ReactMain {
   useWebpack(modifiers?: UseWebpackModifiers): EnvTransformer {
     const overrides: any = {};
     const devServerTransformers = modifiers?.devServerConfig;
-    if (devServerTransformers || modifiers?.webpack || modifiers?.webpackDevServerPath) {
+    if (devServerTransformers || modifiers?.webpackModulePath || modifiers?.webpackDevServerModulePath) {
       overrides.getDevServer = (context: DevServerContext) =>
-        this.reactEnv.getDevServer(context, devServerTransformers, modifiers?.webpack, modifiers?.webpackDevServerPath);
+        this.reactEnv.getDevServer(
+          context,
+          devServerTransformers,
+          modifiers?.webpackModulePath,
+          modifiers?.webpackDevServerModulePath
+        );
       overrides.getDevEnvId = (context: DevServerContext) => this.reactEnv.getDevEnvId(context.envDefinition.id);
     }
     const previewTransformers = modifiers?.previewConfig;
-    if (previewTransformers || modifiers?.webpack) {
+    if (previewTransformers || modifiers?.webpackModulePath) {
       overrides.getBundler = (context: BundlerContext) =>
-        this.reactEnv.getBundler(context, previewTransformers, modifiers?.webpack);
+        this.reactEnv.getBundler(context, previewTransformers, modifiers?.webpackModulePath);
     }
     return this.envs.override(overrides);
   }

--- a/scopes/webpack/webpack/webpack.main.runtime.ts
+++ b/scopes/webpack/webpack/webpack.main.runtime.ts
@@ -83,7 +83,12 @@ export class WebpackMain {
   /**
    * create an instance of bit-compliant webpack dev server for a set of components
    */
-  createDevServer(context: DevServerContext, transformers: WebpackConfigTransformer[] = []): DevServer {
+  createDevServer(
+    context: DevServerContext,
+    transformers: WebpackConfigTransformer[] = [],
+    webpackInstance?: any,
+    webpackDevServerPath?: string
+  ): DevServer {
     const config = this.createDevServerConfig(
       context.entry,
       this.workspace.path,
@@ -92,6 +97,7 @@ export class WebpackMain {
       context.publicPath,
       context.title
     ) as any;
+    const wdsPath = webpackDevServerPath || require.resolve('webpack-dev-server');
     const configMutator = new WebpackConfigMutator(config);
     const transformerContext: WebpackConfigDevServerTransformContext = Object.assign(context, { mode: 'dev' as const });
     const internalTransformers = this.generateTransformers(undefined, transformerContext);
@@ -102,7 +108,7 @@ export class WebpackMain {
       transformerContext
     );
     // @ts-ignore - fix this
-    return new WebpackDevServer(afterMutation.raw, webpack, require.resolve('webpack-dev-server'));
+    return new WebpackDevServer(afterMutation.raw, webpackInstance || webpack, wdsPath);
   }
 
   mergeConfig(target: any, source: any): any {


### PR DESCRIPTION
## Proposed Changes

- allow for a custom env to override `webpack` and `webpack-dev-server` instances by providing alternative paths to load these modules.
- react UseWebpackModifiers now gets to new options: `webpackModulePath` and `webpackDevServerModulePath`
```ts
export type UseWebpackModifiers = {
  previewConfig?: WebpackConfigTransformer[];
  devServerConfig?: WebpackConfigTransformer[];
  webpackModulePath?: string;
  webpackDevServerModulePath?: string;
};
```
- react getDevServer API now accept the `webpackModulePath` and `webpackDevServerModulePath`
- react getBundler API now accept the `webpackModulePath`
- webpack createDevServer API now accept the `webpackModulePath` and `webpackDevServerModulePath`
- webpack createBundler API now accept the either a path to webpack (new) or webpack instance (existing)
