### PR TITLE
fix refactoring replacement by selectively

### DIFF
--- a/scopes/component/refactoring/refactoring.main.runtime.ts
+++ b/scopes/component/refactoring/refactoring.main.runtime.ts
@@ -53,7 +53,7 @@ export class RefactoringMain {
         },
         // replace variables in code, so excluding any instances that are inside quotation marks
         {
-          oldStr: `^((?!.*['"].*).*)${camelCase(sourceId.name)}`,
+          oldStr: `((?!.*['"]))${camelCase(sourceId.name)}`,
           newStr: `$1${camelCase(targetId.name)}`,
         },
         {

--- a/scopes/component/refactoring/refactoring.main.runtime.ts
+++ b/scopes/component/refactoring/refactoring.main.runtime.ts
@@ -46,13 +46,15 @@ export class RefactoringMain {
     await this.replaceMultipleStrings(
       [component],
       [
+        // replace import statements, so of format 'comp-name' with string quotation marks
         {
-          oldStr: sourceId.name,
-          newStr: targetId.name,
+          oldStr: `(['"])${sourceId.name}(['"])`,
+          newStr: `$1${targetId.name}$2`,
         },
+        // replace variables in code, so excluding any instances with quotation marks
         {
-          oldStr: camelCase(sourceId.name),
-          newStr: camelCase(targetId.name),
+          oldStr: `([^'"])${camelCase(sourceId.name)}`,
+          newStr: `$1${camelCase(targetId.name)}`,
         },
         {
           oldStr: camelCase(sourceId.name, { pascalCase: true }),

--- a/scopes/component/refactoring/refactoring.main.runtime.ts
+++ b/scopes/component/refactoring/refactoring.main.runtime.ts
@@ -48,12 +48,12 @@ export class RefactoringMain {
       [
         // replace import statements, so of format 'comp-name' with string quotation marks
         {
-          oldStr: `(['"])${sourceId.name}(['"])`,
+          oldStr: `(['"].+)${sourceId.name}(['"])`,
           newStr: `$1${targetId.name}$2`,
         },
         // replace variables in code, so excluding any instances with quotation marks
         {
-          oldStr: `([^'"])${camelCase(sourceId.name)}`,
+          oldStr: `(\\s)${camelCase(sourceId.name)}`,
           newStr: `$1${camelCase(targetId.name)}`,
         },
         {

--- a/scopes/component/refactoring/refactoring.main.runtime.ts
+++ b/scopes/component/refactoring/refactoring.main.runtime.ts
@@ -51,9 +51,9 @@ export class RefactoringMain {
           oldStr: `(['"].+)${sourceId.name}(['"])`,
           newStr: `$1${targetId.name}$2`,
         },
-        // replace variables in code, so excluding any instances with quotation marks
+        // replace variables in code, so excluding any instances that are inside quotation marks
         {
-          oldStr: `(\\s)${camelCase(sourceId.name)}`,
+          oldStr: `^((?!.*['"].*).*)${camelCase(sourceId.name)}`,
           newStr: `$1${camelCase(targetId.name)}`,
         },
         {


### PR DESCRIPTION
replacing strings and variables

## Proposed Changes

- replace strings (i.e. import statement paths) with kebab case
- replace code entries (i.e. entries not inside a string) with camelCase
