### PR TITLE
refactor(import), change import methods to work with one lane instead of an array

### DIFF
--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -306,7 +306,7 @@ if you need this specific snap, find the lane this snap is belong to, then run "
       : await scopeComponentsImporter.importMany({
           ids,
           ignoreMissingHead,
-          lanes: lane ? [lane] : undefined,
+          lane,
           preferDependencyGraph: !this.options.fetchDeps,
           // when user is running "bit import", we want to re-fetch if it wasn't built. todo: check if this can be disabled when not needed
           reFetchUnBuiltVersion: true,

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -527,13 +527,12 @@ export class ScopeMain implements ComponentFactory {
     const withoutOwnScopeAndLocals = legacyIds.filter((id) => {
       return id.scope !== this.name && id.hasScope();
     });
-    const lanes = lane ? [lane] : undefined;
     await this.legacyScope.scopeImporter.importMany({
       ids: ComponentsIds.fromArray(withoutOwnScopeAndLocals),
       cache: useCache,
       throwForDependencyNotFound: false,
       reFetchUnBuiltVersion,
-      lanes,
+      lane,
       preferDependencyGraph,
     });
 

--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -121,7 +121,7 @@ export class GraphFromFsBuilder {
       throwForDependencyNotFound: this.shouldThrowOnMissingDep,
       throwForSeederNotFound: this.shouldThrowOnMissingDep,
       reFetchUnBuiltVersion: false,
-      lanes: this.currentLane ? [this.currentLane] : [],
+      lane: this.currentLane || undefined,
     });
     allDepsNotImported.map((id) => this.importedIds.push(id.toString()));
   }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -924,7 +924,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     const scopeComponentsImporter = ScopeComponentsImporter.getInstance(this.scope.legacyScope);
     const ids = BitIds.fromArray(lane.toBitIds().filter((id) => id.hasScope()));
     await scopeComponentsImporter.importManyDeltaWithoutDeps({ ids, fromHead: true, lane });
-    await scopeComponentsImporter.importMany({ ids, lanes: [lane] });
+    await scopeComponentsImporter.importMany({ ids, lane });
   }
 
   async use(aspectIdStr: string): Promise<string> {

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -243,7 +243,7 @@ export default class ComponentsList {
       {
         cache: false,
         includeVersionHistory: true,
-        lanes: [forkedFromLane],
+        lane: forkedFromLane,
         ignoreMissingHead: true,
       }
     );

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -100,13 +100,9 @@ export default class ScopeComponentsImporter {
     ignoreMissingHead?: boolean; // needed when fetching "main" objects when on a lane
     preferDependencyGraph?: boolean; // if an external is missing and the remote has it with the dependency graph, don't fetch all its dependencies
   }): Promise<VersionDependencies[]> {
-    logger.debugAndAddBreadCrumb(
-      'importMany',
-      `cache ${cache}, preferDependencyGraph: ${preferDependencyGraph}, reFetchUnBuiltVersion: ${reFetchUnBuiltVersion}, throwForDependencyNotFound: ${throwForDependencyNotFound}. ids: {ids}, lane: {lane}`,
-      {
-        ids: ids.toString(),
-        lane: lane?.toLaneId().toString(),
-      }
+    if (!ids.length) return [];
+    logger.debug(
+      `importMany, cache ${cache}, preferDependencyGraph: ${preferDependencyGraph}, reFetchUnBuiltVersion: ${reFetchUnBuiltVersion}, throwForDependencyNotFound: ${throwForDependencyNotFound}. ids: ${ids.toString()}, lane: ${lane?.id()}`
     );
     const idsToImport = compact(ids.filter((id) => id.hasScope()));
     if (R.isEmpty(idsToImport)) {
@@ -728,13 +724,8 @@ export default class ScopeComponentsImporter {
   ): Promise<VersionDependencies[]> {
     if (!ids.length) return [];
     lane = await this.getLaneForFetcher(lane);
-    logger.debugAndAddBreadCrumb(
-      'ScopeComponentsImporter.getExternalMany',
-      `fetching from remote scope. Ids: {ids}, Lanes: {lane}`,
-      {
-        ids: ids.join(', '),
-        lane: lane?.toLaneId().toString(),
-      }
+    logger.debug(
+      `copeComponentsImporter.getExternalMany, fetching from remote scope. Ids: ${ids.join(', ')}, Lane: ${lane?.id()}`
     );
     const context = {};
     ids.forEach((id) => {


### PR DESCRIPTION
No need for an array of lanes because they all end up calling `getExternalMany` or `getExternalManyWithoutDeps` which don't support multiple lanes and throw if they get more than one. 
