### PR TITLE
API(ui aspect) - restore the public buildUiHash API

### DIFF
--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -523,6 +523,7 @@ export class UiMain {
     });
     return sha1(aspectPathStrings.join(''));
   }
+
   /**
    * Generate hash for a given root
    * This API is public and used by external users, do not rename this function

--- a/scopes/ui-foundation/ui/ui.main.runtime.ts
+++ b/scopes/ui-foundation/ui/ui.main.runtime.ts
@@ -523,6 +523,13 @@ export class UiMain {
     });
     return sha1(aspectPathStrings.join(''));
   }
+  /**
+   * Generate hash for a given root
+   * This API is public and used by external users, do not rename this function
+   */
+  async buildUiHash(uiRoot: UIRoot, runtime = 'ui'): Promise<string> {
+    return this.createBuildUiHash(uiRoot, runtime);
+  }
 
   async createBundleUiHash(uiRoot: UIRoot, runtime = 'ui'): Promise<string> {
     const aspects = await uiRoot.resolveAspects(runtime);


### PR DESCRIPTION
This PR restores the `buidUiHash` that was removed as part of #7336 as this API was reported to being used by external users.