### PR TITLE
fix(fetch), throw if the remote does not complete in 30 minutes

### DIFF
--- a/src/scope/objects-fetcher/objects-writable-stream.ts
+++ b/src/scope/objects-fetcher/objects-writable-stream.ts
@@ -6,7 +6,8 @@ import { ObjectItem } from '../objects/object-list';
 import { WriteObjectsQueue } from './write-objects-queue';
 import { ComponentsPerRemote } from '../component-ops/multiple-component-merger';
 
-const TIMEOUT_MINUTES = 3;
+const TIMEOUT_MINUTES_WARNING = 3;
+const TIMEOUT_MINUTES_EXIT = 30;
 
 /**
  * first, write all immutable objects, such as files/sources/versions into the filesystem, as they arrive.
@@ -30,12 +31,14 @@ export class ObjectsWritable extends Writable {
     if (!this.componentsPerRemote[remoteName]) this.componentsPerRemote[remoteName] = [];
     this.timeoutId = setInterval(() => {
       this.intervalCounter += 1;
-      const msg = `fetching from ${remoteName} takes more than ${
-        this.intervalCounter * TIMEOUT_MINUTES
-      } minutes. make sure the remote is responsive`;
+      const timeLapsedInMinutes = this.intervalCounter * TIMEOUT_MINUTES_WARNING;
+      const msg = `fetching from ${remoteName} takes more than ${timeLapsedInMinutes} minutes. make sure the remote is responsive`;
       logger.warn(msg);
       logger.console(`\n${msg}`, 'warn', 'yellow');
-    }, TIMEOUT_MINUTES * 60 * 1000);
+      if (timeLapsedInMinutes > TIMEOUT_MINUTES_EXIT) {
+        throw new Error(`fetching from ${remoteName} takes more than ${TIMEOUT_MINUTES_EXIT} minutes. exiting...`);
+      }
+    }, TIMEOUT_MINUTES_WARNING * 60 * 1000);
   }
   async _write(obj: ObjectItem, _, callback: Function) {
     logger.trace('ObjectsWritable.write', obj.ref);


### PR DESCRIPTION
Here is an example how the client can wait forever for a remote:
https://app.circleci.com/pipelines/github/teambit/bit/29462/workflows/e5534691-6533-4d43-bbf7-3c48decb86a8/jobs/276346
To avoid this, just exit the process if it takes more than X minutes. Currently set to 30.