### PR TITLE
feat(import), introduce "--include-deprecated" flag and exclude them by default

### DIFF
--- a/e2e/harmony/deprecate.e2e.1.ts
+++ b/e2e/harmony/deprecate.e2e.1.ts
@@ -90,6 +90,28 @@ describe('bit deprecate and undeprecate commands', function () {
             expect(comp2.deprecated).to.equal(true);
           });
         });
+        describe('importing all scope', () => {
+          let output: string;
+          before(() => {
+            helper.scopeHelper.reInitLocalScope();
+            helper.scopeHelper.addRemoteScope();
+            output = helper.command.importComponent('* -x');
+          });
+          it('should not include deprecated by default', () => {
+            expect(output).to.have.string('2 components');
+          });
+        });
+        describe('importing all scope with --include-deprecated flag', () => {
+          let output: string;
+          before(() => {
+            helper.scopeHelper.reInitLocalScope();
+            helper.scopeHelper.addRemoteScope();
+            output = helper.command.importComponent('* -x --include-deprecated');
+          });
+          it('should include deprecated', () => {
+            expect(output).to.have.string('3 components');
+          });
+        });
       });
     });
   });

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -59,6 +59,7 @@ export type ImportOptions = {
   allHistory?: boolean;
   fetchDeps?: boolean; // by default, if a component was tagged with > 0.0.900, it has the flattened-deps-graph in the object
   trackOnly?: boolean;
+  includeDeprecated?: boolean;
 };
 type ComponentMergeStatus = {
   component: Component;
@@ -359,7 +360,7 @@ if you need this specific snap, find the lane this snap is belong to, then run "
     }
 
     await pMapSeries(idsWithWildcard, async (idStr: string) => {
-      const idsFromRemote = await getRemoteBitIdsByWildcards(idStr);
+      const idsFromRemote = await getRemoteBitIdsByWildcards(idStr, this.options.includeDeprecated);
       const existingOnLanes = idsFromRemote.filter((id) => bitIdsFromLane.hasWithoutVersion(id));
       if (!existingOnLanes.length) {
         throw new BitError(`the id with the the wildcard "${idStr}" has been parsed to multiple component ids.
@@ -378,7 +379,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
     await Promise.all(
       this.options.ids.map(async (idStr: string) => {
         if (hasWildcard(idStr)) {
-          const ids = await getRemoteBitIdsByWildcards(idStr);
+          const ids = await getRemoteBitIdsByWildcards(idStr, this.options.includeDeprecated);
           loader.start(BEFORE_IMPORT_ACTION); // it stops the previous loader of BEFORE_REMOTE_LIST
           bitIds.push(...ids);
         } else {

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -65,6 +65,7 @@ export class ImportCmd implements Command {
     ],
     ['', 'fetch-deps', 'fetch dependencies objects'],
     ['', 'track-only', 'do not write any file, just create .bitmap entries of the imported components'],
+    ['', 'include-deprecated', 'when importing with patterns, include deprecated components (default to exclude them)'],
   ] as CommandOptions;
   loader = true;
   migration = true;
@@ -91,6 +92,7 @@ export class ImportCmd implements Command {
       allHistory = false,
       fetchDeps = false,
       trackOnly = false,
+      includeDeprecated = false,
     }: {
       path?: string;
       objects?: boolean;
@@ -107,6 +109,7 @@ export class ImportCmd implements Command {
       allHistory?: boolean;
       fetchDeps?: boolean;
       trackOnly?: boolean;
+      includeDeprecated?: boolean;
     }
   ): Promise<any> {
     if (objects && merge) {
@@ -149,6 +152,7 @@ export class ImportCmd implements Command {
       allHistory,
       fetchDeps,
       trackOnly,
+      includeDeprecated,
     };
     const importResults = await this.importer.import(importOptions, this._packageManagerArgs);
     const { importDetails, importedIds, importedDeps, installationError, compilationError, missingIds } = importResults;

--- a/src/api/consumer/lib/list-scope.ts
+++ b/src/api/consumer/lib/list-scope.ts
@@ -47,7 +47,7 @@ export async function listScope({
   }
 }
 
-export async function getRemoteBitIdsByWildcards(idStr: string): Promise<BitId[]> {
+export async function getRemoteBitIdsByWildcards(idStr: string, includeDeprecated = true): Promise<BitId[]> {
   if (!idStr.includes('/')) {
     throw new GeneralError(
       `import with wildcards expects full scope-name before the wildcards, instead, got "${idStr}"`
@@ -57,8 +57,9 @@ export async function getRemoteBitIdsByWildcards(idStr: string): Promise<BitId[]
   const scopeName = idSplit[0];
   const namespacesUsingWildcards = R.tail(idSplit).join('/');
   const listResult = await listScope({ scopeName, namespacesUsingWildcards });
-  if (!listResult.length) {
+  const listResultFiltered = includeDeprecated ? listResult : listResult.filter((r) => !r.deprecated);
+  if (!listResultFiltered.length) {
     throw new NoIdMatchWildcard([idStr]);
   }
-  return listResult.map((result) => result.id);
+  return listResultFiltered.map((result) => result.id);
 }


### PR DESCRIPTION
Exclude deprecated components when using a pattern in `bit import`.