### PR TITLE
fix(update): fix error "Cannot read properties of undefined (reading 'dependencies')" 

### DIFF
--- a/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.ts
+++ b/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.ts
@@ -86,6 +86,7 @@ function readAllDependenciesFromPolicyObject(
   context: Pick<CurrentPkg, 'source' | 'componentId' | 'variantPattern'>,
   policy: VariantPolicyConfigObject
 ): CurrentPkg[] {
+  if (!policy) return [];
   const pkgs: CurrentPkg[] = [];
   for (const targetField of [
     'dependencies',


### PR DESCRIPTION
Happens when `policy` param is undefined.