### PR TITLE
fix bit start pattern

### DIFF
--- a/scopes/preview/preview/preview.start-plugin.tsx
+++ b/scopes/preview/preview/preview.start-plugin.tsx
@@ -28,12 +28,12 @@ export class PreviewStartPlugin implements StartPlugin {
   async initiate(options: StartPluginOptions) {
     this.listenToDevServers();
 
-    const components = await this.workspace.byPattern(options.pattern || '');
+    const components = await this.workspace.getComponentsByUserInput(!options.pattern, options.pattern);
     // TODO: logic for creating preview servers must be refactored to this aspect from the DevServer aspect.
     const previewServers = await this.bundler.devServer(components);
     // eslint-disable-next-line @typescript-eslint/no-misused-promises
     previewServers.forEach((server) => server.listen());
-    // DON'T add wait! this promise never resolve so it's stop all the start process!
+    // DON'T add wait! this promise never resolves, so it would stop the start process!
     this.watcher
       .watch({
         spawnTSServer: true,

--- a/scopes/ui-foundation/ui/start.cmd.tsx
+++ b/scopes/ui-foundation/ui/start.cmd.tsx
@@ -1,12 +1,13 @@
+import { BitError } from '@teambit/bit-error';
+import { Command, CommandOptions } from '@teambit/cli';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
+import { Logger } from '@teambit/logger';
+import { UIServerConsole } from '@teambit/ui-foundation.cli.ui-server-console';
 import React from 'react';
 import openBrowser from 'react-dev-utils/openBrowser';
-import { Command, CommandOptions } from '@teambit/cli';
-import { Logger } from '@teambit/logger';
-import { BitError } from '@teambit/bit-error';
-import { UIServerConsole } from '@teambit/ui-foundation.cli.ui-server-console';
 import type { UiMain } from './ui.main.runtime';
 
-type StartArgs = [uiName: string, userPattern: string];
+type StartArgs = [userPattern: string];
 type StartFlags = {
   dev: boolean;
   port: string;
@@ -15,11 +16,18 @@ type StartFlags = {
   noBrowser: boolean;
   skipCompilation: boolean;
   skipUiBuild: boolean;
+  uiRootName: string;
 };
 
 export class StartCmd implements Command {
-  name = 'start [type] [pattern]';
+  name = 'start [component-pattern]';
   description = 'run the ui/development server';
+  arguments = [
+    {
+      name: 'component-pattern',
+      description: COMPONENT_PATTERN_HELP,
+    },
+  ];
   alias = 'c';
   group = 'development';
   options = [
@@ -28,8 +36,13 @@ export class StartCmd implements Command {
     ['r', 'rebuild', 'rebuild the UI'],
     ['', 'skip-ui-build', 'skip building UI'],
     ['v', 'verbose', 'show verbose output for inspection and prints stack trace'],
-    ['', 'no-browser', 'do not automatically open browser when ready'],
+    ['n', 'no-browser', 'do not automatically open browser when ready'],
     ['', 'skip-compilation', 'skip the auto-compilation before starting the web-server'],
+    [
+      'u',
+      'ui-root-name [type]',
+      'name of the ui root to use, e.g. "teambit.scope/scope" or "teambit.workspace/workspace"',
+    ],
   ] as CommandOptions;
 
   constructor(
@@ -58,8 +71,8 @@ export class StartCmd implements Command {
   // }
 
   async render(
-    [uiRootName, userPattern]: StartArgs,
-    { dev, port, rebuild, verbose, noBrowser, skipCompilation, skipUiBuild }: StartFlags
+    [userPattern]: StartArgs,
+    { dev, port, rebuild, verbose, noBrowser, skipCompilation, skipUiBuild, uiRootName }: StartFlags
   ): Promise<React.ReactElement> {
     this.logger.off();
     if (!this.ui.isHostAvailable()) {


### PR DESCRIPTION
## Proposed Changes

- use the same pattern matching for components that we use in all other commands (build, test, ...) instead of the deprecated one that bit start was using
- refactor the command to move "type" (aka ui root name) to flags instead of arguments since it was required if you wanted to use a component pattern, and no one seems to even know what it is. The descriptions are also updated to make it more clear (although I still don't think anyone uses it, should we just remove it ?)
