### PR TITLE
fix(aspects) - fix filtering the loading of user aspect when intersect with local scope aspects (file://)

### DIFF
--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -609,6 +609,7 @@ export class AspectLoaderMain {
 
   getAspectIdFromAspectFile(aspectFilePath: string): string | undefined {
     try {
+      // eslint-disable-next-line global-require, import/no-dynamic-require
       const module = aspectFilePath ? require(aspectFilePath) : undefined;
       let manifest = module.default || module;
       if (this.isAspect(manifest)) {
@@ -633,8 +634,10 @@ export class AspectLoaderMain {
         }
       }
       this.logger.warn(`getAspectIdFromAspectFile - aspect at ${aspectFilePath} is not a valid aspect`);
+      return undefined;
     } catch (err) {
       this.logger.warn(`getAspectIdFromAspectFile - couldn't require the aspect file ${aspectFilePath}. err: ${err}`);
+      return undefined;
     }
   }
 

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -205,7 +205,7 @@ needed-for: ${neededFor || '<unknown>'}`);
     const aspectIds = idsWithoutCore.filter((id) => !id.startsWith('file://'));
     // TODO: use diff instead of filter twice
     const localAspects = ids.filter((id) => id.startsWith('file://'));
-    this.scope.localAspects = this.scope.localAspects.concat(localAspects);
+    this.scope.localAspects = uniq(this.scope.localAspects.concat(localAspects));
     // load local aspects for debugging purposes.
     await this.loadAspectFromPath(localAspects);
     const componentIds = await this.scope.resolveMultipleComponentIds(aspectIds);
@@ -223,16 +223,13 @@ needed-for: ${neededFor || '<unknown>'}`);
     const dirs = this.parseLocalAspect(ids);
 
     return dirs.map((dir) => {
-      const runtimeManifest = runtime ? this.findRuntime(dir, runtime) : undefined;
-      const aspectFilePath = runtime ? this.findAspectFile(dir) : undefined;
-      return new AspectDefinition(
-        dir,
-        aspectFilePath ? join(dir, 'dist', aspectFilePath) : null,
-        runtimeManifest ? join(dir, 'dist', runtimeManifest) : null,
-        undefined,
-        undefined,
-        true
-      );
+      const srcRuntimeManifest = runtime ? this.findRuntime(dir, runtime) : undefined;
+      const srcAspectFilePath = runtime ? this.findAspectFile(dir) : undefined;
+      const aspectFilePath = srcAspectFilePath ? join(dir, 'dist', srcAspectFilePath) : null;
+      const runtimeManifest = srcAspectFilePath ? join(dir, 'dist', srcAspectFilePath) : null;
+      let aspectId = aspectFilePath ? this.aspectLoader.getAspectIdFromAspectFile(aspectFilePath) : undefined;
+
+      return new AspectDefinition(dir, aspectFilePath, runtimeManifest, undefined, aspectId, true);
     });
   }
 
@@ -490,7 +487,7 @@ needed-for: ${neededFor || '<unknown>'}`);
     };
     const mergedOpts = { ...defaultOpts, ...opts };
     const coreAspectsIds = this.aspectLoader.getCoreAspectIds();
-    let userAspectsIds;
+    let userAspectsIds: ComponentID[];
     // let requestedCoreStringIds;
     if (componentIds && componentIds.length) {
       const groupedByIsCore = groupBy(componentIds, (id) => coreAspectsIds.includes(id.toString()));
@@ -499,15 +496,14 @@ needed-for: ${neededFor || '<unknown>'}`);
     } else {
       userAspectsIds = await this.scope.resolveMultipleComponentIds(this.aspectLoader.getUserAspects());
     }
+    const localResolved = await this.resolveLocalAspects(this.scope.localAspects, runtimeName);
 
     const withoutLocalAspects = userAspectsIds.filter((aspectId) => {
-      return !this.scope.localAspects.find((localAspect) => {
-        return localAspect.includes(aspectId.fullName.replace('/', '.'));
+      return !localResolved.find((localAspect) => {
+        return localAspect.id === aspectId.toStringWithoutVersion();
       });
     });
-
     const userAspectsDefs = await this.resolveUserAspects(runtimeName, withoutLocalAspects, opts);
-    const localResolved = await this.resolveLocalAspects(this.scope.localAspects, runtimeName);
     const coreAspectsDefs = await this.aspectLoader.getCoreAspectDefs(runtimeName);
 
     const allDefs = userAspectsDefs.concat(coreAspectsDefs).concat(localResolved);

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -226,8 +226,8 @@ needed-for: ${neededFor || '<unknown>'}`);
       const srcRuntimeManifest = runtime ? this.findRuntime(dir, runtime) : undefined;
       const srcAspectFilePath = runtime ? this.findAspectFile(dir) : undefined;
       const aspectFilePath = srcAspectFilePath ? join(dir, 'dist', srcAspectFilePath) : null;
-      const runtimeManifest = srcAspectFilePath ? join(dir, 'dist', srcAspectFilePath) : null;
-      let aspectId = aspectFilePath ? this.aspectLoader.getAspectIdFromAspectFile(aspectFilePath) : undefined;
+      const runtimeManifest = srcRuntimeManifest ? join(dir, 'dist', srcRuntimeManifest) : null;
+      const aspectId = aspectFilePath ? this.aspectLoader.getAspectIdFromAspectFile(aspectFilePath) : undefined;
 
       return new AspectDefinition(dir, aspectFilePath, runtimeManifest, undefined, aspectId, true);
     });


### PR DESCRIPTION
## Proposed Changes

- when loading user aspects we used to filter them if they also local scope aspects (using the `file://` protocol). this filter was done based on checking the user aspect with the path to the local aspect.
This filter might result in wrong filters (for example when trying to load `teambit.node/node` we check if `node` exist in the path of the local aspect (which many times is true because we have `node_modules` in the path). this check is bad.
Now when filtering we are comparing the user aspects with the ids from the `.aspect` file of the local aspect.

