### PR TITLE
fix(preview-task) - pass host root dir when running the preview task

### DIFF
--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -75,8 +75,7 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
         entries,
         components,
         outputPath,
-        /* It's a path to the root of the host component. */
-        // hostRootDir, handle this
+        hostRootDir: context.envRuntime.envAspectDefinition.aspectPath,
         hostDependencies: peers,
         aliasHostDependencies: true,
         externalizeHostDependencies: true,


### PR DESCRIPTION
## Proposed Changes

- this should solve different cases of `Module not found: Error: Can't resolve 'react-dom/client'` which were a result of aliasing react to bit folder (aka react / react-dom 17) instead of the env folder with the correct version.
