### PR TITLE
feat(lane-merge), support squash when merging one lane to another

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1203,4 +1203,36 @@ describe('merge lanes', function () {
       expect(status.mergePendingComponents).to.have.lengthOf(0);
     });
   });
+  describe('merge from one lane to another wish --squash', () => {
+    let previousSnapLaneB: string;
+    let headLaneB: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified'); // should not be part of the history
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      previousSnapLaneB = helper.command.getHeadOfLane('lane-b', 'comp1');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      headLaneB = helper.command.getHeadOfLane('lane-b', 'comp1');
+      helper.command.export();
+      helper.command.switchLocalLane('lane-a', '-x');
+      helper.command.mergeLane('lane-b', '--squash -x');
+    });
+    it('bit log should not include previous versions from lane-b', () => {
+      const log = helper.command.log('comp1');
+      expect(log).to.not.have.string(previousSnapLaneB);
+    });
+    it('Version object should include the squash data', () => {
+      const headVersion = helper.command.catComponent(`${helper.scopes.remote}/comp1@${headLaneB}`);
+      expect(headVersion).to.have.property('squashed');
+      expect(headVersion.squashed).to.have.property('laneId');
+      expect(headVersion.squashed.laneId.name).to.equal('lane-b');
+      expect(headVersion.squashed.previousParents).to.have.lengthOf(1);
+      expect(headVersion.squashed.previousParents[0]).to.equal(previousSnapLaneB);
+    });
+  });
 });

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -36,7 +36,8 @@ it will snap-merge these components to complete the merge. use "no-snap" to opt-
     ['', 'build', 'in case of snap during the merge, run the build-pipeline (similar to bit snap --build)'],
     ['m', 'message <message>', 'override the default message for the auto snap'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
-    ['', 'no-squash', 'EXPERIMENTAL. relevant for merging lanes into main, which by default squash.'],
+    ['', 'no-squash', 'relevant for merging lanes into main, which by default squash'],
+    ['', 'squash', 'EXPERIMENTAL. relevant for merging a lane into another lane, which by default does not squash'],
     [
       '',
       'ignore-config-changes',
@@ -71,6 +72,7 @@ it will snap-merge these components to complete the merge. use "no-snap" to opt-
       manual = false,
       build,
       workspace: existingOnWorkspaceOnly = false,
+      squash = false,
       noSnap = false,
       tag = false,
       message: snapMessage = '',
@@ -92,6 +94,7 @@ it will snap-merge these components to complete the merge. use "no-snap" to opt-
       tag: boolean;
       message: string;
       keepReadme?: boolean;
+      squash?: boolean;
       noSquash: boolean;
       skipDependencyInstallation?: boolean;
       skipFetch: boolean;
@@ -126,6 +129,7 @@ it will snap-merge these components to complete the merge. use "no-snap" to opt-
       noSnap,
       snapMessage,
       keepReadme,
+      squash,
       noSquash,
       tag,
       pattern,

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -40,6 +40,7 @@ export type MergeLaneOptions = {
   existingOnWorkspaceOnly: boolean;
   build: boolean;
   keepReadme: boolean;
+  squash?: boolean;
   noSquash: boolean;
   tag?: boolean;
   pattern?: string;
@@ -79,6 +80,7 @@ export class MergeLanesMain {
       existingOnWorkspaceOnly,
       build,
       keepReadme,
+      squash,
       noSquash,
       pattern,
       includeDeps,
@@ -140,7 +142,7 @@ export class MergeLanesMain {
       resolveUnrelated,
       ignoreConfigChanges,
     });
-    const shouldSquash = currentLaneId.isDefault() && !noSquash;
+    const shouldSquash = squash || (currentLaneId.isDefault() && !noSquash);
 
     if (pattern) {
       const componentIds = await this.workspace.resolveMultipleComponentIds(bitIds);


### PR DESCRIPTION
Until now, only when merging to main it was squashing by default. This PR introduces a new flag `--squash` for when merging two lanes. 