### PR TITLE
add "origin" prop to the export headers

### DIFF
--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -359,6 +359,7 @@ export class MergeLanesMain {
         // all artifacts must be pushed. they're all considered "external" in this case, because it's running from a
         // bare-scope, but we don't want to ignore them, otherwise, they'll be missing from the component-scopes.
         ignoreMissingExternalArtifacts: false,
+        exportOrigin: 'lane-merge',
       });
       exportedIds = exported.map((id) => id.toString());
     }

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -201,7 +201,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     }
     const http = await Http.connect(CENTRAL_BIT_HUB_URL, CENTRAL_BIT_HUB_NAME);
     await http.pushToCentralHub(objectList, {
-      persist: true,
+      origin: 'sign',
       sign: true,
       signComponents: signComponents.map((id) => id.toString()),
       idsHashMaps,

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -282,6 +282,7 @@ to bypass this error, use --skip-new-scope-validation flag (not recommended. it 
       idsWithFutureScope: ids,
       laneObject: this.laneObj,
       allVersions: false,
+      exportOrigin: 'update-dependencies',
     });
   }
 

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -62,6 +62,19 @@ export enum Verb {
   READ = 'read',
 }
 
+export type ExportOrigin = 'export' | 'sign' | 'update-dependencies' | 'lane-merge';
+
+export type PushCentralOptions = {
+  origin: ExportOrigin;
+  signComponents?: string[]; // relevant for bit-sign.
+  idsHashMaps?: { [hash: string]: string }; // relevant for bit-sign. keys are the component hash, values are component-ids as strings
+
+  /**
+   * @deprecated prefer using "origin"
+   */
+  sign?: boolean;
+};
+
 export type ProxyConfig = {
   httpProxy?: string;
   httpsProxy?: string;
@@ -231,7 +244,7 @@ export class Http implements Network {
 
   async pushToCentralHub(
     objectList: ObjectList,
-    options: Record<string, any> = {}
+    options: PushCentralOptions
   ): Promise<{
     successIds: string[];
     failedScopes: string[];


### PR DESCRIPTION
To tell where the export originated: bit-export, update-dependencies, sign or merge-from-scope.