### PR TITLE
improvements(envs resolution) - add a global config to set default value for whether to resolve envs from root components

### DIFF
--- a/scopes/workspace/workspace/workspace.main.runtime.ts
+++ b/scopes/workspace/workspace/workspace.main.runtime.ts
@@ -12,6 +12,7 @@ import { LoggerAspect } from '@teambit/logger';
 import { ScopeAspect } from '@teambit/scope';
 import { UIAspect } from '@teambit/ui';
 import { VariantsAspect } from '@teambit/variants';
+import GlobalConfigAspect from '@teambit/global-config';
 
 import { EXT_NAME } from './constants';
 import { OnComponentAdd, OnComponentChange, OnComponentRemove, OnComponentLoad } from './on-component-events';
@@ -35,6 +36,7 @@ export const WorkspaceMain = {
     BundlerAspect,
     AspectLoaderAspect,
     EnvsAspect,
+    GlobalConfigAspect,
   ],
   slots: [
     Slot.withType<OnComponentLoad>(),

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -17,6 +17,7 @@ import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import LegacyComponentLoader from '@teambit/legacy/dist/consumer/component/component-loader';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { BitId } from '@teambit/legacy-bit-id';
+import { GlobalConfigMain } from '@teambit/global-config';
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
 import { DependencyResolver as LegacyDependencyResolver } from '@teambit/legacy/dist/consumer/component/dependencies/dependency-resolver';
 import { EXT_NAME } from './constants';
@@ -48,7 +49,8 @@ export type WorkspaceDeps = [
   UiMain,
   BundlerMain,
   AspectLoaderMain,
-  EnvsMain
+  EnvsMain,
+  GlobalConfigMain
 ];
 
 export type OnComponentLoadSlot = SlotRegistry<OnComponentLoad>;
@@ -80,6 +82,7 @@ export default async function provideWorkspace(
     bundler,
     aspectLoader,
     envs,
+    globalConfig,
   ]: WorkspaceDeps,
   config: WorkspaceExtConfig,
   [
@@ -119,6 +122,7 @@ export default async function provideWorkspace(
     onComponentLoadSlot,
     onComponentChangeSlot,
     envs,
+    globalConfig,
     onComponentAddSlot,
     onComponentRemoveSlot,
     onAspectsResolveSlot,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1336,8 +1336,8 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     let resolveEnvsFromRoots = this.config.resolveEnvsFromRoots;
     if (resolveEnvsFromRoots === undefined) {
       const resolveEnvsFromRootsConfig = this.globalConfig.getSync(CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS);
-      // @ts-ignore
       const defaultResolveEnvsFromRoots: boolean =
+        // @ts-ignore
         resolveEnvsFromRootsConfig === 'true' || resolveEnvsFromRootsConfig === true;
       resolveEnvsFromRoots = defaultResolveEnvsFromRoots;
     }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -47,7 +47,7 @@ import {
 import fs from 'fs-extra';
 import { CompIdGraph, DepEdgeType } from '@teambit/graph';
 import { slice, isEmpty, merge, compact } from 'lodash';
-import { MergeConfigFilename } from '@teambit/legacy/dist/constants';
+import { MergeConfigFilename, CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS } from '@teambit/legacy/dist/constants';
 import path from 'path';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import type { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
@@ -60,6 +60,8 @@ import { LaneNotFound } from '@teambit/legacy/dist/api/scope/lib/exceptions/lane
 import { ScopeNotFoundOrDenied } from '@teambit/legacy/dist/remotes/exceptions/scope-not-found-or-denied';
 import { isHash } from '@teambit/component-version';
 import { ComponentLoadOptions } from '@teambit/legacy/dist/consumer/component/component-loader';
+import { GlobalConfigMain } from '@teambit/global-config';
+
 import { ComponentConfigFile } from './component-config-file';
 import {
   OnComponentAdd,
@@ -192,6 +194,8 @@ export class Workspace implements ComponentFactory {
     private onComponentChangeSlot: OnComponentChangeSlot,
 
     readonly envs: EnvsMain,
+
+    readonly globalConfig: GlobalConfigMain,
 
     /**
      * on component add slot.
@@ -1329,6 +1333,15 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   }
 
   getWorkspaceAspectsLoader(): WorkspaceAspectsLoader {
+    let resolveEnvsFromRoots = this.config.resolveEnvsFromRoots;
+    if (resolveEnvsFromRoots === undefined) {
+      const resolveEnvsFromRootsConfig = this.globalConfig.getSync(CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS);
+      // @ts-ignore
+      const defaultResolveEnvsFromRoots: boolean =
+        resolveEnvsFromRootsConfig === 'true' || resolveEnvsFromRootsConfig === true;
+      resolveEnvsFromRoots = defaultResolveEnvsFromRoots;
+    }
+
     const workspaceAspectsLoader = new WorkspaceAspectsLoader(
       this,
       this.scope,
@@ -1340,7 +1353,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       this.onAspectsResolveSlot,
       this.onRootAspectAddedSlot,
       this.config.resolveAspectsFromNodeModules,
-      this.config.resolveEnvsFromRoots
+      resolveEnvsFromRoots
     );
     return workspaceAspectsLoader;
   }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -337,6 +337,8 @@ export const CFG_PACKAGE_MANAGER_CACHE = 'package-manager.cache';
 
 export const CFG_CAPSULES_ROOT_BASE_DIR = 'capsules_root_base_dir';
 
+export const CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS = 'default_resolve_envs_from_roots';
+
 export const CFG_PROXY = 'proxy';
 export const CFG_HTTPS_PROXY = 'https_proxy';
 export const CFG_PROXY_NO_PROXY = 'proxy.no_proxy';


### PR DESCRIPTION
## Proposed Changes

- new global config `default_resolve_envs_from_roots` to set the default value of resolveEnvsFromRoots
- to use it, run `bit config set default_resolve_envs_from_roots true` (or `false`) 

