### PR TITLE
improvement(fork) - explicitly don't copy pkg config when forking component

### DIFF
--- a/scopes/component/new-component-helper/index.ts
+++ b/scopes/component/new-component-helper/index.ts
@@ -1,5 +1,5 @@
 import { NewComponentHelperAspect } from './new-component-helper.aspect';
 
-export type { NewComponentHelperMain, CloneConfig } from './new-component-helper.main.runtime';
+export type { NewComponentHelperMain } from './new-component-helper.main.runtime';
 export default NewComponentHelperAspect;
 export { NewComponentHelperAspect };

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -10,6 +10,7 @@ import { ComponentID } from '@teambit/component-id';
 import { Harmony } from '@teambit/harmony';
 import { PathLinuxRelative } from '@teambit/legacy/dist/utils/path';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
+import { PkgAspect } from '@teambit/pkg';
 import { NewComponentHelperAspect } from './new-component-helper.aspect';
 
 export class NewComponentHelperMain {
@@ -86,20 +87,13 @@ export class NewComponentHelperMain {
   }
 
   async getConfigFromExistingToNewComponent(comp: Component) {
-    const aspectIds = comp.state.aspects.entries.map((e) => e.id.toString());
-    // the reason to load aspects is to be able to check later for the `shouldPreserveConfigForClonedComponent` prop.
-    // it's not saved in the model, it's available only on the aspect instance.
-    await this.workspace.loadAspects(aspectIds, undefined, 'new-component-helper.getConfigFromExistingToNewComponent');
     const fromExisting = {};
     comp.state.aspects.entries.forEach((entry) => {
       if (!entry.config) return;
       const aspectId = entry.id.toString();
-      const aspect = this.harmony.get<CloneConfig>(aspectId);
-      if (!aspect) throw new Error(`error: unable to get "${aspectId}" aspect from Harmony`);
-      if (
-        'shouldPreserveConfigForClonedComponent' in aspect &&
-        aspect.shouldPreserveConfigForClonedComponent === false
-      ) {
+      // don't copy the pkg aspect, it's not relevant for the new component
+      // (it might contains values that are bounded to the other component name / id)
+      if (aspectId === PkgAspect.id) {
         return;
       }
       fromExisting[aspectId] = entry.config;

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -110,7 +110,3 @@ export class NewComponentHelperMain {
 }
 
 NewComponentHelperAspect.addRuntime(NewComponentHelperMain);
-
-export interface CloneConfig {
-  readonly shouldPreserveConfigForClonedComponent?: boolean; // default true
-}

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -183,8 +183,6 @@ export class PkgMain implements CloneConfig {
     return pkg;
   }
 
-  readonly shouldPreserveConfigForClonedComponent = false;
-
   /**
    * get the package name of a component.
    */

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -11,7 +11,6 @@ import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
 import { PackageJsonTransformer } from '@teambit/workspace.modules.node-modules-linker';
 import { BuilderMain, BuilderAspect } from '@teambit/builder';
-import { CloneConfig } from '@teambit/new-component-helper';
 import { BitError } from '@teambit/bit-error';
 import { snapToSemver } from '@teambit/component-package-version';
 import { IssuesClasses } from '@teambit/component-issues';
@@ -96,7 +95,7 @@ export type VersionPackageManifest = {
   };
 };
 
-export class PkgMain implements CloneConfig {
+export class PkgMain {
   static runtime = MainRuntime;
   static dependencies = [
     CLIAspect,


### PR DESCRIPTION
## Proposed Changes

- before this change, any aspect can decide if it should be copied during bit fork. 
with this change, it's hardcoded configured for the pkg aspect.
- this is required in order to support `bit config set default_resolve_envs_from_roots true` for bit new. otherwise, we are trying to load envs from the workspace before they are installed. so the entire bit new command is failing.

