### PR TITLE
fix `getComponentDevPatterns` for `TesterMain`

### DIFF
--- a/scopes/defender/tester/tester.main.runtime.ts
+++ b/scopes/defender/tester/tester.main.runtime.ts
@@ -179,7 +179,7 @@ export class TesterMain {
    * @returns
    */
   getPatterns() {
-    return { name: 'tests', pattern: this.patterns };
+    return this.patterns;
   }
 
   getComponentDevPatterns(component: Component) {
@@ -187,7 +187,7 @@ export class TesterMain {
     const componentPatterns: string[] = env.getTestsDevPatterns
       ? env.getTestsDevPatterns(component)
       : this.getPatterns();
-    return componentPatterns;
+    return { name: 'tests', pattern: componentPatterns };
   }
 
   getDevPatternToRegister() {


### PR DESCRIPTION
## Proposed Changes

`getComponentDevPatterns` in TesterMain is not coherent with the same function from DocsMain & CompositionsMain, it is supposed to return `{name: string, pattern: string[]}`, but in TesterMain it sometimes will return `string[]` and sometimes `{name: string, pattern: string[]}`.
Also typescript incorrectly infers the return type to `string[]` (why it doesn't detect the issue? I don't know, it should have thrown a typecast error), which means that you would falsely believe that you would get the correct type until it doesn't...