### PR TITLE
perf(get-snap-distance), huge performance improvement by switching R.difference with _.differenceBy

### DIFF
--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -1,4 +1,4 @@
-import R from 'ramda';
+import { differenceBy } from 'lodash';
 import { ParentNotFound, VersionNotFoundOnFS } from '../exceptions';
 import { NoCommonSnap } from '../exceptions/no-common-snap';
 import { ModelComponent, Version } from '../models';
@@ -154,8 +154,8 @@ bit import ${modelComponent.id()} --objects`);
   }
   addParentsRecursively(targetVersion, snapsOnTarget, false);
 
-  const sourceOnlySnaps = R.difference(snapsOnSource, snapsOnTarget);
-  const targetOnlySnaps = R.difference(snapsOnTarget, snapsOnSource);
+  const sourceOnlySnaps = differenceBy(snapsOnSource, snapsOnTarget, 'hash');
+  const targetOnlySnaps = differenceBy(snapsOnTarget, snapsOnSource, 'hash');
 
   if (sourceHeadExistsInTarget) {
     return new SnapsDistance([], targetOnlySnaps, localHead, error);


### PR DESCRIPTION
For one component with 500 versions, it took 478ms with `R.difference` and just 1ms with `Lodash.differenceBy`. 
(this doesn't mean that Ramda is slower, probably Ramda has an equivalent method. it was just probably the wrong way to compare two huge arrays of objects without specifying the prop to compare).  