### PR TITLE
fix, remove lane-refs from the cache once they are written

### DIFF
--- a/src/scope/lanes/remote-lanes.ts
+++ b/src/scope/lanes/remote-lanes.ts
@@ -166,6 +166,7 @@ export default class RemoteLanes {
       id: { scope: id.scope, name: id.name },
       head: head.toString(),
     }));
-    return fs.outputFile(this.composeRemoteLanePath(remoteName, laneName), JSON.stringify(obj, null, 2));
+    await fs.outputFile(this.composeRemoteLanePath(remoteName, laneName), JSON.stringify(obj, null, 2));
+    delete this.remotes[remoteName][laneName];
   }
 }


### PR DESCRIPTION
Currently, when a ref file (.bit/refs/...) is loaded, it kept in memory forever (until the process exits), and then when the refs are written, it is re-written even if it wasn't changed. For long processes, such as `bit start`, this can be an issue as it may write old values.
This PR fixes it by removing the refs from the cache after writing them to the filesystem.