### PR TITLE
fix(lane-merge), clear component cache before tag/snap

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -397,8 +397,7 @@ describe('merge lanes', function () {
           expect(() => helper.command.untagAll()).to.not.throw();
         });
       });
-      // TODO: @david please fix this
-      describe.skip('switching to main and merging the lane to main (with squash)', () => {
+      describe('switching to main and merging the lane to main (with squash)', () => {
         let beforeMergeHead: string;
         before(() => {
           helper.scopeHelper.getClonedLocalScope(afterMergeToMain);

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -382,7 +382,6 @@ describe('merge lanes', function () {
       it('bit status should not show the components in pending-merge', () => {
         expect(status.mergePendingComponents).to.have.lengthOf(0);
       });
-      // TODO: @david please fix this
       describe('switching to main and merging the lane to main without squash', () => {
         before(() => {
           helper.command.switchLocalLane('main');

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -383,7 +383,7 @@ describe('merge lanes', function () {
         expect(status.mergePendingComponents).to.have.lengthOf(0);
       });
       // TODO: @david please fix this
-      describe.skip('switching to main and merging the lane to main without squash', () => {
+      describe('switching to main and merging the lane to main without squash', () => {
         before(() => {
           helper.command.switchLocalLane('main');
           helper.command.mergeLane('dev', '--no-squash');

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -780,6 +780,8 @@ there are matching among unmodified components thought. consider using --unmodif
   }
 
   private async loadComponentsForTag(ids: BitIds): Promise<ConsumerComponent[]> {
+    const compIds = await this.workspace.resolveMultipleComponentIds(ids);
+    compIds.map((compId) => this.workspace.clearComponentCache(compId));
     const { components, removedComponents } = await this.workspace.consumer.loadComponents(ids.toVersionLatest());
     components.forEach((component) => {
       const componentMap = component.componentMap as ComponentMap;


### PR DESCRIPTION
Fixes an issue when snapping during merge-lane, the snap is using the cached components with the unmerged data. 