### PR TITLE
default to not throw for NoCommonSnap

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1021,9 +1021,11 @@ describe('bit lane command', function () {
     });
   });
   // eventually, this forked lane history is not connected to main.
-  // lane-a merged+squashed into main and then continue snapping.
-  // on main the "squash" prop points to an older version from lane-a.
-  // on lane-b it's unable to connect its head to main. the missing history exists in lane-a only.
+  // lane-a continue snapping and then merged+squashed into main.
+  // on main the "squash" prop points to a newer version from lane-a, which doesn't exist on lane-b.
+  // on lane-b, getDivergeData compares its head to main, not to lane-a because they're different scopes.
+  // as a result, although it traverses the "squash", it's unable to connect main to lane-b.
+  // the missing history exists on lane-a only.
   describe('multiple scopes - fork the lane, then original lane progresses and squashed to main', () => {
     let anotherRemote: string;
     let laneB: string;

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -323,6 +323,7 @@ export class MergeLanesMain {
         modelComponent,
         sourceHead: toLaneHead,
         targetHead: fromLaneHead,
+        throwForNoCommonSnap: true,
       });
       const modifiedVersion = shouldSquash
         ? await squashOneComp(DEFAULT_LANE, fromLaneId, id, divergeData, log, this.scope.legacyScope, fromVersionObj)

--- a/src/consumer/component-ops/component-status-loader.ts
+++ b/src/consumer/component-ops/component-status-loader.ts
@@ -95,7 +95,7 @@ export class ComponentStatusLoader {
     }
 
     const lane = await this.consumer.getCurrentLaneObject();
-    await componentFromModel.setDivergeData(this.consumer.scope.objects, false);
+    await componentFromModel.setDivergeData(this.consumer.scope.objects);
     status.staged = await componentFromModel.isLocallyChanged(this.consumer.scope.objects, lane);
     const versionFromFs = componentFromFileSystem.id.version;
     const idStr = id.toString();

--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -22,6 +22,7 @@ export async function getDivergeData({
   sourceHead, // if empty, use the local head (if on lane - lane head. if on main - component head)
   targetHead,
   throws = true, // otherwise, save the error instance in the `SnapsDistance` object,
+  throwForNoCommonSnap = false, // by default, save the error in `SnapsDistance` obj.
   versionParentsFromObjects, // relevant for remote-scope where during export the data is not in the repo yet.
 }: {
   repo: Repository;
@@ -29,6 +30,7 @@ export async function getDivergeData({
   sourceHead?: Ref | null;
   targetHead: Ref | null;
   throws?: boolean;
+  throwForNoCommonSnap?: boolean;
   versionParentsFromObjects?: VersionParents[];
 }): Promise<SnapsDistance> {
   const isOnLane = modelComponent.laneHeadLocal || modelComponent.laneHeadLocal === null;
@@ -195,7 +197,7 @@ bit import ${modelComponent.id()} --objects`);
       return new SnapsDistance(snapsOnSource, snapsOnTarget, undefined);
     }
     const err = new NoCommonSnap(modelComponent.id());
-    if (throws) throw err;
+    if (throwForNoCommonSnap) throw err;
     return new SnapsDistance(snapsOnSource, snapsOnTarget, undefined, err);
   }
 


### PR DESCRIPTION
In the following case the NoCommonSnap error blocks the user unnecessarily. 
lane-b forked from lane-a. 
lane-a continue snapping and then merged+squashed into main. 
On main the "squash" prop points to a newer version from lane-a, which doesn't exist on lane-b.
On lane-b, getDivergeData compares its head to main, not to lane-a because they're different scopes.
As a result, although it traverses the "squash", it's unable to connect main to lane-b. The missing history exists on lane-a only.
