### PR TITLE
feat(stash): introduce a POC of "bit stash"

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1179,6 +1179,13 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/snapping"
     },
+    "stash": {
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.component",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/component/stash"
+    },
     "status": {
         "scope": "teambit.component",
         "version": "0.0.373",

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -26,6 +26,7 @@ export interface ManyComponentsWriterParams {
   verbose?: boolean;
   resetConfig?: boolean;
   skipWritingToFs?: boolean;
+  skipUpdatingBitMap?: boolean;
 }
 
 export type ComponentWriterResults = { installationError?: Error; compilationError?: Error };
@@ -48,7 +49,7 @@ export class ComponentWriterMain {
     await this.populateComponentsFilesToWrite(opts);
     this.moveComponentsIfNeeded(opts);
     await this.persistComponentsData(opts);
-    await this.consumer.writeBitMap();
+    if (!opts.skipUpdatingBitMap) await this.consumer.writeBitMap();
     let installationError: Error | undefined;
     let compilationError: Error | undefined;
     if (!opts.skipDependencyInstallation) {
@@ -185,6 +186,7 @@ export class ComponentWriterMain {
       component,
       writeToPath: componentRootDir,
       writeConfig: opts.writeConfig,
+      skipUpdatingBitMap: opts.skipUpdatingBitMap,
       ...getParams(),
     };
   }

--- a/scopes/component/component-writer/component-writer.ts
+++ b/scopes/component/component-writer/component-writer.ts
@@ -26,6 +26,7 @@ export type ComponentWriterProps = {
   ignoreBitDependencies?: boolean | BitIds;
   deleteBitDirContent?: boolean;
   existingComponentMap?: ComponentMap;
+  skipUpdatingBitMap?: boolean;
 };
 
 export default class ComponentWriter {
@@ -41,6 +42,7 @@ export default class ComponentWriter {
   ignoreBitDependencies: boolean | BitIds;
   deleteBitDirContent: boolean | undefined;
   existingComponentMap: ComponentMap | undefined;
+  skipUpdatingBitMap?: boolean;
 
   constructor({
     component,
@@ -55,6 +57,7 @@ export default class ComponentWriter {
     ignoreBitDependencies = true,
     deleteBitDirContent,
     existingComponentMap,
+    skipUpdatingBitMap,
   }: ComponentWriterProps) {
     this.component = component;
     this.writeToPath = writeToPath;
@@ -68,6 +71,7 @@ export default class ComponentWriter {
     this.ignoreBitDependencies = ignoreBitDependencies;
     this.deleteBitDirContent = deleteBitDirContent;
     this.existingComponentMap = existingComponentMap;
+    this.skipUpdatingBitMap = skipUpdatingBitMap;
   }
 
   /**
@@ -97,7 +101,9 @@ export default class ComponentWriter {
     this.component.componentMap = this.existingComponentMap || this.addComponentToBitMap(this.writeToPath);
     this.deleteBitDirContent = false;
     this._updateComponentRootPathAccordingToBitMap();
-    this.component.componentMap = this.addComponentToBitMap(this.component.componentMap.rootDir);
+    if (!this.skipUpdatingBitMap) {
+      this.component.componentMap = this.addComponentToBitMap(this.component.componentMap.rootDir);
+    }
     this.writePackageJson = false;
     await this.populateFilesToWriteToComponentDir();
     return this.component;

--- a/scopes/component/stash/index.ts
+++ b/scopes/component/stash/index.ts
@@ -1,0 +1,5 @@
+import { StashAspect } from './stash.aspect';
+
+export type { StashMain } from './stash.main.runtime';
+export default StashAspect;
+export { StashAspect };

--- a/scopes/component/stash/stash-data.ts
+++ b/scopes/component/stash/stash-data.ts
@@ -1,0 +1,35 @@
+import { ComponentID } from '@teambit/component-id';
+import { Ref } from '@teambit/legacy/dist/scope/objects';
+import { Workspace } from '@teambit/workspace';
+
+export type StashCompData = { id: ComponentID; hash: Ref };
+export type StashMetadata = { message?: string };
+
+export class StashData {
+  constructor(readonly metadata: StashMetadata, readonly stashCompsData: StashCompData[]) {}
+
+  toObject() {
+    return {
+      metadata: this.metadata,
+      stashCompsData: this.stashCompsData.map(({ id, hash }) => ({
+        // id: { scope: id._legacy.scope, name: id.fullName },
+        id: id.changeVersion(undefined).toObject(),
+        hash: hash.toString(),
+      })),
+    };
+  }
+
+  static async fromObject(obj: Record<string, any>, workspace: Workspace): Promise<StashData> {
+    const stashCompsData = await Promise.all(
+      obj.stashCompsData.map(async (compData) => {
+        const id = ComponentID.fromObject(compData.id);
+        const resolved = await workspace.resolveComponentId(id);
+        return {
+          id: resolved,
+          hash: Ref.from(compData.hash),
+        };
+      })
+    );
+    return new StashData(obj.metadata, stashCompsData);
+  }
+}

--- a/scopes/component/stash/stash-files.ts
+++ b/scopes/component/stash/stash-files.ts
@@ -1,0 +1,53 @@
+import { Workspace } from '@teambit/workspace';
+import globby from 'globby';
+import path from 'path';
+import fs from 'fs-extra';
+import { StashData } from './stash-data';
+
+const STASH_DIR = 'stash';
+const STASH_FILE_PREFIX = 'stash';
+
+export class StashFiles {
+  constructor(private scopePath: string) {}
+
+  getPath() {
+    return path.join(this.scopePath, STASH_DIR);
+  }
+
+  async getStashFiles(): Promise<string[]> {
+    const stashPath = this.getPath();
+    const files = await globby(`${STASH_FILE_PREFIX}-*`, { cwd: stashPath });
+    return files;
+  }
+
+  async getLatestStashFile(): Promise<string | undefined> {
+    const files = await this.getStashFiles();
+    const latest = files.sort().pop();
+    return latest;
+  }
+
+  async getNextStashFileName(): Promise<string> {
+    const latest = await this.getLatestStashFile();
+    const latestIndex = latest ? parseInt(latest.split('-')[1]) : 0;
+    return `${STASH_FILE_PREFIX}-${latestIndex + 1}.json`;
+  }
+
+  async deleteStashFile(filename: string) {
+    await fs.remove(path.join(this.getPath(), filename));
+  }
+
+  async saveStashData(stashData: StashData) {
+    const nextStashFile = await this.getNextStashFileName();
+    const stashPath = this.getPath();
+    const filePath = path.join(stashPath, nextStashFile);
+    await fs.outputFile(filePath, JSON.stringify(stashData.toObject(), undefined, 4));
+  }
+
+  async getStashData(filename: string, workspace: Workspace): Promise<StashData> {
+    const stashPath = this.getPath();
+    const filePath = path.join(stashPath, filename);
+    const content = await fs.readFile(filePath, 'utf8');
+    const data = JSON.parse(content);
+    return StashData.fromObject(data, workspace);
+  }
+}

--- a/scopes/component/stash/stash.aspect.ts
+++ b/scopes/component/stash/stash.aspect.ts
@@ -1,0 +1,5 @@
+import { Aspect } from '@teambit/harmony';
+
+export const StashAspect = Aspect.create({
+  id: 'teambit.component/stash',
+});

--- a/scopes/component/stash/stash.cmd.ts
+++ b/scopes/component/stash/stash.cmd.ts
@@ -1,0 +1,75 @@
+// eslint-disable-next-line max-classes-per-file
+import chalk from 'chalk';
+import { Command, CommandOptions } from '@teambit/cli';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
+import { StashMain } from './stash.main.runtime';
+
+export class StashSaveCmd implements Command {
+  name = 'save';
+  description = 'stash modified components';
+  group = 'development';
+  options = [
+    ['p', 'pattern', COMPONENT_PATTERN_HELP],
+    ['m', 'message <string>', 'message to be attached to the stashed components'],
+  ] as CommandOptions;
+  loader = true;
+
+  constructor(private stash: StashMain) {}
+
+  async report(
+    _arg: any,
+    {
+      pattern,
+      message,
+    }: {
+      pattern?: string;
+      message?: string;
+    }
+  ) {
+    const compIds = await this.stash.save({ pattern, message });
+    return chalk.green(`stashed ${compIds.length} components`);
+  }
+}
+
+export class StashLoadCmd implements Command {
+  name = 'load';
+  description = 'load latest stash, checkout components and delete stash';
+  group = 'development';
+  options = [] as CommandOptions;
+  loader = true;
+
+  constructor(private stash: StashMain) {}
+
+  async report() {
+    const compIds = await this.stash.loadLatest();
+    return chalk.green(`checked out ${compIds.length} components according to the latest stash`);
+  }
+}
+
+export class StashCmd implements Command {
+  name = 'stash [sub-command]';
+  description = 'EXPERIMENTAL (more like a POC). stash modified components';
+  group = 'development';
+  private = true; // too early to make it public. it's still in a POC mode.
+  options = [
+    ['p', 'pattern', COMPONENT_PATTERN_HELP],
+    ['m', 'message <string>', 'message to be attached to the stashed components'],
+  ] as CommandOptions;
+  loader = true;
+  commands: Command[] = [];
+
+  constructor(private stash: StashMain) {}
+
+  async report(
+    _arg: any,
+    {
+      pattern,
+      message,
+    }: {
+      pattern?: string;
+      message?: string;
+    }
+  ) {
+    return new StashSaveCmd(this.stash).report(undefined, { pattern, message });
+  }
+}

--- a/scopes/component/stash/stash.main.runtime.ts
+++ b/scopes/component/stash/stash.main.runtime.ts
@@ -1,0 +1,105 @@
+import WorkspaceAspect, { Workspace } from '@teambit/workspace';
+import { Component, ComponentID } from '@teambit/component';
+import { BitError } from '@teambit/bit-error';
+import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
+import { compact } from 'lodash';
+import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
+import CheckoutAspect, { CheckoutMain } from '@teambit/checkout';
+import { StashAspect } from './stash.aspect';
+import { StashCmd, StashLoadCmd, StashSaveCmd } from './stash.cmd';
+import { StashData } from './stash-data';
+import { StashFiles } from './stash-files';
+
+export class StashMain {
+  private stashFiles: StashFiles;
+  constructor(private workspace: Workspace, private checkout: CheckoutMain) {
+    this.stashFiles = new StashFiles(workspace.scope.path);
+  }
+
+  async save(options: { message?: string; pattern?: string }): Promise<ComponentID[]> {
+    const compIds = options?.pattern
+      ? await this.workspace.idsByPattern(options?.pattern)
+      : await this.workspace.listIds();
+    const comps = await this.workspace.getMany(compIds);
+    const modifiedComps = compact(
+      await Promise.all(
+        comps.map(async (comp) => {
+          if (!comp.head) return undefined; // it's new
+          const isModified = await this.workspace.isModified(comp);
+          if (isModified) return comp;
+          return undefined;
+        })
+      )
+    );
+    if (!modifiedComps.length) return [];
+
+    // per comp: create Version object, save it in the local scope and return the hash. don't save anything in the .bitmap
+    const hashPerId = await Promise.all(
+      modifiedComps.map(async (comp) => {
+        const versionObj = await this.addComponentDataToRepo(comp);
+        return { id: comp.id, hash: versionObj.hash() };
+      })
+    );
+    await this.workspace.scope.legacyScope.objects.persist();
+    const stashData = new StashData({ message: options?.message }, hashPerId);
+    await this.stashFiles.saveStashData(stashData);
+
+    // reset all modified components
+    const modifiedCompIds = modifiedComps.map((c) => c.id);
+    await this.checkout.checkout({
+      ids: modifiedCompIds,
+      skipNpmInstall: true,
+      reset: true,
+    });
+
+    return modifiedCompIds;
+  }
+
+  async loadLatest() {
+    const stashFile = await this.stashFiles.getLatestStashFile();
+    if (!stashFile) {
+      throw new BitError('no stashed components found');
+    }
+    const stashData = await this.stashFiles.getStashData(stashFile, this.workspace);
+    const compIds = stashData.stashCompsData.map((c) => c.id);
+    const versionPerId = stashData.stashCompsData.map((c) => c.id.changeVersion(c.hash.toString()));
+
+    await this.checkout.checkout({
+      ids: compIds,
+      skipNpmInstall: true,
+      versionPerId,
+      skipUpdatingBitmap: true,
+    });
+
+    await this.stashFiles.deleteStashFile(stashFile);
+
+    return compIds;
+  }
+
+  private async addComponentDataToRepo(component: Component) {
+    const consumerComponent = component.state._consumer.clone() as ConsumerComponent;
+    consumerComponent.setNewVersion();
+    const { version, files } = await this.workspace.scope.legacyScope.sources.consumerComponentToVersion(
+      consumerComponent
+    );
+    const repo = this.workspace.scope.legacyScope.objects;
+    repo.add(version);
+    files.forEach((file) => repo.add(file.file));
+    return version;
+  }
+
+  static slots = [];
+  static dependencies = [CLIAspect, WorkspaceAspect, CheckoutAspect];
+  static runtime = MainRuntime;
+  static async provider([cli, workspace, checkout]: [CLIMain, Workspace, CheckoutMain]) {
+    const stashMain = new StashMain(workspace, checkout);
+    const stashCmd = new StashCmd(stashMain);
+    stashCmd.commands = [new StashSaveCmd(stashMain), new StashLoadCmd(stashMain)];
+    cli.register(stashCmd);
+    return stashMain;
+  }
+}
+
+StashAspect.addRuntime(StashMain);
+
+export default StashMain;

--- a/scopes/harmony/bit/manifests.ts
+++ b/scopes/harmony/bit/manifests.ts
@@ -100,6 +100,7 @@ import { ComponentWriterAspect } from '@teambit/component-writer';
 import { TrackerAspect } from '@teambit/tracker';
 import { MoverAspect } from '@teambit/mover';
 import { WatcherAspect } from '@teambit/watcher';
+import { StashAspect } from '@teambit/stash';
 import { BitAspect } from './bit.aspect';
 
 export const manifestsMap = {
@@ -204,6 +205,7 @@ export const manifestsMap = {
   [TrackerAspect.id]: TrackerAspect,
   [MoverAspect.id]: MoverAspect,
   [WatcherAspect.id]: WatcherAspect,
+  [StashAspect.id]: StashAspect,
 };
 
 export function isCoreAspect(id: string) {


### PR DESCRIPTION
## Proposed Changes

- `bit stash save` - saves the modified components data to the local scope, generate a hash per component and save the map of id:hash in `.bit/stash/stash-{counter}.json`. then, bit-checkout-reset the component. (so then it's not modified anymore).
- `bit stash load` - load the latest stash data, checkout the components according to the hashes and delete the stash file.
