### PR TITLE
chore(webpack) - update webpack version. update webpack config to remove deprecated configs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,7 +69,7 @@ importers:
         version: 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.4
-        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@pnpm/client':
         specifier: 10.0.5
         version: 10.0.5(@pnpm/logger@5.0.0)(bluebird@3.7.2)
@@ -144,7 +144,7 @@ importers:
         version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.82.1)
+        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@react-hook/latest':
         specifier: 1.0.3
         version: 1.0.3(react@17.0.2)
@@ -798,7 +798,7 @@ importers:
         version: 3.0.3
       compression-webpack-plugin:
         specifier: 9.2.0
-        version: 9.2.0(webpack@5.82.1)
+        version: 9.2.0(webpack@5.84.1)
       constants-browserify:
         specifier: 1.0.0
         version: 1.0.0
@@ -825,10 +825,10 @@ importers:
         version: 3.12.0
       css-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.82.1)
+        version: 6.2.0(webpack@5.84.1)
       css-minimizer-webpack-plugin:
         specifier: 3.0.2
-        version: 3.0.2(webpack@5.82.1)
+        version: 3.0.2(webpack@5.84.1)
       css-tree:
         specifier: 1.1.2
         version: 1.1.2
@@ -915,7 +915,7 @@ importers:
         version: 2.1.0
       expose-loader:
         specifier: 3.1.0
-        version: 3.1.0(webpack@5.82.1)
+        version: 3.1.0(webpack@5.84.1)
       express:
         specifier: 4.17.1
         version: 4.17.1
@@ -996,7 +996,7 @@ importers:
         version: 3.0.0
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.82.1)
+        version: 5.3.2(webpack@5.84.1)
       http-proxy:
         specifier: 1.18.1
         version: 1.18.1(debug@4.3.2)
@@ -1101,7 +1101,7 @@ importers:
         version: 4.1.3
       less-loader:
         specifier: 10.0.0
-        version: 10.0.0(less@4.1.3)(webpack@5.82.1)
+        version: 10.0.0(less@4.1.3)(webpack@5.84.1)
       lint-staged:
         specifier: ^12.5.0
         version: 12.5.0(enquirer@2.3.6)
@@ -1164,7 +1164,7 @@ importers:
         version: 2.5.2
       mini-css-extract-plugin:
         specifier: 2.2.2
-        version: 2.2.2(webpack@5.82.1)
+        version: 2.2.2(webpack@5.84.1)
       minimatch:
         specifier: 3.0.5
         version: 3.0.5
@@ -1209,7 +1209,7 @@ importers:
         version: 1.0.0
       new-url-loader:
         specifier: 0.1.1
-        version: 0.1.1(webpack@5.82.1)
+        version: 0.1.1(webpack@5.84.1)
       node-fetch:
         specifier: 2.6.7
         version: 2.6.7
@@ -1305,7 +1305,7 @@ importers:
         version: 5.0.2(postcss@8.4.18)
       postcss-loader:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+        version: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize:
         specifier: 10.0.0
         version: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
@@ -1359,7 +1359,7 @@ importers:
         version: 1.0.6
       react-dev-utils:
         specifier: 11.0.4
-        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-docgen:
         specifier: 5.3.1
         version: 5.3.1
@@ -1437,7 +1437,7 @@ importers:
         version: 1.43.4
       sass-loader:
         specifier: 12.1.0
-        version: 12.1.0(sass@1.43.4)(webpack@5.82.1)
+        version: 12.1.0(sass@1.43.4)(webpack@5.84.1)
       sass-lookup:
         specifier: 3.0.0
         version: 3.0.0
@@ -1464,7 +1464,7 @@ importers:
         version: 5.0.0
       source-map-loader:
         specifier: 3.0.0
-        version: 3.0.0(webpack@5.82.1)
+        version: 3.0.0(webpack@5.84.1)
       ssh2:
         specifier: 1.4.0
         version: 1.4.0
@@ -1491,7 +1491,7 @@ importers:
         version: 6.0.0
       style-loader:
         specifier: 2.0.0
-        version: 2.0.0(webpack@5.82.1)
+        version: 2.0.0(webpack@5.84.1)
       stylus-lookup:
         specifier: 3.0.2
         version: 3.0.2
@@ -1518,7 +1518,7 @@ importers:
         version: 1.0.1
       terser-webpack-plugin:
         specifier: 5.2.0
-        version: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
+        version: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
       timers-browserify:
         specifier: 2.0.12
         version: 2.0.12
@@ -1595,17 +1595,17 @@ importers:
         specifier: 3.16.0
         version: 3.16.0
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
       webpack-assets-manifest:
         specifier: 5.1.0
-        version: 5.1.0(webpack@5.82.1)
+        version: 5.1.0(webpack@5.84.1)
       webpack-dev-server:
         specifier: 4.15.0
-        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
       webpack-manifest-plugin:
         specifier: 4.0.2
-        version: 4.0.2(webpack@5.82.1)
+        version: 4.0.2(webpack@5.84.1)
       webpack-merge:
         specifier: 5.8.0
         version: 5.8.0
@@ -1614,7 +1614,7 @@ importers:
         version: 3.3.3
       workbox-webpack-plugin:
         specifier: 6.2.4
-        version: 6.2.4(@types/babel__core@7.20.0)(webpack@5.82.1)
+        version: 6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1)
       write-file-atomic:
         specifier: 5.0.0
         version: 5.0.0
@@ -1825,13 +1825,13 @@ importers:
         version: 5.28.1(esbuild@0.14.28)
       '@types/webpack-dev-server':
         specifier: 4.7.2
-        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
       '@types/yargs':
         specifier: 17.0.0
         version: 17.0.0
       babel-loader:
         specifier: 8.2.2
-        version: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+        version: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -4658,7 +4658,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -6552,7 +6552,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -8431,7 +8431,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -10310,7 +10310,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -12189,7 +12189,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -14068,7 +14068,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -15947,7 +15947,7 @@ importers:
         version: file:scopes/webpack/config-mutator(esbuild@0.14.28)(react@17.0.2)
       '@teambit/webpack.modules.generate-expose-loaders':
         specifier: workspace:*
-        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1)
+        version: file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1)
       '@teambit/webpack.modules.generate-externals':
         specifier: workspace:*
         version: file:scopes/webpack/modules/generate-externals
@@ -25781,8 +25781,8 @@ importers:
         specifier: 0.5.0
         version: 0.5.0
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
     devDependencies:
       '@babel/preset-env':
         specifier: 7.19.4
@@ -25807,7 +25807,7 @@ importers:
         version: 5.28.1(esbuild@0.14.28)
       babel-loader:
         specifier: 8.2.2
-        version: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+        version: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -26821,7 +26821,7 @@ importers:
         version: 1.6.22(react@17.0.2)
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.4
-        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@prerenderer/prerenderer':
         specifier: ^1.2.0
         version: 1.2.0(@types/express@4.17.13)(debug@4.3.2)
@@ -26830,7 +26830,7 @@ importers:
         version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.82.1)
+        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack':
         specifier: 5.5.0
         version: 5.5.0
@@ -26866,7 +26866,7 @@ importers:
         version: 5.35.1(eslint@7.32.0)(typescript@4.7.4)
       babel-loader:
         specifier: 8.2.2
-        version: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+        version: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-plugin-named-asset-import:
         specifier: 0.3.7
         version: 0.3.7(@babel/core@7.19.6)
@@ -26890,10 +26890,10 @@ importers:
         version: 3.13.0
       css-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.82.1)
+        version: 6.2.0(webpack@5.84.1)
       css-minimizer-webpack-plugin:
         specifier: 3.0.2
-        version: 3.0.2(webpack@5.82.1)
+        version: 3.0.2(webpack@5.84.1)
       esbuild:
         specifier: 0.14.28
         version: 0.14.28
@@ -26941,7 +26941,7 @@ importers:
         version: 4.1.3
       less-loader:
         specifier: 10.0.0
-        version: 10.0.0(less@4.1.3)(webpack@5.82.1)
+        version: 10.0.0(less@4.1.3)(webpack@5.84.1)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -26953,10 +26953,10 @@ importers:
         version: 4.4.0
       mini-css-extract-plugin:
         specifier: 2.2.2
-        version: 2.2.2(webpack@5.82.1)
+        version: 2.2.2(webpack@5.84.1)
       new-url-loader:
         specifier: 0.1.1
-        version: 0.1.1(webpack@5.82.1)
+        version: 0.1.1(webpack@5.84.1)
       postcss:
         specifier: 8.4.18
         version: 8.4.18
@@ -26965,7 +26965,7 @@ importers:
         version: 5.0.2(postcss@8.4.18)
       postcss-loader:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+        version: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize:
         specifier: 10.0.0
         version: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
@@ -26983,7 +26983,7 @@ importers:
         version: 1.0.6
       react-dev-utils:
         specifier: 11.0.4
-        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
@@ -27001,16 +27001,16 @@ importers:
         version: 12.0.1
       sass-loader:
         specifier: 12.1.0
-        version: 12.1.0(sass@1.43.4)(webpack@5.82.1)
+        version: 12.1.0(sass@1.43.4)(webpack@5.84.1)
       strip-ansi:
         specifier: 6.0.0
         version: 6.0.0
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.82.1)
+        version: 2.0.0(webpack@5.84.1)
       terser-webpack-plugin:
         specifier: 5.2.0
-        version: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
+        version: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
       typescript:
         specifier: 4.7.4
         version: 4.7.4
@@ -27018,8 +27018,8 @@ importers:
         specifier: 4.0.1
         version: 4.0.1
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
     devDependencies:
       '@teambit/react.content.react-overview':
         specifier: 1.95.0
@@ -27095,7 +27095,7 @@ importers:
         version: 0.4.6
       babel-loader:
         specifier: 8.2.2
-        version: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+        version: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-preset-react-app:
         specifier: ^10.0.0
         version: 10.0.0
@@ -27104,10 +27104,10 @@ importers:
         version: 3.13.0
       css-loader:
         specifier: 6.2.0
-        version: 6.2.0(webpack@5.82.1)
+        version: 6.2.0(webpack@5.84.1)
       css-minimizer-webpack-plugin:
         specifier: 3.0.2
-        version: 3.0.2(webpack@5.82.1)
+        version: 3.0.2(webpack@5.84.1)
       decamelize:
         specifier: 1.2.0
         version: 1.2.0
@@ -27116,16 +27116,16 @@ importers:
         version: 4.1.3
       less-loader:
         specifier: 10.0.0
-        version: 10.0.0(less@4.1.3)(webpack@5.82.1)
+        version: 10.0.0(less@4.1.3)(webpack@5.84.1)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
       mini-css-extract-plugin:
         specifier: 2.2.2
-        version: 2.2.2(webpack@5.82.1)
+        version: 2.2.2(webpack@5.84.1)
       new-url-loader:
         specifier: 0.1.1
-        version: 0.1.1(webpack@5.82.1)
+        version: 0.1.1(webpack@5.84.1)
       postcss:
         specifier: 8.4.18
         version: 8.4.18
@@ -27134,7 +27134,7 @@ importers:
         version: 5.0.2(postcss@8.4.18)
       postcss-loader:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+        version: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize:
         specifier: 10.0.0
         version: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
@@ -27146,7 +27146,7 @@ importers:
         version: 17.0.2
       react-dev-utils:
         specifier: 11.0.4
-        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
@@ -27155,19 +27155,19 @@ importers:
         version: 5.0.0
       sass-loader:
         specifier: 12.1.0
-        version: 12.1.0(sass@1.43.4)(webpack@5.82.1)
+        version: 12.1.0(sass@1.43.4)(webpack@5.84.1)
       style-loader:
         specifier: 2.0.0
-        version: 2.0.0(webpack@5.82.1)
+        version: 2.0.0(webpack@5.84.1)
       terser-webpack-plugin:
         specifier: 5.2.0
-        version: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
+        version: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
       webpack-manifest-plugin:
         specifier: 4.0.2
-        version: 4.0.2(webpack@5.82.1)
+        version: 4.0.2(webpack@5.84.1)
     devDependencies:
       '@types/jest':
         specifier: ^26.0.0
@@ -29867,7 +29867,7 @@ importers:
         version: 7.20.0
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.4
-        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+        version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@teambit/base-ui.loaders.loader-ribbon':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -29894,7 +29894,7 @@ importers:
         version: 0.0.3(react-dom@17.0.2)(react@17.0.2)
       babel-loader:
         specifier: 8.2.2
-        version: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+        version: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-plugin-named-asset-import:
         specifier: 0.3.7
         version: 0.3.7(@babel/core@7.19.6)
@@ -29909,10 +29909,10 @@ importers:
         version: 3.13.0
       css-loader:
         specifier: 5.2.0
-        version: 5.2.0(webpack@5.82.1)
+        version: 5.2.0(webpack@5.84.1)
       css-minimizer-webpack-plugin:
         specifier: 3.0.2
-        version: 3.0.2(webpack@5.82.1)
+        version: 3.0.2(webpack@5.84.1)
       express:
         specifier: 4.17.1
         version: 4.17.1
@@ -29924,7 +29924,7 @@ importers:
         version: 10.0.0
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.82.1)
+        version: 5.3.2(webpack@5.84.1)
       http-proxy:
         specifier: 1.18.1
         version: 1.18.1(debug@4.3.2)
@@ -29933,13 +29933,13 @@ importers:
         version: 4.1.3
       less-loader:
         specifier: 8.0.0
-        version: 8.0.0(less@4.1.3)(webpack@5.82.1)
+        version: 8.0.0(less@4.1.3)(webpack@5.84.1)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
       mini-css-extract-plugin:
         specifier: 2.2.2
-        version: 2.2.2(webpack@5.82.1)
+        version: 2.2.2(webpack@5.84.1)
       p-map-series:
         specifier: 2.1.0
         version: 2.1.0
@@ -29951,7 +29951,7 @@ importers:
         version: 5.0.2(postcss@8.4.18)
       postcss-loader:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+        version: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize:
         specifier: 10.0.0
         version: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
@@ -29963,7 +29963,7 @@ importers:
         version: 17.0.2
       react-dev-utils:
         specifier: 11.0.4
-        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
@@ -29978,31 +29978,31 @@ importers:
         version: 12.0.1
       sass-loader:
         specifier: 12.1.0
-        version: 12.1.0(sass@1.43.4)(webpack@5.82.1)
+        version: 12.1.0(sass@1.43.4)(webpack@5.84.1)
       source-map-loader:
         specifier: 3.0.0
-        version: 3.0.0(webpack@5.82.1)
+        version: 3.0.0(webpack@5.84.1)
       style-loader:
         specifier: ^2.0.0
-        version: 2.0.0(webpack@5.82.1)
+        version: 2.0.0(webpack@5.84.1)
       terser-webpack-plugin:
         specifier: 5.2.0
-        version: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
+        version: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
       webpack-dev-server:
         specifier: 4.15.0
-        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
       webpack-manifest-plugin:
         specifier: 4.0.2
-        version: 4.0.2(webpack@5.82.1)
+        version: 4.0.2(webpack@5.84.1)
       webpack-merge:
         specifier: 5.8.0
         version: 5.8.0
       workbox-webpack-plugin:
         specifier: 6.2.4
-        version: 6.2.4(@types/babel__core@7.20.0)(webpack@5.82.1)
+        version: 6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1)
     devDependencies:
       '@types/express':
         specifier: 4.17.13
@@ -30045,7 +30045,7 @@ importers:
         version: 5.28.1(esbuild@0.14.28)
       '@types/webpack-dev-server':
         specifier: 4.7.2
-        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
 
   scopes/ui-foundation/uis/constants/z-indexes:
     dependencies:
@@ -31224,13 +31224,13 @@ importers:
         version: 0.0.3(react@17.0.2)
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.82.1)
+        version: 5.3.2(webpack@5.84.1)
       lodash:
         specifier: 4.17.21
         version: 4.17.21
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
       webpack-merge:
         specifier: 5.8.0
         version: 5.8.0
@@ -31261,7 +31261,7 @@ importers:
     dependencies:
       expose-loader:
         specifier: 3.1.0
-        version: 3.1.0(webpack@5.82.1)
+        version: 3.1.0(webpack@5.84.1)
     devDependencies:
       '@babel/runtime':
         specifier: 7.20.0
@@ -31316,7 +31316,7 @@ importers:
     dependencies:
       html-webpack-plugin:
         specifier: ^5.3.1
-        version: 5.3.2(webpack@5.82.1)
+        version: 5.3.2(webpack@5.84.1)
       insert-string-after:
         specifier: 1.0.0
         version: 1.0.0
@@ -31371,7 +31371,7 @@ importers:
         version: 6.2.0
       compression-webpack-plugin:
         specifier: 9.2.0
-        version: 9.2.0(webpack@5.82.1)
+        version: 9.2.0(webpack@5.84.1)
       constants-browserify:
         specifier: 1.0.0
         version: 1.0.0
@@ -31389,13 +31389,13 @@ importers:
         version: 4.5.0
       expose-loader:
         specifier: 3.1.0
-        version: 3.1.0(webpack@5.82.1)
+        version: 3.1.0(webpack@5.84.1)
       find-root:
         specifier: 1.1.0
         version: 1.1.0
       html-webpack-plugin:
         specifier: 5.3.2
-        version: 5.3.2(webpack@5.82.1)
+        version: 5.3.2(webpack@5.84.1)
       https-browserify:
         specifier: 1.0.0
         version: 1.0.0
@@ -31428,7 +31428,7 @@ importers:
         version: 17.0.2
       react-dev-utils:
         specifier: 11.0.4
-        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+        version: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
@@ -31457,14 +31457,14 @@ importers:
         specifier: 1.1.2
         version: 1.1.2
       webpack:
-        specifier: 5.82.1
-        version: 5.82.1(esbuild@0.14.28)
+        specifier: 5.84.1
+        version: 5.84.1(esbuild@0.14.28)
       webpack-assets-manifest:
         specifier: 5.1.0
-        version: 5.1.0(webpack@5.82.1)
+        version: 5.1.0(webpack@5.84.1)
       webpack-dev-server:
         specifier: 4.15.0
-        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
       webpack-merge:
         specifier: 5.8.0
         version: 5.8.0
@@ -31498,7 +31498,7 @@ importers:
         version: 5.28.1(esbuild@0.14.28)
       '@types/webpack-dev-server':
         specifier: 4.7.2
-        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+        version: 4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
 
   scopes/workspace/aspect-docs/variants:
     dependencies:
@@ -36428,7 +36428,7 @@ packages:
       rimraf: 3.0.2
     dev: false
 
-  /@pmmmwh/react-refresh-webpack-plugin@0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1):
+  /@pmmmwh/react-refresh-webpack-plugin@0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1):
     resolution: {integrity: sha512-zZbZeHQDnoTlt2AF+diQT0wsSXpvWiaIOZwBRdltNFhG1+I3ozyaw7U/nBiUwyJ0D+zwdXp0E3bWOl38Ag2BMw==}
     engines: {node: '>= 10.13'}
     peerDependencies:
@@ -36465,8 +36465,8 @@ packages:
       react-refresh: 0.10.0
       schema-utils: 3.1.1
       source-map: 0.7.4
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
     dev: false
 
   /@pnpm/build-modules@11.0.2(@pnpm/logger@5.0.0)(bluebird@3.7.2):
@@ -37948,7 +37948,7 @@ packages:
     dev: false
     optional: true
 
-  /@prerenderer/webpack-plugin@5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.82.1):
+  /@prerenderer/webpack-plugin@5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1):
     resolution: {integrity: sha512-wddJnlweYohyZ3/KSXU1bM+ZE+k82xHIU71Izzah5pvCYwhYpHQGNfYLLwymvF01TGel6Mqwdw2ChitXZ8sJ+w==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -37956,9 +37956,9 @@ packages:
       webpack: ^5
     dependencies:
       '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     optionalDependencies:
       '@prerenderer/renderer-puppeteer': 1.1.3(puppeteer@13.7.0)
     transitivePeerDependencies:
@@ -39232,7 +39232,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.128(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.128.tgz}
+    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/teambit-component.modules.component-url-0.0.128.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -39246,7 +39246,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.140(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.140.tgz}
+    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/teambit-component.modules.component-url-0.0.140.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -39260,7 +39260,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.151(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.151.tgz}
+    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/teambit-component.modules.component-url-0.0.151.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -39287,7 +39287,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.badges.component-count@0.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.10.tgz}
+    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/ui/badges/component-count@0.0.10.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39319,7 +39319,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.hooks.use-component-compare-url@0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
+    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39349,7 +39349,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-change-type@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/@teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
+    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39361,7 +39361,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-hooks@0.0.4(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/@teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
+    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39440,7 +39440,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-state@0.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/@teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
+    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39466,7 +39466,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.utils.lazy-loading@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
+    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39479,7 +39479,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.494(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.494.tgz}
+    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/ui/deprecation-icon@0.0.494.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39496,7 +39496,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.500(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.500.tgz}
+    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/ui/deprecation-icon@0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40482,7 +40482,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.350(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.350.tgz}
+    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/pill-label@0.0.350.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41116,7 +41116,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.6.tgz}
+    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/heading@4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41179,7 +41179,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.8.tgz}
+    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/linked-heading@4.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41393,7 +41393,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.486.tgz}
+    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.envs/ui/env-icon@0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41405,7 +41405,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.492.tgz}
+    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.envs/ui/env-icon@0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41483,7 +41483,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.label@1.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.10.tgz}
+    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.evangelist/input/checkbox/label@1.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41737,7 +41737,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-card@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.495.tgz}
+    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/gallery/component-card@0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41768,7 +41768,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-card@0.0.507(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.507.tgz}
+    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/gallery/component-card@0.0.507.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41948,7 +41948,7 @@ packages:
       user-home: 2.0.0
 
   /@teambit/html.modules.create-element-from-string@0.0.104:
-    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
+    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.bit.cloud/tarballs/teambit.html/modules/create-element-from-string@0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -42466,7 +42466,7 @@ packages:
     dev: false
 
   /@teambit/preview.ui.preview-placeholder@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.496.tgz}
+    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.preview/ui/preview-placeholder@0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42713,7 +42713,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-title@0.0.508(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.508.tgz}
+    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/teambit-scope.ui.scope-title-0.0.508.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42785,16 +42785,16 @@ packages:
     dev: false
 
   /@teambit/toolbox.string.ellipsis@0.0.172:
-    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.172.tgz}
+    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/string/ellipsis@0.0.172.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.string.ellipsis@0.0.173:
-    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.173.tgz}
+    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/string/ellipsis@0.0.173.tgz}
     engines: {node: '>=12.22.0'}
 
   /@teambit/toolbox.string.ellipsis@0.0.181:
-    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
+    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/string/ellipsis@0.0.181.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -42804,17 +42804,17 @@ packages:
     dev: false
 
   /@teambit/toolbox.string.get-initials@0.0.491:
-    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.491.tgz}
+    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/string/get-initials@0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.types.serializable@0.0.483:
-    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.483.tgz}
+    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/types/serializable@0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.types.serializable@0.0.491:
-    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
+    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/types/serializable@0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -42824,7 +42824,7 @@ packages:
     dev: false
 
   /@teambit/toolbox.url.add-avatar-query-params@0.0.492:
-    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.492.tgz}
+    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/url/add-avatar-query-params@0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -42852,7 +42852,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.constants.z-indexes@0.0.498(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.constants.z-indexes/-/@teambit-ui-foundation.ui.constants.z-indexes-0.0.498.tgz}
+    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/constants/z-indexes@0.0.498.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42927,7 +42927,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.get-icon-from-file-name@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.get-icon-from-file-name/-/@teambit-ui-foundation.ui.get-icon-from-file-name-0.0.495.tgz}
+    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/get-icon-from-file-name@0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42940,7 +42940,7 @@ packages:
       vscode-icons-js: 11.0.0
 
   /@teambit/ui-foundation.ui.global-loader@0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.474.tgz}
+    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/global-loader@0.0.474.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.183
@@ -42955,7 +42955,7 @@ packages:
     dev: true
 
   /@teambit/ui-foundation.ui.global-loader@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.487.tgz}
+    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/global-loader@0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42968,7 +42968,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.493.tgz}
+    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/global-loader@0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42981,7 +42981,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.497(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.497.tgz}
+    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/global-loader@0.0.497.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43010,7 +43010,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.496(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.496.tgz}
+    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/hooks/use-data-query@0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -43026,7 +43026,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.500(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.500.tgz}
+    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/hooks/use-data-query@0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -43042,7 +43042,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.486.tgz}
+    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/is-browser@0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43054,7 +43054,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.492.tgz}
+    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/is-browser@0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43066,7 +43066,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.486.tgz}
+    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/keycap@0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43080,7 +43080,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.492.tgz}
+    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/keycap@0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43201,7 +43201,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.487.tgz}
+    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/notification-context@0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43214,7 +43214,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.493.tgz}
+    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/notification-context@0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43227,7 +43227,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.496.tgz}
+    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/notification-context@0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43240,7 +43240,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.486.tgz}
+    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/store@0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43252,7 +43252,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.492.tgz}
+    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/store@0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43264,7 +43264,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.495.tgz}
+    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/notifications/store@0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43296,7 +43296,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.slot-router@0.0.501(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.501.tgz}
+    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/react-router/slot-router@0.0.501.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43316,7 +43316,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.use-query@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.use-query/-/@teambit-ui-foundation.ui.react-router.use-query-0.0.496.tgz}
+    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/react-router/use-query@0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43436,7 +43436,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.512(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
+    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43571,7 +43571,7 @@ packages:
     dev: true
 
   /@teambit/workspace.ui.load-preview@0.0.489(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.489.tgz}
+    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/ui/load-preview@0.0.489.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -43585,7 +43585,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.load-preview@0.0.499(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.499.tgz}
+    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/ui/load-preview@0.0.499.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -43619,7 +43619,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.workspace-component-card@0.0.510(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.510.tgz}
+    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/ui/workspace-component-card@0.0.510.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -44130,7 +44130,7 @@ packages:
     dependencies:
       '@types/node': 12.20.4
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -44375,11 +44375,11 @@ packages:
       - debug
     dev: true
 
-  /@types/webpack-dev-server@4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1):
+  /@types/webpack-dev-server@4.7.2(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1):
     resolution: {integrity: sha512-Y3p0Fmfvp0MHBDoCzo+xFJaWTw0/z37mWIo6P15j+OtmUDLvznJWdZNeD7Q004R+MpQlys12oXbXsrXRmxwg4Q==}
     deprecated: This is a stub types definition. webpack-dev-server provides its own type definitions, so you do not need this installed.
     dependencies:
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -44413,7 +44413,7 @@ packages:
     dependencies:
       '@types/node': 12.20.4
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -45827,8 +45827,8 @@ packages:
       acorn-walk: 7.2.0
     dev: false
 
-  /acorn-import-assertions@1.8.0(acorn@8.8.2):
-    resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
+  /acorn-import-assertions@1.9.0(acorn@8.8.2):
+    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
@@ -46922,7 +46922,7 @@ packages:
       - supports-color
     dev: false
 
-  /babel-loader@8.2.2(@babel/core@7.19.6)(webpack@5.82.1):
+  /babel-loader@8.2.2(@babel/core@7.19.6)(webpack@5.84.1):
     resolution: {integrity: sha512-JvTd0/D889PQBtUXJ2PXaKU/pjZDMtHA9V2ecm+eNRmmBCMR09a+fmpGTNwnJtFmFl5Ei7Vy47LjBb+L0wQ99g==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -46934,7 +46934,7 @@ packages:
       loader-utils: 1.4.2
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
 
   /babel-plugin-apply-mdx-type-prop@1.6.21(@babel/core@7.11.6):
     resolution: {integrity: sha512-+vQarmm+g+kePH4CMp2iEN/HOx1oEvZeSKCdKCEZlnJOthXzkpaRAbM3ZNCiKqVr9WuoqPNfoXQ0EVppYpIwfg==}
@@ -48459,7 +48459,7 @@ packages:
     dependencies:
       mime-db: 1.52.0
 
-  /compression-webpack-plugin@9.2.0(webpack@5.82.1):
+  /compression-webpack-plugin@9.2.0(webpack@5.84.1):
     resolution: {integrity: sha512-R/Oi+2+UHotGfu72fJiRoVpuRifZT0tTC6UqFD/DUo+mv8dbOow9rVOuTvDv5nPPm3GZhHL/fKkwxwIHnJ8Nyw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -48467,7 +48467,7 @@ packages:
     dependencies:
       schema-utils: 4.0.0
       serialize-javascript: 6.0.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /compression@1.7.4:
@@ -48891,7 +48891,7 @@ packages:
     dependencies:
       hyphenate-style-name: 1.0.4
 
-  /css-loader@5.2.0(webpack@5.82.1):
+  /css-loader@5.2.0(webpack@5.84.1):
     resolution: {integrity: sha512-MfRo2MjEeLXMlUkeUwN71Vx5oc6EJnx5UQ4Yi9iUtYQvrPtwLUucYptz0hc6n++kdNcyF5olYBS4vPjJDAcLkw==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -48909,10 +48909,10 @@ packages:
       postcss-value-parser: 4.2.0
       schema-utils: 3.1.1
       semver: 7.3.4
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
-  /css-loader@6.2.0(webpack@5.82.1):
+  /css-loader@6.2.0(webpack@5.84.1):
     resolution: {integrity: sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -48926,10 +48926,10 @@ packages:
       postcss-modules-values: 4.0.0(postcss@8.4.18)
       postcss-value-parser: 4.2.0
       semver: 7.3.8
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
-  /css-minimizer-webpack-plugin@3.0.2(webpack@5.82.1):
+  /css-minimizer-webpack-plugin@3.0.2(webpack@5.84.1):
     resolution: {integrity: sha512-B3I5e17RwvKPJwsxjjWcdgpU/zqylzK1bPVghcmpFHRL48DXiBgrtqz1BJsn68+t/zzaLp9kYAaEDvQ7GyanFQ==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -48949,7 +48949,7 @@ packages:
       schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /css-prefers-color-scheme@6.0.3(postcss@8.4.18):
@@ -49957,8 +49957,8 @@ packages:
       tapable: 1.1.3
     dev: false
 
-  /enhanced-resolve@5.14.0:
-    resolution: {integrity: sha512-+DCows0XNwLDcUhbFJPdlQEVnT2zXlCv7hPxemTz86/O+B/hCQ+mb7ydkPKiflpVraqLPCAfu7lDy+hBXueojw==}
+  /enhanced-resolve@5.14.1:
+    resolution: {integrity: sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
@@ -51100,13 +51100,13 @@ packages:
       jest-message-util: 27.5.1
     dev: false
 
-  /expose-loader@3.1.0(webpack@5.82.1):
+  /expose-loader@3.1.0(webpack@5.84.1):
     resolution: {integrity: sha512-2RExSo0yJiqP+xiUue13jQa2IHE8kLDzTI7b6kn+vUlBVvlzNSiLDzo4e5Pp5J039usvTUnxZ8sUOhv0Kg15NA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /express-graphql@0.12.0(graphql@14.7.0):
@@ -51765,7 +51765,7 @@ packages:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     dev: false
 
-  /fork-ts-checker-webpack-plugin@4.1.6(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1):
+  /fork-ts-checker-webpack-plugin@4.1.6(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1):
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -51787,7 +51787,7 @@ packages:
       semver: 5.7.1
       tapable: 1.1.3
       typescript: 4.7.4
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
@@ -52932,7 +52932,7 @@ packages:
     resolution: {integrity: sha512-uE/TxKuyNIcx44cIWnjr/rfIATDH7ZaOMmstu0CwhFG1Dunhlp4OC6/NMbhiwoq5BpW0ubi303qnEk/PZj614w==}
     dev: false
 
-  /html-webpack-plugin@5.3.2(webpack@5.82.1):
+  /html-webpack-plugin@5.3.2(webpack@5.84.1):
     resolution: {integrity: sha512-HvB33boVNCz2lTyBsSiMffsJ+m0YLIQ+pskblXgN9fnjS1BgEcuAfdInfXfGrkdXV406k9FiDi86eVCDBgJOyQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -52943,7 +52943,7 @@ packages:
       lodash: 4.17.21
       pretty-error: 3.0.4
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /htmlparser2@6.1.0:
@@ -53369,7 +53369,7 @@ packages:
       html-webpack-plugin: ^5.3.1
     dependencies:
       debug: 4.3.4(supports-color@9.3.1)
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       insert-string-after: 1.0.0
       insert-string-before: 1.0.0
     transitivePeerDependencies:
@@ -55128,7 +55128,7 @@ packages:
       readable-stream: 2.3.7
     dev: false
 
-  /less-loader@10.0.0(less@4.1.3)(webpack@5.82.1):
+  /less-loader@10.0.0(less@4.1.3)(webpack@5.84.1):
     resolution: {integrity: sha512-JjioAkw9qyavL0BzMPUOHJa0a20fh+ipq/MNZH4OkU8qERsCMeZIWRE0FDBIx2O+cFguvY01vHh/lmBA9LyWDg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -55137,10 +55137,10 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
-  /less-loader@8.0.0(less@4.1.3)(webpack@5.82.1):
+  /less-loader@8.0.0(less@4.1.3)(webpack@5.84.1):
     resolution: {integrity: sha512-tnDs0ZdwPZgNOg0NGJ0sAD2KViG9TvOMDVibT33fH1bpLkT4xMo5Ue2FsbjFsVsUKtuRTlU0tYp2/lRizrycLg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -55149,7 +55149,7 @@ packages:
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /less@4.1.3:
@@ -56012,14 +56012,14 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /mini-css-extract-plugin@2.2.2(webpack@5.82.1):
+  /mini-css-extract-plugin@2.2.2(webpack@5.84.1):
     resolution: {integrity: sha512-eUjQ/q1rQIeHWgIx7ny/DNgXHcMXHdBwgrZQK7Ev8dbR+HxhroFM2Cb6kMiswOYaq05IRJhPuQqXWUABIjjA3g==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
       schema-utils: 3.1.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /minimalistic-assert@1.0.1:
@@ -56477,13 +56477,13 @@ packages:
     resolution: {integrity: sha512-EZSPZB70jiVsivaBLYDCyntd5eH8NTSMOn3rB+HxwdmKThGELLdYv8qVIMWvZEFy9w8ZZpW9h9OB32l1rGtj7g==}
     dev: false
 
-  /new-url-loader@0.1.1(webpack@5.82.1):
+  /new-url-loader@0.1.1(webpack@5.84.1):
     resolution: {integrity: sha512-e7v5Q3uFk2jXgnL1JSVCszPTg9MYkbNIpKI6azeNlAa1bAwboA63aBsC63jlTEWlTacNL45tqWPx0Nm0SkCxCQ==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /next-path@1.0.0:
@@ -58134,7 +58134,7 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-loader@7.0.1(postcss@8.4.18)(webpack@5.82.1):
+  /postcss-loader@7.0.1(postcss@8.4.18)(webpack@5.84.1):
     resolution: {integrity: sha512-VRviFEyYlLjctSM93gAZtcJJ/iSkPZ79zWbN/1fSH+NisBByEiVLqpdVDrPLVSi8DX0oJo12kL/GppTBdKVXiQ==}
     engines: {node: '>= 14.15.0'}
     peerDependencies:
@@ -58145,7 +58145,7 @@ packages:
       klona: 2.0.6
       postcss: 8.4.18
       semver: 7.3.8
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /postcss-logical@5.0.4(postcss@8.4.18):
@@ -59150,7 +59150,7 @@ packages:
       react: 17.0.2
     dev: false
 
-  /react-dev-utils@11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1):
+  /react-dev-utils@11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1):
     resolution: {integrity: sha512-dx0LvIGHcOPtKbeiSUM4jqpBl3TcY7CDjZdfOIcKeznE7BWr9dg0iPG90G5yfVQ+p/rGNMXdbfStvzQZEVEi4A==}
     engines: {node: '>=10'}
     peerDependencies:
@@ -59169,7 +59169,7 @@ packages:
       escape-string-regexp: 2.0.0
       filesize: 6.1.0
       find-up: 4.1.0
-      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      fork-ts-checker-webpack-plugin: 4.1.6(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       global-modules: 2.0.0
       globby: 11.0.1
       gzip-size: 5.1.1
@@ -59185,7 +59185,7 @@ packages:
       strip-ansi: 6.0.0
       text-table: 0.2.0
       typescript: 4.7.4
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -60453,7 +60453,7 @@ packages:
     resolution: {integrity: sha512-QbusSBnWHaRBZeTxsJyknwI0q+q6m1NtLBmB76JfW/rdVN7Ws6Zz70w65+430/ouVcdNVT3qwrDgrM6PaYyRtw==}
     dev: false
 
-  /sass-loader@12.1.0(sass@1.43.4)(webpack@5.82.1):
+  /sass-loader@12.1.0(sass@1.43.4)(webpack@5.84.1):
     resolution: {integrity: sha512-FVJZ9kxVRYNZTIe2xhw93n3xJNYZADr+q69/s98l9nTCrWASo+DR2Ot0s5xTKQDDEosUkatsGeHxcH4QBp5bSg==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -60472,7 +60472,7 @@ packages:
       klona: 2.0.6
       neo-async: 2.6.2
       sass: 1.43.4
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /sass-lookup@3.0.0:
@@ -61078,7 +61078,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /source-map-loader@3.0.0(webpack@5.82.1):
+  /source-map-loader@3.0.0(webpack@5.84.1):
     resolution: {integrity: sha512-GKGWqWvYr04M7tn8dryIWvb0s8YM41z82iQv01yBtIylgxax0CwvSy6gc2Y02iuXwEfGWRlMicH0nvms9UZphw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -61087,7 +61087,7 @@ packages:
       abab: 2.0.6
       iconv-lite: 0.6.3
       source-map-js: 0.6.2
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /source-map-resolve@0.5.3:
@@ -61699,7 +61699,7 @@ packages:
     resolution: {integrity: sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==}
     dev: false
 
-  /style-loader@2.0.0(webpack@5.82.1):
+  /style-loader@2.0.0(webpack@5.84.1):
     resolution: {integrity: sha512-Z0gYUJmzZ6ZdRUqpg1r8GsaFKypE+3xAzuFeMuoHgjc9KZv3wMyCRjQIWEbhoFSq7+7yoHXySDJyyWQaPajeiQ==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -61707,7 +61707,7 @@ packages:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.1.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
   /style-to-object@0.3.0:
@@ -62058,7 +62058,7 @@ packages:
       supports-hyperlinks: 2.3.0
     dev: false
 
-  /terser-webpack-plugin@5.2.0(esbuild@0.14.28)(webpack@5.82.1):
+  /terser-webpack-plugin@5.2.0(esbuild@0.14.28)(webpack@5.84.1):
     resolution: {integrity: sha512-FpR4Qe0Yt4knSQ5u2bA1wkM0R8VlVsvhyfSHvomXRivS4vPLk0dJV2IhRBIHRABh7AFutdMeElIA5y1dETwMBg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -62081,10 +62081,10 @@ packages:
       serialize-javascript: 6.0.1
       source-map: 0.6.1
       terser: 5.16.2
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
-  /terser-webpack-plugin@5.3.8(esbuild@0.14.28)(webpack@5.82.1):
+  /terser-webpack-plugin@5.3.8(esbuild@0.14.28)(webpack@5.84.1):
     resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
@@ -62106,7 +62106,7 @@ packages:
       schema-utils: 3.1.2
       serialize-javascript: 6.0.1
       terser: 5.17.3
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
 
   /terser@4.8.1:
     resolution: {integrity: sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==}
@@ -63511,7 +63511,7 @@ packages:
     engines: {node: '>=10.4'}
     dev: false
 
-  /webpack-assets-manifest@5.1.0(webpack@5.82.1):
+  /webpack-assets-manifest@5.1.0(webpack@5.84.1):
     resolution: {integrity: sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
@@ -63524,10 +63524,10 @@ packages:
       lodash.has: 4.5.2
       schema-utils: 3.1.1
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     dev: false
 
-  /webpack-dev-middleware@5.3.3(webpack@5.82.1):
+  /webpack-dev-middleware@5.3.3(webpack@5.84.1):
     resolution: {integrity: sha512-hj5CYrY0bZLB+eTO+x/j67Pkrquiy7kWepMHmUMoPsmcUaeEnQJqFzHJOyxgWlq746/wUuA64p9ta34Kyb01pA==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
@@ -63538,9 +63538,9 @@ packages:
       mime-types: 2.1.35
       range-parser: 1.2.1
       schema-utils: 4.0.0
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
 
-  /webpack-dev-server@4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1):
+  /webpack-dev-server@4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1):
     resolution: {integrity: sha512-HmNB5QeSl1KpulTBQ8UT4FPrByYyaLxpJoQ0+s7EvUrMc16m0ZS1sgb1XGqzmgCPk0c9y+aaXxn11tbLzuM7NQ==}
     engines: {node: '>= 12.13.0'}
     hasBin: true
@@ -63581,8 +63581,8 @@ packages:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-dev-middleware: 5.3.3(webpack@5.82.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-dev-middleware: 5.3.3(webpack@5.84.1)
       ws: 8.13.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     transitivePeerDependencies:
       - bufferutil
@@ -63590,14 +63590,14 @@ packages:
       - supports-color
       - utf-8-validate
 
-  /webpack-manifest-plugin@4.0.2(webpack@5.82.1):
+  /webpack-manifest-plugin@4.0.2(webpack@5.84.1):
     resolution: {integrity: sha512-Ld6j05pRblXAVoX8xdXFDsc/s97cFnR1FOmQawhTSlp6F6aeU1Jia5aqTmDpkueaAz8g9sXpgSOqmEgVAR61Xw==}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       webpack: ^4.44.2 || ^5.47.0
     dependencies:
       tapable: 2.2.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
       webpack-sources: 2.3.1
     dev: false
 
@@ -63628,8 +63628,8 @@ packages:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
 
-  /webpack@5.82.1(esbuild@0.14.28):
-    resolution: {integrity: sha512-C6uiGQJ+Gt4RyHXXYt+v9f+SN1v83x68URwgxNQ98cvH8kxiuywWGP4XeNZ1paOzZ63aY3cTciCEQJNFUljlLw==}
+  /webpack@5.84.1(esbuild@0.14.28):
+    resolution: {integrity: sha512-ZP4qaZ7vVn/K8WN/p990SGATmrL1qg4heP/MrVneczYtpDGJWlrgZv55vxaV2ul885Kz+25MP2kSXkPe3LZfmg==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -63644,10 +63644,10 @@ packages:
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
       acorn: 8.8.2
-      acorn-import-assertions: 1.8.0(acorn@8.8.2)
+      acorn-import-assertions: 1.9.0(acorn@8.8.2)
       browserslist: 4.16.3
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.14.0
+      enhanced-resolve: 5.14.1
       es-module-lexer: 1.2.1
       eslint-scope: 5.1.1
       events: 3.3.0
@@ -63659,7 +63659,7 @@ packages:
       neo-async: 2.6.2
       schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.8(esbuild@0.14.28)(webpack@5.82.1)
+      terser-webpack-plugin: 5.3.8(esbuild@0.14.28)(webpack@5.84.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -64002,7 +64002,7 @@ packages:
     resolution: {integrity: sha512-OlWLHNNM+j44sN2OaVXnVcf2wwhJUzcHlXrTrbWDu1JWnrQJ/rLicdc/sbxkZoyE0EbQm7Xr1BXcOjsB7PNlXQ==}
     dev: false
 
-  /workbox-webpack-plugin@6.2.4(@types/babel__core@7.20.0)(webpack@5.82.1):
+  /workbox-webpack-plugin@6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1):
     resolution: {integrity: sha512-G6yeOZDYEbtqgNasqwxHFnma0Vp237kMxpsf8JV/YIhvhUuMwnh1WKv4VnFeqmYaWW/ITx0qj92IEMWB/O1mAA==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
@@ -64012,7 +64012,7 @@ packages:
       pretty-bytes: 5.6.0
       source-map-url: 0.4.1
       upath: 1.2.0
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
       webpack-sources: 1.4.3
       workbox-build: 6.2.4(@types/babel__core@7.20.0)
     transitivePeerDependencies:
@@ -64480,7 +64480,7 @@ packages:
     resolution: {directory: components/ui/compare/lane-compare, type: directory}
     id: file:components/ui/compare/lane-compare
     name: '@teambit/lanes.ui.compare.lane-compare'
-    version: 0.0.93
+    version: 0.0.94
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64499,7 +64499,7 @@ packages:
     resolution: {directory: components/ui/compare/lane-compare-drawer, type: directory}
     id: file:components/ui/compare/lane-compare-drawer
     name: '@teambit/lanes.ui.compare.lane-compare-drawer'
-    version: 0.0.72
+    version: 0.0.73
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64519,7 +64519,7 @@ packages:
     resolution: {directory: components/ui/compare/lane-compare-hooks/use-lane-diff-status, type: directory}
     id: file:components/ui/compare/lane-compare-hooks/use-lane-diff-status
     name: '@teambit/lanes.ui.compare.lane-compare-hooks.use-lane-diff-status'
-    version: 0.0.73
+    version: 0.0.74
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -64552,7 +64552,7 @@ packages:
     resolution: {directory: components/ui/compare/lane-compare-page, type: directory}
     id: file:components/ui/compare/lane-compare-page
     name: '@teambit/lanes.ui.compare.lane-compare-page'
-    version: 0.0.77
+    version: 0.0.78
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64597,7 +64597,7 @@ packages:
     resolution: {directory: components/ui/component-compare/changelog, type: directory}
     id: file:components/ui/component-compare/changelog
     name: '@teambit/component.ui.component-compare.changelog'
-    version: 0.0.93
+    version: 0.0.94
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64633,7 +64633,7 @@ packages:
     resolution: {directory: components/ui/component-compare/compare-aspects/compare-aspects, type: directory}
     id: file:components/ui/component-compare/compare-aspects/compare-aspects
     name: '@teambit/component.ui.component-compare.compare-aspects.compare-aspects'
-    version: 0.0.70
+    version: 0.0.71
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64669,7 +64669,7 @@ packages:
     resolution: {directory: components/ui/component-compare/compare-aspects/hooks/use-compare-aspects, type: directory}
     id: file:components/ui/component-compare/compare-aspects/hooks/use-compare-aspects
     name: '@teambit/component.ui.component-compare.compare-aspects.hooks.use-compare-aspects'
-    version: 0.0.43
+    version: 0.0.44
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -64701,7 +64701,7 @@ packages:
     resolution: {directory: components/ui/component-compare/component-compare, type: directory}
     id: file:components/ui/component-compare/component-compare
     name: '@teambit/component.ui.component-compare.component-compare'
-    version: 0.0.93
+    version: 0.0.94
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64721,7 +64721,7 @@ packages:
     resolution: {directory: components/ui/component-compare/context, type: directory}
     id: file:components/ui/component-compare/context
     name: '@teambit/component.ui.component-compare.context'
-    version: 0.0.43
+    version: 0.0.44
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64735,7 +64735,7 @@ packages:
     resolution: {directory: components/ui/component-compare/hooks/use-component-compare, type: directory}
     id: file:components/ui/component-compare/hooks/use-component-compare
     name: '@teambit/component.ui.component-compare.hooks.use-component-compare'
-    version: 0.0.41
+    version: 0.0.42
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -64812,7 +64812,7 @@ packages:
     resolution: {directory: components/ui/component-compare/models/component-compare-model, type: directory}
     id: file:components/ui/component-compare/models/component-compare-model
     name: '@teambit/component.ui.component-compare.models.component-compare-model'
-    version: 0.0.39
+    version: 0.0.40
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64826,7 +64826,7 @@ packages:
     resolution: {directory: components/ui/component-compare/models/component-compare-props, type: directory}
     id: file:components/ui/component-compare/models/component-compare-props
     name: '@teambit/component.ui.component-compare.models.component-compare-props'
-    version: 0.0.28
+    version: 0.0.29
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64844,7 +64844,7 @@ packages:
     resolution: {directory: components/ui/component-compare/models/component-compare-props, type: directory}
     id: file:components/ui/component-compare/models/component-compare-props
     name: '@teambit/component.ui.component-compare.models.component-compare-props'
-    version: 0.0.28
+    version: 0.0.29
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64935,7 +64935,7 @@ packages:
     resolution: {directory: components/ui/component-compare/utils/sort-tabs, type: directory}
     id: file:components/ui/component-compare/utils/sort-tabs
     name: '@teambit/component.ui.component-compare.utils.sort-tabs'
-    version: 0.0.28
+    version: 0.0.29
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -64949,7 +64949,7 @@ packages:
     resolution: {directory: components/ui/component-compare/version-picker, type: directory}
     id: file:components/ui/component-compare/version-picker
     name: '@teambit/component.ui.component-compare.version-picker'
-    version: 0.0.93
+    version: 0.0.94
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -64962,7 +64962,7 @@ packages:
     resolution: {directory: components/ui/gallery, type: directory}
     id: file:components/ui/gallery
     name: '@teambit/lanes.ui.gallery'
-    version: 0.0.61
+    version: 0.0.62
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65002,7 +65002,7 @@ packages:
     resolution: {directory: components/ui/inputs/lane-selector, type: directory}
     id: file:components/ui/inputs/lane-selector
     name: '@teambit/lanes.ui.inputs.lane-selector'
-    version: 0.0.137
+    version: 0.0.138
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65034,7 +65034,7 @@ packages:
     resolution: {directory: components/ui/inputs/lane-selector, type: directory}
     id: file:components/ui/inputs/lane-selector
     name: '@teambit/lanes.ui.inputs.lane-selector'
-    version: 0.0.137
+    version: 0.0.138
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65066,7 +65066,7 @@ packages:
     resolution: {directory: components/ui/lane-details, type: directory}
     id: file:components/ui/lane-details
     name: '@teambit/lanes.ui.lane-details'
-    version: 0.0.133
+    version: 0.0.134
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65082,7 +65082,7 @@ packages:
     resolution: {directory: components/ui/lane-overview, type: directory}
     id: file:components/ui/lane-overview
     name: '@teambit/lanes.ui.lane-overview'
-    version: 0.0.137
+    version: 0.0.138
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65145,7 +65145,7 @@ packages:
     resolution: {directory: components/ui/menus/use-lanes-menu, type: directory}
     id: file:components/ui/menus/use-lanes-menu
     name: '@teambit/lanes.ui.menus.use-lanes-menu'
-    version: 0.0.136
+    version: 0.0.137
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65166,7 +65166,7 @@ packages:
     resolution: {directory: components/ui/models/lanes-model, type: directory}
     id: file:components/ui/models/lanes-model
     name: '@teambit/lanes.ui.models.lanes-model'
-    version: 0.0.136
+    version: 0.0.137
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65183,7 +65183,7 @@ packages:
     resolution: {directory: components/ui/models_1, type: directory}
     id: file:components/ui/models_1
     name: '@teambit/lanes.ui.models'
-    version: 0.0.60
+    version: 0.0.61
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65200,7 +65200,7 @@ packages:
     resolution: {directory: components/ui/navigation/lane-switcher, type: directory}
     id: file:components/ui/navigation/lane-switcher
     name: '@teambit/lanes.ui.navigation.lane-switcher'
-    version: 0.0.138
+    version: 0.0.139
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65219,7 +65219,7 @@ packages:
     resolution: {directory: components/ui/readme, type: directory}
     id: file:components/ui/readme
     name: '@teambit/lanes.ui.readme'
-    version: 0.0.63
+    version: 0.0.64
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65236,7 +65236,7 @@ packages:
     resolution: {directory: components/ui/readme, type: directory}
     id: file:components/ui/readme
     name: '@teambit/lanes.ui.readme'
-    version: 0.0.63
+    version: 0.0.64
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65253,7 +65253,7 @@ packages:
     resolution: {directory: scopes/api-reference/api-reference, type: directory}
     id: file:scopes/api-reference/api-reference
     name: '@teambit/api-reference'
-    version: 0.0.173
+    version: 0.0.174
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65749,7 +65749,7 @@ packages:
     resolution: {directory: scopes/cloud/cloud, type: directory}
     id: file:scopes/cloud/cloud
     name: '@teambit/cloud'
-    version: 0.0.268
+    version: 0.0.269
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65765,7 +65765,7 @@ packages:
     resolution: {directory: scopes/code/ui/code-compare, type: directory}
     id: file:scopes/code/ui/code-compare
     name: '@teambit/code.ui.code-compare'
-    version: 0.0.207
+    version: 0.0.208
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65891,7 +65891,7 @@ packages:
     resolution: {directory: scopes/community/community, type: directory}
     id: file:scopes/community/community
     name: '@teambit/community'
-    version: 0.0.268
+    version: 0.0.269
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65955,7 +65955,7 @@ packages:
     resolution: {directory: scopes/compilation/babel, type: directory}
     id: file:scopes/compilation/babel
     name: '@teambit/babel'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -65978,7 +65978,7 @@ packages:
     resolution: {directory: scopes/compilation/bundler, type: directory}
     id: file:scopes/compilation/bundler
     name: '@teambit/bundler'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -66019,7 +66019,7 @@ packages:
     resolution: {directory: scopes/compilation/compiler, type: directory}
     id: file:scopes/compilation/compiler
     name: '@teambit/compiler'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66058,7 +66058,7 @@ packages:
     resolution: {directory: scopes/compilation/multi-compiler, type: directory}
     id: file:scopes/compilation/multi-compiler
     name: '@teambit/multi-compiler'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66091,7 +66091,7 @@ packages:
     resolution: {directory: scopes/component/changelog, type: directory}
     id: file:scopes/component/changelog
     name: '@teambit/changelog'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66114,7 +66114,7 @@ packages:
     resolution: {directory: scopes/component/checkout, type: directory}
     id: file:scopes/component/checkout
     name: '@teambit/checkout'
-    version: 0.0.236
+    version: 0.0.237
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66135,7 +66135,7 @@ packages:
     resolution: {directory: scopes/component/code, type: directory}
     id: file:scopes/component/code
     name: '@teambit/code'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66158,7 +66158,7 @@ packages:
     resolution: {directory: scopes/component/code, type: directory}
     id: file:scopes/component/code
     name: '@teambit/code'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66181,7 +66181,7 @@ packages:
     resolution: {directory: scopes/component/component, type: directory}
     id: file:scopes/component/component
     name: '@teambit/component'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -66228,7 +66228,7 @@ packages:
     resolution: {directory: scopes/component/component, type: directory}
     id: file:scopes/component/component
     name: '@teambit/component'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -66275,7 +66275,7 @@ packages:
     resolution: {directory: scopes/component/component-compare, type: directory}
     id: file:scopes/component/component-compare
     name: '@teambit/component-compare'
-    version: 0.0.315
+    version: 0.0.316
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66297,7 +66297,7 @@ packages:
     resolution: {directory: scopes/component/component-compare, type: directory}
     id: file:scopes/component/component-compare
     name: '@teambit/component-compare'
-    version: 0.0.315
+    version: 0.0.316
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66319,7 +66319,7 @@ packages:
     resolution: {directory: scopes/component/component-descriptor, type: directory}
     id: file:scopes/component/component-descriptor
     name: '@teambit/component-descriptor'
-    version: 0.0.289
+    version: 0.0.290
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66336,7 +66336,7 @@ packages:
     resolution: {directory: scopes/component/component-drawer, type: directory}
     id: file:scopes/component/component-drawer
     name: '@teambit/component.ui.component-drawer'
-    version: 0.0.278
+    version: 0.0.279
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66358,7 +66358,7 @@ packages:
     resolution: {directory: scopes/component/component-filters/component-filter-context, type: directory}
     id: file:scopes/component/component-filters/component-filter-context
     name: '@teambit/component.ui.component-filters.component-filter-context'
-    version: 0.0.143
+    version: 0.0.144
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66373,7 +66373,7 @@ packages:
     resolution: {directory: scopes/component/component-filters/deprecate-filter, type: directory}
     id: file:scopes/component/component-filters/deprecate-filter
     name: '@teambit/component.ui.component-filters.deprecate-filter'
-    version: 0.0.143
+    version: 0.0.144
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66389,7 +66389,7 @@ packages:
     resolution: {directory: scopes/component/component-filters/env-filter, type: directory}
     id: file:scopes/component/component-filters/env-filter
     name: '@teambit/component.ui.component-filters.env-filter'
-    version: 0.0.149
+    version: 0.0.150
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66411,7 +66411,7 @@ packages:
     resolution: {directory: scopes/component/component-filters/show-main-filter, type: directory}
     id: file:scopes/component/component-filters/show-main-filter
     name: '@teambit/component.ui.component-filters.show-main-filter'
-    version: 0.0.136
+    version: 0.0.137
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66436,7 +66436,7 @@ packages:
     resolution: {directory: scopes/component/component-log, type: directory}
     id: file:scopes/component/component-log
     name: '@teambit/component-log'
-    version: 0.0.444
+    version: 0.0.445
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66466,7 +66466,7 @@ packages:
     resolution: {directory: scopes/component/component-sizer, type: directory}
     id: file:scopes/component/component-sizer
     name: '@teambit/component-sizer'
-    version: 0.0.440
+    version: 0.0.441
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66485,7 +66485,7 @@ packages:
     resolution: {directory: scopes/component/component-tree, type: directory}
     id: file:scopes/component/component-tree
     name: '@teambit/component-tree'
-    version: 0.0.855
+    version: 0.0.856
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66527,7 +66527,7 @@ packages:
     resolution: {directory: scopes/component/component-writer, type: directory}
     id: file:scopes/component/component-writer
     name: '@teambit/component-writer'
-    version: 0.0.103
+    version: 0.0.104
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66545,7 +66545,7 @@ packages:
     resolution: {directory: scopes/component/deprecation, type: directory}
     id: file:scopes/component/deprecation
     name: '@teambit/deprecation'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66566,7 +66566,7 @@ packages:
     resolution: {directory: scopes/component/dev-files, type: directory}
     id: file:scopes/component/dev-files
     name: '@teambit/dev-files'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66587,7 +66587,7 @@ packages:
     resolution: {directory: scopes/component/forking, type: directory}
     id: file:scopes/component/forking
     name: '@teambit/forking'
-    version: 0.0.471
+    version: 0.0.472
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66611,7 +66611,7 @@ packages:
     resolution: {directory: scopes/component/graph, type: directory}
     id: file:scopes/component/graph
     name: '@teambit/graph'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -66652,7 +66652,7 @@ packages:
     resolution: {directory: scopes/component/isolator, type: directory}
     id: file:scopes/component/isolator
     name: '@teambit/isolator'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66685,7 +66685,7 @@ packages:
     resolution: {directory: scopes/component/issues, type: directory}
     id: file:scopes/component/issues
     name: '@teambit/issues'
-    version: 0.0.375
+    version: 0.0.376
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66709,7 +66709,7 @@ packages:
     resolution: {directory: scopes/component/lister, type: directory}
     id: file:scopes/component/lister
     name: '@teambit/lister'
-    version: 0.0.303
+    version: 0.0.304
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66730,7 +66730,7 @@ packages:
     resolution: {directory: scopes/component/merging, type: directory}
     id: file:scopes/component/merging
     name: '@teambit/merging'
-    version: 0.0.382
+    version: 0.0.383
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66753,7 +66753,7 @@ packages:
     resolution: {directory: scopes/component/mover, type: directory}
     id: file:scopes/component/mover
     name: '@teambit/mover'
-    version: 0.0.98
+    version: 0.0.99
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66772,7 +66772,7 @@ packages:
     resolution: {directory: scopes/component/new-component-helper, type: directory}
     id: file:scopes/component/new-component-helper
     name: '@teambit/new-component-helper'
-    version: 0.0.471
+    version: 0.0.472
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66791,7 +66791,7 @@ packages:
     resolution: {directory: scopes/component/refactoring, type: directory}
     id: file:scopes/component/refactoring
     name: '@teambit/refactoring'
-    version: 0.0.364
+    version: 0.0.365
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66811,7 +66811,7 @@ packages:
     resolution: {directory: scopes/component/remove, type: directory}
     id: file:scopes/component/remove
     name: '@teambit/remove'
-    version: 0.0.244
+    version: 0.0.245
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66835,7 +66835,7 @@ packages:
     resolution: {directory: scopes/component/renaming, type: directory}
     id: file:scopes/component/renaming
     name: '@teambit/renaming'
-    version: 0.0.471
+    version: 0.0.472
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66857,7 +66857,7 @@ packages:
     resolution: {directory: scopes/component/snapping, type: directory}
     id: file:scopes/component/snapping
     name: '@teambit/snapping'
-    version: 0.0.382
+    version: 0.0.383
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66887,7 +66887,7 @@ packages:
     resolution: {directory: scopes/component/stash, type: directory}
     id: file:scopes/component/stash
     name: '@teambit/stash'
-    version: 0.0.5
+    version: 0.0.6
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66908,7 +66908,7 @@ packages:
     resolution: {directory: scopes/component/status, type: directory}
     id: file:scopes/component/status
     name: '@teambit/status'
-    version: 0.0.379
+    version: 0.0.380
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -66930,7 +66930,7 @@ packages:
   file:scopes/component/testing/mock-components:
     resolution: {directory: scopes/component/testing/mock-components, type: directory}
     name: '@teambit/component.testing.mock-components'
-    version: 0.0.84
+    version: 0.0.85
     dependencies:
       fs-extra: 10.0.0
       p-map-series: 2.1.0
@@ -66940,7 +66940,7 @@ packages:
     resolution: {directory: scopes/component/tracker, type: directory}
     id: file:scopes/component/tracker
     name: '@teambit/tracker'
-    version: 0.0.98
+    version: 0.0.99
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67086,7 +67086,7 @@ packages:
     resolution: {directory: scopes/component/ui/component-meta, type: directory}
     id: file:scopes/component/ui/component-meta
     name: '@teambit/component.ui.component-meta'
-    version: 0.0.287
+    version: 0.0.288
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67236,7 +67236,7 @@ packages:
     resolution: {directory: scopes/component/ui/version-block, type: directory}
     id: file:scopes/component/ui/version-block
     name: '@teambit/component.ui.version-block'
-    version: 0.0.803
+    version: 0.0.804
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67259,7 +67259,7 @@ packages:
     resolution: {directory: scopes/component/ui/version-dropdown, type: directory}
     id: file:scopes/component/ui/version-dropdown
     name: '@teambit/component.ui.version-dropdown'
-    version: 0.0.777
+    version: 0.0.778
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -67286,7 +67286,7 @@ packages:
     resolution: {directory: scopes/component/ui/version-dropdown, type: directory}
     id: file:scopes/component/ui/version-dropdown
     name: '@teambit/component.ui.version-dropdown'
-    version: 0.0.777
+    version: 0.0.778
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -67347,7 +67347,7 @@ packages:
     resolution: {directory: scopes/compositions/composition-card, type: directory}
     id: file:scopes/compositions/composition-card
     name: '@teambit/composition-card'
-    version: 0.0.82
+    version: 0.0.83
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67366,7 +67366,7 @@ packages:
     resolution: {directory: scopes/compositions/compositions, type: directory}
     id: file:scopes/compositions/compositions
     name: '@teambit/compositions'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67407,7 +67407,7 @@ packages:
     resolution: {directory: scopes/compositions/compositions, type: directory}
     id: file:scopes/compositions/compositions
     name: '@teambit/compositions'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67468,7 +67468,7 @@ packages:
     resolution: {directory: scopes/compositions/panels/composition-gallery, type: directory}
     id: file:scopes/compositions/panels/composition-gallery
     name: '@teambit/compositions.panels.composition-gallery'
-    version: 0.0.82
+    version: 0.0.83
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -67509,7 +67509,7 @@ packages:
     resolution: {directory: scopes/compositions/ui/composition-compare, type: directory}
     id: file:scopes/compositions/ui/composition-compare
     name: '@teambit/compositions.ui.composition-compare'
-    version: 0.0.182
+    version: 0.0.183
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67534,7 +67534,7 @@ packages:
     resolution: {directory: scopes/compositions/ui/composition-compare-section, type: directory}
     id: file:scopes/compositions/ui/composition-compare-section
     name: '@teambit/compositions.ui.composition-compare-section'
-    version: 0.0.27
+    version: 0.0.28
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67592,7 +67592,7 @@ packages:
     resolution: {directory: scopes/defender/eslint, type: directory}
     id: file:scopes/defender/eslint
     name: '@teambit/eslint'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67626,7 +67626,7 @@ packages:
     resolution: {directory: scopes/defender/formatter, type: directory}
     id: file:scopes/defender/formatter
     name: '@teambit/formatter'
-    version: 0.0.618
+    version: 0.0.619
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67652,7 +67652,7 @@ packages:
     resolution: {directory: scopes/defender/jest, type: directory}
     id: file:scopes/defender/jest
     name: '@teambit/jest'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       jest: 27.5.1
       react: ^16.8.0 || ^17.0.0
@@ -67678,7 +67678,7 @@ packages:
     resolution: {directory: scopes/defender/linter, type: directory}
     id: file:scopes/defender/linter
     name: '@teambit/linter'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67704,7 +67704,7 @@ packages:
     resolution: {directory: scopes/defender/mocha, type: directory}
     id: file:scopes/defender/mocha
     name: '@teambit/mocha'
-    version: 0.0.404
+    version: 0.0.405
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67727,7 +67727,7 @@ packages:
     resolution: {directory: scopes/defender/multi-tester, type: directory}
     id: file:scopes/defender/multi-tester
     name: '@teambit/multi-tester'
-    version: 0.0.236
+    version: 0.0.237
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67745,7 +67745,7 @@ packages:
     resolution: {directory: scopes/defender/prettier, type: directory}
     id: file:scopes/defender/prettier
     name: '@teambit/prettier'
-    version: 0.0.618
+    version: 0.0.619
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67773,7 +67773,7 @@ packages:
     resolution: {directory: scopes/defender/tester, type: directory}
     id: file:scopes/defender/tester
     name: '@teambit/tester'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67810,7 +67810,7 @@ packages:
     resolution: {directory: scopes/defender/ui/test-compare, type: directory}
     id: file:scopes/defender/ui/test-compare
     name: '@teambit/defender.ui.test-compare'
-    version: 0.0.180
+    version: 0.0.181
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -67831,7 +67831,7 @@ packages:
     resolution: {directory: scopes/defender/ui/test-compare-section, type: directory}
     id: file:scopes/defender/ui/test-compare-section
     name: '@teambit/defender.ui.test-compare-section'
-    version: 0.0.27
+    version: 0.0.28
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67963,7 +67963,7 @@ packages:
     resolution: {directory: scopes/dependencies/dependencies, type: directory}
     id: file:scopes/dependencies/dependencies
     name: '@teambit/dependencies'
-    version: 0.0.260
+    version: 0.0.261
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -67986,7 +67986,7 @@ packages:
     resolution: {directory: scopes/dependencies/dependency-resolver, type: directory}
     id: file:scopes/dependencies/dependency-resolver
     name: '@teambit/dependency-resolver'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68045,7 +68045,7 @@ packages:
     resolution: {directory: scopes/dependencies/pnpm, type: directory}
     id: file:scopes/dependencies/pnpm
     name: '@teambit/pnpm'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68087,7 +68087,7 @@ packages:
     resolution: {directory: scopes/dependencies/yarn, type: directory}
     id: file:scopes/dependencies/yarn
     name: '@teambit/yarn'
-    version: 0.0.1068
+    version: 0.0.1069
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68121,7 +68121,7 @@ packages:
     resolution: {directory: scopes/docs/docs, type: directory}
     id: file:scopes/docs/docs
     name: '@teambit/docs'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68146,7 +68146,7 @@ packages:
     resolution: {directory: scopes/docs/ui/overview-compare, type: directory}
     id: file:scopes/docs/ui/overview-compare
     name: '@teambit/docs.ui.overview-compare'
-    version: 0.0.239
+    version: 0.0.240
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68162,7 +68162,7 @@ packages:
     resolution: {directory: scopes/docs/ui/overview-compare-section, type: directory}
     id: file:scopes/docs/ui/overview-compare-section
     name: '@teambit/docs.ui.overview-compare-section'
-    version: 0.0.27
+    version: 0.0.28
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68208,7 +68208,7 @@ packages:
     resolution: {directory: scopes/envs/env, type: directory}
     id: file:scopes/envs/env
     name: '@teambit/env'
-    version: 0.0.440
+    version: 0.0.441
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68224,7 +68224,7 @@ packages:
     resolution: {directory: scopes/envs/envs, type: directory}
     id: file:scopes/envs/envs
     name: '@teambit/envs'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68267,7 +68267,7 @@ packages:
     resolution: {directory: scopes/explorer/command-bar, type: directory}
     id: file:scopes/explorer/command-bar
     name: '@teambit/command-bar'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68292,7 +68292,7 @@ packages:
     resolution: {directory: scopes/explorer/command-bar, type: directory}
     id: file:scopes/explorer/command-bar
     name: '@teambit/command-bar'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68317,7 +68317,7 @@ packages:
     resolution: {directory: scopes/explorer/insights, type: directory}
     id: file:scopes/explorer/insights
     name: '@teambit/insights'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68372,7 +68372,7 @@ packages:
     resolution: {directory: scopes/generator/generator, type: directory}
     id: file:scopes/generator/generator
     name: '@teambit/generator'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68399,7 +68399,7 @@ packages:
     resolution: {directory: scopes/harmony/api-server, type: directory}
     id: file:scopes/harmony/api-server
     name: '@teambit/api-server'
-    version: 0.0.79
+    version: 0.0.80
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68416,7 +68416,7 @@ packages:
     resolution: {directory: scopes/harmony/application, type: directory}
     id: file:scopes/harmony/application
     name: '@teambit/application'
-    version: 0.0.709
+    version: 0.0.710
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68441,7 +68441,7 @@ packages:
     resolution: {directory: scopes/harmony/aspect, type: directory}
     id: file:scopes/harmony/aspect
     name: '@teambit/aspect'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68510,7 +68510,7 @@ packages:
     resolution: {directory: scopes/harmony/aspect-loader, type: directory}
     id: file:scopes/harmony/aspect-loader
     name: '@teambit/aspect-loader'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68533,7 +68533,7 @@ packages:
     resolution: {directory: scopes/harmony/bit, type: directory}
     id: file:scopes/harmony/bit
     name: '@teambit/bit'
-    version: 0.1.54
+    version: 0.1.55
     dependencies:
       '@apollo/client': 3.6.9(graphql@14.7.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0)
       '@babel/runtime': 7.20.0
@@ -68568,7 +68568,7 @@ packages:
     resolution: {directory: scopes/harmony/bit, type: directory}
     id: file:scopes/harmony/bit
     name: '@teambit/bit'
-    version: 0.1.54
+    version: 0.1.55
     dependencies:
       '@apollo/client': 3.6.9(graphql@14.7.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
@@ -68603,7 +68603,7 @@ packages:
     resolution: {directory: scopes/harmony/bit-custom-aspect, type: directory}
     id: file:scopes/harmony/bit-custom-aspect
     name: '@teambit/bit-custom-aspect'
-    version: 0.0.404
+    version: 0.0.405
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68625,7 +68625,7 @@ packages:
     resolution: {directory: scopes/harmony/cache, type: directory}
     id: file:scopes/harmony/cache
     name: '@teambit/cache'
-    version: 0.0.813
+    version: 0.0.814
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68646,7 +68646,7 @@ packages:
     resolution: {directory: scopes/harmony/cli, type: directory}
     id: file:scopes/harmony/cli
     name: '@teambit/cli'
-    version: 0.0.720
+    version: 0.0.721
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68673,7 +68673,7 @@ packages:
     resolution: {directory: scopes/harmony/cli-reference, type: directory}
     id: file:scopes/harmony/cli-reference
     name: '@teambit/harmony.content.cli-reference'
-    version: 1.95.153
+    version: 1.95.154
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68688,7 +68688,7 @@ packages:
     resolution: {directory: scopes/harmony/config, type: directory}
     id: file:scopes/harmony/config
     name: '@teambit/config'
-    version: 0.0.733
+    version: 0.0.734
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68708,7 +68708,7 @@ packages:
     resolution: {directory: scopes/harmony/diagnostic, type: directory}
     id: file:scopes/harmony/diagnostic
     name: '@teambit/diagnostic'
-    version: 0.0.360
+    version: 0.0.361
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68727,7 +68727,7 @@ packages:
     resolution: {directory: scopes/harmony/express, type: directory}
     id: file:scopes/harmony/express
     name: '@teambit/express'
-    version: 0.0.818
+    version: 0.0.819
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68748,7 +68748,7 @@ packages:
     resolution: {directory: scopes/harmony/global-config, type: directory}
     id: file:scopes/harmony/global-config
     name: '@teambit/global-config'
-    version: 0.0.722
+    version: 0.0.723
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68767,7 +68767,7 @@ packages:
     resolution: {directory: scopes/harmony/graphql, type: directory}
     id: file:scopes/harmony/graphql
     name: '@teambit/graphql'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       graphql: 14.7.0
@@ -68814,7 +68814,7 @@ packages:
     resolution: {directory: scopes/harmony/logger, type: directory}
     id: file:scopes/harmony/logger
     name: '@teambit/logger'
-    version: 0.0.813
+    version: 0.0.814
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68844,7 +68844,7 @@ packages:
     resolution: {directory: scopes/harmony/node, type: directory}
     id: file:scopes/harmony/node
     name: '@teambit/node'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68864,7 +68864,7 @@ packages:
     resolution: {directory: scopes/harmony/pubsub, type: directory}
     id: file:scopes/harmony/pubsub
     name: '@teambit/pubsub'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68881,7 +68881,7 @@ packages:
   file:scopes/harmony/testing/load-aspect:
     resolution: {directory: scopes/harmony/testing/load-aspect, type: directory}
     name: '@teambit/harmony.testing.load-aspect'
-    version: 0.0.83
+    version: 0.0.84
     dependencies:
       '@teambit/harmony': 0.4.6
     dev: false
@@ -68910,7 +68910,7 @@ packages:
     resolution: {directory: scopes/harmony/worker, type: directory}
     id: file:scopes/harmony/worker
     name: '@teambit/worker'
-    version: 0.0.1024
+    version: 0.0.1025
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68943,7 +68943,7 @@ packages:
     resolution: {directory: scopes/html/html, type: directory}
     id: file:scopes/html/html
     name: '@teambit/html'
-    version: 0.0.635
+    version: 0.0.636
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -68974,7 +68974,7 @@ packages:
   file:scopes/lanes/diff:
     resolution: {directory: scopes/lanes/diff, type: directory}
     name: '@teambit/lanes.modules.diff'
-    version: 0.0.355
+    version: 0.0.356
     dependencies:
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
@@ -68983,7 +68983,7 @@ packages:
   file:scopes/lanes/entities/lane-diff:
     resolution: {directory: scopes/lanes/entities/lane-diff, type: directory}
     name: '@teambit/lanes.entities.lane-diff'
-    version: 0.0.82
+    version: 0.0.83
     dependencies:
       '@teambit/component-id': 0.0.427
     dev: false
@@ -68992,7 +68992,7 @@ packages:
     resolution: {directory: scopes/lanes/hooks/use-lane-components, type: directory}
     id: file:scopes/lanes/hooks/use-lane-components
     name: '@teambit/lanes.hooks.use-lane-components'
-    version: 0.0.182
+    version: 0.0.183
     peerDependencies:
       '@apollo/client': ^3.6.0
     dependencies:
@@ -69003,7 +69003,7 @@ packages:
     resolution: {directory: scopes/lanes/hooks/use-lane-readme, type: directory}
     id: file:scopes/lanes/hooks/use-lane-readme
     name: '@teambit/lanes.hooks.use-lane-readme'
-    version: 0.0.182
+    version: 0.0.183
     peerDependencies:
       '@apollo/client': ^3.6.0
     dependencies:
@@ -69014,7 +69014,7 @@ packages:
     resolution: {directory: scopes/lanes/hooks/use-lanes, type: directory}
     id: file:scopes/lanes/hooks/use-lanes
     name: '@teambit/lanes.hooks.use-lanes'
-    version: 0.0.183
+    version: 0.0.184
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -69034,7 +69034,7 @@ packages:
     resolution: {directory: scopes/lanes/hooks/use-viewed-lane-from-url, type: directory}
     id: file:scopes/lanes/hooks/use-viewed-lane-from-url
     name: '@teambit/lanes.hooks.use-viewed-lane-from-url'
-    version: 0.0.145
+    version: 0.0.146
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
     transitivePeerDependencies:
@@ -69047,14 +69047,14 @@ packages:
   file:scopes/lanes/lane-id:
     resolution: {directory: scopes/lanes/lane-id, type: directory}
     name: '@teambit/lane-id'
-    version: 0.0.237
+    version: 0.0.238
     dev: false
 
   file:scopes/lanes/lanes(@testing-library/react@12.1.5)(@types/react@17.0.8)(graphql@14.7.0)(react-dom@17.0.2)(react-router-dom@6.2.2)(react@17.0.2):
     resolution: {directory: scopes/lanes/lanes, type: directory}
     id: file:scopes/lanes/lanes
     name: '@teambit/lanes'
-    version: 0.0.639
+    version: 0.0.640
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69086,7 +69086,7 @@ packages:
     resolution: {directory: scopes/lanes/lanes, type: directory}
     id: file:scopes/lanes/lanes
     name: '@teambit/lanes'
-    version: 0.0.639
+    version: 0.0.640
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69118,7 +69118,7 @@ packages:
     resolution: {directory: scopes/lanes/merge-lanes, type: directory}
     id: file:scopes/lanes/merge-lanes
     name: '@teambit/merge-lanes'
-    version: 0.0.244
+    version: 0.0.245
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69157,7 +69157,7 @@ packages:
     resolution: {directory: scopes/mdx/mdx, type: directory}
     id: file:scopes/mdx/mdx
     name: '@teambit/mdx'
-    version: 0.0.1047
+    version: 0.0.1048
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69207,7 +69207,7 @@ packages:
       chai: 4.3.0
       loader-utils: 2.0.4
       memory-fs: 0.5.0
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -69219,7 +69219,7 @@ packages:
     resolution: {directory: scopes/mdx/readme, type: directory}
     id: file:scopes/mdx/readme
     name: '@teambit/readme'
-    version: 0.0.351
+    version: 0.0.352
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69307,7 +69307,7 @@ packages:
     resolution: {directory: scopes/pipelines/builder, type: directory}
     id: file:scopes/pipelines/builder
     name: '@teambit/builder'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69343,7 +69343,7 @@ packages:
     resolution: {directory: scopes/pipelines/modules/builder-data, type: directory}
     id: file:scopes/pipelines/modules/builder-data
     name: '@teambit/builder-data'
-    version: 0.0.272
+    version: 0.0.273
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69383,7 +69383,7 @@ packages:
     resolution: {directory: scopes/pkg/pkg, type: directory}
     id: file:scopes/pkg/pkg
     name: '@teambit/pkg'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69454,7 +69454,7 @@ packages:
     resolution: {directory: scopes/preview/preview, type: directory}
     id: file:scopes/preview/preview
     name: '@teambit/preview'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69580,7 +69580,7 @@ packages:
     resolution: {directory: scopes/react/eslint-config-bit-react, type: directory}
     id: file:scopes/react/eslint-config-bit-react
     name: '@teambit/react.eslint-config-bit-react'
-    version: 0.0.792
+    version: 0.0.793
     peerDependencies:
       eslint: '> 7.0.0'
     dependencies:
@@ -69617,7 +69617,7 @@ packages:
     resolution: {directory: scopes/react/react, type: directory}
     id: file:scopes/react/react
     name: '@teambit/react'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69634,10 +69634,10 @@ packages:
       '@babel/preset-typescript': 7.18.6(@babel/core@7.19.6)
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
       '@prerenderer/renderer-jsdom': 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      '@prerenderer/webpack-plugin': 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.82.1)
+      '@prerenderer/webpack-plugin': 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack': 5.5.0
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -69650,7 +69650,7 @@ packages:
       '@testing-library/jest-dom': 5.16.2
       '@typescript-eslint/eslint-plugin': 5.35.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)(typescript@4.7.4)
       '@typescript-eslint/parser': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
-      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-plugin-named-asset-import: 0.3.7(@babel/core@7.19.6)
       babel-plugin-transform-typescript-metadata: 0.3.1(@babel/core@7.19.6)
       babel-preset-jest: 27.5.1(@babel/core@7.19.6)
@@ -69658,8 +69658,8 @@ packages:
       camelcase: 6.2.0
       comment-json: 3.0.3
       core-js: 3.13.0
-      css-loader: 6.2.0(webpack@5.82.1)
-      css-minimizer-webpack-plugin: 3.0.2(webpack@5.82.1)
+      css-loader: 6.2.0(webpack@5.84.1)
+      css-minimizer-webpack-plugin: 3.0.2(webpack@5.84.1)
       esbuild: 0.14.28
       eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
       eslint-plugin-jest: 24.1.5(eslint@7.32.0)(typescript@4.7.4)
@@ -69675,33 +69675,33 @@ packages:
       jest-environment-jsdom: 27.5.1(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       jest-watch-typeahead: 1.0.0(jest@27.5.1)
       less: 4.1.3
-      less-loader: 10.0.0(less@4.1.3)(webpack@5.82.1)
+      less-loader: 10.0.0(less@4.1.3)(webpack@5.84.1)
       lodash: 4.17.21
       lodash.compact: 3.0.1
       lodash.flatten: 4.4.0
-      mini-css-extract-plugin: 2.2.2(webpack@5.82.1)
-      new-url-loader: 0.1.1(webpack@5.82.1)
+      mini-css-extract-plugin: 2.2.2(webpack@5.84.1)
+      new-url-loader: 0.1.1(webpack@5.84.1)
       postcss: 8.4.18
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.18)
-      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       ramda: 0.27.1
       react: 17.0.2
       react-app-polyfill: 1.0.6
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       react-error-overlay: 6.0.9
       react-refresh: 0.10.0
       resolve-url-loader: 5.0.0
       sanitize.css: 12.0.1
-      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.82.1)
+      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.84.1)
       strip-ansi: 6.0.0
-      style-loader: 2.0.0(webpack@5.82.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
+      style-loader: 2.0.0(webpack@5.84.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
       typescript: 4.7.4
       url-join: 4.0.1
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@swc/core'
@@ -69741,7 +69741,7 @@ packages:
     resolution: {directory: scopes/react/react-elements, type: directory}
     id: file:scopes/react/react-elements
     name: '@teambit/react-elements'
-    version: 0.0.520
+    version: 0.0.521
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69752,31 +69752,31 @@ packages:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@svgr/webpack': 5.5.0
       '@teambit/harmony': 0.4.6
-      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-preset-react-app: 10.0.0
       core-js: 3.13.0
-      css-loader: 6.2.0(webpack@5.82.1)
-      css-minimizer-webpack-plugin: 3.0.2(webpack@5.82.1)
+      css-loader: 6.2.0(webpack@5.84.1)
+      css-minimizer-webpack-plugin: 3.0.2(webpack@5.84.1)
       decamelize: 1.2.0
       less: 4.1.3
-      less-loader: 10.0.0(less@4.1.3)(webpack@5.82.1)
+      less-loader: 10.0.0(less@4.1.3)(webpack@5.84.1)
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.2.2(webpack@5.82.1)
-      new-url-loader: 0.1.1(webpack@5.82.1)
+      mini-css-extract-plugin: 2.2.2(webpack@5.84.1)
+      new-url-loader: 0.1.1(webpack@5.84.1)
       postcss: 8.4.18
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.18)
-      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 17.0.2
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       resolve-url-loader: 5.0.0
-      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.82.1)
-      style-loader: 2.0.0(webpack@5.82.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-manifest-plugin: 4.0.2(webpack@5.82.1)
+      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.84.1)
+      style-loader: 2.0.0(webpack@5.84.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-manifest-plugin: 4.0.2(webpack@5.84.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@swc/core'
@@ -69799,7 +69799,7 @@ packages:
     resolution: {directory: scopes/react/react-native, type: directory}
     id: file:scopes/react/react-native
     name: '@teambit/react-native'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -69999,7 +69999,7 @@ packages:
     resolution: {directory: scopes/scope/export, type: directory}
     id: file:scopes/scope/export
     name: '@teambit/export'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70019,7 +70019,7 @@ packages:
     resolution: {directory: scopes/scope/importer, type: directory}
     id: file:scopes/scope/importer
     name: '@teambit/importer'
-    version: 0.0.496
+    version: 0.0.497
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70039,7 +70039,7 @@ packages:
   file:scopes/scope/models/scope-model:
     resolution: {directory: scopes/scope/models/scope-model, type: directory}
     name: '@teambit/scope.models.scope-model'
-    version: 0.0.378
+    version: 0.0.379
     dependencies:
       '@teambit/component-id': 0.0.427
     dev: false
@@ -70048,7 +70048,7 @@ packages:
     resolution: {directory: scopes/scope/scope, type: directory}
     id: file:scopes/scope/scope
     name: '@teambit/scope'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70089,7 +70089,7 @@ packages:
     resolution: {directory: scopes/scope/scope, type: directory}
     id: file:scopes/scope/scope
     name: '@teambit/scope'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70130,7 +70130,7 @@ packages:
     resolution: {directory: scopes/scope/sign, type: directory}
     id: file:scopes/scope/sign
     name: '@teambit/sign'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70165,7 +70165,7 @@ packages:
     resolution: {directory: scopes/scope/ui/hooks/scope-context, type: directory}
     id: file:scopes/scope/ui/hooks/scope-context
     name: '@teambit/scope.ui.hooks.scope-context'
-    version: 0.0.378
+    version: 0.0.379
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70179,7 +70179,7 @@ packages:
     resolution: {directory: scopes/scope/ui/hooks/use-scope, type: directory}
     id: file:scopes/scope/ui/hooks/use-scope
     name: '@teambit/scope.ui.hooks.use-scope'
-    version: 0.0.383
+    version: 0.0.384
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -70249,7 +70249,7 @@ packages:
     resolution: {directory: scopes/scope/update-dependencies, type: directory}
     id: file:scopes/scope/update-dependencies
     name: '@teambit/update-dependencies'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70280,7 +70280,7 @@ packages:
     resolution: {directory: scopes/semantics/schema, type: directory}
     id: file:scopes/semantics/schema
     name: '@teambit/schema'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70472,7 +70472,7 @@ packages:
     resolution: {directory: scopes/typescript/typescript, type: directory}
     id: file:scopes/typescript/typescript
     name: '@teambit/typescript'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70588,7 +70588,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/harmony-ui-app/harmony-ui-app, type: directory}
     id: file:scopes/ui-foundation/harmony-ui-app/harmony-ui-app
     name: '@teambit/harmony-ui-app'
-    version: 0.0.709
+    version: 0.0.710
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70638,7 +70638,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/notifications/aspect, type: directory}
     id: file:scopes/ui-foundation/notifications/aspect
     name: '@teambit/notifications'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70724,7 +70724,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/panels, type: directory}
     id: file:scopes/ui-foundation/panels
     name: '@teambit/panels'
-    version: 0.0.721
+    version: 0.0.722
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70742,7 +70742,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/react-router/react-router, type: directory}
     id: file:scopes/ui-foundation/react-router/react-router
     name: '@teambit/react-router'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70765,7 +70765,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/react-router/react-router, type: directory}
     id: file:scopes/ui-foundation/react-router/react-router
     name: '@teambit/react-router'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70850,7 +70850,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/sidebar, type: directory}
     id: file:scopes/ui-foundation/sidebar
     name: '@teambit/sidebar'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -70951,7 +70951,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/ui, type: directory}
     id: file:scopes/ui-foundation/ui
     name: '@teambit/ui'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -70960,7 +70960,7 @@ packages:
     dependencies:
       '@apollo/client': 3.6.9(graphql@14.7.0)(react@17.0.2)(subscriptions-transport-ws@0.11.0)
       '@babel/runtime': 7.20.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.fonts.roboto': registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
@@ -70969,43 +70969,43 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/react.rendering.ssr': 0.0.3(react-dom@17.0.2)(react@17.0.2)
-      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-plugin-named-asset-import: 0.3.7(@babel/core@7.19.6)
       babel-preset-react-app: 10.0.0
       chalk: 2.4.2
       core-js: 3.13.0
-      css-loader: 5.2.0(webpack@5.82.1)
-      css-minimizer-webpack-plugin: 3.0.2(webpack@5.82.1)
+      css-loader: 5.2.0(webpack@5.84.1)
+      css-minimizer-webpack-plugin: 3.0.2(webpack@5.84.1)
       express: 4.17.1
       express-history-api-fallback: 2.2.1
       fs-extra: 10.0.0
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       http-proxy: 1.18.1(debug@4.3.2)
       less: 4.1.3
-      less-loader: 8.0.0(less@4.1.3)(webpack@5.82.1)
+      less-loader: 8.0.0(less@4.1.3)(webpack@5.84.1)
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.2.2(webpack@5.82.1)
+      mini-css-extract-plugin: 2.2.2(webpack@5.84.1)
       p-map-series: 2.1.0
       postcss: 8.4.18
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.18)
-      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 17.0.2
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       react-router-dom: 6.2.2(react-dom@17.0.2)(react@17.0.2)
       resolve-url-loader: 5.0.0
       sanitize.css: 12.0.1
-      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.82.1)
-      source-map-loader: 3.0.0(webpack@5.82.1)
-      style-loader: 2.0.0(webpack@5.82.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
-      webpack-manifest-plugin: 4.0.2(webpack@5.82.1)
+      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.84.1)
+      source-map-loader: 3.0.0(webpack@5.84.1)
+      style-loader: 2.0.0(webpack@5.84.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
+      webpack-manifest-plugin: 4.0.2(webpack@5.84.1)
       webpack-merge: 5.8.0
-      workbox-webpack-plugin: 6.2.4(@types/babel__core@7.20.0)(webpack@5.82.1)
+      workbox-webpack-plugin: 6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@swc/core'
@@ -71039,7 +71039,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/ui, type: directory}
     id: file:scopes/ui-foundation/ui
     name: '@teambit/ui'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -71048,7 +71048,7 @@ packages:
     dependencies:
       '@apollo/client': 3.6.9(graphql@14.7.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
-      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.82.1)
+      '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.fonts.roboto': registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
@@ -71057,43 +71057,43 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/react.rendering.ssr': 0.0.3(react-dom@17.0.2)(react@17.0.2)
-      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.82.1)
+      babel-loader: 8.2.2(@babel/core@7.19.6)(webpack@5.84.1)
       babel-plugin-named-asset-import: 0.3.7(@babel/core@7.19.6)
       babel-preset-react-app: 10.0.0
       chalk: 2.4.2
       core-js: 3.13.0
-      css-loader: 5.2.0(webpack@5.82.1)
-      css-minimizer-webpack-plugin: 3.0.2(webpack@5.82.1)
+      css-loader: 5.2.0(webpack@5.84.1)
+      css-minimizer-webpack-plugin: 3.0.2(webpack@5.84.1)
       express: 4.17.1
       express-history-api-fallback: 2.2.1
       fs-extra: 10.0.0
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       http-proxy: 1.18.1(debug@4.3.2)
       less: 4.1.3
-      less-loader: 8.0.0(less@4.1.3)(webpack@5.82.1)
+      less-loader: 8.0.0(less@4.1.3)(webpack@5.84.1)
       lodash: 4.17.21
-      mini-css-extract-plugin: 2.2.2(webpack@5.82.1)
+      mini-css-extract-plugin: 2.2.2(webpack@5.84.1)
       p-map-series: 2.1.0
       postcss: 8.4.18
       postcss-flexbugs-fixes: 5.0.2(postcss@8.4.18)
-      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.82.1)
+      postcss-loader: 7.0.1(postcss@8.4.18)(webpack@5.84.1)
       postcss-normalize: 10.0.0(browserslist@4.16.3)(postcss@8.4.18)
       postcss-preset-env: 7.8.2(postcss@8.4.18)
       react: 17.0.2
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       react-router-dom: 6.3.0(react-dom@17.0.2)(react@17.0.2)
       resolve-url-loader: 5.0.0
       sanitize.css: 12.0.1
-      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.82.1)
-      source-map-loader: 3.0.0(webpack@5.82.1)
-      style-loader: 2.0.0(webpack@5.82.1)
-      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.82.1)
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
-      webpack-manifest-plugin: 4.0.2(webpack@5.82.1)
+      sass-loader: 12.1.0(sass@1.43.4)(webpack@5.84.1)
+      source-map-loader: 3.0.0(webpack@5.84.1)
+      style-loader: 2.0.0(webpack@5.84.1)
+      terser-webpack-plugin: 5.2.0(esbuild@0.14.28)(webpack@5.84.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
+      webpack-manifest-plugin: 4.0.2(webpack@5.84.1)
       webpack-merge: 5.8.0
-      workbox-webpack-plugin: 6.2.4(@types/babel__core@7.20.0)(webpack@5.82.1)
+      workbox-webpack-plugin: 6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1)
     transitivePeerDependencies:
       - '@babel/core'
       - '@swc/core'
@@ -71378,7 +71378,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/uis/side-bar, type: directory}
     id: file:scopes/ui-foundation/uis/side-bar
     name: '@teambit/ui-foundation.ui.side-bar'
-    version: 0.0.795
+    version: 0.0.796
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71568,7 +71568,7 @@ packages:
     resolution: {directory: scopes/ui-foundation/user-agent, type: directory}
     id: file:scopes/ui-foundation/user-agent
     name: '@teambit/user-agent'
-    version: 0.0.753
+    version: 0.0.754
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71585,7 +71585,7 @@ packages:
     resolution: {directory: scopes/web-components/elements, type: directory}
     id: file:scopes/web-components/elements
     name: '@teambit/elements'
-    version: 0.0.520
+    version: 0.0.521
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71611,10 +71611,10 @@ packages:
     version: 0.0.157
     dependencies:
       '@teambit/html.modules.inject-html-element': 0.0.3(react@17.0.2)
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       json-formatter-js: 2.3.4
       lodash: 4.17.21
-      webpack: 5.82.1(esbuild@0.14.28)
+      webpack: 5.84.1(esbuild@0.14.28)
       webpack-merge: 5.8.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -71624,14 +71624,13 @@ packages:
       - webpack-cli
     dev: false
 
-  file:scopes/webpack/modules/generate-expose-loaders(webpack@5.82.1):
+  file:scopes/webpack/modules/generate-expose-loaders(webpack@5.84.1):
     resolution: {directory: scopes/webpack/modules/generate-expose-loaders, type: directory}
     id: file:scopes/webpack/modules/generate-expose-loaders
     name: '@teambit/webpack.modules.generate-expose-loaders'
     version: 0.0.10
     dependencies:
-      expose-loader: 3.1.0(webpack@5.82.1)
-      json-formatter-js: 2.3.4
+      expose-loader: 3.1.0(webpack@5.84.1)
     transitivePeerDependencies:
       - webpack
     dev: false
@@ -71658,7 +71657,7 @@ packages:
     peerDependencies:
       html-webpack-plugin: ^5.3.1
     dependencies:
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       insert-string-after: 1.0.0
       insert-string-before: 1.0.0
     dev: false
@@ -71673,7 +71672,7 @@ packages:
     resolution: {directory: scopes/webpack/webpack, type: directory}
     id: file:scopes/webpack/webpack
     name: '@teambit/webpack'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71684,15 +71683,15 @@ packages:
       browserify-zlib: 0.2.0
       buffer: 6.0.3
       camelcase: 6.2.0
-      compression-webpack-plugin: 9.2.0(webpack@5.82.1)
+      compression-webpack-plugin: 9.2.0(webpack@5.84.1)
       constants-browserify: 1.0.0
       core-js: 3.13.0
       crypto-browserify: 3.12.0
       domain-browser: 4.19.0
       enhanced-resolve: 4.5.0
-      expose-loader: 3.1.0(webpack@5.82.1)
+      expose-loader: 3.1.0(webpack@5.84.1)
       find-root: 1.1.0
-      html-webpack-plugin: 5.3.2(webpack@5.82.1)
+      html-webpack-plugin: 5.3.2(webpack@5.84.1)
       https-browserify: 1.0.0
       inject-body-webpack-plugin: 1.3.0(html-webpack-plugin@5.3.2)
       lodash: 4.17.21
@@ -71703,7 +71702,7 @@ packages:
       punycode: 2.1.1
       querystring-es3: 0.2.1
       react: 17.0.2
-      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.82.1)
+      react-dev-utils: 11.0.4(eslint@7.32.0)(typescript@4.7.4)(webpack@5.84.1)
       react-dom: 17.0.2(react@17.0.2)
       stream-browserify: 3.0.0
       stream-http: 3.2.0
@@ -71713,9 +71712,9 @@ packages:
       url: 0.11.0
       util: 0.12.3
       vm-browserify: 1.1.2
-      webpack: 5.82.1(esbuild@0.14.28)
-      webpack-assets-manifest: 5.1.0(webpack@5.82.1)
-      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.82.1)
+      webpack: 5.84.1(esbuild@0.14.28)
+      webpack-assets-manifest: 5.1.0(webpack@5.84.1)
+      webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
       webpack-merge: 5.8.0
     transitivePeerDependencies:
       - '@swc/core'
@@ -71751,7 +71750,7 @@ packages:
     resolution: {directory: scopes/workspace/bit-roots, type: directory}
     id: file:scopes/workspace/bit-roots
     name: '@teambit/bit-roots'
-    version: 0.0.57
+    version: 0.0.58
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71767,7 +71766,7 @@ packages:
     resolution: {directory: scopes/workspace/clear-cache, type: directory}
     id: file:scopes/workspace/clear-cache
     name: '@teambit/clear-cache'
-    version: 0.0.279
+    version: 0.0.280
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71784,7 +71783,7 @@ packages:
     resolution: {directory: scopes/workspace/eject, type: directory}
     id: file:scopes/workspace/eject
     name: '@teambit/eject'
-    version: 0.0.538
+    version: 0.0.539
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71801,7 +71800,7 @@ packages:
     resolution: {directory: scopes/workspace/install, type: directory}
     id: file:scopes/workspace/install
     name: '@teambit/install'
-    version: 0.0.175
+    version: 0.0.176
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71838,7 +71837,7 @@ packages:
   file:scopes/workspace/modules/node-modules-linker:
     resolution: {directory: scopes/workspace/modules/node-modules-linker, type: directory}
     name: '@teambit/workspace.modules.node-modules-linker'
-    version: 0.0.64
+    version: 0.0.65
     dependencies:
       '@teambit/legacy-bit-id': 0.0.423
       fs-extra: 10.0.0
@@ -71924,7 +71923,7 @@ packages:
     resolution: {directory: scopes/workspace/variants, type: directory}
     id: file:scopes/workspace/variants
     name: '@teambit/variants'
-    version: 0.0.825
+    version: 0.0.826
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71943,7 +71942,7 @@ packages:
     resolution: {directory: scopes/workspace/watcher, type: directory}
     id: file:scopes/workspace/watcher
     name: '@teambit/watcher'
-    version: 0.0.79
+    version: 0.0.80
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -71968,7 +71967,7 @@ packages:
     resolution: {directory: scopes/workspace/workspace, type: directory}
     id: file:scopes/workspace/workspace
     name: '@teambit/workspace'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -72017,7 +72016,7 @@ packages:
     resolution: {directory: scopes/workspace/workspace, type: directory}
     id: file:scopes/workspace/workspace
     name: '@teambit/workspace'
-    version: 0.0.1067
+    version: 0.0.1068
     peerDependencies:
       '@apollo/client': ^3.6.0
       react: ^16.8.0 || ^17.0.0
@@ -72066,7 +72065,7 @@ packages:
     resolution: {directory: scopes/workspace/workspace-config-files, type: directory}
     id: file:scopes/workspace/workspace-config-files
     name: '@teambit/workspace-config-files'
-    version: 0.0.47
+    version: 0.0.48
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -136,18 +136,6 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
         },
       },
 
-      onBeforeSetupMiddleware(wds) {
-        const { app } = wds;
-        // Keep `evalSourceMapMiddleware` and `errorOverlayMiddleware`
-        // middlewares before `redirectServedPath` otherwise will not have any effect
-        // This lets us fetch source contents from webpack for the error overlay
-        // @ts-ignore @types/wds mismatch
-        app.use(evalSourceMapMiddleware(wds));
-        // This lets us open files from the runtime error overlay.
-        // @ts-ignore
-        app.use(errorOverlayMiddleware());
-      },
-
       setupMiddlewares: (middlewares, devServer) => {
         if (!devServer) {
           throw new Error('webpack-dev-server is not defined');

--- a/scopes/webpack/webpack/config/webpack.dev.config.ts
+++ b/scopes/webpack/webpack/config/webpack.dev.config.ts
@@ -109,30 +109,29 @@ export function configFactory(
         overlay: false,
       },
 
-      onBeforeSetupMiddleware(wds) {
-        const { app } = wds;
+      setupMiddlewares: (middlewares, devServer) => {
+        if (!devServer) {
+          throw new Error('webpack-dev-server is not defined');
+        }
+
         // Keep `evalSourceMapMiddleware` and `errorOverlayMiddleware`
         // middlewares before `redirectServedPath` otherwise will not have any effect
         // This lets us fetch source contents from webpack for the error overlay
-        // @ts-ignore - @types/WDS mismatch - 3.11.6 vs 4.0.3
-        app.use(evalSourceMapMiddleware(wds));
-        // This lets us open files from the runtime error overlay.
-        // @ts-ignore
-        app.use(errorOverlayMiddleware());
-      },
-
-      onAfterSetupMiddleware({ app }) {
-        // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
-        // @ts-ignore
-        app.use(redirectServedPath(publicUrlOrPath));
-
-        // This service worker file is effectively a 'no-op' that will reset any
-        // previous service worker registered for the same host:port combination.
-        // We do this in development to avoid hitting the production cache if
-        // it used the same host and port.
-        // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
-        // @ts-ignore
-        app.use(noopServiceWorkerMiddleware(publicUrlOrPath));
+        middlewares.push(
+          // @ts-ignore @types/wds mismatch
+          evalSourceMapMiddleware(devServer),
+          // This lets us open files from the runtime error overlay.
+          errorOverlayMiddleware(),
+          // Redirect to `PUBLIC_URL` or `homepage` from `package.json` if url not match
+          redirectServedPath(publicUrlOrPath),
+          // This service worker file is effectively a 'no-op' that will reset any
+          // previous service worker registered for the same host:port combination.
+          // We do this in development to avoid hitting the production cache if
+          // it used the same host and port.
+          // https://github.com/facebook/create-react-app/issues/2272#issuecomment-302832432
+          noopServiceWorkerMiddleware(publicUrlOrPath)
+        );
+        return middlewares;
       },
 
       devMiddleware: {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -378,7 +378,7 @@
         "vscode-icons-js": "11.0.0",
         "vscode-jsonrpc": "6.0.0",
         "vscode-languageserver-types": "3.16.0",
-        "webpack": "5.82.1",
+        "webpack": "5.84.1",
         "webpack-assets-manifest": "5.1.0",
         "webpack-dev-server": "4.15.0",
         "webpack-manifest-plugin": "4.0.2",


### PR DESCRIPTION
## Proposed Changes

- update webpack version from 5.82.1 to 5.84.1
- this should fix warning on commands like bit start:
```
(node:56404) [DEP_WEBPACK_DEV_SERVER_ON_AFTER_SETUP_MIDDLEWARE] DeprecationWarning: 'onAfterSetupMiddleware' option is deprecated. Please use the 'setupMiddlewares' option.
```

