### PR TITLE
fix(bin): update require to find hoisted dependencies

### DIFF
--- a/bin/bit.js
+++ b/bin/bit.js
@@ -1,3 +1,3 @@
 #!/usr/bin/env node
 
-require('../node_modules/@teambit/bit/dist/app');
+require('@teambit/bit/dist/app');


### PR DESCRIPTION
## Summary

After `bit install` of my team's workspace, I was getting the following error:

`Error: Cannot find module '../node_modules/@teambit/bit/dist/app'`. Which in the require stack trace showed it was coming from `~/.bvm/versions/0.1.52/bit-0.1.52/node_modules/@teambit/legacy/bin/bit.js`.

When poking around that folder, it seemed like the issue is that `@teambit/bit`  was hoisted from `~/.bvm/versions/0.1.52/bit-0.1.52/node_modules/@teambit/bit` to `.bvm/versions/0.1.52/bit-0.1.52/node_modules/@teambit/bit`

So I changed the require line in `~/.bvm/versions/0.1.52/bit-0.1.52/node_modules/@teambit/legacy/bin/bit.js` from `require('../node_modules/@teambit/bit/dist/app')` to `require('@teambit/bit/dist/app');` locally, which fixed the error and allowed `bit help` and `bit install` to run successfully again

I posted in slack, and am I'm creating this PR in case it's helpful. If it's not and there's a better root cause to fix, feel free to close this :).

## Changes:

The previous `require` path in bin/bit.js depended on `@teambit/bit` being in the `node_modules` dir within `@teambit/legacy`.

If the node dependency manager hoists `@teambit/bit` to be in the same location as `@teambit/legacy`, then this `require` breaks.

## Testing

I've only tested this locally, but it fixed an error I was getting in my broken bit workspace installation when running any bit command