### PR TITLE
fix(new), allow specifying scope-without-owner in --scope flag

### DIFF
--- a/scopes/component/tracker/tracker.main.runtime.ts
+++ b/scopes/component/tracker/tracker.main.runtime.ts
@@ -1,6 +1,7 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import EnvsAspect from '@teambit/envs';
 import WorkspaceAspect, { OutsideWorkspaceError, Workspace } from '@teambit/workspace';
+import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
 import { AddCmd } from './add-cmd';
 import AddComponents, { AddActionResults, AddContext, AddProps, Warnings } from './add-components';
@@ -17,10 +18,7 @@ export type TrackData = {
 };
 
 export class TrackerMain {
-  constructor(private workspace: Workspace) {}
-  static slots = [];
-  static dependencies = [CLIAspect, WorkspaceAspect];
-  static runtime = MainRuntime;
+  constructor(private workspace: Workspace, private logger: Logger) {}
 
   /**
    * add a new component to the .bitmap file.
@@ -85,7 +83,9 @@ export class TrackerMain {
     if (isSelfHosted) return scopeName;
     const wsDefaultScope = this.workspace.defaultScope;
     if (!wsDefaultScope.includes('.')) {
-      throw new Error(`the entered scope has no owner nor the defaultScope in workspace.jsonc`);
+      this.logger.warn(`the entered scope ${scopeName} has no owner nor the defaultScope in workspace.jsonc`);
+      // it's possible that the user entered a non-exist scope just to test the command and will change it later.
+      return scopeName;
     }
     const [owner] = wsDefaultScope.split('.');
     return `${owner}.${scopeName}`;
@@ -101,8 +101,12 @@ export class TrackerMain {
     return remotes.isHub(scopeName);
   }
 
-  static async provider([cli, workspace]: [CLIMain, Workspace]) {
-    const trackerMain = new TrackerMain(workspace);
+  static slots = [];
+  static dependencies = [CLIAspect, WorkspaceAspect, LoggerAspect];
+  static runtime = MainRuntime;
+  static async provider([cli, workspace, loggerMain]: [CLIMain, Workspace, LoggerMain]) {
+    const logger = loggerMain.createLogger(TrackerAspect.id);
+    const trackerMain = new TrackerMain(workspace, logger);
     cli.register(new AddCmd(trackerMain));
     return trackerMain;
   }


### PR DESCRIPTION
currently, when running bit-new for templates using fork-components and the scope name has no owner (e.g. `my-org`), it throws an error:

> the entered scope has no owner nor the defaultScope in workspace.jsonc

It's related to an improvement added by https://github.com/teambit/bit/pull/5135. 
This PR just ignores this case and allow specifying such a scope-name.