### PR TITLE
fix(dependencies) - do not add dependencies from env to the manifest if they are also components in the workspace

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-installer.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-installer.ts
@@ -285,6 +285,9 @@ export class DependencyInstaller {
       options,
       this.installingContext
     );
+    const packageNames = componentDirectoryMap.components.map((component) =>
+      this.dependencyResolver.getPackageName(component)
+    );
     const manifests: Record<string, ProjectManifest> = componentDirectoryMap
       .toArray()
       .reduce((acc, [component, dir]) => {
@@ -292,7 +295,10 @@ export class DependencyInstaller {
         const manifest = workspaceManifest.componentsManifestsMap.get(packageName);
         if (manifest) {
           acc[dir] = manifest.toJson({ copyPeerToRuntime: copyPeerToRuntimeOnComponents });
-          acc[dir].defaultPeerDependencies = fromPairs(manifest.envPolicy.selfPolicy.toNameVersionTuple());
+          const selfPolicyWithoutLocal = manifest.envPolicy.selfPolicy.filter(
+            (dep) => !packageNames.includes(dep.dependencyId)
+          );
+          acc[dir].defaultPeerDependencies = fromPairs(selfPolicyWithoutLocal.toNameVersionTuple());
         }
         return acc;
       }, {});


### PR DESCRIPTION
## Proposed Changes

- This fixes a case when an env has a component in its env.jsonc and this component also exist in that workspace. 
before this fix, this would have been added as packages to some of the sub manifest, in that case, sometimes this can lead to different instances of that component.

