### PR TITLE
improve component loading originated from workspace aspect by removing recursive call

### DIFF
--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -98,7 +98,7 @@ export class WorkspaceComponentLoader {
     if (fromCache && useCache) {
       return fromCache;
     }
-    const consumerComponent = legacyComponent || (await this.getConsumerComponent(id));
+    const consumerComponent = legacyComponent || (await this.getConsumerComponent(id, loadOpts));
     // in case of out-of-sync, the id may changed during the load process
     const updatedId = consumerComponent ? ComponentID.fromLegacy(consumerComponent.id, id.scope) : id;
     const component = await this.loadOne(updatedId, consumerComponent, loadOpts);
@@ -208,11 +208,16 @@ export class WorkspaceComponentLoader {
     return undefined;
   }
 
-  async getConsumerComponent(id: ComponentID): Promise<ConsumerComponent | undefined> {
+  async getConsumerComponent(
+    id: ComponentID,
+    loadOpts: ComponentLoadOptions = {}
+  ): Promise<ConsumerComponent | undefined> {
+    loadOpts.originatedFromHarmony = true;
     try {
       const { components, removedComponents } = await this.workspace.consumer.loadComponents(
         BitIds.fromArray([id._legacy]),
-        true
+        true,
+        loadOpts
       );
       return components?.[0] || removedComponents?.[0];
     } catch (err: any) {

--- a/scopes/workspace/workspace/workspace.provider.ts
+++ b/scopes/workspace/workspace/workspace.provider.ts
@@ -14,8 +14,8 @@ import { UiMain } from '@teambit/ui';
 import type { VariantsMain } from '@teambit/variants';
 import { Consumer, loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
-import LegacyComponentLoader from '@teambit/legacy/dist/consumer/component/component-loader';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
+import LegacyComponentLoader, { ComponentLoadOptions } from '@teambit/legacy/dist/consumer/component/component-loader';
 import { BitId } from '@teambit/legacy-bit-id';
 import { GlobalConfigMain } from '@teambit/global-config';
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
@@ -170,7 +170,8 @@ export default async function provideWorkspace(
   consumer.onCacheClear.push(() => workspace.clearCache());
 
   LegacyComponentLoader.registerOnComponentLoadSubscriber(
-    async (legacyComponent: ConsumerComponent, opts?: { loadDocs?: boolean }) => {
+    async (legacyComponent: ConsumerComponent, opts?: ComponentLoadOptions) => {
+      if (opts?.originatedFromHarmony) return legacyComponent;
       const id = await workspace.resolveComponentId(legacyComponent.id);
       const newComponent = await workspace.get(id, legacyComponent, true, true, opts);
       return newComponent.state._consumer;

--- a/src/consumer/component/component-loader.ts
+++ b/src/consumer/component/component-loader.ts
@@ -22,6 +22,7 @@ import loader from '../../cli/loader';
 export type ComponentLoadOptions = {
   loadDocs?: boolean;
   loadCompositions?: boolean;
+  originatedFromHarmony?: boolean;
 };
 export type LoadManyResult = {
   components: Component[];


### PR DESCRIPTION
This PR saves another `workspace.get` call per component loaded from harmony.