### PR TITLE
fix, avoid resolving local-scope to two different paths

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -44,7 +44,7 @@ import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { BitIds } from '@teambit/legacy/dist/bit-id';
-import { propogateUntil as propagateUntil } from '@teambit/legacy/dist/utils';
+import { findScopePath } from '@teambit/legacy/dist/utils';
 import logger from '@teambit/legacy/dist/logger/logger';
 import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
 import loader from '@teambit/legacy/dist/cli/loader';
@@ -62,7 +62,7 @@ async function loadLegacyConfig(config: any) {
 
 async function getConfig(cwd = process.cwd()) {
   const consumerInfo = await getConsumerInfo(cwd);
-  const scopePath = propagateUntil(cwd);
+  const scopePath = findScopePath(cwd);
   const globalConfigOpts = {
     name: '.bitrc.jsonc',
   };

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -1,6 +1,6 @@
 import { resolve, join } from 'path';
 import { getConsumerInfo, loadConsumer } from '@teambit/legacy/dist/consumer';
-import { propogateUntil as propagateUntil } from '@teambit/legacy/dist/utils';
+import { findScopePath } from '@teambit/legacy/dist/utils';
 import { readdirSync } from 'fs';
 import { Harmony, Aspect } from '@teambit/harmony';
 // TODO: expose this types from harmony (once we have a way to expose it only for node)
@@ -88,7 +88,7 @@ function getMainFilePath(aspect: any, id: ComponentID) {
 
 export async function getConfig(cwd = process.cwd()) {
   const consumerInfo = await getConsumerInfo(cwd);
-  const scopePath = propagateUntil(cwd);
+  const scopePath = findScopePath(cwd);
   const globalConfigOpts = {
     name: '.bitrc.jsonc',
   };

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -575,15 +575,6 @@ export default class Consumer {
     await Scope.reset(this.scope.path, true);
   }
 
-  static locateProjectScope(projectPath: string) {
-    if (fs.existsSync(path.join(projectPath, DOT_GIT_DIR, BIT_GIT_DIR))) {
-      return path.join(projectPath, DOT_GIT_DIR, BIT_GIT_DIR);
-    }
-    if (fs.existsSync(path.join(projectPath, BIT_HIDDEN_DIR))) {
-      return path.join(projectPath, BIT_HIDDEN_DIR);
-    }
-    return undefined;
-  }
   static async load(currentPath: PathOsBasedAbsolute): Promise<Consumer> {
     const consumerInfo = await getConsumerInfo(currentPath);
     if (!consumerInfo) {
@@ -601,8 +592,7 @@ export default class Consumer {
       await Promise.all([consumer.config.write({ workspaceDir: consumer.projectPath }), consumer.scope.ensureDir()]);
     }
     const config = consumer && consumer.config ? consumer.config : await WorkspaceConfig.loadIfExist(consumerInfo.path);
-    const scopePath = Consumer.locateProjectScope(consumerInfo.path);
-    const scope = consumer?.scope || (await Scope.load(scopePath as string));
+    const scope = consumer?.scope || (await Scope.load(consumerInfo.path));
     consumer = new Consumer({
       projectPath: consumerInfo.path,
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/src/utils/fs/propogate-until.ts
+++ b/src/utils/fs/propogate-until.ts
@@ -43,22 +43,19 @@ export function pathHasAll(patterns: string[]): (absPath: string) => boolean {
 }
 
 /**
- * propogates the FS from given path and until passing pattern function test.
- * @name propogateUntil
- * @param {string} fromPath
- * @param {(path: string) => boolean} pattern
- * @returns {string|null} first path to pass the test.
- * @example
- * ```js
- *  propogateUntil('/usr/local/var', (path) => path.includes('/usr'));
- *  // => '/usr/local/var'
- * ```
+ * search for a scope path by walking up parent directories until reaching root.
+ * @param fromPath (e.g. /tmp/workspace)
+ * @returns absolute scope-path if found (e.g. /tmp/workspace/.bit or /tmp/workspace/.git/bit)
  */
-export function propogateUntil(fromPath: string): string | undefined {
+export function findScopePath(fromPath: string): string | undefined {
   if (!fromPath) return undefined;
   if (!fs.existsSync(fromPath)) return undefined;
   const filePath = findUp.sync(
-    [OBJECTS_DIR, path.join(BIT_HIDDEN_DIR, OBJECTS_DIR), path.join(DOT_GIT_DIR, BIT_GIT_DIR, OBJECTS_DIR)],
+    [
+      OBJECTS_DIR, // for bare-scope
+      path.join(BIT_HIDDEN_DIR, OBJECTS_DIR),
+      path.join(DOT_GIT_DIR, BIT_GIT_DIR, OBJECTS_DIR),
+    ],
     { cwd: fromPath, type: 'directory' }
   );
   if (!filePath) return undefined;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -9,7 +9,7 @@ import calculateFileInfo from './fs/file-info';
 import getWithoutExt from './fs/fs-no-ext';
 import getExt from './fs/get-ext';
 import isDirEmpty from './fs/is-dir-empty';
-import { pathHas, pathHasAll, propogateUntil } from './fs/propogate-until';
+import { pathHas, pathHasAll, findScopePath } from './fs/propogate-until';
 import readDirIgnoreDsStore, { readDirSyncIgnoreDsStore } from './fs/read-dir-ignore-ds-store';
 import glob from './glob';
 import retrieveIgnoreList from './ignore/ignore';
@@ -78,7 +78,7 @@ export {
   isBitUrl,
   isDir,
   resolveHomePath,
-  propogateUntil,
+  findScopePath,
   pathHas,
   pathHasAll,
   isDirEmpty,


### PR DESCRIPTION
## Proposed Changes

- in case the scope exists in both ".bit" and ".git/bit", resolve always to the same path.  (.bit)
- rename the unhelpful function name (with typo) `progogateUntil` to `findInScope`.
