### PR TITLE
fix(lane-merge), merge soft-removed components when merging from one lane to another

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -248,6 +248,7 @@ describe('bit lane command', function () {
   });
   describe('soft remove on lane when a forked lane changed it and is now merging this lane', () => {
     let beforeRemoveScope: string;
+    let beforeMerge: string;
     let output;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
@@ -270,31 +271,79 @@ describe('bit lane command', function () {
       helper.scopeHelper.getClonedLocalScope(beforeRemoveScope);
       helper.command.snapComponentWithoutBuild('comp2', '--unmodified');
       helper.command.fetchAllLanes();
-      output = helper.command.mergeLane('lane-a', '-x');
+      beforeMerge = helper.scopeHelper.cloneLocalScope();
     });
-    it.skip('should indicate that the component was removed', () => {
-      expect(output).to.have.string('the following 1 component(s) have been removed');
+    describe('when merging with auto-snap', () => {
+      before(() => {
+        output = helper.command.mergeLane('lane-a', '-x');
+      });
+      it('should indicate that the component was removed', () => {
+        expect(output).to.have.string('the following 1 component(s) have been removed');
+      });
+      it('should remove the soft-removed component from .bitmap', () => {
+        const list = helper.command.list();
+        expect(list).to.not.have.string('comp2');
+      });
+      it('should remove the component files from the filesystem', () => {
+        expect(path.join(helper.scopes.localPath, 'comp2')).to.not.be.a.path();
+      });
+      it('should leave the component on the lane and update it according to lane-a to make it soft-removed in lane-b as well', () => {
+        const laneComps = helper.command.catLane('lane-b');
+        const comps = laneComps.components.map((c) => c.id.name);
+        expect(comps).to.include('comp2');
+      });
+      it('bit show should show the component as removed', () => {
+        const removeData = helper.command.showAspectConfig('comp2', Extensions.remove);
+        expect(removeData.config.removed).to.be.true;
+      });
+      it('bit status should show the component as staged', () => {
+        const status = helper.command.statusJson();
+        const staged = status.stagedComponents.map((c) => c.id);
+        expect(staged).to.include(`${helper.scopes.remote}/comp2`);
+      });
     });
-    it('should remove the soft-removed component from .bitmap', () => {
-      const list = helper.command.list();
-      expect(list).to.not.have.string('comp2');
-    });
-    it('should remove the component files from the filesystem', () => {
-      expect(path.join(helper.scopes.localPath, 'comp2')).to.not.be.a.path();
-    });
-    it('should leave the component on the lane and update it according to lane-a to make it soft-removed in lane-b as well', () => {
-      const laneComps = helper.command.catLane('lane-b');
-      const comps = laneComps.components.map((c) => c.id.name);
-      expect(comps).to.include('comp2');
-    });
-    it('bit show should show the component as removed', () => {
-      const removeData = helper.command.showAspectConfig('comp2', Extensions.remove);
-      expect(removeData.config.removed).to.be.true;
-    });
-    it('bit status should show the component as staged', () => {
-      const status = helper.command.statusJson();
-      const staged = status.stagedComponents.map((c) => c.id);
-      expect(staged).to.include(`${helper.scopes.remote}/comp2`);
+    describe('when merging with --no-snap', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(beforeMerge);
+        output = helper.command.mergeLane('lane-a', '-x --no-snap');
+      });
+      it('bit status should not show the component as soft-removed from remote', () => {
+        const status = helper.command.statusJson();
+        expect(status.remotelySoftRemoved).to.have.lengthOf(0);
+      });
+      it('should not remove the component from the filesystem', () => {
+        expect(path.join(helper.scopes.localPath, 'comp2')).to.be.a.directory();
+      });
+      describe('snapping the components', () => {
+        let snapOutput: string;
+        before(() => {
+          snapOutput = helper.command.snapAllComponentsWithoutBuild();
+        });
+        it('should indicate that components were removed', () => {
+          expect(snapOutput).to.have.string('removed components');
+        });
+        it('should remove the soft-removed component from .bitmap', () => {
+          const list = helper.command.list();
+          expect(list).to.not.have.string('comp2');
+        });
+        it('should remove the component files from the filesystem', () => {
+          expect(path.join(helper.scopes.localPath, 'comp2')).to.not.be.a.path();
+        });
+        it('should leave the component on the lane and update it according to lane-a to make it soft-removed in lane-b as well', () => {
+          const laneComps = helper.command.catLane('lane-b');
+          const comps = laneComps.components.map((c) => c.id.name);
+          expect(comps).to.include('comp2');
+        });
+        it('bit show should show the component as removed', () => {
+          const removeData = helper.command.showAspectConfig('comp2', Extensions.remove);
+          expect(removeData.config.removed).to.be.true;
+        });
+        it('bit status should show the component as staged', () => {
+          const status = helper.command.statusJson();
+          const staged = status.stagedComponents.map((c) => c.id);
+          expect(staged).to.include(`${helper.scopes.remote}/comp2`);
+        });
+      });
     });
   });
   describe('soft remove on lane when another user of the same lane is checking out head', () => {

--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -1,6 +1,7 @@
 import chai, { expect } from 'chai';
 import path from 'path';
 import Helper from '../../../src/e2e-helper/e2e-helper';
+import { Extensions } from '../../../src/constants';
 
 chai.use(require('chai-fs'));
 
@@ -228,6 +229,15 @@ describe('bit lane command', function () {
       });
       it('should remove the component files from the filesystem', () => {
         expect(path.join(helper.scopes.localPath, 'comp2')).to.not.be.a.path();
+      });
+      it('should leave the component on the lane and update it according to lane-a to make it soft-removed in lane-b as well', () => {
+        const laneComps = helper.command.catLane('lane-b');
+        const comps = laneComps.components.map((c) => c.id.name);
+        expect(comps).to.include('comp2');
+      });
+      it('bit show should show the component as removed', () => {
+        const removeData = helper.command.showAspectConfig('comp2', Extensions.remove);
+        expect(removeData.config.removed).to.be.true;
       });
     });
   });

--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -239,6 +239,11 @@ describe('bit lane command', function () {
         const removeData = helper.command.showAspectConfig('comp2', Extensions.remove);
         expect(removeData.config.removed).to.be.true;
       });
+      it('bit status should show the component as staged', () => {
+        const status = helper.command.statusJson();
+        const staged = status.stagedComponents.map((c) => c.id);
+        expect(staged).to.include(`${helper.scopes.remote}/comp2`);
+      });
     });
   });
   describe('soft remove on lane when another user of the same lane is checking out head', () => {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -626,7 +626,7 @@ export class MergingMain {
       return consumer.scope.getConsumerComponent(currentId);
     };
     const currentComponent = await getCurrentComponent();
-    if (currentComponent.removed) {
+    if (currentComponent.isRemoved()) {
       return returnUnmerged(`component has been removed`, true);
     }
     const isModified = async () => {

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -8,6 +8,7 @@ import { NOTHING_TO_SNAP_MSG, AUTO_SNAPPED_MSG, COMPONENT_PATTERN_HELP } from '@
 import { BitError } from '@teambit/bit-error';
 import { Logger } from '@teambit/logger';
 import { SnappingMain, SnapResults } from './snapping.main.runtime';
+import { outputIdsIfExists } from './tag-cmd';
 
 export class SnapCmd implements Command {
   name = 'snap [component-pattern]';
@@ -135,7 +136,8 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     });
 
     if (!results) return chalk.yellow(NOTHING_TO_SNAP_MSG);
-    const { snappedComponents, autoSnappedResults, warnings, newComponents, laneName }: SnapResults = results;
+    const { snappedComponents, autoSnappedResults, warnings, newComponents, laneName, removedComponents }: SnapResults =
+      results;
     const changedComponents = snappedComponents.filter(
       (component) => !newComponents.searchWithoutVersion(component.id)
     );
@@ -143,7 +145,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     const autoTaggedCount = autoSnappedResults ? autoSnappedResults.length : 0;
 
     const warningsOutput = warnings && warnings.length ? `${chalk.yellow(warnings.join('\n'))}\n\n` : '';
-    const tagExplanation = `\n(use "bit export" to push these components to a remote")
+    const snapExplanation = `\n(use "bit export" to push these components to a remote")
 (use "bit reset" to unstage versions)\n`;
 
     const compInBold = (id: BitId) => {
@@ -177,9 +179,10 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     return (
       warningsOutput +
       chalk.green(`${snappedComponents.length + autoTaggedCount} component(s) snapped${laneStr}`) +
-      tagExplanation +
+      snapExplanation +
       outputIfExists('new components', 'first version for components', addedComponents) +
-      outputIfExists('changed components', 'components that got a version bump', changedComponents)
+      outputIfExists('changed components', 'components that got a version bump', changedComponents) +
+      outputIdsIfExists('removed components', removedComponents)
     );
   }
 }

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -69,11 +69,9 @@ export type TagDataPerComp = {
   message?: string;
 };
 
-export type SnapResults = {
+export type SnapResults = BasicTagResults & {
   snappedComponents: ConsumerComponent[];
   autoSnappedResults: AutoTagResult[];
-  warnings: string[];
-  newComponents: BitIds;
   laneName: string | null; // null if default
 };
 
@@ -82,13 +80,17 @@ export type SnapFromScopeResults = {
   exportedIds?: string[];
 };
 
-export type TagResults = {
+export type TagResults = BasicTagResults & {
   taggedComponents: ConsumerComponent[];
   autoTaggedResults: AutoTagResult[];
-  warnings: string[];
-  newComponents: BitIds;
   isSoftTag: boolean;
   publishedPackages: string[];
+};
+
+export type BasicTagResults = {
+  warnings: string[];
+  newComponents: BitIds;
+  removedComponents?: BitIds;
 };
 
 export class SnappingMain {
@@ -186,38 +188,43 @@ export class SnappingMain {
     await this.throwForComponentIssues(components, ignoreIssues);
     this.throwForPendingImport(consumerComponents);
 
-    const { taggedComponents, autoTaggedResults, publishedPackages, stagedConfig } = await tagModelComponent({
-      workspace: this.workspace,
-      scope: this.scope,
-      snapping: this,
-      builder: this.builder,
-      consumerComponents,
-      ids: legacyBitIds,
-      message,
-      editor,
-      exactVersion: validExactVersion,
-      releaseType,
-      preReleaseId,
-      ignoreNewestVersion,
-      skipTests,
-      skipAutoTag,
-      soft,
-      build,
-      persist,
-      disableTagAndSnapPipelines,
-      forceDeploy,
-      incrementBy,
-      packageManagerConfigRootDir: this.workspace.path,
-      dependencyResolver: this.dependencyResolver,
-      exitOnFirstFailedTask: failFast,
-    });
+    const { taggedComponents, autoTaggedResults, publishedPackages, stagedConfig, removedComponents } =
+      await tagModelComponent({
+        workspace: this.workspace,
+        scope: this.scope,
+        snapping: this,
+        builder: this.builder,
+        consumerComponents,
+        ids: legacyBitIds,
+        message,
+        editor,
+        exactVersion: validExactVersion,
+        releaseType,
+        preReleaseId,
+        ignoreNewestVersion,
+        skipTests,
+        skipAutoTag,
+        soft,
+        build,
+        persist,
+        disableTagAndSnapPipelines,
+        forceDeploy,
+        incrementBy,
+        packageManagerConfigRootDir: this.workspace.path,
+        dependencyResolver: this.dependencyResolver,
+        exitOnFirstFailedTask: failFast,
+      });
 
-    const tagResults = { taggedComponents, autoTaggedResults, isSoftTag: soft, publishedPackages };
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    tagResults.warnings = warnings;
+    const tagResults = {
+      taggedComponents,
+      autoTaggedResults,
+      isSoftTag: soft,
+      publishedPackages,
+      warnings,
+      newComponents,
+      removedComponents,
+    };
 
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    tagResults.newComponents = newComponents;
     const postHook = isAll ? POST_TAG_ALL_HOOK : POST_TAG_HOOK;
     HooksManagerInstance?.triggerHook(postHook, tagResults);
     Analytics.setExtraData(
@@ -467,7 +474,7 @@ export class SnappingMain {
     await this.throwForComponentIssues(components, ignoreIssues);
     this.throwForPendingImport(consumerComponents);
 
-    const { taggedComponents, autoTaggedResults, stagedConfig } = await tagModelComponent({
+    const { taggedComponents, autoTaggedResults, stagedConfig, removedComponents } = await tagModelComponent({
       workspace: this.workspace,
       scope: this.scope,
       snapping: this,
@@ -493,9 +500,10 @@ export class SnappingMain {
     const snapResults: Partial<SnapResults> = {
       snappedComponents: taggedComponents,
       autoSnappedResults: autoTaggedResults,
+      newComponents,
+      removedComponents,
     };
 
-    snapResults.newComponents = newComponents;
     const currentLane = consumer.getCurrentLaneId();
     snapResults.laneName = currentLane.isDefault() ? null : currentLane.toString();
     await consumer.onDestroy();

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -821,7 +821,7 @@ there are matching among unmodified components thought. consider using --unmodif
 
   private throwForPendingImport(components: ConsumerComponent[]) {
     const componentsMissingFromScope = components
-      .filter((c) => !c.removed)
+      .filter((c) => !c.isRemoved())
       .filter((c) => !c.componentFromModel && c.id.hasScope())
       .map((c) => c.id.toString());
     if (componentsMissingFromScope.length) {

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import { BitIds } from '@teambit/legacy/dist/bit-id';
 import { isFeatureEnabled, BUILD_ON_CI } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
 import { Command, CommandOptions } from '@teambit/cli';
 import { NOTHING_TO_TAG_MSG, AUTO_TAGGED_MSG } from '@teambit/legacy/dist/api/consumer/lib/tag';
@@ -242,7 +243,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
 
     const results = await this.snapping.tag(params);
     if (!results) return chalk.yellow(NOTHING_TO_TAG_MSG);
-    const { taggedComponents, autoTaggedResults, warnings, newComponents }: TagResults = results;
+    const { taggedComponents, autoTaggedResults, warnings, newComponents, removedComponents }: TagResults = results;
     const changedComponents = taggedComponents.filter((component) => !newComponents.searchWithoutVersion(component.id));
     const addedComponents = taggedComponents.filter((component) => newComponents.searchWithoutVersion(component.id));
     const autoTaggedCount = autoTaggedResults ? autoTaggedResults.length : 0;
@@ -313,8 +314,14 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       tagExplanation +
       outputIfExists('new components', newDesc, addedComponents) +
       outputIfExists('changed components', changedDesc, changedComponents) +
+      outputIdsIfExists('removed components', removedComponents) +
       publishOutput() +
       softTagClarification
     );
   }
+}
+
+export function outputIdsIfExists(label: string, ids?: BitIds) {
+  if (!ids?.length) return '';
+  return `\n${chalk.underline(label)}\n${ids.map((id) => id.toStringWithoutVersion()).join('\n')}\n`;
 }

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -45,6 +45,7 @@ import { Types } from '@teambit/legacy/dist/scope/object-registrar';
 import { FETCH_OPTIONS } from '@teambit/legacy/dist/api/scope/lib/fetch';
 import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
+import { SnapsDistance } from '@teambit/legacy/dist/scope/component-ops/snaps-distance';
 import { Http, DEFAULT_AUTH_TYPE, AuthData, getAuthDataFromHeader } from '@teambit/legacy/dist/scope/network/http/http';
 import { remove } from '@teambit/legacy/dist/api/scope';
 import { BitError } from '@teambit/bit-error';
@@ -800,6 +801,12 @@ export class ScopeMain implements ComponentFactory {
       throw new NoIdMatchPattern(pattern);
     }
     return idsFiltered;
+  }
+
+  async getSnapDistance(id: ComponentID): Promise<SnapsDistance> {
+    const modelComp = await this.legacyScope.getModelComponent(id._legacy);
+    await modelComp.setDivergeData(this.legacyScope.objects);
+    return modelComp.getDivergeData();
   }
 
   async getExactVersionBySemverRange(id: ComponentID, range: string): Promise<string | undefined> {

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -158,7 +158,7 @@ export default class ComponentLoader {
         });
         return null;
       }
-      fromModel.removed = true;
+      fromModel.setRemoved();
       fromModel.componentMap = componentMap;
       removedComponents.push(fromModel);
       return null;

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -433,8 +433,11 @@ export default class ComponentsList {
    */
   async listRemotelySoftRemoved(): Promise<Component[]> {
     const fromFs = await this.getFromFileSystem();
-
-    return fromFs.filter((comp) => comp.isRemoved());
+    // if it's during-merge it might be removed on the other lane remote, not this lane remote and then upon snap/tag
+    // the component will be removed from the workspace, so no need to suggest using "bit remove".
+    const duringMerge = this.listDuringMergeStateComponents();
+    const removed = fromFs.filter((comp) => comp.isRemoved());
+    return removed.filter((comp) => !duringMerge.hasWithoutVersion(comp.id));
   }
 
   /**

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -128,7 +128,7 @@ export default class Component {
   modelComponent?: ModelComponent; // populated when loadedFromFileSystem is true and it exists in the model
   issues: IssuesList;
   deprecated: boolean;
-  removed?: boolean; // was it soft-removed
+  private removed?: boolean; // was it soft-removed. to get this data please use isRemoved() method.
   defaultScope: string | null;
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   _isModified: boolean;
@@ -277,6 +277,10 @@ export default class Component {
    */
   isRemoved() {
     return this.extensions.findCoreExtension(Extensions.remove)?.config?.removed || this.removed;
+  }
+
+  setRemoved() {
+    this.removed = true;
   }
 
   _getHomepage() {


### PR DESCRIPTION
This way, lanes can get updates about components that should be removed.
When merging a lane into main - the soft-removed component are not merged.
