### PR TITLE
fix(lane-merge), auto change root-dir in case it is collied with existing

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -195,8 +195,9 @@ describe('import functionality on Harmony', function () {
         helper.scopeHelper.getClonedLocalScope(scopeBeforeImport);
         helper.command.importComponent('foo');
       });
-      it('should throw when importing the child', () => {
-        expect(() => helper.command.importComponent('foo/bar')).to.throw('unable to add');
+      it('should not throw when importing the child and should increment its base-path and preserve the suffix', () => {
+        expect(() => helper.command.importComponent('foo/bar')).to.not.throw();
+        expect(path.join(helper.scopes.localPath, helper.scopes.remoteWithoutOwner, 'foo_1/bar')).to.be.a.directory();
       });
     });
     describe('import the child dir first and then the parent', () => {
@@ -204,8 +205,9 @@ describe('import functionality on Harmony', function () {
         helper.scopeHelper.getClonedLocalScope(scopeBeforeImport);
         helper.command.importComponent('foo/bar');
       });
-      it('should throw when importing the child', () => {
-        expect(() => helper.command.importComponent('foo -O')).to.throw('unable to add');
+      it('should not throw when importing the parent and should increment the path', () => {
+        expect(() => helper.command.importComponent('foo -O')).to.not.throw('unable to add');
+        expect(path.join(helper.scopes.localPath, helper.scopes.remoteWithoutOwner, 'foo_1')).to.be.a.directory();
       });
     });
   });

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1298,4 +1298,27 @@ describe('merge lanes', function () {
       expect(path.join(helper.scopes.localPath, 'comp1/foo.js')).to.not.be.a.path();
     });
   });
+  describe('naming conflict introduced during the merge', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.fs.outputFile('comp1-foo/index.ts');
+      helper.command.addComponent('comp1-foo', '--id comp1/foo');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importLane('lane-a');
+    });
+    it('should merge without error by prefix "_1" to the dir-name', () => {
+      expect(() => helper.command.mergeLane(`${helper.scopes.remote}/lane-b`, '-x')).to.not.throw();
+      const dir = path.join(helper.scopes.localPath, helper.scopes.remote, 'comp1_1');
+      expect(dir).to.be.a.directory();
+    });
+  });
 });

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -148,31 +148,33 @@ export class ComponentWriterMain {
       return newPath;
     };
 
-    if (parentsOfOthersComps.length) {
-      // change the paths of all these parents root-dir to not collide with the children root-dir
-      parentsOfOthersComps.forEach((componentWriter) => {
-        if (existingRootDirs.includes(componentWriter.writeToPath)) return; // component already exists.
-        const newPath = incrementRecursively(componentWriter.writeToPath);
-        componentWriter.writeToPath = newPath;
-      });
-    }
-
-    const conflictWithExistingParents = componentWriterInstances.filter(({ writeToPath }) =>
-      existingRootDirs.find((d) => d.startsWith(`${writeToPath}/`))
-    );
-    if (conflictWithExistingParents.length) {
-      conflictWithExistingParents.forEach((componentWriter) => {
-        if (existingRootDirs.includes(componentWriter.writeToPath)) return; // component already exists.
-        const newPath = incrementRecursively(componentWriter.writeToPath);
-        componentWriter.writeToPath = newPath;
-      });
-    }
-
-    componentWriterInstances.forEach((componentWriter) => {
-      const existingUsedParent = existingRootDirs.find((d) => componentWriter.writeToPath.startsWith(`${d}/`));
-      if (!existingUsedParent) return;
-      const newPath = incrementRecursively(existingUsedParent);
+    // this is when writing multiple components and some of them are parents of the others.
+    // change the paths of all these parents root-dir to not collide with the children root-dir
+    parentsOfOthersComps.forEach((componentWriter) => {
+      if (existingRootDirs.includes(componentWriter.writeToPath)) return; // component already exists.
+      const newPath = incrementRecursively(componentWriter.writeToPath);
       componentWriter.writeToPath = newPath;
+    });
+
+    // this part is when a component's rootDir we about to write is a children of an existing rootDir.
+    // e.g. we're now writing "foo", when an existing component has "foo/bar" as the rootDir.
+    // in this case, we change "foo" to be "foo_1".
+    componentWriterInstances.forEach((componentWriter) => {
+      const existingParent = existingRootDirs.find((d) => d.startsWith(`${componentWriter.writeToPath}/`));
+      if (!existingParent) return;
+      if (existingRootDirs.includes(componentWriter.writeToPath)) return; // component already exists.
+      const newPath = incrementRecursively(componentWriter.writeToPath);
+      componentWriter.writeToPath = newPath;
+    });
+
+    // this part if when for example an existing rootDir is "comp1" and currently written component is "comp1/foo".
+    // obviously we don't want to change existing dirs. we change the "comp1/foo" to be "comp1_1/foo".
+    componentWriterInstances.forEach((componentWriter) => {
+      const existingChildren = existingRootDirs.find((d) => componentWriter.writeToPath.startsWith(`${d}/`));
+      if (!existingChildren) return;
+      // we increment the existing one, because it is used to replace the base-path of the current component
+      const newPath = incrementRecursively(existingChildren);
+      componentWriter.writeToPath = componentWriter.writeToPath.replace(existingChildren, newPath);
     });
   }
 


### PR DESCRIPTION
For example, an existing component has "foo" as the rootDir and now during the `bit lane merge`, another component has "foo/bar" as the rootDir. Instead of throwing an error, this PR changes the rootDir to be "foo_1/bar".
(until now, this path incremental was done only when the entire lane was imported and some components were parents of the others). 