### PR TITLE
fix, catch builder.getDescriptor errors to avoid blocking users

### DIFF
--- a/scopes/pipelines/builder/builder.service.tsx
+++ b/scopes/pipelines/builder/builder.service.tsx
@@ -211,7 +211,12 @@ export class BuilderService implements EnvService<BuildServiceResults, BuilderDe
   getDescriptor(env: EnvDefinition) {
     // @ts-ignore
     const tasks = Object.keys(pipeNames).map((pipeFuncName: PipeFunctionNames) => {
-      const tasksQueue = this.getTasksNamesByPipeFunc(env, pipeFuncName);
+      let tasksQueue: string[];
+      try {
+        tasksQueue = this.getTasksNamesByPipeFunc(env, pipeFuncName);
+      } catch (err: any) {
+        tasksQueue = [`<failed getting task-queue, error: ${err.message}>`];
+      }
       return { pipeName: pipeNames[pipeFuncName], tasks: tasksQueue };
     });
     return tasks as BuilderDescriptor;


### PR DESCRIPTION
An example where this is an issue: the env has changed to add/replace some tasks, then running `bit compile` throws 

> Pipeline error - missing task dependency "teambit.compilation/compiler" of the "teambit.defender/tester:JestTest"

because the builder.getDescriptor is always running when the env is loaded (to show it in `bit env get <comp-id>`).
This PR fixes it by catching these errors and showing them in `bit env get`.