### PR TITLE
fix(ui/component-drawer): set link to exact

### DIFF
--- a/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
@@ -73,6 +73,7 @@ export function ComponentView(props: ComponentViewProps<PayloadType>) {
       className={classNames(indentClass, styles.component, viewingMainCompOnLane && styles.mainOnly)}
       activeClassName={styles.active}
       onClick={handleClick}
+      exact={true}
     >
       <div className={styles.left}>
         <Tooltip className={styles.componentEnvTooltip} placement="right" content={envTooltip}>


### PR DESCRIPTION
fixes the component id selection in the case when the namespace name and the component name is the same

e.g.
component - `teambit.dot-updates/updates`
`http://<host>/teambit/dot-cloud/~lane/bit-cloud/~component/teambit.dot-updates/updates`

component - `teambit.dot-updates/updates/component-updates`
`http://<host>/teambit/dot-cloud/~lane/bit-cloud/~component/teambit.dot-updates/updates/component-updates`