### PR TITLE
fix(watcher): chokidar ignored paths support for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cacache": "15.0.5",
     "chalk": "2.4.2",
     "checksum": "0.1.1",
-    "chokidar": "3.5.1",
+    "chokidar": "3.5.3",
     "cli-spinners": "1.3.1",
     "comment-json": "3.0.3",
     "core-js": "3.9.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -799,8 +799,8 @@ importers:
         specifier: 0.1.1
         version: 0.1.1
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -26417,8 +26417,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       classnames:
         specifier: 2.2.6
         version: 2.2.6
@@ -30648,8 +30648,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       core-js:
         specifier: ^3.0.0
         version: 3.13.0
@@ -31035,7 +31035,7 @@ packages:
       slash: 2.0.0
     optionalDependencies:
       '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
-      chokidar: 3.5.1
+      chokidar: 3.5.3
     dev: false
 
   /@babel/code-frame@7.10.4:
@@ -36555,17 +36555,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.constants.storage/-/@teambit-base-ui.constants.storage-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.0.tgz}
     peerDependencies:
@@ -36654,7 +36643,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.utils.sub-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -36667,19 +36656,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.root-node/-/@teambit-base-ui.graph.tree.root-node-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -36731,18 +36708,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.input.checkbox.hidden@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.input.checkbox.hidden@1.0.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/hidden@1.0.2.tgz}
     peerDependencies:
@@ -36750,31 +36715,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.input.checkbox.indicator@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.indicator/-/@teambit-base-ui.input.checkbox.indicator-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.input.checkbox.label@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.hidden': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -36818,17 +36758,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.breakpoints/-/@teambit-base-ui.layout.breakpoints-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.layout.grid-component@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-s8B7uWwtKRVnglUSUuvOCkW7+HI=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.grid-component/-/@teambit-base-ui.layout.grid-component-1.0.1.tgz}
     peerDependencies:
@@ -36837,17 +36766,6 @@ packages:
     dependencies:
       '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -36864,18 +36782,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
-
-  /@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.loaders.loader-ribbon/-/@teambit-base-ui.loaders.loader-ribbon-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   /@teambit/base-ui.loaders.skeleton@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
@@ -36924,19 +36830,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  /@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.nav-link/-/@teambit-base-ui.routing.nav-link-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.routing-provider': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.routing-provider/-/@teambit-base-ui.routing.routing-provider-1.0.0.tgz}
     peerDependencies:
@@ -36949,17 +36842,7 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.styles.flex-center/-/@teambit-base-ui.styles.flex-center-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
+    dev: true
 
   /@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.0.tgz}
@@ -37004,21 +36887,6 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.card/-/@teambit-base-ui.surfaces.card-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.background': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -37069,81 +36937,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/@teambit-base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.layout@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.layout/-/@teambit-base-ui.surfaces.split-pane.layout-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.pane/-/@teambit-base-ui.surfaces.split-pane.pane-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.split-pane/-/@teambit-base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.splitter/-/@teambit-base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.heading@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.text.heading@1.0.4(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/text/heading@1.0.4.tgz}
     peerDependencies:
@@ -37154,39 +36947,13 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  /@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.muted-text/-/@teambit-base-ui.text.muted-text-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.paragraph@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.text.paragraph@1.0.3(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -37205,78 +36972,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.themed-text/-/@teambit-base-ui.text.themed-text-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.accent-color/-/@teambit-base-ui.theme.accent-color-1.1.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.brand-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.brand-definition/-/@teambit-base-ui.theme.brand-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.color-definition@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.color-definition/-/@teambit-base-ui.theme.color-definition-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.colors/-/@teambit-base-ui.theme.colors-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.dark-theme/-/@teambit-base-ui.theme.dark-theme-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.fonts.book@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37297,81 +36994,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.roboto/-/@teambit-base-ui.theme.fonts.roboto-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.heading-margin-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.heading-margin-definition/-/@teambit-base-ui.theme.heading-margin-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.shadow-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.shadow-definition/-/@teambit-base-ui.theme.shadow-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.size-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.size-definition/-/@teambit-base-ui.theme.size-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.sizes/-/@teambit-base-ui.theme.sizes-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.theme-provider/-/@teambit-base-ui.theme.theme-provider-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.brand-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.color-definition': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.fonts.book': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.heading-margin-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.shadow-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.size-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.composer/-/@teambit-base-ui.utils.composer-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37390,17 +37014,6 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.string.affix/-/@teambit-base-ui.utils.string.affix-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   /@teambit/base-ui.utils.sub-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.sub-paths/-/@teambit-base-ui.utils.sub-paths-1.0.0.tgz}
@@ -37913,21 +37526,6 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/component.instructions.exporting-components/-/@teambit-component.instructions.exporting-components-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
   /@teambit/component.modules.component-url@0.0.124(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/modules/component-url@0.0.124.tgz}
     engines: {node: '>=12.22.0'}
@@ -37946,7 +37544,7 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.405
       query-string: 7.0.0
       react: 17.0.2
@@ -37960,7 +37558,7 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.417
       query-string: 7.0.0
       react: 17.0.2
@@ -38031,8 +37629,8 @@ packages:
     resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -38171,10 +37769,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -38188,10 +37786,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39444,7 +39042,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39460,7 +39058,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39698,20 +39296,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.theme.theme-context/-/@teambit-documenter.theme.theme-context-4.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.theme-provider': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.anchor@4.0.6(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/anchor@4.0.6.tgz}
     peerDependencies:
@@ -39817,19 +39401,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.heading': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.heading@4.1.4(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-jENJgXMvwy825NKKTM8gP90faMc=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.4.tgz}
     peerDependencies:
@@ -39856,32 +39427,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.highlighted-text/-/@teambit-documenter.ui.highlighted-text-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/documenter.ui.inline-code': 0.1.1(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.image@4.0.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/image@4.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.inline-code@0.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39906,31 +39453,6 @@ packages:
 
   /@teambit/documenter.ui.italic@4.0.7(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/italic@4.0.7.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label-list/-/@teambit-documenter.ui.label-list-4.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label/-/@teambit-documenter.ui.label-4.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39981,20 +39503,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.paragraph': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.paragraph@4.1.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-w9jrNz9R2bIsMgLvjNgv9Ycmr3Y=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.5.tgz}
     peerDependencies:
@@ -40027,50 +39535,12 @@ packages:
       - typescript
     dev: false
 
-  /@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.section/-/@teambit-documenter.ui.section-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.separator@4.1.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.sub-title/-/@teambit-documenter.ui.sub-title-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.paragraph': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -40269,18 +39739,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/evangelist.elements.icon@1.0.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-abaBfCKbp8JEu8J7j9OB5kvyo5s=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.5.tgz}
     peerDependencies:
@@ -40300,20 +39758,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.input.checkbox.indicator@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -40371,19 +39815,6 @@ packages:
       '@teambit/base-ui.input.checkbox.label': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.input.checkbox.indicator': 1.0.8(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.label': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.input.checkbox.indicator': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41270,20 +40701,6 @@ packages:
       - '@types/react'
     dev: false
 
-  /@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, tarball: https://node-registry.v2.bit.cloud/@teambit/mdx.ui.mdx-scope-context/-/@teambit-mdx.ui.mdx-scope-context-0.0.368.tgz}
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.86
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/node.deps-detectors.detective-es6@0.0.1:
     resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
     dependencies:
@@ -41317,7 +40734,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41346,7 +40763,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41388,36 +40805,6 @@ packages:
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
-  /@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-compositions/-/@teambit-react.instructions.react.adding-compositions-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
-  /@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-tests/-/@teambit-react.instructions.react.adding-tests-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41599,7 +40986,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/toolbox.string.get-initials': 0.0.483
       '@teambit/toolbox.url.add-avatar-query-params': 0.0.483
       classnames: 2.2.6
@@ -41633,8 +41020,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.78(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41649,8 +41036,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41880,7 +41267,7 @@ packages:
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41898,9 +41285,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42108,7 +41495,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.486(react-dom@17.0.2)(react@17.0.2)
@@ -42126,7 +41513,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.492(react-dom@17.0.2)(react@17.0.2)
@@ -42350,7 +41737,7 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.486(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.lanes': 0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42383,7 +41770,7 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.12(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.492(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.models': 0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42403,7 +41790,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42417,7 +41804,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42469,8 +41856,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42485,8 +41872,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42501,7 +41888,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.104(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42517,7 +41904,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.110(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42566,7 +41953,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42581,7 +41968,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -46877,21 +46264,6 @@ packages:
       '@chevrotain/types': 9.1.0
       '@chevrotain/utils': 9.1.0
       regexp-to-ast: 0.5.0
-    dev: false
-
-  /chokidar@3.5.1:
-    resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
-    engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.5.0
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /chokidar@3.5.3:
@@ -58430,13 +57802,6 @@ packages:
       minimatch: 5.1.6
     dev: false
 
-  /readdirp@3.5.0:
-    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
-    dev: false
-
   /readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -59210,7 +58575,7 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.1
+      chokidar: 3.5.3
       immutable: 4.2.2
       source-map-js: 1.0.2
     dev: false
@@ -63165,10 +62530,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63191,7 +62556,7 @@ packages:
       '@react-hook/previous': 1.0.1(react@17.0.2)
       '@teambit/base-react.hooks.use-1d-nav': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.hooks.use-queued-execution': 0.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.item': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -63215,7 +62580,7 @@ packages:
     dependencies:
       '@teambit/component-id': 0.0.427
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63339,8 +62704,8 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63357,8 +62722,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.dark-theme': 1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -63393,7 +62758,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -63539,7 +62904,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       react: 17.0.2
@@ -63653,8 +63018,8 @@ packages:
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/explorer.ui.gallery.component-grid': 0.0.496(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/lanes.ui.models': 0.0.79(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -63677,7 +63042,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63702,7 +63067,7 @@ packages:
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63722,7 +63087,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63778,7 +63143,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63795,7 +63160,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63954,7 +63319,7 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -64221,12 +63586,12 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -64304,11 +63669,11 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
@@ -64321,7 +63686,7 @@ packages:
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.radio': 1.1.13(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -64343,15 +63708,15 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.code-view': 0.0.508(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label': registry.npmjs.org/@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -64584,10 +63949,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/component.instructions.exporting-components': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.instructions.exporting-components': registry.npmjs.org/@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -64626,7 +63991,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.code-compare-section': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
@@ -64653,15 +64018,15 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/any-fs': 0.0.5
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.navigation.responsive-navbar': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.separator': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.separator': registry.npmjs.org/@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -64730,7 +64095,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.muted-italic': 0.0.44(react-dom@17.0.2)(react@17.0.2)
@@ -64884,7 +64249,7 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       chai: 4.3.0
       query-string: 7.0.0
@@ -64992,15 +64357,15 @@ packages:
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.input.checkbox.label': 1.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.input.checkbox.label': registry.npmjs.org/@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -65342,12 +64707,12 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -65419,15 +64784,15 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.layout.row': 0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.page-frame': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.page-frame': registry.npmjs.org/@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.navigation.content-tabs': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label-list': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label-list': registry.npmjs.org/@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65509,10 +64874,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65564,7 +64929,7 @@ packages:
       '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.contributors': 0.0.514(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65589,8 +64954,8 @@ packages:
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65645,7 +65010,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65663,18 +65028,18 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.status-message-card': 0.0.17(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-context': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65737,11 +65102,11 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65762,8 +65127,8 @@ packages:
       '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       query-string: 7.0.0
       react: 17.0.2
@@ -66096,7 +65461,7 @@ packages:
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -66126,7 +65491,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -66479,7 +65844,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
@@ -67050,7 +66415,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.copied-message': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0
@@ -67581,7 +66946,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       chai: 4.3.0
       classnames: 2.2.6
       core-js: 3.13.0
@@ -67599,7 +66964,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67728,8 +67093,8 @@ packages:
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
-      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-tests': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/react.rendering.ssr': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/typescript.typescript-compiler': 2.0.1(@teambit/legacy@node_modules+@teambit+legacy)
       '@testing-library/jest-dom': 5.16.2
@@ -67896,7 +67261,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       '@teambit/react.instructions.react-native.adding-tests': 0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/jest-native': 4.0.4
       comment-json: 3.0.3
       core-js: 3.13.0
@@ -67920,7 +67285,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.standalone-not-found-page': 0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -67942,7 +67307,7 @@ packages:
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.code.react-playground': 4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       jsx-to-string: 1.4.0
@@ -67963,7 +67328,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67979,7 +67344,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67993,7 +67358,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       lodash: 4.17.21
       react: 17.0.2
@@ -68011,7 +67376,7 @@ packages:
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68028,7 +67393,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.styles.flex-center': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.styles.flex-center': registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.icon-button': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68064,7 +67429,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -68128,9 +67493,9 @@ packages:
       react-router-dom: ^6.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -68139,7 +67504,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.1
+      chokidar: 3.5.3
       classnames: 2.2.6
       core-js: 3.13.0
       fs-extra: 10.0.0
@@ -68185,7 +67550,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68228,7 +67593,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -68259,8 +67624,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68533,7 +67898,7 @@ packages:
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68549,10 +67914,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68570,7 +67935,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68617,7 +67982,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68648,8 +68013,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.theme-provider': registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.elements.level-icon': 0.0.20(react-dom@17.0.2)(react@17.0.2)
@@ -68671,7 +68036,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68809,7 +68174,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68824,11 +68189,11 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.root-node': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.root-node': registry.npmjs.org/@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -68846,9 +68211,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.graph.tree.collapsable-tree-node': 0.0.4(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -68866,9 +68231,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68891,8 +68256,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
-      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.fonts.roboto': registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.theme.icons-font': 2.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
@@ -68988,7 +68353,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69131,8 +68496,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69195,14 +68560,14 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69235,7 +68600,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69253,7 +68618,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69283,10 +68648,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69305,8 +68670,8 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -69328,7 +68693,7 @@ packages:
     dependencies:
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69358,7 +68723,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69662,7 +69027,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69730,7 +69095,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.1
+      chokidar: 3.5.3
       core-js: 3.13.0
       fs-extra: 10.0.0
       lodash: 4.17.21
@@ -69754,8 +69119,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@react-hook/latest': 1.0.3(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -70741,7 +70106,7 @@ packages:
     dependencies:
       '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copied-message': 4.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,13 +149,13 @@ importers:
         version: 2.0.4
       '@prerenderer/prerenderer':
         specifier: ^1.2.0
-        version: 1.2.0(@types/express@4.17.13)(debug@4.3.2)
+        version: 1.2.3(@types/express@4.17.13)(debug@4.3.2)
       '@prerenderer/renderer-jsdom':
         specifier: ^1.1.2
-        version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+        version: 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+        version: 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@react-hook/latest':
         specifier: 1.0.3
         version: 1.0.3(react@17.0.2)
@@ -573,9 +573,6 @@ importers:
       '@teambit/lanes.ui.viewed-lane':
         specifier: 0.0.37
         version: 0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/legacy':
-        specifier: link:/Users/zoltan/.bvm/versions/0.1.91/bit-0.1.91/node_modules/@teambit/legacy
-        version: link:../../../.bvm/versions/0.2.2/bit-0.2.2/node_modules/@teambit/legacy
       '@teambit/legacy-bit-id':
         specifier: ^0.0.423
         version: 0.0.423
@@ -620,7 +617,7 @@ importers:
         version: 0.0.1
       '@teambit/toolbox.network.agent':
         specifier: 0.0.116
-        version: 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+        version: registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/typescript.deps-detectors.detective-typescript':
         specifier: ^0.0.1
         version: 0.0.1(typescript@4.7.4)
@@ -799,8 +796,8 @@ importers:
         specifier: 0.1.1
         version: 0.1.1
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -1842,7 +1839,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/react-tabs':
         specifier: 2.3.2
         version: 2.3.2
@@ -1933,7 +1930,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -1988,7 +1985,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2064,7 +2061,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2119,7 +2116,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2174,7 +2171,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -2217,7 +2214,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2260,7 +2257,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2294,7 +2291,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2331,7 +2328,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2368,7 +2365,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2408,7 +2405,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2460,7 +2457,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2518,7 +2515,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2552,7 +2549,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2595,7 +2592,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2629,7 +2626,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2675,7 +2672,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2709,7 +2706,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2746,7 +2743,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2783,7 +2780,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2823,7 +2820,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2857,7 +2854,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2891,7 +2888,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2925,7 +2922,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2968,7 +2965,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3002,7 +2999,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3045,7 +3042,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3079,7 +3076,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3119,7 +3116,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3153,7 +3150,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3187,7 +3184,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3230,7 +3227,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -3300,7 +3297,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3337,7 +3334,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3407,7 +3404,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3450,7 +3447,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3496,7 +3493,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3551,7 +3548,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3597,7 +3594,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3646,7 +3643,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3692,7 +3689,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3735,7 +3732,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15196,7 +15193,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15242,7 +15239,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15279,7 +15276,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15316,7 +15313,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15353,7 +15350,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15387,7 +15384,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15424,7 +15421,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15476,7 +15473,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15510,7 +15507,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15544,7 +15541,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15587,7 +15584,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15630,7 +15627,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15664,7 +15661,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15698,7 +15695,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15735,7 +15732,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15781,7 +15778,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15836,7 +15833,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15870,7 +15867,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15904,7 +15901,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15944,7 +15941,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15978,7 +15975,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16024,7 +16021,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16064,7 +16061,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16098,7 +16095,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16132,7 +16129,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16199,7 +16196,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16233,7 +16230,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16356,7 +16353,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16459,7 +16456,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16532,7 +16529,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16581,7 +16578,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16618,7 +16615,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16658,7 +16655,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16698,7 +16695,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16738,7 +16735,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16796,7 +16793,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16848,7 +16845,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16943,7 +16940,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17008,7 +17005,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17048,7 +17045,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17103,7 +17100,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17158,7 +17155,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17204,7 +17201,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17328,7 +17325,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -17383,7 +17380,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17423,7 +17420,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17487,7 +17484,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17527,7 +17524,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17570,7 +17567,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17622,7 +17619,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17665,7 +17662,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17742,7 +17739,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17794,7 +17791,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17831,7 +17828,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17939,7 +17936,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17985,7 +17982,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18040,7 +18037,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18101,7 +18098,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18210,7 +18207,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18304,7 +18301,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18353,7 +18350,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18420,7 +18417,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18481,7 +18478,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18536,7 +18533,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18585,7 +18582,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18637,7 +18634,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18704,7 +18701,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18756,7 +18753,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18835,7 +18832,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18902,7 +18899,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18960,7 +18957,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19049,7 +19046,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19086,7 +19083,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19150,7 +19147,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19184,7 +19181,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19221,7 +19218,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19276,7 +19273,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19340,7 +19337,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19383,7 +19380,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19432,7 +19429,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19490,7 +19487,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19545,7 +19542,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19615,7 +19612,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19655,7 +19652,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19692,7 +19689,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19744,7 +19741,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19823,7 +19820,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -19887,7 +19884,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19930,7 +19927,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19979,7 +19976,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20082,7 +20079,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20227,7 +20224,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20276,7 +20273,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20310,7 +20307,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20356,7 +20353,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20390,7 +20387,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20424,7 +20421,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20485,7 +20482,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20571,7 +20568,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20641,7 +20638,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20699,7 +20696,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20754,7 +20751,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20803,7 +20800,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20849,7 +20846,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20956,7 +20953,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21023,7 +21020,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21057,7 +21054,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21103,7 +21100,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21158,7 +21155,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21201,7 +21198,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21244,7 +21241,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21284,7 +21281,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21324,7 +21321,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21364,7 +21361,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21431,7 +21428,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21534,7 +21531,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -21686,7 +21683,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -21771,7 +21768,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21838,7 +21835,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21878,7 +21875,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21912,7 +21909,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21949,7 +21946,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21989,7 +21986,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22026,7 +22023,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22090,7 +22087,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22124,7 +22121,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22188,7 +22185,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22240,7 +22237,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -22283,7 +22280,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22323,7 +22320,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22393,7 +22390,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22442,7 +22439,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22491,7 +22488,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22549,7 +22546,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22649,7 +22646,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22689,7 +22686,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22729,7 +22726,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22793,7 +22790,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22887,7 +22884,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -22927,7 +22924,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22985,7 +22982,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23058,7 +23055,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23098,7 +23095,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23153,7 +23150,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23193,7 +23190,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23245,7 +23242,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23294,7 +23291,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23409,7 +23406,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23455,7 +23452,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23498,7 +23495,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23574,7 +23571,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23617,7 +23614,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23694,7 +23691,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23734,7 +23731,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23774,7 +23771,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23823,7 +23820,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23978,7 +23975,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24085,7 +24082,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24143,7 +24140,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24189,7 +24186,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24247,7 +24244,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24385,7 +24382,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24428,7 +24425,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24462,7 +24459,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24511,7 +24508,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24554,7 +24551,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24651,7 +24648,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24688,7 +24685,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24753,7 +24750,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24832,7 +24829,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24872,7 +24869,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25015,7 +25012,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25070,7 +25067,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25110,7 +25107,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25150,7 +25147,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25190,7 +25187,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25224,7 +25221,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25365,13 +25362,13 @@ importers:
         version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@prerenderer/prerenderer':
         specifier: ^1.2.0
-        version: 1.2.0(@types/express@4.17.13)(debug@4.3.2)
+        version: 1.2.3(@types/express@4.17.13)(debug@4.3.2)
       '@prerenderer/renderer-jsdom':
         specifier: ^1.1.2
-        version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+        version: 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+        version: 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack':
         specifier: 5.5.0
         version: 5.5.0
@@ -25615,7 +25612,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25748,7 +25745,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25821,7 +25818,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25861,7 +25858,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25925,7 +25922,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25965,7 +25962,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26005,7 +26002,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26051,7 +26048,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26094,7 +26091,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26143,7 +26140,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26189,7 +26186,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26229,7 +26226,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26281,7 +26278,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26336,7 +26333,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26399,8 +26396,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       classnames:
         specifier: 2.2.6
         version: 2.2.6
@@ -26464,7 +26461,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -26510,7 +26507,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26550,7 +26547,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26584,7 +26581,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26621,7 +26618,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26670,7 +26667,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26716,7 +26713,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26765,7 +26762,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26814,7 +26811,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26906,7 +26903,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27270,7 +27267,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27402,7 +27399,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27507,7 +27504,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27562,7 +27559,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27602,7 +27599,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27639,7 +27636,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27688,7 +27685,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27734,7 +27731,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27774,7 +27771,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27838,7 +27835,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27884,7 +27881,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27918,7 +27915,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27952,7 +27949,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27998,7 +27995,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/react-tabs':
         specifier: 2.3.2
         version: 2.3.2
@@ -28047,7 +28044,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28096,7 +28093,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28133,7 +28130,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28185,7 +28182,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28231,7 +28228,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28289,7 +28286,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28347,7 +28344,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28399,7 +28396,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28586,7 +28583,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28626,7 +28623,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28672,7 +28669,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28706,7 +28703,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28743,7 +28740,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28786,7 +28783,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28823,7 +28820,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28857,7 +28854,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28891,7 +28888,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28931,7 +28928,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28968,7 +28965,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29008,7 +29005,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29063,7 +29060,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29097,7 +29094,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29140,7 +29137,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29174,7 +29171,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29244,7 +29241,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29284,7 +29281,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29327,7 +29324,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29373,7 +29370,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29407,7 +29404,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29459,7 +29456,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29529,7 +29526,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29572,7 +29569,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29615,7 +29612,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29661,7 +29658,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29701,7 +29698,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29762,7 +29759,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30039,7 +30036,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30085,7 +30082,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30125,7 +30122,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30165,7 +30162,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30205,7 +30202,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30284,7 +30281,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -30414,7 +30411,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30466,7 +30463,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30518,7 +30515,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30555,7 +30552,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30607,7 +30604,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30630,8 +30627,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.1
-        version: 3.5.1
+        specifier: 3.5.3
+        version: 3.5.3
       core-js:
         specifier: ^3.0.0
         version: 3.13.0
@@ -30677,7 +30674,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30810,7 +30807,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30883,7 +30880,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.18
+        version: 17.0.20
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30893,12 +30890,17 @@ importers:
 
 packages:
 
-  /@ampproject/remapping@2.2.0:
-    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
+  /@aashutoshrathi/word-wrap@1.2.6:
+    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /@ampproject/remapping@2.2.1:
+    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
 
   /@apideck/better-ajv-errors@0.2.7(ajv@8.12.0):
     resolution: {integrity: sha512-J2dW+EHYudbwI7MGovcHWLBrxasl21uuroc2zT8bH2RxYuv2g5GqsO5jcKUZz4LaMST45xhKjVuyRYkhcWyMhA==}
@@ -30927,9 +30929,9 @@ packages:
       subscriptions-transport-ws:
         optional: true
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
+      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
       '@wry/context': 0.6.1
-      '@wry/equality': 0.5.3
+      '@wry/equality': 0.5.6
       '@wry/trie': 0.3.2
       graphql: 15.8.0
       graphql-tag: 2.12.6(graphql@15.8.0)
@@ -30940,7 +30942,7 @@ packages:
       subscriptions-transport-ws: 0.9.18(bufferutil@4.0.3)(graphql@15.8.0)(utf-8-validate@5.0.5)
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
-      tslib: 2.5.0
+      tslib: 2.6.0
       zen-observable-ts: 1.2.5
 
   /@apollo/protobufjs@1.2.2:
@@ -30986,7 +30988,7 @@ packages:
     dependencies:
       '@types/express': 4.17.13
       '@types/fs-capacitor': 2.0.0
-      '@types/koa': 2.13.5
+      '@types/koa': 2.13.6
       busboy: 0.3.1
       fs-capacitor: 2.0.4
       graphql: 15.8.0
@@ -31005,54 +31007,54 @@ packages:
     engines: {node: '>=6.9.0'}
     hasBin: true
     peerDependencies:
-      '@babel/core': ^7.0.0-0
+      '@babel/core': '*'
     dependencies:
       '@babel/core': 7.19.6
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.18
       commander: 4.1.1
       convert-source-map: 1.9.0
       fs-readdir-recursive: 1.1.0
-      glob: 7.2.0
+      glob: 7.2.3
       make-dir: 2.1.0
       slash: 2.0.0
     optionalDependencies:
       '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
-      chokidar: 3.5.1
+      chokidar: 3.5.3
     dev: false
 
   /@babel/code-frame@7.10.4:
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.5
     dev: false
 
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.5
     dev: false
 
-  /@babel/code-frame@7.18.6:
-    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
+  /@babel/code-frame@7.22.5:
+    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.18.6
+      '@babel/highlight': 7.22.5
 
-  /@babel/compat-data@7.20.14:
-    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
+  /@babel/compat-data@7.22.9:
+    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
     engines: {node: '>=6.9.0'}
 
   /@babel/core@7.11.6:
     resolution: {integrity: sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.22.4
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.11.6)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31060,7 +31062,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.1
+      semver: 5.7.2
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31070,13 +31072,13 @@ packages:
     resolution: {integrity: sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.22.4
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31084,7 +31086,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.1
+      semver: 5.7.2
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31094,13 +31096,13 @@ packages:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.22.4
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31108,7 +31110,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.1
+      semver: 5.7.2
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31118,173 +31120,173 @@ packages:
     resolution: {integrity: sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.13
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/core@7.20.12:
-    resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
+  /@babel/core@7.22.9:
+    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.0
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helpers': 7.20.13
-      '@babel/parser': 7.20.13
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.22.3
+      '@ampproject/remapping': 2.2.1
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
+      '@babel/helpers': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
       convert-source-map: 1.9.0
       debug: 4.3.2
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/generator@7.20.14:
-    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
+  /@babel/generator@7.22.9:
+    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
-      '@jridgewell/gen-mapping': 0.3.2
+      '@babel/types': 7.22.5
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
       jsesc: 2.5.2
 
-  /@babel/helper-annotate-as-pure@7.18.6:
-    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
+  /@babel/helper-annotate-as-pure@7.22.5:
+    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-builder-binary-assignment-operator-visitor@7.18.9:
-    resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
+  /@babel/helper-builder-binary-assignment-operator-visitor@7.22.5:
+    resolution: {integrity: sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-check-duplicate-nodes@7.18.6:
-    resolution: {integrity: sha512-gQkMniJ8+GfcRk98xGNlBXSEuWOJpEb7weoHDJpw4xxQrikPRvO1INlqbCM6LynKYKVZ/suN869xudV5DzAkzQ==}
+  /@babel/helper-check-duplicate-nodes@7.22.5:
+    resolution: {integrity: sha512-7QAOFIO853OUOVr7ILo9caP3+eb3dNsVzs9iNKr8xi4FIBMQOCN72mv2YENxjNEK/2q/DYlWNAZuTwFn+sJVbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
     dev: false
 
-  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.12.3
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.5
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
-  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.19.6
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.5
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
 
-  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.20.12):
-    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
+  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.20.14
-      '@babel/core': 7.20.12
-      '@babel/helper-validator-option': 7.18.6
-      browserslist: 4.21.5
+      '@babel/compat-data': 7.22.9
+      '@babel/core': 7.22.9
+      '@babel/helper-validator-option': 7.22.5
+      browserslist: 4.21.9
       lru-cache: 5.1.1
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
-  /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.12.3):
-    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-member-expression-to-functions': 7.20.7
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.19.6):
-    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-member-expression-to-functions': 7.20.7
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/helper-split-export-declaration': 7.18.6
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+  /@babel/helper-create-class-features-plugin@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      regexpu-core: 5.2.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+  /@babel/helper-create-class-features-plugin@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      regexpu-core: 5.2.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      semver: 6.3.1
+
+  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.22.5
+      regexpu-core: 5.3.2
+      semver: 6.3.1
+    dev: false
+
+  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-annotate-as-pure': 7.22.5
+      regexpu-core: 5.3.2
+      semver: 6.3.1
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -31292,83 +31294,131 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
       debug: 4.3.2
       lodash.debounce: 4.0.8
       resolve: 1.20.0
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helper-environment-visitor@7.18.9:
-    resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
+  /@babel/helper-environment-visitor@7.22.5:
+    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-explode-assignable-expression@7.18.6:
-    resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
+  /@babel/helper-fixtures@7.22.9:
+    resolution: {integrity: sha512-rg767Kf9oS6Djcum2sDFlKqaTJcnbmEwhk+K0eCFcbbAtlJfWXW6pT7OdX2VIJmEs73v3XMOsbKb6499rxIJhg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
-
-  /@babel/helper-fixtures@7.19.4:
-    resolution: {integrity: sha512-yscO1xHvHA4QzKO2KL5Vcdi1bY6m/uT/NzrL2DlU60uUr9lcaG6/tN7VC+ZwNnY2FN3YbArnyc0gN+aFdJN8mA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
-  /@babel/helper-function-name@7.19.0:
-    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+  /@babel/helper-function-name@7.22.5:
+    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/types': 7.22.3
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
 
-  /@babel/helper-hoist-variables@7.18.6:
-    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
+  /@babel/helper-hoist-variables@7.22.5:
+    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-member-expression-to-functions@7.20.7:
-    resolution: {integrity: sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==}
+  /@babel/helper-member-expression-to-functions@7.22.5:
+    resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-module-imports@7.18.6:
-    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
+  /@babel/helper-module-imports@7.22.5:
+    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-module-transforms@7.20.11:
-    resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.11.6):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
     engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-simple-access': 7.20.2
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/helper-validator-identifier': 7.19.1
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.22.3
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/core': 7.11.6
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: false
 
-  /@babel/helper-optimise-call-expression@7.18.6:
-    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: false
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.12.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: false
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+
+  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
+    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-validator-identifier': 7.22.5
+    dev: false
+
+  /@babel/helper-optimise-call-expression@7.22.5:
+    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
   /@babel/helper-plugin-test-runner@7.16.7:
     resolution: {integrity: sha512-8MAd2mKWTpWdLPkpCR2i1EJ/FWr31FjhSrSIJPNwWH7FzM9R7lxlfkbCiGgvDxRd4rCvb9l1oo8hS3DWCx2NQg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-transform-fixture-test-runner': 7.20.14
+      '@babel/helper-transform-fixture-test-runner': 7.22.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -31377,157 +31427,151 @@ packages:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
     dev: false
 
-  /@babel/helper-plugin-utils@7.20.2:
-    resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
+  /@babel/helper-plugin-utils@7.22.5:
+    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.22.3
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-wrap-function': 7.22.9
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
+  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-wrap-function': 7.20.5
-      '@babel/types': 7.22.3
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-wrap-function': 7.22.9
 
-  /@babel/helper-replace-supers@7.20.7:
-    resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+    dev: false
+
+  /@babel/helper-replace-supers@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-member-expression-to-functions': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+
+  /@babel/helper-simple-access@7.22.5:
+    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.20.7
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.22.3
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/types': 7.22.5
 
-  /@babel/helper-simple-access@7.20.2:
-    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
+  /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
+    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
-    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
+  /@babel/helper-split-export-declaration@7.22.6:
+    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
+      '@babel/types': 7.22.5
 
-  /@babel/helper-split-export-declaration@7.18.6:
-    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
+  /@babel/helper-string-parser@7.22.5:
+    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-transform-fixture-test-runner@7.22.7:
+    resolution: {integrity: sha512-1fkiBWo29W6RAYNdbCmztmzNY9bchqNHPHuAGIqIdXqweemSX3jqIrgmtn+hTqueLXhlP0gJU9tV/fLqS9UG6w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.3
-
-  /@babel/helper-string-parser@7.21.5:
-    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-transform-fixture-test-runner@7.20.14:
-    resolution: {integrity: sha512-ZHUTYhE4jq+0bNVj0X49yR0e7VQgurJcYos7LU6VO14ZKwUDBv4TbmUH8hufGqRGFCmstxaii7nq9aHhjGScZw==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/core': 7.20.12
-      '@babel/helper-check-duplicate-nodes': 7.18.6
-      '@babel/helper-fixtures': 7.19.4
+      '@babel/code-frame': 7.22.5
+      '@babel/core': 7.22.9
+      '@babel/helper-check-duplicate-nodes': 7.22.5
+      '@babel/helper-fixtures': 7.22.9
       quick-lru: 5.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helper-validator-identifier@7.19.1:
-    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
+  /@babel/helper-validator-identifier@7.22.5:
+    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-option@7.18.6:
-    resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
+  /@babel/helper-validator-option@7.22.5:
+    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-wrap-function@7.20.5:
-    resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
+  /@babel/helper-wrap-function@7.22.9:
+    resolution: {integrity: sha512-sZ+QzfauuUEfxSEjKFmi3qDSHgLsTPK/pEpoD/qonZKOtTPTLbf59oabPQ4rKekt9lFcj/hTZaOhWwFYrgjk+Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.19.0
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.22.3
+      '@babel/helper-function-name': 7.22.5
+      '@babel/template': 7.22.5
+      '@babel/types': 7.22.5
+
+  /@babel/helpers@7.22.6:
+    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/template': 7.22.5
+      '@babel/traverse': 7.22.8
+      '@babel/types': 7.22.5
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helpers@7.20.13:
-    resolution: {integrity: sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==}
+  /@babel/highlight@7.22.5:
+    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.20.7
-      '@babel/traverse': 7.20.13
-      '@babel/types': 7.22.3
-    transitivePeerDependencies:
-      - supports-color
-
-  /@babel/highlight@7.18.6:
-    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-validator-identifier': 7.22.5
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.20.13:
-    resolution: {integrity: sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==}
+  /@babel/parser@7.22.7:
+    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.22.3
 
-  /@babel/parser@7.22.4:
-    resolution: {integrity: sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==}
-    engines: {node: '>=6.0.0'}
-    hasBin: true
-    dependencies:
-      '@babel/types': 7.22.3
-
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-transform-optional-chaining': 7.22.6(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.12.3):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -31536,12 +31580,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.12.3)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.19.6):
@@ -31551,12 +31593,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.19.6)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-class-properties@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==}
@@ -31564,10 +31604,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.12.13(@babel/core@7.19.6):
@@ -31576,10 +31614,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.12.3):
@@ -31589,10 +31625,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.19.6):
@@ -31602,23 +31636,19 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-proposal-class-static-block@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
+  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-decorators@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-knNIuusychgYN8fGJHONL0RbFxLGawhXOJNLBk75TniTsZZeA+wdkDuv6wp4lGwzQEKjZi6/WYtnb3udNPmQmQ==}
@@ -31626,11 +31656,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.12.3)
     dev: false
 
   /@babel/plugin-proposal-decorators@7.12.13(@babel/core@7.19.6):
@@ -31639,11 +31667,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.19.6)
     dev: false
 
   /@babel/plugin-proposal-decorators@7.20.0(@babel/core@7.19.6):
@@ -31653,13 +31679,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.19.6)
     dev: false
 
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.12.3):
@@ -31669,7 +31693,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31680,7 +31704,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.12.3):
@@ -31690,7 +31714,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31701,7 +31725,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.12.3):
@@ -31711,7 +31735,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31722,7 +31746,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.12.3):
@@ -31732,7 +31756,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
     dev: false
 
@@ -31743,7 +31767,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.12.1(@babel/core@7.12.3):
@@ -31752,7 +31776,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31763,7 +31787,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-numeric-separator@7.12.1(@babel/core@7.12.3):
@@ -31772,7 +31796,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
     dev: false
 
@@ -31783,7 +31807,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-object-rest-spread@7.11.0(@babel/core@7.11.6):
@@ -31792,9 +31816,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.11.6)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.11.6)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.11.6)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9):
@@ -31803,9 +31827,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.10.4
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.9)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.12.13(@babel/core@7.19.6):
@@ -31814,9 +31838,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.19.4(@babel/core@7.12.3):
@@ -31825,12 +31849,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.3)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.19.4(@babel/core@7.19.6):
@@ -31839,12 +31863,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -31853,7 +31877,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31864,7 +31888,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-optional-chaining@7.12.1(@babel/core@7.12.3):
@@ -31873,20 +31897,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
+  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.12.3):
@@ -31896,10 +31920,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.19.6):
@@ -31909,39 +31931,33 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
+  /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.12.3):
+    resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
+  /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.19.6):
+    resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -31950,8 +31966,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.19.6):
@@ -31961,8 +31977,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -31970,7 +31986,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.19.6):
@@ -31979,7 +31995,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -31987,7 +32003,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.12.3):
@@ -31996,7 +32012,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.19.6):
@@ -32005,7 +32021,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.19.6):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -32014,26 +32030,26 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-decorators@7.19.0(@babel/core@7.12.3):
-    resolution: {integrity: sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==}
+  /@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-decorators@7.19.0(@babel/core@7.19.6):
-    resolution: {integrity: sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==}
+  /@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.12.3):
@@ -32042,7 +32058,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.19.6):
@@ -32051,7 +32067,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -32059,7 +32075,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.19.6):
@@ -32068,26 +32084,26 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
+  /@babel/plugin-syntax-flow@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.19.6):
-    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
+  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.19.6):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -32095,7 +32111,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.12.3):
@@ -32104,7 +32120,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.19.6):
@@ -32113,7 +32129,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.10.4(@babel/core@7.11.6):
     resolution: {integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==}
@@ -32121,7 +32137,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
@@ -32130,27 +32146,27 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.10.4
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
+  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -32158,7 +32174,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.19.6):
@@ -32167,7 +32183,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -32175,7 +32191,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.19.6):
@@ -32184,7 +32200,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -32192,7 +32208,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.19.6):
@@ -32201,7 +32217,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.11.6):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -32209,7 +32225,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.3):
@@ -32218,7 +32234,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
@@ -32227,7 +32243,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.19.6):
@@ -32236,7 +32252,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -32244,7 +32260,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.19.6):
@@ -32253,7 +32269,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -32261,7 +32277,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.19.6):
@@ -32270,7 +32286,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.12.3):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -32279,7 +32295,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.19.6):
@@ -32289,7 +32305,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.12.3):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -32298,7 +32314,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.19.6):
@@ -32308,251 +32324,243 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-syntax-typescript@7.20.0(@babel/core@7.12.3):
-    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-syntax-typescript@7.20.0(@babel/core@7.19.6):
-    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
+  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
+  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
+  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.19.6)
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
+  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-block-scoping@7.20.14(@babel/core@7.12.3):
-    resolution: {integrity: sha512-sMPepQtsOs5fM1bwNvuJJHvaCfOEQfmc01FGw0ELlTpTJj5Ql/zuNRRldYhAPys4ghXdBIQJbRVYi44/7QflQQ==}
+  /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-block-scoping@7.20.14(@babel/core@7.19.6):
-    resolution: {integrity: sha512-sMPepQtsOs5fM1bwNvuJJHvaCfOEQfmc01FGw0ELlTpTJj5Ql/zuNRRldYhAPys4ghXdBIQJbRVYi44/7QflQQ==}
+  /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-classes@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
-  /@babel/plugin-transform-classes@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
+  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-optimise-call-expression': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-split-export-declaration': 7.22.6
       globals: 11.12.0
-    transitivePeerDependencies:
-      - supports-color
 
-  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/template': 7.20.7
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/template': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
+  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/template': 7.20.7
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/template': 7.22.5
 
-  /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
+  /@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
+  /@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
+  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
+  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
+  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-flow-strip-types@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==}
@@ -32560,114 +32568,110 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.12.3):
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
+  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.19.6):
-    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
+  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
+  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
+  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
+  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.12.3):
-    resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.19.6):
-    resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
+  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-modules-commonjs@7.12.13(@babel/core@7.19.6):
     resolution: {integrity: sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==}
@@ -32675,12 +32679,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
       babel-plugin-dynamic-import-node: 2.3.3
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.12.3):
@@ -32690,11 +32692,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
     dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.19.6):
@@ -32704,197 +32704,194 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-simple-access': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-simple-access': 7.22.5
 
-  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.12.3):
-    resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
+  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.19.6):
-    resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
+  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-identifier': 7.19.1
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
 
-  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
+  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.20.11
-      '@babel/helper-plugin-utils': 7.20.2
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
+  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
+  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
+  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.20.7
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
 
-  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.11.6):
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-optional-chaining@7.22.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
+
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.11.6):
+    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.12.9):
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.12.9):
+    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
+  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
+  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-react-constant-elements@7.20.2(@babel/core@7.19.6):
-    resolution: {integrity: sha512-KS/G8YI8uwMGKErLFOHS/ekhqdHhpEloxs43NecQHVgo2QuQSyJhGIY1fL8UGl9wy5ItVwwoUL4YxVqsplGq2g==}
+  /@babel/plugin-transform-react-constant-elements@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-BF5SXoO+nX3h5OhlN78XbbDrBOffv+AxPP2ENaJOVqjWCgBDeOY3WcaUcddutGSfoap+5NEQ/q/4I3WZIvgkXA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /@babel/plugin-transform-react-display-name@7.12.1(@babel/core@7.12.3):
@@ -32903,144 +32900,144 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
+  /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
+  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
 
-  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
+  /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx-source@7.19.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
+  /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.12.3):
-    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
+  /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.12.3)
-      '@babel/types': 7.22.3
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.12.3)
+      '@babel/types': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.19.6):
-    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
+  /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.19.6)
-      '@babel/types': 7.22.3
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.19.6)
+      '@babel/types': 7.22.5
 
-  /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
+  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
+  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
+  /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.1
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
+  /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       regenerator-transform: 0.15.1
 
-  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
+  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-transform-runtime@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==}
@@ -33048,10 +33045,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
       resolve: 1.20.0
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /@babel/plugin-transform-runtime@7.12.17(@babel/core@7.19.6):
@@ -33060,9 +33057,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      semver: 5.7.1
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      semver: 5.7.2
     dev: false
 
   /@babel/plugin-transform-runtime@7.19.6(@babel/core@7.19.6):
@@ -33072,192 +33069,190 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.19.6)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.19.6)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.19.6)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
+  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.12.3):
-    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.19.6):
-    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
+  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
 
-  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
+  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
+  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
+  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-typescript@7.20.13(@babel/core@7.12.3):
-    resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
+  /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-typescript@7.20.13(@babel/core@7.19.6):
-    resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
+  /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-annotate-as-pure': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.19.6)
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.12.3):
-    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
+  /@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.19.6):
-    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
+  /@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
 
-  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
-  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
+  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/preset-env@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.12.3)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.3)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.12.3)
@@ -33283,44 +33278,42 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.12.3)
-      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.12.3)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.12.3)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.12.3)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.12.3)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.12.3)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.12.3)
       '@babel/preset-modules': 0.1.5(@babel/core@7.12.3)
       '@babel/types': 7.22.3
-      core-js-compat: 3.27.2
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - supports-color
+      core-js-compat: 3.31.1
+      semver: 5.7.2
     dev: false
 
   /@babel/preset-env@7.12.17(@babel/core@7.19.6):
@@ -33328,12 +33321,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-module-imports': 7.18.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.19.6)
@@ -33344,7 +33337,7 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-object-rest-spread': 7.19.4(@babel/core@7.19.6)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.19.6)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
@@ -33359,44 +33352,42 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.19.6)
-      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.19.6)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.19.6)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.19.6)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.19.6)
       '@babel/preset-modules': 0.1.5(@babel/core@7.19.6)
       '@babel/types': 7.22.3
-      core-js-compat: 3.27.2
-      semver: 5.7.1
-    transitivePeerDependencies:
-      - supports-color
+      core-js-compat: 3.31.1
+      semver: 5.7.2
     dev: false
 
   /@babel/preset-env@7.19.4(@babel/core@7.19.6):
@@ -33405,16 +33396,16 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.19.6)
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-class-static-block': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.19.6)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.19.6)
       '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.19.6)
@@ -33423,16 +33414,16 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-object-rest-spread': 7.19.4(@babel/core@7.19.6)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.19.6)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.19.6)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.19.6)
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.19.6)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.19.6)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.19.6)
+      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.19.6)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.19.6)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.19.6)
@@ -33442,45 +33433,45 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.19.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.19.6)
-      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.19.6)
-      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.19.6)
+      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.19.6)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.19.6)
-      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.19.6)
       '@babel/preset-modules': 0.1.5(@babel/core@7.19.6)
       '@babel/types': 7.22.3
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.19.6)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.19.6)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.19.6)
-      core-js-compat: 3.27.2
-      semver: 6.3.0
+      core-js-compat: 3.31.1
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -33490,9 +33481,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.12.3)
       '@babel/types': 7.22.3
       esutils: 2.0.3
     dev: false
@@ -33503,9 +33494,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
       '@babel/types': 7.22.3
       esutils: 2.0.3
 
@@ -33515,13 +33506,13 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-transform-react-display-name': 7.12.1(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.12.3)
     dev: false
 
   /@babel/preset-react@7.13.13(@babel/core@7.19.6):
@@ -33530,12 +33521,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.19.6)
     dev: false
 
   /@babel/preset-react@7.18.6(@babel/core@7.19.6):
@@ -33545,12 +33536,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.19.6)
 
   /@babel/preset-typescript@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==}
@@ -33558,10 +33549,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.12.3)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.12.3)
     dev: false
 
   /@babel/preset-typescript@7.18.6(@babel/core@7.19.6):
@@ -33571,11 +33560,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.19.6)
-    transitivePeerDependencies:
-      - supports-color
+      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-validator-option': 7.22.5
+      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.19.6)
     dev: false
 
   /@babel/register@7.18.9(@babel/core@7.19.6):
@@ -33588,15 +33575,18 @@ packages:
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
-      pirates: 4.0.5
+      pirates: 4.0.6
       source-map-support: 0.5.21
     dev: false
 
-  /@babel/runtime-corejs3@7.20.13:
-    resolution: {integrity: sha512-p39/6rmY9uvlzRiLZBIB3G9/EBr66LBMcYm7fIDeSBNdRjF2AGD3rFZucUyAgGHC2N+7DdLvVi33uTjSE44FIw==}
+  /@babel/regjsgen@0.8.0:
+    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
+
+  /@babel/runtime-corejs3@7.22.6:
+    resolution: {integrity: sha512-M+37LLIRBTEVjktoJjbw4KVhupF0U/3PYUCbBwgAd9k17hoKhRu1n935QiG7Tuxv0LJOMrb2vuKEeYUlv0iyiw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.27.2
+      core-js-pure: 3.31.1
       regenerator-runtime: 0.13.11
     dev: false
 
@@ -33617,26 +33607,26 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/template@7.20.7:
-    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
+  /@babel/template@7.22.5:
+    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.3
+      '@babel/code-frame': 7.22.5
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
 
-  /@babel/traverse@7.20.13:
-    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
+  /@babel/traverse@7.22.8:
+    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.18.6
-      '@babel/generator': 7.20.14
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-hoist-variables': 7.18.6
-      '@babel/helper-split-export-declaration': 7.18.6
-      '@babel/parser': 7.22.4
-      '@babel/types': 7.22.3
+      '@babel/code-frame': 7.22.5
+      '@babel/generator': 7.22.9
+      '@babel/helper-environment-visitor': 7.22.5
+      '@babel/helper-function-name': 7.22.5
+      '@babel/helper-hoist-variables': 7.22.5
+      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/parser': 7.22.7
+      '@babel/types': 7.22.5
       debug: 4.3.2
       globals: 11.12.0
     transitivePeerDependencies:
@@ -33646,8 +33636,16 @@ packages:
     resolution: {integrity: sha512-P3na3xIQHTKY4L0YOG7pM8M8uoUIB910WQaSiiMCZUC2Cy8XFEQONGABFnHWBa2gpGKODTAJcNhi5Zk0sLRrzg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.21.5
-      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
+      to-fast-properties: 2.0.0
+
+  /@babel/types@7.22.5:
+    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-string-parser': 7.22.5
+      '@babel/helper-validator-identifier': 7.22.5
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage@0.2.3:
@@ -33677,9 +33675,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
+      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /@csstools/postcss-color-function@1.1.1(postcss@8.4.18):
@@ -33730,9 +33728,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
+      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /@csstools/postcss-nested-calc@1.0.0(postcss@8.4.18):
@@ -33815,15 +33813,13 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /@csstools/selector-specificity@2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18):
-    resolution: {integrity: sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==}
+  /@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.0.13):
+    resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
-      postcss: ^8.4
       postcss-selector-parser: ^6.0.10
     dependencies:
-      postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /@dabh/diagnostics@2.0.3:
@@ -33868,8 +33864,8 @@ packages:
   /@floating-ui/react-dom@0.7.2(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@floating-ui/dom': 0.5.4
       react: 17.0.2
@@ -33886,7 +33882,7 @@ packages:
   /@graphql-modules/core@0.7.17(graphql@15.8.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-hGJa1VIsIHTKJ0Hc5gJfFrdhHAF1Vm+LWYeMNC5mPbVd/IZA1wVSpdLDjjliylLI6GnVRu1YreS2gXvFNXPJFA==}
     peerDependencies:
-      graphql: ^14.1.1 || ^15.0.0
+      graphql: '*'
     dependencies:
       '@graphql-modules/di': 0.7.17(reflect-metadata@0.1.13)
       '@graphql-toolkit/common': 0.10.6(graphql@15.8.0)
@@ -33904,7 +33900,7 @@ packages:
   /@graphql-modules/di@0.7.17(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-Lq5sd/3RO+bNb8wVnAg43LWbwrqD57D0AVEqZlqiTwUj1f0mITtQdGMRN7g2sG79U7ngoaQx8VK/IiKh8E1OFQ==}
     peerDependencies:
-      reflect-metadata: ^0.1.12
+      reflect-metadata: '*'
     dependencies:
       events: 3.1.0
       reflect-metadata: 0.1.13
@@ -33915,7 +33911,7 @@ packages:
     resolution: {integrity: sha512-rrH/KPheh/wCZzqUmNayBHd+aNWl/751C4iTL/327TzONdAVrV7ZQOyEkpGLW6YEFWPIlWxNkaBoEALIjCxTGg==}
     deprecated: GraphQL Toolkit is deprecated and merged into GraphQL Tools, so it will no longer get updates. Use GraphQL Tools instead to stay up-to-date! Check out https://www.graphql-tools.com/docs/migration-from-toolkit for migration and https://the-guild.dev/blog/graphql-tools-v6 for new changes.
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: '*'
     dependencies:
       aggregate-error: 3.0.1
       camel-case: 4.1.1
@@ -33946,9 +33942,9 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@15.8.0)
+      '@graphql-tools/utils': 10.0.3(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /@graphql-tools/schema@10.0.0(graphql@15.8.0):
@@ -33958,29 +33954,23 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/merge': 9.0.0(graphql@15.8.0)
-      '@graphql-tools/utils': 10.0.1(graphql@15.8.0)
+      '@graphql-tools/utils': 10.0.3(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.0
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/utils@10.0.1(graphql@15.8.0):
-    resolution: {integrity: sha512-i1FozbDGHgdsFA47V/JvQZ0FE8NAy0Eiz7HGCJO2MkNdZAKNnwei66gOq0JWYVFztwpwbVQ09GkKhq7Kjcq5Cw==}
+  /@graphql-tools/utils@10.0.3(graphql@15.8.0):
+    resolution: {integrity: sha512-6uO41urAEIs4sXQT2+CYGsUTkHkVo/2MpM/QjoHj6D6xoEF2woXHBpdAVi0HKIInDwZqWgEYOwIFez0pERxa1Q==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      dset: 3.1.2
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
-
-  /@graphql-typed-document-node/core@3.1.1(graphql@15.8.0):
-    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
-    peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      graphql: 15.8.0
 
   /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -33988,7 +33978,6 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
-    dev: false
 
   /@gwhitney/detect-indent@7.0.1:
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
@@ -34142,7 +34131,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 12.20.4
       chalk: 4.1.2
-      collect-v8-coverage: 1.0.1
+      collect-v8-coverage: 1.0.2
       exit: 0.1.2
       glob: 7.1.6
       graceful-fs: 4.2.10
@@ -34180,7 +34169,7 @@ packages:
       '@jest/console': 26.6.2
       '@jest/types': 26.6.2
       '@types/istanbul-lib-coverage': 2.0.4
-      collect-v8-coverage: 1.0.1
+      collect-v8-coverage: 1.0.2
     dev: false
 
   /@jest/test-result@27.5.1:
@@ -34190,7 +34179,7 @@ packages:
       '@jest/console': 27.5.1
       '@jest/types': 27.5.1
       '@types/istanbul-lib-coverage': 2.0.4
-      collect-v8-coverage: 1.0.1
+      collect-v8-coverage: 1.0.2
     dev: false
 
   /@jest/test-sequencer@27.5.1:
@@ -34220,7 +34209,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
       micromatch: 4.0.5
-      pirates: 4.0.5
+      pirates: 4.0.6
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
@@ -34262,20 +34251,13 @@ packages:
     resolution: {integrity: sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==}
     dev: false
 
-  /@jridgewell/gen-mapping@0.1.1:
-    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
+  /@jridgewell/gen-mapping@0.3.3:
+    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
-
-  /@jridgewell/gen-mapping@0.3.2:
-    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
-    engines: {node: '>=6.0.0'}
-    dependencies:
-      '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/sourcemap-codec': 1.4.15
+      '@jridgewell/trace-mapping': 0.3.18
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -34285,17 +34267,20 @@ packages:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
 
-  /@jridgewell/source-map@0.3.2:
-    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
+  /@jridgewell/source-map@0.3.5:
+    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/trace-mapping': 0.3.18
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
-  /@jridgewell/trace-mapping@0.3.17:
-    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
+  /@jridgewell/sourcemap-codec@1.4.15:
+    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
+
+  /@jridgewell/trace-mapping@0.3.18:
+    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -34332,7 +34317,7 @@ packages:
   /@mdx-js/react@1.6.22(react@17.0.2):
     resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
     peerDependencies:
-      react: ^16.13.1 || ^17.0.0
+      react: '*'
     dependencies:
       react: 17.0.2
 
@@ -34344,8 +34329,8 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: false
 
-  /@monaco-editor/loader@1.3.2(monaco-editor@0.33.0):
-    resolution: {integrity: sha512-BTDbpHl3e47r3AAtpfVFTlAi7WXv4UQ/xZmz8atKl4q7epQV5e7+JbigFDViWF71VBi4IIBdcWP57Hj+OWuc9g==}
+  /@monaco-editor/loader@1.3.3(monaco-editor@0.33.0):
+    resolution: {integrity: sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==}
     peerDependencies:
       monaco-editor: '>= 0.21.0 < 1'
     dependencies:
@@ -34356,11 +34341,11 @@ packages:
   /@monaco-editor/react@4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==}
     peerDependencies:
-      monaco-editor: '>= 0.25.0 < 1'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      monaco-editor: '*'
+      react: '*'
+      react-dom: '*'
     dependencies:
-      '@monaco-editor/loader': 1.3.2(monaco-editor@0.33.0)
+      '@monaco-editor/loader': 1.3.3(monaco-editor@0.33.0)
       monaco-editor: 0.33.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -34439,13 +34424,13 @@ packages:
       '@types/webpack': 5.28.1(esbuild@0.14.29)
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
-      core-js-pure: 3.27.2
+      core-js-pure: 3.31.1
       error-stack-parser: 2.1.4
       find-up: 5.0.0
-      html-entities: 2.3.3
+      html-entities: 2.4.0
       loader-utils: 2.0.4
       react-refresh: 0.10.0
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       source-map: 0.7.4
       webpack: 5.84.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
@@ -34551,7 +34536,7 @@ packages:
     dev: false
 
   /@pnpm/config.env-replace@1.1.0:
-    resolution: {integrity: sha1-GTiz4TEVgTwrNypNzHfyEQ0tIk0=, tarball: https://node-registry.v2.bit.cloud/@pnpm/config.env-replace/-/@pnpm-config.env-replace-1.1.0.tgz}
+    resolution: {integrity: sha1-GTiz4TEVgTwrNypNzHfyEQ0tIk0=, tarball: https://node-registry.bit.cloud/@pnpm/config.env-replace/-/@pnpm-config.env-replace-1.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -35202,7 +35187,7 @@ packages:
     resolution: {integrity: sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==}
     engines: {node: '>=12.17'}
     dependencies:
-      bole: 5.0.3
+      bole: 5.0.6
       ndjson: 2.0.0
     dev: false
 
@@ -35266,7 +35251,7 @@ packages:
     dev: false
 
   /@pnpm/network.agent@0.0.3:
-    resolution: {integrity: sha1-g28zSZMRCjzekv8O3yavci0Lt4c=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.0.3.tgz}
+    resolution: {integrity: sha1-g28zSZMRCjzekv8O3yavci0Lt4c=, tarball: https://node-registry.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.proxy-agent': 0.0.3
@@ -35277,7 +35262,7 @@ packages:
     dev: false
 
   /@pnpm/network.agent@0.1.0:
-    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/agent@0.1.0.tgz}
+    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.proxy-agent': 0.1.0
@@ -35296,21 +35281,21 @@ packages:
     dev: false
 
   /@pnpm/network.ca-file@1.0.1:
-    resolution: {integrity: sha1-6O8TBzfQYCe8rNSKZc9Vk/Y50g0=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.1.tgz}
+    resolution: {integrity: sha1-6O8TBzfQYCe8rNSKZc9Vk/Y50g0=, tarball: https://node-registry.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.1.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: false
 
   /@pnpm/network.ca-file@1.0.2:
-    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/ca-file@1.0.2.tgz}
+    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.2.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: false
 
   /@pnpm/network.proxy-agent@0.0.3:
-    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/proxy-agent@0.0.3.tgz}
+    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       http-proxy-agent: 5.0.0
@@ -35322,7 +35307,7 @@ packages:
     dev: false
 
   /@pnpm/network.proxy-agent@0.1.0:
-    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/proxy-agent@0.1.0.tgz}
+    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/error': 4.0.1
@@ -35440,7 +35425,7 @@ packages:
       '@pnpm/error': 5.0.2
       '@pnpm/logger': 5.0.0
       '@pnpm/types': 9.2.0
-      detect-libc: 2.0.1
+      detect-libc: 2.0.2
       execa: /safe-execa@0.1.2
       mem: 8.1.1
       semver: 7.5.4
@@ -35527,10 +35512,10 @@ packages:
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
       klaw-sync: 6.0.0
-      minimist: 1.2.7
+      minimist: 1.2.8
       open: 7.4.2
       rimraf: 2.7.1
-      semver: 5.7.1
+      semver: 5.7.2
       slash: 2.0.0
       tmp: 0.0.33
       yaml: 2.3.1
@@ -35737,7 +35722,7 @@ packages:
       read-yaml-file: 2.1.0
       rimraf: 3.0.2
       tempy: 1.0.1
-      verdaccio: 5.25.0
+      verdaccio: 5.26.0
       write-yaml-file: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -35976,7 +35961,7 @@ packages:
     dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
-    resolution: {integrity: sha1-C31RMSZdb1uqS+gSx4IeULjTngk=, tarball: https://node-registry.v2.bit.cloud/@pnpm/util.lex-comparator/-/@pnpm-util.lex-comparator-1.0.0.tgz}
+    resolution: {integrity: sha1-C31RMSZdb1uqS+gSx4IeULjTngk=, tarball: https://node-registry.bit.cloud/@pnpm/util.lex-comparator/-/@pnpm-util.lex-comparator-1.0.0.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -36022,19 +36007,19 @@ packages:
       write-yaml-file: 5.0.0
     dev: false
 
-  /@popperjs/core@2.11.6:
-    resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
+  /@popperjs/core@2.11.8:
+    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
     dev: false
 
-  /@prerenderer/prerenderer@1.2.0(@types/express@4.17.13)(debug@4.3.2):
-    resolution: {integrity: sha512-Wfr7gbKepJ0F1xoUTKL2vXBfd9IWOqn0+brlG1Lp/IWcWTQ64FjdeU9xXvk7IZ97UluP8tlqsfI7219KF9+pqQ==}
+  /@prerenderer/prerenderer@1.2.3(@types/express@4.17.13)(debug@4.3.2):
+    resolution: {integrity: sha512-ildOGNPo6vg2SNSBd/wjTljem98BJ0bzgCFcHL0SZEgTf9c26ucTvreZnGgqrqZ+lpiYb6c4RbPABvZW69x6lw==}
     engines: {node: '>=8.0.0'}
     dependencies:
       express: 4.18.2
       portfinder: 1.0.32
       schema-utils: 4.0.0
       stoppable: 1.1.0
-      ts-deepmerge: 6.0.3
+      ts-deepmerge: 6.2.0
     optionalDependencies:
       http-proxy-middleware: 2.0.6(@types/express@4.17.13)(debug@4.3.2)
     transitivePeerDependencies:
@@ -36043,15 +36028,15 @@ packages:
       - supports-color
     dev: false
 
-  /@prerenderer/renderer-jsdom@1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5):
-    resolution: {integrity: sha512-qVSmbZsYK+/Ad9Q5gX7dZ4UtvTODjtLbLosiXCx4se9cWq143WbvRXpMRJujI+213EFSv1BOWxZNaPWAjkyKzA==}
+  /@prerenderer/renderer-jsdom@1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5):
+    resolution: {integrity: sha512-pLU/aS7uWHodu58Jf+aO54woLOGZB4xp46x15SriicwUQLpaKQCCwxw7frNzdbG7w5OLKvjV33s5j5VhIw0snA==}
     engines: {node: '>=8.0.0'}
     dependencies:
       '@types/jsdom': 20.0.1
-      jsdom: 16.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      jsdom: 22.1.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       promise-limit: 2.7.0
       schema-utils: 4.0.0
-      whatwg-fetch: 3.6.2
+      whatwg-fetch: 3.6.16
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -36059,8 +36044,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@prerenderer/renderer-puppeteer@1.1.3(puppeteer@13.7.0):
-    resolution: {integrity: sha512-A76iTPUcBV4yeOdXrVR2EiJlaNtHy+jITniL3JdKLmxkSjYLwUBwUpglFkesAtqyL24Ca+piVPIJW/NSBK3dRg==}
+  /@prerenderer/renderer-puppeteer@1.2.2(puppeteer@13.7.0):
+    resolution: {integrity: sha512-tTdhhxrm7sgZC4i6hrDuOwFN3JVLiotgk2NmaLlJbEO+HVgpPbDLPGITNAlNRXlTYHaaHTd11Sdwh1eZoStOMQ==}
     engines: {node: '>=8.0.0'}
     requiresBuild: true
     peerDependencies:
@@ -36069,23 +36054,23 @@ packages:
       deepmerge: 4.3.1
       promise-limit: 2.7.0
       puppeteer: 13.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
     dev: false
     optional: true
 
-  /@prerenderer/webpack-plugin@5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1):
-    resolution: {integrity: sha512-wddJnlweYohyZ3/KSXU1bM+ZE+k82xHIU71Izzah5pvCYwhYpHQGNfYLLwymvF01TGel6Mqwdw2ChitXZ8sJ+w==}
+  /@prerenderer/webpack-plugin@5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1):
+    resolution: {integrity: sha512-U5Q2bmXe7IdRX3HGmttOp5AJ6Ci1TJjC8y5IYYK3wxTTsPQTb5Up+pG26JP94Tz0yZx3+iRkuWwpdZBrnkSf0w==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       html-webpack-plugin: ^5
       webpack: ^5
     dependencies:
-      '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
+      '@prerenderer/prerenderer': 1.2.3(@types/express@4.17.13)(debug@4.3.2)
       html-webpack-plugin: 5.3.2(webpack@5.84.1)
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
       webpack: 5.84.1(esbuild@0.14.29)
     optionalDependencies:
-      '@prerenderer/renderer-puppeteer': 1.1.3(puppeteer@13.7.0)
+      '@prerenderer/renderer-puppeteer': 1.2.2(puppeteer@13.7.0)
     transitivePeerDependencies:
       - '@types/express'
       - debug
@@ -36139,7 +36124,7 @@ packages:
   /@react-hook/latest@1.0.3(react@17.0.2):
     resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
     peerDependencies:
-      react: '>=16.8'
+      react: '*'
     dependencies:
       react: 17.0.2
     dev: false
@@ -36164,7 +36149,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.22.5
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       '@types/babel__core': 7.20.0
       rollup: 2.79.1
@@ -36364,7 +36349,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cosmiconfig: 7.1.0
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       svgo: 1.3.2
     dev: false
 
@@ -36373,7 +36358,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/plugin-transform-react-constant-elements': 7.20.2(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-constant-elements': 7.22.5(@babel/core@7.19.6)
       '@babel/preset-env': 7.19.4(@babel/core@7.19.6)
       '@babel/preset-react': 7.18.6(@babel/core@7.19.6)
       '@svgr/core': 5.5.0
@@ -36410,7 +36395,7 @@ packages:
     dev: false
 
   /@teambit/base-react.forms.form@0.0.13(react@17.0.2):
-    resolution: {integrity: sha1-b206QQgFqXvG7gLm7FNajEn8IF0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.forms.form/-/@teambit-base-react.forms.form-0.0.13.tgz}
+    resolution: {integrity: sha1-b206QQgFqXvG7gLm7FNajEn8IF0=, tarball: https://node-registry.bit.cloud/@teambit/base-react.forms.form/-/@teambit-base-react.forms.form-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36441,7 +36426,7 @@ packages:
     dev: false
 
   /@teambit/base-react.layout.row@0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/layout/row@0.0.3.tgz}
+    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.bit.cloud/@teambit/base-react.layout.row/-/@teambit-base-react.layout.row-0.0.3.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36455,7 +36440,7 @@ packages:
     dev: false
 
   /@teambit/base-react.navigation.link@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dkmFy935I+/7kialZCzjASBEjs0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-1.23.0.tgz}
+    resolution: {integrity: sha1-dkmFy935I+/7kialZCzjASBEjs0=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36472,7 +36457,7 @@ packages:
     dev: true
 
   /@teambit/base-react.navigation.link@2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/teambit-base-react.navigation.link-2.0.27.tgz}
+    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-2.0.27.tgz}
     peerDependencies:
       '@testing-library/react': ^12.0.0
       '@types/react': ^17.0.0
@@ -36516,7 +36501,7 @@ packages:
     dev: true
 
   /@teambit/base-react.theme.theme-provider@1.95.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/theme/theme-provider@1.95.3.tgz}
+    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.bit.cloud/@teambit/base-react.theme.theme-provider/-/@teambit-base-react.theme.theme-provider-1.95.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36527,29 +36512,7 @@ packages:
     dev: false
 
   /@teambit/base-react.themes.theme-switcher@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/themes/theme-switcher@1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.constants.storage/-/@teambit-base-ui.constants.storage-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.0.tgz}
+    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.bit.cloud/@teambit/base-react.themes.theme-switcher/-/@teambit-base-react.themes.theme-switcher-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36560,21 +36523,10 @@ packages:
     dev: false
 
   /@teambit/base-ui.css-components.elevation@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/css-components/elevation@1.0.1.tgz}
+    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.1.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.roundness/-/@teambit-base-ui.css-components.roundness-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -36582,19 +36534,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.elements.dots-loader@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/elements/dots-loader@1.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.icon/-/@teambit-base-ui.elements.icon-1.0.0.tgz}
+    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.elements.dots-loader/-/@teambit-base-ui.elements.dots-loader-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36606,7 +36546,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.graph.tree.collapsable-tree-node@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/graph/tree/collapsable-tree-node@0.0.4.tgz}
+    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.graph.tree.collapsable-tree-node/-/@teambit-base-ui.graph.tree.collapsable-tree-node-0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36619,81 +36559,11 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.indent/-/@teambit-base-ui.graph.tree.indent-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.inflate-paths/-/@teambit-base-ui.graph.tree.inflate-paths-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.sub-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.recursive-tree/-/@teambit-base-ui.graph.tree.recursive-tree-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.root-node/-/@teambit-base-ui.graph.tree.root-node-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.tree-context/-/@teambit-base-ui.graph.tree.tree-context-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.hook.use-click-outside@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-MWkSceL3FJ7qLtW2mGtE9h7+a6Y=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.1.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -36701,7 +36571,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.button@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/button@1.0.5.tgz}
+    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.button/-/@teambit-base-ui.input.button-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36713,57 +36583,20 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.input.checkbox.hidden@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.input.checkbox.hidden@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/hidden@1.0.2.tgz}
+    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.input.checkbox.indicator@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.indicator/-/@teambit-base-ui.input.checkbox.indicator-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.input.checkbox.label@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.hidden': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/base-ui.input.checkbox.label@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/label@1.0.2.tgz}
+    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36776,7 +36609,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.checkbox.label@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/label@1.0.4.tgz}
+    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36789,47 +36622,25 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.error@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/error@1.0.3.tgz}
+    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.error/-/@teambit-base-ui.input.error-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.breakpoints/-/@teambit-base-ui.layout.breakpoints-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/base-ui.layout.grid-component@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s8B7uWwtKRVnglUSUuvOCkW7+HI=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.grid-component/-/@teambit-base-ui.layout.grid-component-1.0.1.tgz}
+    resolution: {integrity: sha1-s8B7uWwtKRVnglUSUuvOCkW7+HI=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.layout.grid-component/-/@teambit-base-ui.layout.grid-component-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -36847,18 +36658,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.loaders.loader-ribbon/-/@teambit-base-ui.loaders.loader-ribbon-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.loaders.skeleton@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
     peerDependencies:
@@ -36871,93 +36670,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.compare-url/-/@teambit-base-ui.routing.compare-url-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      url-parse: 1.5.1
-
-  /@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.native-link/-/@teambit-base-ui.routing.native-link-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.native-nav-link/-/@teambit-base-ui.routing.native-nav-link-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.routing.compare-url': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.nav-link/-/@teambit-base-ui.routing.nav-link-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.routing-provider': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.routing-provider/-/@teambit-base-ui.routing.routing-provider-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.styles.flex-center/-/@teambit-base-ui.styles.flex-center-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-create-ref: 1.0.1(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.surfaces.abs-container@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/surfaces/abs-container@1.0.1.tgz}
+    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36966,58 +36680,17 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-create-ref: 1.0.1(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/base-ui.surfaces.background@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Fd/DNRswrfBD+PdvbiMsN869QYU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.2.tgz}
+    resolution: {integrity: sha1-Fd/DNRswrfBD+PdvbiMsN869QYU=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.2.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.card/-/@teambit-base-ui.surfaces.card-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.background': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.drawer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.hook.use-click-outside': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-create-ref: 1.0.1(react@17.0.2)
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
@@ -37037,7 +36710,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.surfaces.drawer@1.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/surfaces/drawer@1.1.3.tgz}
+    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37051,83 +36724,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/@teambit-base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.layout@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.layout/-/@teambit-base-ui.surfaces.split-pane.layout-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.pane/-/@teambit-base-ui.surfaces.split-pane.pane-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.split-pane/-/@teambit-base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.surfaces.split-pane.splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.splitter/-/@teambit-base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.heading@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/base-ui.text.heading@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/text/heading@1.0.4.tgz}
+    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37135,263 +36733,28 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.muted-text/-/@teambit-base-ui.text.muted-text-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.paragraph@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   /@teambit/base-ui.text.paragraph@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
+    resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.text-sizes/-/@teambit-base-ui.text.text-sizes-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.themed-text/-/@teambit-base-ui.text.themed-text-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.accent-color/-/@teambit-base-ui.theme.accent-color-1.1.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.brand-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.brand-definition/-/@teambit-base-ui.theme.brand-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.color-definition@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.color-definition/-/@teambit-base-ui.theme.color-definition-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.colors/-/@teambit-base-ui.theme.colors-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.dark-theme/-/@teambit-base-ui.theme.dark-theme-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.fonts.book@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/base-ui.theme.fonts.book@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/theme/fonts/book@1.0.2.tgz}
+    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.roboto/-/@teambit-base-ui.theme.fonts.roboto-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.heading-margin-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.heading-margin-definition/-/@teambit-base-ui.theme.heading-margin-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.shadow-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.shadow-definition/-/@teambit-base-ui.theme.shadow-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.size-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.size-definition/-/@teambit-base-ui.theme.size-definition-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.sizes/-/@teambit-base-ui.theme.sizes-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.theme-provider/-/@teambit-base-ui.theme.theme-provider-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.brand-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.color-definition': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.fonts.book': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.heading-margin-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.shadow-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.size-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.composer/-/@teambit-base-ui.utils.composer-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.is-browser/-/@teambit-base-ui.utils.is-browser-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
-  /@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.string.affix/-/@teambit-base-ui.utils.string.affix-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/base-ui.utils.sub-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.sub-paths/-/@teambit-base-ui.utils.sub-paths-1.0.0.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      path-browserify: 1.0.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
@@ -37455,7 +36818,7 @@ packages:
     dev: true
 
   /@teambit/bvm.config@0.2.2:
-    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.bvm/config@0.2.2.tgz}
+    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.bit.cloud/@teambit/bvm.config/-/@teambit-bvm.config-0.2.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       chalk: 4.1.0
@@ -37467,7 +36830,7 @@ packages:
     dev: false
 
   /@teambit/bvm.list@0.1.6:
-    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.bvm/list@0.1.6.tgz}
+    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.bit.cloud/@teambit/bvm.list/-/@teambit-bvm.list-0.1.6.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/bvm.config': 0.2.2
@@ -37491,7 +36854,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.code-compare-section@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-uCNGPFa1JA80ygcbuav0SJO+7CY=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.code-compare-section/-/@teambit-code.ui.code-compare-section-0.0.5.tgz}
+    resolution: {integrity: sha1-uCNGPFa1JA80ygcbuav0SJO+7CY=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.code-compare-section/-/@teambit-code.ui.code-compare-section-0.0.5.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37508,28 +36871,8 @@ packages:
       - react-router-dom
     dev: false
 
-  /@teambit/code.ui.code-view@0.0.508(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LK6VE0Lwgyc82TP2Ym204QzbIQ8=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.code-view/-/@teambit-code.ui.code-view-0.0.508.tgz}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      react-syntax-highlighter: 15.4.3(react@17.0.2)
-    transitivePeerDependencies:
-      - '@apollo/client'
-    dev: false
-
   /@teambit/code.ui.dependency-tree@0.0.546(@apollo/client@3.6.9)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MuKMwTaPPYPp2kXrz7shpGhxR5c=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.dependency-tree/-/@teambit-code.ui.dependency-tree-0.0.546.tgz}
+    resolution: {integrity: sha1-MuKMwTaPPYPp2kXrz7shpGhxR5c=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.dependency-tree/-/@teambit-code.ui.dependency-tree-0.0.546.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37550,7 +36893,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.hooks.use-code-params@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-j29tMGoZ9guzGFifVoqC4b0TZbY=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.hooks.use-code-params/-/@teambit-code.ui.hooks.use-code-params-0.0.496.tgz}
+    resolution: {integrity: sha1-j29tMGoZ9guzGFifVoqC4b0TZbY=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.hooks.use-code-params/-/@teambit-code.ui.hooks.use-code-params-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37568,7 +36911,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.object-formatter@0.0.1(react@17.0.2):
-    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.code/ui/object-formatter@0.0.1.tgz}
+    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.object-formatter/-/@teambit-code.ui.object-formatter-0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37576,9 +36919,10 @@ packages:
       core-js: 3.13.0
       json-formatter-js: 2.3.4
       react: 17.0.2
+    dev: true
 
   /@teambit/code.ui.queries.get-component-code@0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9dIl+N7tMk19y1KHuKigBn3Kd1o=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.queries.get-component-code/-/@teambit-code.ui.queries.get-component-code-0.0.502.tgz}
+    resolution: {integrity: sha1-9dIl+N7tMk19y1KHuKigBn3Kd1o=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.queries.get-component-code/-/@teambit-code.ui.queries.get-component-code-0.0.502.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -37593,7 +36937,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.queries.get-file-content@0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YQOLQBWamClUyQBmOCo79xHhlqU=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.queries.get-file-content/-/@teambit-code.ui.queries.get-file-content-0.0.504.tgz}
+    resolution: {integrity: sha1-YQOLQBWamClUyQBmOCo79xHhlqU=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.queries.get-file-content/-/@teambit-code.ui.queries.get-file-content-0.0.504.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -37608,7 +36952,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.utils.get-file-icon@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-BhgHI8gqiuINycujdxk0HWv8SQA=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.utils.get-file-icon/-/@teambit-code.ui.utils.get-file-icon-0.0.495.tgz}
+    resolution: {integrity: sha1-BhgHI8gqiuINycujdxk0HWv8SQA=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.utils.get-file-icon/-/@teambit-code.ui.utils.get-file-icon-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37620,11 +36964,11 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/community.constants.links@0.0.2:
-    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/constants/links@0.0.2.tgz}
+    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.bit.cloud/@teambit/community.constants.links/-/@teambit-community.constants.links-0.0.2.tgz}
     dev: false
 
   /@teambit/community.entity.graph.bubble-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/entity/graph/bubble-graph@1.95.0.tgz}
+    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.bit.cloud/@teambit/community.entity.graph.bubble-graph/-/@teambit-community.entity.graph.bubble-graph-1.95.0.tgz}
     dependencies:
       '@teambit/community.entity.graph.grid-graph': 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
     transitivePeerDependencies:
@@ -37634,7 +36978,7 @@ packages:
     dev: true
 
   /@teambit/community.entity.graph.grid-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/entity/graph/grid-graph@1.95.0.tgz}
+    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.bit.cloud/@teambit/community.entity.graph.grid-graph/-/@teambit-community.entity.graph.grid-graph-1.95.0.tgz}
     dependencies:
       '@teambit/component-id': 0.0.369(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       react-xarrows: 2.0.2(react@17.0.2)
@@ -37645,14 +36989,14 @@ packages:
     dev: true
 
   /@teambit/compilation.compiler-task@0.0.4:
-    resolution: {integrity: sha1-E7zkrOiXjuabhEx8JTjD1ojIYX4=, tarball: https://node-registry.v2.bit.cloud/@teambit/compilation.compiler-task/-/@teambit-compilation.compiler-task-0.0.4.tgz}
+    resolution: {integrity: sha1-E7zkrOiXjuabhEx8JTjD1ojIYX4=, tarball: https://node-registry.bit.cloud/@teambit/compilation.compiler-task/-/@teambit-compilation.compiler-task-0.0.4.tgz}
     dependencies:
       '@teambit/toolbox.fs.hard-link-directory': 0.0.9
       fs-extra: 10.1.0
     dev: false
 
   /@teambit/compilation.content.compiler-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.compilation/content/compiler-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.bit.cloud/@teambit/compilation.content.compiler-overview/-/@teambit-compilation.content.compiler-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37725,20 +37069,6 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
-
-  /@teambit/component-descriptor@0.0.263(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ZhLH1/tdRyYovNezpEwnYNybji+bsNMft6wutIDwt8sjWk1tDHEuxzyY1tSIrOVpqzAnthBvpKJ6D40XMgyivw==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.474
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.20.0
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   /@teambit/component-descriptor@0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-/OEPdA80xS76HvGaSlZqNTyvQ/WlO3lERzUNnPnldLye2OWST69vhga8tefBRKMeNpPsITck6adfiLm1DH8m6g==}
@@ -37868,7 +37198,7 @@ packages:
       semver: 7.3.4
 
   /@teambit/component.content.component-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/content/component-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.bit.cloud/@teambit/component.content.component-overview/-/@teambit-component.content.component-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37885,7 +37215,7 @@ packages:
     dev: true
 
   /@teambit/component.content.dev-files@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/content/dev-files@1.95.9.tgz}
+    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.bit.cloud/@teambit/component.content.dev-files/-/@teambit-component.content.dev-files-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -37895,23 +37225,8 @@ packages:
       - react-dom
     dev: true
 
-  /@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/component.instructions.exporting-components/-/@teambit-component.instructions.exporting-components-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
   /@teambit/component.modules.component-url@0.0.124(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/modules/component-url@0.0.124.tgz}
+    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.124.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -37923,12 +37238,12 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.128(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.128.tgz}
+    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.128.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.405
       query-string: 7.0.0
       react: 17.0.2
@@ -37937,12 +37252,12 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.140(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.140.tgz}
+    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.140.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.417
       query-string: 7.0.0
       react: 17.0.2
@@ -37951,7 +37266,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.151(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.151.tgz}
+    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.151.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -37965,7 +37280,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.badges.component-count@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-zxXwT+ngFF13gDKZOHkzkIRk1/0=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.1.tgz}
+    resolution: {integrity: sha1-zxXwT+ngFF13gDKZOHkzkIRk1/0=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37978,7 +37293,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.badges.component-count@0.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.10.tgz}
+    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.10.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37990,27 +37305,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/component.ui.component-compare.context@0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wDW0unfbbFiQf8O8zMeZHlug2Xc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.context/-/teambit-component.ui.component-compare.context-0.0.22.tgz}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/component.ui.component-compare.models.component-compare-hooks': 0.0.4(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.models.component-compare-model': 0.0.18(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-      - '@testing-library/react'
-      - '@types/react'
-    dev: false
-
   /@teambit/component.ui.component-compare.hooks.use-component-compare-url@0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
+    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38026,21 +37322,8 @@ packages:
       - '@types/react'
     dev: false
 
-  /@teambit/component.ui.component-compare.layouts.compare-split-layout-preset@0.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-PREhw4bzeUeolT/NsV/If+7MEmU=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.layouts.compare-split-layout-preset/-/teambit-component.ui.component-compare.layouts.compare-split-layout-preset-0.0.3.tgz}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/component.ui.component-compare.models.component-compare-change-type@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/@teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
+    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/@teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38052,11 +37335,11 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-hooks@0.0.4(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/@teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
+    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/@teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
@@ -38068,24 +37351,8 @@ packages:
       - '@types/react'
     dev: false
 
-  /@teambit/component.ui.component-compare.models.component-compare-model@0.0.18(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OU3X7NtfpUteBkaucDHtrI0kTCw=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-model/-/teambit-component.ui.component-compare.models.component-compare-model-0.0.18.tgz}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/component-descriptor': 0.0.263(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/legacy-component-log': 0.0.399
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
   /@teambit/component.ui.component-compare.models.component-compare-props@0.0.6(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-pEoCCl4OPgBaX15b4pJZedanetU=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-props/-/@teambit-component.ui.component-compare.models.component-compare-props-0.0.6.tgz}
+    resolution: {integrity: sha1-pEoCCl4OPgBaX15b4pJZedanetU=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-props/-/@teambit-component.ui.component-compare.models.component-compare-props-0.0.6.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38108,33 +37375,19 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-state@0.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/@teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
+    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/@teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/component.ui.component-compare.status-resolver@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yI4EdeDCrzJGlRurBIXds86peVA=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.status-resolver/-/teambit-component.ui.component-compare.status-resolver-0.0.4.tgz}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/component.ui.component-compare.utils.lazy-loading@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
+    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38147,16 +37400,16 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.494(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.494.tgz}
+    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.494.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -38164,16 +37417,16 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.500(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.500.tgz}
+    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -38181,7 +37434,7 @@ packages:
     dev: false
 
   /@teambit/components.blocks.component-card-display@0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.bit.cloud/tarballs/teambit.components/blocks/component-card-display@0.0.13.tgz}
+    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38311,7 +37564,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-components@0.0.11(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.components/hooks/use-components@0.0.11.tgz}
+    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.11.tgz}
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -38362,7 +37615,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.linter-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/content/linter-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.linter-overview/-/@teambit-defender.content.linter-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38377,7 +37630,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.tester-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/content/tester-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.tester-overview/-/@teambit-defender.content.tester-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38392,7 +37645,7 @@ packages:
     dev: true
 
   /@teambit/defender.eslint-linter@1.0.1(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-gssBFBe4jru0ekrjQgN0yhUsmY0dePmyGSSb3NqOaNObbafwEalQKhJDzkJYvV/eBFYz7gGiC+gHvdiAZF5EPw==, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.eslint-linter/-/@teambit-defender.eslint-linter-1.0.1.tgz}
+    resolution: {integrity: sha1-bFEw5JZ6hemOj0Rftc+DHzM7KDs=, tarball: https://node-registry.bit.cloud/@teambit/defender.eslint-linter/-/@teambit-defender.eslint-linter-1.0.1.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.520
     dependencies:
@@ -38412,16 +37665,17 @@ packages:
     dev: false
 
   /@teambit/defender.fs.global-bit-temp-dir@0.0.1:
-    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/fs/global-bit-temp-dir@0.0.1.tgz}
+    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.bit.cloud/@teambit/defender.fs.global-bit-temp-dir/-/@teambit-defender.fs.global-bit-temp-dir-0.0.1.tgz}
     dependencies:
       fs-extra: 10.1.0
+    dev: true
 
   /@teambit/defender.linter-task@0.0.5:
-    resolution: {integrity: sha1-SVz+88G7j/lePhSSy3g+xt4F7wQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.linter-task/-/@teambit-defender.linter-task-0.0.5.tgz}
+    resolution: {integrity: sha1-SVz+88G7j/lePhSSy3g+xt4F7wQ=, tarball: https://node-registry.bit.cloud/@teambit/defender.linter-task/-/@teambit-defender.linter-task-0.0.5.tgz}
     dev: false
 
   /@teambit/defender.prettier-formatter@1.0.0(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-dt97BR5ah+8GB1o5VSFwgMJIW+39b6MXdjU8rUijRIiCvmDVC94vAjXaJRqsxqjdbVcoUsv8gLjS7dkKmKHySg==, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.prettier-formatter/-/@teambit-defender.prettier-formatter-1.0.0.tgz}
+    resolution: {integrity: sha1-OIdWIfIb6CpTWFO2+40HqmRgpfY=, tarball: https://node-registry.bit.cloud/@teambit/defender.prettier-formatter/-/@teambit-defender.prettier-formatter-1.0.0.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.383
     dependencies:
@@ -38439,14 +37693,14 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/design.elements.icon@1.0.24(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E5RHg/MkpEnxu4q/iNzweEfD7Qw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.24.tgz}
+    resolution: {integrity: sha1-E5RHg/MkpEnxu4q/iNzweEfD7Qw=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.24.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38488,7 +37742,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@1.2.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1TIt8cwqQpiR9YywJC7oXyxBoik=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.10.tgz}
+    resolution: {integrity: sha1-1TIt8cwqQpiR9YywJC7oXyxBoik=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38507,7 +37761,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@1.2.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/dropdown@1.2.16.tgz}
+    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.16.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38527,7 +37781,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.input-text@1.0.21(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WM/hzM8HqxE31Ta0holHiA3m2uw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.input-text/-/@teambit-design.inputs.input-text-1.0.21.tgz}
+    resolution: {integrity: sha1-WM/hzM8HqxE31Ta0holHiA3m2uw=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.input-text/-/@teambit-design.inputs.input-text-1.0.21.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38559,7 +37813,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.checkbox-item@1.1.11(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/checkbox-item@1.1.11.tgz}
+    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-1.1.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38585,7 +37839,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.13(react@17.0.2):
-    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/menu-item@1.0.13.tgz}
+    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38595,7 +37849,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.15(react@17.0.2):
-    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/menu-item@1.0.15.tgz}
+    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38621,7 +37875,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.toggle-button@0.0.9(@testing-library/react@12.1.5)(react@17.0.2):
-    resolution: {integrity: sha1-PynRScryoPBvaSuiiMVVgApDBSs=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.toggle-button/-/@teambit-design.inputs.toggle-button-0.0.9.tgz}
+    resolution: {integrity: sha1-PynRScryoPBvaSuiiMVVgApDBSs=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.toggle-button/-/@teambit-design.inputs.toggle-button-0.0.9.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -38634,7 +37888,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.toggle-switch@0.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/toggle-switch@0.0.6.tgz}
+    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.toggle-switch/-/@teambit-design.inputs.toggle-switch-0.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38647,7 +37901,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.content-tabs@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/navigation/content-tabs@0.0.5.tgz}
+    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.content-tabs/-/@teambit-design.navigation.content-tabs-0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': ^17.0.2
@@ -38679,7 +37933,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.responsive-navbar@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/navigation/responsive-navbar@0.0.5.tgz}
+    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': 17.0.8
@@ -38698,7 +37952,7 @@ packages:
     dev: false
 
   /@teambit/design.overlays.notice-tooltip@0.0.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hiBek7x9g7cSYDsOWzzthWd5h+o=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.overlays.notice-tooltip/-/@teambit-design.overlays.notice-tooltip-0.0.1.tgz}
+    resolution: {integrity: sha1-hiBek7x9g7cSYDsOWzzthWd5h+o=, tarball: https://node-registry.bit.cloud/@teambit/design.overlays.notice-tooltip/-/@teambit-design.overlays.notice-tooltip-0.0.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38715,7 +37969,7 @@ packages:
     dev: false
 
   /@teambit/design.theme.icons-font@1.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-64IRscIeqjVac9Qgt8SeTPg98mw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-1.0.8.tgz}
+    resolution: {integrity: sha1-64IRscIeqjVac9Qgt8SeTPg98mw=, tarball: https://node-registry.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-1.0.8.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38727,7 +37981,7 @@ packages:
     dev: false
 
   /@teambit/design.theme.icons-font@2.0.26(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-FX52TAodHE86b9jUb6gNDUAg/fI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-2.0.26.tgz}
+    resolution: {integrity: sha1-FX52TAodHE86b9jUb6gNDUAg/fI=, tarball: https://node-registry.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-2.0.26.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38739,7 +37993,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/base-theme@0.1.0.tgz}
+    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38755,7 +38009,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/base-theme@0.1.1.tgz}
+    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38785,7 +38039,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.dark-theme@1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/dark-theme@1.91.4.tgz}
+    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.4.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38799,7 +38053,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.light-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/light-theme@0.1.0.tgz}
+    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.light-theme/-/@teambit-design.themes.light-theme-0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38813,7 +38067,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.theme-toggler@0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/theme-toggler@0.1.3.tgz}
+    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.theme-toggler/-/@teambit-design.themes.theme-toggler-0.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38830,7 +38084,7 @@ packages:
     dev: false
 
   /@teambit/design.typography.text@0.0.15(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nh8HyUQD19A5njwNWjU9VoBriBU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.typography.text/-/@teambit-design.typography.text-0.0.15.tgz}
+    resolution: {integrity: sha1-nh8HyUQD19A5njwNWjU9VoBriBU=, tarball: https://node-registry.bit.cloud/@teambit/design.typography.text/-/@teambit-design.typography.text-0.0.15.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38843,7 +38097,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.alert-card@0.0.26(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-C2ZsSkEl2DnU6nx6apGBMtEv+TQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.alert-card/-/@teambit-design.ui.alert-card-0.0.26.tgz}
+    resolution: {integrity: sha1-C2ZsSkEl2DnU6nx6apGBMtEv+TQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.alert-card/-/@teambit-design.ui.alert-card-0.0.26.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38861,7 +38115,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.avatar@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VdvPJ3drC0gVj81ozEeHmsPdWy0=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.avatar/-/@teambit-design.ui.avatar-1.0.16.tgz}
+    resolution: {integrity: sha1-VdvPJ3drC0gVj81ozEeHmsPdWy0=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.avatar/-/@teambit-design.ui.avatar-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38893,7 +38147,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.cli-snippet@0.0.359(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lDAh4FHDGWGY/vsT0cMkjpyvbIM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.cli-snippet/-/@teambit-design.ui.cli-snippet-0.0.359.tgz}
+    resolution: {integrity: sha1-lDAh4FHDGWGY/vsT0cMkjpyvbIM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.cli-snippet/-/@teambit-design.ui.cli-snippet-0.0.359.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38908,7 +38162,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.contributors@0.0.514(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-O9oAE8rJS/xkrGo8g8ZsJyUaakU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.contributors/-/@teambit-design.ui.contributors-0.0.514.tgz}
+    resolution: {integrity: sha1-O9oAE8rJS/xkrGo8g8ZsJyUaakU=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.contributors/-/@teambit-design.ui.contributors-0.0.514.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38925,7 +38179,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.elements.level-icon@0.0.20(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-49zehFhJty3QSPq98CIbd3e/Q+A=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.elements.level-icon/-/@teambit-design.ui.elements.level-icon-0.0.20.tgz}
+    resolution: {integrity: sha1-49zehFhJty3QSPq98CIbd3e/Q+A=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.elements.level-icon/-/@teambit-design.ui.elements.level-icon-0.0.20.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38940,7 +38194,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.empty-box@0.0.363(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3LbHMr0jVbXfIqJIVeOrDZT4EdQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.empty-box/-/@teambit-design.ui.empty-box-0.0.363.tgz}
+    resolution: {integrity: sha1-3LbHMr0jVbXfIqJIVeOrDZT4EdQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.empty-box/-/@teambit-design.ui.empty-box-0.0.363.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38954,11 +38208,11 @@ packages:
     dev: false
 
   /@teambit/design.ui.error-page@0.0.364(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vQV7Te5JyvHLSgtDRcCjbwF7v6E=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.error-page/-/@teambit-design.ui.error-page-0.0.364.tgz}
+    resolution: {integrity: sha1-vQV7Te5JyvHLSgtDRcCjbwF7v6E=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.error-page/-/@teambit-design.ui.error-page-0.0.364.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
@@ -38984,7 +38238,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.icon-button@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/icon-button@1.0.16.tgz}
+    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38998,7 +38252,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.icon-button@1.1.15(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-t2miG1hmgZa2WhYHCra9krURC9U=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.1.15.tgz}
+    resolution: {integrity: sha1-t2miG1hmgZa2WhYHCra9krURC9U=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.1.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39011,7 +38265,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.icon-text@1.0.13(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-odcuytUuxPY1DYGuyxgKqSAPsRg=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.icon-text/-/@teambit-design.ui.input.icon-text-1.0.13.tgz}
+    resolution: {integrity: sha1-odcuytUuxPY1DYGuyxgKqSAPsRg=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.icon-text/-/@teambit-design.ui.input.icon-text-1.0.13.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -39027,7 +38281,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.option-button@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/option-button@1.0.0.tgz}
+    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.option-button/-/@teambit-design.ui.input.option-button-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39041,7 +38295,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.radio@1.1.13(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/radio@1.1.13.tgz}
+    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.radio/-/@teambit-design.ui.input.radio-1.1.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39054,7 +38308,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.text@1.0.13(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yDzLGDQq/e1iPljU/m+BKm3Bp5g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.text/-/@teambit-design.ui.input.text-1.0.13.tgz}
+    resolution: {integrity: sha1-yDzLGDQq/e1iPljU/m+BKm3Bp5g=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.text/-/@teambit-design.ui.input.text-1.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39067,10 +38321,10 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.toggle@1.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/toggle@1.0.12.tgz}
+    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.toggle/-/@teambit-design.ui.input.toggle-1.0.12.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.input.checkbox.label': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -39080,7 +38334,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.label@0.0.357(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yS015t1G11s8gZ9x8auOQTdqx/g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.label/-/@teambit-design.ui.label-0.0.357.tgz}
+    resolution: {integrity: sha1-yS015t1G11s8gZ9x8auOQTdqx/g=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.label/-/@teambit-design.ui.label-0.0.357.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39105,7 +38359,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.pages.not-found@0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-k9HJT7pUUTGpFWQC2Ofnv4D+Mec=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.not-found/-/@teambit-design.ui.pages.not-found-0.0.366.tgz}
+    resolution: {integrity: sha1-k9HJT7pUUTGpFWQC2Ofnv4D+Mec=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.not-found/-/@teambit-design.ui.pages.not-found-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39121,7 +38375,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pages.server-error@0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-23wJXHdEaXKFQtZr+SLOU9bbRng=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.server-error/-/@teambit-design.ui.pages.server-error-0.0.366.tgz}
+    resolution: {integrity: sha1-23wJXHdEaXKFQtZr+SLOU9bbRng=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.server-error/-/@teambit-design.ui.pages.server-error-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39137,7 +38391,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pages.standalone-not-found-page@0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Q17KZ3YgFS9Cy6ecXUeUd0rFNhU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.standalone-not-found-page/-/@teambit-design.ui.pages.standalone-not-found-page-0.0.369.tgz}
+    resolution: {integrity: sha1-Q17KZ3YgFS9Cy6ecXUeUd0rFNhU=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.standalone-not-found-page/-/@teambit-design.ui.pages.standalone-not-found-page-0.0.369.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39153,7 +38407,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.350(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.350.tgz}
+    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.350.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39166,11 +38420,11 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.356(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/pill-label@0.0.356.tgz}
+    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.356.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39179,7 +38433,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.round-loader@0.0.355(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mnyr1oThLKpyZJkwXDiC5Mr/Au4=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.round-loader/-/@teambit-design.ui.round-loader-0.0.355.tgz}
+    resolution: {integrity: sha1-mnyr1oThLKpyZJkwXDiC5Mr/Au4=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.round-loader/-/@teambit-design.ui.round-loader-0.0.355.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39192,7 +38446,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.separator@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/separator@0.0.354.tgz}
+    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.separator/-/@teambit-design.ui.separator-0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39206,7 +38460,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.skeletons.sidebar-loader@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K1dhTThqMPnGpf7CeI1QGZi4J7U=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.skeletons.sidebar-loader/-/@teambit-design.ui.skeletons.sidebar-loader-0.0.4.tgz}
+    resolution: {integrity: sha1-K1dhTThqMPnGpf7CeI1QGZi4J7U=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.skeletons.sidebar-loader/-/@teambit-design.ui.skeletons.sidebar-loader-0.0.4.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39220,7 +38474,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.colors-by-letter@0.0.30(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F5BwgU/2w2aFfe3tAR1RJW+hdCo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.30.tgz}
+    resolution: {integrity: sha1-F5BwgU/2w2aFfe3tAR1RJW+hdCo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.30.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39232,7 +38486,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.colors-by-letter@0.0.41(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6Xb4MfnYkNwns5OpivxANSsNSNI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.41.tgz}
+    resolution: {integrity: sha1-6Xb4MfnYkNwns5OpivxANSsNSNI=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.41.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39244,7 +38498,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.ellipsis@0.0.346(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tvLAoURNuXdsEZlXLxvewQlj0Yo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.346.tgz}
+    resolution: {integrity: sha1-tvLAoURNuXdsEZlXLxvewQlj0Yo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.346.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39257,7 +38511,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.styles.ellipsis@0.0.347(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LjDi1VsjWOmDi1kN1l+C+Ef0ArQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.347.tgz}
+    resolution: {integrity: sha1-LjDi1VsjWOmDi1kN1l+C+Ef0ArQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.347.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39269,7 +38523,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/design.ui.styles.ellipsis@0.0.353(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RNZDdmW66l51GMZAdkqOqSZVVvw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.353.tgz}
+    resolution: {integrity: sha1-RNZDdmW66l51GMZAdkqOqSZVVvw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.353.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39282,7 +38536,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.ellipsis@0.0.357(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7ElER+9hfOnjVZ834tsgNMseDQY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.357.tgz}
+    resolution: {integrity: sha1-7ElER+9hfOnjVZ834tsgNMseDQY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.357.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39295,7 +38549,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.35(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-D8Cw5SAZAAL1AwynU9udvgC+X08=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.35.tgz}
+    resolution: {integrity: sha1-D8Cw5SAZAAL1AwynU9udvgC+X08=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.35.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39307,7 +38561,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.41(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pJpFIAjz3jZwDqyr1Lc8G2Kj9jE=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.41.tgz}
+    resolution: {integrity: sha1-pJpFIAjz3jZwDqyr1Lc8G2Kj9jE=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.41.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39319,7 +38573,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.44(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uJlo9PPuh2V0z5RYLehmk1KGxvo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.44.tgz}
+    resolution: {integrity: sha1-uJlo9PPuh2V0z5RYLehmk1KGxvo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.44.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39331,7 +38585,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.item@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/surfaces/menu/item@0.0.354.tgz}
+    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.item/-/@teambit-design.ui.surfaces.menu.item-0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39345,7 +38599,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.link-item@1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
+    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/@teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39363,7 +38617,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.section@0.0.351(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lzKC8iCprlewLu0mu78ma+RN3oo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.section/-/@teambit-design.ui.surfaces.menu.section-0.0.351.tgz}
+    resolution: {integrity: sha1-lzKC8iCprlewLu0mu78ma+RN3oo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.section/-/@teambit-design.ui.surfaces.menu.section-0.0.351.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39375,7 +38629,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.message-card@0.0.17(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rW7P0hcEKdMnf5/rVvkrqRC3ztk=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.message-card/-/@teambit-design.ui.surfaces.message-card-0.0.17.tgz}
+    resolution: {integrity: sha1-rW7P0hcEKdMnf5/rVvkrqRC3ztk=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.message-card/-/@teambit-design.ui.surfaces.message-card-0.0.17.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39390,7 +38644,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.status-message-card@0.0.17(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9uu83ti/6Rwlm4z5r+5YHUJ+Ogc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.status-message-card/-/@teambit-design.ui.surfaces.status-message-card-0.0.17.tgz}
+    resolution: {integrity: sha1-9uu83ti/6Rwlm4z5r+5YHUJ+Ogc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.status-message-card/-/@teambit-design.ui.surfaces.status-message-card-0.0.17.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39403,7 +38657,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.time-ago@0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-trBnEefw+hpWvPDiKVtuLFAL6kM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.time-ago/-/@teambit-design.ui.time-ago-0.0.366.tgz}
+    resolution: {integrity: sha1-trBnEefw+hpWvPDiKVtuLFAL6kM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.time-ago/-/@teambit-design.ui.time-ago-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -39420,13 +38674,13 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.352(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3TBRHBTzvQMC9IGDz2uorqDWNcQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.352.tgz}
+    resolution: {integrity: sha1-3TBRHBTzvQMC9IGDz2uorqDWNcQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.352.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39436,13 +38690,13 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.358(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+cA/naxci4q2SsevRkPkTAb7sGo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.358.tgz}
+    resolution: {integrity: sha1-+cA/naxci4q2SsevRkPkTAb7sGo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.358.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39452,7 +38706,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.361(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OA4fKc63w/KyZwVIpb4/8Gkt0tA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.361.tgz}
+    resolution: {integrity: sha1-OA4fKc63w/KyZwVIpb4/8Gkt0tA=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.361.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39468,13 +38722,13 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9YKgP7x/RJ6ArJ6OCXRAtMUQgd8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.12.tgz}
+    resolution: {integrity: sha1-9YKgP7x/RJ6ArJ6OCXRAtMUQgd8=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.12.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-animate-height: 2.0.23(react-dom@17.0.2)(react@17.0.2)
@@ -39482,7 +38736,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.15(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Kp0MIgNQpp81LGK/hyZsTA0o094=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.15.tgz}
+    resolution: {integrity: sha1-Kp0MIgNQpp81LGK/hyZsTA0o094=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.15.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39496,13 +38750,13 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6BTmF257To6E3JNxdhilk4ybqhY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.6.tgz}
+    resolution: {integrity: sha1-6BTmF257To6E3JNxdhilk4ybqhY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.6.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-animate-height: 2.0.23(react-dom@17.0.2)(react@17.0.2)
@@ -39510,7 +38764,7 @@ packages:
     dev: false
 
   /@teambit/docs.content.docs-overview@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/content/docs-overview@1.95.9.tgz}
+    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.bit.cloud/@teambit/docs.content.docs-overview/-/@teambit-docs.content.docs-overview-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/docs.ui.zoomable-image': 1.95.8(react-dom@17.0.2)(react@17.0.2)
@@ -39522,21 +38776,21 @@ packages:
     dev: true
 
   /@teambit/docs.entities.doc@0.0.12:
-    resolution: {integrity: sha1-QcOwLxOYF0onRasI3QprayQsvMk=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.12.tgz}
+    resolution: {integrity: sha1-QcOwLxOYF0onRasI3QprayQsvMk=, tarball: https://node-registry.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.12.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/toolbox.types.serializable': 0.0.491
     dev: false
 
   /@teambit/docs.entities.doc@0.0.2:
-    resolution: {integrity: sha1-Ljj4ksQWmKMbUZy58m0cB7MnSWo=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.2.tgz}
+    resolution: {integrity: sha1-Ljj4ksQWmKMbUZy58m0cB7MnSWo=, tarball: https://node-registry.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.2.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/toolbox.types.serializable': 0.0.483
     dev: true
 
   /@teambit/docs.ui.hooks.use-element-on-fold@1.96.5(react@17.0.2):
-    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/hooks/use-element-on-fold@1.96.5.tgz}
+    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.hooks.use-element-on-fold/-/@teambit-docs.ui.hooks.use-element-on-fold-1.96.5.tgz}
     peerDependencies:
       '@testing-library/react-hooks': ^8.0.0
       react: ^16.8.0 || ^17.0.0
@@ -39547,7 +38801,7 @@ packages:
     dev: false
 
   /@teambit/docs.ui.zoomable-image@1.95.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/zoomable-image@1.95.0.tgz}
+    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39561,7 +38815,7 @@ packages:
     dev: true
 
   /@teambit/docs.ui.zoomable-image@1.95.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/zoomable-image@1.95.8.tgz}
+    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39597,7 +38851,7 @@ packages:
     dev: false
 
   /@teambit/documenter.content.documentation-links@4.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/content/documentation-links@4.1.3.tgz}
+    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.bit.cloud/@teambit/documenter.content.documentation-links/-/@teambit-documenter.content.documentation-links-4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39608,7 +38862,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.heading@0.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/markdown/heading@0.1.8.tgz}
+    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.heading/-/@teambit-documenter.markdown.heading-0.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39623,8 +38877,8 @@ packages:
   /@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
     resolution: {integrity: sha1-zmQgh2QvXfcHXFpnL6t0u4Ur2OQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.hybrid-live-code-snippet/-/@teambit-documenter.markdown.hybrid-live-code-snippet-0.1.12.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/documenter.code.react-playground': 4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
@@ -39669,25 +38923,11 @@ packages:
     dev: false
 
   /@teambit/documenter.routing.external-link@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/routing/external-link@4.1.2.tgz}
+    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.bit.cloud/@teambit/documenter.routing.external-link/-/@teambit-documenter.routing.external-link-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.theme.theme-context/-/@teambit-documenter.theme.theme-context-4.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.theme-provider': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39695,7 +38935,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.anchor@4.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/anchor@4.0.6.tgz}
+    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39708,7 +38948,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.anchor@4.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/anchor@4.0.8.tgz}
+    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39721,7 +38961,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.block-quote@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/block-quote@4.0.7.tgz}
+    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.block-quote/-/@teambit-documenter.ui.block-quote-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39733,7 +38973,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.bold@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/bold@4.0.7.tgz}
+    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.bold/-/@teambit-documenter.ui.bold-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39759,20 +38999,8 @@ packages:
       react-syntax-highlighter: 13.5.3(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.copied-message@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/copied-message@4.1.6.tgz}
+    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39784,7 +39012,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.copy-box@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/copy-box@4.1.6.tgz}
+    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.copy-box/-/@teambit-documenter.ui.copy-box-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39794,19 +39022,6 @@ packages:
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.heading': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -39826,7 +39041,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.6.tgz}
+    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39838,32 +39053,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.highlighted-text/-/@teambit-documenter.ui.highlighted-text-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/documenter.ui.inline-code': 0.1.1(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.image@4.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/image@4.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.inline-code@0.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.1.tgz}
+    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.image/-/@teambit-documenter.ui.image-4.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39875,7 +39066,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.inline-code@0.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/inline-code@0.1.5.tgz}
+    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39887,32 +39078,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.italic@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/italic@4.0.7.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label-list/-/@teambit-documenter.ui.label-list-4.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label/-/@teambit-documenter.ui.label-4.0.3.tgz}
+    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.italic/-/@teambit-documenter.ui.italic-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39924,7 +39090,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/linked-heading@4.1.6.tgz}
+    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39938,7 +39104,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.8.tgz}
+    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39952,25 +39118,11 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ol@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/ol@4.1.5.tgz}
+    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.ol/-/@teambit-documenter.ui.ol-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.paragraph': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39984,7 +39136,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.text.paragraph': 1.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39992,7 +39144,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.property-table@4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/property-table@4.1.3.tgz}
+    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.property-table/-/@teambit-documenter.ui.property-table-4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40009,30 +39161,6 @@ packages:
       - typescript
     dev: false
 
-  /@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.section/-/@teambit-documenter.ui.section-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.separator@4.1.5(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
     peerDependencies:
@@ -40045,22 +39173,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.sub-title/-/@teambit-documenter.ui.sub-title-4.1.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.paragraph': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/documenter.ui.sup@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/sup@4.0.7.tgz}
+    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.sup/-/@teambit-documenter.ui.sup-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40072,7 +39186,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-column@4.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SCWMxMt8UkvvI4Ya/ZkJuMIIXSs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-column/-/@teambit-documenter.ui.table-column-4.0.2.tgz}
+    resolution: {integrity: sha1-SCWMxMt8UkvvI4Ya/ZkJuMIIXSs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-column/-/@teambit-documenter.ui.table-column-4.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40111,7 +39225,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-row@4.1.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+r5wtOO/p3k1vMKiU+K9LY/pL+I=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.10.tgz}
+    resolution: {integrity: sha1-+r5wtOO/p3k1vMKiU+K9LY/pL+I=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.10.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40127,7 +39241,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-row@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-eWzMJmyZbLH5RL03UwVgy6xrZAs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.2.tgz}
+    resolution: {integrity: sha1-eWzMJmyZbLH5RL03UwVgy6xrZAs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40142,7 +39256,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.base-table@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/base-table@4.1.5.tgz}
+    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.base-table/-/@teambit-documenter.ui.table.base-table-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40154,7 +39268,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.td@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/td@4.1.5.tgz}
+    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.td/-/@teambit-documenter.ui.table.td-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40166,7 +39280,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.tr@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/tr@4.1.5.tgz}
+    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.tr/-/@teambit-documenter.ui.table.tr-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40178,7 +39292,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table@4.1.2.tgz}
+    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table/-/@teambit-documenter.ui.table-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40192,7 +39306,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ul@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/ul@4.1.5.tgz}
+    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.ul/-/@teambit-documenter.ui.ul-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40204,7 +39318,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.v2.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.486.tgz}
+    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40216,7 +39330,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.v2.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.492.tgz}
+    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40227,37 +39341,14 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/evangelist.css-components.fade-in-out@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.css-components.fade-in-out/-/@teambit-evangelist.css-components.fade-in-out-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/evangelist.elements.button@1.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.evangelist/elements/button@1.0.6.tgz}
+    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.button/-/@teambit-evangelist.elements.button-1.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.input.button': 1.0.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -40276,26 +39367,12 @@ packages:
     dev: false
 
   /@teambit/evangelist.elements.x-button@1.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.evangelist/elements/x-button@1.0.7.tgz}
+    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.x-button/-/@teambit-evangelist.elements.x-button-1.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/evangelist.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.input.checkbox.indicator@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -40317,7 +39394,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.indicator@1.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
+    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40331,7 +39408,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.label@1.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.10.tgz}
+    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40358,56 +39435,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.3.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.input.checkbox.label': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.input.checkbox.indicator': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.surfaces.dropdown/-/@teambit-evangelist.surfaces.dropdown-1.0.2.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.background': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.drawer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.css-components.fade-in-out': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.surfaces.tooltip/-/@teambit-evangelist.surfaces.tooltip-1.0.1.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.drawer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.css-components.fade-in-out': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/explorer.plugins.env-plugin@0.0.10(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/plugins/env-plugin@0.0.10.tgz}
+    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -40433,7 +39462,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.preview-plugin@0.0.4(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/plugins/preview-plugin@0.0.4.tgz}
+    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -40449,9 +39478,9 @@ packages:
   /@teambit/explorer.plugins.preview-plugin@0.0.9(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz}
     peerDependencies:
-      '@testing-library/react': 12.1.3
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      '@testing-library/react': '*'
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/component-descriptor': 0.0.46(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
@@ -40464,7 +39493,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card-grid@0.0.12(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/component-card-grid@0.0.12.tgz}
+    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.12.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -40498,7 +39527,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card@0.0.11(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/component-card@0.0.11.tgz}
+    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -40540,7 +39569,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.base-component-card@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3PAYOsXMLxyP9FOt//xSgkdAscg=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.492.tgz}
+    resolution: {integrity: sha1-3PAYOsXMLxyP9FOt//xSgkdAscg=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40554,7 +39583,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/explorer.ui.gallery.base-component-card@0.0.503(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VRRMW1hKZbRNl9DSh23pvZh06t4=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.503.tgz}
+    resolution: {integrity: sha1-VRRMW1hKZbRNl9DSh23pvZh06t4=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.503.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40585,7 +39614,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-card@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.495.tgz}
+    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40599,7 +39628,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-card@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-k7X/LAKZj7h1M19wgvJAYEkL4B0=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.496.tgz}
+    resolution: {integrity: sha1-k7X/LAKZj7h1M19wgvJAYEkL4B0=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40616,7 +39645,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-card@0.0.507(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.507.tgz}
+    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.507.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40633,7 +39662,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.484(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1JJr4vIMX4zfPor98vVev8V5g/c=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.484.tgz}
+    resolution: {integrity: sha1-1JJr4vIMX4zfPor98vVev8V5g/c=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.484.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.193
@@ -40648,7 +39677,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G7vGhAafW+HEcBuKFaOCCqv2Rrk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.486.tgz}
+    resolution: {integrity: sha1-G7vGhAafW+HEcBuKFaOCCqv2Rrk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40660,7 +39689,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ui9I65n8fuNEc04KK4yjtW24rAk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.496.tgz}
+    resolution: {integrity: sha1-Ui9I65n8fuNEc04KK4yjtW24rAk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40673,7 +39702,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.search.search-input@1.95.7(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LERb06ynDzJ2v7lmYlZBgmjgpIs=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.search.search-input/-/@teambit-explorer.ui.search.search-input-1.95.7.tgz}
+    resolution: {integrity: sha1-LERb06ynDzJ2v7lmYlZBgmjgpIs=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.search.search-input/-/@teambit-explorer.ui.search.search-input-1.95.7.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -40689,7 +39718,7 @@ packages:
     dev: false
 
   /@teambit/gcp.storage@0.1.2:
-    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.gcp/storage@0.1.2.tgz}
+    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.bit.cloud/@teambit/gcp.storage/-/@teambit-gcp.storage-0.1.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/toolbox.network.agent': 0.0.540
@@ -40701,20 +39730,20 @@ packages:
     dev: false
 
   /@teambit/graph.algorithms.tarjan@0.0.1:
-    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graph/algorithms/tarjan@0.0.1.tgz}
+    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.bit.cloud/@teambit/graph.algorithms.tarjan/-/@teambit-graph.algorithms.tarjan-0.0.1.tgz}
     dependencies:
       lodash: 4.17.20
     dev: false
 
   /@teambit/graph.cleargraph@0.0.1:
-    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graph/cleargraph@0.0.1.tgz}
+    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.bit.cloud/@teambit/graph.cleargraph/-/@teambit-graph.cleargraph-0.0.1.tgz}
     dependencies:
       '@teambit/graph.algorithms.tarjan': 0.0.1
       lodash: 4.17.20
     dev: false
 
   /@teambit/graphql.hooks.use-query-light@1.0.0(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graphql/hooks/use-query-light@1.0.0.tgz}
+    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query-light/-/@teambit-graphql.hooks.use-query-light-1.0.0.tgz}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0
@@ -40733,9 +39762,9 @@ packages:
   /@teambit/graphql.hooks.use-query@0.0.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz}
     peerDependencies:
-      '@apollo/client': 3.3.7
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      '@apollo/client': '*'
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.global-loader': 0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40749,9 +39778,9 @@ packages:
   /@teambit/graphql.hooks.use-query@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz}
     peerDependencies:
-      '@apollo/client': 3.3.7
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      '@apollo/client': '*'
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.global-loader': 0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40785,12 +39814,12 @@ packages:
     dev: false
 
   /@teambit/html.modules.create-element-from-string@0.0.104:
-    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
+    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/html.modules.inject-html-element@0.0.4(react@17.0.2):
-    resolution: {integrity: sha1-JjRYtBb6Yrjgj6QiMOHweMGxbYc=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.inject-html-element/-/@teambit-html.modules.inject-html-element-0.0.4.tgz}
+    resolution: {integrity: sha1-JjRYtBb6Yrjgj6QiMOHweMGxbYc=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.inject-html-element/-/@teambit-html.modules.inject-html-element-0.0.4.tgz}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
     dependencies:
@@ -40816,7 +39845,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lane-components@0.0.149(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-QnNvne623/kMU2CO4PdxzQk1JKo=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lane-components/-/@teambit-lanes.hooks.use-lane-components-0.0.149.tgz}
+    resolution: {integrity: sha1-QnNvne623/kMU2CO4PdxzQk1JKo=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lane-components/-/@teambit-lanes.hooks.use-lane-components-0.0.149.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40832,7 +39861,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lane-readme@0.0.149(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RKSkeINQXYiw5iJ+WRsQjqt0OqM=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lane-readme/-/@teambit-lanes.hooks.use-lane-readme-0.0.149.tgz}
+    resolution: {integrity: sha1-RKSkeINQXYiw5iJ+WRsQjqt0OqM=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lane-readme/-/@teambit-lanes.hooks.use-lane-readme-0.0.149.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40848,7 +39877,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lanes@0.0.150(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uE0g2+AYjmmO3bOuNdBrVBDfSOw=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.150.tgz}
+    resolution: {integrity: sha1-uE0g2+AYjmmO3bOuNdBrVBDfSOw=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.150.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40871,7 +39900,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lanes@0.0.38(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VAc8cwDyJeOiQcjhaQbwQYT+/0o=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.38.tgz}
+    resolution: {integrity: sha1-VAc8cwDyJeOiQcjhaQbwQYT+/0o=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.38.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40890,7 +39919,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.drawer@0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WwUn89Kmbuz1EDpJYn/Tf9sIK5U=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.drawer/-/@teambit-lanes.ui.drawer-0.0.37.tgz}
+    resolution: {integrity: sha1-WwUn89Kmbuz1EDpJYn/Tf9sIK5U=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.drawer/-/@teambit-lanes.ui.drawer-0.0.37.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40922,7 +39951,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-details@0.0.109(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-GQDoQzmLDF00KviTRMKBX1iFfBc=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-details/-/@teambit-lanes.ui.lane-details-0.0.109.tgz}
+    resolution: {integrity: sha1-GQDoQzmLDF00KviTRMKBX1iFfBc=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-details/-/@teambit-lanes.ui.lane-details-0.0.109.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40942,7 +39971,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-overview@0.0.113(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-fzSebCVkXOz7sR1ky8DK3Hbw8gw=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-overview/-/@teambit-lanes.ui.lane-overview-0.0.113.tgz}
+    resolution: {integrity: sha1-fzSebCVkXOz7sR1ky8DK3Hbw8gw=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-overview/-/@teambit-lanes.ui.lane-overview-0.0.113.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40970,7 +39999,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-readme@0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-JEGwWrr5eWvABOe4EwzRxBA/k5o=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-readme/-/@teambit-lanes.ui.lane-readme-0.0.116.tgz}
+    resolution: {integrity: sha1-JEGwWrr5eWvABOe4EwzRxBA/k5o=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-readme/-/@teambit-lanes.ui.lane-readme-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40999,7 +40028,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lanes@0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-WN3sGDeI+kgG3vDEd/OSxsPQRKc=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lanes/-/@teambit-lanes.ui.lanes-0.0.116.tgz}
+    resolution: {integrity: sha1-WN3sGDeI+kgG3vDEd/OSxsPQRKc=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lanes/-/@teambit-lanes.ui.lanes-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -41056,7 +40085,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.menus@0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-a3nLuMEgJFzVxVG9k09sWykZHog=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.menus/-/@teambit-lanes.ui.menus-0.0.36.tgz}
+    resolution: {integrity: sha1-a3nLuMEgJFzVxVG9k09sWykZHog=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.menus/-/@teambit-lanes.ui.menus-0.0.36.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41087,7 +40116,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models.lanes-model@0.0.112(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2Ogukm35n+YDM3SlwD8MSQWmaLM=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models.lanes-model/-/@teambit-lanes.ui.models.lanes-model-0.0.112.tgz}
+    resolution: {integrity: sha1-2Ogukm35n+YDM3SlwD8MSQWmaLM=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models.lanes-model/-/@teambit-lanes.ui.models.lanes-model-0.0.112.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41105,7 +40134,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models@0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-W4YrdKa3aLz+Kli79jTaBVVyU+c=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.36.tgz}
+    resolution: {integrity: sha1-W4YrdKa3aLz+Kli79jTaBVVyU+c=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.36.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41141,7 +40170,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.viewed-lane@0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Jf6uIOO5As4EcHtoPwPqmiyX1s4=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.viewed-lane/-/@teambit-lanes.ui.viewed-lane-0.0.37.tgz}
+    resolution: {integrity: sha1-Jf6uIOO5As4EcHtoPwPqmiyX1s4=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.viewed-lane/-/@teambit-lanes.ui.viewed-lane-0.0.37.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41230,13 +40259,8 @@ packages:
       lodash: 4.17.21
       semver: 7.3.4
 
-  /@teambit/legacy-component-log@0.0.399:
-    resolution: {integrity: sha512-FkTmlkS/QfQ+uJaJCbFMJ8Hp2fakMkFq5B4bAl45lMzOgQYGP5am+OuFrPimm7NWUN5l3BIXv6DjSAJuWhQE8A==}
-    engines: {node: '>=12.22.0'}
-    dev: false
-
   /@teambit/mdx.ui.docs.link@0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.bit.cloud/@teambit/mdx.ui.docs.link/-/teambit-mdx.ui.docs.link-0.0.500.tgz}
+    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.bit.cloud/@teambit/mdx.ui.docs.link/-/@teambit-mdx.ui.docs.link-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -41252,33 +40276,19 @@ packages:
       - '@types/react'
     dev: false
 
-  /@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, tarball: https://node-registry.v2.bit.cloud/@teambit/mdx.ui.mdx-scope-context/-/@teambit-mdx.ui.mdx-scope-context-0.0.368.tgz}
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.86
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/node.deps-detectors.detective-es6@0.0.1:
-    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
+    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/@teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
-      node-source-walk: 5.0.1
+      node-source-walk: 5.0.2
     dev: false
 
   /@teambit/node.deps-detectors.parser-helper@0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a:
-    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
+    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/@teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
     dev: false
 
   /@teambit/pkg.content.packages-overview@1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.pkg/content/packages-overview@1.95.9.tgz}
+    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.bit.cloud/@teambit/pkg.content.packages-overview/-/@teambit-pkg.content.packages-overview-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/components.blocks.component-card-display': 0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
@@ -41293,20 +40303,20 @@ packages:
     dev: true
 
   /@teambit/preview.ui.component-preview@0.0.494(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-kQ74YKJ8qAfBudrAMmsIb9+RB04=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.494.tgz}
+    resolution: {integrity: sha1-kQ74YKJ8qAfBudrAMmsIb9+RB04=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.494.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/preview.ui.component-preview@0.0.517(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vbMAv1mM7+LCz8uEFv9TEXzR1Rc=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.517.tgz}
+    resolution: {integrity: sha1-vbMAv1mM7+LCz8uEFv9TEXzR1Rc=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.517.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41322,20 +40332,20 @@ packages:
     dev: false
 
   /@teambit/preview.ui.preview-placeholder@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lnjRd/jLhUCpg0Zpdy/7JpVkve0=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.487.tgz}
+    resolution: {integrity: sha1-lnjRd/jLhUCpg0Zpdy/7JpVkve0=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/preview.ui.preview-placeholder@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.496.tgz}
+    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41348,7 +40358,7 @@ packages:
     dev: false
 
   /@teambit/react.content.react-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/content/react-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.bit.cloud/@teambit/react.content.react-overview/-/@teambit-react.content.react-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41363,7 +40373,7 @@ packages:
     dev: true
 
   /@teambit/react.instructions.react-native.adding-tests@0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/instructions/react-native/adding-tests@0.0.1.tgz}
+    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.bit.cloud/@teambit/react.instructions.react-native.adding-tests/-/@teambit-react.instructions.react-native.adding-tests-0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41377,38 +40387,8 @@ packages:
       - '@teambit/legacy'
     dev: false
 
-  /@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-compositions/-/@teambit-react.instructions.react.adding-compositions-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
-  /@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-tests/-/@teambit-react.instructions.react.adding-tests-0.0.6.tgz}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
   /@teambit/react.modules.dom-to-react@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/modules/dom-to-react@0.2.0.tgz}
+    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.bit.cloud/@teambit/react.modules.dom-to-react/-/@teambit-react.modules.dom-to-react-0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41437,7 +40417,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.component-highlighter@0.2.1(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/component-highlighter@0.2.1.tgz}
+    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.component-highlighter/-/@teambit-react.ui.component-highlighter-0.2.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41452,7 +40432,7 @@ packages:
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.2
       core-js: 3.13.0
-      get-xpath: 3.0.1
+      get-xpath: 3.1.0
       lodash.compact: 3.0.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41464,7 +40444,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.highlighter.component-metadata.bit-component-meta@0.0.21(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/highlighter/component-metadata/bit-component-meta@0.0.21.tgz}
+    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/@teambit-react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41476,7 +40456,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.hover-selector@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/hover-selector@0.2.0.tgz}
+    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.hover-selector/-/@teambit-react.ui.hover-selector-0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41487,7 +40467,7 @@ packages:
     dev: false
 
   /@teambit/scope.content.scope-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.scope/content/scope-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.bit.cloud/@teambit/scope.content.scope-overview/-/@teambit-scope.content.scope-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41503,7 +40483,7 @@ packages:
     dev: true
 
   /@teambit/scope.models.scope-model@0.0.199(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uKcM8GxZ7PY7qjtrnglrcNdWOl8=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.199.tgz}
+    resolution: {integrity: sha1-uKcM8GxZ7PY7qjtrnglrcNdWOl8=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.199.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.110(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -41515,7 +40495,7 @@ packages:
     dev: false
 
   /@teambit/scope.models.scope-model@0.0.235(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ivlq0sF9GaNYn7ubwN/99AzJJLE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.235.tgz}
+    resolution: {integrity: sha1-Ivlq0sF9GaNYn7ubwN/99AzJJLE=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.235.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.146(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -41539,7 +40519,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.hooks.use-scope@0.0.203(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-fe5QGB7RCxZZ8GGovNrm3KlMnsQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.203.tgz}
+    resolution: {integrity: sha1-fe5QGB7RCxZZ8GGovNrm3KlMnsQ=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.203.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -41557,7 +40537,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.hooks.use-scope@0.0.240(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ArQ+DdQNq/Aw2rjpUZcWpcveyck=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.240.tgz}
+    resolution: {integrity: sha1-ArQ+DdQNq/Aw2rjpUZcWpcveyck=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.240.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -41575,13 +40555,13 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-icon@0.0.78(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-psEzvN8g43aV3xmdw3TPaMqK7bE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.78.tgz}
+    resolution: {integrity: sha1-psEzvN8g43aV3xmdw3TPaMqK7bE=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.78.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/toolbox.string.get-initials': 0.0.483
       '@teambit/toolbox.url.add-avatar-query-params': 0.0.483
       classnames: 2.2.6
@@ -41591,7 +40571,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-icon@0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.scope/ui/scope-icon@0.0.91.tgz}
+    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.91.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -41609,14 +40589,14 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-title@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-l+v2cdXuIPGuUzuBne1ADczrYH0=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.495.tgz}
+    resolution: {integrity: sha1-l+v2cdXuIPGuUzuBne1ADczrYH0=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.78(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41625,14 +40605,14 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-title@0.0.508(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.508.tgz}
+    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.508.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41655,32 +40635,32 @@ packages:
     dev: true
 
   /@teambit/styling.deps-detectors.detective-css-and-preprocessors@0.0.2:
-    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
+    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/@teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
     dependencies:
       css-tree: 2.3.1
       is-url: 1.2.4
     dev: false
 
   /@teambit/styling.deps-detectors.detective-css@0.0.2:
-    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
+    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/@teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-less@0.0.2:
-    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
+    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/@teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-sass@0.0.2:
-    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
+    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/@teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-scss@0.0.2:
-    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
+    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/@teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
@@ -41688,33 +40668,20 @@ packages:
   /@teambit/styling.deps-lookups.lookup-styling@0.0.1:
     resolution: {integrity: sha1-2rGGrYqcJkFXt52QqUL3ZHKAVmM=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-lookups.lookup-styling/-/@teambit-styling.deps-lookups.lookup-styling-0.0.1.tgz}
     dependencies:
-      enhanced-resolve: 5.14.1
+      enhanced-resolve: 5.15.0
       is-relative-path: 2.0.0
       sass-lookup: 5.0.1
     dev: false
 
   /@teambit/toolbox.fs.hard-link-directory@0.0.9:
-    resolution: {integrity: sha1-St+dQX5yyoZajHllbcoy69isL1I=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.fs.hard-link-directory/-/@teambit-toolbox.fs.hard-link-directory-0.0.9.tgz}
+    resolution: {integrity: sha1-St+dQX5yyoZajHllbcoy69isL1I=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.fs.hard-link-directory/-/@teambit-toolbox.fs.hard-link-directory-0.0.9.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       fs-extra: 10.0.0
     dev: false
 
-  /@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==}
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.108
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      '@teambit/toolbox.network.proxy-agent': 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
-      agentkeepalive: 4.1.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@teambit/toolbox.network.agent@0.0.540:
-    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/network/agent@0.0.540.tgz}
+    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.540.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.agent': 0.0.3
@@ -41724,71 +40691,56 @@ packages:
       - supports-color
     dev: false
 
-  /@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==}
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.108
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      '@teambit/toolbox.network.agent': 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      socks-proxy-agent: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /@teambit/toolbox.string.ellipsis@0.0.172:
-    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.172.tgz}
+    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.172.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.string.ellipsis@0.0.173:
-    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.173.tgz}
+    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.173.tgz}
     engines: {node: '>=12.22.0'}
 
   /@teambit/toolbox.string.ellipsis@0.0.181:
-    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
+    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.string.get-initials@0.0.483:
-    resolution: {integrity: sha1-7BsxTG+qhcTHltoBu9McFKOq0/Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.483.tgz}
+    resolution: {integrity: sha1-7BsxTG+qhcTHltoBu9McFKOq0/Y=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.string.get-initials@0.0.491:
-    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.491.tgz}
+    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.types.serializable@0.0.483:
-    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.483.tgz}
+    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.types.serializable@0.0.491:
-    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
+    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.url.add-avatar-query-params@0.0.483:
-    resolution: {integrity: sha1-oyxnM4oFZ2iiNiqxDPWHI2v7IeE=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.483.tgz}
+    resolution: {integrity: sha1-oyxnM4oFZ2iiNiqxDPWHI2v7IeE=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.url.add-avatar-query-params@0.0.492:
-    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.492.tgz}
+    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/typescript.deps-detectors.detective-typescript@0.0.1(typescript@4.7.4):
-    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
+    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/@teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
-      '@typescript-eslint/typescript-estree': 5.57.0(typescript@4.7.4)
-      node-source-walk: 5.0.1
+      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.7.4)
+      node-source-walk: 5.0.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -41798,16 +40750,16 @@ packages:
     resolution: {integrity: sha1-nP/TKhnV0nBBFoCd1wddzxta10o=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-lookups.lookup-typescript/-/@teambit-typescript.deps-lookups.lookup-typescript-0.0.1.tgz}
     dependencies:
       app-module-path: 2.2.0
-      enhanced-resolve: 5.14.1
+      enhanced-resolve: 5.15.0
       is-relative-path: 2.0.0
       module-definition: 5.0.1
       object-assign: 4.1.1
       resolve: 1.22.2
-      typescript: 5.1.3
+      typescript: 5.1.6
     dev: false
 
   /@teambit/typescript.typescript-compiler@2.0.0(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-EFZGBxoNSgv33z/72QHsND2jvsjzGSFgY3rqhZcoYcWN1DfvUHLbeQDSlYA9/afT6vzV+WLhFy4K9fdgVJu+NQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.0.tgz}
+    resolution: {integrity: sha1-nKHh81Xpb0BexVonuzyAFskhrQ4=, tarball: https://node-registry.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.0.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.380
     dependencies:
@@ -41824,7 +40776,7 @@ packages:
     dev: false
 
   /@teambit/typescript.typescript-compiler@2.0.1(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-bxTazYfFjnqp1DrfL9FvwnnVDCUk+8fu2LiQEMCdGNU+bsrtYzZBKfA6DXHoh4kkynBQsBcbf7cgTp5hxh7uEw==, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.1.tgz}
+    resolution: {integrity: sha1-ROMqppit0ToLogpx8275MJcOXT0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.1.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.380
     dependencies:
@@ -41854,15 +40806,15 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.empty-component-gallery@0.0.492(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-qbHcWdrV0bnFFe4SC6a3qjVjURA=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.492.tgz}
+    resolution: {integrity: sha1-qbHcWdrV0bnFFe4SC6a3qjVjURA=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41873,16 +40825,16 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.empty-component-gallery@0.0.502(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nbagGhpo63WfemtMvlC2tuGRsok=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.502.tgz}
+    resolution: {integrity: sha1-nbagGhpo63WfemtMvlC2tuGRsok=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.502.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41893,7 +40845,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.full-loader@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-S37SXs9caAwDs/8uQ8rEFHJe2Ic=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.486.tgz}
+    resolution: {integrity: sha1-S37SXs9caAwDs/8uQ8rEFHJe2Ic=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41905,7 +40857,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.full-loader@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-oz+Ex8oBR8tdgWT5kZCDECCGUY0=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.492.tgz}
+    resolution: {integrity: sha1-oz+Ex8oBR8tdgWT5kZCDECCGUY0=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41917,7 +40869,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.get-icon-from-file-name@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.get-icon-from-file-name/-/@teambit-ui-foundation.ui.get-icon-from-file-name-0.0.495.tgz}
+    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.get-icon-from-file-name/-/@teambit-ui-foundation.ui.get-icon-from-file-name-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41930,7 +40882,7 @@ packages:
       vscode-icons-js: 11.0.0
 
   /@teambit/ui-foundation.ui.global-loader@0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.474.tgz}
+    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.474.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.183
@@ -41945,7 +40897,7 @@ packages:
     dev: true
 
   /@teambit/ui-foundation.ui.global-loader@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.487.tgz}
+    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41958,7 +40910,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.493.tgz}
+    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41971,7 +40923,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.497(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.497.tgz}
+    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.497.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41984,7 +40936,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.488(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dWr5imk7thG6uDJFhiZvgbx4YXk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.488.tgz}
+    resolution: {integrity: sha1-dWr5imk7thG6uDJFhiZvgbx4YXk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.488.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -42000,7 +40952,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.496(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.496.tgz}
+    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -42016,7 +40968,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.500(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.500.tgz}
+    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -42032,7 +40984,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.486.tgz}
+    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42044,7 +40996,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.492.tgz}
+    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42056,7 +41008,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.486.tgz}
+    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42070,7 +41022,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.492.tgz}
+    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42084,14 +41036,14 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.main-dropdown@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wWEqL2L6GAIzxMKArBJlORClpEI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.487.tgz}
+    resolution: {integrity: sha1-wWEqL2L6GAIzxMKArBJlORClpEI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.486(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -42102,14 +41054,14 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.main-dropdown@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/N8qsGnMUUEAbq9KCc5nemtQSUo=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.493.tgz}
+    resolution: {integrity: sha1-/N8qsGnMUUEAbq9KCc5nemtQSUo=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.492(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -42120,7 +41072,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.menu@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-X0CD1f29BhUCpEAz1Y0YcHIM9tM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.487.tgz}
+    resolution: {integrity: sha1-X0CD1f29BhUCpEAz1Y0YcHIM9tM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42136,7 +41088,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.menu@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hbjImHPNUVgx0j7BykmzOxMKqxs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.493.tgz}
+    resolution: {integrity: sha1-hbjImHPNUVgx0j7BykmzOxMKqxs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42152,7 +41104,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.navigation.react-router-adapter@6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/navigation/react-router-adapter@6.1.1.tgz}
+    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.navigation.react-router-adapter/-/@teambit-ui-foundation.ui.navigation.react-router-adapter-6.1.1.tgz}
     peerDependencies:
       '@types/react': ^17.0.0
       react: ^16.8.0 || ^17.0.0
@@ -42172,7 +41124,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.487.tgz}
+    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42185,7 +41137,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.493.tgz}
+    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42198,7 +41150,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.496.tgz}
+    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42211,7 +41163,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.486.tgz}
+    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42223,7 +41175,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.492.tgz}
+    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42235,7 +41187,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.495.tgz}
+    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42247,7 +41199,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.slot-router@0.0.490(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-W8Yot/K3sHr8a/diXZfp0zRLXyQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.490.tgz}
+    resolution: {integrity: sha1-W8Yot/K3sHr8a/diXZfp0zRLXyQ=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.490.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42267,7 +41219,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.slot-router@0.0.501(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.501.tgz}
+    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.501.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42287,7 +41239,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.use-query@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.use-query/-/@teambit-ui-foundation.ui.react-router.use-query-0.0.496.tgz}
+    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.use-query/-/@teambit-ui-foundation.ui.react-router.use-query-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42306,8 +41258,8 @@ packages:
     resolution: {integrity: sha1-wLxfPsjKW+2sB5juwlbAA60Oirk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.rendering.html/-/@teambit-ui-foundation.ui.rendering.html-0.0.69.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -42315,24 +41267,24 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.side-bar@0.0.613(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-8vs4qdsE5d7E5gOwpXlFYZ3/GPI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.613.tgz}
+    resolution: {integrity: sha1-8vs4qdsE5d7E5gOwpXlFYZ3/GPI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.613.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.modules.component-url': 0.0.128(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.deprecation-icon': 0.0.494(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.486(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.lanes': 0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42348,24 +41300,24 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.side-bar@0.0.649(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5VNC36o2vGNZ87v66MegcwO04gc=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.649.tgz}
+    resolution: {integrity: sha1-5VNC36o2vGNZ87v66MegcwO04gc=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.649.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.modules.component-url': 0.0.140(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.deprecation-icon': 0.0.500(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.12(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.492(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.models': 0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42379,13 +41331,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.499(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pjQ48Y76Vdev7zJsLJnmefJUmDs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.499.tgz}
+    resolution: {integrity: sha1-pjQ48Y76Vdev7zJsLJnmefJUmDs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.499.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42393,13 +41345,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.505(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Vepk8IZRMgaa4EOB59zsA8taYkc=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.505.tgz}
+    resolution: {integrity: sha1-Vepk8IZRMgaa4EOB59zsA8taYkc=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.505.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42407,7 +41359,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.512(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
+    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42421,7 +41373,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.bottom-link@0.0.104(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xosebUlECtQu7XyRfyllNsaeV2k=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.104.tgz}
+    resolution: {integrity: sha1-xosebUlECtQu7XyRfyllNsaeV2k=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42433,7 +41385,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.bottom-link@0.0.110(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vhb5IhCvfJ/k7kzr+PredFNWIiw=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.110.tgz}
+    resolution: {integrity: sha1-vhb5IhCvfJ/k7kzr+PredFNWIiw=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.110.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42445,15 +41397,15 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.dropdown@0.0.116(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G5A0Rl7gBRyIgYgmp0CwOXeKmFY=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.116.tgz}
+    resolution: {integrity: sha1-G5A0Rl7gBRyIgYgmp0CwOXeKmFY=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42461,15 +41413,15 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.dropdown@0.0.122(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-eh496FT5rh2oPpBs+/uzavLItnM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.122.tgz}
+    resolution: {integrity: sha1-eh496FT5rh2oPpBs+/uzavLItnM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.122.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42477,13 +41429,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.tab-content@0.0.105(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YEje8xEfnAIM89gF18c29RD0aYw=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.105.tgz}
+    resolution: {integrity: sha1-YEje8xEfnAIM89gF18c29RD0aYw=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.105.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.104(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42493,13 +41445,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.tab-content@0.0.111(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KYawBhoq9Gzqt3JvqDroB0c5h7Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.111.tgz}
+    resolution: {integrity: sha1-KYawBhoq9Gzqt3JvqDroB0c5h7Y=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.111.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.110(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42515,7 +41467,7 @@ packages:
     dev: true
 
   /@teambit/workspace.content.variants@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/content/variants@1.95.9.tgz}
+    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.bit.cloud/@teambit/workspace.content.variants/-/@teambit-workspace.content.variants-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -42526,7 +41478,7 @@ packages:
     dev: true
 
   /@teambit/workspace.content.workspace-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/content/workspace-overview@1.95.0.tgz}
+    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.bit.cloud/@teambit/workspace.content.workspace-overview/-/@teambit-workspace.content.workspace-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -42542,13 +41494,13 @@ packages:
     dev: true
 
   /@teambit/workspace.ui.load-preview@0.0.489(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.489.tgz}
+    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.489.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -42556,14 +41508,14 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.load-preview@0.0.499(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.499.tgz}
+    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.499.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -42572,7 +41524,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.workspace-component-card@0.0.498(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OEC9ofhKQOIaKS5lk3GpvkAQqE8=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.498.tgz}
+    resolution: {integrity: sha1-OEC9ofhKQOIaKS5lk3GpvkAQqE8=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.498.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42590,7 +41542,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.workspace-component-card@0.0.510(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.510.tgz}
+    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.510.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42607,17 +41559,17 @@ packages:
       - '@types/react'
     dev: false
 
-  /@testing-library/dom@8.20.0:
-    resolution: {integrity: sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==}
+  /@testing-library/dom@8.20.1:
+    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       '@babel/runtime': 7.20.0
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
-      lz-string: 1.4.4
+      lz-string: 1.5.0
       pretty-format: 27.5.1
 
   /@testing-library/jest-dom@5.16.2:
@@ -42626,7 +41578,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@types/testing-library__jest-dom': 5.9.5
-      aria-query: 5.1.3
+      aria-query: 5.3.0
       chalk: 3.0.0
       css: 3.0.0
       css.escape: 1.5.1
@@ -42653,16 +41605,16 @@ packages:
       react-dom: <18.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@testing-library/dom': 8.20.0
-      '@types/react-dom': 17.0.18
+      '@testing-library/dom': 8.20.1
+      '@types/react-dom': 17.0.20
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
   /@tippyjs/react@4.2.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-T6UcHtwtGkvgsBQ4bNp8BtXGxa2ujfOkWUogYkRtN4UVJ2QRgDdFoJeaPxdndnVYFEa2uTVxSFxs8QkSkZ2Gdw==}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '*'
+      react-dom: '*'
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -42693,7 +41645,7 @@ packages:
   /@types/archiver@5.3.1:
     resolution: {integrity: sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==}
     dependencies:
-      '@types/glob': 8.0.1
+      '@types/glob': 8.1.0
     dev: true
 
   /@types/aria-query@5.0.1:
@@ -42702,11 +41654,11 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.20.13
+      '@babel/parser': 7.22.7
       '@babel/types': 7.22.3
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.18.3
+      '@types/babel__traverse': 7.20.1
 
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
@@ -42716,11 +41668,11 @@ packages:
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.20.13
+      '@babel/parser': 7.22.7
       '@babel/types': 7.22.3
 
-  /@types/babel__traverse@7.18.3:
-    resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
+  /@types/babel__traverse@7.20.1:
+    resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
     dependencies:
       '@babel/types': 7.22.3
 
@@ -42798,10 +41750,10 @@ packages:
     resolution: {integrity: sha512-m3+6WWfSSl6zqoXy8uQQifbgqV7Gt6fsyWnHLgUWVtJQk75+OfUB+edSZ52YDj7leSiZtX7w1/E4w2x/Hb0orA==}
     dev: true
 
-  /@types/connect-history-api-fallback@1.3.5:
-    resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
+  /@types/connect-history-api-fallback@1.5.0:
+    resolution: {integrity: sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==}
     dependencies:
-      '@types/express-serve-static-core': 4.17.33
+      '@types/express-serve-static-core': 4.17.35
       '@types/node': 12.20.4
 
   /@types/connect@3.4.35:
@@ -42841,7 +41793,7 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 7.28.0
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
 
   /@types/eslint-visitor-keys@1.0.0:
     resolution: {integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==}
@@ -42850,30 +41802,31 @@ packages:
   /@types/eslint@7.28.0:
     resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
     dependencies:
-      '@types/estree': 1.0.0
-      '@types/json-schema': 7.0.11
+      '@types/estree': 1.0.1
+      '@types/json-schema': 7.0.12
 
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: false
 
-  /@types/estree@1.0.0:
-    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+  /@types/estree@1.0.1:
+    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
 
-  /@types/express-serve-static-core@4.17.33:
-    resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
+  /@types/express-serve-static-core@4.17.35:
+    resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
     dependencies:
       '@types/node': 12.20.4
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
+      '@types/send': 0.17.1
 
   /@types/express@4.17.13:
     resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==}
     dependencies:
       '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.33
+      '@types/express-serve-static-core': 4.17.35
       '@types/qs': 6.9.7
-      '@types/serve-static': 1.15.0
+      '@types/serve-static': 1.15.2
 
   /@types/find-root@1.1.2:
     resolution: {integrity: sha512-lGuMq71TL466jtCpvh7orGd+mrdBmo2h8ozvtOOTbq3ByfWpuN+UVxv4sOv3YpsD4NhW2k6ESGhnT/FIg4Ouzw==}
@@ -42891,8 +41844,8 @@ packages:
       '@types/node': 12.20.4
     dev: true
 
-  /@types/glob@8.0.1:
-    resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
+  /@types/glob@8.1.0:
+    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 12.20.4
@@ -42908,10 +41861,10 @@ packages:
     resolution: {integrity: sha512-K7T1n6U2HbTYu+SFHlBjz/RH74OA2D/zF1qlzn8uXbvB4uRg7knOM85ugS2bbXI1TXMh7rLqk4OVRwIwEBaixg==}
     dev: true
 
-  /@types/hast@2.3.4:
-    resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
+  /@types/hast@2.3.5:
+    resolution: {integrity: sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: false
 
   /@types/html-minifier-terser@5.1.2:
@@ -42944,7 +41897,6 @@ packages:
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
-    dev: false
 
   /@types/http-proxy-agent@2.0.2:
     resolution: {integrity: sha512-2S6IuBRhqUnH1/AUx9k8KWtY3Esg4eqri946MnxTG5HwehF1S5mqLln8fcyMiuQkY72p2gH3W+rIPqp5li0LyQ==}
@@ -42952,8 +41904,8 @@ packages:
       '@types/node': 12.20.4
     dev: false
 
-  /@types/http-proxy@1.17.9:
-    resolution: {integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==}
+  /@types/http-proxy@1.17.11:
+    resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
     dependencies:
       '@types/node': 12.20.4
 
@@ -42977,8 +41929,8 @@ packages:
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
 
-  /@types/jasmine@3.10.7:
-    resolution: {integrity: sha512-brLuHhITMz4YV2IxLstAJtyRJgtWfLqFKiqiJFvFWMSmydpAmn42CE4wfw7ywkSk02UrufhtzipTcehk8FctoQ==}
+  /@types/jasmine@3.10.11:
+    resolution: {integrity: sha512-tAiqDJrwRKyjpCgJE07OXFsXsXQWDhoJhyRwzl+yfEToy72s0LhHAfquMi2s4T4Iq3nanKOfZ8/PZFaL/0pQmA==}
 
   /@types/jest@26.0.20:
     resolution: {integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==}
@@ -42998,8 +41950,8 @@ packages:
       parse5: 7.1.2
     dev: false
 
-  /@types/json-schema@7.0.11:
-    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
+  /@types/json-schema@7.0.12:
+    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -43018,11 +41970,11 @@ packages:
   /@types/koa-compose@3.2.5:
     resolution: {integrity: sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==}
     dependencies:
-      '@types/koa': 2.13.5
+      '@types/koa': 2.13.6
     dev: false
 
-  /@types/koa@2.13.5:
-    resolution: {integrity: sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==}
+  /@types/koa@2.13.6:
+    resolution: {integrity: sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==}
     dependencies:
       '@types/accepts': 1.3.5
       '@types/content-disposition': 0.5.5
@@ -43076,10 +42028,10 @@ packages:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
     dev: false
 
-  /@types/mdast@3.0.10:
-    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
+  /@types/mdast@3.0.12:
+    resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: false
 
   /@types/mdx-js__react@1.5.5:
@@ -43091,6 +42043,9 @@ packages:
   /@types/memoizee@0.4.5:
     resolution: {integrity: sha512-+ZzZZ3+0a7/ajBPeAAD4+LxrBsCat0EFZQtO3o0rwpIeLmDmSaM8KF/oYPuFxeUFAMiHIHFcGucFnY/8S4Hszg==}
     dev: true
+
+  /@types/mime@1.3.2:
+    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
 
   /@types/mime@2.0.3:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==}
@@ -43141,8 +42096,8 @@ packages:
     resolution: {integrity: sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==}
     dev: false
 
-  /@types/node@18.11.18:
-    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
+  /@types/node@18.16.19:
+    resolution: {integrity: sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==}
     dev: false
 
   /@types/normalize-package-data@2.4.1:
@@ -43203,8 +42158,8 @@ packages:
       - debug
     dev: true
 
-  /@types/react-dom@17.0.18:
-    resolution: {integrity: sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==}
+  /@types/react-dom@17.0.20:
+    resolution: {integrity: sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==}
     dependencies:
       '@types/react': 17.0.8
 
@@ -43218,8 +42173,8 @@ packages:
     resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==}
     dependencies:
       '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.2
-      csstype: 3.1.1
+      '@types/scheduler': 0.16.3
+      csstype: 3.1.2
 
   /@types/relateurl@0.2.29:
     resolution: {integrity: sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==}
@@ -43247,8 +42202,8 @@ packages:
       sass: 1.63.6
     dev: false
 
-  /@types/scheduler@0.16.2:
-    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
+  /@types/scheduler@0.16.3:
+    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
 
   /@types/semver@6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -43257,14 +42212,21 @@ packages:
   /@types/semver@7.3.4:
     resolution: {integrity: sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==}
 
+  /@types/send@0.17.1:
+    resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
+    dependencies:
+      '@types/mime': 1.3.2
+      '@types/node': 12.20.4
+
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
     dependencies:
       '@types/express': 4.17.13
 
-  /@types/serve-static@1.15.0:
-    resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
+  /@types/serve-static@1.15.2:
+    resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
     dependencies:
+      '@types/http-errors': 2.0.1
       '@types/mime': 2.0.3
       '@types/node': 12.20.4
 
@@ -43308,8 +42270,12 @@ packages:
     resolution: {integrity: sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==}
     dev: false
 
-  /@types/trusted-types@2.0.2:
-    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
+  /@types/triple-beam@1.3.2:
+    resolution: {integrity: sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==}
+    dev: false
+
+  /@types/trusted-types@2.0.3:
+    resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
     dev: false
 
   /@types/ua-parser-js@0.7.35:
@@ -43322,8 +42288,8 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /@types/unist@2.0.6:
-    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
+  /@types/unist@2.0.7:
+    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
     dev: false
 
   /@types/url-join@4.0.0:
@@ -43341,9 +42307,9 @@ packages:
   /@types/webpack-dev-server@3.11.6(debug@4.3.2):
     resolution: {integrity: sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==}
     dependencies:
-      '@types/connect-history-api-fallback': 1.3.5
+      '@types/connect-history-api-fallback': 1.5.0
       '@types/express': 4.17.13
-      '@types/serve-static': 1.15.0
+      '@types/serve-static': 1.15.2
       '@types/webpack': 4.41.33
       http-proxy-middleware: 1.3.1(debug@4.3.2)
     transitivePeerDependencies:
@@ -43401,8 +42367,8 @@ packages:
       '@types/node': 12.20.4
     dev: false
 
-  /@types/ws@8.5.4:
-    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
+  /@types/ws@8.5.5:
+    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
     dependencies:
       '@types/node': 12.20.4
 
@@ -43459,7 +42425,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/type-utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
       '@typescript-eslint/utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
@@ -43477,7 +42443,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.7.4)
       eslint: 7.32.0
       eslint-scope: 5.1.1
@@ -43493,7 +42459,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1(typescript@3.9.10)
       eslint: 6.8.0
@@ -43510,7 +42476,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.7.4)
@@ -43596,7 +42562,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/typescript-estree': 5.35.1(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.32.0
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -43638,7 +42604,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@4.7.4)
       typescript: 4.7.4
@@ -43666,8 +42632,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/types@5.57.0:
-    resolution: {integrity: sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==}
+  /@typescript-eslint/types@5.62.0:
+    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -43768,7 +42734,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/visitor-keys': 5.35.1
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -43778,8 +42744,8 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.57.0(typescript@4.7.4):
-    resolution: {integrity: sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==}
+  /@typescript-eslint/typescript-estree@5.62.0(typescript@4.7.4):
+    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -43787,9 +42753,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.57.0
-      '@typescript-eslint/visitor-keys': 5.57.0
-      debug: 4.3.4(supports-color@9.3.1)
+      '@typescript-eslint/types': 5.62.0
+      '@typescript-eslint/visitor-keys': 5.62.0
+      debug: 4.3.4(supports-color@9.4.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -43805,7 +42771,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/typescript-estree': 5.35.1(typescript@4.7.4)
@@ -43845,15 +42811,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.35.1
-      eslint-visitor-keys: 3.3.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
-  /@typescript-eslint/visitor-keys@5.57.0:
-    resolution: {integrity: sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==}
+  /@typescript-eslint/visitor-keys@5.62.0:
+    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.57.0
-      eslint-visitor-keys: 3.3.0
+      '@typescript-eslint/types': 5.62.0
+      eslint-visitor-keys: 3.4.1
     dev: false
 
   /@ungap/promise-all-settled@1.1.2:
@@ -43868,13 +42834,13 @@ packages:
       http-status-codes: 2.2.0
     dev: false
 
-  /@verdaccio/config@6.0.0-6-next.71:
-    resolution: {integrity: sha512-PvXXVNw28I9JWw7TYCbjA5jkkwbliZTB+TNXzWaFVOpW6s+94WWQzBNUUvPG67iPW4Wgo1ciHVdde/zOeFNfYw==}
+  /@verdaccio/config@6.0.0-6-next.74:
+    resolution: {integrity: sha512-qpP3Hc6OCdUjJw17SQaEBPfTY/YFAGpWuiUizX5D9P46Xf/pEL99oViqA77xJPI0VZIlVue4kxcAO/zJ2oxNwA==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
-      '@verdaccio/utils': 6.0.0-6-next.39
-      debug: 4.3.4(supports-color@9.3.1)
+      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/utils': 6.0.0-6-next.42
+      debug: 4.3.4(supports-color@9.4.0)
       js-yaml: 4.1.0
       lodash: 4.17.21
       minimatch: 3.1.2
@@ -43883,8 +42849,8 @@ packages:
       - supports-color
     dev: false
 
-  /@verdaccio/core@6.0.0-6-next.71:
-    resolution: {integrity: sha512-leREshFssUKy+yI+Y6r9uyfuOEluLbdEs47WpI0hlV6htXkgBjfWIi884i4V/SCm+UIU8Dhn2iHPRo06KlRvFQ==}
+  /@verdaccio/core@6.0.0-6-next.74:
+    resolution: {integrity: sha512-aXryZX2GyvWLvEn2pnxarTY6nOedrh9W7uGsXaW7uYOD7dq8lOQ4NH8Hhl/nw+Sswp3mE5JNl2P3nIoGyhOYiQ==}
     engines: {node: '>=12'}
     dependencies:
       ajv: 8.12.0
@@ -43892,7 +42858,7 @@ packages:
       http-errors: 2.0.0
       http-status-codes: 2.2.0
       process-warning: 1.0.0
-      semver: 7.5.0
+      semver: 7.5.4
     dev: false
 
   /@verdaccio/file-locking@10.3.1:
@@ -43917,7 +42883,7 @@ packages:
       '@verdaccio/file-locking': 10.3.1
       '@verdaccio/streams': 10.2.1
       async: 3.2.4
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       lodash: 4.17.21
       lowdb: 1.0.0
       mkdirp: 1.0.4
@@ -43925,24 +42891,24 @@ packages:
       - supports-color
     dev: false
 
-  /@verdaccio/logger-7@6.0.0-6-next.16:
-    resolution: {integrity: sha512-QElvJcICP3DiJgDPUP4JRjWuImh6RbLWeK83iubrb/y865OmvrOgCgnBAZn0/i/L6buPFa/Sh5A07PBRuYWHgw==}
+  /@verdaccio/logger-7@6.0.0-6-next.19:
+    resolution: {integrity: sha512-DQwmPPRWvrT4TMur4g4+c5dNr7WnoT6sXYpw0Yh6NgZpH2D6FMcaxpH1me0rklpfnnXZmV3/zs2MvLJaWmRl4w==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/logger-commons': 6.0.0-6-next.39
+      '@verdaccio/logger-commons': 6.0.0-6-next.42
       pino: 7.11.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/logger-commons@6.0.0-6-next.39:
-    resolution: {integrity: sha512-jdk8nDu2u3307XV2RtBo+FrC30xXGuSvZN7pQqFWCB9dJo21LpsMPTCgj9eBEwaAT+/ICTJURjO0VBkMlvcbGQ==}
+  /@verdaccio/logger-commons@6.0.0-6-next.42:
+    resolution: {integrity: sha512-ydp12CVXdYhkXPxJevGW38Qf9HJdOF/KWcDmCWo7pi9atfiMkUWoOuEC1nr+7Dx+S5dA7kDfTqFLdadAuyO93A==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.74
       '@verdaccio/logger-prettify': 6.0.0-6-next.10
       colorette: 2.0.20
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -43958,15 +42924,15 @@ packages:
       sonic-boom: 3.3.0
     dev: false
 
-  /@verdaccio/middleware@6.0.0-6-next.50:
-    resolution: {integrity: sha512-eWn1C3p4Tc2ijqrzM0YjSb48DyNkH30UURjh23WyUVrMC7sn7s0DR9DlrRlVC8OSi8oqyQzV1KihowkzFLDcag==}
+  /@verdaccio/middleware@6.0.0-6-next.53:
+    resolution: {integrity: sha512-shzf8+ww161TGOQA+Ee+JsWLgji07kkxLJr+YQSj3d9glbq4OE64sw51cV3BwpBbIALWziLTmIbYLaZgaRkZYg==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.71
-      '@verdaccio/core': 6.0.0-6-next.71
-      '@verdaccio/url': 11.0.0-6-next.37
-      '@verdaccio/utils': 6.0.0-6-next.39
-      debug: 4.3.4(supports-color@9.3.1)
+      '@verdaccio/config': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/url': 11.0.0-6-next.40
+      '@verdaccio/utils': 6.0.0-6-next.42
+      debug: 4.3.4(supports-color@9.4.0)
       express: 4.18.2
       express-rate-limit: 5.5.1
       lodash: 4.17.21
@@ -43985,7 +42951,7 @@ packages:
     resolution: {integrity: sha512-aFvMbxxHzJCpPmqSgVuQYvYN2RP11CoSEcTXikkyb1zF4Uf3cOy53zUZ1Y7iOKCRYTgWrmet9KP7+24e44GHxg==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       jsonwebtoken: 9.0.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -43997,43 +42963,43 @@ packages:
     engines: {node: '>=12', npm: '>=5'}
     dev: false
 
-  /@verdaccio/tarball@11.0.0-6-next.40:
-    resolution: {integrity: sha512-1470DzyV9fdEsjqFhjOQ/5kU5EEgHXV8tyqKyZK+AQ+2g6mpj6NfU5Q82fpmoyzNlPGjREygE75KBv/niRCgRA==}
+  /@verdaccio/tarball@11.0.0-6-next.43:
+    resolution: {integrity: sha512-/cojl1+EWLhfu5FJh/dLBtwwC+vI6dR0xldJvE7BHJ5P79DnBUbzAqtwoWwsOR2FkGkWoReXZjPR4QVrUivhLA==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
-      '@verdaccio/url': 11.0.0-6-next.37
-      '@verdaccio/utils': 6.0.0-6-next.39
-      debug: 4.3.4(supports-color@9.3.1)
+      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/url': 11.0.0-6-next.40
+      '@verdaccio/utils': 6.0.0-6-next.42
+      debug: 4.3.4(supports-color@9.4.0)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/ui-theme@6.0.0-6-next.71:
-    resolution: {integrity: sha512-HX9NY0pZSg/H1C4GHLGzt91Xo5Oq8+VyZYN3JocHKev/EIE6G2/UuInKGAJxxdSIkno6jUyfrGZi2t9Qhgwwnw==}
+  /@verdaccio/ui-theme@6.0.0-6-next.74:
+    resolution: {integrity: sha512-IoAl4bbLF9SFJsQvyEbJeubRs0O2WusOOgry6vsfp1w48+oarcnGkdOU/WZuIdlFhmPdhOJpYL0cFDUBRDvdOA==}
     dev: false
 
-  /@verdaccio/url@11.0.0-6-next.37:
-    resolution: {integrity: sha512-bPEq/aS77IzMUv7H1Zq4fVJeM7IxIImCan+ydQzFWGJfoGXgAz8p5PBm1+fqCgtEyQ/TeK6EowdXitX9lAIGVQ==}
+  /@verdaccio/url@11.0.0-6-next.40:
+    resolution: {integrity: sha512-TGP+96QEgvQMIx+0WsFmxpeV/YJlX+os85zrBipioZDUm/JmNK6i9wCfYjA5Uncn+NGRsI6bUJhi05Ymoh10cA==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
-      debug: 4.3.4(supports-color@9.3.1)
+      '@verdaccio/core': 6.0.0-6-next.74
+      debug: 4.3.4(supports-color@9.4.0)
       lodash: 4.17.21
       validator: 13.9.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/utils@6.0.0-6-next.39:
-    resolution: {integrity: sha512-V4+pBaXxObgofHcAw7BZXv2RZwCi2KaWNIcpQNYz6AcF15gLT0C2/8e1M8nMLb7Qnips3fetpA26VNNvl5XRdw==}
+  /@verdaccio/utils@6.0.0-6-next.42:
+    resolution: {integrity: sha512-ckf1N0rlnWd07aQQx+K9/fvO1LtSVGAAls22Isdfb+dfBjUYalIha/EDIEr3mq7QTqm0zA6mLhP7m4Bv35FH6g==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.74
       lodash: 4.17.21
       minimatch: 3.1.2
-      semver: 7.5.0
+      semver: 7.5.4
     dev: false
 
   /@webassemblyjs/ast@1.11.6:
@@ -44131,13 +43097,13 @@ packages:
     resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
 
-  /@wry/context@0.7.0:
-    resolution: {integrity: sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==}
+  /@wry/context@0.7.3:
+    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
 
   /@wry/equality@0.1.11:
     resolution: {integrity: sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==}
@@ -44145,17 +43111,17 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@wry/equality@0.5.3:
-    resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
+  /@wry/equality@0.5.6:
+    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
 
   /@wry/trie@0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
 
   /@xobotyi/scrollbar-width@1.9.5:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
@@ -44199,7 +43165,7 @@ packages:
       clipanion: 3.2.0-rc.4
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.12.1
+      typanion: 3.13.0
       yup: 0.32.11
     dev: false
 
@@ -44248,10 +43214,10 @@ packages:
       '@arcanis/slice-ansi': 1.1.1
       '@types/semver': 7.3.4
       '@types/treeify': 1.0.0
-      '@yarnpkg/fslib': 3.0.0-rc.45
-      '@yarnpkg/libzip': 3.0.0-rc.45(@yarnpkg/fslib@3.0.0-rc.45)
-      '@yarnpkg/parsers': 3.0.0-rc.45
-      '@yarnpkg/shell': 4.0.0-rc.45
+      '@yarnpkg/fslib': 3.0.0-rc.48
+      '@yarnpkg/libzip': 3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48)
+      '@yarnpkg/parsers': 3.0.0-rc.48.1
+      '@yarnpkg/shell': 4.0.0-rc.48
       camelcase: 5.3.1
       chalk: 3.0.0
       ci-info: 3.8.0
@@ -44268,7 +43234,39 @@ packages:
       tar: 6.1.11
       tinylogic: 2.0.0
       treeify: 1.1.0
-      tslib: 2.5.0
+      tslib: 2.6.0
+      tunnel: 0.0.6
+    dev: false
+
+  /@yarnpkg/core@4.0.0-rc.48:
+    resolution: {integrity: sha512-GEJyVLD9XqnUr9f+ndpvewKYWenFbQ/Ki82mIW/YAIeomEF6Nqis2idL71LaxSr6kkTHvaa7JOSnNALLdbaD6w==}
+    engines: {node: '>=18.12.0'}
+    dependencies:
+      '@arcanis/slice-ansi': 1.1.1
+      '@types/semver': 7.3.4
+      '@types/treeify': 1.0.0
+      '@yarnpkg/fslib': 3.0.0-rc.48
+      '@yarnpkg/libzip': 3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48)
+      '@yarnpkg/parsers': 3.0.0-rc.48.1
+      '@yarnpkg/shell': 4.0.0-rc.48
+      camelcase: 5.3.1
+      chalk: 3.0.0
+      ci-info: 3.8.0
+      clipanion: 3.2.1
+      cross-spawn: 7.0.3
+      diff: 5.1.0
+      dotenv: 16.3.1
+      globby: 11.0.1
+      got: 11.8.6
+      lodash: 4.17.21
+      micromatch: 4.0.5
+      p-limit: 2.3.0
+      semver: 7.5.2
+      strip-ansi: 6.0.0
+      tar: 6.1.11
+      tinylogic: 2.0.0
+      treeify: 1.1.0
+      tslib: 2.6.0
       tunnel: 0.0.6
     dev: false
 
@@ -44298,11 +43296,11 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/fslib@3.0.0-rc.45:
-    resolution: {integrity: sha512-XarEtHTbeO4+rgZQObn16+uFzb1dXiVHuoqDNGoMywwBm/FF7DeCqSANeKiNYbi79WMgoLk8l3lO4g0vRYkJBg==}
-    engines: {node: '>=14.15.0'}
+  /@yarnpkg/fslib@3.0.0-rc.48:
+    resolution: {integrity: sha512-ej3fAmvcOHaKP5urPKw3MnSxTllfsFGEyjavHR4IlVkCwC+TdFN4OT64XvxBLXA51/RhkfRyIQq1BVrNiafTwQ==}
+    engines: {node: '>=18.12.0'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /@yarnpkg/json-proxy@2.1.1:
@@ -44321,15 +43319,15 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/libzip@3.0.0-rc.45(@yarnpkg/fslib@3.0.0-rc.45):
-    resolution: {integrity: sha512-ZsYi6Y01yMJOLnJ5ISZgOFvCEXzp4EScrM91D7bvCx0lIfH3DZ40H4M5nGNeVFk7jXUHOXuJkNYlNoXixSconA==}
-    engines: {node: '>=14.15.0'}
+  /@yarnpkg/libzip@3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48):
+    resolution: {integrity: sha512-WqqbaqRsS72LY3JXiHHrojTDG8PeeVwKBdn3NfQyqowzSVDr6Vu9c/WwWirR6K4QVmJKC1Obt1lKsAfMiRry0A==}
+    engines: {node: '>=18.12.0'}
     peerDependencies:
-      '@yarnpkg/fslib': ^3.0.0-rc.45
+      '@yarnpkg/fslib': ^3.0.0-rc.48
     dependencies:
       '@types/emscripten': 1.39.6
-      '@yarnpkg/fslib': 3.0.0-rc.45
-      tslib: 2.5.0
+      '@yarnpkg/fslib': 3.0.0-rc.48
+      tslib: 2.6.0
     dev: false
 
   /@yarnpkg/lockfile@1.1.0:
@@ -44349,9 +43347,9 @@ packages:
     resolution: {integrity: sha512-cMKhX2znU0JqkPNM5jSrHyS6zIcJrIf1SgzopNtWqzuvpmtpChRMUUS6RJafS8Gzq2iDXAnyb4pn0RIqlwB+Cw==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@yarnpkg/core': 4.0.0-rc.45
-      '@yarnpkg/fslib': 3.0.0-rc.45
-      '@yarnpkg/pnp': 4.0.0-rc.45
+      '@yarnpkg/core': 4.0.0-rc.48
+      '@yarnpkg/fslib': 3.0.0-rc.48
+      '@yarnpkg/pnp': 4.0.0-rc.48
     dev: false
 
   /@yarnpkg/parsers@2.5.1:
@@ -44362,12 +43360,11 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/parsers@3.0.0-rc.45:
-    resolution: {integrity: sha512-Aj0aHBV/crFQTpKQvL6k1xNiOhnlfVLu06LunelQAvl1MTeWrSi8LD9UJJDCFJiG4kx8NysUE6Tx0KZyPQUzIw==}
-    engines: {node: '>=14.15.0'}
+  /@yarnpkg/parsers@3.0.0-rc.48.1:
+    resolution: {integrity: sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==}
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /@yarnpkg/plugin-compat@3.1.13(@yarnpkg/core@3.5.2)(@yarnpkg/plugin-patch@3.2.4):
@@ -44418,7 +43415,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.12.1
+      typanion: 3.13.0
     dev: false
 
   /@yarnpkg/plugin-file@2.3.1(@yarnpkg/core@3.5.2):
@@ -44538,7 +43535,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.12.1
+      typanion: 3.13.0
     dev: false
 
   /@yarnpkg/plugin-npm@2.7.4(@yarnpkg/core@3.5.2)(@yarnpkg/plugin-pack@3.2.0):
@@ -44655,12 +43652,12 @@ packages:
       '@yarnpkg/fslib': 2.10.3
     dev: false
 
-  /@yarnpkg/pnp@4.0.0-rc.45:
-    resolution: {integrity: sha512-3m1gsj+ptDH2aAmmfP6RqVU0cyLJDNT2QUIe7yIRVs0oX1d6YK3Xkacm8d/EwOfDvwliEP0t6boRp2NQGxGB8Q==}
-    engines: {node: '>=14.15.0'}
+  /@yarnpkg/pnp@4.0.0-rc.48:
+    resolution: {integrity: sha512-veLzNrT9EUev/jEjZcZolw6KYbINN3UsBIVM0OlPNZhNBmHTdwO5dnNhhPoTQgauEye1zg7MEIUC9j5+5p1+mg==}
+    engines: {node: '>=18.12.0'}
     dependencies:
-      '@types/node': 18.11.18
-      '@yarnpkg/fslib': 3.0.0-rc.45
+      '@types/node': 18.16.19
+      '@yarnpkg/fslib': 3.0.0-rc.48
     dev: false
 
   /@yarnpkg/shell@3.2.5:
@@ -44679,19 +43676,19 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/shell@4.0.0-rc.45:
-    resolution: {integrity: sha512-I8VxA7GKlf6Uov9XaAJR0Xgvoh5+6CRsAB0AhV+/x8HwZzhF2CN8sytpiMJ5v7MtZpYk9kRkZsPypIY+/tkj+A==}
-    engines: {node: '>=14.15.0'}
+  /@yarnpkg/shell@4.0.0-rc.48:
+    resolution: {integrity: sha512-0FMPepj3C/hr6Vsbmcv3+/Go6fxn1imO25l2ctSem5fFKLPpH2vsYysyfG60tX+UgM3yysBwMKSFZTRUSYOmdQ==}
+    engines: {node: '>=18.12.0'}
     hasBin: true
     dependencies:
-      '@yarnpkg/fslib': 3.0.0-rc.45
-      '@yarnpkg/parsers': 3.0.0-rc.45
+      '@yarnpkg/fslib': 3.0.0-rc.48
+      '@yarnpkg/parsers': 3.0.0-rc.48.1
       chalk: 3.0.0
       clipanion: 3.2.1
       cross-spawn: 7.0.3
       fast-glob: 3.3.0
       micromatch: 4.0.5
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /@zkochan/cmd-shim@5.4.1:
@@ -44800,12 +43797,12 @@ packages:
       acorn-walk: 7.2.0
     dev: false
 
-  /acorn-import-assertions@1.9.0(acorn@8.8.2):
+  /acorn-import-assertions@1.9.0(acorn@8.10.0):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
 
   /acorn-jsx@3.0.1:
     resolution: {integrity: sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==}
@@ -44844,8 +43841,8 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn@8.8.2:
-    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
+  /acorn@8.10.0:
+    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -45147,7 +44144,7 @@ packages:
     peerDependencies:
       graphql: ^14.2.1 || ^15.0.0
     dependencies:
-      core-js-pure: 3.27.2
+      core-js-pure: 3.31.1
       graphql: 15.8.0
       lodash.sortby: 4.7.0
       sha.js: 2.4.11
@@ -45276,7 +44273,7 @@ packages:
     deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     dependencies:
       node-fetch: 2.6.7
-      util.promisify: 1.1.1
+      util.promisify: 1.1.2
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -45303,7 +44300,7 @@ packages:
       '@types/body-parser': 1.19.0
       '@types/cors': 2.8.10
       '@types/express': 4.17.13
-      '@types/express-serve-static-core': 4.17.33
+      '@types/express-serve-static-core': 4.17.35
       accepts: 1.3.8
       apollo-server-core: 2.26.1(bufferutil@4.0.3)(graphql@15.8.0)(utf-8-validate@5.0.5)
       apollo-server-types: 0.10.0(graphql@15.8.0)
@@ -45445,7 +44442,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.union: 4.6.0
       normalize-path: 3.0.0
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /archiver@5.3.1:
@@ -45455,8 +44452,8 @@ packages:
       archiver-utils: 2.1.0
       async: 3.2.4
       buffer-crc32: 0.2.13
-      readable-stream: 3.6.0
-      readdir-glob: 1.1.2
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
       tar-stream: 2.2.0
       zip-stream: 4.1.0
     dev: false
@@ -45469,7 +44466,7 @@ packages:
     resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
     optional: true
 
@@ -45478,7 +44475,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /argparse@1.0.10:
@@ -45510,13 +44507,18 @@ packages:
     engines: {node: '>=6.0'}
     dependencies:
       '@babel/runtime': 7.20.0
-      '@babel/runtime-corejs3': 7.20.13
+      '@babel/runtime-corejs3': 7.22.6
     dev: false
 
   /aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
     dependencies:
-      deep-equal: 2.2.0
+      deep-equal: 2.2.2
+
+  /aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+    dependencies:
+      dequal: 2.0.3
 
   /arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
@@ -45532,6 +44534,12 @@ packages:
     resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
     engines: {node: '>=0.10.0'}
     dev: false
+
+  /array-buffer-byte-length@1.0.0:
+    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
+    dependencies:
+      call-bind: 1.0.2
+      is-array-buffer: 3.0.2
 
   /array-differ@3.0.0:
     resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
@@ -45562,9 +44570,9 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
-      get-intrinsic: 1.2.0
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      get-intrinsic: 1.2.1
       is-string: 1.0.7
     dev: false
 
@@ -45587,8 +44595,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -45597,8 +44605,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -45607,10 +44615,22 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
       es-array-method-boxes-properly: 1.0.0
       is-string: 1.0.7
+    dev: false
+
+  /arraybuffer.prototype.slice@1.0.1:
+    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      array-buffer-byte-length: 1.0.0
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      get-intrinsic: 1.2.1
+      is-array-buffer: 3.0.2
+      is-shared-array-buffer: 1.0.2
     dev: false
 
   /arraybuffer.slice@0.0.7:
@@ -45705,7 +44725,7 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /ast-types@0.9.6:
@@ -45729,7 +44749,7 @@ packages:
   /async-mutex@0.3.1:
     resolution: {integrity: sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /async-retry@1.3.3:
@@ -45779,15 +44799,15 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /autoprefixer@10.4.13(postcss@8.4.18):
-    resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
+  /autoprefixer@10.4.14(postcss@8.4.18):
+    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.21.5
-      caniuse-lite: 1.0.30001450
+      browserslist: 4.21.9
+      caniuse-lite: 1.0.30001517
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -45822,8 +44842,8 @@ packages:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: false
 
-  /axe-core@4.6.3:
-    resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
+  /axe-core@4.7.2:
+    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
     engines: {node: '>=4'}
     dev: false
 
@@ -45867,7 +44887,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       find-cache-dir: 3.3.2
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
       webpack: 5.84.1(esbuild@0.14.29)
 
   /babel-plugin-apply-mdx-type-prop@1.6.21(@babel/core@7.11.6):
@@ -45896,7 +44916,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -45909,10 +44929,10 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.20.7
+      '@babel/template': 7.22.5
       '@babel/types': 7.22.3
       '@types/babel__core': 7.20.0
-      '@types/babel__traverse': 7.18.3
+      '@types/babel__traverse': 7.20.1
     dev: false
 
   /babel-plugin-macros@2.8.0:
@@ -45936,10 +44956,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.20.14
+      '@babel/compat-data': 7.22.9
       '@babel/core': 7.19.6
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.19.6)
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
@@ -45950,7 +44970,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.19.6)
-      core-js-compat: 3.27.2
+      core-js-compat: 3.31.1
     transitivePeerDependencies:
       - supports-color
 
@@ -45967,7 +44987,7 @@ packages:
   /babel-plugin-ramda@2.1.1:
     resolution: {integrity: sha512-J/+7vUTTmwF47QFsLx7A1YjAg0ZS3kx5NtajMGuYEntwD+4jg8vFEos4sNsiEBj4LsXZNqpkQEa7/bbJ3IvEEg==}
     dependencies:
-      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-module-imports': 7.22.5
     dev: false
 
   /babel-plugin-transform-react-remove-prop-types@0.4.24:
@@ -45984,7 +45004,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-plugin-utils': 7.22.5
     dev: false
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.19.6):
@@ -46027,7 +45047,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-proposal-numeric-separator': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-proposal-optional-chaining': 7.12.1(@babel/core@7.12.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.12.3)
       '@babel/plugin-transform-flow-strip-types': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-transform-react-display-name': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-transform-runtime': 7.12.1(@babel/core@7.12.3)
@@ -46113,7 +45133,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       cmd-shim: 6.0.1
-      npm-normalize-package-bin: 3.0.0
+      npm-normalize-package-bin: 3.0.1
       read-cmd-shim: 4.0.0
       write-file-atomic: 5.0.0
     dev: false
@@ -46139,7 +45159,7 @@ packages:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /blob@0.0.5:
@@ -46149,7 +45169,7 @@ packages:
   /block-stream2@2.1.0:
     resolution: {integrity: sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==}
     dependencies:
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /bluebird@3.7.2:
@@ -46221,28 +45241,8 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /body-parser@1.20.2:
-    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
-    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
-    dependencies:
-      bytes: 3.1.2
-      content-type: 1.0.5
-      debug: 2.6.9
-      depd: 2.0.0
-      destroy: 1.2.0
-      http-errors: 2.0.0
-      iconv-lite: 0.4.24
-      on-finished: 2.4.1
-      qs: 6.11.0
-      raw-body: 2.5.2
-      type-is: 1.6.18
-      unpipe: 1.0.0
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /bole@5.0.3:
-    resolution: {integrity: sha512-4o8wk9dlpU0e69sXhIsPIaFfXgOvj6en2GgZkG8hadkqNEqYKcz9Y70ijg7Kjq9hz2prJkWXljca5OBJZ451xg==}
+  /bole@5.0.6:
+    resolution: {integrity: sha512-HtZbVmxHqreaC29XVvGPShDtL2zSafkLe8vMdvFr4ppvtjrObVxtejoU/3jpRbxzxFeqDLXv5oIxUhSVw1NaAw==}
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
@@ -46362,7 +45362,7 @@ packages:
     resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
     dependencies:
       cipher-base: 1.0.4
-      des.js: 1.0.1
+      des.js: 1.1.0
       inherits: 2.0.4
       safe-buffer: 5.2.1
     dev: false
@@ -46384,7 +45384,7 @@ packages:
       elliptic: 6.5.4
       inherits: 2.0.4
       parse-asn1: 5.1.6
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       safe-buffer: 5.2.1
     dev: false
 
@@ -46405,8 +45405,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001450
-      electron-to-chromium: 1.4.284
+      caniuse-lite: 1.0.30001517
+      electron-to-chromium: 1.4.466
       escalade: 3.1.1
       node-releases: 1.1.77
     dev: false
@@ -46416,21 +45416,21 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001450
+      caniuse-lite: 1.0.30001517
       colorette: 1.4.0
-      electron-to-chromium: 1.4.284
+      electron-to-chromium: 1.4.466
       escalade: 3.1.1
       node-releases: 1.1.77
 
-  /browserslist@4.21.5:
-    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
+  /browserslist@4.21.9:
+    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001450
-      electron-to-chromium: 1.4.284
-      node-releases: 2.0.9
-      update-browserslist-db: 1.0.10(browserslist@4.21.5)
+      caniuse-lite: 1.0.30001517
+      electron-to-chromium: 1.4.466
+      node-releases: 2.0.13
+      update-browserslist-db: 1.0.11(browserslist@4.21.9)
 
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -46457,7 +45457,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.2.1
+      ieee754: 1.1.13
       isarray: 1.0.0
     dev: false
 
@@ -46591,14 +45591,14 @@ packages:
     engines: {node: '>=10.6.0'}
     dev: false
 
-  /cacheable-request@7.0.2:
-    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
+  /cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
     dependencies:
       clone-response: 1.0.3
       get-stream: 5.2.0
       http-cache-semantics: 4.1.1
-      keyv: 4.5.2
+      keyv: 4.5.3
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
@@ -46608,7 +45608,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
 
   /call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
@@ -46642,7 +45642,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /camelcase-css@2.0.1:
@@ -46688,20 +45688,20 @@ packages:
     resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
     engines: {node: '>=10.13'}
     dependencies:
-      path-temp: 2.0.0
+      path-temp: 2.1.0
     dev: false
 
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.16.3
-      caniuse-lite: 1.0.30001450
+      caniuse-lite: 1.0.30001517
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
 
-  /caniuse-lite@1.0.30001450:
-    resolution: {integrity: sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==}
+  /caniuse-lite@1.0.30001517:
+    resolution: {integrity: sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==}
 
   /capture-stack-trace@1.0.2:
     resolution: {integrity: sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==}
@@ -46861,21 +45861,6 @@ packages:
       regexp-to-ast: 0.5.0
     dev: false
 
-  /chokidar@3.5.1:
-    resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
-    engines: {node: '>= 8.10.0'}
-    dependencies:
-      anymatch: 3.1.3
-      braces: 3.0.2
-      glob-parent: 5.1.2
-      is-binary-path: 2.1.0
-      is-glob: 4.0.1
-      normalize-path: 3.0.0
-      readdirp: 3.5.0
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -46928,8 +45913,8 @@ packages:
     deprecated: CircularJSON is in maintenance only, flatted is its successor.
     dev: false
 
-  /cjs-module-lexer@1.2.2:
-    resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+  /cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
     dev: false
 
   /class-transformer@0.5.1:
@@ -47040,8 +46025,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /cli-spinners@2.7.0:
-    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
+  /cli-spinners@2.9.0:
+    resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
     engines: {node: '>=6'}
     dev: false
 
@@ -47077,22 +46062,16 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /clipanion@3.2.0:
-    resolution: {integrity: sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==}
-    dependencies:
-      typanion: 3.12.1
-    dev: false
-
   /clipanion@3.2.0-rc.4:
     resolution: {integrity: sha512-wkW5IYIK63i2aSmFr8EoRjEpZmy3KFXezDn4K8dBct7pq0hWWDFUoqwXTMIXWyBIEJFekmZ9v5wX+JtRBMZbOA==}
     dependencies:
-      typanion: 3.12.1
+      typanion: 3.13.0
     dev: false
 
   /clipanion@3.2.1:
     resolution: {integrity: sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==}
     dependencies:
-      typanion: 3.12.1
+      typanion: 3.13.0
     dev: false
 
   /cliui@6.0.0:
@@ -47150,7 +46129,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       process-nextick-args: 2.0.1
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /clsx@1.2.1:
@@ -47198,8 +46177,8 @@ packages:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
     dev: false
 
-  /collect-v8-coverage@1.0.1:
-    resolution: {integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==}
+  /collect-v8-coverage@1.0.2:
+    resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
     dev: false
 
   /collection-visit@1.0.0:
@@ -47252,9 +46231,6 @@ packages:
 
   /colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
-
-  /colorette@2.0.19:
-    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -47389,7 +46365,7 @@ packages:
       buffer-crc32: 0.2.13
       crc32-stream: 4.0.2
       normalize-path: 3.0.0
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /compressible@2.0.18:
@@ -47404,7 +46380,7 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
       serialize-javascript: 6.0.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -47437,7 +46413,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       typedarray: 0.0.6
     dev: false
 
@@ -47447,7 +46423,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       typedarray: 0.0.6
     dev: false
 
@@ -47552,13 +46528,13 @@ packages:
     dependencies:
       toggle-selection: 1.0.6
 
-  /core-js-compat@3.27.2:
-    resolution: {integrity: sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==}
+  /core-js-compat@3.31.1:
+    resolution: {integrity: sha512-wIDWd2s5/5aJSdpOJHfSibxNODxoGoWOBHt8JSPB41NOE94M7kuTPZCYLOlTtuoXTsBPKobpJ6T+y0SSy5L9SA==}
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
 
-  /core-js-pure@3.27.2:
-    resolution: {integrity: sha512-Cf2jqAbXgWH3VVzjyaaFkY1EBazxugUepGymDoeteyYr9ByX51kD2jdHZlsEF/xnJMyN3Prua7mQuzwMg6Zc9A==}
+  /core-js-pure@3.31.1:
+    resolution: {integrity: sha512-w+C62kvWti0EPs4KPMCMVv9DriHSXfQOCQ94bGGBiEW5rrbtt/Rz8n5Krhfw9cpFyzXBjf3DB3QnPdEzGDY4Fw==}
     requiresBuild: true
     dev: false
 
@@ -47625,7 +46601,7 @@ packages:
     hasBin: true
     dependencies:
       graceful-fs: 4.2.10
-      minimist: 1.2.7
+      minimist: 1.2.8
       mkdirp: 0.5.6
       rimraf: 2.7.1
     dev: false
@@ -47650,7 +46626,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       crc-32: 1.2.2
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /create-ecdh@4.0.4:
@@ -47732,7 +46708,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.1
+      semver: 5.7.2
       shebang-command: 1.2.0
       which: 1.3.1
     dev: false
@@ -47783,11 +46759,11 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
-  /css-declaration-sorter@6.3.1(postcss@8.4.18):
-    resolution: {integrity: sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==}
+  /css-declaration-sorter@6.4.1(postcss@8.4.18):
+    resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
@@ -47803,7 +46779,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /css-in-js-utils@2.0.1:
@@ -47830,11 +46806,11 @@ packages:
       loader-utils: 2.0.4
       postcss: 8.4.18
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.18)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.18)
+      postcss-modules-local-by-default: 4.0.3(postcss@8.4.18)
       postcss-modules-scope: 3.0.0(postcss@8.4.18)
       postcss-modules-values: 4.0.0(postcss@8.4.18)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       semver: 7.5.2
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -47848,7 +46824,7 @@ packages:
       icss-utils: 5.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.18)
-      postcss-modules-local-by-default: 4.0.0(postcss@8.4.18)
+      postcss-modules-local-by-default: 4.0.3(postcss@8.4.18)
       postcss-modules-scope: 3.0.0(postcss@8.4.18)
       postcss-modules-values: 4.0.0(postcss@8.4.18)
       postcss-value-parser: 4.2.0
@@ -47869,11 +46845,11 @@ packages:
       csso:
         optional: true
     dependencies:
-      cssnano: 5.1.14(postcss@8.4.18)
+      cssnano: 5.1.15(postcss@8.4.18)
       jest-worker: 27.5.1
       p-limit: 3.1.0
       postcss: 8.4.18
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
       webpack: 5.84.1(esbuild@0.14.29)
@@ -47963,8 +46939,8 @@ packages:
       source-map: 0.6.1
       source-map-resolve: 0.6.0
 
-  /cssdb@7.4.1:
-    resolution: {integrity: sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==}
+  /cssdb@7.6.0:
+    resolution: {integrity: sha512-Nna7rph8V0jC6+JBY4Vk4ndErUmfJfV6NJCaZdurL0omggabiy+QB2HCQtu5c/ACLZ0I7REv7A4QyPIoYzZx0w==}
     dev: false
 
   /cssesc@3.0.0:
@@ -47977,24 +46953,24 @@ packages:
     resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
     dev: false
 
-  /cssnano-preset-default@5.2.13(postcss@8.4.18):
-    resolution: {integrity: sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==}
+  /cssnano-preset-default@5.2.14(postcss@8.4.18):
+    resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.3.1(postcss@8.4.18)
+      css-declaration-sorter: 6.4.1(postcss@8.4.18)
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-calc: 8.2.4(postcss@8.4.18)
-      postcss-colormin: 5.3.0(postcss@8.4.18)
+      postcss-colormin: 5.3.1(postcss@8.4.18)
       postcss-convert-values: 5.1.3(postcss@8.4.18)
       postcss-discard-comments: 5.1.2(postcss@8.4.18)
       postcss-discard-duplicates: 5.1.0(postcss@8.4.18)
       postcss-discard-empty: 5.1.1(postcss@8.4.18)
       postcss-discard-overridden: 5.1.0(postcss@8.4.18)
       postcss-merge-longhand: 5.1.7(postcss@8.4.18)
-      postcss-merge-rules: 5.1.3(postcss@8.4.18)
+      postcss-merge-rules: 5.1.4(postcss@8.4.18)
       postcss-minify-font-values: 5.1.0(postcss@8.4.18)
       postcss-minify-gradients: 5.1.1(postcss@8.4.18)
       postcss-minify-params: 5.1.4(postcss@8.4.18)
@@ -48009,7 +46985,7 @@ packages:
       postcss-normalize-url: 5.1.0(postcss@8.4.18)
       postcss-normalize-whitespace: 5.1.1(postcss@8.4.18)
       postcss-ordered-values: 5.1.3(postcss@8.4.18)
-      postcss-reduce-initial: 5.1.1(postcss@8.4.18)
+      postcss-reduce-initial: 5.1.2(postcss@8.4.18)
       postcss-reduce-transforms: 5.1.0(postcss@8.4.18)
       postcss-svgo: 5.1.0(postcss@8.4.18)
       postcss-unique-selectors: 5.1.1(postcss@8.4.18)
@@ -48024,14 +47000,14 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /cssnano@5.1.14(postcss@8.4.18):
-    resolution: {integrity: sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==}
+  /cssnano@5.1.15(postcss@8.4.18):
+    resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-preset-default: 5.2.13(postcss@8.4.18)
-      lilconfig: 2.0.6
+      cssnano-preset-default: 5.2.14(postcss@8.4.18)
+      lilconfig: 2.1.0
       postcss: 8.4.18
       yaml: 1.10.2
     dev: false
@@ -48058,8 +47034,15 @@ packages:
       cssom: 0.3.8
     dev: false
 
-  /csstype@3.1.1:
-    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+  /cssstyle@3.0.0:
+    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
+    engines: {node: '>=14'}
+    dependencies:
+      rrweb-cssom: 0.6.0
+    dev: false
+
+  /csstype@3.1.2:
+    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
 
   /cycle@1.0.3:
     resolution: {integrity: sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==}
@@ -48165,6 +47148,15 @@ packages:
       whatwg-url: 8.7.0
     dev: false
 
+  /data-urls@4.0.0:
+    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
+    engines: {node: '>=14'}
+    dependencies:
+      abab: 2.0.6
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
+    dev: false
+
   /date-format@0.0.2:
     resolution: {integrity: sha512-M4obuJx8jU5T91lcbwi0+QPNVaWOY1DQYz5xUuKYWO93osVzB2ZPqyDUc5T+mDjbA1X8VOb4JDZ+8r2MrSOp7Q==}
     deprecated: 0.x is no longer supported. Please upgrade to 4.x or higher.
@@ -48235,7 +47227,7 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /debug@4.3.4(supports-color@9.3.1):
+  /debug@4.3.4(supports-color@9.4.0):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -48245,7 +47237,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 9.3.1
+      supports-color: 9.4.0
     dev: false
 
   /decamelize@1.2.0:
@@ -48301,14 +47293,15 @@ packages:
     resolution: {integrity: sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ==}
     dev: false
 
-  /deep-equal@2.2.0:
-    resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
+  /deep-equal@2.2.2:
+    resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
     dependencies:
+      array-buffer-byte-length: 1.0.0
       call-bind: 1.0.2
       es-get-iterator: 1.1.3
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       is-arguments: 1.1.1
-      is-array-buffer: 3.0.1
+      is-array-buffer: 3.0.2
       is-date-object: 1.0.5
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
@@ -48316,11 +47309,11 @@ packages:
       object-is: 1.1.5
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
+      regexp.prototype.flags: 1.5.0
       side-channel: 1.0.4
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.9
+      which-typed-array: 1.1.11
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -48333,11 +47326,6 @@ packages:
 
   /deepmerge@4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  /deepmerge@4.3.0:
-    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -48367,8 +47355,8 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  /define-properties@1.1.4:
-    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
+  /define-properties@1.2.0:
+    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
@@ -48444,8 +47432,12 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /des.js@1.0.1:
-    resolution: {integrity: sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==}
+  /dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  /des.js@1.1.0:
+    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
@@ -48475,8 +47467,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /detect-libc@2.0.1:
-    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
+  /detect-libc@2.0.2:
+    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
     engines: {node: '>=8'}
     dev: false
 
@@ -48666,6 +47658,13 @@ packages:
       webidl-conversions: 5.0.0
     dev: false
 
+  /domexception@4.0.0:
+    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
+    engines: {node: '>=12'}
+    dependencies:
+      webidl-conversions: 7.0.0
+    dev: false
+
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
@@ -48692,7 +47691,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /dot-prop@4.2.1:
@@ -48700,6 +47699,16 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-obj: 1.0.1
+    dev: false
+
+  /dotenv@16.3.1:
+    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /dset@3.1.2:
+    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
+    engines: {node: '>=4'}
     dev: false
 
   /duplexer2@0.0.2:
@@ -48721,7 +47730,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       inherits: 2.0.4
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       stream-shift: 1.0.1
     dev: false
 
@@ -48730,7 +47739,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       stream-shift: 1.0.1
     dev: false
 
@@ -48743,7 +47752,7 @@ packages:
     peerDependencies:
       react: ^16.8.0
     dependencies:
-      immer: 9.0.19
+      immer: 9.0.21
       is-plain-object: 5.0.0
       memoizerific: 1.11.3
       react: 17.0.2
@@ -48776,8 +47785,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /electron-to-chromium@1.4.284:
-    resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
+  /electron-to-chromium@1.4.466:
+    resolution: {integrity: sha512-TSkRvbXRXD8BwhcGlZXDsbI2lRoP8dvqR7LQnqQNk9KxXBc4tG8O+rTuXgTyIpEdiqSGKEBSqrxdqEntnjNncA==}
 
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -48830,7 +47839,6 @@ packages:
 
   /encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-    requiresBuild: true
     dependencies:
       iconv-lite: 0.6.3
     dev: false
@@ -48886,8 +47894,8 @@ packages:
       tapable: 1.1.3
     dev: false
 
-  /enhanced-resolve@5.14.1:
-    resolution: {integrity: sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==}
+  /enhanced-resolve@5.15.0:
+    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
@@ -48931,8 +47939,8 @@ packages:
       through: 2.3.8
     dev: false
 
-  /envinfo@7.8.1:
-    resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
+  /envinfo@7.10.0:
+    resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
     engines: {node: '>=4'}
     hasBin: true
     dev: false
@@ -48959,17 +47967,18 @@ packages:
     dependencies:
       stackframe: 1.3.4
 
-  /es-abstract@1.21.1:
-    resolution: {integrity: sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==}
+  /es-abstract@1.22.1:
+    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
     engines: {node: '>= 0.4'}
     dependencies:
+      array-buffer-byte-length: 1.0.0
+      arraybuffer.prototype.slice: 1.0.1
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
-      function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
@@ -48977,25 +47986,30 @@ packages:
       has-property-descriptors: 1.0.0
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.4
-      is-array-buffer: 3.0.1
+      internal-slot: 1.0.5
+      is-array-buffer: 3.0.2
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.4.3
+      regexp.prototype.flags: 1.5.0
+      safe-array-concat: 1.0.0
       safe-regex-test: 1.0.0
+      string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
+      typed-array-buffer: 1.0.0
+      typed-array-byte-length: 1.0.0
+      typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.9
+      which-typed-array: 1.1.11
     dev: false
 
   /es-array-method-boxes-properly@1.0.0:
@@ -49006,7 +48020,7 @@ packages:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has-symbols: 1.0.3
       is-arguments: 1.1.1
       is-map: 2.0.2
@@ -49015,14 +48029,14 @@ packages:
       isarray: 2.0.5
       stop-iteration-iterator: 1.0.0
 
-  /es-module-lexer@1.2.1:
-    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
+  /es-module-lexer@1.3.0:
+    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: false
@@ -49309,15 +48323,14 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /escodegen@2.0.0:
-    resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
+  /escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:
       esprima: 4.0.1
       estraverse: 5.3.0
       esutils: 2.0.3
-      optionator: 0.8.3
     optionalDependencies:
       source-map: 0.6.1
     dev: false
@@ -49328,6 +48341,20 @@ packages:
     peerDependencies:
       eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
       eslint-plugin-import: ^2.21.2
+    dependencies:
+      confusing-browser-globals: 1.0.11
+      eslint: 7.32.0
+      eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
+      object.assign: 4.1.4
+      object.entries: 1.1.6
+    dev: false
+
+  /eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0):
+    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.22.1
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
@@ -49359,8 +48386,8 @@ packages:
     resolution: {integrity: sha512-pzkOGX76OEd3AmxWPJUwasz4CY98KHNQgdwsiFpYd/M35vC33WiD9OaLq8eFYysy7+NVJtUuElgn879lrQ1rPw==}
     dependencies:
       '@typescript-eslint/parser': 2.34.0(eslint@7.32.0)(typescript@4.7.4)
-      eslint-config-airbnb: 18.2.0(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)
-      eslint-config-airbnb-base: 14.2.0(eslint-plugin-import@2.22.1)(eslint@7.32.0)
+      eslint-config-airbnb: 18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)
+      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0)
     transitivePeerDependencies:
       - eslint
       - eslint-plugin-import
@@ -49383,6 +48410,26 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-airbnb-base: 14.2.0(eslint-plugin-import@2.22.1)(eslint@7.32.0)
+      eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
+      eslint-plugin-jsx-a11y: 6.4.1(eslint@7.32.0)
+      eslint-plugin-react: 7.22.0(eslint@7.32.0)
+      eslint-plugin-react-hooks: 4.2.0(eslint@7.32.0)
+      object.assign: 4.1.4
+      object.entries: 1.1.6
+    dev: false
+
+  /eslint-config-airbnb@18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0):
+    resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
+    engines: {node: '>= 6'}
+    peerDependencies:
+      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
+      eslint-plugin-import: ^2.22.1
+      eslint-plugin-jsx-a11y: ^6.4.1
+      eslint-plugin-react: ^7.21.5
+      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
+    dependencies:
+      eslint: 7.32.0
+      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0)
       eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.4.1(eslint@7.32.0)
       eslint-plugin-react: 7.22.0(eslint@7.32.0)
@@ -49420,14 +48467,14 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.5.0
+      tslib: 2.6.0
       unified: 9.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0):
-    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -49473,13 +48520,13 @@ packages:
       doctrine: 1.5.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0)
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0)
       has: 1.0.3
       minimatch: 3.0.5
       object.values: 1.1.6
       read-pkg-up: 2.0.0
       resolve: 1.20.0
-      tsconfig-paths: 3.14.1
+      tsconfig-paths: 3.14.2
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -49509,14 +48556,14 @@ packages:
       aria-query: 4.2.2
       array-includes: 3.1.6
       ast-types-flow: 0.0.7
-      axe-core: 4.6.3
+      axe-core: 4.7.2
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 7.32.0
       has: 1.0.3
-      jsx-ast-utils: 3.3.3
-      language-tags: 1.0.7
+      jsx-ast-utils: 3.3.4
+      language-tags: 1.0.8
     dev: false
 
   /eslint-plugin-markdown@2.2.1(eslint@7.32.0):
@@ -49545,7 +48592,7 @@ packages:
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
       synckit: 0.1.6
-      tslib: 2.5.0
+      tslib: 2.6.0
       unified: 9.2.2
       vfile: 4.2.1
     transitivePeerDependencies:
@@ -49588,7 +48635,7 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       has: 1.0.3
-      jsx-ast-utils: 3.3.3
+      jsx-ast-utils: 3.3.4
       object.entries: 1.1.6
       object.fromentries: 2.0.6
       object.values: 1.1.6
@@ -49646,8 +48693,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-visitor-keys@3.3.0:
-    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
+  /eslint-visitor-keys@3.4.1:
+    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -49666,7 +48713,7 @@ packages:
       eslint-scope: 3.7.3
       eslint-visitor-keys: 1.3.0
       espree: 3.5.4
-      esquery: 1.4.0
+      esquery: 1.5.0
       esutils: 2.0.3
       file-entry-cache: 2.0.0
       functional-red-black-tree: 1.0.1
@@ -49689,7 +48736,7 @@ packages:
       progress: 2.0.3
       regexpp: 1.1.0
       require-uncached: 1.0.3
-      semver: 5.7.1
+      semver: 5.7.2
       strip-ansi: 4.0.0
       strip-json-comments: 2.0.1
       table: 4.0.2
@@ -49703,7 +48750,7 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
@@ -49713,7 +48760,7 @@ packages:
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.3.0
       espree: 6.2.1
-      esquery: 1.4.0
+      esquery: 1.5.0
       esutils: 2.0.3
       file-entry-cache: 5.0.1
       functional-red-black-tree: 1.0.1
@@ -49734,7 +48781,7 @@ packages:
       optionator: 0.8.3
       progress: 2.0.3
       regexpp: 2.0.1
-      semver: 6.3.0
+      semver: 6.3.1
       strip-ansi: 5.2.0
       strip-json-comments: 3.1.1
       table: 5.4.6
@@ -49763,7 +48810,7 @@ packages:
       eslint-utils: 2.1.0
       eslint-visitor-keys: 2.1.0
       espree: 7.3.1
-      esquery: 1.4.0
+      esquery: 1.5.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
@@ -49780,7 +48827,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.0.5
       natural-compare: 1.4.0
-      optionator: 0.9.1
+      optionator: 0.9.3
       progress: 2.0.3
       regexpp: 3.2.0
       semver: 7.5.2
@@ -49837,8 +48884,8 @@ packages:
     hasBin: true
     dev: false
 
-  /esquery@1.4.0:
-    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
+  /esquery@1.5.0:
+    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -50016,7 +49063,7 @@ packages:
       content-type: 1.0.5
       graphql: 15.8.0
       http-errors: 1.8.0
-      raw-body: 2.5.1
+      raw-body: 2.5.2
     dev: false
 
   /express-history-api-fallback@2.2.1:
@@ -50250,17 +49297,6 @@ packages:
     resolution: {integrity: sha512-XXA9RmlPatkFKUzqVZAFth18R4Wo+Xug/S+C7YlYA3xrXwfPlW3dqNwOb4hvQo7wZJ2cNDYhrYuPzVOfHy5/uQ==}
     dev: false
 
-  /fast-glob@3.2.12:
-    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
-    engines: {node: '>=8.6.0'}
-    dependencies:
-      '@nodelib/fs.stat': 2.0.5
-      '@nodelib/fs.walk': 1.2.8
-      glob-parent: 5.1.2
-      merge2: 1.4.1
-      micromatch: 4.0.5
-    dev: false
-
   /fast-glob@3.3.0:
     resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
     engines: {node: '>=8.6.0'}
@@ -50282,8 +49318,8 @@ packages:
   /fast-loops@1.1.3:
     resolution: {integrity: sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==}
 
-  /fast-redact@3.1.2:
-    resolution: {integrity: sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==}
+  /fast-redact@3.2.0:
+    resolution: {integrity: sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==}
     engines: {node: '>=6'}
     dev: false
 
@@ -50357,8 +49393,8 @@ packages:
       ua-parser-js: 0.7.24
     dev: false
 
-  /fbjs@3.0.4:
-    resolution: {integrity: sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==}
+  /fbjs@3.0.5:
+    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
     dependencies:
       cross-fetch: 3.1.5
       fbjs-css-vars: 1.0.2
@@ -50366,7 +49402,7 @@ packages:
       object-assign: 4.1.1
       promise: 7.3.1
       setimmediate: 1.0.5
-      ua-parser-js: 0.7.33
+      ua-parser-js: 1.0.35
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -50581,7 +49617,7 @@ packages:
     resolution: {integrity: sha512-X8Z+b/0L4lToKYq+lwnKqi9X/Zek0NibLpsJgVsSxpoYq7JtiCtRb5HqKVEjEw/qAb/4AKKRLOwwKHlWNpm2Eg==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /firstline@2.0.2:
@@ -50683,12 +49719,12 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.10.4
       chalk: 2.4.2
       eslint: 7.32.0
       micromatch: 3.1.10
       minimatch: 3.0.5
-      semver: 5.7.1
+      semver: 5.7.2
       tapable: 1.1.3
       typescript: 4.7.4
       webpack: 5.84.1(esbuild@0.14.29)
@@ -50713,6 +49749,15 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
+
+  /form-data@4.0.0:
+    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: false
 
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -50804,6 +49849,10 @@ packages:
 
   /fs-monkey@1.0.3:
     resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==}
+    dev: false
+
+  /fs-monkey@1.0.4:
+    resolution: {integrity: sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==}
 
   /fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -50827,8 +49876,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
       functions-have-names: 1.2.3
     dev: false
 
@@ -50896,11 +49945,12 @@ packages:
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
 
-  /get-intrinsic@1.2.0:
-    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
+  /get-intrinsic@1.2.1:
+    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
+      has-proto: 1.0.1
       has-symbols: 1.0.3
 
   /get-npm-tarball-url@2.0.3:
@@ -50945,7 +49995,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
     dev: false
 
   /get-tsconfig@4.2.0:
@@ -50964,8 +50014,8 @@ packages:
       isobject: 3.0.1
     dev: false
 
-  /get-xpath@3.0.1:
-    resolution: {integrity: sha512-GWG+RbJ7VE40rn4/NYYGojQbgN3Eha0s223ZSz1IhHFcGlMU+X7H5Iyrbuz6csiWqedAKplpS3udLw9X1nqX5Q==}
+  /get-xpath@3.1.0:
+    resolution: {integrity: sha512-R/52dpa+WO8bO/df5VivWIf+VoI++iPVEPrAKRUSQHOBEK1cxKMmTxbhCoGUNIH+znE9ZvU5rFd188QkV4Q6QA==}
     dev: false
 
   /getpass@0.1.7:
@@ -51110,6 +50160,17 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
+  /glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.2
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+    dev: false
+
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
@@ -51166,7 +50227,7 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.1.4
+      define-properties: 1.2.0
     dev: false
 
   /globby@11.0.1:
@@ -51175,7 +50236,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.2.12
+      fast-glob: 3.3.0
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -51196,7 +50257,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
 
   /got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
@@ -51207,7 +50268,7 @@ packages:
       '@types/cacheable-request': 6.0.3
       '@types/responselike': 1.0.0
       cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.2
+      cacheable-request: 7.0.4
       decompress-response: 6.0.0
       http2-wrapper: 1.0.3
       lowercase-keys: 2.0.0
@@ -51324,7 +50385,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.5.0
+      tslib: 2.6.0
 
   /graphql-tools@4.0.8(graphql@15.8.0):
     resolution: {integrity: sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==}
@@ -51423,7 +50484,7 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
@@ -51485,12 +50546,11 @@ packages:
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
-    dev: false
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
@@ -51555,7 +50615,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       safe-buffer: 5.2.1
     dev: false
 
@@ -51569,7 +50629,7 @@ packages:
   /hast-to-hyperscript@9.0.1:
     resolution: {integrity: sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       comma-separated-tokens: 1.0.8
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
@@ -51606,7 +50666,7 @@ packages:
   /hast-util-raw@6.0.1:
     resolution: {integrity: sha512-ZMuiYA+UF7BXBtsTBNcLBF5HzXzkyE6MLzJnL605LKE8GJylNjGc4jjxazAHUtcwT5/CEt6afRKViYB4X66dig==}
     dependencies:
-      '@types/hast': 2.3.4
+      '@types/hast': 2.3.5
       hast-util-from-parse5: 6.0.1
       hast-util-to-parse5: 6.0.0
       html-void-elements: 1.0.5
@@ -51640,7 +50700,7 @@ packages:
   /hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
     dependencies:
-      '@types/hast': 2.3.4
+      '@types/hast': 2.3.5
       comma-separated-tokens: 1.0.8
       hast-util-parse-selector: 2.2.5
       property-information: 5.6.0
@@ -51661,7 +50721,7 @@ packages:
     resolution: {integrity: sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==}
     dependencies:
       glob: 8.1.0
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /highlight.js@10.7.3:
@@ -51710,7 +50770,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       obuf: 1.1.2
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       wbuf: 1.7.3
 
   /html-encoding-sniffer@2.0.1:
@@ -51720,8 +50780,15 @@ packages:
       whatwg-encoding: 1.0.5
     dev: false
 
-  /html-entities@2.3.3:
-    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
+  /html-encoding-sniffer@3.0.0:
+    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
+    engines: {node: '>=12'}
+    dependencies:
+      whatwg-encoding: 2.0.0
+    dev: false
+
+  /html-entities@2.4.0:
+    resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -51871,7 +50938,7 @@ packages:
     resolution: {integrity: sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/http-proxy': 1.17.9
+      '@types/http-proxy': 1.17.11
       http-proxy: 1.18.1(debug@4.3.2)
       is-glob: 4.0.1
       is-plain-obj: 3.0.0
@@ -51890,7 +50957,7 @@ packages:
         optional: true
     dependencies:
       '@types/express': 4.17.13
-      '@types/http-proxy': 1.17.9
+      '@types/http-proxy': 1.17.11
       http-proxy: 1.18.1(debug@4.3.2)
       is-glob: 4.0.1
       is-plain-obj: 3.0.0
@@ -52081,12 +51148,12 @@ packages:
     resolution: {integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==}
     dev: false
 
-  /immer@9.0.19:
-    resolution: {integrity: sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==}
+  /immer@9.0.21:
+    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
     dev: false
 
-  /immutable@4.2.2:
-    resolution: {integrity: sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==}
+  /immutable@4.3.1:
+    resolution: {integrity: sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==}
     dev: false
 
   /import-fresh@3.3.0:
@@ -52172,7 +51239,7 @@ packages:
     peerDependencies:
       html-webpack-plugin: ^5.3.1
     dependencies:
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.2
       html-webpack-plugin: 5.3.2(webpack@5.84.1)
       insert-string-after: 1.0.0
       insert-string-before: 1.0.0
@@ -52187,7 +51254,7 @@ packages:
       ink: '>=3.0.5'
       react: '>=16.8.2'
     dependencies:
-      cli-spinners: 2.7.0
+      cli-spinners: 2.9.0
       ink: 3.2.0(@types/react@17.0.8)(bufferutil@4.0.3)(react@17.0.2)(utf-8-validate@5.0.5)
       react: 17.0.2
     dev: false
@@ -52215,7 +51282,7 @@ packages:
       lodash: 4.17.21
       patch-console: 1.0.0
       react: 17.0.2
-      react-devtools-core: 4.27.1(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      react-devtools-core: 4.28.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       react-reconciler: 0.26.2(react@17.0.2)
       scheduler: 0.20.2
       signal-exit: 3.0.7
@@ -52338,11 +51405,11 @@ packages:
     resolution: {integrity: sha512-Z3sKgwLX+x22HyEUjHJe05GdetR3aYtJy17cXRaym57AwXwI8Z7dCbAiYB+3d8u9NW/qi8ZLNhTev29H7QXnXw==}
     dev: false
 
-  /internal-slot@1.0.4:
-    resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
+  /internal-slot@1.0.5:
+    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       has: 1.0.3
       side-channel: 1.0.4
 
@@ -52354,8 +51421,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  /ipaddr.js@2.0.1:
-    resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
+  /ipaddr.js@2.1.0:
+    resolution: {integrity: sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==}
     engines: {node: '>= 10'}
 
   /is-accessor-descriptor@0.1.6:
@@ -52395,12 +51462,12 @@ packages:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
 
-  /is-array-buffer@3.0.1:
-    resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
+  /is-array-buffer@3.0.2:
+    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
-      is-typed-array: 1.1.10
+      get-intrinsic: 1.2.1
+      is-typed-array: 1.1.12
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -52462,8 +51529,8 @@ packages:
       ci-info: 2.0.0
     dev: false
 
-  /is-core-module@2.11.0:
-    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
+  /is-core-module@2.12.1:
+    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
     dependencies:
       has: 1.0.3
 
@@ -52627,7 +51694,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
     dev: false
 
   /is-negative-zero@2.0.2:
@@ -52791,15 +51858,11 @@ packages:
     dependencies:
       has-symbols: 1.0.3
 
-  /is-typed-array@1.1.10:
-    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
+  /is-typed-array@1.1.12:
+    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      gopd: 1.0.1
-      has-tostringtag: 1.0.0
+      which-typed-array: 1.1.11
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -52831,7 +51894,7 @@ packages:
     resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
 
   /is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
@@ -52898,7 +51961,7 @@ packages:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
     dependencies:
       node-fetch: 1.7.3
-      whatwg-fetch: 3.6.2
+      whatwg-fetch: 3.6.16
     dev: false
 
   /isstream@0.1.2:
@@ -52915,10 +51978,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 6.3.0
+      semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -53234,7 +52297,7 @@ packages:
     resolution: {integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       '@jest/types': 26.6.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -53249,7 +52312,7 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -53356,8 +52419,8 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      cjs-module-lexer: 1.2.2
-      collect-v8-coverage: 1.0.1
+      cjs-module-lexer: 1.2.3
+      collect-v8-coverage: 1.0.2
       execa: 5.1.1
       glob: 7.1.6
       graceful-fs: 4.2.10
@@ -53387,13 +52450,13 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/generator': 7.20.14
-      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.19.6)
-      '@babel/traverse': 7.20.13
+      '@babel/generator': 7.22.9
+      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.19.6)
+      '@babel/traverse': 7.22.8
       '@babel/types': 7.22.3
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/babel__traverse': 7.18.3
+      '@types/babel__traverse': 7.20.1
       '@types/prettier': 2.3.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.19.6)
       chalk: 4.1.2
@@ -53461,7 +52524,7 @@ packages:
       jest-watcher: 27.5.1
       slash: 4.0.0
       string-length: 5.0.1
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: false
 
   /jest-watcher@27.5.1:
@@ -53565,24 +52628,24 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.8.2
+      acorn: 8.10.0
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
       data-urls: 2.0.0
       decimal.js: 10.4.3
       domexception: 2.0.1
-      escodegen: 2.0.0
+      escodegen: 2.1.0
       form-data: 3.0.1
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.0
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.2
+      nwsapi: 2.2.7
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.2
+      tough-cookie: 4.1.3
       w3c-hr-time: 1.0.2
       w3c-xmlserializer: 2.0.0
       webidl-conversions: 6.1.0
@@ -53591,6 +52654,44 @@ packages:
       whatwg-url: 8.7.0
       ws: 7.5.9(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+    dev: false
+
+  /jsdom@22.1.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
+    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+    dependencies:
+      abab: 2.0.6
+      cssstyle: 3.0.0
+      data-urls: 4.0.0
+      decimal.js: 10.4.3
+      domexception: 4.0.0
+      form-data: 4.0.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.7
+      parse5: 7.1.2
+      rrweb-cssom: 0.6.0
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.3
+      w3c-xmlserializer: 4.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 2.0.0
+      whatwg-mimetype: 3.0.0
+      whatwg-url: 12.0.1
+      ws: 8.13.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -53669,7 +52770,7 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: false
 
   /json5@2.2.3:
@@ -53710,6 +52811,16 @@ packages:
       semver: 7.5.2
     dev: false
 
+  /jsonwebtoken@9.0.1:
+    resolution: {integrity: sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==}
+    engines: {node: '>=12', npm: '>=6'}
+    dependencies:
+      jws: 3.2.2
+      lodash: 4.17.21
+      ms: 2.1.3
+      semver: 7.5.2
+    dev: false
+
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -53732,18 +52843,20 @@ packages:
       source-map: 0.4.4
     dev: false
 
-  /jsx-ast-utils@3.3.3:
-    resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
+  /jsx-ast-utils@3.3.4:
+    resolution: {integrity: sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.6
+      array.prototype.flat: 1.3.1
       object.assign: 4.1.4
+      object.values: 1.1.6
     dev: false
 
   /jsx-to-string@1.4.0:
     resolution: {integrity: sha512-BmDM0gMngtBcjET7iEDuMxU+ZA4fTFWhMWAfbJeZP0X0VIaN7+At3wa64v48hzuE9rf77VAwlI/aMJrR+9LEZA==}
     dependencies:
-      immutable: 4.2.2
+      immutable: 4.3.1
       json-stringify-pretty-compact: 1.2.0
       react: 0.14.10
     dev: false
@@ -53784,8 +52897,8 @@ packages:
       tsscmp: 1.0.6
     dev: false
 
-  /keyv@4.5.2:
-    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
+  /keyv@4.5.3:
+    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
     dependencies:
       json-buffer: 3.0.1
     dev: false
@@ -53843,8 +52956,8 @@ packages:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
 
-  /language-tags@1.0.7:
-    resolution: {integrity: sha512-bSytju1/657hFjgUzPAPqszxH62ouE8nQFoFaVlIQfne4wO/wXC9A4+m8jYve7YBBvi59eq0SUpcshvG8h5Usw==}
+  /language-tags@1.0.8:
+    resolution: {integrity: sha512-aWAZwgPLS8hJ20lNPm9HNVs4inexz6S2sQa3wx/+ycuutMNE5/IfYxiWYBbi+9UWCQVaXYCOPUl6gFrPR7+jGg==}
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false
@@ -53860,13 +52973,13 @@ packages:
     resolution: {integrity: sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==}
     dependencies:
       picocolors: 1.0.0
-      shell-quote: 1.8.0
+      shell-quote: 1.8.1
 
   /lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /less-loader@10.0.0(less@4.1.3)(webpack@5.84.1):
@@ -53900,7 +53013,7 @@ packages:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.5.0
+      tslib: 2.6.0
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.10
@@ -53939,8 +53052,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /lilconfig@2.0.6:
-    resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
+  /lilconfig@2.1.0:
+    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
     engines: {node: '>=10'}
     dev: false
 
@@ -53965,9 +53078,9 @@ packages:
     hasBin: true
     dependencies:
       cli-truncate: 3.1.0
-      colorette: 2.0.19
+      colorette: 2.0.20
       commander: 9.5.0
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       execa: 5.1.1
       lilconfig: 2.0.5
       listr2: 4.0.5(enquirer@2.3.6)
@@ -53975,8 +53088,8 @@ packages:
       normalize-path: 3.0.0
       object-inspect: 1.12.3
       pidtree: 0.5.0
-      string-argv: 0.3.1
-      supports-color: 9.3.1
+      string-argv: 0.3.2
+      supports-color: 9.4.0
       yaml: 1.10.2
     transitivePeerDependencies:
       - enquirer
@@ -54227,14 +53340,15 @@ packages:
       wrap-ansi: 6.2.0
     dev: false
 
-  /logform@2.4.2:
-    resolution: {integrity: sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==}
+  /logform@2.5.1:
+    resolution: {integrity: sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==}
     dependencies:
       '@colors/colors': 1.5.0
+      '@types/triple-beam': 1.3.2
       fecha: 4.2.3
       ms: 2.1.3
-      safe-stable-stringify: 2.4.2
-      triple-beam: 1.3.0
+      safe-stable-stringify: 2.4.3
+      triple-beam: 1.4.1
     dev: false
 
   /loglevel-colored-level-prefix@1.0.0:
@@ -54287,7 +53401,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /lowercase-keys@1.0.1:
@@ -54346,8 +53460,8 @@ packages:
       es5-ext: 0.10.62
     dev: false
 
-  /lz-string@1.4.4:
-    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
+  /lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
 
   /magic-string@0.25.9:
@@ -54368,14 +53482,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
 
   /make-empty-dir@2.0.0:
     resolution: {integrity: sha512-kKvqQBL0LzLd6tmG1TwGTxAS8kgS0LPtKMlH5M0awKGixPo6EEaE2i0gHpXXoywoSjYOvZpdWrxln6NdgQ3q4g==}
@@ -54402,7 +53516,7 @@ packages:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.3
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.1.1
+      socks-proxy-agent: 6.2.1
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
@@ -54490,7 +53604,7 @@ packages:
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.12
       mdast-util-to-string: 2.0.0
       micromark: 2.11.4
       parse-entities: 2.0.0
@@ -54502,8 +53616,8 @@ packages:
   /mdast-util-to-hast@9.1.2:
     resolution: {integrity: sha512-OpkFLBC2VnNAb2FNKcKWu9FMbJhQKog+FCT8nuKmQNIKXyT1n3SIskE7uWDep6x+cA20QXlK5AETHQtYmQmxtQ==}
     dependencies:
-      '@types/mdast': 3.0.10
-      '@types/unist': 2.0.6
+      '@types/mdast': 3.0.12
+      '@types/unist': 2.0.7
       mdast-util-definitions: 3.0.1
       mdurl: 1.0.1
       unist-builder: 2.0.3
@@ -54565,11 +53679,11 @@ packages:
       fs-monkey: 1.0.3
     dev: false
 
-  /memfs@3.4.13:
-    resolution: {integrity: sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==}
+  /memfs@3.5.3:
+    resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
     engines: {node: '>= 4.0.0'}
     dependencies:
-      fs-monkey: 1.0.3
+      fs-monkey: 1.0.4
 
   /memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -54599,7 +53713,7 @@ packages:
     engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
     dependencies:
       errno: 0.1.8
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
     dev: false
 
   /memorystream@0.3.1:
@@ -54738,7 +53852,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
@@ -54773,6 +53887,13 @@ packages:
       brace-expansion: 2.0.1
     dev: false
 
+  /minimatch@9.0.3:
+    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    dependencies:
+      brace-expansion: 2.0.1
+    dev: false
+
   /minimist@0.0.10:
     resolution: {integrity: sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==}
     dev: false
@@ -54781,8 +53902,8 @@ packages:
     resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
     dev: false
 
-  /minimist@1.2.7:
-    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
+  /minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
     dev: false
 
   /minio@7.0.32:
@@ -54796,7 +53917,7 @@ packages:
       crypto-browserify: 3.12.0
       es6-error: 4.1.1
       fast-xml-parser: 3.21.1
-      ipaddr.js: 2.0.1
+      ipaddr.js: 2.1.0
       json-stream: 1.0.0
       lodash: 4.17.21
       mime-types: 2.1.35
@@ -54854,8 +53975,8 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /minipass@4.0.1:
-    resolution: {integrity: sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==}
+  /minipass@4.2.8:
+    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
     engines: {node: '>=8'}
     dev: false
 
@@ -54896,7 +54017,7 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
+      minimist: 1.2.8
     dev: false
 
   /mkdirp@1.0.4:
@@ -55099,7 +54220,7 @@ packages:
       react-dom: '*'
     dependencies:
       css-tree: 1.1.2
-      csstype: 3.1.1
+      csstype: 3.1.2
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 6.0.4
       react: 17.0.2
@@ -55107,7 +54228,7 @@ packages:
       rtl-css-js: 1.16.1
       sourcemap-codec: 1.4.8
       stacktrace-js: 2.0.2
-      stylis: 4.1.3
+      stylis: 4.3.0
     dev: true
 
   /nanoclone@0.2.1:
@@ -55126,8 +54247,8 @@ packages:
     hasBin: true
     dev: false
 
-  /nanoid@3.3.4:
-    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
+  /nanoid@3.3.6:
+    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
@@ -55181,8 +54302,8 @@ packages:
     hasBin: true
     dependencies:
       json-stringify-safe: 5.0.1
-      minimist: 1.2.7
-      readable-stream: 3.6.0
+      minimist: 1.2.8
+      readable-stream: 3.6.2
       split2: 3.2.2
       through2: 4.0.2
     dev: false
@@ -55248,7 +54369,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /node-dir@0.1.17:
@@ -55262,7 +54383,7 @@ packages:
     resolution: {integrity: sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==}
     dependencies:
       encoding: 0.1.13
-      is-stream: registry.npmjs.org/is-stream@1.1.0
+      is-stream: 1.1.0
     dev: false
 
   /node-fetch@2.6.7:
@@ -55322,35 +54443,35 @@ packages:
   /node-releases@1.1.77:
     resolution: {integrity: sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==}
 
-  /node-releases@2.0.9:
-    resolution: {integrity: sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA==}
+  /node-releases@2.0.13:
+    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
 
   /node-source-walk@4.2.0:
     resolution: {integrity: sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/parser': 7.20.13
+      '@babel/parser': 7.22.7
     dev: false
 
   /node-source-walk@4.3.0:
     resolution: {integrity: sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
     dev: false
 
-  /node-source-walk@5.0.1:
-    resolution: {integrity: sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==}
+  /node-source-walk@5.0.2:
+    resolution: {integrity: sha512-Y4jr/8SRS5hzEdZ7SGuvZGwfORvNsSsNRwDXx5WisiqzsVfeftDvRgfeqWNgZvWSJbgubTRVRYBzK6UO+ErqjA==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/parser': 7.20.13
+      '@babel/parser': 7.22.7
     dev: false
 
   /node-source-walk@6.0.2:
     resolution: {integrity: sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/parser': 7.22.4
+      '@babel/parser': 7.22.7
     dev: false
 
   /node.extend@2.0.2:
@@ -55385,7 +54506,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.20.0
-      semver: 5.7.1
+      semver: 5.7.2
       validate-npm-package-license: 3.0.4
     dev: false
 
@@ -55394,7 +54515,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.11.0
+      is-core-module: 2.12.1
       semver: 7.5.2
       validate-npm-package-license: 3.0.4
     dev: false
@@ -55429,8 +54550,8 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dev: false
 
-  /npm-normalize-package-bin@3.0.0:
-    resolution: {integrity: sha512-g+DPQSkusnk7HYXr75NtzkIP4+N81i3RPsGFidF3DzHd9MT9wWngmqoeg/fnHFz5MNdtG4w03s+QnhewSLTT2Q==}
+  /npm-normalize-package-bin@3.0.1:
+    resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: false
 
@@ -55439,7 +54560,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       osenv: 0.1.5
-      semver: 5.7.1
+      semver: 5.7.2
       validate-npm-package-name: 3.0.0
     dev: false
 
@@ -55466,7 +54587,7 @@ packages:
       minimatch: 3.0.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.0
+      shell-quote: 1.8.1
       string.prototype.padend: 3.1.4
     dev: false
 
@@ -55658,8 +54779,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /nwsapi@2.2.2:
-    resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
+  /nwsapi@2.2.7:
+    resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
     dev: false
 
   /oauth-sign@0.9.0:
@@ -55706,7 +54827,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -55729,7 +54850,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
 
@@ -55738,8 +54859,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
   /object.fromentries@2.0.6:
@@ -55747,18 +54868,19 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
-  /object.getownpropertydescriptors@2.1.5:
-    resolution: {integrity: sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==}
+  /object.getownpropertydescriptors@2.1.6:
+    resolution: {integrity: sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==}
     engines: {node: '>= 0.8'}
     dependencies:
       array.prototype.reduce: 1.0.5
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      safe-array-concat: 1.0.0
     dev: false
 
   /object.pick@1.3.0:
@@ -55773,8 +54895,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
   /objnest@5.1.1:
@@ -55862,8 +54984,8 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /open@8.4.0:
-    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
+  /open@8.4.2:
+    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
     engines: {node: '>=12'}
     dependencies:
       define-lazy-prop: 2.0.0
@@ -55873,7 +54995,7 @@ packages:
   /optimism@0.16.2:
     resolution: {integrity: sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==}
     dependencies:
-      '@wry/context': 0.7.0
+      '@wry/context': 0.7.3
       '@wry/trie': 0.3.2
 
   /optimist@0.3.7:
@@ -55898,19 +55020,19 @@ packages:
       levn: 0.3.0
       prelude-ls: 1.1.2
       type-check: 0.3.2
-      word-wrap: 1.2.3
+      word-wrap: 1.2.4
     dev: false
 
-  /optionator@0.9.1:
-    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
+  /optionator@0.9.3:
+    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
     engines: {node: '>= 0.8.0'}
     dependencies:
+      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
-      word-wrap: 1.2.3
     dev: false
 
   /ora@5.4.1:
@@ -55920,7 +55042,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.7.0
+      cli-spinners: 2.9.0
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -56140,7 +55262,7 @@ packages:
       got: 6.7.1
       registry-auth-token: 3.4.0
       registry-url: 3.1.0
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /pad-right@0.2.2:
@@ -56162,7 +55284,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /parent-module@1.0.1:
@@ -56217,7 +55339,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -56237,7 +55359,7 @@ packages:
     resolution: {integrity: sha512-InpdgIdNe5xWMEUcrVQUniQKwnggBtJ7+SCwh7zQAZwbbIYZV9XdgJyhtmDSSvykFyQXoe4BINnzKTfCwWLs5g==}
     engines: {node: '>=8.15'}
     dependencies:
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
   /parse-package-name@0.1.0:
@@ -56293,7 +55415,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: false
 
   /pascalcase@0.1.1:
@@ -56470,33 +55592,33 @@ packages:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
     dependencies:
       duplexify: 4.1.2
-      split2: 4.1.0
+      split2: 4.2.0
     dev: false
 
   /pino-abstract-transport@1.0.0:
     resolution: {integrity: sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==}
     dependencies:
-      readable-stream: 4.3.0
-      split2: 4.1.0
+      readable-stream: 4.4.2
+      split2: 4.2.0
     dev: false
 
   /pino-pretty@9.1.0:
     resolution: {integrity: sha512-IM6NY9LLo/dVgY7/prJhCh4rAJukafdt0ibxeNOWc2fxKMyTk90SOB9Ao2HfbtShT9QPeP0ePpJktksMhSQMYA==}
     hasBin: true
     dependencies:
-      colorette: 2.0.19
+      colorette: 2.0.20
       dateformat: 4.6.3
       fast-copy: 2.1.7
       fast-safe-stringify: 2.1.1
       help-me: 4.2.0
       joycon: 3.1.1
-      minimist: 1.2.7
+      minimist: 1.2.8
       on-exit-leak-free: 2.1.0
       pino-abstract-transport: 1.0.0
       pump: 3.0.0
-      readable-stream: 4.3.0
+      readable-stream: 4.4.2
       secure-json-parse: 2.7.0
-      sonic-boom: 3.2.1
+      sonic-boom: 3.3.0
       strip-json-comments: 3.1.1
     dev: false
 
@@ -56504,8 +55626,8 @@ packages:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
     dev: false
 
-  /pino-std-serializers@6.1.0:
-    resolution: {integrity: sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==}
+  /pino-std-serializers@6.2.2:
+    resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
     dev: false
 
   /pino@7.11.0:
@@ -56513,14 +55635,14 @@ packages:
     hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.1.2
+      fast-redact: 3.2.0
       on-exit-leak-free: 0.2.0
       pino-abstract-transport: 0.5.0
       pino-std-serializers: 4.0.0
       process-warning: 1.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.1.0
-      safe-stable-stringify: 2.4.2
+      safe-stable-stringify: 2.4.3
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
     dev: false
@@ -56530,20 +55652,20 @@ packages:
     hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.1.2
+      fast-redact: 3.2.0
       on-exit-leak-free: 2.1.0
       pino-abstract-transport: 1.0.0
-      pino-std-serializers: 6.1.0
-      process-warning: 2.1.0
+      pino-std-serializers: 6.2.2
+      process-warning: 2.2.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
-      safe-stable-stringify: 2.4.2
-      sonic-boom: 3.2.1
+      safe-stable-stringify: 2.4.3
+      sonic-boom: 3.3.0
       thread-stream: 2.3.0
     dev: false
 
-  /pirates@4.0.5:
-    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
+  /pirates@4.0.6:
+    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
     engines: {node: '>= 6'}
     dev: false
 
@@ -56605,7 +55727,7 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-browser-comments@4.0.0(browserslist@4.16.3)(postcss@8.4.18):
@@ -56625,7 +55747,7 @@ packages:
       postcss: ^8.2.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
     dev: false
 
@@ -56669,13 +55791,13 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-colormin@5.3.0(postcss@8.4.18):
-    resolution: {integrity: sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==}
+  /postcss-colormin@5.3.1(postcss@8.4.18):
+    resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.18
@@ -56688,7 +55810,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
     dev: false
@@ -56720,7 +55842,7 @@ packages:
       postcss: ^8.3
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-dir-pseudo-class@6.0.5(postcss@8.4.18):
@@ -56730,7 +55852,7 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-discard-comments@5.1.2(postcss@8.4.18):
@@ -56805,7 +55927,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-focus-within@5.0.4(postcss@8.4.18):
@@ -56815,7 +55937,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-font-variant@5.0.0(postcss@8.4.18):
@@ -56907,17 +56029,17 @@ packages:
       stylehacks: 5.1.1(postcss@8.4.18)
     dev: false
 
-  /postcss-merge-rules@5.1.3(postcss@8.4.18):
-    resolution: {integrity: sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==}
+  /postcss-merge-rules@5.1.4(postcss@8.4.18):
+    resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-minify-font-values@5.1.0(postcss@8.4.18):
@@ -56948,7 +56070,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
@@ -56961,7 +56083,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-modules-extract-imports@3.0.0(postcss@8.4.18):
@@ -56973,15 +56095,15 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /postcss-modules-local-by-default@4.0.0(postcss@8.4.18):
-    resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
+  /postcss-modules-local-by-default@4.0.3(postcss@8.4.18):
+    resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
     dev: false
 
@@ -56992,7 +56114,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-modules-values@4.0.0(postcss@8.4.18):
@@ -57011,9 +56133,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
+      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-normalize-charset@5.1.0(postcss@8.4.18):
@@ -57081,7 +56203,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
     dev: false
@@ -57189,12 +56311,12 @@ packages:
       '@csstools/postcss-text-decoration-shorthand': 1.0.0(postcss@8.4.18)
       '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.4.18)
       '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.18)
-      autoprefixer: 10.4.13(postcss@8.4.18)
-      browserslist: 4.21.5
+      autoprefixer: 10.4.14(postcss@8.4.18)
+      browserslist: 4.21.9
       css-blank-pseudo: 3.0.3(postcss@8.4.18)
       css-has-pseudo: 3.0.4(postcss@8.4.18)
       css-prefers-color-scheme: 6.0.3(postcss@8.4.18)
-      cssdb: 7.4.1
+      cssdb: 7.6.0
       postcss: 8.4.18
       postcss-attribute-case-insensitive: 5.0.2(postcss@8.4.18)
       postcss-clamp: 4.1.0(postcss@8.4.18)
@@ -57234,16 +56356,16 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
-  /postcss-reduce-initial@5.1.1(postcss@8.4.18):
-    resolution: {integrity: sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==}
+  /postcss-reduce-initial@5.1.2(postcss@8.4.18):
+    resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       caniuse-api: 3.0.0
       postcss: 8.4.18
     dev: false
@@ -57273,11 +56395,11 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
-  /postcss-selector-parser@6.0.11:
-    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
+  /postcss-selector-parser@6.0.13:
+    resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -57302,7 +56424,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
   /postcss-value-parser@4.2.0:
@@ -57321,7 +56443,7 @@ packages:
     resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.4
+      nanoid: 3.3.6
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
@@ -57487,8 +56609,8 @@ packages:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
     dev: false
 
-  /process-warning@2.1.0:
-    resolution: {integrity: sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==}
+  /process-warning@2.2.0:
+    resolution: {integrity: sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==}
     dev: false
 
   /process@0.11.10:
@@ -57681,14 +56803,19 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
+  /punycode@2.3.0:
+    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
+    engines: {node: '>=6'}
+    dev: false
+
   /puppeteer@13.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
     resolution: {integrity: sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==}
     engines: {node: '>=10.18.1'}
-    deprecated: < 18.1.0 is no longer supported
+    deprecated: < 19.4.0 is no longer supported
     requiresBuild: true
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       devtools-protocol: 0.0.981744
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -57856,7 +56983,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-json-comments: 2.0.1
     dev: false
 
@@ -57881,8 +57008,8 @@ packages:
       object-assign: 4.1.1
       promise: 8.3.0
       raf: 3.4.1
-      regenerator-runtime: 0.13.11
-      whatwg-fetch: 3.6.2
+      regenerator-runtime: 0.13.7
+      whatwg-fetch: 3.6.16
     dev: false
 
   /react-create-ref@1.0.1(react@17.0.2):
@@ -57935,10 +57062,10 @@ packages:
       - vue-template-compiler
     dev: false
 
-  /react-devtools-core@4.27.1(bufferutil@4.0.3)(utf-8-validate@5.0.5):
-    resolution: {integrity: sha512-qXhcxxDWiFmFAOq48jts9YQYe1+wVoUXzJTlY4jbaATzyio6dd6CUGu3dXBhREeVgpZ+y4kg6vFJzIOZh6vY2w==}
+  /react-devtools-core@4.28.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
+    resolution: {integrity: sha512-E3C3X1skWBdBzwpOUbmXG8SgH6BtsluSMe+s6rRcujNKG1DGi8uIfhdhszkgDpAsMoE55hwqRUzeXCmETDBpTg==}
     dependencies:
-      shell-quote: 1.8.0
+      shell-quote: 1.8.1
       ws: 7.4.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     transitivePeerDependencies:
       - bufferutil
@@ -58032,7 +57159,7 @@ packages:
       prism-react-renderer: 1.3.5(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      sucrase: 3.32.0
+      sucrase: 3.34.0
       use-editable: 2.3.3(react@17.0.2)
     dev: false
 
@@ -58046,7 +57173,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-use: 17.4.0(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: true
 
   /react-native-web@0.14.13(react-dom@17.0.2)(react@17.0.2):
@@ -58077,7 +57204,7 @@ packages:
     dependencies:
       array-find-index: 1.0.2
       create-react-class: 15.7.0
-      fbjs: 3.0.4
+      fbjs: 3.0.5
       hyphenate-style-name: 1.0.4
       inline-style-prefixer: 6.0.4
       normalize-css-color: 1.0.2
@@ -58188,14 +57315,14 @@ packages:
     resolution: {integrity: sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==}
     dev: false
 
-  /react-universal-interface@0.6.2(react@17.0.2)(tslib@2.5.0):
+  /react-universal-interface@0.6.2(react@17.0.2)(tslib@2.6.0):
     resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
     peerDependencies:
       react: '*'
       tslib: '*'
     dependencies:
       react: 17.0.2
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: true
 
   /react-use-dimensions@1.2.1(@types/react@17.0.8)(react@17.0.2)(typescript@4.7.4):
@@ -58225,13 +57352,13 @@ packages:
       nano-css: 5.3.5(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-universal-interface: 0.6.2(react@17.0.2)(tslib@2.5.0)
+      react-universal-interface: 0.6.2(react@17.0.2)(tslib@2.6.0)
       resize-observer-polyfill: 1.5.1
       screenfull: 5.2.0
       set-harmonic-interval: 1.0.1
       throttle-debounce: 3.0.1
       ts-easing: 0.2.0
-      tslib: 2.5.0
+      tslib: 2.6.0
     dev: true
 
   /react-xarrows@2.0.2(react@17.0.2):
@@ -58369,8 +57496,8 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /readable-stream@2.3.7:
-    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
+  /readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -58380,22 +57507,23 @@ packages:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
-  /readable-stream@3.6.0:
-    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
+  /readable-stream@3.6.2:
+    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  /readable-stream@4.3.0:
-    resolution: {integrity: sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==}
+  /readable-stream@4.4.2:
+    resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       abort-controller: 3.0.0
       buffer: 6.0.3
       events: 3.3.0
       process: 0.11.10
+      string_decoder: 1.3.0
     dev: false
 
   /readdir-enhanced@1.5.2:
@@ -58406,17 +57534,10 @@ packages:
       glob-to-regexp: 0.3.0
     dev: false
 
-  /readdir-glob@1.1.2:
-    resolution: {integrity: sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==}
+  /readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
     dependencies:
       minimatch: 5.1.6
-    dev: false
-
-  /readdirp@3.5.0:
-    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
-    engines: {node: '>=8.10.0'}
-    dependencies:
-      picomatch: 2.3.1
     dev: false
 
   /readdirp@3.6.0:
@@ -58538,12 +57659,12 @@ packages:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
     dev: false
 
-  /regexp.prototype.flags@1.4.3:
-    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
+  /regexp.prototype.flags@1.5.0:
+    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       functions-have-names: 1.2.3
 
   /regexpp@1.1.0:
@@ -58561,13 +57682,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /regexpu-core@5.2.2:
-    resolution: {integrity: sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==}
+  /regexpu-core@5.3.2:
+    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
     engines: {node: '>=4'}
     dependencies:
+      '@babel/regjsgen': 0.8.0
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.1.0
-      regjsgen: 0.7.1
       regjsparser: 0.9.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
@@ -58585,9 +57706,6 @@ packages:
     dependencies:
       rc: 1.2.8
     dev: false
-
-  /regjsgen@0.7.1:
-    resolution: {integrity: sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==}
 
   /regjsparser@0.9.1:
     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
@@ -58889,14 +58007,14 @@ packages:
   /resolve@1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.1
       path-parse: 1.0.7
 
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.11.0
+      is-core-module: 2.12.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
@@ -59008,11 +58126,11 @@ packages:
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.18.6
+      '@babel/code-frame': 7.22.5
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
-      terser: 5.17.3
+      terser: 5.19.1
     dev: false
 
   /rollup@2.79.1:
@@ -59030,6 +58148,10 @@ packages:
       can-link: 2.0.0
       next-path: 1.0.0
       path-temp: 2.0.0
+    dev: false
+
+  /rrweb-cssom@0.6.0:
+    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
     dev: false
 
   /rtl-css-js@1.16.1:
@@ -59076,7 +58198,17 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
+    dev: false
+
+  /safe-array-concat@1.0.0:
+    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
+    engines: {node: '>=0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      has-symbols: 1.0.3
+      isarray: 2.0.5
     dev: false
 
   /safe-buffer@5.1.2:
@@ -59114,7 +58246,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       is-regex: 1.1.4
     dev: false
 
@@ -59124,8 +58256,8 @@ packages:
       ret: 0.1.15
     dev: false
 
-  /safe-stable-stringify@2.4.2:
-    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
+  /safe-stable-stringify@2.4.3:
+    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
     engines: {node: '>=10'}
     dev: false
 
@@ -59192,8 +58324,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.1
-      immutable: 4.2.2
+      chokidar: 3.5.3
+      immutable: 4.3.1
       source-map-js: 1.0.2
     dev: false
 
@@ -59212,26 +58344,24 @@ packages:
       xmlchars: 2.2.0
     dev: false
 
+  /saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
+    dependencies:
+      xmlchars: 2.2.0
+    dev: false
+
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
-  /schema-utils@3.1.1:
-    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+  /schema-utils@3.3.0:
+    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.11
-      ajv: 6.12.6
-      ajv-keywords: 3.5.2(ajv@6.12.6)
-    dev: false
-
-  /schema-utils@3.1.2:
-    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
-    engines: {node: '>= 10.13.0'}
-    dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
@@ -59239,7 +58369,17 @@ packages:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
     engines: {node: '>= 12.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.11
+      '@types/json-schema': 7.0.12
+      ajv: 8.12.0
+      ajv-formats: 2.1.1
+      ajv-keywords: 5.1.0(ajv@8.12.0)
+    dev: false
+
+  /schema-utils@4.2.0:
+    resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
+    engines: {node: '>= 12.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.12
       ajv: 8.12.0
       ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
@@ -59270,13 +58410,13 @@ packages:
     resolution: {integrity: sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /semver-intersect@1.4.0:
     resolution: {integrity: sha512-d8fvGg5ycKAq0+I6nfWeCx6ffaWJCsBYU0H2Rq56+/zFePYfT8mXkB3tWBSjR5BerkHNZ5eTPIk1/LBYas35xQ==}
     dependencies:
-      semver: 5.7.1
+      semver: 5.7.2
     dev: false
 
   /semver-range-intersect@0.3.1:
@@ -59284,7 +58424,7 @@ packages:
     engines: {node: '>=8.3.0'}
     dependencies:
       '@types/semver': 6.2.3
-      semver: 6.3.0
+      semver: 6.3.1
     dev: false
 
   /semver-regex@3.1.4:
@@ -59296,7 +58436,7 @@ packages:
     resolution: {integrity: sha512-JicVlQKz/C//4BiPmbHEDou6HihXxo5xqB/8Hm9FaLJ6HHkRRvYgCECq4u/z0XF8kyJQ/KAZt++A/kYz/oOSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      semver: 5.7.1
+      semver: 5.7.2
       semver-regex: 3.1.4
     dev: false
 
@@ -59304,13 +58444,13 @@ packages:
     resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
     dev: false
 
-  /semver@5.7.1:
-    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
+  /semver@5.7.2:
+    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
     dev: false
 
-  /semver@6.3.0:
-    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
+  /semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
   /semver@7.3.4:
@@ -59327,22 +58467,6 @@ packages:
     dependencies:
       lru-cache: 6.0.0
     dev: true
-
-  /semver@7.5.0:
-    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: false
-
-  /semver@7.5.1:
-    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      lru-cache: 6.0.0
-    dev: false
 
   /semver@7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
@@ -59543,8 +58667,8 @@ packages:
     resolution: {integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==}
     dev: false
 
-  /shell-quote@1.8.0:
-    resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
+  /shell-quote@1.8.1:
+    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
 
   /shelljs@0.3.0:
     resolution: {integrity: sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==}
@@ -59556,7 +58680,7 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.0
+      get-intrinsic: 1.2.1
       object-inspect: 1.12.3
 
   /signal-exit@3.0.7:
@@ -59746,6 +58870,17 @@ packages:
       - supports-color
     dev: false
 
+  /socks-proxy-agent@6.2.1:
+    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
+    engines: {node: '>= 10'}
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.3.4(supports-color@9.4.0)
+      socks: 2.7.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
@@ -59756,12 +58891,6 @@ packages:
 
   /sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
-    dependencies:
-      atomic-sleep: 1.0.0
-    dev: false
-
-  /sonic-boom@3.2.1:
-    resolution: {integrity: sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==}
     dependencies:
       atomic-sleep: 1.0.0
     dev: false
@@ -59880,11 +59009,11 @@ packages:
       proc-output: 1.0.8
     dev: false
 
-  /spdx-correct@3.1.1:
-    resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
+  /spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.12
+      spdx-license-ids: 3.0.13
     dev: false
 
   /spdx-exceptions@2.3.0:
@@ -59895,11 +59024,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.12
+      spdx-license-ids: 3.0.13
     dev: false
 
-  /spdx-license-ids@3.0.12:
-    resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
+  /spdx-license-ids@3.0.13:
+    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
     dev: false
 
   /spdy-transport@3.0.0:
@@ -59909,7 +59038,7 @@ packages:
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       wbuf: 1.7.3
     transitivePeerDependencies:
       - supports-color
@@ -59950,11 +59079,11 @@ packages:
   /split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
     dependencies:
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
-  /split2@4.1.0:
-    resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
+  /split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
     engines: {node: '>= 10.x'}
     dev: false
 
@@ -59994,7 +59123,7 @@ packages:
     resolution: {integrity: sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 4.0.1
+      minipass: 4.2.8
     dev: false
 
   /ssri@10.0.4:
@@ -60098,7 +59227,7 @@ packages:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      internal-slot: 1.0.4
+      internal-slot: 1.0.5
 
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -60109,7 +59238,7 @@ packages:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /stream-buffers@3.0.2:
@@ -60122,7 +59251,7 @@ packages:
     dependencies:
       builtin-status-codes: 3.0.0
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       xtend: 4.0.2
     dev: false
 
@@ -60154,8 +59283,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /string-argv@0.3.1:
-    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
+  /string-argv@0.3.2:
+    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
     engines: {node: '>=0.6.19'}
     dev: false
 
@@ -60176,7 +59305,7 @@ packages:
     engines: {node: '>=12.20'}
     dependencies:
       char-regex: 2.0.1
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: false
 
   /string-width@1.0.2:
@@ -60220,19 +59349,19 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.0.1
+      strip-ansi: 7.1.0
     dev: false
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
-      get-intrinsic: 1.2.0
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      get-intrinsic: 1.2.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.4
-      regexp.prototype.flags: 1.4.3
+      internal-slot: 1.0.5
+      regexp.prototype.flags: 1.5.0
       side-channel: 1.0.4
     dev: false
 
@@ -60241,24 +59370,33 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+    dev: false
+
+  /string.prototype.trim@1.2.7:
+    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: false
 
   /string_decoder@0.10.31:
@@ -60337,8 +59475,8 @@ packages:
       ansi-regex: 5.0.1
     dev: false
 
-  /strip-ansi@7.0.1:
-    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
+  /strip-ansi@7.1.0:
+    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
@@ -60433,7 +59571,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
@@ -60449,13 +59587,13 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.11
+      postcss-selector-parser: 6.0.13
     dev: false
 
-  /stylis@4.1.3:
-    resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}
+  /stylis@4.3.0:
+    resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
     dev: true
 
   /stylus-lookup@3.0.2:
@@ -60464,7 +59602,7 @@ packages:
     hasBin: true
     dependencies:
       commander: 2.20.3
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -60502,17 +59640,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sucrase@3.32.0:
-    resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
+  /sucrase@3.34.0:
+    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/gen-mapping': 0.3.3
       commander: 4.1.1
       glob: 7.1.6
       lines-and-columns: 1.2.4
       mz: 2.7.0
-      pirates: 4.0.5
+      pirates: 4.0.6
       ts-interface-checker: 0.1.13
     dev: false
 
@@ -60546,8 +59684,8 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
-  /supports-color@9.3.1:
-    resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
+  /supports-color@9.4.0:
+    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
     engines: {node: '>=12'}
     dev: false
 
@@ -60633,7 +59771,7 @@ packages:
     resolution: {integrity: sha512-5pk9meINInVUZ4nKn5942/x/mY5OE9SVzkOFIxiCDnellaz1cwTd4m7Xl1ibz1F3AxnZ8NxQMEbF7eMWMGECGg==}
     engines: {node: '>=4.0'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
       uuid: 8.3.2
     dev: false
 
@@ -60695,7 +59833,7 @@ packages:
       end-of-stream: 1.4.4
       fs-constants: 1.0.0
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /tar@6.1.11:
@@ -60775,15 +59913,15 @@ packages:
       esbuild: 0.14.29
       jest-worker: 27.5.1
       p-limit: 3.1.0
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      terser: 5.16.2
+      terser: 5.19.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
-  /terser-webpack-plugin@5.3.8(esbuild@0.14.29)(webpack@5.84.1):
-    resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
+  /terser-webpack-plugin@5.3.9(esbuild@0.14.29)(webpack@5.84.1):
+    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -60798,12 +59936,12 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.17
+      '@jridgewell/trace-mapping': 0.3.18
       esbuild: 0.14.29
       jest-worker: 27.5.1
-      schema-utils: 3.1.2
+      schema-utils: 3.3.0
       serialize-javascript: 6.0.1
-      terser: 5.17.3
+      terser: 5.19.1
       webpack: 5.84.1(esbuild@0.14.29)
 
   /terser@4.8.1:
@@ -60811,30 +59949,19 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      acorn: 8.8.2
+      acorn: 8.10.0
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
     dev: false
 
-  /terser@5.16.2:
-    resolution: {integrity: sha512-JKuM+KvvWVqT7muHVyrwv7FVRPnmHDwF6XwoIxdbF5Witi0vu99RYpxDexpJndXt3jbZZmmWr2/mQa6HvSNdSg==}
+  /terser@5.19.1:
+    resolution: {integrity: sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.2
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    dev: false
-
-  /terser@5.17.3:
-    resolution: {integrity: sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dependencies:
-      '@jridgewell/source-map': 0.3.2
-      acorn: 8.8.2
+      '@jridgewell/source-map': 0.3.5
+      acorn: 8.10.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -60899,7 +60026,7 @@ packages:
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
     dependencies:
-      readable-stream: 2.3.7
+      readable-stream: 2.3.8
       xtend: 4.0.2
     dev: false
 
@@ -60907,13 +60034,13 @@ packages:
     resolution: {integrity: sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
     dependencies:
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /through@2.3.8:
@@ -60955,7 +60082,7 @@ packages:
   /tippy.js@6.2.7:
     resolution: {integrity: sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==}
     dependencies:
-      '@popperjs/core': 2.11.6
+      '@popperjs/core': 2.11.8
     dev: false
 
   /tmp@0.0.33:
@@ -61039,8 +60166,8 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /tough-cookie@4.1.2:
-    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
+  /tough-cookie@4.1.3:
+    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
@@ -61066,6 +60193,13 @@ packages:
       punycode: 2.1.1
     dev: false
 
+  /tr46@4.1.1:
+    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
+    engines: {node: '>=14'}
+    dependencies:
+      punycode: 2.3.0
+    dev: false
+
   /treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
     engines: {node: '>=0.6'}
@@ -61084,10 +60218,12 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
+    deprecated: Use String.prototype.trim() instead
     dev: false
 
-  /triple-beam@1.3.0:
-    resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
+  /triple-beam@1.4.1:
+    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
+    engines: {node: '>= 14.0.0'}
     dev: false
 
   /trough@1.0.5:
@@ -61100,8 +60236,8 @@ packages:
       utf8-byte-length: 1.0.4
     dev: false
 
-  /ts-deepmerge@6.0.3:
-    resolution: {integrity: sha512-MBBJL0UK/mMnZRONMz4J1CRu5NsGtsh+gR1nkn8KLE9LXo/PCzeHhQduhNary8m5/m9ryOOyFwVKxq81cPlaow==}
+  /ts-deepmerge@6.2.0:
+    resolution: {integrity: sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==}
     engines: {node: '>=14.13.1'}
     dev: false
 
@@ -61117,7 +60253,7 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.5.0
+      tslib: 2.6.0
 
   /ts-invariant@0.4.4:
     resolution: {integrity: sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==}
@@ -61129,12 +60265,12 @@ packages:
     resolution: {integrity: sha512-hnGJXIgC49ZuF5g5oDthoge8t4cvT0dYg2pYO5C6yV/HmUUy1koooU2U/5K2N+Uw++hcXQpJAToLRa+GRp28Sg==}
     dev: false
 
-  /tsconfig-paths@3.14.1:
-    resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
+  /tsconfig-paths@3.14.2:
+    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
-      minimist: 1.2.7
+      minimist: 1.2.8
       strip-bom: 3.0.0
     dev: false
 
@@ -61149,8 +60285,8 @@ packages:
     resolution: {integrity: sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==}
     dev: false
 
-  /tslib@2.5.0:
-    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
+  /tslib@2.6.0:
+    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -61196,8 +60332,8 @@ packages:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: false
 
-  /typanion@3.12.1:
-    resolution: {integrity: sha512-3SJF/czpzqq6G3lprGFLa6ps12yb1uQ1EmitNnep2fDMNh1aO/Zbq9sWY+3lem0zYb2oHJnQWyabTGUZ+L1ScQ==}
+  /typanion@3.13.0:
+    resolution: {integrity: sha512-AkZMjMIW8MGeQwBxu1bixzu/2Zk7rH6ILrI/9zBoW0sAiVaWwHjXSnmPBomfY2t7tSG6m5bIE+OYYyyuGnFVHA==}
     dev: false
 
   /type-check@0.3.2:
@@ -61214,15 +60350,15 @@ packages:
       prelude-ls: 1.2.1
     dev: false
 
-  /type-coverage-core@2.24.1(typescript@4.7.4):
-    resolution: {integrity: sha512-HZCiVINVnrekaEQuq/lKEerAZO/L7rR9vMDs+QRhTfb7HrD2OO6JDQKxJiKLJGAoGhjjQY5248mmX3t/+zLXxg==}
+  /type-coverage-core@2.26.0(typescript@4.7.4):
+    resolution: {integrity: sha512-/9VQ0ySU1CKbWd/BNnbVYMJ67oOt7qdXXxm4W5VIM07AUB5eelcDjrWG7qdIj0ZafnNkpv+v5qcD68ExOVK+Sw==}
     peerDependencies:
-      typescript: 2 || 3 || 4
+      typescript: 2 || 3 || 4 || 5
     dependencies:
-      fast-glob: 3.2.12
-      minimatch: 3.0.5
+      fast-glob: 3.3.0
+      minimatch: 9.0.3
       normalize-path: 3.0.0
-      tslib: 2.5.0
+      tslib: 2.6.0
       tsutils: 3.21.0(typescript@4.7.4)
       typescript: 4.7.4
     dev: false
@@ -61231,8 +60367,8 @@ packages:
     resolution: {integrity: sha512-HvqD19WtsUlmbSCY3De/HcKUyohjgtQoNHdlVjed8WcySGVgEjGpjF4pZUiLZDVsZf3+VwNvkHoLewLEWXWdQQ==}
     hasBin: true
     dependencies:
-      minimist: 1.2.7
-      type-coverage-core: 2.24.1(typescript@4.7.4)
+      minimist: 1.2.8
+      type-coverage-core: 2.26.0(typescript@4.7.4)
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -61291,12 +60427,42 @@ packages:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
     dev: false
 
+  /typed-array-buffer@1.0.0:
+    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      get-intrinsic: 1.2.1
+      is-typed-array: 1.1.12
+    dev: false
+
+  /typed-array-byte-length@1.0.0:
+    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+    dev: false
+
+  /typed-array-byte-offset@1.0.0:
+    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      has-proto: 1.0.1
+      is-typed-array: 1.1.12
+    dev: false
+
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
     dev: false
 
   /typedarray-to-buffer@3.1.5:
@@ -61339,12 +60505,18 @@ packages:
     hasBin: true
     dev: false
 
+  /typescript@5.1.6:
+    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+    dev: false
+
   /ua-parser-js@0.7.24:
     resolution: {integrity: sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==}
     dev: false
 
-  /ua-parser-js@0.7.33:
-    resolution: {integrity: sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==}
+  /ua-parser-js@1.0.35:
+    resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
     dev: false
 
   /uglify-js@3.17.4:
@@ -61408,7 +60580,7 @@ packages:
   /unified@8.4.2:
     resolution: {integrity: sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       bail: 1.0.5
       extend: 3.0.2
       is-plain-obj: 2.1.0
@@ -61419,7 +60591,7 @@ packages:
   /unified@9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -61431,7 +60603,7 @@ packages:
   /unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -61519,20 +60691,20 @@ packages:
   /unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
     dev: false
 
   /unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 4.1.0
     dev: false
 
   /unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
     dev: false
@@ -61581,13 +60753,13 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /update-browserslist-db@1.0.10(browserslist@4.21.5):
-    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
+  /update-browserslist-db@1.0.11(browserslist@4.21.9):
+    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.5
+      browserslist: 4.21.9
       escalade: 3.1.1
       picocolors: 1.0.0
 
@@ -61759,7 +60931,7 @@ packages:
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.5.0
+      tslib: 2.6.0
       use-constant: 1.1.1(react@17.0.2)
     dev: false
 
@@ -61795,20 +60967,22 @@ packages:
   /util.promisify@1.0.1:
     resolution: {integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==}
     dependencies:
-      define-properties: 1.1.4
-      es-abstract: 1.21.1
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
       has-symbols: 1.0.3
-      object.getownpropertydescriptors: 2.1.5
+      object.getownpropertydescriptors: 2.1.6
     dev: false
 
-  /util.promisify@1.1.1:
-    resolution: {integrity: sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==}
+  /util.promisify@1.1.2:
+    resolution: {integrity: sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.1.4
+      define-properties: 1.2.0
       for-each: 0.3.3
+      has-proto: 1.0.1
       has-symbols: 1.0.3
-      object.getownpropertydescriptors: 2.1.5
+      object.getownpropertydescriptors: 2.1.6
+      safe-array-concat: 1.0.0
     dev: false
 
   /util@0.12.3:
@@ -61817,9 +60991,9 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.10
+      is-typed-array: 1.1.12
       safe-buffer: 5.2.1
-      which-typed-array: 1.1.9
+      which-typed-array: 1.1.11
     dev: false
 
   /utila@0.4.0:
@@ -61883,7 +61057,7 @@ packages:
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
-      spdx-correct: 3.1.1
+      spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
     dev: false
 
@@ -61921,12 +61095,12 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /verdaccio-audit@11.0.0-6-next.34:
-    resolution: {integrity: sha512-TF+gnJJveEI4TGJTsVBCNwbfx5WBvlP7QoaDDxSmJQlmhzrsJ2MjhagWgAA/OoLV7p45bJ7e00v391Frv0pwnw==}
+  /verdaccio-audit@11.0.0-6-next.37:
+    resolution: {integrity: sha512-hzQq90HmKwy327PueS58V720MRDycSCmo7DNgOy+h8dvITG6XAQ6bSsiTgQScjmwImdp3tkl3bqu9kXh33bPxA==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.71
-      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/config': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.74
       express: 4.18.2
       https-proxy-agent: 5.0.1
       node-fetch: 2.6.7
@@ -61935,54 +61109,53 @@ packages:
       - supports-color
     dev: false
 
-  /verdaccio-htpasswd@11.0.0-6-next.41:
-    resolution: {integrity: sha512-HS1/3No2W7Dhl9DJ3tXUDgSOIL3do5tW2O2OvRVPc6aNKbqXFg22FIqjzpn1yG2sydTuBFKUSjMvmk/1oliKPg==}
+  /verdaccio-htpasswd@11.0.0-6-next.44:
+    resolution: {integrity: sha512-ZKCpZ5KhcHXjAlYkCI6CM6O8KO/Pr/x5C89zqjRR7OMaPyOAu0psIJjvhTycn1efZub4pT6Tlj7rCRlmvIbR0w==}
     engines: {node: '>=14', npm: '>=6'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.74
       '@verdaccio/file-locking': 11.0.0-6-next.7
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
       core-js: 3.30.2
-      debug: 4.3.4(supports-color@9.3.1)
+      debug: 4.3.4(supports-color@9.4.0)
       http-errors: 2.0.0
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /verdaccio@5.25.0:
-    resolution: {integrity: sha512-h/BDAudOZtwC52waErxCjZA+YKuUi7Ojt3haRGxZ1ZTL26BkbjaKkzt0Y72Z2bauRLxmwtGevJWm2LV7ZTeIug==}
+  /verdaccio@5.26.0:
+    resolution: {integrity: sha512-XuVUL5TYwMrky0w6wjgWhgviXmjbLluYy29vjJT9hByLa7TX3zBsqyBWIm+ncb5SxaiYLIEv8fJCrNXujpvUsA==}
     engines: {node: '>=12.18'}
     hasBin: true
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.71
-      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/config': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.74
       '@verdaccio/local-storage': 10.3.3
-      '@verdaccio/logger-7': 6.0.0-6-next.16
-      '@verdaccio/middleware': 6.0.0-6-next.50
+      '@verdaccio/logger-7': 6.0.0-6-next.19
+      '@verdaccio/middleware': 6.0.0-6-next.53
       '@verdaccio/search': 6.0.0-6-next.2
       '@verdaccio/signature': 6.0.0-6-next.2
       '@verdaccio/streams': 10.2.1
-      '@verdaccio/tarball': 11.0.0-6-next.40
-      '@verdaccio/ui-theme': 6.0.0-6-next.71
-      '@verdaccio/url': 11.0.0-6-next.37
-      '@verdaccio/utils': 6.0.0-6-next.39
+      '@verdaccio/tarball': 11.0.0-6-next.43
+      '@verdaccio/ui-theme': 6.0.0-6-next.74
+      '@verdaccio/url': 11.0.0-6-next.40
+      '@verdaccio/utils': 6.0.0-6-next.42
       JSONStream: 1.3.5
       async: 3.2.4
-      body-parser: 1.20.2
-      clipanion: 3.2.0
+      clipanion: 3.2.1
       compression: 1.7.4
       cookies: 0.8.0
       cors: 2.8.5
-      debug: 4.3.4(supports-color@9.3.1)
-      envinfo: 7.8.1
+      debug: 4.3.4(supports-color@9.4.0)
+      envinfo: 7.10.0
       express: 4.18.2
       express-rate-limit: 5.5.1
       fast-safe-stringify: 2.1.1
       handlebars: 4.7.7
       js-yaml: 4.1.0
-      jsonwebtoken: 9.0.0
+      jsonwebtoken: 9.0.1
       kleur: 4.1.5
       lodash: 4.17.21
       lru-cache: 7.18.3
@@ -61991,10 +61164,10 @@ packages:
       mv: 2.1.1
       pkginfo: 0.4.1
       request: 2.88.2
-      semver: 7.5.1
+      semver: 7.5.4
       validator: 13.9.0
-      verdaccio-audit: 11.0.0-6-next.34
-      verdaccio-htpasswd: 11.0.0-6-next.41
+      verdaccio-audit: 11.0.0-6-next.37
+      verdaccio-htpasswd: 11.0.0-6-next.44
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -62023,14 +61196,14 @@ packages:
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       unist-util-stringify-position: 2.0.3
     dev: false
 
   /vfile@4.2.0:
     resolution: {integrity: sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       is-buffer: 2.0.5
       replace-ext: 1.0.0
       unist-util-stringify-position: 2.0.3
@@ -62040,7 +61213,7 @@ packages:
   /vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
-      '@types/unist': 2.0.6
+      '@types/unist': 2.0.7
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
@@ -62076,7 +61249,7 @@ packages:
   /vscode-icons-js@11.0.0:
     resolution: {integrity: sha512-Rx/vgLY3KSCPp53RXPY/t/jk8sOrBUEDDQlLoTaTzxwnsKyrorUXfrtw9UlG5D97z5DRxERn1ek0KB9RTuPxmQ==}
     dependencies:
-      '@types/jasmine': 3.10.7
+      '@types/jasmine': 3.10.11
 
   /vscode-jsonrpc@6.0.0:
     resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
@@ -62098,7 +61271,7 @@ packages:
       eslint-scope: 5.1.1
       eslint-visitor-keys: 1.3.0
       espree: 6.2.1
-      esquery: 1.4.0
+      esquery: 1.5.0
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -62116,6 +61289,13 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xml-name-validator: 3.0.0
+    dev: false
+
+  /w3c-xmlserializer@4.0.0:
+    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
+    engines: {node: '>=14'}
+    dependencies:
+      xml-name-validator: 4.0.0
     dev: false
 
   /walker@1.0.8:
@@ -62172,6 +61352,11 @@ packages:
     engines: {node: '>=10.4'}
     dev: false
 
+  /webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+    dev: false
+
   /webpack-assets-manifest@5.1.0(webpack@5.84.1):
     resolution: {integrity: sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==}
     engines: {node: '>=10.13.0'}
@@ -62179,11 +61364,11 @@ packages:
       webpack: ^5.2.0
     dependencies:
       chalk: 4.1.2
-      deepmerge: 4.3.0
+      deepmerge: 4.3.1
       lockfile: 1.0.4
       lodash.get: 4.4.2
       lodash.has: 4.5.2
-      schema-utils: 3.1.1
+      schema-utils: 3.3.0
       tapable: 2.2.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -62195,10 +61380,10 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       colorette: 2.0.20
-      memfs: 3.4.13
+      memfs: 3.5.3
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
       webpack: 5.84.1(esbuild@0.14.29)
 
   /webpack-dev-server@4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1):
@@ -62215,29 +61400,29 @@ packages:
         optional: true
     dependencies:
       '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.3.5
+      '@types/connect-history-api-fallback': 1.5.0
       '@types/express': 4.17.13
       '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.0
+      '@types/serve-static': 1.15.2
       '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.4
+      '@types/ws': 8.5.5
       ansi-html-community: 0.0.8
       bonjour-service: 1.1.1
       chokidar: 3.5.3
-      colorette: 2.0.19
+      colorette: 2.0.20
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
       express: 4.18.2
       graceful-fs: 4.2.10
-      html-entities: 2.3.3
+      html-entities: 2.4.0
       http-proxy-middleware: 2.0.6(@types/express@4.17.13)(debug@4.3.2)
-      ipaddr.js: 2.0.1
+      ipaddr.js: 2.1.0
       launch-editor: 2.6.0
-      open: 8.4.0
+      open: 8.4.2
       p-retry: 4.6.2
       rimraf: 3.0.2
-      schema-utils: 4.0.0
+      schema-utils: 4.2.0
       selfsigned: 2.1.1
       serve-index: 1.9.1
       sockjs: 0.3.24
@@ -62267,7 +61452,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       clone-deep: 4.0.1
-      wildcard: 2.0.0
+      wildcard: 2.0.1
     dev: false
 
   /webpack-sources@1.4.3:
@@ -62300,16 +61485,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.0
+      '@types/estree': 1.0.1
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.8.2
-      acorn-import-assertions: 1.9.0(acorn@8.8.2)
+      acorn: 8.10.0
+      acorn-import-assertions: 1.9.0(acorn@8.10.0)
       browserslist: 4.16.3
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.14.1
-      es-module-lexer: 1.2.1
+      enhanced-resolve: 5.15.0
+      es-module-lexer: 1.3.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -62318,9 +61503,9 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.1.2
+      schema-utils: 3.3.0
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.8(esbuild@0.14.29)(webpack@5.84.1)
+      terser-webpack-plugin: 5.3.9(esbuild@0.14.29)(webpack@5.84.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -62346,16 +61531,36 @@ packages:
       iconv-lite: 0.4.24
     dev: false
 
+  /whatwg-encoding@2.0.0:
+    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
+    engines: {node: '>=12'}
+    dependencies:
+      iconv-lite: 0.6.3
+    dev: false
+
   /whatwg-fetch@0.9.0:
     resolution: {integrity: sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw==}
     dev: false
 
-  /whatwg-fetch@3.6.2:
-    resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
+  /whatwg-fetch@3.6.16:
+    resolution: {integrity: sha512-83avoGbZ0qtjtNrU3UTT3/Xd3uZ7DyfSYLuc1fL5iYs+93P+UkIVF6/6xpRVWeQcvbc7kSnVybSAVbd6QFW5Fg==}
     dev: false
 
   /whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
+    dev: false
+
+  /whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+    dev: false
+
+  /whatwg-url@12.0.1:
+    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
+    engines: {node: '>=14'}
+    dependencies:
+      tr46: 4.1.1
+      webidl-conversions: 7.0.0
     dev: false
 
   /whatwg-url@5.0.0:
@@ -62399,8 +61604,8 @@ packages:
       is-weakmap: 2.0.1
       is-weakset: 2.0.2
 
-  /which-module@2.0.0:
-    resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
+  /which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
     dev: false
 
   /which-pm@2.0.0:
@@ -62411,8 +61616,8 @@ packages:
       path-exists: 4.0.0
     dev: false
 
-  /which-typed-array@1.1.9:
-    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
+  /which-typed-array@1.1.11:
+    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
@@ -62420,7 +61625,6 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
-      is-typed-array: 1.1.10
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -62447,7 +61651,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 4.2.3
+      string-width: 1.0.2
     dev: false
 
   /widest-line@2.0.1:
@@ -62464,17 +61668,17 @@ packages:
       string-width: 4.2.3
     dev: false
 
-  /wildcard@2.0.0:
-    resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+  /wildcard@2.0.1:
+    resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
     dev: false
 
   /winston-transport@4.5.0:
     resolution: {integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==}
     engines: {node: '>= 6.4.0'}
     dependencies:
-      logform: 2.4.2
-      readable-stream: 3.6.0
-      triple-beam: 1.3.0
+      logform: 2.5.1
+      readable-stream: 3.6.2
+      triple-beam: 1.4.1
     dev: false
 
   /winston@2.4.7:
@@ -62496,16 +61700,16 @@ packages:
       '@dabh/diagnostics': 2.0.3
       async: 3.2.4
       is-stream: 2.0.1
-      logform: 2.4.2
+      logform: 2.5.1
       one-time: 1.0.0
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
       stack-trace: 0.0.10
-      triple-beam: 1.3.0
+      triple-beam: 1.4.1
       winston-transport: 4.5.0
     dev: false
 
-  /word-wrap@1.2.3:
-    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
+  /word-wrap@1.2.4:
+    resolution: {integrity: sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -62684,7 +61888,7 @@ packages:
   /workbox-window@6.2.4:
     resolution: {integrity: sha512-9jD6THkwGEASj1YP56ZBHYJ147733FoGpJlMamYk38k/EBFE75oc6K3Vs2tGOBx5ZGq54+mHSStnlrtFG3IiOg==}
     dependencies:
-      '@types/trusted-types': 2.0.2
+      '@types/trusted-types': 2.0.3
       workbox-core: 6.2.4
     dev: false
 
@@ -62881,10 +62085,15 @@ packages:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
     dev: false
 
+  /xml-name-validator@4.0.0:
+    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
+    engines: {node: '>=12'}
+    dev: false
+
   /xml2js@0.4.19:
     resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
     dependencies:
-      sax: 1.2.4
+      sax: 1.2.1
       xmlbuilder: 9.0.7
     dev: false
 
@@ -63011,7 +62220,7 @@ packages:
       require-main-filename: 2.0.0
       set-blocking: 2.0.0
       string-width: 4.2.3
-      which-module: 2.0.0
+      which-module: 2.0.1
       y18n: 4.0.3
       yargs-parser: 18.1.3
     dev: false
@@ -63114,7 +62323,7 @@ packages:
     dependencies:
       archiver-utils: 2.1.0
       compress-commons: 4.1.1
-      readable-stream: 3.6.0
+      readable-stream: 3.6.2
     dev: false
 
   /zwitch@1.0.5:
@@ -63147,10 +62356,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63173,7 +62382,7 @@ packages:
       '@react-hook/previous': 1.0.1(react@17.0.2)
       '@teambit/base-react.hooks.use-1d-nav': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.hooks.use-queued-execution': 0.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.item': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -63197,7 +62406,7 @@ packages:
     dependencies:
       '@teambit/component-id': 0.0.427
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63277,7 +62486,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component-id': 0.0.427
-      '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63321,8 +62529,8 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63339,8 +62547,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.dark-theme': 1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -63375,7 +62583,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -63521,7 +62729,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       react: 17.0.2
@@ -63635,8 +62843,8 @@ packages:
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/explorer.ui.gallery.component-grid': 0.0.496(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/lanes.ui.models': 0.0.79(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -63659,7 +62867,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63677,14 +62885,10 @@ packages:
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.dropdown': 1.2.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.input-text': 1.0.21(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.inputs.selectors.checkbox-item': 1.1.11(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.inputs.toggle-button': 0.0.9(@testing-library/react@12.1.5)(react@17.0.2)
-      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63704,7 +62908,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63760,7 +62964,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63777,7 +62981,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63936,7 +63140,7 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -64203,12 +63407,12 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -64286,24 +63490,21 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
-      '@teambit/component.ui.component-compare.context': 0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.status-resolver': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.selectors.checkbox-item': 1.1.11(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.dark-theme': 1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.radio': 1.1.13(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -64325,15 +63526,14 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/code.ui.code-view': 0.0.508(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label': registry.npmjs.org/@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -64392,7 +63592,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64407,7 +63606,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64422,7 +63620,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64521,7 +63718,6 @@ packages:
     name: '@teambit/compilation.modules.babel-compiler'
     dependencies:
       '@babel/core': 7.19.6
-      json-formatter-js: 2.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -64551,7 +63747,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64566,10 +63761,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/component.instructions.exporting-components': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.instructions.exporting-components': registry.npmjs.org/@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -64608,7 +63803,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.code-compare-section': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
@@ -64635,15 +63830,15 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/any-fs': 0.0.5
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.navigation.responsive-navbar': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.separator': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.separator': registry.npmjs.org/@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -64697,8 +63892,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/code.ui.object-formatter': 0.0.1(react@17.0.2)
-      '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64712,7 +63905,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.muted-italic': 0.0.44(react-dom@17.0.2)(react@17.0.2)
@@ -64822,8 +64015,6 @@ packages:
   file:scopes/component/component-package-version:
     resolution: {directory: scopes/component/component-package-version, type: directory}
     name: '@teambit/component-package-version'
-    dependencies:
-      '@teambit/component-version': 0.0.406
     dev: false
 
   file:scopes/component/component-sizer(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
@@ -64866,9 +64057,8 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
-      chai: 4.3.0
       query-string: 7.0.0
       react: 17.0.2
     transitivePeerDependencies:
@@ -64879,7 +64069,6 @@ packages:
     resolution: {directory: scopes/component/component-version, type: directory}
     name: '@teambit/component-version'
     dependencies:
-      chai: 4.3.0
       semver: 7.5.2
     dev: false
 
@@ -64974,15 +64163,15 @@ packages:
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.input.checkbox.label': 1.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.input.checkbox.label': registry.npmjs.org/@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -65087,7 +64276,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
-      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
@@ -65209,13 +64397,11 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
-      '@teambit/component-version': 0.0.406
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
       core-js: 3.13.0
-      fs-extra: 10.0.0
       lodash: 4.17.21
       node-fetch: 2.6.7
       p-map: 4.0.0
@@ -65259,7 +64445,6 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
-      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
@@ -65324,12 +64509,12 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -65401,15 +64586,15 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.layout.row': 0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.page-frame': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.page-frame': registry.npmjs.org/@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.navigation.content-tabs': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label-list': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label-list': registry.npmjs.org/@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65491,10 +64676,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65543,10 +64728,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.contributors': 0.0.514(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65567,12 +64751,11 @@ packages:
       react-router-dom: ^6.0.0
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65610,7 +64793,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65627,7 +64809,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65645,18 +64827,18 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.status-message-card': 0.0.17(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-context': 4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -65678,7 +64860,6 @@ packages:
     resolution: {directory: scopes/compositions/model/composition-id, type: directory}
     name: '@teambit/compositions.model.composition-id'
     dependencies:
-      chai: 4.3.0
       humanize-string: 2.1.0
     dev: false
 
@@ -65719,11 +64900,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65739,13 +64919,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/component.ui.component-compare.context': 0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       query-string: 7.0.0
       react: 17.0.2
@@ -65966,7 +65143,6 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       core-js: 3.13.0
-      fs-extra: 10.0.0
       p-map-series: 2.1.0
       prettier: 2.3.2
       react: 17.0.2
@@ -66058,7 +65234,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -66078,7 +65253,7 @@ packages:
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -66108,7 +65283,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -66124,7 +65299,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66139,7 +65313,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66154,7 +65327,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66390,7 +65562,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66461,7 +65632,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
@@ -66519,7 +65690,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66660,7 +65830,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66675,7 +65844,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66768,11 +65936,9 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       cacache: 15.0.5(bluebird@3.7.2)
-      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      uuid: 8.3.2
     transitivePeerDependencies:
       - bluebird
     dev: false
@@ -67032,7 +66198,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.copied-message': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0
@@ -67067,7 +66233,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67234,7 +66399,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       lodash: 4.17.21
@@ -67255,7 +66419,6 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
-      chai: 4.3.0
       core-js: 3.13.0
       fs-extra: 10.0.0
       minimatch: 3.0.5
@@ -67324,7 +66487,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.markdown.mdx': 0.1.13(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -67358,8 +66520,6 @@ packages:
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67377,7 +66537,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67427,7 +66586,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67449,7 +66607,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67494,7 +66651,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67560,8 +66716,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      chai: 4.3.0
+      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -67578,7 +66733,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67593,7 +66748,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67608,7 +66762,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67697,9 +66850,9 @@ packages:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
-      '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
-      '@prerenderer/renderer-jsdom': 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      '@prerenderer/webpack-plugin': 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+      '@prerenderer/prerenderer': 1.2.3(@types/express@4.17.13)(debug@4.3.2)
+      '@prerenderer/renderer-jsdom': 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      '@prerenderer/webpack-plugin': 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack': 5.5.0
       '@teambit/component-id': 0.0.427
       '@teambit/defender.eslint-linter': 1.0.1(@teambit/legacy@node_modules+@teambit+legacy)
@@ -67707,8 +66860,8 @@ packages:
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
-      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-tests': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/react.rendering.ssr': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/typescript.typescript-compiler': 2.0.1(@teambit/legacy@node_modules+@teambit+legacy)
       '@testing-library/jest-dom': 5.16.2
@@ -67875,7 +67028,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       '@teambit/react.instructions.react-native.adding-tests': 0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/jest-native': 4.0.4
       comment-json: 3.0.3
       core-js: 3.13.0
@@ -67888,7 +67041,6 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@teambit/legacy'
-      - supports-color
     dev: false
 
   file:scopes/react/ui/compositions-app(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
@@ -67899,7 +67051,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.standalone-not-found-page': 0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -67921,7 +67073,7 @@ packages:
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.code.react-playground': 4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       jsx-to-string: 1.4.0
@@ -67942,7 +67094,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67958,7 +67110,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67972,7 +67124,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       lodash: 4.17.21
       react: 17.0.2
@@ -67990,7 +67142,7 @@ packages:
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68007,7 +67159,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.styles.flex-center': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.styles.flex-center': registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.icon-button': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68043,7 +67195,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -68106,9 +67258,9 @@ packages:
       react-router-dom: ^6.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -68117,7 +67269,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.1
+      chokidar: 3.5.3
       classnames: 2.2.6
       core-js: 3.13.0
       fs-extra: 10.0.0
@@ -68145,7 +67297,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       chalk: 2.4.2
       core-js: 3.13.0
@@ -68162,8 +67313,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68205,8 +67355,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -68237,8 +67386,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68257,7 +67406,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       chalk: 2.4.2
       core-js: 3.13.0
@@ -68305,7 +67453,6 @@ packages:
     resolution: {directory: scopes/toolbox/fs/hard-link-directory, type: directory}
     name: '@teambit/toolbox.fs.hard-link-directory'
     dependencies:
-      '@teambit/defender.fs.global-bit-temp-dir': 0.0.1
       fs-extra: 10.0.0
       resolve-link-target: 1.0.1
       symlink-dir: 5.1.1
@@ -68332,8 +67479,6 @@ packages:
   file:scopes/toolbox/network/get-port:
     resolution: {directory: scopes/toolbox/network/get-port, type: directory}
     name: '@teambit/toolbox.network.get-port'
-    dependencies:
-      chai: 4.3.0
     dev: false
 
   file:scopes/toolbox/path/is-path-inside:
@@ -68345,7 +67490,6 @@ packages:
     resolution: {directory: scopes/toolbox/path/match-patterns, type: directory}
     name: '@teambit/toolbox.path.match-patterns'
     dependencies:
-      chai: 4.3.0
       minimatch: 3.0.5
     dev: false
 
@@ -68418,7 +67562,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68428,7 +67571,6 @@ packages:
     resolution: {directory: scopes/typescript/modules/ts-config-mutator, type: directory}
     name: '@teambit/typescript.modules.ts-config-mutator'
     dependencies:
-      json-formatter-js: 2.3.4
       lodash: 4.17.21
       typescript: 4.7.4
     dev: false
@@ -68455,9 +67597,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
-      chai: 4.3.0
       chalk: 2.4.2
-      comment-json: 3.0.3
       core-js: 3.13.0
       fs-extra: 10.0.0
       get-tsconfig: 4.2.0
@@ -68510,8 +67650,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68527,10 +67666,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68548,7 +67686,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68595,7 +67733,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68626,10 +67764,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.theme-provider': registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.elements.level-icon': 0.0.20(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.x-button': 1.0.7(react-dom@17.0.2)(react@17.0.2)
@@ -68649,7 +67785,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68786,8 +67922,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68802,14 +67937,12 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.root-node': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.root-node': registry.npmjs.org/@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68824,11 +67957,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.graph.tree.collapsable-tree-node': 0.0.4(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68844,9 +67976,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68869,8 +68001,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
-      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.fonts.roboto': registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.theme.icons-font': 2.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
@@ -68966,8 +68098,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69109,8 +68240,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69173,14 +68304,14 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69213,7 +68344,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69231,7 +68362,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69261,10 +68392,9 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69283,8 +68413,8 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -69306,7 +68436,7 @@ packages:
     dependencies:
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69336,7 +68466,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69413,8 +68543,6 @@ packages:
   file:scopes/webpack/modules/generate-externals:
     resolution: {directory: scopes/webpack/modules/generate-externals, type: directory}
     name: '@teambit/webpack.modules.generate-externals'
-    dependencies:
-      json-formatter-js: 2.3.4
     dev: false
 
   file:scopes/webpack/modules/generate-style-loaders:
@@ -69509,7 +68637,6 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69592,7 +68719,6 @@ packages:
     resolution: {directory: scopes/workspace/modules/match-pattern, type: directory}
     name: '@teambit/workspace.modules.match-pattern'
     dependencies:
-      chai: 4.3.0
       lodash: 4.17.21
       minimatch: 3.0.5
       ramda: 0.27.1
@@ -69604,9 +68730,7 @@ packages:
     dependencies:
       '@teambit/legacy-bit-id': 0.0.423
       fs-extra: 10.0.0
-      glob: 7.1.6
       p-map-series: 2.1.0
-      ramda: 0.27.1
     dev: false
 
   file:scopes/workspace/testing/mock-workspace:
@@ -69625,7 +68749,6 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -69640,7 +68763,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69708,7 +68831,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.1
+      chokidar: 3.5.3
       core-js: 3.13.0
       fs-extra: 10.0.0
       lodash: 4.17.21
@@ -69732,8 +68855,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@react-hook/latest': 1.0.3(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -69777,9 +68900,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
-      chai: 4.3.0
       chalk: 2.4.2
-      cli-table: 0.3.6
       core-js: 3.13.0
       fs-extra: 10.0.0
       globby: 11.0.1
@@ -69793,7 +68914,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.constants.storage/-/base-ui.constants.storage-1.0.0.tgz}
+    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.constants.storage/-/base-ui.constants.storage-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.constants.storage/1.0.0
     name: '@teambit/base-ui.constants.storage'
     version: 1.0.0
@@ -69806,7 +68927,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.elevation/-/base-ui.css-components.elevation-1.0.0.tgz}
+    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.elevation/-/base-ui.css-components.elevation-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.css-components.elevation/1.0.0
     name: '@teambit/base-ui.css-components.elevation'
     version: 1.0.0
@@ -69820,13 +68941,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.roundness/-/base-ui.css-components.roundness-1.0.0.tgz}
+    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.roundness/-/base-ui.css-components.roundness-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.css-components.roundness/1.0.0
     name: '@teambit/base-ui.css-components.roundness'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69834,7 +68955,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.icon/-/base-ui.elements.icon-1.0.0.tgz}
+    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.icon/-/base-ui.elements.icon-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.elements.icon/1.0.0
     name: '@teambit/base-ui.elements.icon'
     version: 1.0.0
@@ -69849,7 +68970,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.image/-/base-ui.elements.image-1.0.0.tgz}
+    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.image/-/base-ui.elements.image-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.elements.image/1.0.0
     name: '@teambit/base-ui.elements.image'
     version: 1.0.0
@@ -69864,7 +68985,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.indent/-/base-ui.graph.tree.indent-1.0.0.tgz}
+    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.indent/-/base-ui.graph.tree.indent-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.indent/1.0.0
     name: '@teambit/base-ui.graph.tree.indent'
     version: 1.0.0
@@ -69878,7 +68999,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/-/base-ui.graph.tree.inflate-paths-1.0.0.tgz}
+    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/-/base-ui.graph.tree.inflate-paths-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/1.0.0
     name: '@teambit/base-ui.graph.tree.inflate-paths'
     version: 1.0.0
@@ -69894,7 +69015,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/-/base-ui.graph.tree.recursive-tree-1.0.0.tgz}
+    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/-/base-ui.graph.tree.recursive-tree-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/1.0.0
     name: '@teambit/base-ui.graph.tree.recursive-tree'
     version: 1.0.0
@@ -69909,7 +69030,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/-/base-ui.graph.tree.root-node-1.0.0.tgz}
+    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/-/base-ui.graph.tree.root-node-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/1.0.0
     name: '@teambit/base-ui.graph.tree.root-node'
     version: 1.0.0
@@ -69924,7 +69045,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/-/base-ui.graph.tree.tree-context-1.0.0.tgz}
+    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/-/base-ui.graph.tree.tree-context-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/1.0.0
     name: '@teambit/base-ui.graph.tree.tree-context'
     version: 1.0.0
@@ -69938,13 +69059,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/-/base-ui.hook.use-click-outside-1.0.0.tgz}
+    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/-/base-ui.hook.use-click-outside-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/1.0.0
     name: '@teambit/base-ui.hook.use-click-outside'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69952,7 +69073,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/-/base-ui.input.checkbox.hidden-1.0.1.tgz}
+    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/-/base-ui.input.checkbox.hidden-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/1.0.1
     name: '@teambit/base-ui.input.checkbox.hidden'
     version: 1.0.1
@@ -69967,13 +69088,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/-/base-ui.input.checkbox.indicator-1.0.0.tgz}
+    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/-/base-ui.input.checkbox.indicator-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/1.0.0
     name: '@teambit/base-ui.input.checkbox.indicator'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69982,7 +69103,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.label@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.label/-/base-ui.input.checkbox.label-1.0.1.tgz}
+    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.label/-/base-ui.input.checkbox.label-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.label/1.0.1
     name: '@teambit/base-ui.input.checkbox.label'
     version: 1.0.1
@@ -69998,7 +69119,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.breakpoints/-/base-ui.layout.breakpoints-1.0.0.tgz}
+    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.breakpoints/-/base-ui.layout.breakpoints-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.breakpoints/1.0.0
     name: '@teambit/base-ui.layout.breakpoints'
     version: 1.0.0
@@ -70012,7 +69133,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-CIqH04NFmVRkfFdA3MA94FJ6Z2PXETUBPyRneu9Aik1SQhQJsXUyoIoZHloL1/6K6B4F/TfESPVXn7hsPNzI3A==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.grid-component/-/base-ui.layout.grid-component-1.0.0.tgz}
+    resolution: {integrity: sha512-CIqH04NFmVRkfFdA3MA94FJ6Z2PXETUBPyRneu9Aik1SQhQJsXUyoIoZHloL1/6K6B4F/TfESPVXn7hsPNzI3A==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.grid-component/-/base-ui.layout.grid-component-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.grid-component/1.0.0
     name: '@teambit/base-ui.layout.grid-component'
     version: 1.0.0
@@ -70028,7 +69149,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.page-frame/-/base-ui.layout.page-frame-1.0.0.tgz}
+    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.page-frame/-/base-ui.layout.page-frame-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.page-frame/1.0.0
     name: '@teambit/base-ui.layout.page-frame'
     version: 1.0.0
@@ -70042,7 +69163,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/-/base-ui.loaders.loader-ribbon-1.0.0.tgz}
+    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/-/base-ui.loaders.loader-ribbon-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/1.0.0
     name: '@teambit/base-ui.loaders.loader-ribbon'
     version: 1.0.0
@@ -70057,7 +69178,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.compare-url/-/base-ui.routing.compare-url-1.0.0.tgz}
+    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.compare-url/-/base-ui.routing.compare-url-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.compare-url/1.0.0
     name: '@teambit/base-ui.routing.compare-url'
     version: 1.0.0
@@ -70069,10 +69190,9 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       url-parse: 1.5.1
-    dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.link/-/base-ui.routing.link-1.0.0.tgz}
+    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.link/-/base-ui.routing.link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.link/1.0.0
     name: '@teambit/base-ui.routing.link'
     version: 1.0.0
@@ -70081,27 +69201,27 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.routing-provider': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.routing-provider': registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
   registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-link/-/base-ui.routing.native-link-1.0.0.tgz}
+    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-link/-/base-ui.routing.native-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.native-link/1.0.0
     name: '@teambit/base-ui.routing.native-link'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/-/base-ui.routing.native-nav-link-1.0.0.tgz}
+    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/-/base-ui.routing.native-nav-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/1.0.0
     name: '@teambit/base-ui.routing.native-nav-link'
     version: 1.0.0
@@ -70109,17 +69229,16 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.compare-url': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.compare-url': registry.npmjs.org/@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.nav-link/-/base-ui.routing.nav-link-1.0.0.tgz}
+    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.nav-link/-/base-ui.routing.nav-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.nav-link/1.0.0
     name: '@teambit/base-ui.routing.nav-link'
     version: 1.0.0
@@ -70135,7 +69254,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.routing-provider/-/base-ui.routing.routing-provider-1.0.0.tgz}
+    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.routing-provider/-/base-ui.routing.routing-provider-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.routing-provider/1.0.0
     name: '@teambit/base-ui.routing.routing-provider'
     version: 1.0.0
@@ -70143,16 +69262,15 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-nav-link': registry.npmjs.org/@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: false
 
   registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.styles.flex-center/-/base-ui.styles.flex-center-1.0.0.tgz}
+    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.styles.flex-center/-/base-ui.styles.flex-center-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.styles.flex-center/1.0.0
     name: '@teambit/base-ui.styles.flex-center'
     version: 1.0.0
@@ -70166,7 +69284,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/-/base-ui.surfaces.abs-container-1.0.0.tgz}
+    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/-/base-ui.surfaces.abs-container-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/1.0.0
     name: '@teambit/base-ui.surfaces.abs-container'
     version: 1.0.0
@@ -70182,13 +69300,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.1.tgz}
+    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.1
     name: '@teambit/base-ui.surfaces.background'
     version: 1.0.1
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -70196,7 +69314,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.1.tgz}
+    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.1
     name: '@teambit/base-ui.surfaces.card'
     version: 1.0.1
@@ -70214,7 +69332,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.drawer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.drawer/-/base-ui.surfaces.drawer-1.0.0.tgz}
+    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.drawer/-/base-ui.surfaces.drawer-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.drawer/1.0.0
     name: '@teambit/base-ui.surfaces.drawer'
     version: 1.0.0
@@ -70232,7 +69350,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
+    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.hover-splitter'
     version: 1.0.0
@@ -70248,7 +69366,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/-/base-ui.surfaces.split-pane.layout-1.0.0.tgz}
+    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/-/base-ui.surfaces.split-pane.layout-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.layout'
     version: 1.0.0
@@ -70262,7 +69380,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/-/base-ui.surfaces.split-pane.pane-1.0.0.tgz}
+    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/-/base-ui.surfaces.split-pane.pane-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.pane'
     version: 1.0.0
@@ -70278,7 +69396,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/-/base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
+    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/-/base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.split-pane'
     version: 1.0.0
@@ -70296,13 +69414,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/-/base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
+    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/-/base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.splitter'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -70311,7 +69429,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.heading@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.heading/-/base-ui.text.heading-1.0.1.tgz}
+    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.heading/-/base-ui.text.heading-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.heading/1.0.1
     name: '@teambit/base-ui.text.heading'
     version: 1.0.1
@@ -70325,7 +69443,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.muted-text/-/base-ui.text.muted-text-1.0.1.tgz}
+    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.muted-text/-/base-ui.text.muted-text-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.muted-text/1.0.1
     name: '@teambit/base-ui.text.muted-text'
     version: 1.0.1
@@ -70340,7 +69458,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.paragraph@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.paragraph/-/base-ui.text.paragraph-1.0.1.tgz}
+    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.paragraph/-/base-ui.text.paragraph-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.paragraph/1.0.1
     name: '@teambit/base-ui.text.paragraph'
     version: 1.0.1
@@ -70357,7 +69475,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.text-sizes/-/base-ui.text.text-sizes-1.0.0.tgz}
+    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.text-sizes/-/base-ui.text.text-sizes-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.text-sizes/1.0.0
     name: '@teambit/base-ui.text.text-sizes'
     version: 1.0.0
@@ -70371,7 +69489,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.themed-text/-/base-ui.text.themed-text-1.0.1.tgz}
+    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.themed-text/-/base-ui.text.themed-text-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.themed-text/1.0.1
     name: '@teambit/base-ui.text.themed-text'
     version: 1.0.1
@@ -70386,7 +69504,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-1.1.0.tgz}
+    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-1.1.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.accent-color/1.1.0
     name: '@teambit/base-ui.theme.accent-color'
     version: 1.1.0
@@ -70401,7 +69519,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.brand-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.brand-definition/-/base-ui.theme.brand-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.brand-definition/-/base-ui.theme.brand-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.brand-definition/1.0.0
     name: '@teambit/base-ui.theme.brand-definition'
     version: 1.0.0
@@ -70414,7 +69532,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.color-definition@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.color-definition/-/base-ui.theme.color-definition-1.0.1.tgz}
+    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.color-definition/-/base-ui.theme.color-definition-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.color-definition/1.0.1
     name: '@teambit/base-ui.theme.color-definition'
     version: 1.0.1
@@ -70428,7 +69546,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-1.0.0.tgz}
+    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0
     name: '@teambit/base-ui.theme.colors'
     version: 1.0.0
@@ -70441,7 +69559,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.2.tgz}
+    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.2
     name: '@teambit/base-ui.theme.dark-theme'
     version: 1.0.2
@@ -70455,7 +69573,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.fonts.book@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.book/-/base-ui.theme.fonts.book-1.0.0.tgz}
+    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.book/-/base-ui.theme.fonts.book-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.fonts.book/1.0.0
     name: '@teambit/base-ui.theme.fonts.book'
     version: 1.0.0
@@ -70468,7 +69586,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/-/base-ui.theme.fonts.roboto-1.0.0.tgz}
+    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/-/base-ui.theme.fonts.roboto-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/1.0.0
     name: '@teambit/base-ui.theme.fonts.roboto'
     version: 1.0.0
@@ -70481,7 +69599,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/-/base-ui.theme.heading-margin-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/-/base-ui.theme.heading-margin-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/1.0.0
     name: '@teambit/base-ui.theme.heading-margin-definition'
     version: 1.0.0
@@ -70494,7 +69612,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.shadow-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/-/base-ui.theme.shadow-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/-/base-ui.theme.shadow-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/1.0.0
     name: '@teambit/base-ui.theme.shadow-definition'
     version: 1.0.0
@@ -70507,7 +69625,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.size-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.size-definition/-/base-ui.theme.size-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.size-definition/-/base-ui.theme.size-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.size-definition/1.0.0
     name: '@teambit/base-ui.theme.size-definition'
     version: 1.0.0
@@ -70520,7 +69638,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.sizes/-/base-ui.theme.sizes-1.0.0.tgz}
+    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.sizes/-/base-ui.theme.sizes-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.sizes/1.0.0
     name: '@teambit/base-ui.theme.sizes'
     version: 1.0.0
@@ -70534,7 +69652,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.theme-provider/-/base-ui.theme.theme-provider-1.0.1.tgz}
+    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.theme-provider/-/base-ui.theme.theme-provider-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.theme-provider/1.0.1
     name: '@teambit/base-ui.theme.theme-provider'
     version: 1.0.1
@@ -70554,7 +69672,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.composer/-/base-ui.utils.composer-1.0.0.tgz}
+    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.composer/-/base-ui.utils.composer-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.composer/1.0.0
     name: '@teambit/base-ui.utils.composer'
     version: 1.0.0
@@ -70567,8 +69685,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.is-browser/-/base-ui.utils.is-browser-1.0.0.tgz}
+    id: registry.npmjs.org/@teambit/base-ui.utils.is-browser/1.0.0
+    name: '@teambit/base-ui.utils.is-browser'
+    version: 1.0.0
+    peerDependencies:
+      react: '*'
+      react-dom: '*'
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.string.affix/-/base-ui.utils.string.affix-1.0.0.tgz}
+    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.string.affix/-/base-ui.utils.string.affix-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.string.affix/1.0.0
     name: '@teambit/base-ui.utils.string.affix'
     version: 1.0.0
@@ -70582,7 +69713,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.utils.sub-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.sub-paths/-/base-ui.utils.sub-paths-1.0.0.tgz}
+    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.sub-paths/-/base-ui.utils.sub-paths-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.sub-paths/1.0.0
     name: '@teambit/base-ui.utils.sub-paths'
     version: 1.0.0
@@ -70597,7 +69728,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component.instructions.exporting-components/-/component.instructions.exporting-components-0.0.6.tgz}
+    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component.instructions.exporting-components/-/component.instructions.exporting-components-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6
     name: '@teambit/component.instructions.exporting-components'
     version: 0.0.6
@@ -70615,7 +69746,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-dCfQMPt3JfXboNOf21tM23kjsZkj6lW8apc4lJerC9vOn5TjU22PgC68SQ7xgF276rjIC896DVwGzsJijwjWpw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.theme.icons-font/-/design.theme.icons-font-1.0.0.tgz}
+    resolution: {integrity: sha512-dCfQMPt3JfXboNOf21tM23kjsZkj6lW8apc4lJerC9vOn5TjU22PgC68SQ7xgF276rjIC896DVwGzsJijwjWpw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.theme.icons-font/-/design.theme.icons-font-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/design.theme.icons-font/1.0.0
     name: '@teambit/design.theme.icons-font'
     version: 1.0.0
@@ -70627,9 +69758,10 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: true
 
   registry.npmjs.org/@teambit/design.ui.styles.ellipsis@0.0.344(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-SwTlVagmcCvedxD9hrq+1pt9MxkYY+GfYAyF4BUsTjKYAv37ZqOX8dqNgmkKhKlTBXSAw70rfGDQ5BBE8Ptipw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.344.tgz}
+    resolution: {integrity: sha512-SwTlVagmcCvedxD9hrq+1pt9MxkYY+GfYAyF4BUsTjKYAv37ZqOX8dqNgmkKhKlTBXSAw70rfGDQ5BBE8Ptipw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.344.tgz}
     id: registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.344
     name: '@teambit/design.ui.styles.ellipsis'
     version: 0.0.344
@@ -70645,7 +69777,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-compositions/-/documenter.theme.theme-compositions-4.1.1.tgz}
+    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-compositions/-/documenter.theme.theme-compositions-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.theme.theme-compositions/4.1.1
     name: '@teambit/documenter.theme.theme-compositions'
     version: 4.1.1
@@ -70658,9 +69790,10 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: true
 
   registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-context/-/documenter.theme.theme-context-4.0.3.tgz}
+    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-context/-/documenter.theme.theme-context-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.theme.theme-context/4.0.3
     name: '@teambit/documenter.theme.theme-context'
     version: 4.0.3
@@ -70676,7 +69809,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.consumable-link/-/documenter.ui.consumable-link-4.0.3.tgz}
+    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.consumable-link/-/documenter.ui.consumable-link-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.consumable-link/4.0.3
     name: '@teambit/documenter.ui.consumable-link'
     version: 4.0.3
@@ -70693,8 +69826,23 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  registry.npmjs.org/@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.0.1.tgz}
+    id: registry.npmjs.org/@teambit/documenter.ui.copied-message/4.0.1
+    name: '@teambit/documenter.ui.copied-message'
+    version: 4.0.1
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   registry.npmjs.org/@teambit/documenter.ui.copied-message@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PbXQD3l6iydMLDoWtOTNj9HBpgUMK2melalxXRAAudCwG5Tk0cdWMAgKOLIa8lT7ObMBUcdy9Ed7LCcIWEOIQg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.1.1.tgz}
+    resolution: {integrity: sha512-PbXQD3l6iydMLDoWtOTNj9HBpgUMK2melalxXRAAudCwG5Tk0cdWMAgKOLIa8lT7ObMBUcdy9Ed7LCcIWEOIQg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copied-message/4.1.1
     name: '@teambit/documenter.ui.copied-message'
     version: 4.1.1
@@ -70709,7 +69857,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.copy-box@4.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-G1RaI94h1TuMe+wpBOUnLhP82/LNV1QY5IyFqLbarYtRsddhQePNu+R7PmKhKBwbPHPyAbeFr6qWVybUXDbvXw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.0.1.tgz}
+    resolution: {integrity: sha512-G1RaI94h1TuMe+wpBOUnLhP82/LNV1QY5IyFqLbarYtRsddhQePNu+R7PmKhKBwbPHPyAbeFr6qWVybUXDbvXw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.0.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copy-box/4.0.1
     name: '@teambit/documenter.ui.copy-box'
     version: 4.0.1
@@ -70718,8 +69866,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.copied-message': 4.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.copied-message': registry.npmjs.org/@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0
@@ -70728,7 +69876,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-7mzL2LeRxV6O6QyQl+q0yCNL+DsHVVHgkzJoE1favbn+di5BUdw+4XmZeI5LxeLq2WSrc6pmMwln97CkTGvLHg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.1.1.tgz}
+    resolution: {integrity: sha512-7mzL2LeRxV6O6QyQl+q0yCNL+DsHVVHgkzJoE1favbn+di5BUdw+4XmZeI5LxeLq2WSrc6pmMwln97CkTGvLHg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copy-box/4.1.1
     name: '@teambit/documenter.ui.copy-box'
     version: 4.1.1
@@ -70747,7 +69895,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.heading/-/documenter.ui.heading-4.1.1.tgz}
+    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.heading/-/documenter.ui.heading-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.heading/4.1.1
     name: '@teambit/documenter.ui.heading'
     version: 4.1.1
@@ -70763,7 +69911,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.highlighted-text/-/documenter.ui.highlighted-text-4.1.1.tgz}
+    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.highlighted-text/-/documenter.ui.highlighted-text-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.highlighted-text/4.1.1
     name: '@teambit/documenter.ui.highlighted-text'
     version: 4.1.1
@@ -70778,7 +69926,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.inline-code@0.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.inline-code/-/documenter.ui.inline-code-0.1.1.tgz}
+    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.inline-code/-/documenter.ui.inline-code-0.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.inline-code/0.1.1
     name: '@teambit/documenter.ui.inline-code'
     version: 0.1.1
@@ -70793,7 +69941,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label-list/-/documenter.ui.label-list-4.0.3.tgz}
+    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label-list/-/documenter.ui.label-list-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.label-list/4.0.3
     name: '@teambit/documenter.ui.label-list'
     version: 4.0.3
@@ -70809,7 +69957,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label/-/documenter.ui.label-4.0.3.tgz}
+    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label/-/documenter.ui.label-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.label/4.0.3
     name: '@teambit/documenter.ui.label'
     version: 4.0.3
@@ -70824,7 +69972,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.paragraph/-/documenter.ui.paragraph-4.1.1.tgz}
+    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.paragraph/-/documenter.ui.paragraph-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.paragraph/4.1.1
     name: '@teambit/documenter.ui.paragraph'
     version: 4.1.1
@@ -70841,7 +69989,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.section/-/documenter.ui.section-4.1.1.tgz}
+    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.section/-/documenter.ui.section-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.section/4.1.1
     name: '@teambit/documenter.ui.section'
     version: 4.1.1
@@ -70855,7 +70003,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.separator/-/documenter.ui.separator-4.1.1.tgz}
+    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.separator/-/documenter.ui.separator-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.separator/4.1.1
     name: '@teambit/documenter.ui.separator'
     version: 4.1.1
@@ -70869,7 +70017,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.sub-title/-/documenter.ui.sub-title-4.1.1.tgz}
+    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.sub-title/-/documenter.ui.sub-title-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.sub-title/4.1.1
     name: '@teambit/documenter.ui.sub-title'
     version: 4.1.1
@@ -70886,7 +70034,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.table-column@4.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sGMLD+Lu2snQ1g1xUXYHqhbUcH3iOp0CUc69T76SNt3cQBabNGb5T9yg0A/7JYN4Ams1IKJ8Anws8+T64huSDg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.table-column/-/documenter.ui.table-column-4.0.0.tgz}
+    resolution: {integrity: sha512-sGMLD+Lu2snQ1g1xUXYHqhbUcH3iOp0CUc69T76SNt3cQBabNGb5T9yg0A/7JYN4Ams1IKJ8Anws8+T64huSDg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.table-column/-/documenter.ui.table-column-4.0.0.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.table-column/4.0.0
     name: '@teambit/documenter.ui.table-column'
     version: 4.0.0
@@ -70901,7 +70049,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/-/evangelist.css-components.fade-in-out-1.0.1.tgz}
+    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/-/evangelist.css-components.fade-in-out-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/1.0.1
     name: '@teambit/evangelist.css-components.fade-in-out'
     version: 1.0.1
@@ -70915,7 +70063,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.elements.icon/-/evangelist.elements.icon-1.0.2.tgz}
+    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.elements.icon/-/evangelist.elements.icon-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.elements.icon/1.0.2
     name: '@teambit/evangelist.elements.icon'
     version: 1.0.2
@@ -70930,7 +70078,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/-/evangelist.input.checkbox.indicator-1.0.2.tgz}
+    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/-/evangelist.input.checkbox.indicator-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/1.0.2
     name: '@teambit/evangelist.input.checkbox.indicator'
     version: 1.0.2
@@ -70947,7 +70095,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.label/-/evangelist.input.checkbox.label-1.0.3.tgz}
+    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.label/-/evangelist.input.checkbox.label-1.0.3.tgz}
     id: registry.npmjs.org/@teambit/evangelist.input.checkbox.label/1.0.3
     name: '@teambit/evangelist.input.checkbox.label'
     version: 1.0.3
@@ -70963,13 +70111,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/-/evangelist.surfaces.dropdown-1.0.2.tgz}
+    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/-/evangelist.surfaces.dropdown-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/1.0.2
     name: '@teambit/evangelist.surfaces.dropdown'
     version: 1.0.2
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.css-components.elevation': registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.css-components.roundness': registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -70984,7 +70132,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/-/evangelist.surfaces.tooltip-1.0.1.tgz}
+    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/-/evangelist.surfaces.tooltip-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/1.0.1
     name: '@teambit/evangelist.surfaces.tooltip'
     version: 1.0.1
@@ -71004,7 +70152,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/-/mdx.ui.mdx-scope-context-0.0.368.tgz}
+    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/-/mdx.ui.mdx-scope-context-0.0.368.tgz}
     id: registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368
     name: '@teambit/mdx.ui.mdx-scope-context'
     version: 0.0.368
@@ -71020,7 +70168,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/-/react.instructions.react.adding-compositions-0.0.6.tgz}
+    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/-/react.instructions.react.adding-compositions-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6
     name: '@teambit/react.instructions.react.adding-compositions'
     version: 0.0.6
@@ -71038,7 +70186,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-tests/-/react.instructions.react.adding-tests-0.0.6.tgz}
+    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-tests/-/react.instructions.react.adding-tests-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6
     name: '@teambit/react.instructions.react.adding-tests'
     version: 0.0.6
@@ -71055,9 +70203,36 @@ packages:
       - '@teambit/legacy'
     dev: false
 
-  registry.npmjs.org/is-stream@1.1.0:
-    resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz}
-    name: is-stream
-    version: 1.1.0
-    engines: {node: '>=0.10.0'}
+  registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
+    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.agent/-/toolbox.network.agent-0.0.116.tgz}
+    id: registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116
+    name: '@teambit/toolbox.network.agent'
+    version: 0.0.116
+    engines: {node: '>=12.15.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.108
+    dependencies:
+      '@teambit/legacy': link:node_modules/@teambit/legacy
+      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+      agentkeepalive: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  registry.npmjs.org/@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
+    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.proxy-agent/-/toolbox.network.proxy-agent-0.0.116.tgz}
+    id: registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116
+    name: '@teambit/toolbox.network.proxy-agent'
+    version: 0.0.116
+    engines: {node: '>=12.15.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.108
+    dependencies:
+      '@teambit/legacy': link:node_modules/@teambit/legacy
+      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.0
+      socks-proxy-agent: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -470,7 +470,7 @@ importers:
         version: 4.2.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.consumable-link':
         specifier: 4.0.3
-        version: registry.npmjs.org/@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2)
+        version: 4.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copied-message':
         specifier: 4.1.6
         version: 4.1.6(react-dom@17.0.2)(react@17.0.2)
@@ -617,7 +617,7 @@ importers:
         version: 0.0.1
       '@teambit/toolbox.network.agent':
         specifier: 0.0.116
-        version: registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+        version: 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/typescript.deps-detectors.detective-typescript':
         specifier: ^0.0.1
         version: 0.0.1(typescript@4.7.4)
@@ -1710,7 +1710,7 @@ importers:
         version: 1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.95.9
         version: 1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
@@ -16640,7 +16640,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16680,7 +16680,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16720,7 +16720,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -17030,7 +17030,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19408,7 +19408,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -19460,7 +19460,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19518,7 +19518,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19585,7 +19585,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19793,7 +19793,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19857,7 +19857,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19912,7 +19912,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -20206,7 +20206,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -21082,7 +21082,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -21266,7 +21266,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21306,7 +21306,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21346,7 +21346,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21971,7 +21971,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22305,7 +22305,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22671,7 +22671,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22711,7 +22711,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -23756,7 +23756,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24171,7 +24171,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24287,7 +24287,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24410,7 +24410,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24487,7 +24487,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24536,7 +24536,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24735,7 +24735,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24854,7 +24854,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25132,7 +25132,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25172,7 +25172,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26532,7 +26532,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27252,7 +27252,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27486,7 +27486,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27541,7 +27541,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28210,7 +28210,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28271,7 +28271,7 @@ importers:
         version: 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -28326,7 +28326,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -29438,7 +29438,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -30067,7 +30067,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -30396,7 +30396,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -30442,7 +30442,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -30494,7 +30494,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -31007,7 +31007,7 @@ packages:
     engines: {node: '>=6.9.0'}
     hasBin: true
     peerDependencies:
-      '@babel/core': '*'
+      '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
       '@jridgewell/trace-mapping': 0.3.18
@@ -33900,7 +33900,7 @@ packages:
   /@graphql-modules/di@0.7.17(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-Lq5sd/3RO+bNb8wVnAg43LWbwrqD57D0AVEqZlqiTwUj1f0mITtQdGMRN7g2sG79U7ngoaQx8VK/IiKh8E1OFQ==}
     peerDependencies:
-      reflect-metadata: '*'
+      reflect-metadata: ^0.1.12
     dependencies:
       events: 3.1.0
       reflect-metadata: 0.1.13
@@ -33911,7 +33911,7 @@ packages:
     resolution: {integrity: sha512-rrH/KPheh/wCZzqUmNayBHd+aNWl/751C4iTL/327TzONdAVrV7ZQOyEkpGLW6YEFWPIlWxNkaBoEALIjCxTGg==}
     deprecated: GraphQL Toolkit is deprecated and merged into GraphQL Tools, so it will no longer get updates. Use GraphQL Tools instead to stay up-to-date! Check out https://www.graphql-tools.com/docs/migration-from-toolkit for migration and https://the-guild.dev/blog/graphql-tools-v6 for new changes.
     peerDependencies:
-      graphql: '*'
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       aggregate-error: 3.0.1
       camel-case: 4.1.1
@@ -33925,7 +33925,7 @@ packages:
   /@graphql-toolkit/schema-merging@0.10.6(graphql@15.8.0):
     resolution: {integrity: sha512-BNABgYaNCw4Li3EiH/x7oDpkN+ml3M0SWqjnsW1Pf2NcyfGlv033Bda+O/q4XYtseZ0OOOh52GLXtUgwyPFb8A==}
     peerDependencies:
-      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: '*'
     dependencies:
       '@graphql-toolkit/common': 0.10.6(graphql@15.8.0)
       deepmerge: 4.2.2
@@ -34399,20 +34399,24 @@ packages:
     resolution: {integrity: sha512-zZbZeHQDnoTlt2AF+diQT0wsSXpvWiaIOZwBRdltNFhG1+I3ozyaw7U/nBiUwyJ0D+zwdXp0E3bWOl38Ag2BMw==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': 4.x || 5.x
-      react-refresh: '>=0.10.0 <1.0.0'
-      sockjs-client: ^1.4.0
-      type-fest: '>=0.17.0 <3.0.0'
-      webpack: '>=4.43.0 <6.0.0'
-      webpack-dev-server: 3.x || 4.x
-      webpack-hot-middleware: 2.x
-      webpack-plugin-serve: 0.x || 1.x
+      '@types/webpack': '*'
+      react-refresh: '*'
+      sockjs-client: '*'
+      type-fest: '*'
+      webpack: '*'
+      webpack-dev-server: '*'
+      webpack-hot-middleware: '*'
+      webpack-plugin-serve: '*'
     peerDependenciesMeta:
       '@types/webpack':
+        optional: true
+      react-refresh:
         optional: true
       sockjs-client:
         optional: true
       type-fest:
+        optional: true
+      webpack:
         optional: true
       webpack-dev-server:
         optional: true
@@ -34536,7 +34540,7 @@ packages:
     dev: false
 
   /@pnpm/config.env-replace@1.1.0:
-    resolution: {integrity: sha1-GTiz4TEVgTwrNypNzHfyEQ0tIk0=, tarball: https://node-registry.bit.cloud/@pnpm/config.env-replace/-/@pnpm-config.env-replace-1.1.0.tgz}
+    resolution: {integrity: sha1-GTiz4TEVgTwrNypNzHfyEQ0tIk0=, tarball: https://node-registry.v2.bit.cloud/@pnpm/config.env-replace/-/@pnpm-config.env-replace-1.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -35251,7 +35255,7 @@ packages:
     dev: false
 
   /@pnpm/network.agent@0.0.3:
-    resolution: {integrity: sha1-g28zSZMRCjzekv8O3yavci0Lt4c=, tarball: https://node-registry.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.0.3.tgz}
+    resolution: {integrity: sha1-g28zSZMRCjzekv8O3yavci0Lt4c=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.proxy-agent': 0.0.3
@@ -35262,7 +35266,7 @@ packages:
     dev: false
 
   /@pnpm/network.agent@0.1.0:
-    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.1.0.tgz}
+    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.proxy-agent': 0.1.0
@@ -35281,21 +35285,21 @@ packages:
     dev: false
 
   /@pnpm/network.ca-file@1.0.1:
-    resolution: {integrity: sha1-6O8TBzfQYCe8rNSKZc9Vk/Y50g0=, tarball: https://node-registry.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.1.tgz}
+    resolution: {integrity: sha1-6O8TBzfQYCe8rNSKZc9Vk/Y50g0=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.1.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: false
 
   /@pnpm/network.ca-file@1.0.2:
-    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.2.tgz}
+    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.2.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: false
 
   /@pnpm/network.proxy-agent@0.0.3:
-    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.0.3.tgz}
+    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       http-proxy-agent: 5.0.0
@@ -35307,7 +35311,7 @@ packages:
     dev: false
 
   /@pnpm/network.proxy-agent@0.1.0:
-    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.1.0.tgz}
+    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/error': 4.0.1
@@ -35961,7 +35965,7 @@ packages:
     dev: false
 
   /@pnpm/util.lex-comparator@1.0.0:
-    resolution: {integrity: sha1-C31RMSZdb1uqS+gSx4IeULjTngk=, tarball: https://node-registry.bit.cloud/@pnpm/util.lex-comparator/-/@pnpm-util.lex-comparator-1.0.0.tgz}
+    resolution: {integrity: sha1-C31RMSZdb1uqS+gSx4IeULjTngk=, tarball: https://node-registry.v2.bit.cloud/@pnpm/util.lex-comparator/-/@pnpm-util.lex-comparator-1.0.0.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -36377,7 +36381,7 @@ packages:
     dev: false
 
   /@teambit/analytics.timeseries@0.0.25(graphql@15.8.0)(react@17.0.2):
-    resolution: {integrity: sha1-v6T2aEqGAqJ+6pxyfVToHSCgdwo=, tarball: https://node-registry.bit.cloud/@teambit/analytics.timeseries/-/@teambit-analytics.timeseries-0.0.25.tgz}
+    resolution: {integrity: sha1-v6T2aEqGAqJ+6pxyfVToHSCgdwo=, tarball: https://node-registry.v2.bit.cloud/@teambit/analytics.timeseries/-/@teambit-analytics.timeseries-0.0.25.tgz}
     peerDependencies:
       graphql: 14.7.0
       react: 17.0.2
@@ -36395,7 +36399,7 @@ packages:
     dev: false
 
   /@teambit/base-react.forms.form@0.0.13(react@17.0.2):
-    resolution: {integrity: sha1-b206QQgFqXvG7gLm7FNajEn8IF0=, tarball: https://node-registry.bit.cloud/@teambit/base-react.forms.form/-/@teambit-base-react.forms.form-0.0.13.tgz}
+    resolution: {integrity: sha1-b206QQgFqXvG7gLm7FNajEn8IF0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.forms.form/-/@teambit-base-react.forms.form-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36404,7 +36408,7 @@ packages:
     dev: false
 
   /@teambit/base-react.hooks.use-1d-nav@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8CXqMfKPcSY3md7/e96pRRCexzM=, tarball: https://node-registry.bit.cloud/@teambit/base-react.hooks.use-1d-nav/-/@teambit-base-react.hooks.use-1d-nav-1.0.0.tgz}
+    resolution: {integrity: sha1-8CXqMfKPcSY3md7/e96pRRCexzM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.hooks.use-1d-nav/-/@teambit-base-react.hooks.use-1d-nav-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36415,7 +36419,7 @@ packages:
     dev: false
 
   /@teambit/base-react.hooks.use-queued-execution@0.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xeZQchaS1QCoGLT0bRc9m4LShns=, tarball: https://node-registry.bit.cloud/@teambit/base-react.hooks.use-queued-execution/-/@teambit-base-react.hooks.use-queued-execution-0.0.3.tgz}
+    resolution: {integrity: sha1-xeZQchaS1QCoGLT0bRc9m4LShns=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.hooks.use-queued-execution/-/@teambit-base-react.hooks.use-queued-execution-0.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36426,7 +36430,7 @@ packages:
     dev: false
 
   /@teambit/base-react.layout.row@0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.bit.cloud/@teambit/base-react.layout.row/-/@teambit-base-react.layout.row-0.0.3.tgz}
+    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.layout.row/-/@teambit-base-react.layout.row-0.0.3.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36440,7 +36444,7 @@ packages:
     dev: false
 
   /@teambit/base-react.navigation.link@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dkmFy935I+/7kialZCzjASBEjs0=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-1.23.0.tgz}
+    resolution: {integrity: sha1-dkmFy935I+/7kialZCzjASBEjs0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36457,7 +36461,7 @@ packages:
     dev: true
 
   /@teambit/base-react.navigation.link@2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-2.0.27.tgz}
+    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-2.0.27.tgz}
     peerDependencies:
       '@testing-library/react': ^12.0.0
       '@types/react': ^17.0.0
@@ -36474,7 +36478,7 @@ packages:
     dev: false
 
   /@teambit/base-react.navigation.router-context@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wstk3EwVqDvsrgZ1MWrlQuaE2bU=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.router-context/-/@teambit-base-react.navigation.router-context-1.23.0.tgz}
+    resolution: {integrity: sha1-wstk3EwVqDvsrgZ1MWrlQuaE2bU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.router-context/-/@teambit-base-react.navigation.router-context-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36487,7 +36491,7 @@ packages:
     dev: true
 
   /@teambit/base-react.navigation.use-location@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RnAncyEZdkh94hrIVvUl/aOkzco=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.use-location/-/@teambit-base-react.navigation.use-location-1.23.0.tgz}
+    resolution: {integrity: sha1-RnAncyEZdkh94hrIVvUl/aOkzco=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.use-location/-/@teambit-base-react.navigation.use-location-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36501,7 +36505,7 @@ packages:
     dev: true
 
   /@teambit/base-react.theme.theme-provider@1.95.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.bit.cloud/@teambit/base-react.theme.theme-provider/-/@teambit-base-react.theme.theme-provider-1.95.3.tgz}
+    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.theme.theme-provider/-/@teambit-base-react.theme.theme-provider-1.95.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36512,7 +36516,7 @@ packages:
     dev: false
 
   /@teambit/base-react.themes.theme-switcher@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.bit.cloud/@teambit/base-react.themes.theme-switcher/-/@teambit-base-react.themes.theme-switcher-1.0.2.tgz}
+    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.themes.theme-switcher/-/@teambit-base-react.themes.theme-switcher-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36523,7 +36527,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.css-components.elevation@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.1.tgz}
+    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.1.tgz}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -36534,7 +36538,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.elements.dots-loader@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.elements.dots-loader/-/@teambit-base-ui.elements.dots-loader-1.0.3.tgz}
+    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.dots-loader/-/@teambit-base-ui.elements.dots-loader-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36545,8 +36549,20 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.image/-/@teambit-base-ui.elements.image-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: true
+
   /@teambit/base-ui.graph.tree.collapsable-tree-node@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.graph.tree.collapsable-tree-node/-/@teambit-base-ui.graph.tree.collapsable-tree-node-0.0.4.tgz}
+    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.collapsable-tree-node/-/@teambit-base-ui.graph.tree.collapsable-tree-node-0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36560,7 +36576,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.hook.use-click-outside@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MWkSceL3FJ7qLtW2mGtE9h7+a6Y=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.1.tgz}
+    resolution: {integrity: sha1-MWkSceL3FJ7qLtW2mGtE9h7+a6Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.1.tgz}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -36571,7 +36587,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.button@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.button/-/@teambit-base-ui.input.button-1.0.5.tgz}
+    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.button/-/@teambit-base-ui.input.button-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36584,7 +36600,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.checkbox.hidden@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.2.tgz}
+    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36596,7 +36612,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.checkbox.label@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.2.tgz}
+    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36609,7 +36625,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.checkbox.label@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.4.tgz}
+    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36622,7 +36638,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.error@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.input.error/-/@teambit-base-ui.input.error-1.0.3.tgz}
+    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.error/-/@teambit-base-ui.input.error-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36634,7 +36650,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.layout.grid-component@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s8B7uWwtKRVnglUSUuvOCkW7+HI=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.layout.grid-component/-/@teambit-base-ui.layout.grid-component-1.0.1.tgz}
+    resolution: {integrity: sha1-s8B7uWwtKRVnglUSUuvOCkW7+HI=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.grid-component/-/@teambit-base-ui.layout.grid-component-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36647,7 +36663,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.layout.page-frame@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RRuzSP5iAICgm17gD1Ez2nD/UQM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.2.tgz}
+    resolution: {integrity: sha1-RRuzSP5iAICgm17gD1Ez2nD/UQM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36659,7 +36675,7 @@ packages:
     dev: true
 
   /@teambit/base-ui.loaders.skeleton@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
+    resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36670,8 +36686,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.link/-/@teambit-base-ui.routing.link-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.routing-provider': registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: true
+
   /@teambit/base-ui.surfaces.abs-container@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.1.tgz}
+    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36684,10 +36713,10 @@ packages:
     dev: false
 
   /@teambit/base-ui.surfaces.background@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Fd/DNRswrfBD+PdvbiMsN869QYU=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.2.tgz}
+    resolution: {integrity: sha1-Fd/DNRswrfBD+PdvbiMsN869QYU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.2.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -36695,7 +36724,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.surfaces.drawer@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NGtL6iO8yNoadw8lq3L6rLtvdxw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.1.tgz}
+    resolution: {integrity: sha1-NGtL6iO8yNoadw8lq3L6rLtvdxw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36710,10 +36739,10 @@ packages:
     dev: false
 
   /@teambit/base-ui.surfaces.drawer@1.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.1.3.tgz}
+    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.1.3.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.hook.use-click-outside': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.abs-container': 1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -36725,7 +36754,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.text.heading@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.4.tgz}
+    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36735,7 +36764,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/base-ui.text.paragraph@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
+    resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36749,7 +36778,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.theme.fonts.book@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.2.tgz}
+    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36760,7 +36789,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.utils.time-ago@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ykLJEZKzUxWJWMsLladKg3mcwQM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.utils.time-ago/-/@teambit-base-ui.utils.time-ago-1.0.1.tgz}
+    resolution: {integrity: sha1-ykLJEZKzUxWJWMsLladKg3mcwQM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.time-ago/-/@teambit-base-ui.utils.time-ago-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36800,7 +36829,7 @@ packages:
     engines: {node: '>=12.22.0'}
 
   /@teambit/bit.content.what-is-bit@1.96.2(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F6iK8JMYsiTXqPK4KiYe2lUP42k=, tarball: https://node-registry.bit.cloud/@teambit/bit.content.what-is-bit/-/@teambit-bit.content.what-is-bit-1.96.2.tgz}
+    resolution: {integrity: sha1-F6iK8JMYsiTXqPK4KiYe2lUP42k=, tarball: https://node-registry.v2.bit.cloud/@teambit/bit.content.what-is-bit/-/@teambit-bit.content.what-is-bit-1.96.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36818,7 +36847,7 @@ packages:
     dev: true
 
   /@teambit/bvm.config@0.2.2:
-    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.bit.cloud/@teambit/bvm.config/-/@teambit-bvm.config-0.2.2.tgz}
+    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.v2.bit.cloud/@teambit/bvm.config/-/@teambit-bvm.config-0.2.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       chalk: 4.1.0
@@ -36830,7 +36859,7 @@ packages:
     dev: false
 
   /@teambit/bvm.list@0.1.6:
-    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.bit.cloud/@teambit/bvm.list/-/@teambit-bvm.list-0.1.6.tgz}
+    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.v2.bit.cloud/@teambit/bvm.list/-/@teambit-bvm.list-0.1.6.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/bvm.config': 0.2.2
@@ -36854,7 +36883,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.code-compare-section@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-uCNGPFa1JA80ygcbuav0SJO+7CY=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.code-compare-section/-/@teambit-code.ui.code-compare-section-0.0.5.tgz}
+    resolution: {integrity: sha1-uCNGPFa1JA80ygcbuav0SJO+7CY=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.code-compare-section/-/@teambit-code.ui.code-compare-section-0.0.5.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -36872,7 +36901,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.dependency-tree@0.0.546(@apollo/client@3.6.9)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MuKMwTaPPYPp2kXrz7shpGhxR5c=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.dependency-tree/-/@teambit-code.ui.dependency-tree-0.0.546.tgz}
+    resolution: {integrity: sha1-MuKMwTaPPYPp2kXrz7shpGhxR5c=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.dependency-tree/-/@teambit-code.ui.dependency-tree-0.0.546.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -36893,7 +36922,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.hooks.use-code-params@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-j29tMGoZ9guzGFifVoqC4b0TZbY=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.hooks.use-code-params/-/@teambit-code.ui.hooks.use-code-params-0.0.496.tgz}
+    resolution: {integrity: sha1-j29tMGoZ9guzGFifVoqC4b0TZbY=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.hooks.use-code-params/-/@teambit-code.ui.hooks.use-code-params-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -36911,7 +36940,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.object-formatter@0.0.1(react@17.0.2):
-    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.object-formatter/-/@teambit-code.ui.object-formatter-0.0.1.tgz}
+    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.object-formatter/-/@teambit-code.ui.object-formatter-0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36922,12 +36951,12 @@ packages:
     dev: true
 
   /@teambit/code.ui.queries.get-component-code@0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9dIl+N7tMk19y1KHuKigBn3Kd1o=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.queries.get-component-code/-/@teambit-code.ui.queries.get-component-code-0.0.502.tgz}
+    resolution: {integrity: sha1-9dIl+N7tMk19y1KHuKigBn3Kd1o=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.queries.get-component-code/-/@teambit-code.ui.queries.get-component-code-0.0.502.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      '@apollo/client': ^3.6.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      '@apollo/client': '*'
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.500(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
@@ -36937,7 +36966,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.queries.get-file-content@0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YQOLQBWamClUyQBmOCo79xHhlqU=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.queries.get-file-content/-/@teambit-code.ui.queries.get-file-content-0.0.504.tgz}
+    resolution: {integrity: sha1-YQOLQBWamClUyQBmOCo79xHhlqU=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.queries.get-file-content/-/@teambit-code.ui.queries.get-file-content-0.0.504.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -36952,7 +36981,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.utils.get-file-icon@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-BhgHI8gqiuINycujdxk0HWv8SQA=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.utils.get-file-icon/-/@teambit-code.ui.utils.get-file-icon-0.0.495.tgz}
+    resolution: {integrity: sha1-BhgHI8gqiuINycujdxk0HWv8SQA=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.utils.get-file-icon/-/@teambit-code.ui.utils.get-file-icon-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -36964,11 +36993,11 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/community.constants.links@0.0.2:
-    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.bit.cloud/@teambit/community.constants.links/-/@teambit-community.constants.links-0.0.2.tgz}
+    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.constants.links/-/@teambit-community.constants.links-0.0.2.tgz}
     dev: false
 
   /@teambit/community.entity.graph.bubble-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.bit.cloud/@teambit/community.entity.graph.bubble-graph/-/@teambit-community.entity.graph.bubble-graph-1.95.0.tgz}
+    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.entity.graph.bubble-graph/-/@teambit-community.entity.graph.bubble-graph-1.95.0.tgz}
     dependencies:
       '@teambit/community.entity.graph.grid-graph': 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
     transitivePeerDependencies:
@@ -36978,7 +37007,7 @@ packages:
     dev: true
 
   /@teambit/community.entity.graph.grid-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.bit.cloud/@teambit/community.entity.graph.grid-graph/-/@teambit-community.entity.graph.grid-graph-1.95.0.tgz}
+    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.entity.graph.grid-graph/-/@teambit-community.entity.graph.grid-graph-1.95.0.tgz}
     dependencies:
       '@teambit/component-id': 0.0.369(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       react-xarrows: 2.0.2(react@17.0.2)
@@ -36989,14 +37018,14 @@ packages:
     dev: true
 
   /@teambit/compilation.compiler-task@0.0.4:
-    resolution: {integrity: sha1-E7zkrOiXjuabhEx8JTjD1ojIYX4=, tarball: https://node-registry.bit.cloud/@teambit/compilation.compiler-task/-/@teambit-compilation.compiler-task-0.0.4.tgz}
+    resolution: {integrity: sha1-E7zkrOiXjuabhEx8JTjD1ojIYX4=, tarball: https://node-registry.v2.bit.cloud/@teambit/compilation.compiler-task/-/@teambit-compilation.compiler-task-0.0.4.tgz}
     dependencies:
       '@teambit/toolbox.fs.hard-link-directory': 0.0.9
       fs-extra: 10.1.0
     dev: false
 
   /@teambit/compilation.content.compiler-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.bit.cloud/@teambit/compilation.content.compiler-overview/-/@teambit-compilation.content.compiler-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.v2.bit.cloud/@teambit/compilation.content.compiler-overview/-/@teambit-compilation.content.compiler-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37198,7 +37227,7 @@ packages:
       semver: 7.3.4
 
   /@teambit/component.content.component-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.bit.cloud/@teambit/component.content.component-overview/-/@teambit-component.content.component-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.content.component-overview/-/@teambit-component.content.component-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37215,7 +37244,7 @@ packages:
     dev: true
 
   /@teambit/component.content.dev-files@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.bit.cloud/@teambit/component.content.dev-files/-/@teambit-component.content.dev-files-1.95.9.tgz}
+    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.content.dev-files/-/@teambit-component.content.dev-files-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -37226,7 +37255,7 @@ packages:
     dev: true
 
   /@teambit/component.modules.component-url@0.0.124(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.124.tgz}
+    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.124.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -37238,7 +37267,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.128(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.128.tgz}
+    resolution: {integrity: sha1-E5szS9hGfk/lAwEma3/ViMkm32A=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.128.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -37252,7 +37281,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.140(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.140.tgz}
+    resolution: {integrity: sha1-cmcWwISlL+PSKta3Q4HkpLTARBc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.140.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -37266,7 +37295,7 @@ packages:
     dev: false
 
   /@teambit/component.modules.component-url@0.0.151(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.151.tgz}
+    resolution: {integrity: sha1-/dj3W/oKQC/p0X74zRJ+Mov/bec=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.151.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: 17.0.2
@@ -37280,7 +37309,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.badges.component-count@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-zxXwT+ngFF13gDKZOHkzkIRk1/0=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.1.tgz}
+    resolution: {integrity: sha1-zxXwT+ngFF13gDKZOHkzkIRk1/0=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37293,7 +37322,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.badges.component-count@0.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.10.tgz}
+    resolution: {integrity: sha1-/KG3gyg1xt3Gk+7z1Yf2Ww9qd50=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.badges.component-count/-/@teambit-component.ui.badges.component-count-0.0.10.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37306,11 +37335,11 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.hooks.use-component-compare-url@0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
+    resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -37323,7 +37352,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-change-type@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/@teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
+    resolution: {integrity: sha1-2Er9FIkcKdYqxW2aeyZ5Gd370Kc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-change-type/-/@teambit-component.ui.component-compare.models.component-compare-change-type-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37335,11 +37364,11 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-hooks@0.0.4(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/@teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
+    resolution: {integrity: sha1-kVPksYnom+gsZNPMZVx6uJqAHlI=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-hooks/-/@teambit-component.ui.component-compare.models.component-compare-hooks-0.0.4.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
@@ -37352,7 +37381,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-props@0.0.6(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-pEoCCl4OPgBaX15b4pJZedanetU=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-props/-/@teambit-component.ui.component-compare.models.component-compare-props-0.0.6.tgz}
+    resolution: {integrity: sha1-pEoCCl4OPgBaX15b4pJZedanetU=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-props/-/@teambit-component.ui.component-compare.models.component-compare-props-0.0.6.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37375,11 +37404,11 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-state@0.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/@teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
+    resolution: {integrity: sha1-KOvqyfEiwlEHJBWwxZZtLxWBc74=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-state/-/@teambit-component.ui.component-compare.models.component-compare-state-0.0.2.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -37387,7 +37416,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.component-compare.utils.lazy-loading@0.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
+    resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37400,7 +37429,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.494(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.494.tgz}
+    resolution: {integrity: sha1-h1I4/6SkzcVxwWznLLLEW4M8r6g=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.494.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37417,7 +37446,7 @@ packages:
     dev: false
 
   /@teambit/component.ui.deprecation-icon@0.0.500(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.500.tgz}
+    resolution: {integrity: sha1-KGzcqsYSN1S/mTpBE7Ohs8qm414=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.deprecation-icon/-/@teambit-component.ui.deprecation-icon-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37434,7 +37463,7 @@ packages:
     dev: false
 
   /@teambit/components.blocks.component-card-display@0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.13.tgz}
+    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37455,7 +37484,7 @@ packages:
     dev: true
 
   /@teambit/components.blocks.component-card-display@0.0.24(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OlVc0FyFcCB5yfe3qAG/tJbiAco=, tarball: https://node-registry.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.24.tgz}
+    resolution: {integrity: sha1-OlVc0FyFcCB5yfe3qAG/tJbiAco=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.24.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37479,7 +37508,7 @@ packages:
     dev: true
 
   /@teambit/components.clients.components-node@0.0.5(graphql@15.8.0):
-    resolution: {integrity: sha1-0yetOPD2nk9MNBEvOc+dNfhjQaE=, tarball: https://node-registry.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.5.tgz}
+    resolution: {integrity: sha1-0yetOPD2nk9MNBEvOc+dNfhjQaE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.5.tgz}
     peerDependencies:
       graphql: ^14.3.0
     dependencies:
@@ -37488,7 +37517,7 @@ packages:
     dev: true
 
   /@teambit/components.clients.components-node@0.0.6(graphql@15.8.0):
-    resolution: {integrity: sha1-QV4RQpjp35zf+ihMEPrtU1ppTt4=, tarball: https://node-registry.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.6.tgz}
+    resolution: {integrity: sha1-QV4RQpjp35zf+ihMEPrtU1ppTt4=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.6.tgz}
     peerDependencies:
       graphql: ^14.3.0
     dependencies:
@@ -37497,7 +37526,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.14(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZeYw+0jEa9tTCVUggXlIVFTJxaE=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.14.tgz}
+    resolution: {integrity: sha1-ZeYw+0jEa9tTCVUggXlIVFTJxaE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.14.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.402
@@ -37509,7 +37538,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VoayQSccNGOoiQn0eXOQUTylk6Q=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.6.tgz}
+    resolution: {integrity: sha1-VoayQSccNGOoiQn0eXOQUTylk6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.6.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.12(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.401
@@ -37521,7 +37550,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.7(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-HkbSWB5GKqJNAMc3Eo8n3AiRkOo=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.7.tgz}
+    resolution: {integrity: sha1-HkbSWB5GKqJNAMc3Eo8n3AiRkOo=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.7.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.401
@@ -37533,7 +37562,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-component-count@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-CjYLTYK0d4z4soJFrz3oU0+z81M=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-component-count/-/@teambit-components.hooks.use-component-count-0.0.7.tgz}
+    resolution: {integrity: sha1-CjYLTYK0d4z4soJFrz3oU0+z81M=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-component-count/-/@teambit-components.hooks.use-component-count-0.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37550,7 +37579,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-components@0.0.10(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2):
-    resolution: {integrity: sha1-sSRUFzKDbhghNcEX8/UteRwCjdM=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.10.tgz}
+    resolution: {integrity: sha1-sSRUFzKDbhghNcEX8/UteRwCjdM=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.10.tgz}
     dependencies:
       '@teambit/components.clients.components-node': 0.0.5(graphql@15.8.0)
       '@teambit/components.descriptors.component-descriptor': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -37564,7 +37593,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-components@0.0.11(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.11.tgz}
+    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.11.tgz}
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -37580,7 +37609,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-list-components@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rj+nJVVF4Wp2GAPOkzrVdAt5WKE=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-list-components/-/@teambit-components.hooks.use-list-components-0.0.7.tgz}
+    resolution: {integrity: sha1-rj+nJVVF4Wp2GAPOkzrVdAt5WKE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-list-components/-/@teambit-components.hooks.use-list-components-0.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37598,7 +37627,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.formatter-overview@1.96.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-r+8A4YQj5e9uNgpqwFhEVQ4UpoA=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.formatter-overview/-/@teambit-defender.content.formatter-overview-1.96.1.tgz}
+    resolution: {integrity: sha1-r+8A4YQj5e9uNgpqwFhEVQ4UpoA=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.formatter-overview/-/@teambit-defender.content.formatter-overview-1.96.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37615,7 +37644,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.linter-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.linter-overview/-/@teambit-defender.content.linter-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.linter-overview/-/@teambit-defender.content.linter-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37630,7 +37659,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.tester-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.tester-overview/-/@teambit-defender.content.tester-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.tester-overview/-/@teambit-defender.content.tester-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37645,7 +37674,7 @@ packages:
     dev: true
 
   /@teambit/defender.eslint-linter@1.0.1(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha1-bFEw5JZ6hemOj0Rftc+DHzM7KDs=, tarball: https://node-registry.bit.cloud/@teambit/defender.eslint-linter/-/@teambit-defender.eslint-linter-1.0.1.tgz}
+    resolution: {integrity: sha512-gssBFBe4jru0ekrjQgN0yhUsmY0dePmyGSSb3NqOaNObbafwEalQKhJDzkJYvV/eBFYz7gGiC+gHvdiAZF5EPw==, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.eslint-linter/-/@teambit-defender.eslint-linter-1.0.1.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.520
     dependencies:
@@ -37665,17 +37694,17 @@ packages:
     dev: false
 
   /@teambit/defender.fs.global-bit-temp-dir@0.0.1:
-    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.bit.cloud/@teambit/defender.fs.global-bit-temp-dir/-/@teambit-defender.fs.global-bit-temp-dir-0.0.1.tgz}
+    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.fs.global-bit-temp-dir/-/@teambit-defender.fs.global-bit-temp-dir-0.0.1.tgz}
     dependencies:
       fs-extra: 10.1.0
     dev: true
 
   /@teambit/defender.linter-task@0.0.5:
-    resolution: {integrity: sha1-SVz+88G7j/lePhSSy3g+xt4F7wQ=, tarball: https://node-registry.bit.cloud/@teambit/defender.linter-task/-/@teambit-defender.linter-task-0.0.5.tgz}
+    resolution: {integrity: sha1-SVz+88G7j/lePhSSy3g+xt4F7wQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.linter-task/-/@teambit-defender.linter-task-0.0.5.tgz}
     dev: false
 
   /@teambit/defender.prettier-formatter@1.0.0(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha1-OIdWIfIb6CpTWFO2+40HqmRgpfY=, tarball: https://node-registry.bit.cloud/@teambit/defender.prettier-formatter/-/@teambit-defender.prettier-formatter-1.0.0.tgz}
+    resolution: {integrity: sha512-dt97BR5ah+8GB1o5VSFwgMJIW+39b6MXdjU8rUijRIiCvmDVC94vAjXaJRqsxqjdbVcoUsv8gLjS7dkKmKHySg==, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.prettier-formatter/-/@teambit-defender.prettier-formatter-1.0.0.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.383
     dependencies:
@@ -37688,7 +37717,7 @@ packages:
     dev: false
 
   /@teambit/design.elements.icon@1.0.11(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yCfxRpQ4oY22Mumu7HeMm1oh240=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.11.tgz}
+    resolution: {integrity: sha1-yCfxRpQ4oY22Mumu7HeMm1oh240=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37700,7 +37729,7 @@ packages:
     dev: false
 
   /@teambit/design.elements.icon@1.0.24(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E5RHg/MkpEnxu4q/iNzweEfD7Qw=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.24.tgz}
+    resolution: {integrity: sha1-E5RHg/MkpEnxu4q/iNzweEfD7Qw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.24.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37712,7 +37741,7 @@ packages:
     dev: false
 
   /@teambit/design.elements.icon@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-blViHnlGeQASLRUR/mum3QbdXoY=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.5.tgz}
+    resolution: {integrity: sha1-blViHnlGeQASLRUR/mum3QbdXoY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37724,7 +37753,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@0.0.9(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-l4lNKhFxzeHrm3T3mqFI/EIP2Oo=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-0.0.9.tgz}
+    resolution: {integrity: sha1-l4lNKhFxzeHrm3T3mqFI/EIP2Oo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-0.0.9.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37742,7 +37771,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@1.2.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1TIt8cwqQpiR9YywJC7oXyxBoik=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.10.tgz}
+    resolution: {integrity: sha1-1TIt8cwqQpiR9YywJC7oXyxBoik=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37761,7 +37790,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@1.2.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.16.tgz}
+    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.16.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37781,7 +37810,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.input-text@1.0.21(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WM/hzM8HqxE31Ta0holHiA3m2uw=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.input-text/-/@teambit-design.inputs.input-text-1.0.21.tgz}
+    resolution: {integrity: sha1-WM/hzM8HqxE31Ta0holHiA3m2uw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.input-text/-/@teambit-design.inputs.input-text-1.0.21.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -37799,7 +37828,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.checkbox-item@0.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZVtMy39V13AQ9j2D0/iNMNWyy44=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-0.0.12.tgz}
+    resolution: {integrity: sha1-ZVtMy39V13AQ9j2D0/iNMNWyy44=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-0.0.12.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37813,7 +37842,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.checkbox-item@1.1.11(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-1.1.11.tgz}
+    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-1.1.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37826,7 +37855,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@0.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-d2GR5gucZYaRufqN4h85EwByUkw=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-0.0.5.tgz}
+    resolution: {integrity: sha1-d2GR5gucZYaRufqN4h85EwByUkw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-0.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37839,7 +37868,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.13(react@17.0.2):
-    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.13.tgz}
+    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37849,7 +37878,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.15(react@17.0.2):
-    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.15.tgz}
+    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37859,7 +37888,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.multi-select@0.0.20(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LqKnnNV56NAPtfqYoh/DleSskIA=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.multi-select/-/@teambit-design.inputs.selectors.multi-select-0.0.20.tgz}
+    resolution: {integrity: sha1-LqKnnNV56NAPtfqYoh/DleSskIA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.multi-select/-/@teambit-design.inputs.selectors.multi-select-0.0.20.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37875,7 +37904,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.toggle-button@0.0.9(@testing-library/react@12.1.5)(react@17.0.2):
-    resolution: {integrity: sha1-PynRScryoPBvaSuiiMVVgApDBSs=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.toggle-button/-/@teambit-design.inputs.toggle-button-0.0.9.tgz}
+    resolution: {integrity: sha1-PynRScryoPBvaSuiiMVVgApDBSs=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.toggle-button/-/@teambit-design.inputs.toggle-button-0.0.9.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -37888,7 +37917,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.toggle-switch@0.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.toggle-switch/-/@teambit-design.inputs.toggle-switch-0.0.6.tgz}
+    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.toggle-switch/-/@teambit-design.inputs.toggle-switch-0.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37901,7 +37930,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.content-tabs@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.content-tabs/-/@teambit-design.navigation.content-tabs-0.0.5.tgz}
+    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.content-tabs/-/@teambit-design.navigation.content-tabs-0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': ^17.0.2
@@ -37917,7 +37946,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.responsive-navbar@0.0.1(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-XcXtpFdOvn4Gs7wKdgDmvCKGVCs=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.1.tgz}
+    resolution: {integrity: sha1-XcXtpFdOvn4Gs7wKdgDmvCKGVCs=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.1.tgz}
     peerDependencies:
       '@types/react': ^17.0.2
       react: ^16.8.0 || ^17.0.0
@@ -37933,7 +37962,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.responsive-navbar@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.5.tgz}
+    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': 17.0.8
@@ -37952,7 +37981,7 @@ packages:
     dev: false
 
   /@teambit/design.overlays.notice-tooltip@0.0.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hiBek7x9g7cSYDsOWzzthWd5h+o=, tarball: https://node-registry.bit.cloud/@teambit/design.overlays.notice-tooltip/-/@teambit-design.overlays.notice-tooltip-0.0.1.tgz}
+    resolution: {integrity: sha1-hiBek7x9g7cSYDsOWzzthWd5h+o=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.overlays.notice-tooltip/-/@teambit-design.overlays.notice-tooltip-0.0.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -37969,7 +37998,7 @@ packages:
     dev: false
 
   /@teambit/design.theme.icons-font@1.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-64IRscIeqjVac9Qgt8SeTPg98mw=, tarball: https://node-registry.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-1.0.8.tgz}
+    resolution: {integrity: sha1-64IRscIeqjVac9Qgt8SeTPg98mw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-1.0.8.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37981,7 +38010,7 @@ packages:
     dev: false
 
   /@teambit/design.theme.icons-font@2.0.26(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-FX52TAodHE86b9jUb6gNDUAg/fI=, tarball: https://node-registry.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-2.0.26.tgz}
+    resolution: {integrity: sha1-FX52TAodHE86b9jUb6gNDUAg/fI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.theme.icons-font/-/@teambit-design.theme.icons-font-2.0.26.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37993,7 +38022,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.0.tgz}
+    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38009,7 +38038,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.1.tgz}
+    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38025,7 +38054,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.dark-theme@1.91.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bwvJgtmAX99/BfXo/HXq4uBsppY=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.0.tgz}
+    resolution: {integrity: sha1-bwvJgtmAX99/BfXo/HXq4uBsppY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38039,7 +38068,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.dark-theme@1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.4.tgz}
+    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.4.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38053,7 +38082,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.light-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.light-theme/-/@teambit-design.themes.light-theme-0.1.0.tgz}
+    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.light-theme/-/@teambit-design.themes.light-theme-0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38067,7 +38096,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.theme-toggler@0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.theme-toggler/-/@teambit-design.themes.theme-toggler-0.1.3.tgz}
+    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.theme-toggler/-/@teambit-design.themes.theme-toggler-0.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38084,7 +38113,7 @@ packages:
     dev: false
 
   /@teambit/design.typography.text@0.0.15(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nh8HyUQD19A5njwNWjU9VoBriBU=, tarball: https://node-registry.bit.cloud/@teambit/design.typography.text/-/@teambit-design.typography.text-0.0.15.tgz}
+    resolution: {integrity: sha1-nh8HyUQD19A5njwNWjU9VoBriBU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.typography.text/-/@teambit-design.typography.text-0.0.15.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38097,11 +38126,11 @@ packages:
     dev: false
 
   /@teambit/design.ui.alert-card@0.0.26(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-C2ZsSkEl2DnU6nx6apGBMtEv+TQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.alert-card/-/@teambit-design.ui.alert-card-0.0.26.tgz}
+    resolution: {integrity: sha1-C2ZsSkEl2DnU6nx6apGBMtEv+TQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.alert-card/-/@teambit-design.ui.alert-card-0.0.26.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.surfaces.background': registry.npmjs.org/@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -38115,7 +38144,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.avatar@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VdvPJ3drC0gVj81ozEeHmsPdWy0=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.avatar/-/@teambit-design.ui.avatar-1.0.16.tgz}
+    resolution: {integrity: sha1-VdvPJ3drC0gVj81ozEeHmsPdWy0=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.avatar/-/@teambit-design.ui.avatar-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38133,12 +38162,12 @@ packages:
     dev: false
 
   /@teambit/design.ui.brand.logo@1.96.2(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Fu8NOXINYLBeQP8HQ7o/fK8i/EY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.brand.logo/-/@teambit-design.ui.brand.logo-1.96.2.tgz}
+    resolution: {integrity: sha1-Fu8NOXINYLBeQP8HQ7o/fK8i/EY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.brand.logo/-/@teambit-design.ui.brand.logo-1.96.2.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -38147,7 +38176,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.cli-snippet@0.0.359(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lDAh4FHDGWGY/vsT0cMkjpyvbIM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.cli-snippet/-/@teambit-design.ui.cli-snippet-0.0.359.tgz}
+    resolution: {integrity: sha1-lDAh4FHDGWGY/vsT0cMkjpyvbIM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.cli-snippet/-/@teambit-design.ui.cli-snippet-0.0.359.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38162,7 +38191,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.contributors@0.0.514(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-O9oAE8rJS/xkrGo8g8ZsJyUaakU=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.contributors/-/@teambit-design.ui.contributors-0.0.514.tgz}
+    resolution: {integrity: sha1-O9oAE8rJS/xkrGo8g8ZsJyUaakU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.contributors/-/@teambit-design.ui.contributors-0.0.514.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38179,7 +38208,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.elements.level-icon@0.0.20(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-49zehFhJty3QSPq98CIbd3e/Q+A=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.elements.level-icon/-/@teambit-design.ui.elements.level-icon-0.0.20.tgz}
+    resolution: {integrity: sha1-49zehFhJty3QSPq98CIbd3e/Q+A=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.elements.level-icon/-/@teambit-design.ui.elements.level-icon-0.0.20.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38194,7 +38223,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.empty-box@0.0.363(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3LbHMr0jVbXfIqJIVeOrDZT4EdQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.empty-box/-/@teambit-design.ui.empty-box-0.0.363.tgz}
+    resolution: {integrity: sha1-3LbHMr0jVbXfIqJIVeOrDZT4EdQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.empty-box/-/@teambit-design.ui.empty-box-0.0.363.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38208,7 +38237,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.error-page@0.0.364(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vQV7Te5JyvHLSgtDRcCjbwF7v6E=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.error-page/-/@teambit-design.ui.error-page-0.0.364.tgz}
+    resolution: {integrity: sha1-vQV7Te5JyvHLSgtDRcCjbwF7v6E=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.error-page/-/@teambit-design.ui.error-page-0.0.364.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: '*'
@@ -38225,7 +38254,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.heading@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4R3FOpvDcf3haYi5H6tGaP61uDg=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.heading/-/@teambit-design.ui.heading-1.0.16.tgz}
+    resolution: {integrity: sha1-4R3FOpvDcf3haYi5H6tGaP61uDg=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.heading/-/@teambit-design.ui.heading-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38238,7 +38267,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.icon-button@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.0.16.tgz}
+    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38252,7 +38281,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.icon-button@1.1.15(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-t2miG1hmgZa2WhYHCra9krURC9U=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.1.15.tgz}
+    resolution: {integrity: sha1-t2miG1hmgZa2WhYHCra9krURC9U=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.1.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38265,7 +38294,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.icon-text@1.0.13(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-odcuytUuxPY1DYGuyxgKqSAPsRg=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.icon-text/-/@teambit-design.ui.input.icon-text-1.0.13.tgz}
+    resolution: {integrity: sha1-odcuytUuxPY1DYGuyxgKqSAPsRg=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.icon-text/-/@teambit-design.ui.input.icon-text-1.0.13.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -38281,7 +38310,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.option-button@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.option-button/-/@teambit-design.ui.input.option-button-1.0.0.tgz}
+    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.option-button/-/@teambit-design.ui.input.option-button-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38295,7 +38324,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.radio@1.1.13(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.radio/-/@teambit-design.ui.input.radio-1.1.13.tgz}
+    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.radio/-/@teambit-design.ui.input.radio-1.1.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38308,7 +38337,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.text@1.0.13(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yDzLGDQq/e1iPljU/m+BKm3Bp5g=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.text/-/@teambit-design.ui.input.text-1.0.13.tgz}
+    resolution: {integrity: sha1-yDzLGDQq/e1iPljU/m+BKm3Bp5g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.text/-/@teambit-design.ui.input.text-1.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38321,7 +38350,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.toggle@1.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.input.toggle/-/@teambit-design.ui.input.toggle-1.0.12.tgz}
+    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.toggle/-/@teambit-design.ui.input.toggle-1.0.12.tgz}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -38334,7 +38363,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.label@0.0.357(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yS015t1G11s8gZ9x8auOQTdqx/g=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.label/-/@teambit-design.ui.label-0.0.357.tgz}
+    resolution: {integrity: sha1-yS015t1G11s8gZ9x8auOQTdqx/g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.label/-/@teambit-design.ui.label-0.0.357.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38347,7 +38376,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.layouts.sections.left-right@1.96.2(@testing-library/react@12.1.5)(react@17.0.2):
-    resolution: {integrity: sha1-OWvICi+qk0vNq5inFufcRYRjI/A=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.layouts.sections.left-right/-/@teambit-design.ui.layouts.sections.left-right-1.96.2.tgz}
+    resolution: {integrity: sha1-OWvICi+qk0vNq5inFufcRYRjI/A=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.layouts.sections.left-right/-/@teambit-design.ui.layouts.sections.left-right-1.96.2.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38359,7 +38388,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.pages.not-found@0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-k9HJT7pUUTGpFWQC2Ofnv4D+Mec=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.not-found/-/@teambit-design.ui.pages.not-found-0.0.366.tgz}
+    resolution: {integrity: sha1-k9HJT7pUUTGpFWQC2Ofnv4D+Mec=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.not-found/-/@teambit-design.ui.pages.not-found-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38375,7 +38404,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pages.server-error@0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-23wJXHdEaXKFQtZr+SLOU9bbRng=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.server-error/-/@teambit-design.ui.pages.server-error-0.0.366.tgz}
+    resolution: {integrity: sha1-23wJXHdEaXKFQtZr+SLOU9bbRng=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.server-error/-/@teambit-design.ui.pages.server-error-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38391,7 +38420,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pages.standalone-not-found-page@0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Q17KZ3YgFS9Cy6ecXUeUd0rFNhU=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pages.standalone-not-found-page/-/@teambit-design.ui.pages.standalone-not-found-page-0.0.369.tgz}
+    resolution: {integrity: sha1-Q17KZ3YgFS9Cy6ecXUeUd0rFNhU=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pages.standalone-not-found-page/-/@teambit-design.ui.pages.standalone-not-found-page-0.0.369.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38407,7 +38436,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.350(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.350.tgz}
+    resolution: {integrity: sha1-gPPLmQYfh6MMno1X4Hnu3eG+Pqw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.350.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38420,7 +38449,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.356(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.356.tgz}
+    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.356.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: '*'
@@ -38433,7 +38462,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.round-loader@0.0.355(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mnyr1oThLKpyZJkwXDiC5Mr/Au4=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.round-loader/-/@teambit-design.ui.round-loader-0.0.355.tgz}
+    resolution: {integrity: sha1-mnyr1oThLKpyZJkwXDiC5Mr/Au4=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.round-loader/-/@teambit-design.ui.round-loader-0.0.355.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38446,7 +38475,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.separator@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.separator/-/@teambit-design.ui.separator-0.0.354.tgz}
+    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.separator/-/@teambit-design.ui.separator-0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38460,7 +38489,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.skeletons.sidebar-loader@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K1dhTThqMPnGpf7CeI1QGZi4J7U=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.skeletons.sidebar-loader/-/@teambit-design.ui.skeletons.sidebar-loader-0.0.4.tgz}
+    resolution: {integrity: sha1-K1dhTThqMPnGpf7CeI1QGZi4J7U=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.skeletons.sidebar-loader/-/@teambit-design.ui.skeletons.sidebar-loader-0.0.4.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38474,7 +38503,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.colors-by-letter@0.0.30(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F5BwgU/2w2aFfe3tAR1RJW+hdCo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.30.tgz}
+    resolution: {integrity: sha1-F5BwgU/2w2aFfe3tAR1RJW+hdCo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.30.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38486,7 +38515,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.colors-by-letter@0.0.41(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6Xb4MfnYkNwns5OpivxANSsNSNI=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.41.tgz}
+    resolution: {integrity: sha1-6Xb4MfnYkNwns5OpivxANSsNSNI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.colors-by-letter/-/@teambit-design.ui.styles.colors-by-letter-0.0.41.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38498,7 +38527,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.ellipsis@0.0.346(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tvLAoURNuXdsEZlXLxvewQlj0Yo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.346.tgz}
+    resolution: {integrity: sha1-tvLAoURNuXdsEZlXLxvewQlj0Yo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.346.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38511,7 +38540,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.styles.ellipsis@0.0.347(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LjDi1VsjWOmDi1kN1l+C+Ef0ArQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.347.tgz}
+    resolution: {integrity: sha1-LjDi1VsjWOmDi1kN1l+C+Ef0ArQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.347.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38523,7 +38552,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/design.ui.styles.ellipsis@0.0.353(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RNZDdmW66l51GMZAdkqOqSZVVvw=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.353.tgz}
+    resolution: {integrity: sha1-RNZDdmW66l51GMZAdkqOqSZVVvw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.353.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38536,7 +38565,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.ellipsis@0.0.357(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7ElER+9hfOnjVZ834tsgNMseDQY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.357.tgz}
+    resolution: {integrity: sha1-7ElER+9hfOnjVZ834tsgNMseDQY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.ellipsis/-/@teambit-design.ui.styles.ellipsis-0.0.357.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38549,7 +38578,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.35(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-D8Cw5SAZAAL1AwynU9udvgC+X08=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.35.tgz}
+    resolution: {integrity: sha1-D8Cw5SAZAAL1AwynU9udvgC+X08=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.35.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38561,7 +38590,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.41(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pJpFIAjz3jZwDqyr1Lc8G2Kj9jE=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.41.tgz}
+    resolution: {integrity: sha1-pJpFIAjz3jZwDqyr1Lc8G2Kj9jE=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.41.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38573,7 +38602,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.styles.muted-italic@0.0.44(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uJlo9PPuh2V0z5RYLehmk1KGxvo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.44.tgz}
+    resolution: {integrity: sha1-uJlo9PPuh2V0z5RYLehmk1KGxvo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.styles.muted-italic/-/@teambit-design.ui.styles.muted-italic-0.0.44.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38585,7 +38614,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.item@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.item/-/@teambit-design.ui.surfaces.menu.item-0.0.354.tgz}
+    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.item/-/@teambit-design.ui.surfaces.menu.item-0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38599,7 +38628,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.link-item@1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/@teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
+    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/@teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38617,7 +38646,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.section@0.0.351(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lzKC8iCprlewLu0mu78ma+RN3oo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.section/-/@teambit-design.ui.surfaces.menu.section-0.0.351.tgz}
+    resolution: {integrity: sha1-lzKC8iCprlewLu0mu78ma+RN3oo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.section/-/@teambit-design.ui.surfaces.menu.section-0.0.351.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38629,7 +38658,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.message-card@0.0.17(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rW7P0hcEKdMnf5/rVvkrqRC3ztk=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.message-card/-/@teambit-design.ui.surfaces.message-card-0.0.17.tgz}
+    resolution: {integrity: sha1-rW7P0hcEKdMnf5/rVvkrqRC3ztk=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.message-card/-/@teambit-design.ui.surfaces.message-card-0.0.17.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38644,7 +38673,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.status-message-card@0.0.17(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9uu83ti/6Rwlm4z5r+5YHUJ+Ogc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.status-message-card/-/@teambit-design.ui.surfaces.status-message-card-0.0.17.tgz}
+    resolution: {integrity: sha1-9uu83ti/6Rwlm4z5r+5YHUJ+Ogc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.status-message-card/-/@teambit-design.ui.surfaces.status-message-card-0.0.17.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38657,7 +38686,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.time-ago@0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-trBnEefw+hpWvPDiKVtuLFAL6kM=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.time-ago/-/@teambit-design.ui.time-ago-0.0.366.tgz}
+    resolution: {integrity: sha1-trBnEefw+hpWvPDiKVtuLFAL6kM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.time-ago/-/@teambit-design.ui.time-ago-0.0.366.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -38674,7 +38703,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.352(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3TBRHBTzvQMC9IGDz2uorqDWNcQ=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.352.tgz}
+    resolution: {integrity: sha1-3TBRHBTzvQMC9IGDz2uorqDWNcQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.352.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38690,7 +38719,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.358(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+cA/naxci4q2SsevRkPkTAb7sGo=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.358.tgz}
+    resolution: {integrity: sha1-+cA/naxci4q2SsevRkPkTAb7sGo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.358.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38706,7 +38735,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tooltip@0.0.361(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OA4fKc63w/KyZwVIpb4/8Gkt0tA=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.361.tgz}
+    resolution: {integrity: sha1-OA4fKc63w/KyZwVIpb4/8Gkt0tA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tooltip/-/@teambit-design.ui.tooltip-0.0.361.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38722,7 +38751,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9YKgP7x/RJ6ArJ6OCXRAtMUQgd8=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.12.tgz}
+    resolution: {integrity: sha1-9YKgP7x/RJ6ArJ6OCXRAtMUQgd8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.12.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38736,7 +38765,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.15(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Kp0MIgNQpp81LGK/hyZsTA0o094=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.15.tgz}
+    resolution: {integrity: sha1-Kp0MIgNQpp81LGK/hyZsTA0o094=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.15.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38750,7 +38779,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.tree@0.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6BTmF257To6E3JNxdhilk4ybqhY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.6.tgz}
+    resolution: {integrity: sha1-6BTmF257To6E3JNxdhilk4ybqhY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.tree/-/@teambit-design.ui.tree-0.0.6.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38764,7 +38793,7 @@ packages:
     dev: false
 
   /@teambit/docs.content.docs-overview@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.bit.cloud/@teambit/docs.content.docs-overview/-/@teambit-docs.content.docs-overview-1.95.9.tgz}
+    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.content.docs-overview/-/@teambit-docs.content.docs-overview-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/docs.ui.zoomable-image': 1.95.8(react-dom@17.0.2)(react@17.0.2)
@@ -38776,21 +38805,21 @@ packages:
     dev: true
 
   /@teambit/docs.entities.doc@0.0.12:
-    resolution: {integrity: sha1-QcOwLxOYF0onRasI3QprayQsvMk=, tarball: https://node-registry.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.12.tgz}
+    resolution: {integrity: sha1-QcOwLxOYF0onRasI3QprayQsvMk=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.12.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/toolbox.types.serializable': 0.0.491
     dev: false
 
   /@teambit/docs.entities.doc@0.0.2:
-    resolution: {integrity: sha1-Ljj4ksQWmKMbUZy58m0cB7MnSWo=, tarball: https://node-registry.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.2.tgz}
+    resolution: {integrity: sha1-Ljj4ksQWmKMbUZy58m0cB7MnSWo=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.entities.doc/-/@teambit-docs.entities.doc-0.0.2.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/toolbox.types.serializable': 0.0.483
     dev: true
 
   /@teambit/docs.ui.hooks.use-element-on-fold@1.96.5(react@17.0.2):
-    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.hooks.use-element-on-fold/-/@teambit-docs.ui.hooks.use-element-on-fold-1.96.5.tgz}
+    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.hooks.use-element-on-fold/-/@teambit-docs.ui.hooks.use-element-on-fold-1.96.5.tgz}
     peerDependencies:
       '@testing-library/react-hooks': ^8.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38801,11 +38830,11 @@ packages:
     dev: false
 
   /@teambit/docs.ui.zoomable-image@1.95.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.0.tgz}
+    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.1
       core-js: 3.13.0
       react: 17.0.2
@@ -38815,11 +38844,11 @@ packages:
     dev: true
 
   /@teambit/docs.ui.zoomable-image@1.95.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.8.tgz}
+    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.1
       core-js: 3.13.0
       react: 17.0.2
@@ -38829,7 +38858,7 @@ packages:
     dev: true
 
   /@teambit/documenter.code.react-playground@4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-ueDTBxYfB7E+D/E0mmLm31aSjh8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.code.react-playground/-/@teambit-documenter.code.react-playground-4.1.9.tgz}
+    resolution: {integrity: sha1-ueDTBxYfB7E+D/E0mmLm31aSjh8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.code.react-playground/-/@teambit-documenter.code.react-playground-4.1.9.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38851,7 +38880,7 @@ packages:
     dev: false
 
   /@teambit/documenter.content.documentation-links@4.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.bit.cloud/@teambit/documenter.content.documentation-links/-/@teambit-documenter.content.documentation-links-4.1.3.tgz}
+    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.content.documentation-links/-/@teambit-documenter.content.documentation-links-4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38862,7 +38891,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.heading@0.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.heading/-/@teambit-documenter.markdown.heading-0.1.8.tgz}
+    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.heading/-/@teambit-documenter.markdown.heading-0.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38875,7 +38904,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-zmQgh2QvXfcHXFpnL6t0u4Ur2OQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.hybrid-live-code-snippet/-/@teambit-documenter.markdown.hybrid-live-code-snippet-0.1.12.tgz}
+    resolution: {integrity: sha1-zmQgh2QvXfcHXFpnL6t0u4Ur2OQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.hybrid-live-code-snippet/-/@teambit-documenter.markdown.hybrid-live-code-snippet-0.1.12.tgz}
     peerDependencies:
       react: '*'
       react-dom: '*'
@@ -38891,7 +38920,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.mdx@0.1.13(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-TdvNoPVAs7pDrsmto8DiGKjvVdI=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.mdx/-/@teambit-documenter.markdown.mdx-0.1.13.tgz}
+    resolution: {integrity: sha1-TdvNoPVAs7pDrsmto8DiGKjvVdI=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.mdx/-/@teambit-documenter.markdown.mdx-0.1.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38923,7 +38952,7 @@ packages:
     dev: false
 
   /@teambit/documenter.routing.external-link@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.bit.cloud/@teambit/documenter.routing.external-link/-/@teambit-documenter.routing.external-link-4.1.2.tgz}
+    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.routing.external-link/-/@teambit-documenter.routing.external-link-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38934,8 +38963,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.theme.theme-compositions/-/@teambit-documenter.theme.theme-compositions-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/design.theme.icons-font': registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: true
+
   /@teambit/documenter.ui.anchor@4.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.6.tgz}
+    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38948,7 +38990,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.anchor@4.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.8.tgz}
+    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38961,7 +39003,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.block-quote@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.block-quote/-/@teambit-documenter.ui.block-quote-4.0.7.tgz}
+    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.block-quote/-/@teambit-documenter.ui.block-quote-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38973,7 +39015,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.bold@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.bold/-/@teambit-documenter.ui.bold-4.0.7.tgz}
+    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.bold/-/@teambit-documenter.ui.bold-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38985,7 +39027,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.code-snippet@4.2.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dgCI6suKWJxi4A2jJFLa0UUESpQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.code-snippet/-/@teambit-documenter.ui.code-snippet-4.2.2.tgz}
+    resolution: {integrity: sha1-dgCI6suKWJxi4A2jJFLa0UUESpQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.code-snippet/-/@teambit-documenter.ui.code-snippet-4.2.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38999,8 +39041,23 @@ packages:
       react-syntax-highlighter: 13.5.3(react@17.0.2)
     dev: false
 
+  /@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.consumable-link/-/@teambit-documenter.ui.consumable-link-4.0.3.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.copy-box': registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.paragraph': registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/documenter.ui.copied-message@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.1.6.tgz}
+    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39012,7 +39069,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.copy-box@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.copy-box/-/@teambit-documenter.ui.copy-box-4.1.6.tgz}
+    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copy-box/-/@teambit-documenter.ui.copy-box-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39028,7 +39085,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.heading@4.1.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jENJgXMvwy825NKKTM8gP90faMc=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.4.tgz}
+    resolution: {integrity: sha1-jENJgXMvwy825NKKTM8gP90faMc=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39041,7 +39098,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.6.tgz}
+    resolution: {integrity: sha1-nCoruiI/7n5xcXd4GEMdtuU5nIU=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39054,7 +39111,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.image@4.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.image/-/@teambit-documenter.ui.image-4.0.2.tgz}
+    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.image/-/@teambit-documenter.ui.image-4.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39066,7 +39123,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.inline-code@0.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.5.tgz}
+    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39078,7 +39135,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.italic@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.italic/-/@teambit-documenter.ui.italic-4.0.7.tgz}
+    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.italic/-/@teambit-documenter.ui.italic-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39090,7 +39147,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.6.tgz}
+    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39104,7 +39161,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.8.tgz}
+    resolution: {integrity: sha1-LGpmPIXZSWsXbYgkS/WR1VxJcCg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39118,7 +39175,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ol@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.ol/-/@teambit-documenter.ui.ol-4.1.5.tgz}
+    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.ol/-/@teambit-documenter.ui.ol-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39130,7 +39187,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.paragraph@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-w9jrNz9R2bIsMgLvjNgv9Ycmr3Y=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.5.tgz}
+    resolution: {integrity: sha1-w9jrNz9R2bIsMgLvjNgv9Ycmr3Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39144,7 +39201,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.property-table@4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.property-table/-/@teambit-documenter.ui.property-table-4.1.3.tgz}
+    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.property-table/-/@teambit-documenter.ui.property-table-4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39162,7 +39219,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.separator@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
+    resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39174,7 +39231,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.sup@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.sup/-/@teambit-documenter.ui.sup-4.0.7.tgz}
+    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.sup/-/@teambit-documenter.ui.sup-4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39186,10 +39243,10 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-column@4.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SCWMxMt8UkvvI4Ya/ZkJuMIIXSs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-column/-/@teambit-documenter.ui.table-column-4.0.2.tgz}
+    resolution: {integrity: sha1-SCWMxMt8UkvvI4Ya/ZkJuMIIXSs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-column/-/@teambit-documenter.ui.table-column-4.0.2.tgz}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39198,7 +39255,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-heading-column@4.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-88YzrKFIcEPPln9jc6nKCGB69Qs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-heading-column/-/@teambit-documenter.ui.table-heading-column-4.0.4.tgz}
+    resolution: {integrity: sha1-88YzrKFIcEPPln9jc6nKCGB69Qs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-heading-column/-/@teambit-documenter.ui.table-heading-column-4.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39210,7 +39267,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-heading-row@4.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5Y0+Bx4PBE8oyFlUjczMJdil4ig=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-heading-row/-/@teambit-documenter.ui.table-heading-row-4.0.4.tgz}
+    resolution: {integrity: sha1-5Y0+Bx4PBE8oyFlUjczMJdil4ig=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-heading-row/-/@teambit-documenter.ui.table-heading-row-4.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39225,7 +39282,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-row@4.1.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+r5wtOO/p3k1vMKiU+K9LY/pL+I=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.10.tgz}
+    resolution: {integrity: sha1-+r5wtOO/p3k1vMKiU+K9LY/pL+I=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.10.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39241,7 +39298,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-row@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-eWzMJmyZbLH5RL03UwVgy6xrZAs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.2.tgz}
+    resolution: {integrity: sha1-eWzMJmyZbLH5RL03UwVgy6xrZAs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-row/-/@teambit-documenter.ui.table-row-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39256,7 +39313,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.base-table@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.base-table/-/@teambit-documenter.ui.table.base-table-4.1.5.tgz}
+    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.base-table/-/@teambit-documenter.ui.table.base-table-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39268,7 +39325,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.td@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.td/-/@teambit-documenter.ui.table.td-4.1.5.tgz}
+    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.td/-/@teambit-documenter.ui.table.td-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39280,7 +39337,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.tr@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table.tr/-/@teambit-documenter.ui.table.tr-4.1.5.tgz}
+    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.tr/-/@teambit-documenter.ui.table.tr-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39292,7 +39349,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table/-/@teambit-documenter.ui.table-4.1.2.tgz}
+    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table/-/@teambit-documenter.ui.table-4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39306,7 +39363,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ul@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.ul/-/@teambit-documenter.ui.ul-4.1.5.tgz}
+    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.ul/-/@teambit-documenter.ui.ul-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39318,7 +39375,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.486.tgz}
+    resolution: {integrity: sha1-w7KPvgzoXLcmnBjlu8gNuRffmsA=, tarball: https://node-registry.v2.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39330,7 +39387,7 @@ packages:
     dev: false
 
   /@teambit/envs.ui.env-icon@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.492.tgz}
+    resolution: {integrity: sha1-WSxQWxQY/fhy5bqXSjp3fz3XUDY=, tarball: https://node-registry.v2.bit.cloud/@teambit/envs.ui.env-icon/-/@teambit-envs.ui.env-icon-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39342,7 +39399,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.elements.button@1.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.button/-/@teambit-evangelist.elements.button-1.0.6.tgz}
+    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.button/-/@teambit-evangelist.elements.button-1.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39355,7 +39412,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.elements.icon@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-abaBfCKbp8JEu8J7j9OB5kvyo5s=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.5.tgz}
+    resolution: {integrity: sha1-abaBfCKbp8JEu8J7j9OB5kvyo5s=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39367,7 +39424,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.elements.x-button@1.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.x-button/-/@teambit-evangelist.elements.x-button-1.0.7.tgz}
+    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.x-button/-/@teambit-evangelist.elements.x-button-1.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39380,7 +39437,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.indicator@1.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NYg/ZeFXH2J0ujDD82H5Bl1vEIk=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.7.tgz}
+    resolution: {integrity: sha1-NYg/ZeFXH2J0ujDD82H5Bl1vEIk=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39394,7 +39451,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.indicator@1.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
+    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39408,7 +39465,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.label@1.0.10(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.10.tgz}
+    resolution: {integrity: sha1-ub516a6yD7zFu3GeZXNeH97ULNo=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39422,7 +39479,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.label@1.0.14(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-U/7VYoZk5VQauXz4/8r2tuGljA4=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.14.tgz}
+    resolution: {integrity: sha1-U/7VYoZk5VQauXz4/8r2tuGljA4=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.14.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39436,7 +39493,7 @@ packages:
     dev: false
 
   /@teambit/explorer.plugins.env-plugin@0.0.10(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.10.tgz}
+    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39449,7 +39506,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.env-plugin@0.0.13(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-C1OuYM2sDr31NrxpBce2W8bIQgI=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.13.tgz}
+    resolution: {integrity: sha1-C1OuYM2sDr31NrxpBce2W8bIQgI=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39462,7 +39519,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.preview-plugin@0.0.4(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.4.tgz}
+    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39476,11 +39533,11 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.preview-plugin@0.0.9(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz}
+    resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz}
     peerDependencies:
-      '@testing-library/react': '*'
-      react: '*'
-      react-dom: '*'
+      '@testing-library/react': 12.1.3
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component-descriptor': 0.0.46(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
@@ -39493,7 +39550,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card-grid@0.0.12(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.12.tgz}
+    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.12.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39510,7 +39567,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card-grid@0.0.15(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nw+ae8xtNXYeGHCfeGh/7kjMHpc=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.15.tgz}
+    resolution: {integrity: sha1-nw+ae8xtNXYeGHCfeGh/7kjMHpc=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39527,7 +39584,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card@0.0.11(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.11.tgz}
+    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39548,7 +39605,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card@0.0.14(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NXxynFuK+QaIgLiPjuVV9PpH1uY=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.14.tgz}
+    resolution: {integrity: sha1-NXxynFuK+QaIgLiPjuVV9PpH1uY=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.14.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39569,7 +39626,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.base-component-card@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-3PAYOsXMLxyP9FOt//xSgkdAscg=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.492.tgz}
+    resolution: {integrity: sha1-3PAYOsXMLxyP9FOt//xSgkdAscg=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39583,7 +39640,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/explorer.ui.gallery.base-component-card@0.0.503(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VRRMW1hKZbRNl9DSh23pvZh06t4=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.503.tgz}
+    resolution: {integrity: sha1-VRRMW1hKZbRNl9DSh23pvZh06t4=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.base-component-card/-/@teambit-explorer.ui.gallery.base-component-card-0.0.503.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39598,7 +39655,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-card-group@1.96.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KuF3gKj4pPNpjsPxlnZlgMKMdhg=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card-group/-/@teambit-explorer.ui.gallery.component-card-group-1.96.1.tgz}
+    resolution: {integrity: sha1-KuF3gKj4pPNpjsPxlnZlgMKMdhg=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card-group/-/@teambit-explorer.ui.gallery.component-card-group-1.96.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -39614,13 +39671,13 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-card@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.495.tgz}
+    resolution: {integrity: sha1-gkm3X+OtPpzJSabL3xj7V6z75XA=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.link': registry.npmjs.org/@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/explorer.ui.gallery.base-component-card': 0.0.492(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -39628,7 +39685,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-card@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-k7X/LAKZj7h1M19wgvJAYEkL4B0=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.496.tgz}
+    resolution: {integrity: sha1-k7X/LAKZj7h1M19wgvJAYEkL4B0=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39645,7 +39702,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-card@0.0.507(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.507.tgz}
+    resolution: {integrity: sha1-p3EePsVfQINlcsiNPimNv3dK1Po=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card/-/@teambit-explorer.ui.gallery.component-card-0.0.507.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39662,7 +39719,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.484(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1JJr4vIMX4zfPor98vVev8V5g/c=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.484.tgz}
+    resolution: {integrity: sha1-1JJr4vIMX4zfPor98vVev8V5g/c=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.484.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.193
@@ -39677,7 +39734,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G7vGhAafW+HEcBuKFaOCCqv2Rrk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.486.tgz}
+    resolution: {integrity: sha1-G7vGhAafW+HEcBuKFaOCCqv2Rrk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39689,7 +39746,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/explorer.ui.gallery.component-grid@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ui9I65n8fuNEc04KK4yjtW24rAk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.496.tgz}
+    resolution: {integrity: sha1-Ui9I65n8fuNEc04KK4yjtW24rAk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-grid/-/@teambit-explorer.ui.gallery.component-grid-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39702,7 +39759,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.search.search-input@1.95.7(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LERb06ynDzJ2v7lmYlZBgmjgpIs=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.search.search-input/-/@teambit-explorer.ui.search.search-input-1.95.7.tgz}
+    resolution: {integrity: sha1-LERb06ynDzJ2v7lmYlZBgmjgpIs=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.search.search-input/-/@teambit-explorer.ui.search.search-input-1.95.7.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -39718,7 +39775,7 @@ packages:
     dev: false
 
   /@teambit/gcp.storage@0.1.2:
-    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.bit.cloud/@teambit/gcp.storage/-/@teambit-gcp.storage-0.1.2.tgz}
+    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.v2.bit.cloud/@teambit/gcp.storage/-/@teambit-gcp.storage-0.1.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/toolbox.network.agent': 0.0.540
@@ -39730,20 +39787,20 @@ packages:
     dev: false
 
   /@teambit/graph.algorithms.tarjan@0.0.1:
-    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.bit.cloud/@teambit/graph.algorithms.tarjan/-/@teambit-graph.algorithms.tarjan-0.0.1.tgz}
+    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.v2.bit.cloud/@teambit/graph.algorithms.tarjan/-/@teambit-graph.algorithms.tarjan-0.0.1.tgz}
     dependencies:
       lodash: 4.17.20
     dev: false
 
   /@teambit/graph.cleargraph@0.0.1:
-    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.bit.cloud/@teambit/graph.cleargraph/-/@teambit-graph.cleargraph-0.0.1.tgz}
+    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/graph.cleargraph/-/@teambit-graph.cleargraph-0.0.1.tgz}
     dependencies:
       '@teambit/graph.algorithms.tarjan': 0.0.1
       lodash: 4.17.20
     dev: false
 
   /@teambit/graphql.hooks.use-query-light@1.0.0(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query-light/-/@teambit-graphql.hooks.use-query-light-1.0.0.tgz}
+    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query-light/-/@teambit-graphql.hooks.use-query-light-1.0.0.tgz}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0
@@ -39760,11 +39817,11 @@ packages:
     dev: false
 
   /@teambit/graphql.hooks.use-query@0.0.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz}
+    resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz}
     peerDependencies:
-      '@apollo/client': '*'
-      react: '*'
-      react-dom: '*'
+      '@apollo/client': 3.3.7
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.global-loader': 0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -39776,11 +39833,11 @@ packages:
     dev: true
 
   /@teambit/graphql.hooks.use-query@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz}
+    resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz}
     peerDependencies:
-      '@apollo/client': '*'
-      react: '*'
-      react-dom: '*'
+      '@apollo/client': 3.3.7
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.global-loader': 0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -39814,12 +39871,12 @@ packages:
     dev: false
 
   /@teambit/html.modules.create-element-from-string@0.0.104:
-    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
+    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/html.modules.inject-html-element@0.0.4(react@17.0.2):
-    resolution: {integrity: sha1-JjRYtBb6Yrjgj6QiMOHweMGxbYc=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.inject-html-element/-/@teambit-html.modules.inject-html-element-0.0.4.tgz}
+    resolution: {integrity: sha1-JjRYtBb6Yrjgj6QiMOHweMGxbYc=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.inject-html-element/-/@teambit-html.modules.inject-html-element-0.0.4.tgz}
     peerDependencies:
       react: ^17.0.0 || ^18.0.0
     dependencies:
@@ -39828,7 +39885,7 @@ packages:
     dev: false
 
   /@teambit/html.modules.render-template@0.0.104:
-    resolution: {integrity: sha1-yC2M/azDU2z/3qMW0teWd04DjOM=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.render-template/-/@teambit-html.modules.render-template-0.0.104.tgz}
+    resolution: {integrity: sha1-yC2M/azDU2z/3qMW0teWd04DjOM=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.render-template/-/@teambit-html.modules.render-template-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/html.modules.create-element-from-string': 0.0.104
@@ -39845,7 +39902,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lane-components@0.0.149(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-QnNvne623/kMU2CO4PdxzQk1JKo=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lane-components/-/@teambit-lanes.hooks.use-lane-components-0.0.149.tgz}
+    resolution: {integrity: sha1-QnNvne623/kMU2CO4PdxzQk1JKo=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lane-components/-/@teambit-lanes.hooks.use-lane-components-0.0.149.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -39861,7 +39918,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lane-readme@0.0.149(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RKSkeINQXYiw5iJ+WRsQjqt0OqM=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lane-readme/-/@teambit-lanes.hooks.use-lane-readme-0.0.149.tgz}
+    resolution: {integrity: sha1-RKSkeINQXYiw5iJ+WRsQjqt0OqM=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lane-readme/-/@teambit-lanes.hooks.use-lane-readme-0.0.149.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -39877,7 +39934,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lanes@0.0.150(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uE0g2+AYjmmO3bOuNdBrVBDfSOw=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.150.tgz}
+    resolution: {integrity: sha1-uE0g2+AYjmmO3bOuNdBrVBDfSOw=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.150.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -39900,7 +39957,7 @@ packages:
     dev: false
 
   /@teambit/lanes.hooks.use-lanes@0.0.38(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VAc8cwDyJeOiQcjhaQbwQYT+/0o=, tarball: https://node-registry.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.38.tgz}
+    resolution: {integrity: sha1-VAc8cwDyJeOiQcjhaQbwQYT+/0o=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.hooks.use-lanes/-/@teambit-lanes.hooks.use-lanes-0.0.38.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -39919,7 +39976,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.drawer@0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WwUn89Kmbuz1EDpJYn/Tf9sIK5U=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.drawer/-/@teambit-lanes.ui.drawer-0.0.37.tgz}
+    resolution: {integrity: sha1-WwUn89Kmbuz1EDpJYn/Tf9sIK5U=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.drawer/-/@teambit-lanes.ui.drawer-0.0.37.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39951,7 +40008,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-details@0.0.109(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-GQDoQzmLDF00KviTRMKBX1iFfBc=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-details/-/@teambit-lanes.ui.lane-details-0.0.109.tgz}
+    resolution: {integrity: sha1-GQDoQzmLDF00KviTRMKBX1iFfBc=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-details/-/@teambit-lanes.ui.lane-details-0.0.109.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39971,7 +40028,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-overview@0.0.113(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-fzSebCVkXOz7sR1ky8DK3Hbw8gw=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-overview/-/@teambit-lanes.ui.lane-overview-0.0.113.tgz}
+    resolution: {integrity: sha1-fzSebCVkXOz7sR1ky8DK3Hbw8gw=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-overview/-/@teambit-lanes.ui.lane-overview-0.0.113.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -39999,7 +40056,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lane-readme@0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-JEGwWrr5eWvABOe4EwzRxBA/k5o=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lane-readme/-/@teambit-lanes.ui.lane-readme-0.0.116.tgz}
+    resolution: {integrity: sha1-JEGwWrr5eWvABOe4EwzRxBA/k5o=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lane-readme/-/@teambit-lanes.ui.lane-readme-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40028,7 +40085,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.lanes@0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-WN3sGDeI+kgG3vDEd/OSxsPQRKc=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.lanes/-/@teambit-lanes.ui.lanes-0.0.116.tgz}
+    resolution: {integrity: sha1-WN3sGDeI+kgG3vDEd/OSxsPQRKc=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.lanes/-/@teambit-lanes.ui.lanes-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -40085,7 +40142,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.menus@0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-a3nLuMEgJFzVxVG9k09sWykZHog=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.menus/-/@teambit-lanes.ui.menus-0.0.36.tgz}
+    resolution: {integrity: sha1-a3nLuMEgJFzVxVG9k09sWykZHog=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.menus/-/@teambit-lanes.ui.menus-0.0.36.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40116,7 +40173,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models.lanes-model@0.0.112(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2Ogukm35n+YDM3SlwD8MSQWmaLM=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models.lanes-model/-/@teambit-lanes.ui.models.lanes-model-0.0.112.tgz}
+    resolution: {integrity: sha1-2Ogukm35n+YDM3SlwD8MSQWmaLM=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models.lanes-model/-/@teambit-lanes.ui.models.lanes-model-0.0.112.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40134,7 +40191,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models@0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-W4YrdKa3aLz+Kli79jTaBVVyU+c=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.36.tgz}
+    resolution: {integrity: sha1-W4YrdKa3aLz+Kli79jTaBVVyU+c=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.36.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40152,7 +40209,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models@0.0.79(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YNs02OA7tmpvXL3Fe4OwyYYG5v8=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.79.tgz}
+    resolution: {integrity: sha512-q+qkOiVQ24JKN4OzYCe6+8HW83AQD027I05RegOGjXSCeEv21JKWls1UA9Ru5LZSIWd5LndPqzRGI8o2KXVY8A==, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.79.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40170,7 +40227,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.viewed-lane@0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Jf6uIOO5As4EcHtoPwPqmiyX1s4=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.viewed-lane/-/@teambit-lanes.ui.viewed-lane-0.0.37.tgz}
+    resolution: {integrity: sha1-Jf6uIOO5As4EcHtoPwPqmiyX1s4=, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.viewed-lane/-/@teambit-lanes.ui.viewed-lane-0.0.37.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40260,7 +40317,7 @@ packages:
       semver: 7.3.4
 
   /@teambit/mdx.ui.docs.link@0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.bit.cloud/@teambit/mdx.ui.docs.link/-/@teambit-mdx.ui.docs.link-0.0.500.tgz}
+    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.v2.bit.cloud/@teambit/mdx.ui.docs.link/-/@teambit-mdx.ui.docs.link-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -40277,18 +40334,18 @@ packages:
     dev: false
 
   /@teambit/node.deps-detectors.detective-es6@0.0.1:
-    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/@teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
+    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.v2.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/@teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
       node-source-walk: 5.0.2
     dev: false
 
   /@teambit/node.deps-detectors.parser-helper@0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a:
-    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/@teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
+    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.v2.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/@teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
     dev: false
 
   /@teambit/pkg.content.packages-overview@1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.bit.cloud/@teambit/pkg.content.packages-overview/-/@teambit-pkg.content.packages-overview-1.95.9.tgz}
+    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/pkg.content.packages-overview/-/@teambit-pkg.content.packages-overview-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/components.blocks.component-card-display': 0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
@@ -40303,7 +40360,7 @@ packages:
     dev: true
 
   /@teambit/preview.ui.component-preview@0.0.494(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-kQ74YKJ8qAfBudrAMmsIb9+RB04=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.494.tgz}
+    resolution: {integrity: sha1-kQ74YKJ8qAfBudrAMmsIb9+RB04=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.494.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40316,7 +40373,7 @@ packages:
     dev: false
 
   /@teambit/preview.ui.component-preview@0.0.517(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vbMAv1mM7+LCz8uEFv9TEXzR1Rc=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.517.tgz}
+    resolution: {integrity: sha1-vbMAv1mM7+LCz8uEFv9TEXzR1Rc=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.component-preview/-/@teambit-preview.ui.component-preview-0.0.517.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40332,7 +40389,7 @@ packages:
     dev: false
 
   /@teambit/preview.ui.preview-placeholder@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lnjRd/jLhUCpg0Zpdy/7JpVkve0=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.487.tgz}
+    resolution: {integrity: sha1-lnjRd/jLhUCpg0Zpdy/7JpVkve0=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40345,7 +40402,7 @@ packages:
     dev: false
 
   /@teambit/preview.ui.preview-placeholder@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.496.tgz}
+    resolution: {integrity: sha1-MgSJUaYFpLjSPyLWttgR63sM/Xg=, tarball: https://node-registry.v2.bit.cloud/@teambit/preview.ui.preview-placeholder/-/@teambit-preview.ui.preview-placeholder-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40358,7 +40415,7 @@ packages:
     dev: false
 
   /@teambit/react.content.react-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.bit.cloud/@teambit/react.content.react-overview/-/@teambit-react.content.react-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.content.react-overview/-/@teambit-react.content.react-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40373,7 +40430,7 @@ packages:
     dev: true
 
   /@teambit/react.instructions.react-native.adding-tests@0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.bit.cloud/@teambit/react.instructions.react-native.adding-tests/-/@teambit-react.instructions.react-native.adding-tests-0.0.1.tgz}
+    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react-native.adding-tests/-/@teambit-react.instructions.react-native.adding-tests-0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40388,7 +40445,7 @@ packages:
     dev: false
 
   /@teambit/react.modules.dom-to-react@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.bit.cloud/@teambit/react.modules.dom-to-react/-/@teambit-react.modules.dom-to-react-0.2.0.tgz}
+    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.modules.dom-to-react/-/@teambit-react.modules.dom-to-react-0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40399,7 +40456,7 @@ packages:
     dev: false
 
   /@teambit/react.rendering.ssr@0.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-A61JbXqd1zNXk1aW4Ur5vs86BpY=, tarball: https://node-registry.bit.cloud/@teambit/react.rendering.ssr/-/@teambit-react.rendering.ssr-0.0.3.tgz}
+    resolution: {integrity: sha1-A61JbXqd1zNXk1aW4Ur5vs86BpY=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.rendering.ssr/-/@teambit-react.rendering.ssr-0.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40417,7 +40474,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.component-highlighter@0.2.1(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.component-highlighter/-/@teambit-react.ui.component-highlighter-0.2.1.tgz}
+    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.component-highlighter/-/@teambit-react.ui.component-highlighter-0.2.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40444,7 +40501,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.highlighter.component-metadata.bit-component-meta@0.0.21(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/@teambit-react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
+    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/@teambit-react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40456,7 +40513,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.hover-selector@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.bit.cloud/@teambit/react.ui.hover-selector/-/@teambit-react.ui.hover-selector-0.2.0.tgz}
+    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.hover-selector/-/@teambit-react.ui.hover-selector-0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40467,7 +40524,7 @@ packages:
     dev: false
 
   /@teambit/scope.content.scope-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.bit.cloud/@teambit/scope.content.scope-overview/-/@teambit-scope.content.scope-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.content.scope-overview/-/@teambit-scope.content.scope-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40483,7 +40540,7 @@ packages:
     dev: true
 
   /@teambit/scope.models.scope-model@0.0.199(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uKcM8GxZ7PY7qjtrnglrcNdWOl8=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.199.tgz}
+    resolution: {integrity: sha1-uKcM8GxZ7PY7qjtrnglrcNdWOl8=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.199.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.110(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40495,7 +40552,7 @@ packages:
     dev: false
 
   /@teambit/scope.models.scope-model@0.0.235(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ivlq0sF9GaNYn7ubwN/99AzJJLE=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.235.tgz}
+    resolution: {integrity: sha1-Ivlq0sF9GaNYn7ubwN/99AzJJLE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.235.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.146(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40507,7 +40564,7 @@ packages:
     dev: false
 
   /@teambit/scope.models.scope-model@0.0.397(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MrbiRXyS84BL1peQ4qmNEam03+8=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.397.tgz}
+    resolution: {integrity: sha1-MrbiRXyS84BL1peQ4qmNEam03+8=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.397.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.308(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40519,7 +40576,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.hooks.use-scope@0.0.203(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-fe5QGB7RCxZZ8GGovNrm3KlMnsQ=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.203.tgz}
+    resolution: {integrity: sha1-fe5QGB7RCxZZ8GGovNrm3KlMnsQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.203.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -40537,7 +40594,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.hooks.use-scope@0.0.240(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ArQ+DdQNq/Aw2rjpUZcWpcveyck=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.240.tgz}
+    resolution: {integrity: sha1-ArQ+DdQNq/Aw2rjpUZcWpcveyck=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.hooks.use-scope/-/@teambit-scope.ui.hooks.use-scope-0.0.240.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40555,7 +40612,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-icon@0.0.78(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-psEzvN8g43aV3xmdw3TPaMqK7bE=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.78.tgz}
+    resolution: {integrity: sha1-psEzvN8g43aV3xmdw3TPaMqK7bE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.78.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40571,7 +40628,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-icon@0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.91.tgz}
+    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.91.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -40589,7 +40646,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-title@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-l+v2cdXuIPGuUzuBne1ADczrYH0=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.495.tgz}
+    resolution: {integrity: sha1-l+v2cdXuIPGuUzuBne1ADczrYH0=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40605,7 +40662,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-title@0.0.508(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.508.tgz}
+    resolution: {integrity: sha1-2lOC51kJif9bWAma5M4yaPPo/U4=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-title/-/@teambit-scope.ui.scope-title-0.0.508.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40623,50 +40680,50 @@ packages:
     dev: false
 
   /@teambit/scopes.scope-id@0.0.1:
-    resolution: {integrity: sha1-05xOQrV0zf4O4Y6AJZIsA5tT0kE=, tarball: https://node-registry.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.1.tgz}
+    resolution: {integrity: sha1-05xOQrV0zf4O4Y6AJZIsA5tT0kE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.1.tgz}
     dependencies:
       '@emotion/hash': 0.8.0
     dev: true
 
   /@teambit/scopes.scope-id@0.0.3:
-    resolution: {integrity: sha1-DudP/eIcKQEx/kKIZW80qqsfp/A=, tarball: https://node-registry.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.3.tgz}
+    resolution: {integrity: sha1-DudP/eIcKQEx/kKIZW80qqsfp/A=, tarball: https://node-registry.v2.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.3.tgz}
     dependencies:
       '@emotion/hash': 0.8.0
     dev: true
 
   /@teambit/styling.deps-detectors.detective-css-and-preprocessors@0.0.2:
-    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/@teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
+    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/@teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
     dependencies:
       css-tree: 2.3.1
       is-url: 1.2.4
     dev: false
 
   /@teambit/styling.deps-detectors.detective-css@0.0.2:
-    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/@teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
+    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/@teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-less@0.0.2:
-    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/@teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
+    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/@teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-sass@0.0.2:
-    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/@teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
+    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/@teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-scss@0.0.2:
-    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/@teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
+    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/@teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-lookups.lookup-styling@0.0.1:
-    resolution: {integrity: sha1-2rGGrYqcJkFXt52QqUL3ZHKAVmM=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-lookups.lookup-styling/-/@teambit-styling.deps-lookups.lookup-styling-0.0.1.tgz}
+    resolution: {integrity: sha1-2rGGrYqcJkFXt52QqUL3ZHKAVmM=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-lookups.lookup-styling/-/@teambit-styling.deps-lookups.lookup-styling-0.0.1.tgz}
     dependencies:
       enhanced-resolve: 5.15.0
       is-relative-path: 2.0.0
@@ -40674,14 +40731,27 @@ packages:
     dev: false
 
   /@teambit/toolbox.fs.hard-link-directory@0.0.9:
-    resolution: {integrity: sha1-St+dQX5yyoZajHllbcoy69isL1I=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.fs.hard-link-directory/-/@teambit-toolbox.fs.hard-link-directory-0.0.9.tgz}
+    resolution: {integrity: sha1-St+dQX5yyoZajHllbcoy69isL1I=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.fs.hard-link-directory/-/@teambit-toolbox.fs.hard-link-directory-0.0.9.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       fs-extra: 10.0.0
     dev: false
 
+  /@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
+    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.116.tgz}
+    engines: {node: '>=12.15.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.108
+    dependencies:
+      '@teambit/legacy': link:node_modules/@teambit/legacy
+      '@teambit/toolbox.network.proxy-agent': 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+      agentkeepalive: 4.1.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@teambit/toolbox.network.agent@0.0.540:
-    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.540.tgz}
+    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.540.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.agent': 0.0.3
@@ -40691,52 +40761,67 @@ packages:
       - supports-color
     dev: false
 
+  /@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
+    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.proxy-agent/-/@teambit-toolbox.network.proxy-agent-0.0.116.tgz}
+    engines: {node: '>=12.15.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.108
+    dependencies:
+      '@teambit/legacy': link:node_modules/@teambit/legacy
+      '@teambit/toolbox.network.agent': 0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
+      http-proxy-agent: 4.0.1
+      https-proxy-agent: 5.0.0
+      socks-proxy-agent: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@teambit/toolbox.string.ellipsis@0.0.172:
-    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.172.tgz}
+    resolution: {integrity: sha1-nbLwbPi2d8Qeg6aCX2TYlARSRew=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.172.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.string.ellipsis@0.0.173:
-    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.173.tgz}
+    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.173.tgz}
     engines: {node: '>=12.22.0'}
 
   /@teambit/toolbox.string.ellipsis@0.0.181:
-    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
+    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.string.get-initials@0.0.483:
-    resolution: {integrity: sha1-7BsxTG+qhcTHltoBu9McFKOq0/Y=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.483.tgz}
+    resolution: {integrity: sha1-7BsxTG+qhcTHltoBu9McFKOq0/Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.string.get-initials@0.0.491:
-    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.491.tgz}
+    resolution: {integrity: sha1-dMkF7hxhtmK2aXz7QCkAAajSrKI=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.string.get-initials/-/@teambit-toolbox.string.get-initials-0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.types.serializable@0.0.483:
-    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.483.tgz}
+    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
   /@teambit/toolbox.types.serializable@0.0.491:
-    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
+    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.url.add-avatar-query-params@0.0.483:
-    resolution: {integrity: sha1-oyxnM4oFZ2iiNiqxDPWHI2v7IeE=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.483.tgz}
+    resolution: {integrity: sha1-oyxnM4oFZ2iiNiqxDPWHI2v7IeE=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.483.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/toolbox.url.add-avatar-query-params@0.0.492:
-    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.492.tgz}
+    resolution: {integrity: sha1-dECMYTXTkMlAIUaK22cpmNlTsak=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.url.add-avatar-query-params/-/@teambit-toolbox.url.add-avatar-query-params-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
   /@teambit/typescript.deps-detectors.detective-typescript@0.0.1(typescript@4.7.4):
-    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/@teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
+    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/@teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.7.4)
@@ -40747,7 +40832,7 @@ packages:
     dev: false
 
   /@teambit/typescript.deps-lookups.lookup-typescript@0.0.1:
-    resolution: {integrity: sha1-nP/TKhnV0nBBFoCd1wddzxta10o=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-lookups.lookup-typescript/-/@teambit-typescript.deps-lookups.lookup-typescript-0.0.1.tgz}
+    resolution: {integrity: sha1-nP/TKhnV0nBBFoCd1wddzxta10o=, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.deps-lookups.lookup-typescript/-/@teambit-typescript.deps-lookups.lookup-typescript-0.0.1.tgz}
     dependencies:
       app-module-path: 2.2.0
       enhanced-resolve: 5.15.0
@@ -40759,7 +40844,7 @@ packages:
     dev: false
 
   /@teambit/typescript.typescript-compiler@2.0.0(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha1-nKHh81Xpb0BexVonuzyAFskhrQ4=, tarball: https://node-registry.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.0.tgz}
+    resolution: {integrity: sha512-EFZGBxoNSgv33z/72QHsND2jvsjzGSFgY3rqhZcoYcWN1DfvUHLbeQDSlYA9/afT6vzV+WLhFy4K9fdgVJu+NQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.0.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.380
     dependencies:
@@ -40776,7 +40861,7 @@ packages:
     dev: false
 
   /@teambit/typescript.typescript-compiler@2.0.1(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha1-ROMqppit0ToLogpx8275MJcOXT0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.1.tgz}
+    resolution: {integrity: sha512-bxTazYfFjnqp1DrfL9FvwnnVDCUk+8fu2LiQEMCdGNU+bsrtYzZBKfA6DXHoh4kkynBQsBcbf7cgTp5hxh7uEw==, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.typescript-compiler/-/@teambit-typescript.typescript-compiler-2.0.1.tgz}
     peerDependencies:
       '@teambit/legacy': ^1.0.380
     dependencies:
@@ -40794,7 +40879,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.constants.z-indexes@0.0.498(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.constants.z-indexes/-/@teambit-ui-foundation.ui.constants.z-indexes-0.0.498.tgz}
+    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.constants.z-indexes/-/@teambit-ui-foundation.ui.constants.z-indexes-0.0.498.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40806,7 +40891,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.empty-component-gallery@0.0.492(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-qbHcWdrV0bnFFe4SC6a3qjVjURA=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.492.tgz}
+    resolution: {integrity: sha1-qbHcWdrV0bnFFe4SC6a3qjVjURA=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40825,7 +40910,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.empty-component-gallery@0.0.502(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nbagGhpo63WfemtMvlC2tuGRsok=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.502.tgz}
+    resolution: {integrity: sha1-nbagGhpo63WfemtMvlC2tuGRsok=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.empty-component-gallery/-/@teambit-ui-foundation.ui.empty-component-gallery-0.0.502.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40845,7 +40930,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.full-loader@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-S37SXs9caAwDs/8uQ8rEFHJe2Ic=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.486.tgz}
+    resolution: {integrity: sha1-S37SXs9caAwDs/8uQ8rEFHJe2Ic=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40857,7 +40942,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.full-loader@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-oz+Ex8oBR8tdgWT5kZCDECCGUY0=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.492.tgz}
+    resolution: {integrity: sha1-oz+Ex8oBR8tdgWT5kZCDECCGUY0=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.full-loader/-/@teambit-ui-foundation.ui.full-loader-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40869,7 +40954,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.get-icon-from-file-name@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.get-icon-from-file-name/-/@teambit-ui-foundation.ui.get-icon-from-file-name-0.0.495.tgz}
+    resolution: {integrity: sha1-KzxZCIVyVGbjJHC01V/8RI6cyhY=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.get-icon-from-file-name/-/@teambit-ui-foundation.ui.get-icon-from-file-name-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40882,7 +40967,7 @@ packages:
       vscode-icons-js: 11.0.0
 
   /@teambit/ui-foundation.ui.global-loader@0.0.474(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.474.tgz}
+    resolution: {integrity: sha1-7X0x1qLPQV7ySEUh5Rs1iXt+AX4=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.474.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.183
@@ -40897,7 +40982,7 @@ packages:
     dev: true
 
   /@teambit/ui-foundation.ui.global-loader@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.487.tgz}
+    resolution: {integrity: sha1-t9IdwYuJBCHPUYK73ELRUHQHPVs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40910,7 +40995,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.493.tgz}
+    resolution: {integrity: sha1-0DiiKiGSijunFyRRRSMD4R2iQMk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40923,7 +41008,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.global-loader@0.0.497(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.497.tgz}
+    resolution: {integrity: sha1-5fU/29iOW7vvZBaoyaRiSUCyl2I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.global-loader/-/@teambit-ui-foundation.ui.global-loader-0.0.497.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40936,7 +41021,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.488(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dWr5imk7thG6uDJFhiZvgbx4YXk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.488.tgz}
+    resolution: {integrity: sha1-dWr5imk7thG6uDJFhiZvgbx4YXk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.488.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.0.0
@@ -40952,7 +41037,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.496(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.496.tgz}
+    resolution: {integrity: sha1-oL6ZvMzY0Y/1C9rivf+CdsmJFdI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40968,7 +41053,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.hooks.use-data-query@0.0.500(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.500.tgz}
+    resolution: {integrity: sha1-mKHB9+tWg+S+JJ5s4peW17vUf3s=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.hooks.use-data-query/-/@teambit-ui-foundation.ui.hooks.use-data-query-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@apollo/client': ^3.6.0
@@ -40984,7 +41069,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.486.tgz}
+    resolution: {integrity: sha1-KCR60Lp5r8XU/qN5aU6JnKyCo0U=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40996,7 +41081,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.is-browser@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.492.tgz}
+    resolution: {integrity: sha1-K8F9fjln4vfhtryfNuzr8RulqLo=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.is-browser/-/@teambit-ui-foundation.ui.is-browser-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41008,7 +41093,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.486.tgz}
+    resolution: {integrity: sha1-8os8TC+l8rJUXtJe4ehMT7H6+98=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41022,7 +41107,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.keycap@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.492.tgz}
+    resolution: {integrity: sha1-/XlMitYklsPYhMXE0hPJZw+1JHM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.keycap/-/@teambit-ui-foundation.ui.keycap-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41036,7 +41121,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.main-dropdown@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wWEqL2L6GAIzxMKArBJlORClpEI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.487.tgz}
+    resolution: {integrity: sha1-wWEqL2L6GAIzxMKArBJlORClpEI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41054,7 +41139,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.main-dropdown@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/N8qsGnMUUEAbq9KCc5nemtQSUo=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.493.tgz}
+    resolution: {integrity: sha1-/N8qsGnMUUEAbq9KCc5nemtQSUo=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.main-dropdown/-/@teambit-ui-foundation.ui.main-dropdown-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41072,7 +41157,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.menu@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-X0CD1f29BhUCpEAz1Y0YcHIM9tM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.487.tgz}
+    resolution: {integrity: sha1-X0CD1f29BhUCpEAz1Y0YcHIM9tM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41088,7 +41173,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.menu@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hbjImHPNUVgx0j7BykmzOxMKqxs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.493.tgz}
+    resolution: {integrity: sha1-hbjImHPNUVgx0j7BykmzOxMKqxs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.menu/-/@teambit-ui-foundation.ui.menu-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41104,7 +41189,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.navigation.react-router-adapter@6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.navigation.react-router-adapter/-/@teambit-ui-foundation.ui.navigation.react-router-adapter-6.1.1.tgz}
+    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.navigation.react-router-adapter/-/@teambit-ui-foundation.ui.navigation.react-router-adapter-6.1.1.tgz}
     peerDependencies:
       '@types/react': ^17.0.0
       react: ^16.8.0 || ^17.0.0
@@ -41124,7 +41209,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.487(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.487.tgz}
+    resolution: {integrity: sha1-WvEy3IkkGkdqrKLZvWO5ay+2LH4=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.487.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41137,7 +41222,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.493(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.493.tgz}
+    resolution: {integrity: sha1-LqvYMR2i+ZTOqyqWpBg/tXCzdgU=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.493.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41150,7 +41235,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.notification-context@0.0.496(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.496.tgz}
+    resolution: {integrity: sha1-x23R91AzUscSV2WS2yZC2LY8CHE=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.notification-context/-/@teambit-ui-foundation.ui.notifications.notification-context-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41163,7 +41248,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.486(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.486.tgz}
+    resolution: {integrity: sha1-ZQ4iOfpuzj+jE12XS3b51WELT7I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.486.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41175,7 +41260,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.492(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.492.tgz}
+    resolution: {integrity: sha1-8IWuSf9Qt6QHdudIbjqQ7IHiMFg=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.492.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41187,7 +41272,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.notifications.store@0.0.495(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.495.tgz}
+    resolution: {integrity: sha1-SciOZ58oyKDy8q/0nvQ4OpvuPz8=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.notifications.store/-/@teambit-ui-foundation.ui.notifications.store-0.0.495.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41199,7 +41284,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.slot-router@0.0.490(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-W8Yot/K3sHr8a/diXZfp0zRLXyQ=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.490.tgz}
+    resolution: {integrity: sha1-W8Yot/K3sHr8a/diXZfp0zRLXyQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.490.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41219,7 +41304,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.slot-router@0.0.501(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.501.tgz}
+    resolution: {integrity: sha1-uUc0/zKzRjSFXhWhBUDlDnIJuO0=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.slot-router/-/@teambit-ui-foundation.ui.react-router.slot-router-0.0.501.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41239,7 +41324,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.react-router.use-query@0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.react-router.use-query/-/@teambit-ui-foundation.ui.react-router.use-query-0.0.496.tgz}
+    resolution: {integrity: sha1-rCJcyZss+uCe7COvKqfs0UQ0TME=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.react-router.use-query/-/@teambit-ui-foundation.ui.react-router.use-query-0.0.496.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41255,11 +41340,11 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.rendering.html@0.0.69(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wLxfPsjKW+2sB5juwlbAA60Oirk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.rendering.html/-/@teambit-ui-foundation.ui.rendering.html-0.0.69.tgz}
+    resolution: {integrity: sha1-wLxfPsjKW+2sB5juwlbAA60Oirk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.rendering.html/-/@teambit-ui-foundation.ui.rendering.html-0.0.69.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -41267,7 +41352,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.side-bar@0.0.613(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-8vs4qdsE5d7E5gOwpXlFYZ3/GPI=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.613.tgz}
+    resolution: {integrity: sha1-8vs4qdsE5d7E5gOwpXlFYZ3/GPI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.613.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41300,7 +41385,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.side-bar@0.0.649(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5VNC36o2vGNZ87v66MegcwO04gc=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.649.tgz}
+    resolution: {integrity: sha1-5VNC36o2vGNZ87v66MegcwO04gc=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.side-bar/-/@teambit-ui-foundation.ui.side-bar-0.0.649.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41331,7 +41416,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.499(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pjQ48Y76Vdev7zJsLJnmefJUmDs=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.499.tgz}
+    resolution: {integrity: sha1-pjQ48Y76Vdev7zJsLJnmefJUmDs=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.499.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41345,7 +41430,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.505(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Vepk8IZRMgaa4EOB59zsA8taYkc=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.505.tgz}
+    resolution: {integrity: sha1-Vepk8IZRMgaa4EOB59zsA8taYkc=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.505.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41359,7 +41444,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.tree.drawer@0.0.512(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
+    resolution: {integrity: sha1-bU5bUChvqZ6FgR2iDflWJU+hU8U=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.tree.drawer/-/@teambit-ui-foundation.ui.tree.drawer-0.0.512.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41373,7 +41458,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.bottom-link@0.0.104(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xosebUlECtQu7XyRfyllNsaeV2k=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.104.tgz}
+    resolution: {integrity: sha1-xosebUlECtQu7XyRfyllNsaeV2k=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41385,7 +41470,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.bottom-link@0.0.110(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vhb5IhCvfJ/k7kzr+PredFNWIiw=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.110.tgz}
+    resolution: {integrity: sha1-vhb5IhCvfJ/k7kzr+PredFNWIiw=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.bottom-link/-/@teambit-ui-foundation.ui.use-box.bottom-link-0.0.110.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41397,7 +41482,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.dropdown@0.0.116(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G5A0Rl7gBRyIgYgmp0CwOXeKmFY=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.116.tgz}
+    resolution: {integrity: sha1-G5A0Rl7gBRyIgYgmp0CwOXeKmFY=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.116.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41413,7 +41498,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.dropdown@0.0.122(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-eh496FT5rh2oPpBs+/uzavLItnM=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.122.tgz}
+    resolution: {integrity: sha1-eh496FT5rh2oPpBs+/uzavLItnM=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.dropdown/-/@teambit-ui-foundation.ui.use-box.dropdown-0.0.122.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41429,7 +41514,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.tab-content@0.0.105(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YEje8xEfnAIM89gF18c29RD0aYw=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.105.tgz}
+    resolution: {integrity: sha1-YEje8xEfnAIM89gF18c29RD0aYw=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.105.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41445,7 +41530,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.use-box.tab-content@0.0.111(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KYawBhoq9Gzqt3JvqDroB0c5h7Y=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.111.tgz}
+    resolution: {integrity: sha1-KYawBhoq9Gzqt3JvqDroB0c5h7Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.use-box.tab-content/-/@teambit-ui-foundation.ui.use-box.tab-content-0.0.111.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41461,13 +41546,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.urls.compare-url@1.23.0:
-    resolution: {integrity: sha1-7u6LJFiuBnbQPmwi791Dow7G95I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.urls.compare-url/-/@teambit-ui-foundation.urls.compare-url-1.23.0.tgz}
+    resolution: {integrity: sha1-7u6LJFiuBnbQPmwi791Dow7G95I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.urls.compare-url/-/@teambit-ui-foundation.urls.compare-url-1.23.0.tgz}
     dependencies:
       url-parse: 1.5.3
     dev: true
 
   /@teambit/workspace.content.variants@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.bit.cloud/@teambit/workspace.content.variants/-/@teambit-workspace.content.variants-1.95.9.tgz}
+    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.content.variants/-/@teambit-workspace.content.variants-1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -41478,7 +41563,7 @@ packages:
     dev: true
 
   /@teambit/workspace.content.workspace-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.bit.cloud/@teambit/workspace.content.workspace-overview/-/@teambit-workspace.content.workspace-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.content.workspace-overview/-/@teambit-workspace.content.workspace-overview-1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41494,7 +41579,7 @@ packages:
     dev: true
 
   /@teambit/workspace.ui.load-preview@0.0.489(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.489.tgz}
+    resolution: {integrity: sha1-e9OonGao9UxvvbCfsJKdGTPbXIg=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.489.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41508,7 +41593,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.load-preview@0.0.499(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.499.tgz}
+    resolution: {integrity: sha1-lvfO7zmO9ZnlI+NPWAFOW3ViZwo=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.load-preview/-/@teambit-workspace.ui.load-preview-0.0.499.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -41524,7 +41609,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.workspace-component-card@0.0.498(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OEC9ofhKQOIaKS5lk3GpvkAQqE8=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.498.tgz}
+    resolution: {integrity: sha1-OEC9ofhKQOIaKS5lk3GpvkAQqE8=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.498.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41542,7 +41627,7 @@ packages:
     dev: false
 
   /@teambit/workspace.ui.workspace-component-card@0.0.510(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.510.tgz}
+    resolution: {integrity: sha1-bO15xcj1TSQ5iEfw8QBu6GxTigM=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.ui.workspace-component-card/-/@teambit-workspace.ui.workspace-component-card-0.0.510.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -42553,9 +42638,11 @@ packages:
     resolution: {integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
+      eslint: '*'
       typescript: '*'
     peerDependenciesMeta:
+      eslint:
+        optional: true
       typescript:
         optional: true
     dependencies:
@@ -44196,7 +44283,7 @@ packages:
   /apollo-link@1.2.14(graphql@15.8.0):
     resolution: {integrity: sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==}
     peerDependencies:
-      graphql: ^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0
+      graphql: '*'
     dependencies:
       apollo-utilities: 1.3.4(graphql@15.8.0)
       graphql: 15.8.0
@@ -57279,7 +57366,7 @@ packages:
   /react-syntax-highlighter@15.4.3(react@17.0.2):
     resolution: {integrity: sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==}
     peerDependencies:
-      react: '>= 0.14.0'
+      react: '*'
     dependencies:
       '@babel/runtime': 7.20.0
       highlight.js: 10.7.3
@@ -68914,7 +69001,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.constants.storage/-/base-ui.constants.storage-1.0.0.tgz}
+    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.constants.storage/-/base-ui.constants.storage-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.constants.storage/1.0.0
     name: '@teambit/base-ui.constants.storage'
     version: 1.0.0
@@ -68927,13 +69014,13 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.elevation/-/base-ui.css-components.elevation-1.0.0.tgz}
+    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.elevation/-/base-ui.css-components.elevation-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.css-components.elevation/1.0.0
     name: '@teambit/base-ui.css-components.elevation'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -68941,7 +69028,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.roundness/-/base-ui.css-components.roundness-1.0.0.tgz}
+    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.css-components.roundness/-/base-ui.css-components.roundness-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.css-components.roundness/1.0.0
     name: '@teambit/base-ui.css-components.roundness'
     version: 1.0.0
@@ -68955,7 +69042,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.icon/-/base-ui.elements.icon-1.0.0.tgz}
+    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.icon/-/base-ui.elements.icon-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.elements.icon/1.0.0
     name: '@teambit/base-ui.elements.icon'
     version: 1.0.0
@@ -68969,23 +69056,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.image/-/base-ui.elements.image-1.0.0.tgz}
-    id: registry.npmjs.org/@teambit/base-ui.elements.image/1.0.0
-    name: '@teambit/base-ui.elements.image'
-    version: 1.0.0
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: true
-
   registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.indent/-/base-ui.graph.tree.indent-1.0.0.tgz}
+    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.indent/-/base-ui.graph.tree.indent-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.indent/1.0.0
     name: '@teambit/base-ui.graph.tree.indent'
     version: 1.0.0
@@ -68999,7 +69071,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/-/base-ui.graph.tree.inflate-paths-1.0.0.tgz}
+    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/-/base-ui.graph.tree.inflate-paths-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths/1.0.0
     name: '@teambit/base-ui.graph.tree.inflate-paths'
     version: 1.0.0
@@ -69015,7 +69087,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/-/base-ui.graph.tree.recursive-tree-1.0.0.tgz}
+    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/-/base-ui.graph.tree.recursive-tree-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree/1.0.0
     name: '@teambit/base-ui.graph.tree.recursive-tree'
     version: 1.0.0
@@ -69030,7 +69102,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/-/base-ui.graph.tree.root-node-1.0.0.tgz}
+    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/-/base-ui.graph.tree.root-node-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.root-node/1.0.0
     name: '@teambit/base-ui.graph.tree.root-node'
     version: 1.0.0
@@ -69045,7 +69117,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/-/base-ui.graph.tree.tree-context-1.0.0.tgz}
+    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/-/base-ui.graph.tree.tree-context-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context/1.0.0
     name: '@teambit/base-ui.graph.tree.tree-context'
     version: 1.0.0
@@ -69059,7 +69131,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/-/base-ui.hook.use-click-outside-1.0.0.tgz}
+    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/-/base-ui.hook.use-click-outside-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.hook.use-click-outside/1.0.0
     name: '@teambit/base-ui.hook.use-click-outside'
     version: 1.0.0
@@ -69073,7 +69145,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/-/base-ui.input.checkbox.hidden-1.0.1.tgz}
+    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/-/base-ui.input.checkbox.hidden-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.hidden/1.0.1
     name: '@teambit/base-ui.input.checkbox.hidden'
     version: 1.0.1
@@ -69088,13 +69160,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/-/base-ui.input.checkbox.indicator-1.0.0.tgz}
+    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/-/base-ui.input.checkbox.indicator-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.indicator/1.0.0
     name: '@teambit/base-ui.input.checkbox.indicator'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69103,7 +69175,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.input.checkbox.label@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.label/-/base-ui.input.checkbox.label-1.0.1.tgz}
+    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.input.checkbox.label/-/base-ui.input.checkbox.label-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.input.checkbox.label/1.0.1
     name: '@teambit/base-ui.input.checkbox.label'
     version: 1.0.1
@@ -69119,7 +69191,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.breakpoints/-/base-ui.layout.breakpoints-1.0.0.tgz}
+    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.breakpoints/-/base-ui.layout.breakpoints-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.breakpoints/1.0.0
     name: '@teambit/base-ui.layout.breakpoints'
     version: 1.0.0
@@ -69133,7 +69205,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-CIqH04NFmVRkfFdA3MA94FJ6Z2PXETUBPyRneu9Aik1SQhQJsXUyoIoZHloL1/6K6B4F/TfESPVXn7hsPNzI3A==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.grid-component/-/base-ui.layout.grid-component-1.0.0.tgz}
+    resolution: {integrity: sha512-CIqH04NFmVRkfFdA3MA94FJ6Z2PXETUBPyRneu9Aik1SQhQJsXUyoIoZHloL1/6K6B4F/TfESPVXn7hsPNzI3A==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.grid-component/-/base-ui.layout.grid-component-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.grid-component/1.0.0
     name: '@teambit/base-ui.layout.grid-component'
     version: 1.0.0
@@ -69149,7 +69221,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.page-frame/-/base-ui.layout.page-frame-1.0.0.tgz}
+    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.layout.page-frame/-/base-ui.layout.page-frame-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.layout.page-frame/1.0.0
     name: '@teambit/base-ui.layout.page-frame'
     version: 1.0.0
@@ -69163,7 +69235,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/-/base-ui.loaders.loader-ribbon-1.0.0.tgz}
+    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/-/base-ui.loaders.loader-ribbon-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon/1.0.0
     name: '@teambit/base-ui.loaders.loader-ribbon'
     version: 1.0.0
@@ -69178,7 +69250,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.compare-url/-/base-ui.routing.compare-url-1.0.0.tgz}
+    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.compare-url/-/base-ui.routing.compare-url-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.compare-url/1.0.0
     name: '@teambit/base-ui.routing.compare-url'
     version: 1.0.0
@@ -69191,24 +69263,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
       url-parse: 1.5.1
 
-  registry.npmjs.org/@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.link/-/base-ui.routing.link-1.0.0.tgz}
-    id: registry.npmjs.org/@teambit/base-ui.routing.link/1.0.0
-    name: '@teambit/base-ui.routing.link'
-    version: 1.0.0
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.routing-provider': registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: true
-
   registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-link/-/base-ui.routing.native-link-1.0.0.tgz}
+    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-link/-/base-ui.routing.native-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.native-link/1.0.0
     name: '@teambit/base-ui.routing.native-link'
     version: 1.0.0
@@ -69221,7 +69277,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/-/base-ui.routing.native-nav-link-1.0.0.tgz}
+    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/-/base-ui.routing.native-nav-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.native-nav-link/1.0.0
     name: '@teambit/base-ui.routing.native-nav-link'
     version: 1.0.0
@@ -69238,7 +69294,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.nav-link/-/base-ui.routing.nav-link-1.0.0.tgz}
+    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.nav-link/-/base-ui.routing.nav-link-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.nav-link/1.0.0
     name: '@teambit/base-ui.routing.nav-link'
     version: 1.0.0
@@ -69254,7 +69310,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.routing-provider/-/base-ui.routing.routing-provider-1.0.0.tgz}
+    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.routing-provider/-/base-ui.routing.routing-provider-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.routing.routing-provider/1.0.0
     name: '@teambit/base-ui.routing.routing-provider'
     version: 1.0.0
@@ -69270,13 +69326,13 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.styles.flex-center/-/base-ui.styles.flex-center-1.0.0.tgz}
+    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.styles.flex-center/-/base-ui.styles.flex-center-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.styles.flex-center/1.0.0
     name: '@teambit/base-ui.styles.flex-center'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69284,7 +69340,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/-/base-ui.surfaces.abs-container-1.0.0.tgz}
+    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/-/base-ui.surfaces.abs-container-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.abs-container/1.0.0
     name: '@teambit/base-ui.surfaces.abs-container'
     version: 1.0.0
@@ -69300,13 +69356,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.1.tgz}
+    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.background/-/base-ui.surfaces.background-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.background/1.0.1
     name: '@teambit/base-ui.surfaces.background'
     version: 1.0.1
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69314,13 +69370,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.1.tgz}
+    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.card/-/base-ui.surfaces.card-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.card/1.0.1
     name: '@teambit/base-ui.surfaces.card'
     version: 1.0.1
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.css-components.elevation': registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.css-components.roundness': registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -69332,13 +69388,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.drawer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.drawer/-/base-ui.surfaces.drawer-1.0.0.tgz}
+    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.drawer/-/base-ui.surfaces.drawer-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.drawer/1.0.0
     name: '@teambit/base-ui.surfaces.drawer'
     version: 1.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@teambit/base-ui.hook.use-click-outside': registry.npmjs.org/@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.abs-container': registry.npmjs.org/@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -69350,7 +69406,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
+    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.hover-splitter'
     version: 1.0.0
@@ -69366,7 +69422,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/-/base-ui.surfaces.split-pane.layout-1.0.0.tgz}
+    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/-/base-ui.surfaces.split-pane.layout-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.layout/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.layout'
     version: 1.0.0
@@ -69380,7 +69436,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/-/base-ui.surfaces.split-pane.pane-1.0.0.tgz}
+    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/-/base-ui.surfaces.split-pane.pane-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.pane/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.pane'
     version: 1.0.0
@@ -69396,7 +69452,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/-/base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
+    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/-/base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.split-pane'
     version: 1.0.0
@@ -69414,7 +69470,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/-/base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
+    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/-/base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.splitter/1.0.0
     name: '@teambit/base-ui.surfaces.split-pane.splitter'
     version: 1.0.0
@@ -69429,7 +69485,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.heading@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.heading/-/base-ui.text.heading-1.0.1.tgz}
+    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.heading/-/base-ui.text.heading-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.heading/1.0.1
     name: '@teambit/base-ui.text.heading'
     version: 1.0.1
@@ -69443,13 +69499,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.muted-text/-/base-ui.text.muted-text-1.0.1.tgz}
+    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.muted-text/-/base-ui.text.muted-text-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.muted-text/1.0.1
     name: '@teambit/base-ui.text.muted-text'
     version: 1.0.1
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69458,7 +69514,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.paragraph@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.paragraph/-/base-ui.text.paragraph-1.0.1.tgz}
+    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.paragraph/-/base-ui.text.paragraph-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.paragraph/1.0.1
     name: '@teambit/base-ui.text.paragraph'
     version: 1.0.1
@@ -69475,7 +69531,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.text-sizes/-/base-ui.text.text-sizes-1.0.0.tgz}
+    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.text-sizes/-/base-ui.text.text-sizes-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.text-sizes/1.0.0
     name: '@teambit/base-ui.text.text-sizes'
     version: 1.0.0
@@ -69489,7 +69545,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.themed-text/-/base-ui.text.themed-text-1.0.1.tgz}
+    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.text.themed-text/-/base-ui.text.themed-text-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.text.themed-text/1.0.1
     name: '@teambit/base-ui.text.themed-text'
     version: 1.0.1
@@ -69504,7 +69560,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-1.1.0.tgz}
+    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.accent-color/-/base-ui.theme.accent-color-1.1.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.accent-color/1.1.0
     name: '@teambit/base-ui.theme.accent-color'
     version: 1.1.0
@@ -69519,7 +69575,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.brand-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.brand-definition/-/base-ui.theme.brand-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.brand-definition/-/base-ui.theme.brand-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.brand-definition/1.0.0
     name: '@teambit/base-ui.theme.brand-definition'
     version: 1.0.0
@@ -69532,7 +69588,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.color-definition@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.color-definition/-/base-ui.theme.color-definition-1.0.1.tgz}
+    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.color-definition/-/base-ui.theme.color-definition-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.color-definition/1.0.1
     name: '@teambit/base-ui.theme.color-definition'
     version: 1.0.1
@@ -69546,7 +69602,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-1.0.0.tgz}
+    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.colors/-/base-ui.theme.colors-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.colors/1.0.0
     name: '@teambit/base-ui.theme.colors'
     version: 1.0.0
@@ -69559,7 +69615,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.2.tgz}
+    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.dark-theme/-/base-ui.theme.dark-theme-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.dark-theme/1.0.2
     name: '@teambit/base-ui.theme.dark-theme'
     version: 1.0.2
@@ -69573,7 +69629,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.fonts.book@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.book/-/base-ui.theme.fonts.book-1.0.0.tgz}
+    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.book/-/base-ui.theme.fonts.book-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.fonts.book/1.0.0
     name: '@teambit/base-ui.theme.fonts.book'
     version: 1.0.0
@@ -69586,7 +69642,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/-/base-ui.theme.fonts.roboto-1.0.0.tgz}
+    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/-/base-ui.theme.fonts.roboto-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto/1.0.0
     name: '@teambit/base-ui.theme.fonts.roboto'
     version: 1.0.0
@@ -69599,7 +69655,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/-/base-ui.theme.heading-margin-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/-/base-ui.theme.heading-margin-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.heading-margin-definition/1.0.0
     name: '@teambit/base-ui.theme.heading-margin-definition'
     version: 1.0.0
@@ -69612,7 +69668,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.shadow-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/-/base-ui.theme.shadow-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/-/base-ui.theme.shadow-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.shadow-definition/1.0.0
     name: '@teambit/base-ui.theme.shadow-definition'
     version: 1.0.0
@@ -69625,7 +69681,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.size-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.size-definition/-/base-ui.theme.size-definition-1.0.0.tgz}
+    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.size-definition/-/base-ui.theme.size-definition-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.size-definition/1.0.0
     name: '@teambit/base-ui.theme.size-definition'
     version: 1.0.0
@@ -69638,7 +69694,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.sizes/-/base-ui.theme.sizes-1.0.0.tgz}
+    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.sizes/-/base-ui.theme.sizes-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.sizes/1.0.0
     name: '@teambit/base-ui.theme.sizes'
     version: 1.0.0
@@ -69652,7 +69708,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.theme-provider/-/base-ui.theme.theme-provider-1.0.1.tgz}
+    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.theme.theme-provider/-/base-ui.theme.theme-provider-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/base-ui.theme.theme-provider/1.0.1
     name: '@teambit/base-ui.theme.theme-provider'
     version: 1.0.1
@@ -69672,7 +69728,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.composer/-/base-ui.utils.composer-1.0.0.tgz}
+    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.composer/-/base-ui.utils.composer-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.composer/1.0.0
     name: '@teambit/base-ui.utils.composer'
     version: 1.0.0
@@ -69686,7 +69742,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.is-browser/-/base-ui.utils.is-browser-1.0.0.tgz}
+    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.is-browser/-/base-ui.utils.is-browser-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.is-browser/1.0.0
     name: '@teambit/base-ui.utils.is-browser'
     version: 1.0.0
@@ -69699,7 +69755,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.string.affix/-/base-ui.utils.string.affix-1.0.0.tgz}
+    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.string.affix/-/base-ui.utils.string.affix-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.string.affix/1.0.0
     name: '@teambit/base-ui.utils.string.affix'
     version: 1.0.0
@@ -69713,7 +69769,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/base-ui.utils.sub-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.sub-paths/-/base-ui.utils.sub-paths-1.0.0.tgz}
+    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.sub-paths/-/base-ui.utils.sub-paths-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.sub-paths/1.0.0
     name: '@teambit/base-ui.utils.sub-paths'
     version: 1.0.0
@@ -69728,7 +69784,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component.instructions.exporting-components/-/component.instructions.exporting-components-0.0.6.tgz}
+    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/component.instructions.exporting-components/-/component.instructions.exporting-components-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/component.instructions.exporting-components/0.0.6
     name: '@teambit/component.instructions.exporting-components'
     version: 0.0.6
@@ -69746,7 +69802,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-dCfQMPt3JfXboNOf21tM23kjsZkj6lW8apc4lJerC9vOn5TjU22PgC68SQ7xgF276rjIC896DVwGzsJijwjWpw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.theme.icons-font/-/design.theme.icons-font-1.0.0.tgz}
+    resolution: {integrity: sha512-dCfQMPt3JfXboNOf21tM23kjsZkj6lW8apc4lJerC9vOn5TjU22PgC68SQ7xgF276rjIC896DVwGzsJijwjWpw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.theme.icons-font/-/design.theme.icons-font-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/design.theme.icons-font/1.0.0
     name: '@teambit/design.theme.icons-font'
     version: 1.0.0
@@ -69761,7 +69817,7 @@ packages:
     dev: true
 
   registry.npmjs.org/@teambit/design.ui.styles.ellipsis@0.0.344(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-SwTlVagmcCvedxD9hrq+1pt9MxkYY+GfYAyF4BUsTjKYAv37ZqOX8dqNgmkKhKlTBXSAw70rfGDQ5BBE8Ptipw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.344.tgz}
+    resolution: {integrity: sha512-SwTlVagmcCvedxD9hrq+1pt9MxkYY+GfYAyF4BUsTjKYAv37ZqOX8dqNgmkKhKlTBXSAw70rfGDQ5BBE8Ptipw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.344.tgz}
     id: registry.npmjs.org/@teambit/design.ui.styles.ellipsis/0.0.344
     name: '@teambit/design.ui.styles.ellipsis'
     version: 0.0.344
@@ -69776,24 +69832,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-compositions/-/documenter.theme.theme-compositions-4.1.1.tgz}
-    id: registry.npmjs.org/@teambit/documenter.theme.theme-compositions/4.1.1
-    name: '@teambit/documenter.theme.theme-compositions'
-    version: 4.1.1
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/design.theme.icons-font': registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: true
-
   registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-context/-/documenter.theme.theme-context-4.0.3.tgz}
+    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-context/-/documenter.theme.theme-context-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.theme.theme-context/4.0.3
     name: '@teambit/documenter.theme.theme-context'
     version: 4.0.3
@@ -69808,26 +69848,8 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  registry.npmjs.org/@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.consumable-link/-/documenter.ui.consumable-link-4.0.3.tgz}
-    id: registry.npmjs.org/@teambit/documenter.ui.consumable-link/4.0.3
-    name: '@teambit/documenter.ui.consumable-link'
-    version: 4.0.3
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.copy-box': registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.paragraph': registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   registry.npmjs.org/@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.0.1.tgz}
+    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.0.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copied-message/4.0.1
     name: '@teambit/documenter.ui.copied-message'
     version: 4.0.1
@@ -69842,7 +69864,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.copied-message@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PbXQD3l6iydMLDoWtOTNj9HBpgUMK2melalxXRAAudCwG5Tk0cdWMAgKOLIa8lT7ObMBUcdy9Ed7LCcIWEOIQg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.1.1.tgz}
+    resolution: {integrity: sha512-PbXQD3l6iydMLDoWtOTNj9HBpgUMK2melalxXRAAudCwG5Tk0cdWMAgKOLIa8lT7ObMBUcdy9Ed7LCcIWEOIQg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copied-message/4.1.1
     name: '@teambit/documenter.ui.copied-message'
     version: 4.1.1
@@ -69857,7 +69879,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.copy-box@4.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-G1RaI94h1TuMe+wpBOUnLhP82/LNV1QY5IyFqLbarYtRsddhQePNu+R7PmKhKBwbPHPyAbeFr6qWVybUXDbvXw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.0.1.tgz}
+    resolution: {integrity: sha512-G1RaI94h1TuMe+wpBOUnLhP82/LNV1QY5IyFqLbarYtRsddhQePNu+R7PmKhKBwbPHPyAbeFr6qWVybUXDbvXw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.0.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copy-box/4.0.1
     name: '@teambit/documenter.ui.copy-box'
     version: 4.0.1
@@ -69876,7 +69898,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-7mzL2LeRxV6O6QyQl+q0yCNL+DsHVVHgkzJoE1favbn+di5BUdw+4XmZeI5LxeLq2WSrc6pmMwln97CkTGvLHg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.1.1.tgz}
+    resolution: {integrity: sha512-7mzL2LeRxV6O6QyQl+q0yCNL+DsHVVHgkzJoE1favbn+di5BUdw+4XmZeI5LxeLq2WSrc6pmMwln97CkTGvLHg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copy-box/-/documenter.ui.copy-box-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.copy-box/4.1.1
     name: '@teambit/documenter.ui.copy-box'
     version: 4.1.1
@@ -69895,7 +69917,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.heading/-/documenter.ui.heading-4.1.1.tgz}
+    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.heading/-/documenter.ui.heading-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.heading/4.1.1
     name: '@teambit/documenter.ui.heading'
     version: 4.1.1
@@ -69911,7 +69933,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.highlighted-text/-/documenter.ui.highlighted-text-4.1.1.tgz}
+    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.highlighted-text/-/documenter.ui.highlighted-text-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.highlighted-text/4.1.1
     name: '@teambit/documenter.ui.highlighted-text'
     version: 4.1.1
@@ -69926,7 +69948,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.inline-code@0.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.inline-code/-/documenter.ui.inline-code-0.1.1.tgz}
+    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.inline-code/-/documenter.ui.inline-code-0.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.inline-code/0.1.1
     name: '@teambit/documenter.ui.inline-code'
     version: 0.1.1
@@ -69941,7 +69963,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label-list/-/documenter.ui.label-list-4.0.3.tgz}
+    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label-list/-/documenter.ui.label-list-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.label-list/4.0.3
     name: '@teambit/documenter.ui.label-list'
     version: 4.0.3
@@ -69957,7 +69979,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label/-/documenter.ui.label-4.0.3.tgz}
+    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.label/-/documenter.ui.label-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.label/4.0.3
     name: '@teambit/documenter.ui.label'
     version: 4.0.3
@@ -69972,7 +69994,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.paragraph/-/documenter.ui.paragraph-4.1.1.tgz}
+    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.paragraph/-/documenter.ui.paragraph-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.paragraph/4.1.1
     name: '@teambit/documenter.ui.paragraph'
     version: 4.1.1
@@ -69989,7 +70011,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.section/-/documenter.ui.section-4.1.1.tgz}
+    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.section/-/documenter.ui.section-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.section/4.1.1
     name: '@teambit/documenter.ui.section'
     version: 4.1.1
@@ -70003,7 +70025,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.separator/-/documenter.ui.separator-4.1.1.tgz}
+    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.separator/-/documenter.ui.separator-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.separator/4.1.1
     name: '@teambit/documenter.ui.separator'
     version: 4.1.1
@@ -70017,7 +70039,7 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.sub-title/-/documenter.ui.sub-title-4.1.1.tgz}
+    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.sub-title/-/documenter.ui.sub-title-4.1.1.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.sub-title/4.1.1
     name: '@teambit/documenter.ui.sub-title'
     version: 4.1.1
@@ -70034,13 +70056,13 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/documenter.ui.table-column@4.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-sGMLD+Lu2snQ1g1xUXYHqhbUcH3iOp0CUc69T76SNt3cQBabNGb5T9yg0A/7JYN4Ams1IKJ8Anws8+T64huSDg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.table-column/-/documenter.ui.table-column-4.0.0.tgz}
+    resolution: {integrity: sha512-sGMLD+Lu2snQ1g1xUXYHqhbUcH3iOp0CUc69T76SNt3cQBabNGb5T9yg0A/7JYN4Ams1IKJ8Anws8+T64huSDg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.table-column/-/documenter.ui.table-column-4.0.0.tgz}
     id: registry.npmjs.org/@teambit/documenter.ui.table-column/4.0.0
     name: '@teambit/documenter.ui.table-column'
     version: 4.0.0
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -70049,7 +70071,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/-/evangelist.css-components.fade-in-out-1.0.1.tgz}
+    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/-/evangelist.css-components.fade-in-out-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/1.0.1
     name: '@teambit/evangelist.css-components.fade-in-out'
     version: 1.0.1
@@ -70063,7 +70085,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.elements.icon/-/evangelist.elements.icon-1.0.2.tgz}
+    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.elements.icon/-/evangelist.elements.icon-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.elements.icon/1.0.2
     name: '@teambit/evangelist.elements.icon'
     version: 1.0.2
@@ -70078,7 +70100,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/-/evangelist.input.checkbox.indicator-1.0.2.tgz}
+    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/-/evangelist.input.checkbox.indicator-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.input.checkbox.indicator/1.0.2
     name: '@teambit/evangelist.input.checkbox.indicator'
     version: 1.0.2
@@ -70095,7 +70117,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.label/-/evangelist.input.checkbox.label-1.0.3.tgz}
+    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.input.checkbox.label/-/evangelist.input.checkbox.label-1.0.3.tgz}
     id: registry.npmjs.org/@teambit/evangelist.input.checkbox.label/1.0.3
     name: '@teambit/evangelist.input.checkbox.label'
     version: 1.0.3
@@ -70111,7 +70133,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/-/evangelist.surfaces.dropdown-1.0.2.tgz}
+    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/-/evangelist.surfaces.dropdown-1.0.2.tgz}
     id: registry.npmjs.org/@teambit/evangelist.surfaces.dropdown/1.0.2
     name: '@teambit/evangelist.surfaces.dropdown'
     version: 1.0.2
@@ -70132,7 +70154,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/-/evangelist.surfaces.tooltip-1.0.1.tgz}
+    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/-/evangelist.surfaces.tooltip-1.0.1.tgz}
     id: registry.npmjs.org/@teambit/evangelist.surfaces.tooltip/1.0.1
     name: '@teambit/evangelist.surfaces.tooltip'
     version: 1.0.1
@@ -70152,7 +70174,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/-/mdx.ui.mdx-scope-context-0.0.368.tgz}
+    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/-/mdx.ui.mdx-scope-context-0.0.368.tgz}
     id: registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context/0.0.368
     name: '@teambit/mdx.ui.mdx-scope-context'
     version: 0.0.368
@@ -70168,13 +70190,13 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/-/react.instructions.react.adding-compositions-0.0.6.tgz}
+    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/-/react.instructions.react.adding-compositions-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-compositions/0.0.6
     name: '@teambit/react.instructions.react.adding-compositions'
     version: 0.0.6
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -70186,7 +70208,7 @@ packages:
     dev: false
 
   registry.npmjs.org/@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-tests/-/react.instructions.react.adding-tests-0.0.6.tgz}
+    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/react.instructions.react.adding-tests/-/react.instructions.react.adding-tests-0.0.6.tgz}
     id: registry.npmjs.org/@teambit/react.instructions.react.adding-tests/0.0.6
     name: '@teambit/react.instructions.react.adding-tests'
     version: 0.0.6
@@ -70201,38 +70223,4 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     transitivePeerDependencies:
       - '@teambit/legacy'
-    dev: false
-
-  registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.agent/-/toolbox.network.agent-0.0.116.tgz}
-    id: registry.npmjs.org/@teambit/toolbox.network.agent/0.0.116
-    name: '@teambit/toolbox.network.agent'
-    version: 0.0.116
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.108
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      '@teambit/toolbox.network.proxy-agent': registry.npmjs.org/@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
-      agentkeepalive: 4.1.4
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  registry.npmjs.org/@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==, registry: https://node-registry.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/toolbox.network.proxy-agent/-/toolbox.network.proxy-agent-0.0.116.tgz}
-    id: registry.npmjs.org/@teambit/toolbox.network.proxy-agent/0.0.116
-    name: '@teambit/toolbox.network.proxy-agent'
-    version: 0.0.116
-    engines: {node: '>=12.15.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.108
-    dependencies:
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      '@teambit/toolbox.network.agent': registry.npmjs.org/@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy)
-      http-proxy-agent: 4.0.1
-      https-proxy-agent: 5.0.0
-      socks-proxy-agent: 5.0.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,13 +149,13 @@ importers:
         version: 2.0.4
       '@prerenderer/prerenderer':
         specifier: ^1.2.0
-        version: 1.2.3(@types/express@4.17.13)(debug@4.3.2)
+        version: 1.2.0(@types/express@4.17.13)(debug@4.3.2)
       '@prerenderer/renderer-jsdom':
         specifier: ^1.1.2
-        version: 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+        version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@react-hook/latest':
         specifier: 1.0.3
         version: 1.0.3(react@17.0.2)
@@ -470,7 +470,7 @@ importers:
         version: 4.2.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.consumable-link':
         specifier: 4.0.3
-        version: 4.0.3(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copied-message':
         specifier: 4.1.6
         version: 4.1.6(react-dom@17.0.2)(react@17.0.2)
@@ -573,6 +573,9 @@ importers:
       '@teambit/lanes.ui.viewed-lane':
         specifier: 0.0.37
         version: 0.0.37(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/legacy':
+        specifier: link:/Users/zoltan/.bvm/versions/0.1.91/bit-0.1.91/node_modules/@teambit/legacy
+        version: link:../../../.bvm/versions/0.2.2/bit-0.2.2/node_modules/@teambit/legacy
       '@teambit/legacy-bit-id':
         specifier: ^0.0.423
         version: 0.0.423
@@ -796,8 +799,8 @@ importers:
         specifier: 0.1.1
         version: 0.1.1
       chokidar:
-        specifier: 3.5.3
-        version: 3.5.3
+        specifier: 3.5.1
+        version: 3.5.1
       class-transformer:
         specifier: 0.5.1
         version: 0.5.1
@@ -1710,7 +1713,7 @@ importers:
         version: 1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.95.9
         version: 1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
@@ -1839,7 +1842,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/react-tabs':
         specifier: 2.3.2
         version: 2.3.2
@@ -1930,7 +1933,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -1985,7 +1988,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2061,7 +2064,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2116,7 +2119,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2171,7 +2174,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -2214,7 +2217,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2257,7 +2260,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2291,7 +2294,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2328,7 +2331,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2365,7 +2368,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2405,7 +2408,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2457,7 +2460,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2515,7 +2518,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2549,7 +2552,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2592,7 +2595,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2626,7 +2629,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2672,7 +2675,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2706,7 +2709,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2743,7 +2746,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2780,7 +2783,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2820,7 +2823,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2854,7 +2857,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2888,7 +2891,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2922,7 +2925,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2965,7 +2968,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -2999,7 +3002,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3042,7 +3045,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3076,7 +3079,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3116,7 +3119,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3150,7 +3153,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3184,7 +3187,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3227,7 +3230,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -3297,7 +3300,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3334,7 +3337,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3404,7 +3407,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3447,7 +3450,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3493,7 +3496,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3548,7 +3551,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3594,7 +3597,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3643,7 +3646,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3689,7 +3692,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -3732,7 +3735,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15193,7 +15196,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15239,7 +15242,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15276,7 +15279,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15313,7 +15316,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15350,7 +15353,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15384,7 +15387,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15421,7 +15424,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15473,7 +15476,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15507,7 +15510,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15541,7 +15544,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15584,7 +15587,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15627,7 +15630,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15661,7 +15664,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15695,7 +15698,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15732,7 +15735,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15778,7 +15781,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15833,7 +15836,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15867,7 +15870,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15901,7 +15904,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15941,7 +15944,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -15975,7 +15978,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16021,7 +16024,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16061,7 +16064,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16095,7 +16098,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16129,7 +16132,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16196,7 +16199,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16230,7 +16233,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16353,7 +16356,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16456,7 +16459,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16529,7 +16532,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16578,7 +16581,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16615,7 +16618,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16640,7 +16643,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16655,7 +16658,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16680,7 +16683,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16695,7 +16698,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16720,7 +16723,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16735,7 +16738,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16793,7 +16796,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16845,7 +16848,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -16940,7 +16943,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17005,7 +17008,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17030,7 +17033,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -17045,7 +17048,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17100,7 +17103,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17155,7 +17158,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17201,7 +17204,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17325,7 +17328,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -17380,7 +17383,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17420,7 +17423,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17484,7 +17487,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17524,7 +17527,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17567,7 +17570,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17619,7 +17622,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17662,7 +17665,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17739,7 +17742,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17791,7 +17794,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17828,7 +17831,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17936,7 +17939,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -17982,7 +17985,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18037,7 +18040,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18098,7 +18101,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18207,7 +18210,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18301,7 +18304,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18350,7 +18353,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18417,7 +18420,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18478,7 +18481,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18533,7 +18536,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18582,7 +18585,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18634,7 +18637,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18701,7 +18704,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18753,7 +18756,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18832,7 +18835,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -18899,7 +18902,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -18957,7 +18960,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19046,7 +19049,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19083,7 +19086,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19147,7 +19150,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19181,7 +19184,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19218,7 +19221,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19273,7 +19276,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19337,7 +19340,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19380,7 +19383,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19408,7 +19411,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -19429,7 +19432,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19460,7 +19463,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19487,7 +19490,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19518,7 +19521,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19542,7 +19545,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19585,7 +19588,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19612,7 +19615,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19652,7 +19655,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19689,7 +19692,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19741,7 +19744,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19793,7 +19796,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19820,7 +19823,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -19857,7 +19860,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19884,7 +19887,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19912,7 +19915,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19927,7 +19930,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -19976,7 +19979,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20079,7 +20082,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20206,7 +20209,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -20224,7 +20227,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20273,7 +20276,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20307,7 +20310,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20353,7 +20356,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20387,7 +20390,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20421,7 +20424,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20482,7 +20485,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20568,7 +20571,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20638,7 +20641,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20696,7 +20699,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20751,7 +20754,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20800,7 +20803,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20846,7 +20849,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -20953,7 +20956,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21020,7 +21023,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21054,7 +21057,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21082,7 +21085,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -21100,7 +21103,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21155,7 +21158,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21198,7 +21201,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21241,7 +21244,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21266,7 +21269,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21281,7 +21284,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21306,7 +21309,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21321,7 +21324,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21346,7 +21349,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21361,7 +21364,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21428,7 +21431,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21531,7 +21534,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -21683,7 +21686,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -21768,7 +21771,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21835,7 +21838,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21875,7 +21878,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21909,7 +21912,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21946,7 +21949,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -21971,7 +21974,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21986,7 +21989,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22023,7 +22026,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22087,7 +22090,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22121,7 +22124,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22185,7 +22188,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22237,7 +22240,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -22280,7 +22283,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22305,7 +22308,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22320,7 +22323,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22390,7 +22393,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22439,7 +22442,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22488,7 +22491,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22546,7 +22549,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22646,7 +22649,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22671,7 +22674,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22686,7 +22689,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22711,7 +22714,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22726,7 +22729,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22790,7 +22793,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22884,7 +22887,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -22924,7 +22927,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -22982,7 +22985,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23055,7 +23058,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23095,7 +23098,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23150,7 +23153,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23190,7 +23193,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23242,7 +23245,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23291,7 +23294,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23406,7 +23409,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23452,7 +23455,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23495,7 +23498,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23571,7 +23574,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23614,7 +23617,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23691,7 +23694,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23731,7 +23734,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23756,7 +23759,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -23771,7 +23774,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23820,7 +23823,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -23975,7 +23978,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24082,7 +24085,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24152,7 +24155,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24183,7 +24186,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24198,7 +24201,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24256,7 +24259,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24299,7 +24302,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24394,7 +24397,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24422,7 +24425,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24437,7 +24440,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24471,7 +24474,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24499,7 +24502,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24520,7 +24523,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24548,7 +24551,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24563,7 +24566,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24660,7 +24663,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24697,7 +24700,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24747,7 +24750,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24762,7 +24765,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24841,7 +24844,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -24866,7 +24869,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24881,7 +24884,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25024,7 +25027,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25079,7 +25082,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25119,7 +25122,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25144,7 +25147,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25159,7 +25162,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25184,7 +25187,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25199,7 +25202,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25233,7 +25236,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25374,13 +25377,13 @@ importers:
         version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
       '@prerenderer/prerenderer':
         specifier: ^1.2.0
-        version: 1.2.3(@types/express@4.17.13)(debug@4.3.2)
+        version: 1.2.0(@types/express@4.17.13)(debug@4.3.2)
       '@prerenderer/renderer-jsdom':
         specifier: ^1.1.2
-        version: 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+        version: 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@prerenderer/webpack-plugin':
         specifier: ^5.2.0
-        version: 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+        version: 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack':
         specifier: 5.5.0
         version: 5.5.0
@@ -25624,7 +25627,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25757,7 +25760,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25830,7 +25833,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25870,7 +25873,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25934,7 +25937,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -25974,7 +25977,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26014,7 +26017,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26060,7 +26063,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26103,7 +26106,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26152,7 +26155,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26198,7 +26201,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26238,7 +26241,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26296,7 +26299,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26351,7 +26354,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26414,8 +26417,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.3
-        version: 3.5.3
+        specifier: 3.5.1
+        version: 3.5.1
       classnames:
         specifier: 2.2.6
         version: 2.2.6
@@ -26479,7 +26482,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -26525,7 +26528,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26550,7 +26553,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26565,7 +26568,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26599,7 +26602,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26636,7 +26639,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26685,7 +26688,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26731,7 +26734,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26780,7 +26783,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26829,7 +26832,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -26921,7 +26924,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27270,7 +27273,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27285,7 +27288,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27417,7 +27420,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27504,7 +27507,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27522,7 +27525,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27559,7 +27562,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27577,7 +27580,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27617,7 +27620,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27654,7 +27657,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27703,7 +27706,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27749,7 +27752,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27789,7 +27792,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27853,7 +27856,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27899,7 +27902,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27933,7 +27936,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -27967,7 +27970,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28013,7 +28016,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/react-tabs':
         specifier: 2.3.2
         version: 2.3.2
@@ -28062,7 +28065,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28111,7 +28114,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28148,7 +28151,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28200,7 +28203,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28228,7 +28231,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28246,7 +28249,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28289,7 +28292,7 @@ importers:
         version: 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -28304,7 +28307,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28344,7 +28347,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28362,7 +28365,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28414,7 +28417,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28601,7 +28604,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28641,7 +28644,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28687,7 +28690,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28721,7 +28724,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28758,7 +28761,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28801,7 +28804,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28838,7 +28841,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28872,7 +28875,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28906,7 +28909,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28946,7 +28949,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -28983,7 +28986,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29023,7 +29026,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29078,7 +29081,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29112,7 +29115,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29155,7 +29158,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29189,7 +29192,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29259,7 +29262,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29299,7 +29302,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29342,7 +29345,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29388,7 +29391,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29422,7 +29425,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29456,7 +29459,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -29474,7 +29477,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29544,7 +29547,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29587,7 +29590,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29630,7 +29633,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29676,7 +29679,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29716,7 +29719,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -29777,7 +29780,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30054,7 +30057,7 @@ importers:
         version: 9.0.10(debug@4.3.2)
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30085,7 +30088,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -30100,7 +30103,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30140,7 +30143,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30180,7 +30183,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30220,7 +30223,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30299,7 +30302,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
@@ -30414,7 +30417,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -30429,7 +30432,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30460,7 +30463,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -30481,7 +30484,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30512,7 +30515,7 @@ importers:
         version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
-        version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
+        version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -30533,7 +30536,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30570,7 +30573,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30622,7 +30625,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30645,8 +30648,8 @@ importers:
         specifier: 2.4.2
         version: 2.4.2
       chokidar:
-        specifier: 3.5.3
-        version: 3.5.3
+        specifier: 3.5.1
+        version: 3.5.1
       core-js:
         specifier: ^3.0.0
         version: 3.13.0
@@ -30692,7 +30695,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30825,7 +30828,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30898,7 +30901,7 @@ importers:
         version: 17.0.8
       '@types/react-dom':
         specifier: ^17.0.5
-        version: 17.0.20
+        version: 17.0.18
       '@types/testing-library__jest-dom':
         specifier: 5.9.5
         version: 5.9.5
@@ -30908,17 +30911,12 @@ importers:
 
 packages:
 
-  /@aashutoshrathi/word-wrap@1.2.6:
-    resolution: {integrity: sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
-  /@ampproject/remapping@2.2.1:
-    resolution: {integrity: sha512-lFMjJTrFL3j7L9yBxwYfCq2k6qqwHyzuUl/XBnif78PWTJYyL/dfowQHWE3sp6U6ZzqWiiIZnpTMO96zhkjwtg==}
+  /@ampproject/remapping@2.2.0:
+    resolution: {integrity: sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==}
     engines: {node: '>=6.0.0'}
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/gen-mapping': 0.1.1
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@apideck/better-ajv-errors@0.2.7(ajv@8.12.0):
     resolution: {integrity: sha512-J2dW+EHYudbwI7MGovcHWLBrxasl21uuroc2zT8bH2RxYuv2g5GqsO5jcKUZz4LaMST45xhKjVuyRYkhcWyMhA==}
@@ -30947,9 +30945,9 @@ packages:
       subscriptions-transport-ws:
         optional: true
     dependencies:
-      '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
+      '@graphql-typed-document-node/core': 3.1.1(graphql@15.8.0)
       '@wry/context': 0.6.1
-      '@wry/equality': 0.5.6
+      '@wry/equality': 0.5.3
       '@wry/trie': 0.3.2
       graphql: 15.8.0
       graphql-tag: 2.12.6(graphql@15.8.0)
@@ -30960,7 +30958,7 @@ packages:
       subscriptions-transport-ws: 0.9.18(bufferutil@4.0.3)(graphql@15.8.0)(utf-8-validate@5.0.5)
       symbol-observable: 4.0.0
       ts-invariant: 0.10.3
-      tslib: 2.6.0
+      tslib: 2.5.0
       zen-observable-ts: 1.2.5
 
   /@apollo/protobufjs@1.2.2:
@@ -31006,7 +31004,7 @@ packages:
     dependencies:
       '@types/express': 4.17.13
       '@types/fs-capacitor': 2.0.0
-      '@types/koa': 2.13.6
+      '@types/koa': 2.13.5
       busboy: 0.3.1
       fs-capacitor: 2.0.4
       graphql: 15.8.0
@@ -31028,51 +31026,51 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.17
       commander: 4.1.1
       convert-source-map: 1.9.0
       fs-readdir-recursive: 1.1.0
-      glob: 7.2.3
+      glob: 7.2.0
       make-dir: 2.1.0
       slash: 2.0.0
     optionalDependencies:
       '@nicolo-ribaudo/chokidar-2': 2.1.8-no-fsevents.3
-      chokidar: 3.5.3
+      chokidar: 3.5.1
     dev: false
 
   /@babel/code-frame@7.10.4:
     resolution: {integrity: sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==}
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.18.6
     dev: false
 
   /@babel/code-frame@7.12.11:
     resolution: {integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==}
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.18.6
     dev: false
 
-  /@babel/code-frame@7.22.5:
-    resolution: {integrity: sha512-Xmwn266vad+6DAqEB2A6V/CcZVp62BbwVmcOJc2RPuwih1kw02TjQvWVWlcKGbBPd+8/0V5DEkOcizRGYsspYQ==}
+  /@babel/code-frame@7.18.6:
+    resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/highlight': 7.22.5
+      '@babel/highlight': 7.18.6
 
-  /@babel/compat-data@7.22.9:
-    resolution: {integrity: sha512-5UamI7xkUcJ3i9qVDS+KFDEK8/7oJ55/sJMB1Ge7IEapr7KfdfV/HErR+koZwOfd+SgtFKOKRhRakdg++DcJpQ==}
+  /@babel/compat-data@7.20.14:
+    resolution: {integrity: sha512-0YpKHD6ImkWMEINCyDAD0HLLUH/lPCefG8ld9it8DJB2wnApraKuhgYTvTY1z7UFIfBTGy5LwncZ+5HWWGbhFw==}
     engines: {node: '>=6.9.0'}
 
   /@babel/core@7.11.6:
     resolution: {integrity: sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.11.6)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.22.4
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31080,7 +31078,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.2
+      semver: 5.7.1
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31090,13 +31088,13 @@ packages:
     resolution: {integrity: sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.22.4
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31104,7 +31102,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.2
+      semver: 5.7.1
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31114,13 +31112,13 @@ packages:
     resolution: {integrity: sha512-gTXYh3M5wb7FRXQy+FErKFAv90BnlOuNn1QkCK2lREoPAjrQCO49+HVSrFoe5uakFAF5eenS75KbO2vQiLrTMQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.9)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.22.4
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
@@ -31128,7 +31126,7 @@ packages:
       json5: 2.2.3
       lodash: 4.17.21
       resolve: 1.20.0
-      semver: 5.7.2
+      semver: 5.7.1
       source-map: 0.5.7
     transitivePeerDependencies:
       - supports-color
@@ -31138,173 +31136,173 @@ packages:
     resolution: {integrity: sha512-D2Ue4KHpc6Ys2+AxpIx1BZ8+UegLLLE2p3KJEuJRKmokHOtl49jQ5ny1773KsGLZs8MQvBidAF6yWUJxRqtKtg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.20.13
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/core@7.22.9:
-    resolution: {integrity: sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==}
+  /@babel/core@7.20.12:
+    resolution: {integrity: sha512-XsMfHovsUYHFMdrIHkZphTN/2Hzzi78R08NuHfDBehym2VsPDL6Zn/JAD/JQdnRvbSsbQc4mVaU1m6JgtTEElg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@ampproject/remapping': 2.2.1
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.22.9)
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.22.9)
-      '@babel/helpers': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
+      '@ampproject/remapping': 2.2.0
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.20.12)
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helpers': 7.20.13
+      '@babel/parser': 7.20.13
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
+      '@babel/types': 7.22.3
       convert-source-map: 1.9.0
       debug: 4.3.2
       gensync: 1.0.0-beta.2
       json5: 2.2.3
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/generator@7.22.9:
-    resolution: {integrity: sha512-KtLMbmicyuK2Ak/FTCJVbDnkN1SlT8/kceFTiuDiiRUUSMnHMidxSCdG4ndkTOHHpoomWe/4xkvHkEOncwjYIw==}
+  /@babel/generator@7.20.14:
+    resolution: {integrity: sha512-AEmuXHdcD3A52HHXxaTmYlb8q/xMEhoRP67B3T4Oq7lbmSoqroMZzjnGj3+i1io3pdnF8iBYVu4Ilj+c4hBxYg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@babel/types': 7.22.3
+      '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
-  /@babel/helper-annotate-as-pure@7.22.5:
-    resolution: {integrity: sha512-LvBTxu8bQSQkcyKOU+a1btnNFQ1dMAd0R6PyW3arXes06F6QLWLIrd681bxRPIXlrMGR3XYnW9JyML7dP3qgxg==}
+  /@babel/helper-annotate-as-pure@7.18.6:
+    resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-builder-binary-assignment-operator-visitor@7.22.5:
-    resolution: {integrity: sha512-m1EP3lVOPptR+2DwD125gziZNcmoNSHGmJROKoy87loWUQyJaVXDgpmruWqDARZSmtYQ+Dl25okU8+qhVzuykw==}
+  /@babel/helper-builder-binary-assignment-operator-visitor@7.18.9:
+    resolution: {integrity: sha512-yFQ0YCHoIqarl8BCRwBL8ulYUaZpz3bNsA7oFepAzee+8/+ImtADXNOmO5vJvsPff3qi+hvpkY/NYBTrBQgdNw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/helper-explode-assignable-expression': 7.18.6
+      '@babel/types': 7.22.3
 
-  /@babel/helper-check-duplicate-nodes@7.22.5:
-    resolution: {integrity: sha512-7QAOFIO853OUOVr7ILo9caP3+eb3dNsVzs9iNKr8xi4FIBMQOCN72mv2YENxjNEK/2q/DYlWNAZuTwFn+sJVbA==}
+  /@babel/helper-check-duplicate-nodes@7.18.6:
+    resolution: {integrity: sha512-gQkMniJ8+GfcRk98xGNlBXSEuWOJpEb7weoHDJpw4xxQrikPRvO1INlqbCM6LynKYKVZ/suN869xudV5DzAkzQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
     dev: false
 
-  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.12.3
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.9
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.5
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 6.3.0
     dev: false
 
-  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.19.6
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.9
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.5
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 6.3.0
 
-  /@babel/helper-compilation-targets@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-7qYrNM6HjpnPHJbopxmb8hSPoZ0gsX8IvUS32JGVoy+pU9e5N0nLr1VjJoR6kA4d9dmGLxNYOjeB8sUDal2WMw==}
+  /@babel/helper-compilation-targets@7.20.7(@babel/core@7.20.12):
+    resolution: {integrity: sha512-4tGORmfQcrc+bvrjb5y3dG9Mx1IOZjsHqQVUz7XCNHO+iTmqxWnVg3KRygjGmpRLJGdQSKuvFinbIb0CnZwHAQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
-      '@babel/compat-data': 7.22.9
-      '@babel/core': 7.22.9
-      '@babel/helper-validator-option': 7.22.5
-      browserslist: 4.21.9
+      '@babel/compat-data': 7.20.14
+      '@babel/core': 7.20.12
+      '@babel/helper-validator-option': 7.18.6
+      browserslist: 4.21.5
       lru-cache: 5.1.1
-      semver: 6.3.1
+      semver: 6.3.0
     dev: false
 
-  /@babel/helper-create-class-features-plugin@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-    dev: false
-
-  /@babel/helper-create-class-features-plugin@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Pwyi89uO4YrGKxL/eNJ8lfEH55DnRloGPOseaA8NFNL6jAUnn+KccaISiFazCj5IolPPDjGSdzQzXVzODVRqUQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      semver: 6.3.1
-
-  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
+  /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.12.3):
+    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      regexpu-core: 5.3.2
-      semver: 6.3.1
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/helper-create-regexp-features-plugin@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-+svjVa/tFwsNSG4NEy1h85+HQ5imbT92Q5/bgtS7P0GTQlP8WuFdqsiABmQouhiFGyV66oGxZFpeYHza1rNsKw==}
+  /@babel/helper-create-class-features-plugin@7.20.12(@babel/core@7.19.6):
+    resolution: {integrity: sha512-9OunRkbT0JQcednL0UFvbfXpAsUXiGjUk0a7sN8fUXX7Mue79cUSMjHGDRRi/Vz9vYlpIhLV5fMD5dKoMhhsNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      regexpu-core: 5.3.2
-      semver: 6.3.1
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/helper-split-export-declaration': 7.18.6
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.12.3
+      '@babel/helper-annotate-as-pure': 7.18.6
+      regexpu-core: 5.2.2
+    dev: false
+
+  /@babel/helper-create-regexp-features-plugin@7.20.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-m68B1lkg3XDGX5yCvGO0kPx3v9WIYLnzjKfPcQiwntEQa5ZeRkPmo2X/ISJc8qxWGfwUr+kvZAeEzAwLec2r2w==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+    dependencies:
+      '@babel/core': 7.19.6
+      '@babel/helper-annotate-as-pure': 7.18.6
+      regexpu-core: 5.2.2
 
   /@babel/helper-define-polyfill-provider@0.3.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-z5aQKU4IzbqCC1XH0nAqfsFLMVSo22SBKUc0BxGrLkolTdPTructy0ToNnlO2zA4j9Q/7pjMZf0DSY+DSTYzww==}
@@ -31312,131 +31310,83 @@ packages:
       '@babel/core': ^7.4.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
       debug: 4.3.2
       lodash.debounce: 4.0.8
       resolve: 1.20.0
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/helper-environment-visitor@7.22.5:
-    resolution: {integrity: sha512-XGmhECfVA/5sAt+H+xpSg0mfrHq6FzNr9Oxh7PSEBBRUb/mL7Kz3NICXb194rCqAEdxkhPT1a88teizAFyvk8Q==}
+  /@babel/helper-environment-visitor@7.18.9:
+    resolution: {integrity: sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-fixtures@7.22.9:
-    resolution: {integrity: sha512-rg767Kf9oS6Djcum2sDFlKqaTJcnbmEwhk+K0eCFcbbAtlJfWXW6pT7OdX2VIJmEs73v3XMOsbKb6499rxIJhg==}
+  /@babel/helper-explode-assignable-expression@7.18.6:
+    resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      semver: 6.3.1
+      '@babel/types': 7.22.3
+
+  /@babel/helper-fixtures@7.19.4:
+    resolution: {integrity: sha512-yscO1xHvHA4QzKO2KL5Vcdi1bY6m/uT/NzrL2DlU60uUr9lcaG6/tN7VC+ZwNnY2FN3YbArnyc0gN+aFdJN8mA==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      semver: 6.3.0
     dev: false
 
-  /@babel/helper-function-name@7.22.5:
-    resolution: {integrity: sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==}
+  /@babel/helper-function-name@7.19.0:
+    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
+      '@babel/template': 7.20.7
+      '@babel/types': 7.22.3
 
-  /@babel/helper-hoist-variables@7.22.5:
-    resolution: {integrity: sha512-wGjk9QZVzvknA6yKIUURb8zY3grXCcOZt+/7Wcy8O2uctxhplmUPkOdlgoNhmdVee2c92JXbf1xpMtVNbfoxRw==}
+  /@babel/helper-hoist-variables@7.18.6:
+    resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-member-expression-to-functions@7.22.5:
-    resolution: {integrity: sha512-aBiH1NKMG0H2cGZqspNvsaBe6wNGjbJjuLy29aU+eDZjSbbN53BaxlpB02xm9v34pLTZ1nIQPFYn2qMZoa5BQQ==}
+  /@babel/helper-member-expression-to-functions@7.20.7:
+    resolution: {integrity: sha512-9J0CxJLq315fEdi4s7xK5TQaNYjZw+nDVpVqr1axNGKzdrdwYBD5b4uKv3n75aABG0rCCTK8Im8Ww7eYfMrZgw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-module-imports@7.22.5:
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
+  /@babel/helper-module-imports@7.18.6:
+    resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.11.6):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
+  /@babel/helper-module-transforms@7.20.11:
+    resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
     engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
     dependencies:
-      '@babel/core': 7.11.6
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-    dev: false
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-simple-access': 7.20.2
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/helper-validator-identifier': 7.19.1
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
+      '@babel/types': 7.22.3
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-    dev: false
-
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.12.9):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.12.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-    dev: false
-
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.19.6
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-
-  /@babel/helper-module-transforms@7.22.9(@babel/core@7.22.9):
-    resolution: {integrity: sha512-t+WA2Xn5K+rTeGtC8jCsdAH52bjggG5TKRuRrAGNM/mjIbO4GxvlLMFOEz9wXY5I2XQ60PMFsAG2WIcG82dQMQ==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/helper-validator-identifier': 7.22.5
-    dev: false
-
-  /@babel/helper-optimise-call-expression@7.22.5:
-    resolution: {integrity: sha512-HBwaojN0xFRx4yIvpwGqxiV2tUfl7401jlok564NgB9EHS1y6QT17FmKWm4ztqjeVdXLuC4fSvHc5ePpQjoTbw==}
+  /@babel/helper-optimise-call-expression@7.18.6:
+    resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
   /@babel/helper-plugin-test-runner@7.16.7:
     resolution: {integrity: sha512-8MAd2mKWTpWdLPkpCR2i1EJ/FWr31FjhSrSIJPNwWH7FzM9R7lxlfkbCiGgvDxRd4rCvb9l1oo8hS3DWCx2NQg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-transform-fixture-test-runner': 7.22.7
+      '@babel/helper-transform-fixture-test-runner': 7.20.14
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -31445,151 +31395,157 @@ packages:
     resolution: {integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==}
     dev: false
 
-  /@babel/helper-plugin-utils@7.22.5:
-    resolution: {integrity: sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==}
+  /@babel/helper-plugin-utils@7.20.2:
+    resolution: {integrity: sha512-8RvlJG2mj4huQ4pZ+rU9lqKi9ZKiRmuvGuM2HlWmkmgOhbs6zEAw6IEiJ5cQqGbDzGZOhwuOQNtZMi/ENLjZoQ==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
+  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-wrap-function': 7.22.9
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-wrap-function': 7.20.5
+      '@babel/types': 7.22.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/helper-remap-async-to-generator@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-8WWC4oR4Px+tr+Fp0X3RHDVfINGpF3ad1HIbrc8A77epiR6eMMc6jsgozkzT2uDiOOdoS9cLIQ+XD2XvI2WSmQ==}
+  /@babel/helper-remap-async-to-generator@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-dI7q50YKd8BAv3VEfgg7PS7yD3Rtbi2J1XMXaalXO0W0164hYLnh8zpjRS0mte9MfVp/tltvr/cfdXPvJr1opA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-wrap-function': 7.22.9
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-wrap-function': 7.20.5
+      '@babel/types': 7.22.3
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/helper-replace-supers@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.12.3
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-    dev: false
-
-  /@babel/helper-replace-supers@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-LJIKvvpgPOPUThdYqcX6IXRuIcTkcAub0IaDRGCZH0p5GPUp7PhRU9QVgFcDDd51BaPkk77ZjqFwh6DZTAEmGg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-    dependencies:
-      '@babel/core': 7.19.6
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-member-expression-to-functions': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-
-  /@babel/helper-simple-access@7.22.5:
-    resolution: {integrity: sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==}
+  /@babel/helper-replace-supers@7.20.7:
+    resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-member-expression-to-functions': 7.20.7
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
+      '@babel/types': 7.22.3
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/helper-skip-transparent-expression-wrappers@7.22.5:
-    resolution: {integrity: sha512-tK14r66JZKiC43p8Ki33yLBVJKlQDFoA8GYN67lWCDCqoL6EMMSuM9b+Iff2jHaM/RRFYl7K+iiru7hbRqNx8Q==}
+  /@babel/helper-simple-access@7.20.2:
+    resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-split-export-declaration@7.22.6:
-    resolution: {integrity: sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==}
+  /@babel/helper-skip-transparent-expression-wrappers@7.20.0:
+    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.22.5
+      '@babel/types': 7.22.3
 
-  /@babel/helper-string-parser@7.22.5:
-    resolution: {integrity: sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==}
-    engines: {node: '>=6.9.0'}
-
-  /@babel/helper-transform-fixture-test-runner@7.22.7:
-    resolution: {integrity: sha512-1fkiBWo29W6RAYNdbCmztmzNY9bchqNHPHuAGIqIdXqweemSX3jqIrgmtn+hTqueLXhlP0gJU9tV/fLqS9UG6w==}
+  /@babel/helper-split-export-declaration@7.18.6:
+    resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/core': 7.22.9
-      '@babel/helper-check-duplicate-nodes': 7.22.5
-      '@babel/helper-fixtures': 7.22.9
+      '@babel/types': 7.22.3
+
+  /@babel/helper-string-parser@7.21.5:
+    resolution: {integrity: sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==}
+    engines: {node: '>=6.9.0'}
+
+  /@babel/helper-transform-fixture-test-runner@7.20.14:
+    resolution: {integrity: sha512-ZHUTYhE4jq+0bNVj0X49yR0e7VQgurJcYos7LU6VO14ZKwUDBv4TbmUH8hufGqRGFCmstxaii7nq9aHhjGScZw==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/code-frame': 7.18.6
+      '@babel/core': 7.20.12
+      '@babel/helper-check-duplicate-nodes': 7.18.6
+      '@babel/helper-fixtures': 7.19.4
       quick-lru: 5.1.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/helper-validator-identifier@7.22.5:
-    resolution: {integrity: sha512-aJXu+6lErq8ltp+JhkJUfk1MTGyuA4v7f3pA+BJ5HLfNC6nAQ0Cpi9uOquUj8Hehg0aUiHzWQbOVJGao6ztBAQ==}
+  /@babel/helper-validator-identifier@7.19.1:
+    resolution: {integrity: sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-validator-option@7.22.5:
-    resolution: {integrity: sha512-R3oB6xlIVKUnxNUxbmgq7pKjxpru24zlimpE8WK47fACIlM0II/Hm1RS8IaOI7NgCr6LNS+jl5l75m20npAziw==}
+  /@babel/helper-validator-option@7.18.6:
+    resolution: {integrity: sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==}
     engines: {node: '>=6.9.0'}
 
-  /@babel/helper-wrap-function@7.22.9:
-    resolution: {integrity: sha512-sZ+QzfauuUEfxSEjKFmi3qDSHgLsTPK/pEpoD/qonZKOtTPTLbf59oabPQ4rKekt9lFcj/hTZaOhWwFYrgjk+Q==}
+  /@babel/helper-wrap-function@7.20.5:
+    resolution: {integrity: sha512-bYMxIWK5mh+TgXGVqAtnu5Yn1un+v8DDZtqyzKRLUzrh70Eal2O3aZ7aPYiMADO4uKlkzOiRiZ6GX5q3qxvW9Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.22.5
-      '@babel/template': 7.22.5
-      '@babel/types': 7.22.5
-
-  /@babel/helpers@7.22.6:
-    resolution: {integrity: sha512-YjDs6y/fVOYFV8hAf1rxd1QvR9wJe1pDBZ2AREKq/SDayfPzgk0PBnVuTCE5X1acEpMMNOVUqoe+OwiZGJ+OaA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/template': 7.22.5
-      '@babel/traverse': 7.22.8
-      '@babel/types': 7.22.5
+      '@babel/helper-function-name': 7.19.0
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
+      '@babel/types': 7.22.3
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/highlight@7.22.5:
-    resolution: {integrity: sha512-BSKlD1hgnedS5XRnGOljZawtag7H1yPfQp0tdNJCHoH6AZ+Pcm9VvkrK59/Yy593Ypg0zMxH2BxD1VPYUQ7UIw==}
+  /@babel/helpers@7.20.13:
+    resolution: {integrity: sha512-nzJ0DWCL3gB5RCXbUO3KIMMsBY2Eqbx8mBpKGE/02PgyRQFcPQLbkQ1vyy596mZLaP+dAfD+R4ckASzNVmW3jg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.13
+      '@babel/types': 7.22.3
+    transitivePeerDependencies:
+      - supports-color
+
+  /@babel/highlight@7.18.6:
+    resolution: {integrity: sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-validator-identifier': 7.19.1
       chalk: 2.4.2
       js-tokens: 4.0.0
 
-  /@babel/parser@7.22.7:
-    resolution: {integrity: sha512-7NF8pOkHP5o2vpmGgNGcfAeCvOYhGLyA3Z4eBQkT1RJlWu47n63bCs93QfJ2hIAFCil7L5P2IWhs1oToVgrL0Q==}
+  /@babel/parser@7.20.13:
+    resolution: {integrity: sha512-gFDLKMfpiXCsjt4za2JA9oTMn70CeseCehb11kRZgvd7+F67Hih3OHOK24cRrWECJ/ljfPGac6ygXAs/C8kIvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
       '@babel/types': 7.22.3
 
-  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-NP1M5Rf+u2Gw9qfSO4ihjcTGW5zXTi36ITLd4/EoAcEhIZ0yjMqmftDNl3QC19CX7olhrjpyU454g/2W7X0jvQ==}
+  /@babel/parser@7.22.4:
+    resolution: {integrity: sha512-VLLsx06XkEYqBtE5YGPwfSGwfrjnyPP5oiGty3S8pQLFDFLaS8VwWSIxkTXpcvr5zeYLE6+MBNl2npl/YnfofA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+    dependencies:
+      '@babel/types': 7.22.3
+
+  /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-31Bb65aZaUwqCbWMnZPduIZxCBngHFlzyN6Dq6KAJjtx+lx6ohKHubc61OomYi7XwVD4Ol0XCVz4h+pYFR048g==}
+  /@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-sbr9+wNE5aXMBBFBICk01tt7sBf2Oc9ikRFEcem/ZORup9IMUdNhW7/wVLEbbtlWOsEubJet46mHAL2C8+2jKQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.13.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-transform-optional-chaining': 7.22.6(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.12.3):
     resolution: {integrity: sha512-xMbiLsn/8RK7Wq7VeVytytS2L6qE69bXPB10YCmMdDZbKF4okCqY74pI/jJQ/8U0b/F6NrT2+14b8/P9/3AMGA==}
@@ -31598,10 +31554,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-async-generator-functions@7.20.7(@babel/core@7.19.6):
@@ -31611,10 +31569,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/plugin-proposal-class-properties@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==}
@@ -31622,8 +31582,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.12.13(@babel/core@7.19.6):
@@ -31632,8 +31594,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.12.3):
@@ -31643,8 +31607,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-class-properties@7.18.6(@babel/core@7.19.6):
@@ -31654,19 +31620,23 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-proposal-class-static-block@7.21.0(@babel/core@7.19.6):
-    resolution: {integrity: sha512-XP5G9MWNUskFuP30IfFSEFB0Z6HzLIUcjYM4bYOPHXl7eiJ9HFv8tWj6TXTN5QODiEhDZAeI4hLok2iHFFV4hw==}
+  /@babel/plugin-proposal-class-static-block@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-AveGOoi9DAjUYYuUAG//Ig69GlazLnoyzMw68VCDux+c1tsnnH/OkYcpz/5xzMkEFC6UxjR5Gw1c+iY2wOGVeQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/plugin-proposal-decorators@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-knNIuusychgYN8fGJHONL0RbFxLGawhXOJNLBk75TniTsZZeA+wdkDuv6wp4lGwzQEKjZi6/WYtnb3udNPmQmQ==}
@@ -31674,9 +31644,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.12.3)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-decorators@7.12.13(@babel/core@7.19.6):
@@ -31685,9 +31657,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-decorators@7.20.0(@babel/core@7.19.6):
@@ -31697,11 +31671,13 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/plugin-syntax-decorators': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/plugin-syntax-decorators': 7.19.0(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-dynamic-import@7.18.6(@babel/core@7.12.3):
@@ -31711,7 +31687,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31722,7 +31698,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-export-namespace-from@7.18.9(@babel/core@7.12.3):
@@ -31732,7 +31708,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31743,7 +31719,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-json-strings@7.18.6(@babel/core@7.12.3):
@@ -31753,7 +31729,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31764,7 +31740,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-logical-assignment-operators@7.20.7(@babel/core@7.12.3):
@@ -31774,7 +31750,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.12.3)
     dev: false
 
@@ -31785,7 +31761,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-nullish-coalescing-operator@7.12.1(@babel/core@7.12.3):
@@ -31794,7 +31770,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31805,7 +31781,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-numeric-separator@7.12.1(@babel/core@7.12.3):
@@ -31814,7 +31790,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.12.3)
     dev: false
 
@@ -31825,7 +31801,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-numeric-separator': 7.10.4(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-object-rest-spread@7.11.0(@babel/core@7.11.6):
@@ -31834,9 +31810,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.11.6)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.11.6)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.11.6)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.12.1(@babel/core@7.12.9):
@@ -31845,9 +31821,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.9)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.9)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.12.13(@babel/core@7.19.6):
@@ -31856,9 +31832,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.19.4(@babel/core@7.12.3):
@@ -31867,12 +31843,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
     dev: false
 
   /@babel/plugin-proposal-object-rest-spread@7.19.4(@babel/core@7.19.6):
@@ -31881,12 +31857,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-optional-catch-binding@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-Q40HEhs9DJQyaZfUjjn6vE8Cv4GmMHCYuMGIWUnlxH6400VGxOuwWsPt4FxXxJkC/5eOzgn0z21M9gMT4MOhbw==}
@@ -31895,7 +31871,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
     dev: false
 
@@ -31906,7 +31882,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-optional-chaining@7.12.1(@babel/core@7.12.3):
@@ -31915,20 +31891,20 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-proposal-optional-chaining@7.21.0(@babel/core@7.19.6):
-    resolution: {integrity: sha512-p4zeefM72gpmEe2fkUr/OnOXpWEf8nAgk7ZYVqqfFiyIG7oFfVZcCrU64hWn5xp4tQ9LkV4bTIa5rD0KANpKNA==}
+  /@babel/plugin-proposal-optional-chaining@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-T+A7b1kfjtRM51ssoOfS1+wbyCVqorfyZhT99TvxxLMirPShD8CzKMRepMlCBGM5RpHMbn8s+5MMHnPstJH6mQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.12.3):
@@ -31938,8 +31914,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-proposal-private-methods@7.18.6(@babel/core@7.19.6):
@@ -31949,33 +31927,39 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.12.3):
-    resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
+  /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-proposal-private-property-in-object@7.21.11(@babel/core@7.19.6):
-    resolution: {integrity: sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==}
+  /@babel/plugin-proposal-private-property-in-object@7.20.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Vq7b9dUA12ByzB4EjQTPo25sFhY+08pQDBSZRtUAkj7lb7jahaHR5igera16QZ+3my1nYR4dKsNdYj5IjPHilQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.12.3):
     resolution: {integrity: sha512-2BShG/d5yoZyXZfVePH91urL5wTG6ASZU9M4o03lKK8u8UW1y08OMttBSOADTcJrnPMpvDXRG3G8fyLh4ovs8w==}
@@ -31984,8 +31968,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-proposal-unicode-property-regex@7.18.6(@babel/core@7.19.6):
@@ -31995,8 +31979,8 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==}
@@ -32004,7 +31988,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-async-generators@7.8.4(@babel/core@7.19.6):
@@ -32013,7 +31997,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-bigint@7.8.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==}
@@ -32021,7 +32005,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.12.3):
@@ -32030,7 +32014,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-class-properties@7.12.13(@babel/core@7.19.6):
@@ -32039,7 +32023,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-class-static-block@7.14.5(@babel/core@7.19.6):
     resolution: {integrity: sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==}
@@ -32048,26 +32032,26 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==}
+  /@babel/plugin-syntax-decorators@7.19.0(@babel/core@7.12.3):
+    resolution: {integrity: sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-decorators@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-avpUOBS7IU6al8MmF1XpAyj9QYeLPuSDJI5D4pVMSMdL7xQokKqJPYQC67RCT0aCTashUXPiGwMJ0DEXXCEmMA==}
+  /@babel/plugin-syntax-decorators@7.19.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-xaBZUEDntt4faL1yN8oIFlhfXeQAWJW7CLKYsHTUqriCUbj8xOra8bfxxKGi/UwExPFBuPdH4XfHc9rGQhrVkQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.12.3):
@@ -32076,7 +32060,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.19.6):
@@ -32085,7 +32069,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==}
@@ -32093,7 +32077,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-export-namespace-from@7.8.3(@babel/core@7.19.6):
@@ -32102,26 +32086,26 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-syntax-flow@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==}
+  /@babel/plugin-syntax-flow@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-import-assertions@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-rdV97N7KqsRzeNGoWUOK6yUsWarLjE5Su/Snk9IYPU9CwkWHs4t+rTGOvffTR8XGkJMTAdLfO0xVnXm8wugIJg==}
+  /@babel/plugin-syntax-import-assertions@7.20.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-IUh1vakzNoWalR8ch/areW7qFopR2AEw03JlG7BbrDqmQ4X3q9uuipQwSGrUn7oGiemKjtSLDhNtQHzMHr1JdQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-import-meta@7.10.4(@babel/core@7.19.6):
     resolution: {integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==}
@@ -32129,7 +32113,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.12.3):
@@ -32138,7 +32122,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-json-strings@7.8.3(@babel/core@7.19.6):
@@ -32147,7 +32131,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-jsx@7.10.4(@babel/core@7.11.6):
     resolution: {integrity: sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==}
@@ -32155,7 +32139,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-jsx@7.12.1(@babel/core@7.12.9):
@@ -32164,27 +32148,27 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-jsx@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-gvyP4hZrgrs/wWMaocvxZ44Hw0b3W8Pe+cMxc8V1ULQ07oh8VNbIRaoD1LRZVTvD+0nieDKjfgKg89sD7rrKrg==}
+  /@babel/plugin-syntax-jsx@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-6mmljtAedFGTWu2p/8WIORGwy+61PLgOMPOdazc7YoJ9ZCWUyFy3A6CpPkRKLKD1ToAesxX8KGEViAiLo9N+7Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==}
@@ -32192,7 +32176,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-logical-assignment-operators@7.10.4(@babel/core@7.19.6):
@@ -32201,7 +32185,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==}
@@ -32209,7 +32193,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-nullish-coalescing-operator@7.8.3(@babel/core@7.19.6):
@@ -32218,7 +32202,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.12.3):
     resolution: {integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==}
@@ -32226,7 +32210,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-numeric-separator@7.10.4(@babel/core@7.19.6):
@@ -32235,7 +32219,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.11.6):
     resolution: {integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==}
@@ -32243,7 +32227,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.3):
@@ -32252,7 +32236,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.12.9):
@@ -32261,7 +32245,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-object-rest-spread@7.8.3(@babel/core@7.19.6):
@@ -32270,7 +32254,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==}
@@ -32278,7 +32262,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-optional-catch-binding@7.8.3(@babel/core@7.19.6):
@@ -32287,7 +32271,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.12.3):
     resolution: {integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==}
@@ -32295,7 +32279,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-optional-chaining@7.8.3(@babel/core@7.19.6):
@@ -32304,7 +32288,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.12.3):
     resolution: {integrity: sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==}
@@ -32313,7 +32297,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-private-property-in-object@7.14.5(@babel/core@7.19.6):
@@ -32323,7 +32307,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.12.3):
     resolution: {integrity: sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==}
@@ -32332,7 +32316,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-syntax-top-level-await@7.14.5(@babel/core@7.19.6):
@@ -32342,243 +32326,251 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
+  /@babel/plugin-syntax-typescript@7.20.0(@babel/core@7.12.3):
+    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-syntax-typescript@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-1mS2o03i7t1c6VzH6fdQ3OA8tcEIxwG18zIPRp+UY1Ihv6W+XZzBCVxExF9upussPXJ0xE9XRHwMoNs1ep/nRQ==}
+  /@babel/plugin-syntax-typescript@7.20.0(@babel/core@7.19.6):
+    resolution: {integrity: sha512-rd9TkG+u1CExzS4SM1BlMEhMXwFLKVjOAFFCDx9PbX5ycJWDoWMcwdJH9RhkPu1dOgn5TrxLot/Gx6lWFuAUNQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
+  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-arrow-functions@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-26lTNXoVRdAnsaDXPpvCNUq+OVWEVC6bx7Vvz9rC53F2bagUWW4u4ii2+h8Fejfh7RYqPxn+libeFBBck9muEw==}
+  /@babel/plugin-transform-arrow-functions@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-3poA5E7dzDomxj9WXWwuD6A5F3kc7VXwIJO+E+J8qtDtS+pXPAhrgEyh+9GBwBgPq1Z+bB+/JD60lp5jsN7JPQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
+  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-async-to-generator@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-b1A8D8ZzE/VhNDoV1MSJTnpKkCG5bJo+19R4o4oy03zM7ws8yEMK755j61Dc3EyvdysbqH5BOOTquJ7ZX9C6vQ==}
+  /@babel/plugin-transform-async-to-generator@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Uo5gwHPT9vgnSXQxqGtpdufUiWp96gk7yiP4Mp5bm1QMkEmLXBO7PAGYbKoJ6DhAwiNkcHFBol/x5zZZkL/t0Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-remap-async-to-generator': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-remap-async-to-generator': 7.18.9(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-block-scoped-functions@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-tdXZ2UdknEKQWKJP1KMNmuF5Lx3MymtMN/pvA+p/VEkhK8jVcQ1fzSy8KM9qRYhAf2/lV33hoMPKI/xaI9sADA==}
+  /@babel/plugin-transform-block-scoped-functions@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-ExUcOqpPWnliRcPqves5HJcJOvHvIIWfuS4sroBUenPuMdmW+SMHDakmtS7qOo13sVppmUijqeTv7qqGsvURpQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==}
+  /@babel/plugin-transform-block-scoping@7.20.14(@babel/core@7.12.3):
+    resolution: {integrity: sha512-sMPepQtsOs5fM1bwNvuJJHvaCfOEQfmc01FGw0ELlTpTJj5Ql/zuNRRldYhAPys4ghXdBIQJbRVYi44/7QflQQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-block-scoping@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-EcACl1i5fSQ6bt+YGuU/XGCeZKStLmyVGytWkpyhCLeQVA0eu6Wtiw92V+I1T/hnezUv7j74dA/Ro69gWcU+hg==}
+  /@babel/plugin-transform-block-scoping@7.20.14(@babel/core@7.19.6):
+    resolution: {integrity: sha512-sMPepQtsOs5fM1bwNvuJJHvaCfOEQfmc01FGw0ELlTpTJj5Ql/zuNRRldYhAPys4ghXdBIQJbRVYi44/7QflQQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.12.3):
-    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
+  /@babel/plugin-transform-classes@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-classes@7.22.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-58EgM6nuPNG6Py4Z3zSuu0xWu2VfodiMi72Jt5Kj2FECmaYk1RrTXA45z6KBFsu9tRgwQDwIiY4FXTt+YsSFAQ==}
+  /@babel/plugin-transform-classes@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-LWYbsiXTPKl+oBlXUGlwNlJZetXD5Am+CyBdqhPsDVjM9Jc8jwBJFrKhHf900Kfk2eZG1y9MAG3UNajol7A4VQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-optimise-call-expression': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-split-export-declaration': 7.22.6
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
+  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/template': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/template': 7.20.7
     dev: false
 
-  /@babel/plugin-transform-computed-properties@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-4GHWBgRf0krxPX+AaPtgBAlTgTeZmqDynokHOX7aqqAB4tHs3U2Y02zH6ETFdLZGcg9UQSD1WCmkVrE9ErHeOg==}
+  /@babel/plugin-transform-computed-properties@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Lz7MvBK6DTjElHAmfu6bfANzKcxpyNPeYBGEafyA6E5HtRpjpZwU+u7Qrgz/2OR0z+5TvKYbPdphfSaAcZBrYQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/template': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/template': 7.20.7
 
-  /@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==}
+  /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-destructuring@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-GfqcFuGW8vnEqTUBM7UtPd5A4q797LTvvwKxXTgRsFjoqaJiEg9deBG6kWeQYkVEL569NpnmpC0Pkr/8BLKGnQ==}
+  /@babel/plugin-transform-destructuring@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-Xwg403sRrZb81IVB79ZPqNQME23yhugYVqgTxAhT99h485F4f+GMELFhhOsscDUB7HCswepKeCKLn/GZvUKoBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
+  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-dotall-regex@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-5/Yk9QxCQCl+sOIB1WelKnVRxTJDSAIxtJLL2/pqL14ZVlbH0fUQUZa/T5/UnQtBNgghR7mfB8ERBKyKPCi7Vw==}
+  /@babel/plugin-transform-dotall-regex@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-6S3jpun1eEbAxq7TdjLotAsl4WpQI9DxfkycRcKrjhQYzU87qpXdknpBg/e+TdcMehqGnLFi7tnFUBR02Vq6wg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
+  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-duplicate-keys@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-dEnYD+9BBgld5VBXHnF/DbYGp3fqGMsyxKbtD1mDyIA7AkTSpKXFhCVuj/oQVOoALfBs77DudA0BE4d5mcpmqw==}
+  /@babel/plugin-transform-duplicate-keys@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-d2bmXCtZXYc59/0SanQKbiWINadaJXqtvIQIzd4+hNwkWBgyCd5F/2t1kXoUdvPMrxzPvhK6EMQRROxsue+mfw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
+  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-exponentiation-operator@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-vIpJFNM/FjZ4rh1myqIya9jXwrwwgFRHPjT3DkUA9ZLHuzox8jiXkOLvwm1H+PQIP3CqfC++WPKeuDi0Sjdj1g==}
+  /@babel/plugin-transform-exponentiation-operator@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-wzEtc0+2c88FVR34aQmiz56dxEkxr2g8DQb/KfaFa1JYXOFVsbhvAonFN6PwVWj++fKmku8NP80plJ5Et4wqHw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-builder-binary-assignment-operator-visitor': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-builder-binary-assignment-operator-visitor': 7.18.9
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-flow-strip-types@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==}
@@ -32586,110 +32578,114 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-flow': 7.22.5(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-flow': 7.18.6(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
+  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.12.3):
+    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-for-of@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-3kxQjX1dU9uudwSshyLeEipvrLjBCVthCgeTp6CzE/9JYrlAIaeekVxRpCWsDDfYTfRZRoCeZatCQvwo+wvK8A==}
+  /@babel/plugin-transform-for-of@7.18.8(@babel/core@7.19.6):
+    resolution: {integrity: sha512-yEfTRnjuskWYo0k1mHUqrVWaZwrdq8AYbfrpqULOJOaucGSp4mNMVps+YtA8byoevxS/urwU75vyhQIxcCgiBQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-function-name@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-UIzQNMS0p0HHiQm3oelztj+ECwFnj+ZRV4KnguvlsD2of1whUeM6o7wGNj6oLwcDoAXQ8gEqfgC24D+VdIcevg==}
+  /@babel/plugin-transform-function-name@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-WvIBoRPaJQ5yVHzcnJFor7oS5Ls0PYixlTYE63lCj2RtdQEl15M68FXQlxnG6wdraJIXRdR7KI+hQ7q/9QjrCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-literals@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-fTLj4D79M+mepcw3dgFBTIDYpbcB9Sm0bpm4ppXPaO+U+PKFFyV9MGRvS0gvGw62sd10kT5lRMKXAADb9pWy8g==}
+  /@babel/plugin-transform-literals@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-IFQDSRoTPnrAIrI5zoZv73IFeZu2dhu6irxQjY9rNjTT53VmKg9fenjvoiOWOkJ6mm4jKVPtdMzBY98Fp4Z4cg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-member-expression-literals@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-RZEdkNtzzYCFl9SE9ATaUMTj2hqMb4StarOJLrZRbqqU4HSBE7UlBw9WBWQiDzrJZJdUWiMTVDI6Gv/8DPvfew==}
+  /@babel/plugin-transform-member-expression-literals@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-qSF1ihLGO3q+/g48k85tUjD033C29TNTVB2paCwZPVmOsjn9pClvYYrM2VeJpBY2bcNkuny0YUyTNRyRxJ54KA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
+  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.12.3):
+    resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-amd@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-R+PTfLTcYEmb1+kK7FNkhQ1gP4KgjpSO6HfH9+f8/yfp2Nt3ggBjiVpRwmwTlfqZLafYKJACy36yDXlEmI9HjQ==}
+  /@babel/plugin-transform-modules-amd@7.20.11(@babel/core@7.19.6):
+    resolution: {integrity: sha512-NuzCt5IIYOW0O30UvqktzHYR2ud5bOWbY0yaxWZ6G+aFzOMJvrs5YHNikrbdaT15+KNO31nPOy5Fim3ku6Zb5g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
 
   /@babel/plugin-transform-modules-commonjs@7.12.13(@babel/core@7.19.6):
     resolution: {integrity: sha512-OGQoeVXVi1259HjuoDnsQMlMkT9UkZT9TpXAsqWplS/M0N1g3TJAn/ByOCeQu7mfjc5WpSsRU+jV1Hd89ts0kQ==}
@@ -32697,10 +32693,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-simple-access': 7.20.2
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.12.3):
@@ -32710,9 +32708,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-simple-access': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/plugin-transform-modules-commonjs@7.19.6(@babel/core@7.19.6):
@@ -32722,194 +32722,197 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-simple-access': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-simple-access': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
+  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.12.3):
+    resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-identifier': 7.19.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-systemjs@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-emtEpoaTMsOs6Tzz+nbmcePl6AKVtS1yC4YNAeMun9U8YCsgadPNxnOPQ8GhHFB2qdx+LZu9LgoC0Lthuu05DQ==}
+  /@babel/plugin-transform-modules-systemjs@7.20.11(@babel/core@7.19.6):
+    resolution: {integrity: sha512-vVu5g9BPQKSFEmvt2TA4Da5N+QVS66EX21d8uoOihC+OCpUoGvzVsXeqFdtAEfVa5BILAeFt+U7yVmLbQnAJmw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-identifier': 7.19.1
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
+  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-modules-umd@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-+S6kzefN/E1vkSsKx8kmQuqeQsvCKCd1fraCM7zXm4SFoggI099Tr4G8U81+5gtMdUeMQ4ipdQffbKLX0/7dBQ==}
+  /@babel/plugin-transform-modules-umd@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-dcegErExVeXcRqNtkRU/z8WlBLnvD4MRnHgNs3MytRO1Mn1sHRyhbcpYbVMGclAqOjdW+9cfkdZno9dFdfKLfQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-transforms': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-transforms': 7.20.11
+      '@babel/helper-plugin-utils': 7.20.2
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
+  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-named-capturing-groups-regex@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-YgLLKmS3aUBhHaxp5hi1WJTgOUb/NCuDHzGT9z9WTt3YG+CPRhJs6nprbStx6DnWM4dh6gt7SU3sZodbZ08adQ==}
+  /@babel/plugin-transform-named-capturing-groups-regex@7.20.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-mOW4tTzi5iTLnw+78iEq3gr8Aoq4WNRGpmSlrogqaiCBoR1HFhpU4JkpQFOHfeYx3ReVIFWOQJS4aZBRvuZ6mA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
+  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-new-target@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-AsF7K0Fx/cNKVyk3a+DW0JLo+Ua598/NxMRvxDnkpCIGFh43+h/v2xyhRUYf6oD8gE4QtL83C7zZVghMjHd+iw==}
+  /@babel/plugin-transform-new-target@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-DjwFA/9Iu3Z+vrAn+8pBUGcjhxKguSMlsFqeCKbhb9BAV756v0krzVK04CRDi/4aqmk8BsHb4a/gFcaA5joXRw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-object-super@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-klXqyaT9trSjIUrcsYIfETAzmOEZL3cBYqOYLJxBHfMFFggmXOv+NYSX/Jbs9mzMVESw/WycLFPRx8ba/b2Ipw==}
+  /@babel/plugin-transform-object-super@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-uvGz6zk+pZoS1aTZrOvrbj6Pp/kK2mp45t2B+bTDre2UgsZZ8EZLSJtUg7m/no0zOJUWgFONpB7Zv9W2tSaFlA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-replace-supers': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-replace-supers': 7.20.7
+    transitivePeerDependencies:
+      - supports-color
 
-  /@babel/plugin-transform-optional-chaining@7.22.6(@babel/core@7.19.6):
-    resolution: {integrity: sha512-Vd5HiWml0mDVtcLHIoEU5sw6HOUW/Zk0acLs/SAeuLzkGNOPc9DB4nkUajemhCmTIz3eiaKREZn2hQQqF79YTg==}
-    engines: {node: '>=6.9.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0-0
-    dependencies:
-      '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
-      '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
-
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.11.6):
-    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
+  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.11.6):
+    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.11.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
+  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.12.9):
-    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
+  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.12.9):
+    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-parameters@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-AVkFUBurORBREOmHRKo06FjHYgjrabpdqRSwq6+C7R5iTCZOsM4QbcB27St0a4U6fffyAOqh3s/qEfybAhfivg==}
+  /@babel/plugin-transform-parameters@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-WiWBIkeHKVOSYPO0pWkxGPfKeWrCJyD3NJ53+Lrp/QMSZbsVPovrVl2aWZ19D/LTVnaDv5Ap7GJ/B2CTOZdrfA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-property-literals@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-TiOArgddK3mK/x1Qwf5hay2pxI6wCZnvQqrFSqbtg1GLl2JcNMitVH/YnqjP+M31pLUeTfzY1HAXFDnUBV30rQ==}
+  /@babel/plugin-transform-property-literals@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-cYcs6qlgafTud3PAzrrRNbQtfpQ8+y/+M5tKmksS9+M1ckbH6kzY8MrexEM9mcA6JDsukE19iIRvAyYl463sMg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-react-constant-elements@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-BF5SXoO+nX3h5OhlN78XbbDrBOffv+AxPP2ENaJOVqjWCgBDeOY3WcaUcddutGSfoap+5NEQ/q/4I3WZIvgkXA==}
+  /@babel/plugin-transform-react-constant-elements@7.20.2(@babel/core@7.19.6):
+    resolution: {integrity: sha512-KS/G8YI8uwMGKErLFOHS/ekhqdHhpEloxs43NecQHVgo2QuQSyJhGIY1fL8UGl9wy5ItVwwoUL4YxVqsplGq2g==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /@babel/plugin-transform-react-display-name@7.12.1(@babel/core@7.12.3):
@@ -32918,144 +32921,144 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-react-display-name@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-PVk3WPYudRF5z4GKMEYUrLjPl38fJSKNaEOkFuoprioowGuWN6w2RKznuFNSlJx7pzzXXStPUnNSOEO0jL5EVw==}
+  /@babel/plugin-transform-react-display-name@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-TV4sQ+T013n61uMoygyMRm+xf04Bd5oqFpv2jAEQwSZ8NwQA7zeRPg1LMVg2PWi3zWBz+CLKD+v5bcpZ/BS0aA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
+  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.12.3)
     dev: false
 
-  /@babel/plugin-transform-react-jsx-development@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-bDhuzwWMuInwCYeDeMzyi7TaBgRQei6DqxhbyniL7/VG4RSS7HtSL2QbY4eESy1KJqlWt8g3xeEBGPuo+XqC8A==}
+  /@babel/plugin-transform-react-jsx-development@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-SA6HEjwYFKF7WDjWcMcMGUimmw/nhNRDWxr+KaLSCrkD/LMDBvWRmHAYgE1HDeF8KUuI8OAu+RT6EOtKxSW2qA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
 
-  /@babel/plugin-transform-react-jsx-self@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-nTh2ogNUtxbiSbxaT4Ds6aXnXEipHweN9YRgOX/oNXdf0cCrGn/+2LozFa3lnPV5D90MkjhgckCPBrsoSc1a7g==}
+  /@babel/plugin-transform-react-jsx-self@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-A0LQGx4+4Jv7u/tWzoJF7alZwnBDQd6cGLh9P+Ttk4dpiL+J5p7NSNv/9tlEFFJDq3kjxOavWmbm6t0Gk+A3Ig==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-react-jsx-source@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-yIiRO6yobeEIaI0RTbIr8iAK9FcBHLtZq0S89ZPjDLQXBA4xvghaKqI0etp/tF3htTM0sazJKKLz9oEiGRtu7w==}
+  /@babel/plugin-transform-react-jsx-source@7.19.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-RpAi004QyMNisst/pvSanoRdJ4q+jMCWyk9zdw/CyLB9j8RXEahodR6l2GyttDRyEVWZtbN+TpLiHJ3t34LbsQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==}
+  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.12.3):
+    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.12.3)
-      '@babel/types': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.12.3)
+      '@babel/types': 7.22.3
     dev: false
 
-  /@babel/plugin-transform-react-jsx@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-rog5gZaVbUip5iWDMTYbVM15XQq+RkUKhET/IHR6oizR+JEoN6CAfTTuHcK4vwUyzca30qqHqEpzBOnaRMWYMA==}
+  /@babel/plugin-transform-react-jsx@7.20.13(@babel/core@7.19.6):
+    resolution: {integrity: sha512-MmTZx/bkUrfJhhYAYt3Urjm+h8DQGrPrnKQ94jLo7NLuOU+T89a7IByhKmrb8SKhrIYIQ0FN0CHMbnFRen4qNw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-jsx': 7.22.5(@babel/core@7.19.6)
-      '@babel/types': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-jsx': 7.18.6(@babel/core@7.19.6)
+      '@babel/types': 7.22.3
 
-  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
+  /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-react-pure-annotations@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-gP4k85wx09q+brArVinTXhWiyzLl9UpmGva0+mWyKxk6JZequ05x3eUcIUE+FyttPKJFRRVtAvQaJ6YF9h1ZpA==}
+  /@babel/plugin-transform-react-pure-annotations@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-I8VfEPg9r2TRDdvnHgPepTKvuRomzA8+u+nhY7qSI1fR2hRNebasZEETLyM5mAUr0Ku56OkXJ0I7NHJnO6cJiQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-annotate-as-pure': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
+  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.12.3):
+    resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
     dev: false
 
-  /@babel/plugin-transform-regenerator@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-rR7KePOE7gfEtNTh9Qw+iO3Q/e4DEsoQ+hdvM6QUDH7JRJ5qxq5AA52ZzBWbI5i9lfNuvySgOGP8ZN7LAmaiPw==}
+  /@babel/plugin-transform-regenerator@7.20.5(@babel/core@7.19.6):
+    resolution: {integrity: sha512-kW/oO7HPBtntbsahzQ0qSE3tFvkFwnbozz3NWFhLGqH75vLEg+sCGngLlhVkePlCs3Jv0dBBHDzCHxNiFAQKCQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       regenerator-transform: 0.15.1
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
+  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-reserved-words@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-DTtGKFRQUDm8svigJzZHzb/2xatPc6TzNvAIJ5GqOKDsGFYgAskjRulbR/vGsPKq3OPqtexnz327qYpP57RFyA==}
+  /@babel/plugin-transform-reserved-words@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-oX/4MyMoypzHjFrT1CdivfKZ+XvIPMFXwwxHp/r0Ddy2Vuomt4HDFGmft1TAY2yiTKiNSsh3kjBAzcM8kSdsjA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/plugin-transform-runtime@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-Ac/H6G9FEIkS2tXsZjL4RAdS3L3WHxci0usAnz7laPWUmFiGtj7tIASChqKZMHTSQTQY6xDbOq+V1/vIq3QrWg==}
@@ -33063,10 +33066,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
       resolve: 1.20.0
-      semver: 5.7.2
+      semver: 5.7.1
     dev: false
 
   /@babel/plugin-transform-runtime@7.12.17(@babel/core@7.19.6):
@@ -33075,9 +33078,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      semver: 5.7.2
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      semver: 5.7.1
     dev: false
 
   /@babel/plugin-transform-runtime@7.19.6(@babel/core@7.19.6):
@@ -33087,190 +33090,192 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.19.6)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.19.6)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.19.6)
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-shorthand-properties@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-vM4fq9IXHscXVKzDv5itkO1X52SmdFBFcMIBZ2FRn2nqVYqw6dBexUgMvAjHW+KXpPPViD/Yo3GrDEBaRC0QYA==}
+  /@babel/plugin-transform-shorthand-properties@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-eCLXXJqv8okzg86ywZJbRn19YJHU4XUa55oz2wbHhaQVn/MM+XhukiT7SYqp/7o00dg52Rj51Ny+Ecw4oyoygw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
+  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.12.3):
+    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: false
 
-  /@babel/plugin-transform-spread@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-5ZzDQIGyvN4w8+dMmpohL6MBo+l2G7tfC/O2Dg7/hjpgeWvUx8FzfeOKxGog9IimPa4YekaQ9PlDqTLOljkcxg==}
+  /@babel/plugin-transform-spread@7.20.7(@babel/core@7.19.6):
+    resolution: {integrity: sha512-ewBbHQ+1U/VnH1fxltbJqDeWBU1oNLG8Dj11uIv3xVf7nrQu0bPGe5Rf716r7K5Qz+SqtAOVswoVunoiBtGhxw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-skip-transparent-expression-wrappers': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
+  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-sticky-regex@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-zf7LuNpHG0iEeiyCNwX4j3gDg1jgt1k3ZdXBKbZSoA3BbGQGvMiSvfbZRR3Dr3aeJe3ooWFZxOOG3IRStYp2Bw==}
+  /@babel/plugin-transform-sticky-regex@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-kfiDrDQ+PBsQDO85yj1icueWMfGfJFKN1KCkndygtu/C9+XUfydLC8Iv5UYJqRwy4zk8EcplRxEOeLyjq1gm6Q==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-template-literals@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-5ciOehRNf+EyUeewo8NkbQiUs4d6ZxiHo6BcBcnFlgiJfu16q0bQUw9Jvo0b0gBKFG1SMhDSjeKXSYuJLeFSMA==}
+  /@babel/plugin-transform-template-literals@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-S8cOWfT82gTezpYOiVaGHrCbhlHgKhQt8XH5ES46P2XWmX92yisoZywf5km75wv5sYcXDUCLMmMxOLCtthDgMA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
+  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.12.3):
+    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-typeof-symbol@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-bYkI5lMzL4kPii4HHEEChkD0rkc+nvnlR6+o/qdqR6zrm0Sv/nodmyLhlq2DO0YKLUNd2VePmPRjJXSBh9OIdA==}
+  /@babel/plugin-transform-typeof-symbol@7.18.9(@babel/core@7.19.6):
+    resolution: {integrity: sha512-SRfwTtF11G2aemAZWivL7PD+C9z52v9EvMqH9BuYbabyPuKUvSWks3oCg6041pT925L4zVFqaVBeECwsmlguEw==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.12.3):
-    resolution: {integrity: sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==}
+  /@babel/plugin-transform-typescript@7.20.13(@babel/core@7.12.3):
+    resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.12.3)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-typescript@7.22.9(@babel/core@7.19.6):
-    resolution: {integrity: sha512-BnVR1CpKiuD0iobHPaM1iLvcwPYN2uVFAqoLVSpEDKWuOikoCv5HbKLxclhKYUXlWkX86DoZGtqI4XhbOsyrMg==}
+  /@babel/plugin-transform-typescript@7.20.13(@babel/core@7.19.6):
+    resolution: {integrity: sha512-O7I/THxarGcDZxkgWKMUrk7NK1/WbHAg3Xx86gqS6x9MTrNL6AwIluuZ96ms4xeDe6AVx6rjHbWHP7x26EPQBA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-annotate-as-pure': 7.22.5
-      '@babel/helper-create-class-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-create-class-features-plugin': 7.20.12(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==}
+  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.12.3):
+    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-unicode-escapes@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-biEmVg1IYB/raUO5wT1tgfacCef15Fbzhkx493D3urBI++6hpJ+RFG4SrWMn0NEZLfvilqKf3QDrRVZHo08FYg==}
+  /@babel/plugin-transform-unicode-escapes@7.18.10(@babel/core@7.19.6):
+    resolution: {integrity: sha512-kKAdAI+YzPgGY/ftStBFXTI1LZFju38rYThnfMykS+IXy8BVx+res7s2fxf1l8I35DV2T97ezo6+SGrXz6B3iQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.12.3):
-    resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
+  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.12.3):
+    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-unicode-regex@7.22.5(@babel/core@7.19.6):
-    resolution: {integrity: sha512-028laaOKptN5vHJf9/Arr/HiJekMd41hOEZYvNsrsXqJ7YPYuX2bQxh31fkZzGmq3YqHRJzYFFAVYvKfMPKqyg==}
+  /@babel/plugin-transform-unicode-regex@7.18.6(@babel/core@7.19.6):
+    resolution: {integrity: sha512-gE7A6Lt7YLnNOL3Pb9BNeZvi+d8l7tcRrG4+pwJjK9hD2xX4mEvjlQW60G9EEmfXVYRPv9VRQcyegIVHCql/AA==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-create-regexp-features-plugin': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-create-regexp-features-plugin': 7.20.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
 
   /@babel/preset-env@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-H8kxXmtPaAGT7TyBvSSkoSTUK6RHh61So05SyEbpmr0MCZrsNYn7mGMzzeYoOUCdHzww61k8XBft2TaES+xPLg==}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.12.3
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.12.3)
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.12.3)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.12.3)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.12.3)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.12.3)
@@ -33296,42 +33301,44 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.12.3)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.12.3)
+      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.12.3)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.12.3)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.12.3)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.12.3)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.12.3)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/preset-modules': 0.1.5(@babel/core@7.12.3)
       '@babel/types': 7.22.3
-      core-js-compat: 3.31.1
-      semver: 5.7.2
+      core-js-compat: 3.27.2
+      semver: 5.7.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-env@7.12.17(@babel/core@7.19.6):
@@ -33339,12 +33346,12 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-module-imports': 7.22.5
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-module-imports': 7.18.6
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.19.6)
@@ -33355,7 +33362,7 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-object-rest-spread': 7.19.4(@babel/core@7.19.6)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.19.6)
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
@@ -33370,42 +33377,44 @@ packages:
       '@babel/plugin-syntax-optional-catch-binding': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.19.6)
+      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.19.6)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.19.6)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/preset-modules': 0.1.5(@babel/core@7.19.6)
       '@babel/types': 7.22.3
-      core-js-compat: 3.31.1
-      semver: 5.7.2
+      core-js-compat: 3.27.2
+      semver: 5.7.1
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-env@7.19.4(@babel/core@7.19.6):
@@ -33414,16 +33423,16 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.19.6
-      '@babel/helper-compilation-targets': 7.22.9(@babel/core@7.19.6)
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-compilation-targets': 7.20.7(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-async-generator-functions': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-class-properties': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-class-static-block': 7.21.0(@babel/core@7.19.6)
+      '@babel/plugin-proposal-class-static-block': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-dynamic-import': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-export-namespace-from': 7.18.9(@babel/core@7.19.6)
       '@babel/plugin-proposal-json-strings': 7.18.6(@babel/core@7.19.6)
@@ -33432,16 +33441,16 @@ packages:
       '@babel/plugin-proposal-numeric-separator': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-proposal-object-rest-spread': 7.19.4(@babel/core@7.19.6)
       '@babel/plugin-proposal-optional-catch-binding': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-optional-chaining': 7.21.0(@babel/core@7.19.6)
+      '@babel/plugin-proposal-optional-chaining': 7.20.7(@babel/core@7.19.6)
       '@babel/plugin-proposal-private-methods': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.19.6)
+      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.19.6)
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/plugin-syntax-async-generators': 7.8.4(@babel/core@7.19.6)
       '@babel/plugin-syntax-class-properties': 7.12.13(@babel/core@7.19.6)
       '@babel/plugin-syntax-class-static-block': 7.14.5(@babel/core@7.19.6)
       '@babel/plugin-syntax-dynamic-import': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-export-namespace-from': 7.8.3(@babel/core@7.19.6)
-      '@babel/plugin-syntax-import-assertions': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-syntax-import-assertions': 7.20.0(@babel/core@7.19.6)
       '@babel/plugin-syntax-json-strings': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-logical-assignment-operators': 7.10.4(@babel/core@7.19.6)
       '@babel/plugin-syntax-nullish-coalescing-operator': 7.8.3(@babel/core@7.19.6)
@@ -33451,45 +33460,45 @@ packages:
       '@babel/plugin-syntax-optional-chaining': 7.8.3(@babel/core@7.19.6)
       '@babel/plugin-syntax-private-property-in-object': 7.14.5(@babel/core@7.19.6)
       '@babel/plugin-syntax-top-level-await': 7.14.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-arrow-functions': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-async-to-generator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoped-functions': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-block-scoping': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-classes': 7.22.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-computed-properties': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-destructuring': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-duplicate-keys': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-exponentiation-operator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-for-of': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-function-name': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-member-expression-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-amd': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-arrow-functions': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-async-to-generator': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoped-functions': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-block-scoping': 7.20.14(@babel/core@7.19.6)
+      '@babel/plugin-transform-classes': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-computed-properties': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-destructuring': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-duplicate-keys': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-exponentiation-operator': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-for-of': 7.18.8(@babel/core@7.19.6)
+      '@babel/plugin-transform-function-name': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-literals': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-member-expression-literals': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-amd': 7.20.11(@babel/core@7.19.6)
       '@babel/plugin-transform-modules-commonjs': 7.19.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-systemjs': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-modules-umd': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-named-capturing-groups-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-new-target': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-object-super': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-parameters': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-property-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-regenerator': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-reserved-words': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-shorthand-properties': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-spread': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-sticky-regex': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-template-literals': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-typeof-symbol': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-escapes': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-unicode-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-systemjs': 7.20.11(@babel/core@7.19.6)
+      '@babel/plugin-transform-modules-umd': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-named-capturing-groups-regex': 7.20.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-new-target': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-object-super': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-parameters': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-property-literals': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-regenerator': 7.20.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-reserved-words': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-shorthand-properties': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-spread': 7.20.7(@babel/core@7.19.6)
+      '@babel/plugin-transform-sticky-regex': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-template-literals': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-typeof-symbol': 7.18.9(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-escapes': 7.18.10(@babel/core@7.19.6)
+      '@babel/plugin-transform-unicode-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/preset-modules': 0.1.5(@babel/core@7.19.6)
       '@babel/types': 7.22.3
       babel-plugin-polyfill-corejs2: 0.3.3(@babel/core@7.19.6)
       babel-plugin-polyfill-corejs3: 0.6.0(@babel/core@7.19.6)
       babel-plugin-polyfill-regenerator: 0.4.1(@babel/core@7.19.6)
-      core-js-compat: 3.31.1
-      semver: 6.3.1
+      core-js-compat: 3.27.2
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -33499,9 +33508,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.12.3)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.12.3)
       '@babel/types': 7.22.3
       esutils: 2.0.3
     dev: false
@@ -33512,9 +33521,9 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6(@babel/core@7.19.6)
-      '@babel/plugin-transform-dotall-regex': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-dotall-regex': 7.18.6(@babel/core@7.19.6)
       '@babel/types': 7.22.3
       esutils: 2.0.3
 
@@ -33524,13 +33533,13 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-transform-react-display-name': 7.12.1(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-self': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-jsx-source': 7.22.5(@babel/core@7.12.3)
-      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-self': 7.18.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-jsx-source': 7.19.6(@babel/core@7.12.3)
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.12.3)
     dev: false
 
   /@babel/preset-react@7.13.13(@babel/core@7.19.6):
@@ -33539,12 +33548,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.19.6)
     dev: false
 
   /@babel/preset-react@7.18.6(@babel/core@7.19.6):
@@ -33554,12 +33563,12 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-transform-react-display-name': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-jsx-development': 7.22.5(@babel/core@7.19.6)
-      '@babel/plugin-transform-react-pure-annotations': 7.22.5(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-react-display-name': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx': 7.20.13(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-jsx-development': 7.18.6(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-pure-annotations': 7.18.6(@babel/core@7.19.6)
 
   /@babel/preset-typescript@7.12.1(@babel/core@7.12.3):
     resolution: {integrity: sha512-hNK/DhmoJPsksdHuI/RVrcEws7GN5eamhi28JkO52MqIxU8Z0QpmiSOQxZHWOHV7I3P4UjHV97ay4TcamMA6Kw==}
@@ -33567,8 +33576,10 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.3
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.12.3)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.12.3)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/preset-typescript@7.18.6(@babel/core@7.19.6):
@@ -33578,9 +33589,11 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
-      '@babel/helper-validator-option': 7.22.5
-      '@babel/plugin-transform-typescript': 7.22.9(@babel/core@7.19.6)
+      '@babel/helper-plugin-utils': 7.20.2
+      '@babel/helper-validator-option': 7.18.6
+      '@babel/plugin-transform-typescript': 7.20.13(@babel/core@7.19.6)
+    transitivePeerDependencies:
+      - supports-color
     dev: false
 
   /@babel/register@7.18.9(@babel/core@7.19.6):
@@ -33593,18 +33606,15 @@ packages:
       clone-deep: 4.0.1
       find-cache-dir: 2.1.0
       make-dir: 2.1.0
-      pirates: 4.0.6
+      pirates: 4.0.5
       source-map-support: 0.5.21
     dev: false
 
-  /@babel/regjsgen@0.8.0:
-    resolution: {integrity: sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA==}
-
-  /@babel/runtime-corejs3@7.22.6:
-    resolution: {integrity: sha512-M+37LLIRBTEVjktoJjbw4KVhupF0U/3PYUCbBwgAd9k17hoKhRu1n935QiG7Tuxv0LJOMrb2vuKEeYUlv0iyiw==}
+  /@babel/runtime-corejs3@7.20.13:
+    resolution: {integrity: sha512-p39/6rmY9uvlzRiLZBIB3G9/EBr66LBMcYm7fIDeSBNdRjF2AGD3rFZucUyAgGHC2N+7DdLvVi33uTjSE44FIw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      core-js-pure: 3.31.1
+      core-js-pure: 3.27.2
       regenerator-runtime: 0.13.11
     dev: false
 
@@ -33625,26 +33635,26 @@ packages:
     dependencies:
       regenerator-runtime: 0.13.11
 
-  /@babel/template@7.22.5:
-    resolution: {integrity: sha512-X7yV7eiwAxdj9k94NEylvbVHLiVG1nvzCV2EAowhxLTwODV1jl9UzZ48leOC0sH7OnuHrIkllaBgneUykIcZaw==}
+  /@babel/template@7.20.7:
+    resolution: {integrity: sha512-8SegXApWe6VoNw0r9JHpSteLKTpTiLZ4rMlGIm9JQ18KiCtyQiAMEazujAHrUS5flrcqYZa75ukev3P6QmUwUw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
+      '@babel/code-frame': 7.18.6
+      '@babel/parser': 7.22.4
+      '@babel/types': 7.22.3
 
-  /@babel/traverse@7.22.8:
-    resolution: {integrity: sha512-y6LPR+wpM2I3qJrsheCTwhIinzkETbplIgPBbwvqPKc+uljeA5gP+3nP8irdYt1mjQaDnlIcG+dw8OjAco4GXw==}
+  /@babel/traverse@7.20.13:
+    resolution: {integrity: sha512-kMJXfF0T6DIS9E8cgdLCSAL+cuCK+YEZHWiLK0SXpTo8YRj5lpJu3CDNKiIBCne4m9hhTIqUg6SYTAI39tAiVQ==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/code-frame': 7.22.5
-      '@babel/generator': 7.22.9
-      '@babel/helper-environment-visitor': 7.22.5
-      '@babel/helper-function-name': 7.22.5
-      '@babel/helper-hoist-variables': 7.22.5
-      '@babel/helper-split-export-declaration': 7.22.6
-      '@babel/parser': 7.22.7
-      '@babel/types': 7.22.5
+      '@babel/code-frame': 7.18.6
+      '@babel/generator': 7.20.14
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-hoist-variables': 7.18.6
+      '@babel/helper-split-export-declaration': 7.18.6
+      '@babel/parser': 7.22.4
+      '@babel/types': 7.22.3
       debug: 4.3.2
       globals: 11.12.0
     transitivePeerDependencies:
@@ -33654,16 +33664,8 @@ packages:
     resolution: {integrity: sha512-P3na3xIQHTKY4L0YOG7pM8M8uoUIB910WQaSiiMCZUC2Cy8XFEQONGABFnHWBa2gpGKODTAJcNhi5Zk0sLRrzg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
-      to-fast-properties: 2.0.0
-
-  /@babel/types@7.22.5:
-    resolution: {integrity: sha512-zo3MIHGOkPOfoRXitsgHLjEXmlDaD/5KU1Uzuc9GNiZPhSqVxVRtxuPaSBZDsYZ9qV88AjtMtWW7ww98loJ9KA==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-string-parser': 7.22.5
-      '@babel/helper-validator-identifier': 7.22.5
+      '@babel/helper-string-parser': 7.21.5
+      '@babel/helper-validator-identifier': 7.19.1
       to-fast-properties: 2.0.0
 
   /@bcoe/v8-coverage@0.2.3:
@@ -33693,9 +33695,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
+      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /@csstools/postcss-color-function@1.1.1(postcss@8.4.18):
@@ -33746,9 +33748,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
+      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /@csstools/postcss-nested-calc@1.0.0(postcss@8.4.18):
@@ -33831,13 +33833,15 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /@csstools/selector-specificity@2.2.0(postcss-selector-parser@6.0.13):
-    resolution: {integrity: sha512-+OJ9konv95ClSTOJCmMZqpd5+YGsB2S+x6w3E1oaM8UuR5j8nTNHYSz8c9BEPGDOCMQYIEEGlVPj/VY64iTbGw==}
+  /@csstools/selector-specificity@2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18):
+    resolution: {integrity: sha512-jwx+WCqszn53YHOfvFMJJRd/B2GqkCBt+1MJSG6o5/s8+ytHMvDZXsJgUEWLk12UnLd7HYKac4BYU5i/Ron1Cw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
+      postcss: ^8.4
       postcss-selector-parser: ^6.0.10
     dependencies:
-      postcss-selector-parser: 6.0.13
+      postcss: 8.4.18
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /@dabh/diagnostics@2.0.3:
@@ -33882,8 +33886,8 @@ packages:
   /@floating-ui/react-dom@0.7.2(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-1T0sJcpHgX/u4I1OzIEhlcrvkUN8ln39nz7fMoE/2HDHrPiMFoOGR7++GYyfUmIQHkkrTinaeQsO3XWubjSvGg==}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
     dependencies:
       '@floating-ui/dom': 0.5.4
       react: 17.0.2
@@ -33900,7 +33904,7 @@ packages:
   /@graphql-modules/core@0.7.17(graphql@15.8.0)(reflect-metadata@0.1.13):
     resolution: {integrity: sha512-hGJa1VIsIHTKJ0Hc5gJfFrdhHAF1Vm+LWYeMNC5mPbVd/IZA1wVSpdLDjjliylLI6GnVRu1YreS2gXvFNXPJFA==}
     peerDependencies:
-      graphql: '*'
+      graphql: ^14.1.1 || ^15.0.0
     dependencies:
       '@graphql-modules/di': 0.7.17(reflect-metadata@0.1.13)
       '@graphql-toolkit/common': 0.10.6(graphql@15.8.0)
@@ -33943,7 +33947,7 @@ packages:
   /@graphql-toolkit/schema-merging@0.10.6(graphql@15.8.0):
     resolution: {integrity: sha512-BNABgYaNCw4Li3EiH/x7oDpkN+ml3M0SWqjnsW1Pf2NcyfGlv033Bda+O/q4XYtseZ0OOOh52GLXtUgwyPFb8A==}
     peerDependencies:
-      graphql: '*'
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       '@graphql-toolkit/common': 0.10.6(graphql@15.8.0)
       deepmerge: 4.2.2
@@ -33960,9 +33964,9 @@ packages:
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
-      '@graphql-tools/utils': 10.0.3(graphql@15.8.0)
+      '@graphql-tools/utils': 10.0.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /@graphql-tools/schema@10.0.0(graphql@15.8.0):
@@ -33972,23 +33976,29 @@ packages:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-tools/merge': 9.0.0(graphql@15.8.0)
-      '@graphql-tools/utils': 10.0.3(graphql@15.8.0)
+      '@graphql-tools/utils': 10.0.1(graphql@15.8.0)
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.5.0
       value-or-promise: 1.0.12
     dev: false
 
-  /@graphql-tools/utils@10.0.3(graphql@15.8.0):
-    resolution: {integrity: sha512-6uO41urAEIs4sXQT2+CYGsUTkHkVo/2MpM/QjoHj6D6xoEF2woXHBpdAVi0HKIInDwZqWgEYOwIFez0pERxa1Q==}
+  /@graphql-tools/utils@10.0.1(graphql@15.8.0):
+    resolution: {integrity: sha512-i1FozbDGHgdsFA47V/JvQZ0FE8NAy0Eiz7HGCJO2MkNdZAKNnwei66gOq0JWYVFztwpwbVQ09GkKhq7Kjcq5Cw==}
     engines: {node: '>=16.0.0'}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       '@graphql-typed-document-node/core': 3.2.0(graphql@15.8.0)
-      dset: 3.1.2
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
+
+  /@graphql-typed-document-node/core@3.1.1(graphql@15.8.0):
+    resolution: {integrity: sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==}
+    peerDependencies:
+      graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
+    dependencies:
+      graphql: 15.8.0
 
   /@graphql-typed-document-node/core@3.2.0(graphql@15.8.0):
     resolution: {integrity: sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==}
@@ -33996,6 +34006,7 @@ packages:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
     dependencies:
       graphql: 15.8.0
+    dev: false
 
   /@gwhitney/detect-indent@7.0.1:
     resolution: {integrity: sha512-7bQW+gkKa2kKZPeJf6+c6gFK9ARxQfn+FKy9ScTBppyKRWH2KzsmweXUoklqeEiHiNVWaeP5csIdsNq6w7QhzA==}
@@ -34149,7 +34160,7 @@ packages:
       '@jest/types': 27.5.1
       '@types/node': 12.20.4
       chalk: 4.1.2
-      collect-v8-coverage: 1.0.2
+      collect-v8-coverage: 1.0.1
       exit: 0.1.2
       glob: 7.1.6
       graceful-fs: 4.2.10
@@ -34187,7 +34198,7 @@ packages:
       '@jest/console': 26.6.2
       '@jest/types': 26.6.2
       '@types/istanbul-lib-coverage': 2.0.4
-      collect-v8-coverage: 1.0.2
+      collect-v8-coverage: 1.0.1
     dev: false
 
   /@jest/test-result@27.5.1:
@@ -34197,7 +34208,7 @@ packages:
       '@jest/console': 27.5.1
       '@jest/types': 27.5.1
       '@types/istanbul-lib-coverage': 2.0.4
-      collect-v8-coverage: 1.0.2
+      collect-v8-coverage: 1.0.1
     dev: false
 
   /@jest/test-sequencer@27.5.1:
@@ -34227,7 +34238,7 @@ packages:
       jest-regex-util: 27.5.1
       jest-util: 27.5.1
       micromatch: 4.0.5
-      pirates: 4.0.6
+      pirates: 4.0.5
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
@@ -34269,13 +34280,20 @@ packages:
     resolution: {integrity: sha512-CtzORUwWTTOTqfVtHaKRJ0I1kNQd1bpn3sUh8I3nJDVY+5/M/Oe1DnEWzPQvqq/xPIIkzzzIP7mfCoAjFRvDhg==}
     dev: false
 
-  /@jridgewell/gen-mapping@0.3.3:
-    resolution: {integrity: sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==}
+  /@jridgewell/gen-mapping@0.1.1:
+    resolution: {integrity: sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==}
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/set-array': 1.1.2
-      '@jridgewell/sourcemap-codec': 1.4.15
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/sourcemap-codec': 1.4.14
+
+  /@jridgewell/gen-mapping@0.3.2:
+    resolution: {integrity: sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==}
+    engines: {node: '>=6.0.0'}
+    dependencies:
+      '@jridgewell/set-array': 1.1.2
+      '@jridgewell/sourcemap-codec': 1.4.14
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/resolve-uri@3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -34285,20 +34303,17 @@ packages:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
 
-  /@jridgewell/source-map@0.3.5:
-    resolution: {integrity: sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==}
+  /@jridgewell/source-map@0.3.2:
+    resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
-  /@jridgewell/sourcemap-codec@1.4.15:
-    resolution: {integrity: sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==}
-
-  /@jridgewell/trace-mapping@0.3.18:
-    resolution: {integrity: sha512-w+niJYzMHdd7USdiH2U6869nqhD2nbfZXND5Yp93qIbEmnDNk7PD48o+YchRVpzMU7M6jVCbenTR7PA1FLQ9pA==}
+  /@jridgewell/trace-mapping@0.3.17:
+    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -34335,7 +34350,7 @@ packages:
   /@mdx-js/react@1.6.22(react@17.0.2):
     resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
     peerDependencies:
-      react: '*'
+      react: ^16.13.1 || ^17.0.0
     dependencies:
       react: 17.0.2
 
@@ -34347,8 +34362,8 @@ packages:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: false
 
-  /@monaco-editor/loader@1.3.3(monaco-editor@0.33.0):
-    resolution: {integrity: sha512-6KKF4CTzcJiS8BJwtxtfyYt9shBiEv32ateQ9T4UVogwn4HM/uPo9iJd2Dmbkpz8CM6Y0PDUpjnZzCwC+eYo2Q==}
+  /@monaco-editor/loader@1.3.2(monaco-editor@0.33.0):
+    resolution: {integrity: sha512-BTDbpHl3e47r3AAtpfVFTlAi7WXv4UQ/xZmz8atKl4q7epQV5e7+JbigFDViWF71VBi4IIBdcWP57Hj+OWuc9g==}
     peerDependencies:
       monaco-editor: '>= 0.21.0 < 1'
     dependencies:
@@ -34359,11 +34374,11 @@ packages:
   /@monaco-editor/react@4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-Gr3uz3LYf33wlFE3eRnta4RxP5FSNxiIV9ENn2D2/rN8KgGAD8ecvcITRtsbbyuOuNkwbuHYxfeaz2Vr+CtyFA==}
     peerDependencies:
-      monaco-editor: '*'
-      react: '*'
-      react-dom: '*'
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
     dependencies:
-      '@monaco-editor/loader': 1.3.3(monaco-editor@0.33.0)
+      '@monaco-editor/loader': 1.3.2(monaco-editor@0.33.0)
       monaco-editor: 0.33.0
       prop-types: 15.8.1
       react: 17.0.2
@@ -34417,24 +34432,20 @@ packages:
     resolution: {integrity: sha512-zZbZeHQDnoTlt2AF+diQT0wsSXpvWiaIOZwBRdltNFhG1+I3ozyaw7U/nBiUwyJ0D+zwdXp0E3bWOl38Ag2BMw==}
     engines: {node: '>= 10.13'}
     peerDependencies:
-      '@types/webpack': '*'
-      react-refresh: '*'
-      sockjs-client: '*'
-      type-fest: '*'
-      webpack: '*'
-      webpack-dev-server: '*'
-      webpack-hot-middleware: '*'
-      webpack-plugin-serve: '*'
+      '@types/webpack': 4.x || 5.x
+      react-refresh: '>=0.10.0 <1.0.0'
+      sockjs-client: ^1.4.0
+      type-fest: '>=0.17.0 <3.0.0'
+      webpack: '>=4.43.0 <6.0.0'
+      webpack-dev-server: 3.x || 4.x
+      webpack-hot-middleware: 2.x
+      webpack-plugin-serve: 0.x || 1.x
     peerDependenciesMeta:
       '@types/webpack':
-        optional: true
-      react-refresh:
         optional: true
       sockjs-client:
         optional: true
       type-fest:
-        optional: true
-      webpack:
         optional: true
       webpack-dev-server:
         optional: true
@@ -34446,13 +34457,13 @@ packages:
       '@types/webpack': 5.28.1(esbuild@0.14.29)
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
-      core-js-pure: 3.31.1
+      core-js-pure: 3.27.2
       error-stack-parser: 2.1.4
       find-up: 5.0.0
-      html-entities: 2.4.0
+      html-entities: 2.3.3
       loader-utils: 2.0.4
       react-refresh: 0.10.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       source-map: 0.7.4
       webpack: 5.84.1(esbuild@0.14.29)
       webpack-dev-server: 4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1)
@@ -35209,7 +35220,7 @@ packages:
     resolution: {integrity: sha512-YfcB2QrX+Wx1o6LD1G2Y2fhDhOix/bAY/oAnMpHoNLsKkWIRbt1oKLkIFvxBMzLwAEPqnYWguJrYC+J6i4ywbw==}
     engines: {node: '>=12.17'}
     dependencies:
-      bole: 5.0.6
+      bole: 5.0.3
       ndjson: 2.0.0
     dev: false
 
@@ -35284,7 +35295,7 @@ packages:
     dev: false
 
   /@pnpm/network.agent@0.1.0:
-    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.agent/-/@pnpm-network.agent-0.1.0.tgz}
+    resolution: {integrity: sha1-cnnSq8qvIB5cW3nk0a6OXcXcHOM=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/agent@0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.proxy-agent': 0.1.0
@@ -35310,14 +35321,14 @@ packages:
     dev: false
 
   /@pnpm/network.ca-file@1.0.2:
-    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.ca-file/-/@pnpm-network.ca-file-1.0.2.tgz}
+    resolution: {integrity: sha1-kiz5rYFpF+6SDQXN7YadJbYmDaA=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/ca-file@1.0.2.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       graceful-fs: 4.2.10
     dev: false
 
   /@pnpm/network.proxy-agent@0.0.3:
-    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.0.3.tgz}
+    resolution: {integrity: sha1-fbDULpx44yLccnJitzuG5g42Cwo=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/proxy-agent@0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       http-proxy-agent: 5.0.0
@@ -35329,7 +35340,7 @@ packages:
     dev: false
 
   /@pnpm/network.proxy-agent@0.1.0:
-    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.v2.bit.cloud/@pnpm/network.proxy-agent/-/@pnpm-network.proxy-agent-0.1.0.tgz}
+    resolution: {integrity: sha1-OYJw5q15H1RYrjTut5FSV7PtUVY=, tarball: https://node-registry.bit.cloud/tarballs/pnpm.network/proxy-agent@0.1.0.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/error': 4.0.1
@@ -35447,7 +35458,7 @@ packages:
       '@pnpm/error': 5.0.2
       '@pnpm/logger': 5.0.0
       '@pnpm/types': 9.2.0
-      detect-libc: 2.0.2
+      detect-libc: 2.0.1
       execa: /safe-execa@0.1.2
       mem: 8.1.1
       semver: 7.5.4
@@ -35534,10 +35545,10 @@ packages:
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
       klaw-sync: 6.0.0
-      minimist: 1.2.8
+      minimist: 1.2.7
       open: 7.4.2
       rimraf: 2.7.1
-      semver: 5.7.2
+      semver: 5.7.1
       slash: 2.0.0
       tmp: 0.0.33
       yaml: 2.3.1
@@ -35744,7 +35755,7 @@ packages:
       read-yaml-file: 2.1.0
       rimraf: 3.0.2
       tempy: 1.0.1
-      verdaccio: 5.26.0
+      verdaccio: 5.25.0
       write-yaml-file: 4.2.0
     transitivePeerDependencies:
       - encoding
@@ -36029,19 +36040,19 @@ packages:
       write-yaml-file: 5.0.0
     dev: false
 
-  /@popperjs/core@2.11.8:
-    resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
+  /@popperjs/core@2.11.6:
+    resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@prerenderer/prerenderer@1.2.3(@types/express@4.17.13)(debug@4.3.2):
-    resolution: {integrity: sha512-ildOGNPo6vg2SNSBd/wjTljem98BJ0bzgCFcHL0SZEgTf9c26ucTvreZnGgqrqZ+lpiYb6c4RbPABvZW69x6lw==}
+  /@prerenderer/prerenderer@1.2.0(@types/express@4.17.13)(debug@4.3.2):
+    resolution: {integrity: sha512-Wfr7gbKepJ0F1xoUTKL2vXBfd9IWOqn0+brlG1Lp/IWcWTQ64FjdeU9xXvk7IZ97UluP8tlqsfI7219KF9+pqQ==}
     engines: {node: '>=8.0.0'}
     dependencies:
       express: 4.18.2
       portfinder: 1.0.32
       schema-utils: 4.0.0
       stoppable: 1.1.0
-      ts-deepmerge: 6.2.0
+      ts-deepmerge: 6.0.3
     optionalDependencies:
       http-proxy-middleware: 2.0.6(@types/express@4.17.13)(debug@4.3.2)
     transitivePeerDependencies:
@@ -36050,15 +36061,15 @@ packages:
       - supports-color
     dev: false
 
-  /@prerenderer/renderer-jsdom@1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5):
-    resolution: {integrity: sha512-pLU/aS7uWHodu58Jf+aO54woLOGZB4xp46x15SriicwUQLpaKQCCwxw7frNzdbG7w5OLKvjV33s5j5VhIw0snA==}
+  /@prerenderer/renderer-jsdom@1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5):
+    resolution: {integrity: sha512-qVSmbZsYK+/Ad9Q5gX7dZ4UtvTODjtLbLosiXCx4se9cWq143WbvRXpMRJujI+213EFSv1BOWxZNaPWAjkyKzA==}
     engines: {node: '>=8.0.0'}
     dependencies:
       '@types/jsdom': 20.0.1
-      jsdom: 22.1.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      jsdom: 16.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       promise-limit: 2.7.0
       schema-utils: 4.0.0
-      whatwg-fetch: 3.6.16
+      whatwg-fetch: 3.6.2
     transitivePeerDependencies:
       - bufferutil
       - canvas
@@ -36066,8 +36077,8 @@ packages:
       - utf-8-validate
     dev: false
 
-  /@prerenderer/renderer-puppeteer@1.2.2(puppeteer@13.7.0):
-    resolution: {integrity: sha512-tTdhhxrm7sgZC4i6hrDuOwFN3JVLiotgk2NmaLlJbEO+HVgpPbDLPGITNAlNRXlTYHaaHTd11Sdwh1eZoStOMQ==}
+  /@prerenderer/renderer-puppeteer@1.1.3(puppeteer@13.7.0):
+    resolution: {integrity: sha512-A76iTPUcBV4yeOdXrVR2EiJlaNtHy+jITniL3JdKLmxkSjYLwUBwUpglFkesAtqyL24Ca+piVPIJW/NSBK3dRg==}
     engines: {node: '>=8.0.0'}
     requiresBuild: true
     peerDependencies:
@@ -36076,23 +36087,23 @@ packages:
       deepmerge: 4.3.1
       promise-limit: 2.7.0
       puppeteer: 13.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
     dev: false
     optional: true
 
-  /@prerenderer/webpack-plugin@5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1):
-    resolution: {integrity: sha512-U5Q2bmXe7IdRX3HGmttOp5AJ6Ci1TJjC8y5IYYK3wxTTsPQTb5Up+pG26JP94Tz0yZx3+iRkuWwpdZBrnkSf0w==}
+  /@prerenderer/webpack-plugin@5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1):
+    resolution: {integrity: sha512-wddJnlweYohyZ3/KSXU1bM+ZE+k82xHIU71Izzah5pvCYwhYpHQGNfYLLwymvF01TGel6Mqwdw2ChitXZ8sJ+w==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
       html-webpack-plugin: ^5
       webpack: ^5
     dependencies:
-      '@prerenderer/prerenderer': 1.2.3(@types/express@4.17.13)(debug@4.3.2)
+      '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
       html-webpack-plugin: 5.3.2(webpack@5.84.1)
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
       webpack: 5.84.1(esbuild@0.14.29)
     optionalDependencies:
-      '@prerenderer/renderer-puppeteer': 1.2.2(puppeteer@13.7.0)
+      '@prerenderer/renderer-puppeteer': 1.1.3(puppeteer@13.7.0)
     transitivePeerDependencies:
       - '@types/express'
       - debug
@@ -36146,7 +36157,7 @@ packages:
   /@react-hook/latest@1.0.3(react@17.0.2):
     resolution: {integrity: sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==}
     peerDependencies:
-      react: '*'
+      react: '>=16.8'
     dependencies:
       react: 17.0.2
     dev: false
@@ -36171,7 +36182,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-module-imports': 7.18.6
       '@rollup/pluginutils': 3.1.0(rollup@2.79.1)
       '@types/babel__core': 7.20.0
       rollup: 2.79.1
@@ -36371,7 +36382,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       cosmiconfig: 7.1.0
-      deepmerge: 4.3.1
+      deepmerge: 4.3.0
       svgo: 1.3.2
     dev: false
 
@@ -36380,7 +36391,7 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/plugin-transform-react-constant-elements': 7.22.5(@babel/core@7.19.6)
+      '@babel/plugin-transform-react-constant-elements': 7.20.2(@babel/core@7.19.6)
       '@babel/preset-env': 7.19.4(@babel/core@7.19.6)
       '@babel/preset-react': 7.18.6(@babel/core@7.19.6)
       '@svgr/core': 5.5.0
@@ -36399,7 +36410,7 @@ packages:
     dev: false
 
   /@teambit/analytics.timeseries@0.0.25(graphql@15.8.0)(react@17.0.2):
-    resolution: {integrity: sha1-v6T2aEqGAqJ+6pxyfVToHSCgdwo=, tarball: https://node-registry.v2.bit.cloud/@teambit/analytics.timeseries/-/@teambit-analytics.timeseries-0.0.25.tgz}
+    resolution: {integrity: sha1-v6T2aEqGAqJ+6pxyfVToHSCgdwo=, tarball: https://node-registry.bit.cloud/@teambit/analytics.timeseries/-/@teambit-analytics.timeseries-0.0.25.tgz}
     peerDependencies:
       graphql: 14.7.0
       react: 17.0.2
@@ -36426,7 +36437,7 @@ packages:
     dev: false
 
   /@teambit/base-react.hooks.use-1d-nav@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-8CXqMfKPcSY3md7/e96pRRCexzM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.hooks.use-1d-nav/-/@teambit-base-react.hooks.use-1d-nav-1.0.0.tgz}
+    resolution: {integrity: sha1-8CXqMfKPcSY3md7/e96pRRCexzM=, tarball: https://node-registry.bit.cloud/@teambit/base-react.hooks.use-1d-nav/-/@teambit-base-react.hooks.use-1d-nav-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36437,7 +36448,7 @@ packages:
     dev: false
 
   /@teambit/base-react.hooks.use-queued-execution@0.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xeZQchaS1QCoGLT0bRc9m4LShns=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.hooks.use-queued-execution/-/@teambit-base-react.hooks.use-queued-execution-0.0.3.tgz}
+    resolution: {integrity: sha1-xeZQchaS1QCoGLT0bRc9m4LShns=, tarball: https://node-registry.bit.cloud/@teambit/base-react.hooks.use-queued-execution/-/@teambit-base-react.hooks.use-queued-execution-0.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36448,7 +36459,7 @@ packages:
     dev: false
 
   /@teambit/base-react.layout.row@0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.layout.row/-/@teambit-base-react.layout.row-0.0.3.tgz}
+    resolution: {integrity: sha1-j5xgg0boQWvFjzXtRgMOxa5gkaU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/layout/row@0.0.3.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36479,7 +36490,7 @@ packages:
     dev: true
 
   /@teambit/base-react.navigation.link@2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.link/-/@teambit-base-react.navigation.link-2.0.27.tgz}
+    resolution: {integrity: sha1-ZCQxvK+jLOilJMnAnOZAAf9ya+w=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.link/-/teambit-base-react.navigation.link-2.0.27.tgz}
     peerDependencies:
       '@testing-library/react': ^12.0.0
       '@types/react': ^17.0.0
@@ -36496,7 +36507,7 @@ packages:
     dev: false
 
   /@teambit/base-react.navigation.router-context@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wstk3EwVqDvsrgZ1MWrlQuaE2bU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.router-context/-/@teambit-base-react.navigation.router-context-1.23.0.tgz}
+    resolution: {integrity: sha1-wstk3EwVqDvsrgZ1MWrlQuaE2bU=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.router-context/-/@teambit-base-react.navigation.router-context-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36509,7 +36520,7 @@ packages:
     dev: true
 
   /@teambit/base-react.navigation.use-location@1.23.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RnAncyEZdkh94hrIVvUl/aOkzco=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.navigation.use-location/-/@teambit-base-react.navigation.use-location-1.23.0.tgz}
+    resolution: {integrity: sha1-RnAncyEZdkh94hrIVvUl/aOkzco=, tarball: https://node-registry.bit.cloud/@teambit/base-react.navigation.use-location/-/@teambit-base-react.navigation.use-location-1.23.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -36523,7 +36534,7 @@ packages:
     dev: true
 
   /@teambit/base-react.theme.theme-provider@1.95.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.theme.theme-provider/-/@teambit-base-react.theme.theme-provider-1.95.3.tgz}
+    resolution: {integrity: sha1-CBX15Vnm/ZI8JgjJKI170gnN0r8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/theme/theme-provider@1.95.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36534,7 +36545,29 @@ packages:
     dev: false
 
   /@teambit/base-react.themes.theme-switcher@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-react.themes.theme-switcher/-/@teambit-base-react.themes.theme-switcher-1.0.2.tgz}
+    resolution: {integrity: sha1-ohfnPt23FmLPqATiPMmBwSeIpIA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-react/themes/theme-switcher@1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-4fOXti4IhPVuW3fyq8NfYtlqT4mcBUt3587/3kBx2DAcAZE0FOrICpHyCOiUgr7q/0pKy7TZJQxxsL0PfzOwbA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.constants.storage/-/@teambit-base-ui.constants.storage-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-6hC8vHh0PmHU8fOUM81NXLML7rx9SYpzKkEMz1eS5sIrY/cFIdhLKupo01sARPVwcWTQ0VkVYI1fOO3Q4vi3yg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36545,10 +36578,21 @@ packages:
     dev: false
 
   /@teambit/base-ui.css-components.elevation@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.elevation/-/@teambit-base-ui.css-components.elevation-1.0.1.tgz}
+    resolution: {integrity: sha1-1s1wcfF6LWUdqQJ4VqwO5uqJ3Go=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/css-components/elevation@1.0.1.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-92TAw5Cs4wg2h+Ad9/XmY2p5yRlV8a4dIPL776A1OXw/JXR6NIePUl61VtCrW9v0EJanSJywBtka3AWG+PKOmg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.css-components.roundness/-/@teambit-base-ui.css-components.roundness-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -36556,7 +36600,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.elements.dots-loader@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.dots-loader/-/@teambit-base-ui.elements.dots-loader-1.0.3.tgz}
+    resolution: {integrity: sha1-VJCw39xmwHq3wpyTQP8yqmHOqLo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/elements/dots-loader@1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36567,8 +36611,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.image/-/@teambit-base-ui.elements.image-1.0.0.tgz}
+  /@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-qaoHLbt6wNXzgST7N3oE+1hI/PttCzrSLQ9B7d/7yKKxUbHbhjoMX0+wViJxlQq3PYnb8LOHDzwvylfZoeBgKQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.elements.icon/-/@teambit-base-ui.elements.icon-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36577,10 +36621,10 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
+    dev: false
 
   /@teambit/base-ui.graph.tree.collapsable-tree-node@0.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.collapsable-tree-node/-/@teambit-base-ui.graph.tree.collapsable-tree-node-0.0.4.tgz}
+    resolution: {integrity: sha1-iP5CdCfB0WV4Z7WRxrnNxzA7HMs=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/graph/tree/collapsable-tree-node@0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36593,11 +36637,81 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.hook.use-click-outside@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MWkSceL3FJ7qLtW2mGtE9h7+a6Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.1.tgz}
+  /@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.indent/-/@teambit-base-ui.graph.tree.indent-1.0.0.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-GAsT6a06E6Loj0n3UlHpoynSLTD56IAGX3dspM4fq0H5JaOzEb88EGemhN2Ksk9C9MgzqpLzRNBttenJ6TnAyQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.inflate-paths/-/@teambit-base-ui.graph.tree.inflate-paths-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.sub-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-jPsjiwd51/yqQ/gj4nSHn2uX0bILV/5UdC0F5/WEpMb9IVNJaTmUAwZA9wAFIjydvH+fkWCT1c2Ua2/7xkvrdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.recursive-tree/-/@teambit-base-ui.graph.tree.recursive-tree-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gMhF1QwT9L6Rbvuj5tUh9rav5szd0RymBrfOfDmeseexQ1YvYPwzTpuf9P5Kqr7VFvuaaSGtgHOJZTkEFKXzhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.root-node/-/@teambit-base-ui.graph.tree.root-node-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-2Z2eVFVYTl0xpAYMUDuWnz2eI6xlocmNqHAFGhcJKA7gQ0Wd8q7URISZ3gYS8dgj8p2v4B/MnVKHoFLtLQSeKQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.graph.tree.tree-context/-/@teambit-base-ui.graph.tree.tree-context-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-We1J6M2/jBAAIN7/zilrIJKeGILSpkR7/FSSidsiacfm/SqIn+BMuse1GXvd4ThOhvAgFUUbj0fZ4NDyQhu3BQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.hook.use-click-outside@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-MWkSceL3FJ7qLtW2mGtE9h7+a6Y=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.hook.use-click-outside/-/@teambit-base-ui.hook.use-click-outside-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -36605,7 +36719,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.button@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.button/-/@teambit-base-ui.input.button-1.0.5.tgz}
+    resolution: {integrity: sha1-s1c+U4PsHHseDY8rDXs7t3sZZzU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/button@1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36617,8 +36731,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.input.checkbox.hidden@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.2.tgz}
+  /@teambit/base-ui.input.checkbox.hidden@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gGUqZs+n0F2EeJaSryGkNfE1MOslKdKqNveI6jgphoYhhQ2WEOiZaDtsxTKIAzi/tbnEe5kZlC+uAk0q7jo6Ug==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.hidden/-/@teambit-base-ui.input.checkbox.hidden-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36629,8 +36743,45 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.input.checkbox.hidden@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-O8Yps5mBrOsEIvF8nvTyKoBjXxM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/hidden@1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.input.checkbox.indicator@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-yYnwY1ax6nF+HopiSmZe/4tPigdUb5CI2JstC67L+30fitfhtWDL1bO+A3OTJU62yV4XMGtALQbkulMDqazJwg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.indicator/-/@teambit-base-ui.input.checkbox.indicator-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.input.checkbox.label@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5TXD6JGVLxd8vcRZ/PeoyUVp9W20AQFzlamauZt0PGKaWNl7CrGiOsnCAl9wiDO2yWu/gPwelTI3ThjoaIv+rQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.input.checkbox.hidden': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/base-ui.input.checkbox.label@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.2.tgz}
+    resolution: {integrity: sha1-1DriGxnU40B6XI0f0MQRPf6bZuw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/label@1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36643,7 +36794,7 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.checkbox.label@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.checkbox.label/-/@teambit-base-ui.input.checkbox.label-1.0.4.tgz}
+    resolution: {integrity: sha1-vsRm754LxTgZJ6GSsWpuF6YSlIg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/checkbox/label@1.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36656,12 +36807,23 @@ packages:
     dev: false
 
   /@teambit/base-ui.input.error@1.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.input.error/-/@teambit-base-ui.input.error-1.0.3.tgz}
+    resolution: {integrity: sha1-u786FrWekFm9ZXJNbAtguAA+wE0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/input/error@1.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-F7+aHFncCH4iHtClKX9i7Yj6+SBQjQTQkrzxX9Jq4/r4QGEIVVbJ6Tjwa+abI2ef8Ww0fpPpLCP+ithPJWHQtA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.breakpoints/-/@teambit-base-ui.layout.breakpoints-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -36680,8 +36842,19 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-X+lWlURlRu528ink+3e7eqQt866UMYGI3DdPC7FAJ3v1CW0p0+O95K+/mxNmYvQLtW4y2iJ+2rrv/el27d6/Xw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/base-ui.layout.page-frame@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-RRuzSP5iAICgm17gD1Ez2nD/UQM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.2.tgz}
+    resolution: {integrity: sha1-RRuzSP5iAICgm17gD1Ez2nD/UQM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.layout.page-frame/-/@teambit-base-ui.layout.page-frame-1.0.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36692,8 +36865,8 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: true
 
-  /@teambit/base-ui.loaders.skeleton@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
+  /@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-qhCYlHvLy+U1E9a3kXMnZz7dba2PKMsputdJgE3PldsNG01gH0udyrPeOT6Re/fuWHfzXVU2zN6zDWwi+Pygdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.loaders.loader-ribbon/-/@teambit-base-ui.loaders.loader-ribbon-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36704,21 +36877,92 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.link/-/@teambit-base-ui.routing.link-1.0.0.tgz}
+  /@teambit/base-ui.loaders.skeleton@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-4LCHFJkcWhYqauzTcaENE6eznCw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.loaders.skeleton/-/@teambit-base-ui.loaders.skeleton-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.routing-provider': registry.npmjs.org/@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
+    dev: false
 
-  /@teambit/base-ui.surfaces.abs-container@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.1.tgz}
+  /@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-57vlN0+yBZFGsX5JLo237OQ3Bu8eeJ+vEVbeQuioJsuvS0zEhI8EyobYssEfyaCMsbpDpbpL6HkfSvuQB0Vtmw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.compare-url/-/@teambit-base-ui.routing.compare-url-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      url-parse: 1.5.1
+
+  /@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.native-link/-/@teambit-base-ui.routing.native-link-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
+  /@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-elXAzsYT7e7Y6/2n5Xv0iYS48ITG2KDBcrtUifxSlVob3zyRbaX18M6wPrHyD9z9XXwqyxEJreTKL1Gt9IdEaA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.native-nav-link/-/@teambit-base-ui.routing.native-nav-link-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.routing.compare-url': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
+  /@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.nav-link/-/@teambit-base-ui.routing.nav-link-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.routing-provider': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.routing.routing-provider@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-18qOybF12VyqLHbbrHGuzgZx3YRMahiedOMkSDO7fOHQUqCUok0c8LkY3BEenaL3nK0Buy1ih3wNT9GiSWy2MA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.routing.routing-provider/-/@teambit-base-ui.routing.routing-provider-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
+  /@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.styles.flex-center/-/@teambit-base-ui.styles.flex-center-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Gzoj5H/OeIetATQt/zf9qmW2mqEovCNbuqR5JE9Isovjt6oHhXnB0tUC2+bXBn7OIiLySTOg63R7CymWC43w6g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.abs-container/-/@teambit-base-ui.surfaces.abs-container-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36727,6 +36971,30 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-create-ref: 1.0.1(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.abs-container@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-51b87xnd65dXa3utstNjz7HXmtM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/surfaces/abs-container@1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-create-ref: 1.0.1(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-VHPPrzqkHUiYkbief6QtxCbTXUcCh69xMtkbrAsIJXZjrAAN1GhNX2PrErEEaCRIXW1joo06zekyth0+vT1HUg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.background/-/@teambit-base-ui.surfaces.background-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
@@ -36741,8 +37009,38 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-taJIr7LqtuyIrERv9FeT3+91mSrY8WF+AbtfHttb6J8pE4xV0FaqxVXbKT9wRw06XDi5RUo6LXKMZOldkgR8Gw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.card/-/@teambit-base-ui.surfaces.card-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.background': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.drawer@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-4eSIGZGllXif9vXmZjMbV++HjA9EU2MzHL9gud+4NXZgj8JCoplqbvkk1Ptbhvs4BLDwPuujY28+dlAosOpXXQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.hook.use-click-outside': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-create-ref: 1.0.1(react@17.0.2)
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/base-ui.surfaces.drawer@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NGtL6iO8yNoadw8lq3L6rLtvdxw=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.1.tgz}
+    resolution: {integrity: sha1-NGtL6iO8yNoadw8lq3L6rLtvdxw=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36757,10 +37055,10 @@ packages:
     dev: false
 
   /@teambit/base-ui.surfaces.drawer@1.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.drawer/-/@teambit-base-ui.surfaces.drawer-1.1.3.tgz}
+    resolution: {integrity: sha1-EmfvFFxPhsVm6B9oBq1W7S4wzLA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/surfaces/drawer@1.1.3.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.hook.use-click-outside': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.abs-container': 1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -36771,8 +37069,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.text.heading@1.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.4.tgz}
+  /@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-sbN1AgGvc3lzoeWg7KQrYD9lCa4V9s0EctfZSrPCwy/UcHGePgMipBOWJkcNwuq8GGhzSTzH8rP8McWCLUGdew==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.hover-splitter/-/@teambit-base-ui.surfaces.split-pane.hover-splitter-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.split-pane.layout@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Ib4sVeQYp3NU8zz6lhhvQ8B9AHb8bSGDaG5qZP36bXI8N+b9a0G+gCX2kFFmFPuAx74HOYnKz3B5xUPH5yTT0Q==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.layout/-/@teambit-base-ui.surfaces.split-pane.layout-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36780,6 +37091,94 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.split-pane.pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-OUzOlgCzt5pkAN9FcoXzlB+TUuH+5+Hh0EE/7X488rFTDHS6lW3pEgKPsqg1XUw30ivthOdVq7cwnpnB1seRhw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.pane/-/@teambit-base-ui.surfaces.split-pane.pane-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Zomx0m2Gsf9Dl+A3YwyZy1qJO3q6LtI7BTeEWsBLrub9fO0IXMTMjelsK918oAZ3xJ+LOXnEgYYVh+A9CQm2Qg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.split-pane/-/@teambit-base-ui.surfaces.split-pane.split-pane-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.surfaces.split-pane.layout': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.surfaces.split-pane.splitter@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5/oGHEUOQQnQUi2911fLb/rdFLLDoMy1G4fQ4DNkqoHcahi1a26tCtKlV+7FAI1LsFdk0V+wRp6WY+kX+Qbsxw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.surfaces.split-pane.splitter/-/@teambit-base-ui.surfaces.split-pane.splitter-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.text.heading@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-P6N4Mx5YUuCnkVXwpG5UK2/5b56aXJCHq2LRiqambZM/lZbLX2qO+CNolRjYztRf2cXea6/ToUdjAn+BPcwXXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.heading/-/@teambit-base-ui.text.heading-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.text.heading@1.0.4(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-tPpsdOpL9sYJhfliT8AZfDG0p0A=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/text/heading@1.0.4.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
+  /@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-xawuhA+NqttmKRqj0xoDqNAVCmryIUQBpJjIp8LC/0iT7Xo/QAcm5EmrpalCFLhNbcUnQzPK/bwXETz+jFAcrA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.muted-text/-/@teambit-base-ui.text.muted-text-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.text.paragraph@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-cs1ugxwYUCTFBNF+QSlq206u5ZcfJts3LluDO42hi5R1iQ/o1lyhQhmQ9VgTWE1mXuwGrSzkJ02/S7vigxTzJg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@teambit/base-ui.text.paragraph@1.0.3(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-1+iy0XYAMZbJ++r57HBNzAK7hoE=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.paragraph/-/@teambit-base-ui.text.paragraph-1.0.3.tgz}
@@ -36787,16 +37186,16 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/base-ui.theme.fonts.book@1.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.2.tgz}
+  /@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-mCoVLxG3Hm4hgeHJeNnde/4YxpUTvNPNsKbGozErigUrBTf5cKFvLnDYXlEzGOGwNrs9hqIG/nmm3um9E9/5bg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.text-sizes/-/@teambit-base-ui.text.text-sizes-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36806,8 +37205,217 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-YG/xgNwXuFkTDopsmThwea4zHjHZ5yRlN43s81kdqKAjqouHEcNZzte39A/ZA398Cx+TUrlwbKuBHxMMiijv2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.text.themed-text/-/@teambit-base-ui.text.themed-text-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-IASK1+zcJmULcWGbw57lm8kFH/SkKRZEsqYj/QaxyIKjvnrS/uBXUNDGRqgmkR/IC3Fl8rQlbFxELwASTiSNZg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.accent-color/-/@teambit-base-ui.theme.accent-color-1.1.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.brand-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-1IapashD5oxvRsw5On5eHzx3d4Cf2+u+ajb31ATcnFfaGVEvC/V3bFQ6t3VNnyI2ewOYiEuxGJOboxfZi7M+IA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.brand-definition/-/@teambit-base-ui.theme.brand-definition-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.color-definition@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-9JYKPLhxJhsPfA4PkSvoWGlQEb2dlG2uWiCxQuKoRVzM2YivIfEv63BMO8/4xnvGtJsPR/lOrBKDKahjN6jS8g==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.color-definition/-/@teambit-base-ui.theme.color-definition-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-3lKvT0eFMwkOGydNHu8TU2xlRHWHQVzx2Uxk50sICGlIjAcEyIZ1E655qvF8B/KPSES81rj/nozWklslhVBMeQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.colors/-/@teambit-base-ui.theme.colors-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Y/fLbxyb8XW7qZ4wAgl2cEmWXceOfaXN/GcfrVZEBqmM6YerlAkNq9RW3bcN9OuhSVekDjApwbDtELsE9WStdA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.dark-theme/-/@teambit-base-ui.theme.dark-theme-1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.fonts.book@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-yc8/+nkHE8XZs+boxJ0jc8PXMy6bCLpCfDMTuvweD1LshIFhOK01Eiv1Uxxo8IyD8abUZt4gi1LRMKwVqlGnjw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.book/-/@teambit-base-ui.theme.fonts.book-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.fonts.book@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-TzaJASmrWjLeCze8rnRp8IZgxwA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.base-ui/theme/fonts/book@1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-a1DUqAJDdyqGIX4s87zW0unmmlvNI+U1vNT2zgm4hfoAQayOFQHwUlA6lRfu/fomyXYFsKhWNwhSu0lIhNsmqA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.fonts.roboto/-/@teambit-base-ui.theme.fonts.roboto-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.heading-margin-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gPKAXOWOlBqsQ88z15yOffJOwV1nqtnSTiF/a00OUoL/Pm41yATnzM+CpxaKT4g6LFfoQvnZJHVPKQ/u3loDoA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.heading-margin-definition/-/@teambit-base-ui.theme.heading-margin-definition-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.shadow-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-z58KOqj95gjmW48IK53NMlp/NZKhJ3iSQnrFCJ1d46XmimfIe2oQdxFW/B69W+Dc8AyM1ES/pbqLVAmE38uxAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.shadow-definition/-/@teambit-base-ui.theme.shadow-definition-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.size-definition@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-cOexDIzZvG37G76bn0P6SPfR68UKh4ZlH10fZKJsBcIEs4s9Ne5+zPqhDyjgKCHZVOqIj/0I4EVBFIb8o06L2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.size-definition/-/@teambit-base-ui.theme.size-definition-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-A2PoEhZ/8GYSeypqIMGK0Hu/bcpfDdquxQtkXZ34bIpXdYaYGn0tHIJTAuxJTInWM+qLMBAHQ32p3qkm86IuDQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.sizes/-/@teambit-base-ui.theme.sizes-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-PywTliIBJswoOi8LU4HT8BI9dR6/OEZh7nej4Nvyv7U5alVKIgUbSF+whl8vprVjyrDDVJ3QtSdwujvbPhmmAw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.theme.theme-provider/-/@teambit-base-ui.theme.theme-provider-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.theme.brand-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.color-definition': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.fonts.book': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.heading-margin-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.shadow-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.size-definition': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-2w+T+WdEJWxWbGcqRueoww08xeDrPyWxDnWFho4N7WsxKS6zaHp/u29b18KV34VDJV9hdHcrXzhUoaLXd8pFSA==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.composer/-/@teambit-base-ui.utils.composer-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.is-browser/-/@teambit-base-ui.utils.is-browser-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
+  /@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.string.affix/-/@teambit-base-ui.utils.string.affix-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/base-ui.utils.sub-paths@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-SZiCFSzGezESxWl0m4I3WJfX0pmVgjcobOhPL4tGlCmXHqdICQ69nExY7XJsjvNJ57H54UnF/DNEBaSZv2FBdQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.sub-paths/-/@teambit-base-ui.utils.sub-paths-1.0.0.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      path-browserify: 1.0.1
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/base-ui.utils.time-ago@1.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ykLJEZKzUxWJWMsLladKg3mcwQM=, tarball: https://node-registry.v2.bit.cloud/@teambit/base-ui.utils.time-ago/-/@teambit-base-ui.utils.time-ago-1.0.1.tgz}
+    resolution: {integrity: sha1-ykLJEZKzUxWJWMsLladKg3mcwQM=, tarball: https://node-registry.bit.cloud/@teambit/base-ui.utils.time-ago/-/@teambit-base-ui.utils.time-ago-1.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -36847,7 +37455,7 @@ packages:
     engines: {node: '>=12.22.0'}
 
   /@teambit/bit.content.what-is-bit@1.96.2(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F6iK8JMYsiTXqPK4KiYe2lUP42k=, tarball: https://node-registry.v2.bit.cloud/@teambit/bit.content.what-is-bit/-/@teambit-bit.content.what-is-bit-1.96.2.tgz}
+    resolution: {integrity: sha1-F6iK8JMYsiTXqPK4KiYe2lUP42k=, tarball: https://node-registry.bit.cloud/@teambit/bit.content.what-is-bit/-/@teambit-bit.content.what-is-bit-1.96.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36865,7 +37473,7 @@ packages:
     dev: true
 
   /@teambit/bvm.config@0.2.2:
-    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.v2.bit.cloud/@teambit/bvm.config/-/@teambit-bvm.config-0.2.2.tgz}
+    resolution: {integrity: sha1-bhhP6VU8KBxcalnz91zehIKykl0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.bvm/config@0.2.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       chalk: 4.1.0
@@ -36877,7 +37485,7 @@ packages:
     dev: false
 
   /@teambit/bvm.list@0.1.6:
-    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.v2.bit.cloud/@teambit/bvm.list/-/@teambit-bvm.list-0.1.6.tgz}
+    resolution: {integrity: sha1-otpq3k5jfDVByS+TJSTHfV3F/WU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.bvm/list@0.1.6.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/bvm.config': 0.2.2
@@ -36916,6 +37524,26 @@ packages:
       - '@testing-library/react'
       - '@types/react'
       - react-router-dom
+    dev: false
+
+  /@teambit/code.ui.code-view@0.0.508(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-LK6VE0Lwgyc82TP2Ym204QzbIQ8=, tarball: https://node-registry.bit.cloud/@teambit/code.ui.code-view/-/@teambit-code.ui.code-view-0.0.508.tgz}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+      react-syntax-highlighter: 15.4.3(react@17.0.2)
+    transitivePeerDependencies:
+      - '@apollo/client'
     dev: false
 
   /@teambit/code.ui.dependency-tree@0.0.546(@apollo/client@3.6.9)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
@@ -36958,7 +37586,7 @@ packages:
     dev: false
 
   /@teambit/code.ui.object-formatter@0.0.1(react@17.0.2):
-    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.object-formatter/-/@teambit-code.ui.object-formatter-0.0.1.tgz}
+    resolution: {integrity: sha1-Rwi8T+P5e2iAl40auw21JeozQWg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.code/ui/object-formatter@0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -36966,15 +37594,14 @@ packages:
       core-js: 3.13.0
       json-formatter-js: 2.3.4
       react: 17.0.2
-    dev: true
 
   /@teambit/code.ui.queries.get-component-code@0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-9dIl+N7tMk19y1KHuKigBn3Kd1o=, tarball: https://node-registry.v2.bit.cloud/@teambit/code.ui.queries.get-component-code/-/@teambit-code.ui.queries.get-component-code-0.0.502.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      '@apollo/client': '*'
-      react: '*'
-      react-dom: '*'
+      '@apollo/client': ^3.6.0
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.500(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
@@ -37011,11 +37638,11 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
 
   /@teambit/community.constants.links@0.0.2:
-    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.constants.links/-/@teambit-community.constants.links-0.0.2.tgz}
+    resolution: {integrity: sha1-cUo3bbFCwlI564kZTrREbBRp234=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/constants/links@0.0.2.tgz}
     dev: false
 
   /@teambit/community.entity.graph.bubble-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.entity.graph.bubble-graph/-/@teambit-community.entity.graph.bubble-graph-1.95.0.tgz}
+    resolution: {integrity: sha1-DyejJtL3Qht5BLLPYiBdJ4lnK00=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/entity/graph/bubble-graph@1.95.0.tgz}
     dependencies:
       '@teambit/community.entity.graph.grid-graph': 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
     transitivePeerDependencies:
@@ -37025,7 +37652,7 @@ packages:
     dev: true
 
   /@teambit/community.entity.graph.grid-graph@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.v2.bit.cloud/@teambit/community.entity.graph.grid-graph/-/@teambit-community.entity.graph.grid-graph-1.95.0.tgz}
+    resolution: {integrity: sha1-/SO0DWAyqn76HbmhRfTxwsE/2BA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.community/entity/graph/grid-graph@1.95.0.tgz}
     dependencies:
       '@teambit/component-id': 0.0.369(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       react-xarrows: 2.0.2(react@17.0.2)
@@ -37043,7 +37670,7 @@ packages:
     dev: false
 
   /@teambit/compilation.content.compiler-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.v2.bit.cloud/@teambit/compilation.content.compiler-overview/-/@teambit-compilation.content.compiler-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-Tx2zgDjbSEzSAPclXSbRVbNvqfw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.compilation/content/compiler-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37116,6 +37743,20 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: true
+
+  /@teambit/component-descriptor@0.0.263(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-ZhLH1/tdRyYovNezpEwnYNybji+bsNMft6wutIDwt8sjWk1tDHEuxzyY1tSIrOVpqzAnthBvpKJ6D40XMgyivw==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.474
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@babel/runtime': 7.20.0
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   /@teambit/component-descriptor@0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-/OEPdA80xS76HvGaSlZqNTyvQ/WlO3lERzUNnPnldLye2OWST69vhga8tefBRKMeNpPsITck6adfiLm1DH8m6g==}
@@ -37245,7 +37886,7 @@ packages:
       semver: 7.3.4
 
   /@teambit/component.content.component-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.content.component-overview/-/@teambit-component.content.component-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-9Dbi90Jg9C5Jmy4g7IdouEqSuo8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/content/component-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37262,7 +37903,7 @@ packages:
     dev: true
 
   /@teambit/component.content.dev-files@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.content.dev-files/-/@teambit-component.content.dev-files-1.95.9.tgz}
+    resolution: {integrity: sha1-mkTDg0tdxiZhKKExHhyxyG6DPjc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/content/dev-files@1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -37272,8 +37913,23 @@ packages:
       - react-dom
     dev: true
 
+  /@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-ku7UpvjuRW6hu5Uz01g0tBa6hgArnF2WpgotayCe5LL2GBoNs0KTGRPoa16zFVtqmt21eWxIKrZZq4TvL1ZsoQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/component.instructions.exporting-components/-/@teambit-component.instructions.exporting-components-0.0.6.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@teambit/legacy'
+    dev: false
+
   /@teambit/component.modules.component-url@0.0.124(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.modules.component-url/-/@teambit-component.modules.component-url-0.0.124.tgz}
+    resolution: {integrity: sha1-hMQBTfleQnkLfjF4VuHAmNGY8Ho=, tarball: https://node-registry.bit.cloud/tarballs/teambit.component/modules/component-url@0.0.124.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -37290,7 +37946,7 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.405
       query-string: 7.0.0
       react: 17.0.2
@@ -37304,7 +37960,7 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.417
       query-string: 7.0.0
       react: 17.0.2
@@ -37352,12 +38008,31 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/component.ui.component-compare.context@0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-wDW0unfbbFiQf8O8zMeZHlug2Xc=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.context/-/teambit-component.ui.component-compare.context-0.0.22.tgz}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/component.ui.component-compare.models.component-compare-hooks': 0.0.4(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.models.component-compare-model': 0.0.18(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@teambit/legacy'
+      - '@testing-library/react'
+      - '@types/react'
+    dev: false
+
   /@teambit/component.ui.component-compare.hooks.use-component-compare-url@0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-mNono316l0rxMgrR/xuTDv4Rp/E=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.hooks.use-component-compare-url/-/@teambit-component.ui.component-compare.hooks.use-component-compare-url-0.0.3.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.react-router.use-query': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -37367,6 +38042,19 @@ packages:
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
+    dev: false
+
+  /@teambit/component.ui.component-compare.layouts.compare-split-layout-preset@0.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-PREhw4bzeUeolT/NsV/If+7MEmU=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.layouts.compare-split-layout-preset/-/teambit-component.ui.component-compare.layouts.compare-split-layout-preset-0.0.3.tgz}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-change-type@0.0.1(react-dom@17.0.2)(react@17.0.2):
@@ -37396,6 +38084,22 @@ packages:
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
+    dev: false
+
+  /@teambit/component.ui.component-compare.models.component-compare-model@0.0.18(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-OU3X7NtfpUteBkaucDHtrI0kTCw=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.models.component-compare-model/-/teambit-component.ui.component-compare.models.component-compare-model-0.0.18.tgz}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/component-descriptor': 0.0.263(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/legacy-component-log': 0.0.399
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@teambit/legacy'
     dev: false
 
   /@teambit/component.ui.component-compare.models.component-compare-props@0.0.6(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
@@ -37433,6 +38137,20 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/component.ui.component-compare.status-resolver@0.0.4(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-yI4EdeDCrzJGlRurBIXds86peVA=, tarball: https://node-registry.bit.cloud/@teambit/component.ui.component-compare.status-resolver/-/teambit-component.ui.component-compare.status-resolver-0.0.4.tgz}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/component.ui.component-compare.utils.lazy-loading@0.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-K4iYPn+ng7gCPPwwQ3C3vdAWzDE=, tarball: https://node-registry.v2.bit.cloud/@teambit/component.ui.component-compare.utils.lazy-loading/-/@teambit-component.ui.component-compare.utils.lazy-loading-0.0.1.tgz}
     engines: {node: '>=12.22.0'}
@@ -37453,10 +38171,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -37470,10 +38188,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -37481,7 +38199,7 @@ packages:
     dev: false
 
   /@teambit/components.blocks.component-card-display@0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.13.tgz}
+    resolution: {integrity: sha1-jdwURBnGqc7/r4dGZ7hTyoeBPNs=, tarball: https://node-registry.bit.cloud/tarballs/teambit.components/blocks/component-card-display@0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37502,7 +38220,7 @@ packages:
     dev: true
 
   /@teambit/components.blocks.component-card-display@0.0.24(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OlVc0FyFcCB5yfe3qAG/tJbiAco=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.24.tgz}
+    resolution: {integrity: sha1-OlVc0FyFcCB5yfe3qAG/tJbiAco=, tarball: https://node-registry.bit.cloud/@teambit/components.blocks.component-card-display/-/@teambit-components.blocks.component-card-display-0.0.24.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37526,7 +38244,7 @@ packages:
     dev: true
 
   /@teambit/components.clients.components-node@0.0.5(graphql@15.8.0):
-    resolution: {integrity: sha1-0yetOPD2nk9MNBEvOc+dNfhjQaE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.5.tgz}
+    resolution: {integrity: sha1-0yetOPD2nk9MNBEvOc+dNfhjQaE=, tarball: https://node-registry.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.5.tgz}
     peerDependencies:
       graphql: ^14.3.0
     dependencies:
@@ -37535,7 +38253,7 @@ packages:
     dev: true
 
   /@teambit/components.clients.components-node@0.0.6(graphql@15.8.0):
-    resolution: {integrity: sha1-QV4RQpjp35zf+ihMEPrtU1ppTt4=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.6.tgz}
+    resolution: {integrity: sha1-QV4RQpjp35zf+ihMEPrtU1ppTt4=, tarball: https://node-registry.bit.cloud/@teambit/components.clients.components-node/-/@teambit-components.clients.components-node-0.0.6.tgz}
     peerDependencies:
       graphql: ^14.3.0
     dependencies:
@@ -37544,7 +38262,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.14(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZeYw+0jEa9tTCVUggXlIVFTJxaE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.14.tgz}
+    resolution: {integrity: sha1-ZeYw+0jEa9tTCVUggXlIVFTJxaE=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.14.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.402
@@ -37556,7 +38274,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-VoayQSccNGOoiQn0eXOQUTylk6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.6.tgz}
+    resolution: {integrity: sha1-VoayQSccNGOoiQn0eXOQUTylk6Q=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.6.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.12(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.401
@@ -37568,7 +38286,7 @@ packages:
     dev: true
 
   /@teambit/components.descriptors.component-descriptor@0.0.7(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-HkbSWB5GKqJNAMc3Eo8n3AiRkOo=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.7.tgz}
+    resolution: {integrity: sha1-HkbSWB5GKqJNAMc3Eo8n3AiRkOo=, tarball: https://node-registry.bit.cloud/@teambit/components.descriptors.component-descriptor/-/@teambit-components.descriptors.component-descriptor-0.0.7.tgz}
     dependencies:
       '@teambit/component-descriptor': 0.0.3(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.401
@@ -37580,7 +38298,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-component-count@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-CjYLTYK0d4z4soJFrz3oU0+z81M=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-component-count/-/@teambit-components.hooks.use-component-count-0.0.7.tgz}
+    resolution: {integrity: sha1-CjYLTYK0d4z4soJFrz3oU0+z81M=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-component-count/-/@teambit-components.hooks.use-component-count-0.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37597,7 +38315,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-components@0.0.10(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2):
-    resolution: {integrity: sha1-sSRUFzKDbhghNcEX8/UteRwCjdM=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.10.tgz}
+    resolution: {integrity: sha1-sSRUFzKDbhghNcEX8/UteRwCjdM=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.10.tgz}
     dependencies:
       '@teambit/components.clients.components-node': 0.0.5(graphql@15.8.0)
       '@teambit/components.descriptors.component-descriptor': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -37611,7 +38329,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-components@0.0.11(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-components/-/@teambit-components.hooks.use-components-0.0.11.tgz}
+    resolution: {integrity: sha1-mcBupurgV66olC1DdF9uh9enrk8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.components/hooks/use-components@0.0.11.tgz}
     peerDependencies:
       react: 17.0.2
     dependencies:
@@ -37627,7 +38345,7 @@ packages:
     dev: true
 
   /@teambit/components.hooks.use-list-components@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rj+nJVVF4Wp2GAPOkzrVdAt5WKE=, tarball: https://node-registry.v2.bit.cloud/@teambit/components.hooks.use-list-components/-/@teambit-components.hooks.use-list-components-0.0.7.tgz}
+    resolution: {integrity: sha1-rj+nJVVF4Wp2GAPOkzrVdAt5WKE=, tarball: https://node-registry.bit.cloud/@teambit/components.hooks.use-list-components/-/@teambit-components.hooks.use-list-components-0.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37645,7 +38363,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.formatter-overview@1.96.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-r+8A4YQj5e9uNgpqwFhEVQ4UpoA=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.formatter-overview/-/@teambit-defender.content.formatter-overview-1.96.1.tgz}
+    resolution: {integrity: sha1-r+8A4YQj5e9uNgpqwFhEVQ4UpoA=, tarball: https://node-registry.bit.cloud/@teambit/defender.content.formatter-overview/-/@teambit-defender.content.formatter-overview-1.96.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37662,7 +38380,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.linter-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.linter-overview/-/@teambit-defender.content.linter-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-OLOF3LYo6/kauWREJuGF2zgBcls=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/content/linter-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37677,7 +38395,7 @@ packages:
     dev: true
 
   /@teambit/defender.content.tester-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.content.tester-overview/-/@teambit-defender.content.tester-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-rvAmFD+lPqi22iBo4cK1XoOEbsY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/content/tester-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37712,10 +38430,9 @@ packages:
     dev: false
 
   /@teambit/defender.fs.global-bit-temp-dir@0.0.1:
-    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.fs.global-bit-temp-dir/-/@teambit-defender.fs.global-bit-temp-dir-0.0.1.tgz}
+    resolution: {integrity: sha1-bMr2j7yS0vJ7glPYZYyy/hlVoFM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.defender/fs/global-bit-temp-dir@0.0.1.tgz}
     dependencies:
       fs-extra: 10.1.0
-    dev: true
 
   /@teambit/defender.linter-task@0.0.5:
     resolution: {integrity: sha1-SVz+88G7j/lePhSSy3g+xt4F7wQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/defender.linter-task/-/@teambit-defender.linter-task-0.0.5.tgz}
@@ -37735,12 +38452,12 @@ packages:
     dev: false
 
   /@teambit/design.elements.icon@1.0.11(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-yCfxRpQ4oY22Mumu7HeMm1oh240=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.11.tgz}
+    resolution: {integrity: sha1-yCfxRpQ4oY22Mumu7HeMm1oh240=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -37759,7 +38476,7 @@ packages:
     dev: false
 
   /@teambit/design.elements.icon@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-blViHnlGeQASLRUR/mum3QbdXoY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.5.tgz}
+    resolution: {integrity: sha1-blViHnlGeQASLRUR/mum3QbdXoY=, tarball: https://node-registry.bit.cloud/@teambit/design.elements.icon/-/@teambit-design.elements.icon-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37771,7 +38488,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@0.0.9(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-l4lNKhFxzeHrm3T3mqFI/EIP2Oo=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-0.0.9.tgz}
+    resolution: {integrity: sha1-l4lNKhFxzeHrm3T3mqFI/EIP2Oo=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-0.0.9.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37808,7 +38525,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.dropdown@1.2.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.dropdown/-/@teambit-design.inputs.dropdown-1.2.16.tgz}
+    resolution: {integrity: sha1-sOhj24U3VPx4eMpsfD321XHIvno=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/dropdown@1.2.16.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -37846,7 +38563,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.checkbox-item@0.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZVtMy39V13AQ9j2D0/iNMNWyy44=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-0.0.12.tgz}
+    resolution: {integrity: sha1-ZVtMy39V13AQ9j2D0/iNMNWyy44=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-0.0.12.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37860,7 +38577,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.checkbox-item@1.1.11(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.checkbox-item/-/@teambit-design.inputs.selectors.checkbox-item-1.1.11.tgz}
+    resolution: {integrity: sha1-s77hOAb1837dsKI2TDSSxjoUycA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/checkbox-item@1.1.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37873,7 +38590,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@0.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-d2GR5gucZYaRufqN4h85EwByUkw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-0.0.5.tgz}
+    resolution: {integrity: sha1-d2GR5gucZYaRufqN4h85EwByUkw=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-0.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37886,7 +38603,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.13(react@17.0.2):
-    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.13.tgz}
+    resolution: {integrity: sha1-f1s7UR0l1BTxhFDOPH2VMM8GHVM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/menu-item@1.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37896,7 +38613,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.menu-item@1.0.15(react@17.0.2):
-    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.menu-item/-/@teambit-design.inputs.selectors.menu-item-1.0.15.tgz}
+    resolution: {integrity: sha1-nuVoV8dwvn7DVoVSNymTtYv4jJ8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/selectors/menu-item@1.0.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37906,7 +38623,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.selectors.multi-select@0.0.20(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LqKnnNV56NAPtfqYoh/DleSskIA=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.selectors.multi-select/-/@teambit-design.inputs.selectors.multi-select-0.0.20.tgz}
+    resolution: {integrity: sha1-LqKnnNV56NAPtfqYoh/DleSskIA=, tarball: https://node-registry.bit.cloud/@teambit/design.inputs.selectors.multi-select/-/@teambit-design.inputs.selectors.multi-select-0.0.20.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -37935,7 +38652,7 @@ packages:
     dev: false
 
   /@teambit/design.inputs.toggle-switch@0.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.inputs.toggle-switch/-/@teambit-design.inputs.toggle-switch-0.0.6.tgz}
+    resolution: {integrity: sha1-YQdfk7L1SALwnzTAjZ55/6fFv4g=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/inputs/toggle-switch@0.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -37948,7 +38665,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.content-tabs@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.content-tabs/-/@teambit-design.navigation.content-tabs-0.0.5.tgz}
+    resolution: {integrity: sha1-rK2cGFleulDhSc4whU3PkuCZyEc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/navigation/content-tabs@0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': ^17.0.2
@@ -37964,7 +38681,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.responsive-navbar@0.0.1(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-XcXtpFdOvn4Gs7wKdgDmvCKGVCs=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.1.tgz}
+    resolution: {integrity: sha1-XcXtpFdOvn4Gs7wKdgDmvCKGVCs=, tarball: https://node-registry.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.1.tgz}
     peerDependencies:
       '@types/react': ^17.0.2
       react: ^16.8.0 || ^17.0.0
@@ -37980,7 +38697,7 @@ packages:
     dev: false
 
   /@teambit/design.navigation.responsive-navbar@0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.navigation.responsive-navbar/-/@teambit-design.navigation.responsive-navbar-0.0.5.tgz}
+    resolution: {integrity: sha1-GKpJR1VliaSND0YkWNeoGdT6eLw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/navigation/responsive-navbar@0.0.5.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       '@types/react': 17.0.8
@@ -38040,7 +38757,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.0.tgz}
+    resolution: {integrity: sha1-V2cI94Nm8O1ShJoQwK8wavfYo50=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/base-theme@0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38056,7 +38773,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.base-theme@0.1.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.base-theme/-/@teambit-design.themes.base-theme-0.1.1.tgz}
+    resolution: {integrity: sha1-tcObt9R1kJtv++curKsMWFsJqi0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/base-theme@0.1.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38072,7 +38789,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.dark-theme@1.91.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bwvJgtmAX99/BfXo/HXq4uBsppY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.0.tgz}
+    resolution: {integrity: sha1-bwvJgtmAX99/BfXo/HXq4uBsppY=, tarball: https://node-registry.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38086,7 +38803,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.dark-theme@1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.dark-theme/-/@teambit-design.themes.dark-theme-1.91.4.tgz}
+    resolution: {integrity: sha1-6tXoWF2YWrIa0WiSPWogjLYHtF8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/dark-theme@1.91.4.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38100,7 +38817,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.light-theme@0.1.0(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.light-theme/-/@teambit-design.themes.light-theme-0.1.0.tgz}
+    resolution: {integrity: sha1-Ac1kTk+HDvWo8mW3jBcMuChEY8k=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/light-theme@0.1.0.tgz}
     peerDependencies:
       '@testing-library/react': 12.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38114,7 +38831,7 @@ packages:
     dev: false
 
   /@teambit/design.themes.theme-toggler@0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.themes.theme-toggler/-/@teambit-design.themes.theme-toggler-0.1.3.tgz}
+    resolution: {integrity: sha1-YjcrpFPsM/OhlOMlrs12oDM+mnc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/themes/theme-toggler@0.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38147,8 +38864,8 @@ packages:
     resolution: {integrity: sha1-C2ZsSkEl2DnU6nx6apGBMtEv+TQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.alert-card/-/@teambit-design.ui.alert-card-0.0.26.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.surfaces.background': registry.npmjs.org/@teambit/base-ui.surfaces.background@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -38180,12 +38897,12 @@ packages:
     dev: false
 
   /@teambit/design.ui.brand.logo@1.96.2(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Fu8NOXINYLBeQP8HQ7o/fK8i/EY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.brand.logo/-/@teambit-design.ui.brand.logo-1.96.2.tgz}
+    resolution: {integrity: sha1-Fu8NOXINYLBeQP8HQ7o/fK8i/EY=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.brand.logo/-/@teambit-design.ui.brand.logo-1.96.2.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -38258,8 +38975,8 @@ packages:
     resolution: {integrity: sha1-vQV7Te5JyvHLSgtDRcCjbwF7v6E=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.error-page/-/@teambit-design.ui.error-page-0.0.364.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
@@ -38272,7 +38989,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.heading@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4R3FOpvDcf3haYi5H6tGaP61uDg=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.heading/-/@teambit-design.ui.heading-1.0.16.tgz}
+    resolution: {integrity: sha1-4R3FOpvDcf3haYi5H6tGaP61uDg=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.heading/-/@teambit-design.ui.heading-1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38285,7 +39002,7 @@ packages:
     dev: true
 
   /@teambit/design.ui.icon-button@1.0.16(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.icon-button/-/@teambit-design.ui.icon-button-1.0.16.tgz}
+    resolution: {integrity: sha1-4guwxtPII430l1WuK5krEgo4PUY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/icon-button@1.0.16.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38328,7 +39045,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.option-button@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.option-button/-/@teambit-design.ui.input.option-button-1.0.0.tgz}
+    resolution: {integrity: sha1-E1zSSl4YKj6g48oiuNr/PSqHFvM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/option-button@1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38342,7 +39059,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.radio@1.1.13(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.radio/-/@teambit-design.ui.input.radio-1.1.13.tgz}
+    resolution: {integrity: sha1-J0jdSdniS8arJKbkiRb8hicj224=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/radio@1.1.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -38368,10 +39085,10 @@ packages:
     dev: false
 
   /@teambit/design.ui.input.toggle@1.0.12(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.input.toggle/-/@teambit-design.ui.input.toggle-1.0.12.tgz}
+    resolution: {integrity: sha1-LzyE7ou+hprvzwzEucrX4M2Phaw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/input/toggle@1.0.12.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.input.checkbox.label': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -38394,7 +39111,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.layouts.sections.left-right@1.96.2(@testing-library/react@12.1.5)(react@17.0.2):
-    resolution: {integrity: sha1-OWvICi+qk0vNq5inFufcRYRjI/A=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.layouts.sections.left-right/-/@teambit-design.ui.layouts.sections.left-right-1.96.2.tgz}
+    resolution: {integrity: sha1-OWvICi+qk0vNq5inFufcRYRjI/A=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.layouts.sections.left-right/-/@teambit-design.ui.layouts.sections.left-right-1.96.2.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -38467,11 +39184,11 @@ packages:
     dev: false
 
   /@teambit/design.ui.pill-label@0.0.356(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.pill-label/-/@teambit-design.ui.pill-label-0.0.356.tgz}
+    resolution: {integrity: sha1-9o8B9qs+jlvQ9EuAc2Jw7q6UtuY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/pill-label@0.0.356.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -38493,7 +39210,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.separator@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.separator/-/@teambit-design.ui.separator-0.0.354.tgz}
+    resolution: {integrity: sha1-94jUQ9U3hveieBihtoaWedM2yiI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/separator@0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38632,7 +39349,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.item@0.0.354(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.item/-/@teambit-design.ui.surfaces.menu.item-0.0.354.tgz}
+    resolution: {integrity: sha1-pkIlmHpKWiyhN8zs+JKg/J+2aQQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.design/ui/surfaces/menu/item@0.0.354.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -38646,7 +39363,7 @@ packages:
     dev: false
 
   /@teambit/design.ui.surfaces.menu.link-item@1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.v2.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/@teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
+    resolution: {integrity: sha1-gP3ufHm29fgctTIwxm5pwy0Iwwc=, tarball: https://node-registry.bit.cloud/@teambit/design.ui.surfaces.menu.link-item/-/teambit-design.ui.surfaces.menu.link-item-1.0.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38727,7 +39444,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -38743,7 +39460,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -38775,7 +39492,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-animate-height: 2.0.23(react-dom@17.0.2)(react@17.0.2)
@@ -38803,7 +39520,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.icon': registry.npmjs.org/@teambit/base-ui.elements.icon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-animate-height: 2.0.23(react-dom@17.0.2)(react@17.0.2)
@@ -38811,7 +39528,7 @@ packages:
     dev: false
 
   /@teambit/docs.content.docs-overview@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.content.docs-overview/-/@teambit-docs.content.docs-overview-1.95.9.tgz}
+    resolution: {integrity: sha1-mqOj1yh81O1VADkasU8jPw03Hag=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/content/docs-overview@1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/docs.ui.zoomable-image': 1.95.8(react-dom@17.0.2)(react@17.0.2)
@@ -38837,7 +39554,7 @@ packages:
     dev: true
 
   /@teambit/docs.ui.hooks.use-element-on-fold@1.96.5(react@17.0.2):
-    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.hooks.use-element-on-fold/-/@teambit-docs.ui.hooks.use-element-on-fold-1.96.5.tgz}
+    resolution: {integrity: sha1-S5yRjO0ZUXHcY857BVgVxWHwx4o=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/hooks/use-element-on-fold@1.96.5.tgz}
     peerDependencies:
       '@testing-library/react-hooks': ^8.0.0
       react: ^16.8.0 || ^17.0.0
@@ -38848,11 +39565,11 @@ packages:
     dev: false
 
   /@teambit/docs.ui.zoomable-image@1.95.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.0.tgz}
+    resolution: {integrity: sha1-vO/fxO2X1Mnqx83rSt3NwmOR6jY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/zoomable-image@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.1
       core-js: 3.13.0
       react: 17.0.2
@@ -38862,11 +39579,11 @@ packages:
     dev: true
 
   /@teambit/docs.ui.zoomable-image@1.95.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.v2.bit.cloud/@teambit/docs.ui.zoomable-image/-/@teambit-docs.ui.zoomable-image-1.95.8.tgz}
+    resolution: {integrity: sha1-+nKuWyNqWPhDTFif23GfaIOh8i4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.docs/ui/zoomable-image@1.95.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.elements.image': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.elements.image': registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.1
       core-js: 3.13.0
       react: 17.0.2
@@ -38876,7 +39593,7 @@ packages:
     dev: true
 
   /@teambit/documenter.code.react-playground@4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-ueDTBxYfB7E+D/E0mmLm31aSjh8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.code.react-playground/-/@teambit-documenter.code.react-playground-4.1.9.tgz}
+    resolution: {integrity: sha1-ueDTBxYfB7E+D/E0mmLm31aSjh8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.code.react-playground/-/@teambit-documenter.code.react-playground-4.1.9.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38898,7 +39615,7 @@ packages:
     dev: false
 
   /@teambit/documenter.content.documentation-links@4.1.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.content.documentation-links/-/@teambit-documenter.content.documentation-links-4.1.3.tgz}
+    resolution: {integrity: sha1-wgJhlccTF7mlyr89PRVFM1JE3sA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/content/documentation-links@4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38909,7 +39626,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.heading@0.1.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.heading/-/@teambit-documenter.markdown.heading-0.1.8.tgz}
+    resolution: {integrity: sha1-nzm8nvmN4ZhYeKvSemUQ8QCkkmM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/markdown/heading@0.1.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38922,10 +39639,10 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.hybrid-live-code-snippet@0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-zmQgh2QvXfcHXFpnL6t0u4Ur2OQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.hybrid-live-code-snippet/-/@teambit-documenter.markdown.hybrid-live-code-snippet-0.1.12.tgz}
+    resolution: {integrity: sha1-zmQgh2QvXfcHXFpnL6t0u4Ur2OQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.hybrid-live-code-snippet/-/@teambit-documenter.markdown.hybrid-live-code-snippet-0.1.12.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.code.react-playground': 4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
@@ -38938,7 +39655,7 @@ packages:
     dev: false
 
   /@teambit/documenter.markdown.mdx@0.1.13(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-TdvNoPVAs7pDrsmto8DiGKjvVdI=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.markdown.mdx/-/@teambit-documenter.markdown.mdx-0.1.13.tgz}
+    resolution: {integrity: sha1-TdvNoPVAs7pDrsmto8DiGKjvVdI=, tarball: https://node-registry.bit.cloud/@teambit/documenter.markdown.mdx/-/@teambit-documenter.markdown.mdx-0.1.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38970,7 +39687,7 @@ packages:
     dev: false
 
   /@teambit/documenter.routing.external-link@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.routing.external-link/-/@teambit-documenter.routing.external-link-4.1.2.tgz}
+    resolution: {integrity: sha1-x8BwO3dJWu6xpvFCmhyGxIBGUsk=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/routing/external-link@4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -38981,21 +39698,22 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.theme.theme-compositions/-/@teambit-documenter.theme.theme-compositions-4.1.1.tgz}
+  /@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.theme.theme-context/-/@teambit-documenter.theme.theme-context-4.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/design.theme.icons-font': registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.theme-provider': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
+    dev: false
 
   /@teambit/documenter.ui.anchor@4.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.6.tgz}
+    resolution: {integrity: sha1-F/md7GOXvxkNRtlH5aNtoA7s/VY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/anchor@4.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39008,7 +39726,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.anchor@4.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.anchor/-/@teambit-documenter.ui.anchor-4.0.8.tgz}
+    resolution: {integrity: sha1-uCm/XjJzF/uAWNo0M0ZD+EqSK4w=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/anchor@4.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39021,7 +39739,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.block-quote@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.block-quote/-/@teambit-documenter.ui.block-quote-4.0.7.tgz}
+    resolution: {integrity: sha1-7+GPtKk6G3gN7oPmjt/F4b6F84I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/block-quote@4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39033,7 +39751,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.bold@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.bold/-/@teambit-documenter.ui.bold-4.0.7.tgz}
+    resolution: {integrity: sha1-9gJM/LIlweId0FfiXSfJe0b8P6Q=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/bold@4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39045,7 +39763,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.code-snippet@4.2.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-dgCI6suKWJxi4A2jJFLa0UUESpQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.code-snippet/-/@teambit-documenter.ui.code-snippet-4.2.2.tgz}
+    resolution: {integrity: sha1-dgCI6suKWJxi4A2jJFLa0UUESpQ=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.code-snippet/-/@teambit-documenter.ui.code-snippet-4.2.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39059,15 +39777,12 @@ packages:
       react-syntax-highlighter: 13.5.3(react@17.0.2)
     dev: false
 
-  /@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.consumable-link/-/@teambit-documenter.ui.consumable-link-4.0.3.tgz}
+  /@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.copy-box': registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.paragraph': registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39075,7 +39790,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.copied-message@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copied-message/-/@teambit-documenter.ui.copied-message-4.1.6.tgz}
+    resolution: {integrity: sha1-M5pctQny1uKI9T6rUQIR4Nv4iSE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/copied-message@4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39087,7 +39802,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.copy-box@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.copy-box/-/@teambit-documenter.ui.copy-box-4.1.6.tgz}
+    resolution: {integrity: sha1-rg+Zln1Z2FFuFm4R90qr2/DrkTg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/copy-box@4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39102,8 +39817,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-VmHd/0lSMKfUuGllXbCnqZehQ0pcTgio8q9mcbsPs9S36bZW4w5BS9oywVSo47dzLOOV3S/C1gUIdy6P468miw==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.text.heading': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/documenter.ui.heading@4.1.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jENJgXMvwy825NKKTM8gP90faMc=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.4.tgz}
+    resolution: {integrity: sha1-jENJgXMvwy825NKKTM8gP90faMc=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.heading/-/@teambit-documenter.ui.heading-4.1.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39128,8 +39856,32 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-lYt7PwLDWG49/PSgDOQmRzI0oS9GjGageLFdxxLBS29YRBRGhopphOxGnRtBONCxH67ZxLblkzduu7gRl5fvjg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.highlighted-text/-/@teambit-documenter.ui.highlighted-text-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/documenter.ui.inline-code': 0.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/documenter.ui.image@4.0.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.image/-/@teambit-documenter.ui.image-4.0.2.tgz}
+    resolution: {integrity: sha1-lOGzakfJTF07HAYwkCYPeS3MKwI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/image@4.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.inline-code@0.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-HVTX7QiTyeY4lEiFFEf2oyjTbTpkao4FxaD8RQXt/k4dhdxVVyP2Z/WpYWhEpdssMYzEdVHR5VMFvrcby/4RjQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39141,7 +39893,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.inline-code@0.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.inline-code/-/@teambit-documenter.ui.inline-code-0.1.5.tgz}
+    resolution: {integrity: sha1-ds6zetV22NrzIjAju0UoDBjePEY=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/inline-code@0.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39153,7 +39905,32 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.italic@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.italic/-/@teambit-documenter.ui.italic-4.0.7.tgz}
+    resolution: {integrity: sha1-udDO1kKFVhbtzPHibq1fT3cAjtg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/italic@4.0.7.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-BnAlcBLZfgkDgBq8oco2NFnk2yqEHdAYEckhVPNrBsdKiA5CXgXjEWUHkKAsMNn3xbJ7ept7xAlS4RPrLNDlaA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label-list/-/@teambit-documenter.ui.label-list-4.0.3.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5MgPgotrW7JBalA1y6iAMF9YQDyXLS5JGt24+spK0MYWsGPV+g79NirYzH5yl6k7fTehvWJ9zMS4pdT3a4lR9g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.label/-/@teambit-documenter.ui.label-4.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39165,7 +39942,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.linked-heading@4.1.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.linked-heading/-/@teambit-documenter.ui.linked-heading-4.1.6.tgz}
+    resolution: {integrity: sha1-f24gfJKAIAD/V+cvUE/6Zk847U0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/linked-heading@4.1.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39193,11 +39970,25 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ol@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.ol/-/@teambit-documenter.ui.ol-4.1.5.tgz}
+    resolution: {integrity: sha1-lapFqkqFsOmHSTE3otAHINSFdu8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/ol@4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-6SGnp4qO/AOG+sETJ/uStgFt6UY5s3E/55nX7RO7BIJEEVSi+kGU3xze2z10ruK/hKXJ6//JLwP7t5Sld8zj7g==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.text.paragraph': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39205,13 +39996,13 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.paragraph@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-w9jrNz9R2bIsMgLvjNgv9Ycmr3Y=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.5.tgz}
+    resolution: {integrity: sha1-w9jrNz9R2bIsMgLvjNgv9Ycmr3Y=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.paragraph/-/@teambit-documenter.ui.paragraph-4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.text.paragraph': 1.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.sizes': registry.npmjs.org/@teambit/base-ui.theme.sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -39219,7 +40010,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.property-table@4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4):
-    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.property-table/-/@teambit-documenter.ui.property-table-4.1.3.tgz}
+    resolution: {integrity: sha1-JTxLbdTeNEeF6K1N9uOmUpclSYw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/property-table@4.1.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39236,8 +40027,8 @@ packages:
       - typescript
     dev: false
 
-  /@teambit/documenter.ui.separator@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
+  /@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-PwMUmernBbCKKHm4AdXfBTlanIrkF6bE/Uyjg2AobIMf5taLw0L9RiQ2lAjUnSn9Mq4VFId/TrcjdA1p7jqlmQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.section/-/@teambit-documenter.ui.section-4.1.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39248,8 +40039,46 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-ItYHPk2tfpOCb8GvNTBzLCOWD3hXRQrnG1ZhKnvcKkBqRb351+MLWQy0vVo971pFIgI4ei6DV3fM62eJ8/oxXA==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.separator@4.1.5(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha1-xyOoVnbJEVVdAGegDDbr5EXrZH8=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.separator/-/@teambit-documenter.ui.separator-4.1.5.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-kY3gW8069pk9dg3N6HUKXJ+QffI+TrSpqrI7jPUDOO4TndRreZnIdwDsoc5dN+4uhBxocq0kmFTM4qPHlCTsBg==, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.sub-title/-/@teambit-documenter.ui.sub-title-4.1.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.paragraph': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/documenter.ui.sup@4.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.sup/-/@teambit-documenter.ui.sup-4.0.7.tgz}
+    resolution: {integrity: sha1-BsLXxuTjySkYTbpe2bxzPcbamVU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/sup@4.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39263,8 +40092,8 @@ packages:
   /@teambit/documenter.ui.table-column@4.0.2(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha1-SCWMxMt8UkvvI4Ya/ZkJuMIIXSs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-column/-/@teambit-documenter.ui.table-column-4.0.2.tgz}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -39273,7 +40102,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-heading-column@4.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-88YzrKFIcEPPln9jc6nKCGB69Qs=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-heading-column/-/@teambit-documenter.ui.table-heading-column-4.0.4.tgz}
+    resolution: {integrity: sha1-88YzrKFIcEPPln9jc6nKCGB69Qs=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-heading-column/-/@teambit-documenter.ui.table-heading-column-4.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39285,7 +40114,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table-heading-row@4.0.4(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-5Y0+Bx4PBE8oyFlUjczMJdil4ig=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table-heading-row/-/@teambit-documenter.ui.table-heading-row-4.0.4.tgz}
+    resolution: {integrity: sha1-5Y0+Bx4PBE8oyFlUjczMJdil4ig=, tarball: https://node-registry.bit.cloud/@teambit/documenter.ui.table-heading-row/-/@teambit-documenter.ui.table-heading-row-4.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39331,7 +40160,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.base-table@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.base-table/-/@teambit-documenter.ui.table.base-table-4.1.5.tgz}
+    resolution: {integrity: sha1-bdqA6VoAdA2lDnRjrxeUUjk09UQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/base-table@4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39343,7 +40172,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.td@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.td/-/@teambit-documenter.ui.table.td-4.1.5.tgz}
+    resolution: {integrity: sha1-G1IEysSy68nlR2OF+QHUU39HrEw=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/td@4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39355,7 +40184,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table.tr@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table.tr/-/@teambit-documenter.ui.table.tr-4.1.5.tgz}
+    resolution: {integrity: sha1-jNAXpVn9c16u1xtdH/m1beo5TnQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table/tr@4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39367,7 +40196,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.table@4.1.2(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.table/-/@teambit-documenter.ui.table-4.1.2.tgz}
+    resolution: {integrity: sha1-OIJesPzJ1bKWQTPMeEGAPT++8Eo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/table@4.1.2.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39381,7 +40210,7 @@ packages:
     dev: false
 
   /@teambit/documenter.ui.ul@4.1.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.v2.bit.cloud/@teambit/documenter.ui.ul/-/@teambit-documenter.ui.ul-4.1.5.tgz}
+    resolution: {integrity: sha1-tRTv2mMIu1ulZTNVLUDzQsDBuyM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.documenter/ui/ul@4.1.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39416,8 +40245,19 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/evangelist.css-components.fade-in-out@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.css-components.fade-in-out/-/@teambit-evangelist.css-components.fade-in-out-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/evangelist.elements.button@1.0.6(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.button/-/@teambit-evangelist.elements.button-1.0.6.tgz}
+    resolution: {integrity: sha1-pufrVcdf/buVEQzjewcFJrA3fr0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.evangelist/elements/button@1.0.6.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39429,8 +40269,20 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-OoqGwKyhQDETfLYTebBOGUeISdix6eyj9cT3iQoVMtZlcIGOJlQqccDsFbjnhOUMFoI9IbtqTaGL7ymCGbA8rw==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.elements.icon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/evangelist.elements.icon@1.0.5(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-abaBfCKbp8JEu8J7j9OB5kvyo5s=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.5.tgz}
+    resolution: {integrity: sha1-abaBfCKbp8JEu8J7j9OB5kvyo5s=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.elements.icon/-/@teambit-evangelist.elements.icon-1.0.5.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39442,7 +40294,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.elements.x-button@1.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.elements.x-button/-/@teambit-evangelist.elements.x-button-1.0.7.tgz}
+    resolution: {integrity: sha1-Pg4jdfe9Ekb0NdS/IuisL7WnH2I=, tarball: https://node-registry.bit.cloud/tarballs/teambit.evangelist/elements/x-button@1.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39454,8 +40306,22 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/evangelist.input.checkbox.indicator@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-Qc41v9xhW/LVJFSw8bErKpMHlqx10lwmBtp95avVPJvhlaUnrplrJph3ueqhLmQVe6TxnCBPsi849t+7Q7UKzg==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.input.checkbox.indicator': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/evangelist.input.checkbox.indicator@1.0.7(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NYg/ZeFXH2J0ujDD82H5Bl1vEIk=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.7.tgz}
+    resolution: {integrity: sha1-NYg/ZeFXH2J0ujDD82H5Bl1vEIk=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.7.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39469,7 +40335,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.indicator@1.0.8(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/@teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
+    resolution: {integrity: sha1-Nn0xSq1WfQhUKQ4sx4G7T9Q78eM=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.indicator/-/teambit-evangelist.input.checkbox.indicator-1.0.8.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39497,7 +40363,7 @@ packages:
     dev: false
 
   /@teambit/evangelist.input.checkbox.label@1.0.14(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-U/7VYoZk5VQauXz4/8r2tuGljA4=, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.14.tgz}
+    resolution: {integrity: sha1-U/7VYoZk5VQauXz4/8r2tuGljA4=, tarball: https://node-registry.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.14.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -39510,8 +40376,56 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  /@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-xuSc5KUViJovRp1paYkOyzFYxO5JKJsoN6RTjbS4iB2oJWYRmAL8VJwJ4zOc5Cze4fJV9aZu6fYhm/3bLRy8jQ==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.input.checkbox.label/-/@teambit-evangelist.input.checkbox.label-1.0.3.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.input.checkbox.label': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.input.checkbox.indicator': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-6KHnfU91AZXEJDAqwIA1pafnuyOh1QdMIPHLPNm0m8LXJ6krngjIYcXBfhaAn0DRzmx+V1W7A0E+EFMalAfBCg==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.surfaces.dropdown/-/@teambit-evangelist.surfaces.dropdown-1.0.2.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.background': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.drawer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.css-components.fade-in-out': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
+  /@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-tHsYDm7xB2FAlPeHonfAHzFgTtY5ij7ldNZaHMpw87Ecn28J2vtmmCCpfI4/9q/aZiFa6NTtDFsqFEkRUjr3yA==, tarball: https://node-registry.v2.bit.cloud/@teambit/evangelist.surfaces.tooltip/-/@teambit-evangelist.surfaces.tooltip-1.0.1.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.css-components.elevation': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.css-components.roundness': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.abs-container': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.drawer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.css-components.fade-in-out': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/explorer.plugins.env-plugin@0.0.10(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.10.tgz}
+    resolution: {integrity: sha1-onlzjTM5EWSUXIxKh4GogjzLEDE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/plugins/env-plugin@0.0.10.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39524,7 +40438,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.env-plugin@0.0.13(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-C1OuYM2sDr31NrxpBce2W8bIQgI=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.13.tgz}
+    resolution: {integrity: sha1-C1OuYM2sDr31NrxpBce2W8bIQgI=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.env-plugin/-/@teambit-explorer.plugins.env-plugin-0.0.13.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39537,7 +40451,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.preview-plugin@0.0.4(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.4.tgz}
+    resolution: {integrity: sha1-z82y2WLvhzNkdIGKWx0u+UZgeZk=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/plugins/preview-plugin@0.0.4.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39551,7 +40465,7 @@ packages:
     dev: true
 
   /@teambit/explorer.plugins.preview-plugin@0.0.9(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz}
+    resolution: {integrity: sha1-ZIn30mCzb51Upzs9EKsOpS5QaCk=, tarball: https://node-registry.bit.cloud/@teambit/explorer.plugins.preview-plugin/-/@teambit-explorer.plugins.preview-plugin-0.0.9.tgz}
     peerDependencies:
       '@testing-library/react': 12.1.3
       react: ^16.8.0 || ^17.0.0
@@ -39568,7 +40482,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card-grid@0.0.12(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.12.tgz}
+    resolution: {integrity: sha1-grBJIntxQFpGC4y6j4qt5iZ/MO4=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/component-card-grid@0.0.12.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39585,7 +40499,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card-grid@0.0.15(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-nw+ae8xtNXYeGHCfeGh/7kjMHpc=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.15.tgz}
+    resolution: {integrity: sha1-nw+ae8xtNXYeGHCfeGh/7kjMHpc=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card-grid/-/@teambit-explorer.ui.component-card-grid-0.0.15.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39602,7 +40516,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card@0.0.11(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.11.tgz}
+    resolution: {integrity: sha1-MRJol4wIkIWOmlc1++quY0UmjCU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.explorer/ui/component-card@0.0.11.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39623,7 +40537,7 @@ packages:
     dev: true
 
   /@teambit/explorer.ui.component-card@0.0.14(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-NXxynFuK+QaIgLiPjuVV9PpH1uY=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.14.tgz}
+    resolution: {integrity: sha1-NXxynFuK+QaIgLiPjuVV9PpH1uY=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.component-card/-/@teambit-explorer.ui.component-card-0.0.14.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
     dependencies:
@@ -39673,7 +40587,7 @@ packages:
     dev: false
 
   /@teambit/explorer.ui.gallery.component-card-group@1.96.1(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-KuF3gKj4pPNpjsPxlnZlgMKMdhg=, tarball: https://node-registry.v2.bit.cloud/@teambit/explorer.ui.gallery.component-card-group/-/@teambit-explorer.ui.gallery.component-card-group-1.96.1.tgz}
+    resolution: {integrity: sha1-KuF3gKj4pPNpjsPxlnZlgMKMdhg=, tarball: https://node-registry.bit.cloud/@teambit/explorer.ui.gallery.component-card-group/-/@teambit-explorer.ui.gallery.component-card-group-1.96.1.tgz}
     peerDependencies:
       '@testing-library/react': ^12.1.5
       react: ^16.8.0 || ^17.0.0
@@ -39695,7 +40609,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.link': registry.npmjs.org/@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/explorer.ui.gallery.base-component-card': 0.0.492(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -39793,7 +40707,7 @@ packages:
     dev: false
 
   /@teambit/gcp.storage@0.1.2:
-    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.v2.bit.cloud/@teambit/gcp.storage/-/@teambit-gcp.storage-0.1.2.tgz}
+    resolution: {integrity: sha1-+XgOI9N54S7Tgj8lhhfLM+JhdD0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.gcp/storage@0.1.2.tgz}
     engines: {node: '>=12.15.0'}
     dependencies:
       '@teambit/toolbox.network.agent': 0.0.540
@@ -39805,20 +40719,20 @@ packages:
     dev: false
 
   /@teambit/graph.algorithms.tarjan@0.0.1:
-    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.v2.bit.cloud/@teambit/graph.algorithms.tarjan/-/@teambit-graph.algorithms.tarjan-0.0.1.tgz}
+    resolution: {integrity: sha1-qvdq0JPyzU8m1uCKClQ82GhPgH0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graph/algorithms/tarjan@0.0.1.tgz}
     dependencies:
       lodash: 4.17.20
     dev: false
 
   /@teambit/graph.cleargraph@0.0.1:
-    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/graph.cleargraph/-/@teambit-graph.cleargraph-0.0.1.tgz}
+    resolution: {integrity: sha1-BzFkcDs2WlJjbMRpGohV0+mIBIQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graph/cleargraph@0.0.1.tgz}
     dependencies:
       '@teambit/graph.algorithms.tarjan': 0.0.1
       lodash: 4.17.20
     dev: false
 
   /@teambit/graphql.hooks.use-query-light@1.0.0(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query-light/-/@teambit-graphql.hooks.use-query-light-1.0.0.tgz}
+    resolution: {integrity: sha1-FUGp8ZjK399H63okAGKoLjBGtIE=, tarball: https://node-registry.bit.cloud/tarballs/teambit.graphql/hooks/use-query-light@1.0.0.tgz}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0
       react: ^16.8.0 || ^17.0.0
@@ -39835,7 +40749,7 @@ packages:
     dev: false
 
   /@teambit/graphql.hooks.use-query@0.0.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz}
+    resolution: {integrity: sha1-SrTB4E64Ycrvmb/n+SgPPNIdYN8=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.1.tgz}
     peerDependencies:
       '@apollo/client': 3.3.7
       react: ^16.8.0 || ^17.0.0
@@ -39851,7 +40765,7 @@ packages:
     dev: true
 
   /@teambit/graphql.hooks.use-query@0.0.7(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: https://node-registry.v2.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz}
+    resolution: {integrity: sha1-OIQYQIPSBBqKXo2ZLc9bzu4P904=, tarball: https://node-registry.bit.cloud/@teambit/graphql.hooks.use-query/-/@teambit-graphql.hooks.use-query-0.0.7.tgz}
     peerDependencies:
       '@apollo/client': 3.3.7
       react: ^16.8.0 || ^17.0.0
@@ -39903,7 +40817,7 @@ packages:
     dev: false
 
   /@teambit/html.modules.render-template@0.0.104:
-    resolution: {integrity: sha1-yC2M/azDU2z/3qMW0teWd04DjOM=, tarball: https://node-registry.v2.bit.cloud/@teambit/html.modules.render-template/-/@teambit-html.modules.render-template-0.0.104.tgz}
+    resolution: {integrity: sha1-yC2M/azDU2z/3qMW0teWd04DjOM=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.render-template/-/@teambit-html.modules.render-template-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/html.modules.create-element-from-string': 0.0.104
@@ -40227,7 +41141,7 @@ packages:
     dev: false
 
   /@teambit/lanes.ui.models@0.0.79(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-q+qkOiVQ24JKN4OzYCe6+8HW83AQD027I05RegOGjXSCeEv21JKWls1UA9Ru5LZSIWd5LndPqzRGI8o2KXVY8A==, tarball: https://node-registry.v2.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.79.tgz}
+    resolution: {integrity: sha1-YNs02OA7tmpvXL3Fe4OwyYYG5v8=, tarball: https://node-registry.bit.cloud/@teambit/lanes.ui.models/-/@teambit-lanes.ui.models-0.0.79.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40334,8 +41248,13 @@ packages:
       lodash: 4.17.21
       semver: 7.3.4
 
+  /@teambit/legacy-component-log@0.0.399:
+    resolution: {integrity: sha512-FkTmlkS/QfQ+uJaJCbFMJ8Hp2fakMkFq5B4bAl45lMzOgQYGP5am+OuFrPimm7NWUN5l3BIXv6DjSAJuWhQE8A==}
+    engines: {node: '>=12.22.0'}
+    dev: false
+
   /@teambit/mdx.ui.docs.link@0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.v2.bit.cloud/@teambit/mdx.ui.docs.link/-/@teambit-mdx.ui.docs.link-0.0.500.tgz}
+    resolution: {integrity: sha1-9wYyLJ4RST9XSG52npQ+3BJDgJ0=, tarball: https://node-registry.bit.cloud/@teambit/mdx.ui.docs.link/-/teambit-mdx.ui.docs.link-0.0.500.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -40351,19 +41270,33 @@ packages:
       - '@types/react'
     dev: false
 
+  /@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-AoIdyGYo1JmN+3UCoyMJMYiI/CJ6P4x84TQFOJnqxrExxZgZbNx004df3cIsj92mljubGGGXTxd94loqon2G7w==, tarball: https://node-registry.v2.bit.cloud/@teambit/mdx.ui.mdx-scope-context/-/@teambit-mdx.ui.mdx-scope-context-0.0.368.tgz}
+    engines: {node: '>=12.15.0'}
+    peerDependencies:
+      '@teambit/legacy': 1.0.86
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/legacy': link:node_modules/@teambit/legacy
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: false
+
   /@teambit/node.deps-detectors.detective-es6@0.0.1:
-    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.v2.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/@teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
+    resolution: {integrity: sha1-nwO+/PmFgU12kOXA1FqJvDBnVqM=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.detective-es6/-/teambit-node.deps-detectors.detective-es6-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
-      node-source-walk: 5.0.2
+      node-source-walk: 5.0.1
     dev: false
 
   /@teambit/node.deps-detectors.parser-helper@0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a:
-    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.v2.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/@teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
+    resolution: {integrity: sha1-UTUJiakxdUY1KZKMoaxTLTrRap8=, tarball: https://node-registry.bit.cloud/@teambit/node.deps-detectors.parser-helper/-/teambit-node.deps-detectors.parser-helper-0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a.tgz}
     dev: false
 
   /@teambit/pkg.content.packages-overview@1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/pkg.content.packages-overview/-/@teambit-pkg.content.packages-overview-1.95.9.tgz}
+    resolution: {integrity: sha1-zWayNWQaoC66R1elFFytwR1vaLQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.pkg/content/packages-overview@1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/components.blocks.component-card-display': 0.0.13(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
@@ -40384,7 +41317,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -40413,7 +41346,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -40433,7 +41366,7 @@ packages:
     dev: false
 
   /@teambit/react.content.react-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.content.react-overview/-/@teambit-react.content.react-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-pZxx1yJoIMPKGrX/0P+nNCzkDOQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/content/react-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40448,7 +41381,7 @@ packages:
     dev: true
 
   /@teambit/react.instructions.react-native.adding-tests@0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react-native.adding-tests/-/@teambit-react.instructions.react-native.adding-tests-0.0.1.tgz}
+    resolution: {integrity: sha1-Ej1pIaYbWdwLNUbsHMjEQQ/utnQ=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/instructions/react-native/adding-tests@0.0.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40462,8 +41395,38 @@ packages:
       - '@teambit/legacy'
     dev: false
 
+  /@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-6GzCl0ZnmpfQ923yuCahI4mXZ8wSQCeF6D4+xtCq8tk+W5GHb12ZSlHBCD5xAZsc7i7VRUUZcTdhbc8L2RhMpg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-compositions/-/@teambit-react.instructions.react.adding-compositions-0.0.6.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@teambit/legacy'
+    dev: false
+
+  /@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-OoNj8YPPc7I9a3TtUche2IdCHe2d/5hgZbjmZXWSPJVM69JCSzxhUNXaQRbiOuCI7m7+O2bBzMS4G2UboJ5Nmg==, tarball: https://node-registry.v2.bit.cloud/@teambit/react.instructions.react.adding-tests/-/@teambit-react.instructions.react.adding-tests-0.0.6.tgz}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/mdx.ui.mdx-scope-context': 0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    transitivePeerDependencies:
+      - '@teambit/legacy'
+    dev: false
+
   /@teambit/react.modules.dom-to-react@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.modules.dom-to-react/-/@teambit-react.modules.dom-to-react-0.2.0.tgz}
+    resolution: {integrity: sha1-ovU1VeKi095JGMnSfCyc4GCW5xU=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/modules/dom-to-react@0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40474,7 +41437,7 @@ packages:
     dev: false
 
   /@teambit/react.rendering.ssr@0.0.3(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-A61JbXqd1zNXk1aW4Ur5vs86BpY=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.rendering.ssr/-/@teambit-react.rendering.ssr-0.0.3.tgz}
+    resolution: {integrity: sha1-A61JbXqd1zNXk1aW4Ur5vs86BpY=, tarball: https://node-registry.bit.cloud/@teambit/react.rendering.ssr/-/@teambit-react.rendering.ssr-0.0.3.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40492,7 +41455,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.component-highlighter@0.2.1(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.component-highlighter/-/@teambit-react.ui.component-highlighter-0.2.1.tgz}
+    resolution: {integrity: sha1-MqufIIEY/hDpSBDyBy438TrlZ6Q=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/component-highlighter@0.2.1.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40507,7 +41470,7 @@ packages:
       '@tippyjs/react': 4.2.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.3.2
       core-js: 3.13.0
-      get-xpath: 3.1.0
+      get-xpath: 3.0.1
       lodash.compact: 3.0.1
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -40519,7 +41482,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.highlighter.component-metadata.bit-component-meta@0.0.21(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.highlighter.component-metadata.bit-component-meta/-/@teambit-react.ui.highlighter.component-metadata.bit-component-meta-0.0.21.tgz}
+    resolution: {integrity: sha1-lsiO3ZqBVjilHb7RsycL/pe1mmo=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/highlighter/component-metadata/bit-component-meta@0.0.21.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40531,7 +41494,7 @@ packages:
     dev: false
 
   /@teambit/react.ui.hover-selector@0.2.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.v2.bit.cloud/@teambit/react.ui.hover-selector/-/@teambit-react.ui.hover-selector-0.2.0.tgz}
+    resolution: {integrity: sha1-InitpXgCwfQW/Twb8FIsz6VOrDM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.react/ui/hover-selector@0.2.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40542,7 +41505,7 @@ packages:
     dev: false
 
   /@teambit/scope.content.scope-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.content.scope-overview/-/@teambit-scope.content.scope-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-q6rTENX4D2/Cg2fabNBlj8miHdc=, tarball: https://node-registry.bit.cloud/tarballs/teambit.scope/content/scope-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -40582,7 +41545,7 @@ packages:
     dev: false
 
   /@teambit/scope.models.scope-model@0.0.397(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-MrbiRXyS84BL1peQ4qmNEam03+8=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.397.tgz}
+    resolution: {integrity: sha1-MrbiRXyS84BL1peQ4qmNEam03+8=, tarball: https://node-registry.bit.cloud/@teambit/scope.models.scope-model/-/@teambit-scope.models.scope-model-0.0.397.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@teambit/component-descriptor': 0.0.308(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -40636,7 +41599,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/toolbox.string.get-initials': 0.0.483
       '@teambit/toolbox.url.add-avatar-query-params': 0.0.483
       classnames: 2.2.6
@@ -40646,7 +41609,7 @@ packages:
     dev: false
 
   /@teambit/scope.ui.scope-icon@0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.v2.bit.cloud/@teambit/scope.ui.scope-icon/-/@teambit-scope.ui.scope-icon-0.0.91.tgz}
+    resolution: {integrity: sha1-97V68EjNCwa1AUPriiK721YbKXA=, tarball: https://node-registry.bit.cloud/tarballs/teambit.scope/ui/scope-icon@0.0.91.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       '@testing-library/react': ^12.1.5
@@ -40670,8 +41633,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.78(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -40686,8 +41649,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -40698,52 +41661,52 @@ packages:
     dev: false
 
   /@teambit/scopes.scope-id@0.0.1:
-    resolution: {integrity: sha1-05xOQrV0zf4O4Y6AJZIsA5tT0kE=, tarball: https://node-registry.v2.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.1.tgz}
+    resolution: {integrity: sha1-05xOQrV0zf4O4Y6AJZIsA5tT0kE=, tarball: https://node-registry.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.1.tgz}
     dependencies:
       '@emotion/hash': 0.8.0
     dev: true
 
   /@teambit/scopes.scope-id@0.0.3:
-    resolution: {integrity: sha1-DudP/eIcKQEx/kKIZW80qqsfp/A=, tarball: https://node-registry.v2.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.3.tgz}
+    resolution: {integrity: sha1-DudP/eIcKQEx/kKIZW80qqsfp/A=, tarball: https://node-registry.bit.cloud/@teambit/scopes.scope-id/-/@teambit-scopes.scope-id-0.0.3.tgz}
     dependencies:
       '@emotion/hash': 0.8.0
     dev: true
 
   /@teambit/styling.deps-detectors.detective-css-and-preprocessors@0.0.2:
-    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/@teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
+    resolution: {integrity: sha1-qjsgSK3HhK1n24q5HSQ0Y6jegD8=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css-and-preprocessors/-/teambit-styling.deps-detectors.detective-css-and-preprocessors-0.0.2.tgz}
     dependencies:
       css-tree: 2.3.1
       is-url: 1.2.4
     dev: false
 
   /@teambit/styling.deps-detectors.detective-css@0.0.2:
-    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/@teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
+    resolution: {integrity: sha1-ImrQQr9pOJneNv1oG1FK2g3lR1c=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-css/-/teambit-styling.deps-detectors.detective-css-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-less@0.0.2:
-    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/@teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
+    resolution: {integrity: sha1-zcmQ/kox2mUI7FvhyV9vzbfPxuU=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-less/-/teambit-styling.deps-detectors.detective-less-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-sass@0.0.2:
-    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/@teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
+    resolution: {integrity: sha1-LhLQRl14MRng4lXnJZwfbEBehWQ=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-sass/-/teambit-styling.deps-detectors.detective-sass-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-detectors.detective-scss@0.0.2:
-    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/@teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
+    resolution: {integrity: sha1-jnWWyrqLwDsojseYpIhsnQTee70=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-detectors.detective-scss/-/teambit-styling.deps-detectors.detective-scss-0.0.2.tgz}
     dependencies:
       '@teambit/styling.deps-detectors.detective-css-and-preprocessors': 0.0.2
     dev: false
 
   /@teambit/styling.deps-lookups.lookup-styling@0.0.1:
-    resolution: {integrity: sha1-2rGGrYqcJkFXt52QqUL3ZHKAVmM=, tarball: https://node-registry.v2.bit.cloud/@teambit/styling.deps-lookups.lookup-styling/-/@teambit-styling.deps-lookups.lookup-styling-0.0.1.tgz}
+    resolution: {integrity: sha1-2rGGrYqcJkFXt52QqUL3ZHKAVmM=, tarball: https://node-registry.bit.cloud/@teambit/styling.deps-lookups.lookup-styling/-/@teambit-styling.deps-lookups.lookup-styling-0.0.1.tgz}
     dependencies:
-      enhanced-resolve: 5.15.0
+      enhanced-resolve: 5.14.1
       is-relative-path: 2.0.0
       sass-lookup: 5.0.1
     dev: false
@@ -40756,7 +41719,7 @@ packages:
     dev: false
 
   /@teambit/toolbox.network.agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.116.tgz}
+    resolution: {integrity: sha512-WYK7V5bs7S3djNjGepUhhrKcgESo7hULAUOa+6k000Z0QUaa6BfMqJ0X6aicMRJO7d8HD4wIcR0TEfc7Sa2S1Q==}
     engines: {node: '>=12.15.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.108
@@ -40769,7 +41732,7 @@ packages:
     dev: false
 
   /@teambit/toolbox.network.agent@0.0.540:
-    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.agent/-/@teambit-toolbox.network.agent-0.0.540.tgz}
+    resolution: {integrity: sha1-dNSjh0pdx9L2ltKDNdCICf2tLNg=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/network/agent@0.0.540.tgz}
     engines: {node: '>=12.22.0'}
     dependencies:
       '@pnpm/network.agent': 0.0.3
@@ -40780,7 +41743,7 @@ packages:
     dev: false
 
   /@teambit/toolbox.network.proxy-agent@0.0.116(@teambit/legacy@node_modules+@teambit+legacy):
-    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==, tarball: https://node-registry.v2.bit.cloud/@teambit/toolbox.network.proxy-agent/-/@teambit-toolbox.network.proxy-agent-0.0.116.tgz}
+    resolution: {integrity: sha512-XFF8dwV7t0tLh/OtWArayE16/j020YA5nMwOLTeFeQEK9JuA+KK820cWTILyzysOel8Xt9tfvp6x/LLq/wE13w==}
     engines: {node: '>=12.15.0'}
     peerDependencies:
       '@teambit/legacy': 1.0.108
@@ -40839,26 +41802,26 @@ packages:
     dev: false
 
   /@teambit/typescript.deps-detectors.detective-typescript@0.0.1(typescript@4.7.4):
-    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/@teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
+    resolution: {integrity: sha1-CYfE1oMi2/keTM8XJ2LSRLlbVm0=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-detectors.detective-typescript/-/teambit-typescript.deps-detectors.detective-typescript-0.0.1.tgz}
     dependencies:
       '@teambit/node.deps-detectors.parser-helper': 0.0.0-1ca3300f0fe89cba790beb930903095053a2a24a
-      '@typescript-eslint/typescript-estree': 5.62.0(typescript@4.7.4)
-      node-source-walk: 5.0.2
+      '@typescript-eslint/typescript-estree': 5.57.0(typescript@4.7.4)
+      node-source-walk: 5.0.1
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
   /@teambit/typescript.deps-lookups.lookup-typescript@0.0.1:
-    resolution: {integrity: sha1-nP/TKhnV0nBBFoCd1wddzxta10o=, tarball: https://node-registry.v2.bit.cloud/@teambit/typescript.deps-lookups.lookup-typescript/-/@teambit-typescript.deps-lookups.lookup-typescript-0.0.1.tgz}
+    resolution: {integrity: sha1-nP/TKhnV0nBBFoCd1wddzxta10o=, tarball: https://node-registry.bit.cloud/@teambit/typescript.deps-lookups.lookup-typescript/-/@teambit-typescript.deps-lookups.lookup-typescript-0.0.1.tgz}
     dependencies:
       app-module-path: 2.2.0
-      enhanced-resolve: 5.15.0
+      enhanced-resolve: 5.14.1
       is-relative-path: 2.0.0
       module-definition: 5.0.1
       object-assign: 4.1.1
       resolve: 1.22.2
-      typescript: 5.1.6
+      typescript: 5.1.3
     dev: false
 
   /@teambit/typescript.typescript-compiler@2.0.0(@teambit/legacy@node_modules+@teambit+legacy):
@@ -40897,7 +41860,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.constants.z-indexes@0.0.498(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.constants.z-indexes/-/@teambit-ui-foundation.ui.constants.z-indexes-0.0.498.tgz}
+    resolution: {integrity: sha1-q5rrOHpQsr+mATrJu4oRiyU2M2E=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.constants.z-indexes/-/@teambit-ui-foundation.ui.constants.z-indexes-0.0.498.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -40916,8 +41879,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -40935,9 +41898,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41145,8 +42108,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.486(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -41163,8 +42126,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.3.3
       '@teambit/ui-foundation.ui.keycap': 0.0.492(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -41207,7 +42170,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.navigation.react-router-adapter@6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2):
-    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.navigation.react-router-adapter/-/@teambit-ui-foundation.ui.navigation.react-router-adapter-6.1.1.tgz}
+    resolution: {integrity: sha1-tyK9S9+LsKHVvVd84qMFb/CFIeI=, tarball: https://node-registry.bit.cloud/tarballs/teambit.ui-foundation/ui/navigation/react-router-adapter@6.1.1.tgz}
     peerDependencies:
       '@types/react': ^17.0.0
       react: ^16.8.0 || ^17.0.0
@@ -41358,7 +42321,7 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.ui.rendering.html@0.0.69(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-wLxfPsjKW+2sB5juwlbAA60Oirk=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.ui.rendering.html/-/@teambit-ui-foundation.ui.rendering.html-0.0.69.tgz}
+    resolution: {integrity: sha1-wLxfPsjKW+2sB5juwlbAA60Oirk=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.ui.rendering.html/-/@teambit-ui-foundation.ui.rendering.html-0.0.69.tgz}
     engines: {node: '>=12.22.0'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
@@ -41377,17 +42340,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.modules.component-url': 0.0.128(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.deprecation-icon': 0.0.494(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.352(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.486(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.lanes': 0.0.116(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41410,17 +42373,17 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.modules.component-url': 0.0.140(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component.ui.deprecation-icon': 0.0.500(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.358(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.12(react-dom@17.0.2)(react@17.0.2)
       '@teambit/envs.ui.env-icon': 0.0.492(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.models': 0.0.36(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41440,7 +42403,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41454,7 +42417,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41506,9 +42469,9 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41522,9 +42485,9 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41538,7 +42501,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.104(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41554,7 +42517,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.bottom-link': 0.0.110(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41564,13 +42527,13 @@ packages:
     dev: false
 
   /@teambit/ui-foundation.urls.compare-url@1.23.0:
-    resolution: {integrity: sha1-7u6LJFiuBnbQPmwi791Dow7G95I=, tarball: https://node-registry.v2.bit.cloud/@teambit/ui-foundation.urls.compare-url/-/@teambit-ui-foundation.urls.compare-url-1.23.0.tgz}
+    resolution: {integrity: sha1-7u6LJFiuBnbQPmwi791Dow7G95I=, tarball: https://node-registry.bit.cloud/@teambit/ui-foundation.urls.compare-url/-/@teambit-ui-foundation.urls.compare-url-1.23.0.tgz}
     dependencies:
       url-parse: 1.5.3
     dev: true
 
   /@teambit/workspace.content.variants@1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.content.variants/-/@teambit-workspace.content.variants-1.95.9.tgz}
+    resolution: {integrity: sha1-YmooxPFjXZFNY3CxRrKZjmOYXF0=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/content/variants@1.95.9.tgz}
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -41581,7 +42544,7 @@ packages:
     dev: true
 
   /@teambit/workspace.content.workspace-overview@1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.v2.bit.cloud/@teambit/workspace.content.workspace-overview/-/@teambit-workspace.content.workspace-overview-1.95.0.tgz}
+    resolution: {integrity: sha1-x5h4JrPOVGs+OEGkH/thS8QhxhM=, tarball: https://node-registry.bit.cloud/tarballs/teambit.workspace/content/workspace-overview@1.95.0.tgz}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
@@ -41603,7 +42566,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -41618,7 +42581,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -41662,17 +42625,17 @@ packages:
       - '@types/react'
     dev: false
 
-  /@testing-library/dom@8.20.1:
-    resolution: {integrity: sha512-/DiOQ5xBxgdYRC8LNk7U+RWat0S3qRLeIw3ZIkMQ9kkVlRmwD/Eg8k8CqIpD6GW7u20JIUOfMKbxtiLutpjQ4g==}
+  /@testing-library/dom@8.20.0:
+    resolution: {integrity: sha512-d9ULIT+a4EXLX3UU8FBjauG9NnsZHkHztXoIcTsOKoOw030fyjheN9svkTULjJxtYag9DZz5Jz5qkWZDPxTFwA==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       '@babel/runtime': 7.20.0
       '@types/aria-query': 5.0.1
       aria-query: 5.1.3
       chalk: 4.1.2
       dom-accessibility-api: 0.5.16
-      lz-string: 1.5.0
+      lz-string: 1.4.4
       pretty-format: 27.5.1
 
   /@testing-library/jest-dom@5.16.2:
@@ -41681,7 +42644,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@types/testing-library__jest-dom': 5.9.5
-      aria-query: 5.3.0
+      aria-query: 5.1.3
       chalk: 3.0.0
       css: 3.0.0
       css.escape: 1.5.1
@@ -41708,16 +42671,16 @@ packages:
       react-dom: <18.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@testing-library/dom': 8.20.1
-      '@types/react-dom': 17.0.20
+      '@testing-library/dom': 8.20.0
+      '@types/react-dom': 17.0.18
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
   /@tippyjs/react@4.2.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-T6UcHtwtGkvgsBQ4bNp8BtXGxa2ujfOkWUogYkRtN4UVJ2QRgDdFoJeaPxdndnVYFEa2uTVxSFxs8QkSkZ2Gdw==}
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: '>=16.8'
+      react-dom: '>=16.8'
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -41748,7 +42711,7 @@ packages:
   /@types/archiver@5.3.1:
     resolution: {integrity: sha512-wKYZaSXaDvTZuInAWjCeGG7BEAgTWG2zZW0/f7IYFcoHB2X2d9lkVFnrOlXl3W6NrvO6Ml3FLLu8Uksyymcpnw==}
     dependencies:
-      '@types/glob': 8.1.0
+      '@types/glob': 8.0.1
     dev: true
 
   /@types/aria-query@5.0.1:
@@ -41757,11 +42720,11 @@ packages:
   /@types/babel__core@7.20.0:
     resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.20.13
       '@babel/types': 7.22.3
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
-      '@types/babel__traverse': 7.20.1
+      '@types/babel__traverse': 7.18.3
 
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
@@ -41771,11 +42734,11 @@ packages:
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.20.13
       '@babel/types': 7.22.3
 
-  /@types/babel__traverse@7.20.1:
-    resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
+  /@types/babel__traverse@7.18.3:
+    resolution: {integrity: sha512-1kbcJ40lLB7MHsj39U4Sh1uTd2E7rLEa79kmDpI6cy+XiXsteB3POdQomoq4FxszMrO3ZYchkhYJw7A2862b3w==}
     dependencies:
       '@babel/types': 7.22.3
 
@@ -41853,10 +42816,10 @@ packages:
     resolution: {integrity: sha512-m3+6WWfSSl6zqoXy8uQQifbgqV7Gt6fsyWnHLgUWVtJQk75+OfUB+edSZ52YDj7leSiZtX7w1/E4w2x/Hb0orA==}
     dev: true
 
-  /@types/connect-history-api-fallback@1.5.0:
-    resolution: {integrity: sha512-4x5FkPpLipqwthjPsF7ZRbOv3uoLUFkTA9G9v583qi4pACvq0uTELrB8OLUzPWUI4IJIyvM85vzkV1nyiI2Lig==}
+  /@types/connect-history-api-fallback@1.3.5:
+    resolution: {integrity: sha512-h8QJa8xSb1WD4fpKBDcATDNGXghFj6/3GRWG6dhmRcu0RX1Ubasur2Uvx5aeEwlf0MwblEC2bMzzMQntxnw/Cw==}
     dependencies:
-      '@types/express-serve-static-core': 4.17.35
+      '@types/express-serve-static-core': 4.17.33
       '@types/node': 12.20.4
 
   /@types/connect@3.4.35:
@@ -41896,7 +42859,7 @@ packages:
     resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
     dependencies:
       '@types/eslint': 7.28.0
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.0
 
   /@types/eslint-visitor-keys@1.0.0:
     resolution: {integrity: sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==}
@@ -41905,31 +42868,30 @@ packages:
   /@types/eslint@7.28.0:
     resolution: {integrity: sha512-07XlgzX0YJUn4iG1ocY4IX9DzKSmMGUs6ESKlxWhZRaa0fatIWaHWUVapcuGa8r5HFnTqzj+4OCjd5f7EZ/i/A==}
     dependencies:
-      '@types/estree': 1.0.1
-      '@types/json-schema': 7.0.12
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
 
   /@types/estree@0.0.39:
     resolution: {integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==}
     dev: false
 
-  /@types/estree@1.0.1:
-    resolution: {integrity: sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==}
+  /@types/estree@1.0.0:
+    resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
 
-  /@types/express-serve-static-core@4.17.35:
-    resolution: {integrity: sha512-wALWQwrgiB2AWTT91CB62b6Yt0sNHpznUXeZEcnPU3DRdlDIz74x8Qg1UUYKSVFi+va5vKOLYRBI1bRKiLLKIg==}
+  /@types/express-serve-static-core@4.17.33:
+    resolution: {integrity: sha512-TPBqmR/HRYI3eC2E5hmiivIzv+bidAfXofM+sbonAGvyDhySGw9/PQZFt2BLOrjUUR++4eJVpx6KnLQK1Fk9tA==}
     dependencies:
       '@types/node': 12.20.4
       '@types/qs': 6.9.7
       '@types/range-parser': 1.2.4
-      '@types/send': 0.17.1
 
   /@types/express@4.17.13:
     resolution: {integrity: sha512-6bSZTPaTIACxn48l50SR+axgrqm6qXFIxrdAKaG6PaJk3+zuUr35hBlgT7vOmJcum+OEaIBLtHV/qloEAFITeA==}
     dependencies:
       '@types/body-parser': 1.19.2
-      '@types/express-serve-static-core': 4.17.35
+      '@types/express-serve-static-core': 4.17.33
       '@types/qs': 6.9.7
-      '@types/serve-static': 1.15.2
+      '@types/serve-static': 1.15.0
 
   /@types/find-root@1.1.2:
     resolution: {integrity: sha512-lGuMq71TL466jtCpvh7orGd+mrdBmo2h8ozvtOOTbq3ByfWpuN+UVxv4sOv3YpsD4NhW2k6ESGhnT/FIg4Ouzw==}
@@ -41947,8 +42909,8 @@ packages:
       '@types/node': 12.20.4
     dev: true
 
-  /@types/glob@8.1.0:
-    resolution: {integrity: sha512-IO+MJPVhoqz+28h1qLAcBEH2+xHMK6MTyHJc7MTnnYb6wsoLR29POVGJ7LycmVXIqyy/4/2ShP5sUwTXuOwb/w==}
+  /@types/glob@8.0.1:
+    resolution: {integrity: sha512-8bVUjXZvJacUFkJXHdyZ9iH1Eaj5V7I8c4NdH5sQJsdXkqT4CA5Dhb4yb4VE/3asyx4L9ayZr1NIhTsWHczmMw==}
     dependencies:
       '@types/minimatch': 5.1.2
       '@types/node': 12.20.4
@@ -41964,10 +42926,10 @@ packages:
     resolution: {integrity: sha512-K7T1n6U2HbTYu+SFHlBjz/RH74OA2D/zF1qlzn8uXbvB4uRg7knOM85ugS2bbXI1TXMh7rLqk4OVRwIwEBaixg==}
     dev: true
 
-  /@types/hast@2.3.5:
-    resolution: {integrity: sha512-SvQi0L/lNpThgPoleH53cdjB3y9zpLlVjRbqB3rH8hx1jiRSBGAhyjV3H+URFjNVRqt2EdYNrbZE5IsGlNfpRg==}
+  /@types/hast@2.3.4:
+    resolution: {integrity: sha512-wLEm0QvaoawEDoTRwzTXp4b4jpwiJDvR5KMnFnVodm3scufTlBOWRD6N1OBf9TZMhjlNsSfcO5V+7AF4+Vy+9g==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
     dev: false
 
   /@types/html-minifier-terser@5.1.2:
@@ -42000,6 +42962,7 @@ packages:
 
   /@types/http-errors@2.0.1:
     resolution: {integrity: sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ==}
+    dev: false
 
   /@types/http-proxy-agent@2.0.2:
     resolution: {integrity: sha512-2S6IuBRhqUnH1/AUx9k8KWtY3Esg4eqri946MnxTG5HwehF1S5mqLln8fcyMiuQkY72p2gH3W+rIPqp5li0LyQ==}
@@ -42007,8 +42970,8 @@ packages:
       '@types/node': 12.20.4
     dev: false
 
-  /@types/http-proxy@1.17.11:
-    resolution: {integrity: sha512-HC8G7c1WmaF2ekqpnFq626xd3Zz0uvaqFmBJNRZCGEZCXkvSdJoNFn/8Ygbd9fKNQj8UzLdCETaI0UWPAjK7IA==}
+  /@types/http-proxy@1.17.9:
+    resolution: {integrity: sha512-QsbSjA/fSk7xB+UXlCT3wHBy5ai9wOcNDWwZAtud+jXhwOM3l+EYZh8Lng4+/6n8uar0J7xILzqftJdJ/Wdfkw==}
     dependencies:
       '@types/node': 12.20.4
 
@@ -42032,8 +42995,8 @@ packages:
     dependencies:
       '@types/istanbul-lib-report': 3.0.0
 
-  /@types/jasmine@3.10.11:
-    resolution: {integrity: sha512-tAiqDJrwRKyjpCgJE07OXFsXsXQWDhoJhyRwzl+yfEToy72s0LhHAfquMi2s4T4Iq3nanKOfZ8/PZFaL/0pQmA==}
+  /@types/jasmine@3.10.7:
+    resolution: {integrity: sha512-brLuHhITMz4YV2IxLstAJtyRJgtWfLqFKiqiJFvFWMSmydpAmn42CE4wfw7ywkSk02UrufhtzipTcehk8FctoQ==}
 
   /@types/jest@26.0.20:
     resolution: {integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==}
@@ -42053,8 +43016,8 @@ packages:
       parse5: 7.1.2
     dev: false
 
-  /@types/json-schema@7.0.12:
-    resolution: {integrity: sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==}
+  /@types/json-schema@7.0.11:
+    resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -42073,11 +43036,11 @@ packages:
   /@types/koa-compose@3.2.5:
     resolution: {integrity: sha512-B8nG/OoE1ORZqCkBVsup/AKcvjdgoHnfi4pZMn5UwAPCbhk/96xyv284eBYW8JlQbQ7zDmnpFr68I/40mFoIBQ==}
     dependencies:
-      '@types/koa': 2.13.6
+      '@types/koa': 2.13.5
     dev: false
 
-  /@types/koa@2.13.6:
-    resolution: {integrity: sha512-diYUfp/GqfWBAiwxHtYJ/FQYIXhlEhlyaU7lB/bWQrx4Il9lCET5UwpFy3StOAohfsxxvEQ11qIJgT1j2tfBvw==}
+  /@types/koa@2.13.5:
+    resolution: {integrity: sha512-HSUOdzKz3by4fnqagwthW/1w/yJspTgppyyalPVbgZf8jQWvdIXcVW5h2DGtw4zYntOaeRGx49r1hxoPWrD4aA==}
     dependencies:
       '@types/accepts': 1.3.5
       '@types/content-disposition': 0.5.5
@@ -42131,10 +43094,10 @@ packages:
     resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
     dev: false
 
-  /@types/mdast@3.0.12:
-    resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
+  /@types/mdast@3.0.10:
+    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
     dev: false
 
   /@types/mdx-js__react@1.5.5:
@@ -42146,9 +43109,6 @@ packages:
   /@types/memoizee@0.4.5:
     resolution: {integrity: sha512-+ZzZZ3+0a7/ajBPeAAD4+LxrBsCat0EFZQtO3o0rwpIeLmDmSaM8KF/oYPuFxeUFAMiHIHFcGucFnY/8S4Hszg==}
     dev: true
-
-  /@types/mime@1.3.2:
-    resolution: {integrity: sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==}
 
   /@types/mime@2.0.3:
     resolution: {integrity: sha512-Jus9s4CDbqwocc5pOAnh8ShfrnMcPHuJYzVcSUU7lrh8Ni5HuIqX3oilL86p3dlTrk0LzHRCgA/GQ7uNCw6l2Q==}
@@ -42199,8 +43159,8 @@ packages:
     resolution: {integrity: sha512-s3nugnZumCC//n4moGGe6tkNMyYEdaDBitVjwPxXmR5lnMG5dHePinH2EdxkG3Rh1ghFHHixAG4NJhpJW1rthQ==}
     dev: false
 
-  /@types/node@18.16.19:
-    resolution: {integrity: sha512-IXl7o+R9iti9eBW4Wg2hx1xQDig183jj7YLn8F7udNceyfkbn1ZxmzZXuak20gR40D7pIkIY1kYGx5VIGbaHKA==}
+  /@types/node@18.11.18:
+    resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
     dev: false
 
   /@types/normalize-package-data@2.4.1:
@@ -42261,8 +43221,8 @@ packages:
       - debug
     dev: true
 
-  /@types/react-dom@17.0.20:
-    resolution: {integrity: sha512-4pzIjSxDueZZ90F52mU3aPoogkHIoSIDG+oQ+wQK7Cy2B9S+MvOqY0uEA/qawKz381qrEDkvpwyt8Bm31I8sbA==}
+  /@types/react-dom@17.0.18:
+    resolution: {integrity: sha512-rLVtIfbwyur2iFKykP2w0pl/1unw26b5td16d5xMgp7/yjTHomkyxPYChFoCr/FtEX1lN9wY6lFj1qvKdS5kDw==}
     dependencies:
       '@types/react': 17.0.8
 
@@ -42276,8 +43236,8 @@ packages:
     resolution: {integrity: sha512-3sx4c0PbXujrYAKwXxNONXUtRp9C+hE2di0IuxFyf5BELD+B+AXL8G7QrmSKhVwKZDbv0igiAjQAMhXj8Yg3aw==}
     dependencies:
       '@types/prop-types': 15.7.5
-      '@types/scheduler': 0.16.3
-      csstype: 3.1.2
+      '@types/scheduler': 0.16.2
+      csstype: 3.1.1
 
   /@types/relateurl@0.2.29:
     resolution: {integrity: sha512-QSvevZ+IRww2ldtfv1QskYsqVVVwCKQf1XbwtcyyoRvLIQzfyPhj/C+3+PKzSDRdiyejaiLgnq//XTkleorpLg==}
@@ -42305,8 +43265,8 @@ packages:
       sass: 1.63.6
     dev: false
 
-  /@types/scheduler@0.16.3:
-    resolution: {integrity: sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ==}
+  /@types/scheduler@0.16.2:
+    resolution: {integrity: sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==}
 
   /@types/semver@6.2.3:
     resolution: {integrity: sha512-KQf+QAMWKMrtBMsB8/24w53tEsxllMj6TuA80TT/5igJalLI/zm0L3oXRbIAl4Ohfc85gyHX/jhMwsVkmhLU4A==}
@@ -42315,21 +43275,14 @@ packages:
   /@types/semver@7.3.4:
     resolution: {integrity: sha512-+nVsLKlcUCeMzD2ufHEYuJ9a2ovstb6Dp52A5VsoKxDXgvE051XgHI/33I1EymwkRGQkwnA0LkhnUzituGs4EQ==}
 
-  /@types/send@0.17.1:
-    resolution: {integrity: sha512-Cwo8LE/0rnvX7kIIa3QHCkcuF21c05Ayb0ZfxPiv0W8VRiZiNW/WuRupHKpqqGVGf7SUA44QSOUKaEd9lIrd/Q==}
-    dependencies:
-      '@types/mime': 1.3.2
-      '@types/node': 12.20.4
-
   /@types/serve-index@1.9.1:
     resolution: {integrity: sha512-d/Hs3nWDxNL2xAczmOVZNj92YZCS6RGxfBPjKzuu/XirCgXdpKEb88dYNbrYGint6IVWLNP+yonwVAuRC0T2Dg==}
     dependencies:
       '@types/express': 4.17.13
 
-  /@types/serve-static@1.15.2:
-    resolution: {integrity: sha512-J2LqtvFYCzaj8pVYKw8klQXrLLk7TBZmQ4ShlcdkELFKGwGMfevMLneMMRkMgZxotOD9wg497LpC7O8PcvAmfw==}
+  /@types/serve-static@1.15.0:
+    resolution: {integrity: sha512-z5xyF6uh8CbjAu9760KDKsH2FcDxZ2tFCsA4HIMWE6IkiYMXfVoa+4f9KX+FN0ZLsaMw1WNG2ETLA6N+/YA+cg==}
     dependencies:
-      '@types/http-errors': 2.0.1
       '@types/mime': 2.0.3
       '@types/node': 12.20.4
 
@@ -42373,12 +43326,8 @@ packages:
     resolution: {integrity: sha512-ONpcZAEYlbPx4EtJwfTyCDQJGUpKf4sEcuySdCVjK5Fj/3vHp5HII1fqa1/+qrsLnpYELCQTfVW/awsGJePoIg==}
     dev: false
 
-  /@types/triple-beam@1.3.2:
-    resolution: {integrity: sha512-txGIh+0eDFzKGC25zORnswy+br1Ha7hj5cMVwKIU7+s0U2AxxJru/jZSMU6OC9MJWP6+pc/hc6ZjyZShpsyY2g==}
-    dev: false
-
-  /@types/trusted-types@2.0.3:
-    resolution: {integrity: sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==}
+  /@types/trusted-types@2.0.2:
+    resolution: {integrity: sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg==}
     dev: false
 
   /@types/ua-parser-js@0.7.35:
@@ -42391,8 +43340,8 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /@types/unist@2.0.7:
-    resolution: {integrity: sha512-cputDpIbFgLUaGQn6Vqg3/YsJwxUwHLO13v3i5ouxT4lat0khip9AEWxtERujXV9wxIB1EyF97BSJFt6vpdI8g==}
+  /@types/unist@2.0.6:
+    resolution: {integrity: sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==}
     dev: false
 
   /@types/url-join@4.0.0:
@@ -42410,9 +43359,9 @@ packages:
   /@types/webpack-dev-server@3.11.6(debug@4.3.2):
     resolution: {integrity: sha512-XCph0RiiqFGetukCTC3KVnY1jwLcZ84illFRMbyFzCcWl90B/76ew0tSqF46oBhnLC4obNDG7dMO0JfTN0MgMQ==}
     dependencies:
-      '@types/connect-history-api-fallback': 1.5.0
+      '@types/connect-history-api-fallback': 1.3.5
       '@types/express': 4.17.13
-      '@types/serve-static': 1.15.2
+      '@types/serve-static': 1.15.0
       '@types/webpack': 4.41.33
       http-proxy-middleware: 1.3.1(debug@4.3.2)
     transitivePeerDependencies:
@@ -42470,8 +43419,8 @@ packages:
       '@types/node': 12.20.4
     dev: false
 
-  /@types/ws@8.5.5:
-    resolution: {integrity: sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==}
+  /@types/ws@8.5.4:
+    resolution: {integrity: sha512-zdQDHKUgcX/zBc4GrwsE/7dVdAD8JR4EuiAXiiUhhfyIJXXb2+PrGshFyeXWQPMmmZ2XxgaqclgpIC7eTXc1mg==}
     dependencies:
       '@types/node': 12.20.4
 
@@ -42528,7 +43477,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/type-utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
       '@typescript-eslint/utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.4
@@ -42546,7 +43495,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
       '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.7.4)
       eslint: 7.32.0
       eslint-scope: 5.1.1
@@ -42562,7 +43511,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
       '@typescript-eslint/types': 3.10.1
       '@typescript-eslint/typescript-estree': 3.10.1(typescript@3.9.10)
       eslint: 6.8.0
@@ -42579,7 +43528,7 @@ packages:
     peerDependencies:
       eslint: '*'
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
       '@typescript-eslint/typescript-estree': 4.33.0(typescript@4.7.4)
@@ -42656,18 +43605,16 @@ packages:
     resolution: {integrity: sha512-XL2TBTSrh3yWAsMYpKseBYTVpvudNf69rPOWXWVBI08My2JVT5jR66eTt4IgQFHA/giiKJW5dUD4x/ZviCKyGg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
-      eslint: '*'
+      eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
       typescript: '*'
     peerDependenciesMeta:
-      eslint:
-        optional: true
       typescript:
         optional: true
     dependencies:
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/typescript-estree': 5.35.1(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 7.32.0
       typescript: 4.7.4
     transitivePeerDependencies:
@@ -42709,7 +43656,7 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/utils': 5.35.1(eslint@7.32.0)(typescript@4.7.4)
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       eslint: 7.32.0
       tsutils: 3.21.0(typescript@4.7.4)
       typescript: 4.7.4
@@ -42737,8 +43684,8 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/types@5.62.0:
-    resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
+  /@typescript-eslint/types@5.57.0:
+    resolution: {integrity: sha512-mxsod+aZRSyLT+jiqHw1KK6xrANm19/+VFALVFP5qa/aiJnlP38qpyaTd0fEKhWvQk6YeNZ5LGwI1pDpBRBhtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -42839,7 +43786,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/visitor-keys': 5.35.1
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -42849,8 +43796,8 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/typescript-estree@5.62.0(typescript@4.7.4):
-    resolution: {integrity: sha512-CmcQ6uY7b9y694lKdRB8FEel7JbU/40iSAPomu++SjLMntB+2Leay2LO6i8VnJk58MtE9/nQSFIH6jpyRWyYzA==}
+  /@typescript-eslint/typescript-estree@5.57.0(typescript@4.7.4):
+    resolution: {integrity: sha512-LTzQ23TV82KpO8HPnWuxM2V7ieXW8O142I7hQTxWIHDcCEIjtkat6H96PFkYBQqGFLW/G/eVVOB9Z8rcvdY/Vw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       typescript: '*'
@@ -42858,9 +43805,9 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/types': 5.62.0
-      '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.4(supports-color@9.4.0)
+      '@typescript-eslint/types': 5.57.0
+      '@typescript-eslint/visitor-keys': 5.57.0
+      debug: 4.3.4(supports-color@9.3.1)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.5.2
@@ -42876,7 +43823,7 @@ packages:
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.35.1
       '@typescript-eslint/types': 5.35.1
       '@typescript-eslint/typescript-estree': 5.35.1(typescript@4.7.4)
@@ -42916,15 +43863,15 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       '@typescript-eslint/types': 5.35.1
-      eslint-visitor-keys: 3.4.1
+      eslint-visitor-keys: 3.3.0
     dev: false
 
-  /@typescript-eslint/visitor-keys@5.62.0:
-    resolution: {integrity: sha512-07ny+LHRzQXepkGg6w0mFY41fVUNBrL2Roj/++7V1txKugfjm/Ci/qSND03r2RhlJhJYMcTn9AhhSSqQp0Ysyw==}
+  /@typescript-eslint/visitor-keys@5.57.0:
+    resolution: {integrity: sha512-ery2g3k0hv5BLiKpPuwYt9KBkAp2ugT6VvyShXdLOkax895EC55sP0Tx5L0fZaQueiK3fBLvHVvEl3jFS5ia+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
-      '@typescript-eslint/types': 5.62.0
-      eslint-visitor-keys: 3.4.1
+      '@typescript-eslint/types': 5.57.0
+      eslint-visitor-keys: 3.3.0
     dev: false
 
   /@ungap/promise-all-settled@1.1.2:
@@ -42939,13 +43886,13 @@ packages:
       http-status-codes: 2.2.0
     dev: false
 
-  /@verdaccio/config@6.0.0-6-next.74:
-    resolution: {integrity: sha512-qpP3Hc6OCdUjJw17SQaEBPfTY/YFAGpWuiUizX5D9P46Xf/pEL99oViqA77xJPI0VZIlVue4kxcAO/zJ2oxNwA==}
+  /@verdaccio/config@6.0.0-6-next.71:
+    resolution: {integrity: sha512-PvXXVNw28I9JWw7TYCbjA5jkkwbliZTB+TNXzWaFVOpW6s+94WWQzBNUUvPG67iPW4Wgo1ciHVdde/zOeFNfYw==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
-      '@verdaccio/utils': 6.0.0-6-next.42
-      debug: 4.3.4(supports-color@9.4.0)
+      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/utils': 6.0.0-6-next.39
+      debug: 4.3.4(supports-color@9.3.1)
       js-yaml: 4.1.0
       lodash: 4.17.21
       minimatch: 3.1.2
@@ -42954,8 +43901,8 @@ packages:
       - supports-color
     dev: false
 
-  /@verdaccio/core@6.0.0-6-next.74:
-    resolution: {integrity: sha512-aXryZX2GyvWLvEn2pnxarTY6nOedrh9W7uGsXaW7uYOD7dq8lOQ4NH8Hhl/nw+Sswp3mE5JNl2P3nIoGyhOYiQ==}
+  /@verdaccio/core@6.0.0-6-next.71:
+    resolution: {integrity: sha512-leREshFssUKy+yI+Y6r9uyfuOEluLbdEs47WpI0hlV6htXkgBjfWIi884i4V/SCm+UIU8Dhn2iHPRo06KlRvFQ==}
     engines: {node: '>=12'}
     dependencies:
       ajv: 8.12.0
@@ -42963,7 +43910,7 @@ packages:
       http-errors: 2.0.0
       http-status-codes: 2.2.0
       process-warning: 1.0.0
-      semver: 7.5.4
+      semver: 7.5.0
     dev: false
 
   /@verdaccio/file-locking@10.3.1:
@@ -42988,7 +43935,7 @@ packages:
       '@verdaccio/file-locking': 10.3.1
       '@verdaccio/streams': 10.2.1
       async: 3.2.4
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       lodash: 4.17.21
       lowdb: 1.0.0
       mkdirp: 1.0.4
@@ -42996,24 +43943,24 @@ packages:
       - supports-color
     dev: false
 
-  /@verdaccio/logger-7@6.0.0-6-next.19:
-    resolution: {integrity: sha512-DQwmPPRWvrT4TMur4g4+c5dNr7WnoT6sXYpw0Yh6NgZpH2D6FMcaxpH1me0rklpfnnXZmV3/zs2MvLJaWmRl4w==}
+  /@verdaccio/logger-7@6.0.0-6-next.16:
+    resolution: {integrity: sha512-QElvJcICP3DiJgDPUP4JRjWuImh6RbLWeK83iubrb/y865OmvrOgCgnBAZn0/i/L6buPFa/Sh5A07PBRuYWHgw==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/logger-commons': 6.0.0-6-next.42
+      '@verdaccio/logger-commons': 6.0.0-6-next.39
       pino: 7.11.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/logger-commons@6.0.0-6-next.42:
-    resolution: {integrity: sha512-ydp12CVXdYhkXPxJevGW38Qf9HJdOF/KWcDmCWo7pi9atfiMkUWoOuEC1nr+7Dx+S5dA7kDfTqFLdadAuyO93A==}
+  /@verdaccio/logger-commons@6.0.0-6-next.39:
+    resolution: {integrity: sha512-jdk8nDu2u3307XV2RtBo+FrC30xXGuSvZN7pQqFWCB9dJo21LpsMPTCgj9eBEwaAT+/ICTJURjO0VBkMlvcbGQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.71
       '@verdaccio/logger-prettify': 6.0.0-6-next.10
       colorette: 2.0.20
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -43029,15 +43976,15 @@ packages:
       sonic-boom: 3.3.0
     dev: false
 
-  /@verdaccio/middleware@6.0.0-6-next.53:
-    resolution: {integrity: sha512-shzf8+ww161TGOQA+Ee+JsWLgji07kkxLJr+YQSj3d9glbq4OE64sw51cV3BwpBbIALWziLTmIbYLaZgaRkZYg==}
+  /@verdaccio/middleware@6.0.0-6-next.50:
+    resolution: {integrity: sha512-eWn1C3p4Tc2ijqrzM0YjSb48DyNkH30UURjh23WyUVrMC7sn7s0DR9DlrRlVC8OSi8oqyQzV1KihowkzFLDcag==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.74
-      '@verdaccio/core': 6.0.0-6-next.74
-      '@verdaccio/url': 11.0.0-6-next.40
-      '@verdaccio/utils': 6.0.0-6-next.42
-      debug: 4.3.4(supports-color@9.4.0)
+      '@verdaccio/config': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/url': 11.0.0-6-next.37
+      '@verdaccio/utils': 6.0.0-6-next.39
+      debug: 4.3.4(supports-color@9.3.1)
       express: 4.18.2
       express-rate-limit: 5.5.1
       lodash: 4.17.21
@@ -43056,7 +44003,7 @@ packages:
     resolution: {integrity: sha512-aFvMbxxHzJCpPmqSgVuQYvYN2RP11CoSEcTXikkyb1zF4Uf3cOy53zUZ1Y7iOKCRYTgWrmet9KP7+24e44GHxg==}
     engines: {node: '>=12'}
     dependencies:
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       jsonwebtoken: 9.0.0
       lodash: 4.17.21
     transitivePeerDependencies:
@@ -43068,43 +44015,43 @@ packages:
     engines: {node: '>=12', npm: '>=5'}
     dev: false
 
-  /@verdaccio/tarball@11.0.0-6-next.43:
-    resolution: {integrity: sha512-/cojl1+EWLhfu5FJh/dLBtwwC+vI6dR0xldJvE7BHJ5P79DnBUbzAqtwoWwsOR2FkGkWoReXZjPR4QVrUivhLA==}
+  /@verdaccio/tarball@11.0.0-6-next.40:
+    resolution: {integrity: sha512-1470DzyV9fdEsjqFhjOQ/5kU5EEgHXV8tyqKyZK+AQ+2g6mpj6NfU5Q82fpmoyzNlPGjREygE75KBv/niRCgRA==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
-      '@verdaccio/url': 11.0.0-6-next.40
-      '@verdaccio/utils': 6.0.0-6-next.42
-      debug: 4.3.4(supports-color@9.4.0)
+      '@verdaccio/core': 6.0.0-6-next.71
+      '@verdaccio/url': 11.0.0-6-next.37
+      '@verdaccio/utils': 6.0.0-6-next.39
+      debug: 4.3.4(supports-color@9.3.1)
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/ui-theme@6.0.0-6-next.74:
-    resolution: {integrity: sha512-IoAl4bbLF9SFJsQvyEbJeubRs0O2WusOOgry6vsfp1w48+oarcnGkdOU/WZuIdlFhmPdhOJpYL0cFDUBRDvdOA==}
+  /@verdaccio/ui-theme@6.0.0-6-next.71:
+    resolution: {integrity: sha512-HX9NY0pZSg/H1C4GHLGzt91Xo5Oq8+VyZYN3JocHKev/EIE6G2/UuInKGAJxxdSIkno6jUyfrGZi2t9Qhgwwnw==}
     dev: false
 
-  /@verdaccio/url@11.0.0-6-next.40:
-    resolution: {integrity: sha512-TGP+96QEgvQMIx+0WsFmxpeV/YJlX+os85zrBipioZDUm/JmNK6i9wCfYjA5Uncn+NGRsI6bUJhi05Ymoh10cA==}
+  /@verdaccio/url@11.0.0-6-next.37:
+    resolution: {integrity: sha512-bPEq/aS77IzMUv7H1Zq4fVJeM7IxIImCan+ydQzFWGJfoGXgAz8p5PBm1+fqCgtEyQ/TeK6EowdXitX9lAIGVQ==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
-      debug: 4.3.4(supports-color@9.4.0)
+      '@verdaccio/core': 6.0.0-6-next.71
+      debug: 4.3.4(supports-color@9.3.1)
       lodash: 4.17.21
       validator: 13.9.0
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@verdaccio/utils@6.0.0-6-next.42:
-    resolution: {integrity: sha512-ckf1N0rlnWd07aQQx+K9/fvO1LtSVGAAls22Isdfb+dfBjUYalIha/EDIEr3mq7QTqm0zA6mLhP7m4Bv35FH6g==}
+  /@verdaccio/utils@6.0.0-6-next.39:
+    resolution: {integrity: sha512-V4+pBaXxObgofHcAw7BZXv2RZwCi2KaWNIcpQNYz6AcF15gLT0C2/8e1M8nMLb7Qnips3fetpA26VNNvl5XRdw==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.71
       lodash: 4.17.21
       minimatch: 3.1.2
-      semver: 7.5.4
+      semver: 7.5.0
     dev: false
 
   /@webassemblyjs/ast@1.11.6:
@@ -43202,13 +44149,13 @@ packages:
     resolution: {integrity: sha512-LOmVnY1iTU2D8tv4Xf6MVMZZ+juIJ87Kt/plMijjN20NMAXGmH4u8bS1t0uT74cZ5gwpocYueV58YwyI8y+GKw==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
 
-  /@wry/context@0.7.3:
-    resolution: {integrity: sha512-Nl8WTesHp89RF803Se9X3IiHjdmLBrIvPMaJkl+rKVJAYyPsz1TEUbu89943HpvujtSJgDUx9W4vZw3K1Mr3sA==}
+  /@wry/context@0.7.0:
+    resolution: {integrity: sha512-LcDAiYWRtwAoSOArfk7cuYvFXytxfVrdX7yxoUmK7pPITLk5jYh2F8knCwS7LjgYL8u1eidPlKKV6Ikqq0ODqQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
 
   /@wry/equality@0.1.11:
     resolution: {integrity: sha512-mwEVBDUVODlsQQ5dfuLUS5/Tf7jqUKyhKYHmVi4fPB6bDMOfWvUPJmKgS1Z7Za/sOI3vzWt4+O7yCiL/70MogA==}
@@ -43216,17 +44163,17 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@wry/equality@0.5.6:
-    resolution: {integrity: sha512-D46sfMTngaYlrH+OspKf8mIJETntFnf6Hsjb0V41jAXJ7Bx2kB8Rv8RCUujuVWYttFtHkUNp7g+FwxNQAr6mXA==}
+  /@wry/equality@0.5.3:
+    resolution: {integrity: sha512-avR+UXdSrsF2v8vIqIgmeTY0UR91UT+IyablCyKe/uk22uOJ8fusKZnH9JH9e1/EtLeNJBtagNmL3eJdnOV53g==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
 
   /@wry/trie@0.3.2:
     resolution: {integrity: sha512-yRTyhWSls2OY/pYLfwff867r8ekooZ4UI+/gxot5Wj8EFwSf2rG+n+Mo/6LoLQm1TKA4GRj2+LCpbfS937dClQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
 
   /@xobotyi/scrollbar-width@1.9.5:
     resolution: {integrity: sha512-N8tkAACJx2ww8vFMneJmaAgmjAG1tnVBZJRLRcx061tmsLRZHSEZSLuGWnwPtunsSLvSqXQ2wfp7Mgqg1I+2dQ==}
@@ -43270,7 +44217,7 @@ packages:
       clipanion: 3.2.0-rc.4
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.13.0
+      typanion: 3.12.1
       yup: 0.32.11
     dev: false
 
@@ -43319,10 +44266,10 @@ packages:
       '@arcanis/slice-ansi': 1.1.1
       '@types/semver': 7.3.4
       '@types/treeify': 1.0.0
-      '@yarnpkg/fslib': 3.0.0-rc.48
-      '@yarnpkg/libzip': 3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48)
-      '@yarnpkg/parsers': 3.0.0-rc.48.1
-      '@yarnpkg/shell': 4.0.0-rc.48
+      '@yarnpkg/fslib': 3.0.0-rc.45
+      '@yarnpkg/libzip': 3.0.0-rc.45(@yarnpkg/fslib@3.0.0-rc.45)
+      '@yarnpkg/parsers': 3.0.0-rc.45
+      '@yarnpkg/shell': 4.0.0-rc.45
       camelcase: 5.3.1
       chalk: 3.0.0
       ci-info: 3.8.0
@@ -43339,39 +44286,7 @@ packages:
       tar: 6.1.11
       tinylogic: 2.0.0
       treeify: 1.1.0
-      tslib: 2.6.0
-      tunnel: 0.0.6
-    dev: false
-
-  /@yarnpkg/core@4.0.0-rc.48:
-    resolution: {integrity: sha512-GEJyVLD9XqnUr9f+ndpvewKYWenFbQ/Ki82mIW/YAIeomEF6Nqis2idL71LaxSr6kkTHvaa7JOSnNALLdbaD6w==}
-    engines: {node: '>=18.12.0'}
-    dependencies:
-      '@arcanis/slice-ansi': 1.1.1
-      '@types/semver': 7.3.4
-      '@types/treeify': 1.0.0
-      '@yarnpkg/fslib': 3.0.0-rc.48
-      '@yarnpkg/libzip': 3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48)
-      '@yarnpkg/parsers': 3.0.0-rc.48.1
-      '@yarnpkg/shell': 4.0.0-rc.48
-      camelcase: 5.3.1
-      chalk: 3.0.0
-      ci-info: 3.8.0
-      clipanion: 3.2.1
-      cross-spawn: 7.0.3
-      diff: 5.1.0
-      dotenv: 16.3.1
-      globby: 11.0.1
-      got: 11.8.6
-      lodash: 4.17.21
-      micromatch: 4.0.5
-      p-limit: 2.3.0
-      semver: 7.5.2
-      strip-ansi: 6.0.0
-      tar: 6.1.11
-      tinylogic: 2.0.0
-      treeify: 1.1.0
-      tslib: 2.6.0
+      tslib: 2.5.0
       tunnel: 0.0.6
     dev: false
 
@@ -43401,11 +44316,11 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/fslib@3.0.0-rc.48:
-    resolution: {integrity: sha512-ej3fAmvcOHaKP5urPKw3MnSxTllfsFGEyjavHR4IlVkCwC+TdFN4OT64XvxBLXA51/RhkfRyIQq1BVrNiafTwQ==}
-    engines: {node: '>=18.12.0'}
+  /@yarnpkg/fslib@3.0.0-rc.45:
+    resolution: {integrity: sha512-XarEtHTbeO4+rgZQObn16+uFzb1dXiVHuoqDNGoMywwBm/FF7DeCqSANeKiNYbi79WMgoLk8l3lO4g0vRYkJBg==}
+    engines: {node: '>=14.15.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /@yarnpkg/json-proxy@2.1.1:
@@ -43424,15 +44339,15 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/libzip@3.0.0-rc.48(@yarnpkg/fslib@3.0.0-rc.48):
-    resolution: {integrity: sha512-WqqbaqRsS72LY3JXiHHrojTDG8PeeVwKBdn3NfQyqowzSVDr6Vu9c/WwWirR6K4QVmJKC1Obt1lKsAfMiRry0A==}
-    engines: {node: '>=18.12.0'}
+  /@yarnpkg/libzip@3.0.0-rc.45(@yarnpkg/fslib@3.0.0-rc.45):
+    resolution: {integrity: sha512-ZsYi6Y01yMJOLnJ5ISZgOFvCEXzp4EScrM91D7bvCx0lIfH3DZ40H4M5nGNeVFk7jXUHOXuJkNYlNoXixSconA==}
+    engines: {node: '>=14.15.0'}
     peerDependencies:
-      '@yarnpkg/fslib': ^3.0.0-rc.48
+      '@yarnpkg/fslib': ^3.0.0-rc.45
     dependencies:
       '@types/emscripten': 1.39.6
-      '@yarnpkg/fslib': 3.0.0-rc.48
-      tslib: 2.6.0
+      '@yarnpkg/fslib': 3.0.0-rc.45
+      tslib: 2.5.0
     dev: false
 
   /@yarnpkg/lockfile@1.1.0:
@@ -43452,9 +44367,9 @@ packages:
     resolution: {integrity: sha512-cMKhX2znU0JqkPNM5jSrHyS6zIcJrIf1SgzopNtWqzuvpmtpChRMUUS6RJafS8Gzq2iDXAnyb4pn0RIqlwB+Cw==}
     engines: {node: '>=14.15.0'}
     dependencies:
-      '@yarnpkg/core': 4.0.0-rc.48
-      '@yarnpkg/fslib': 3.0.0-rc.48
-      '@yarnpkg/pnp': 4.0.0-rc.48
+      '@yarnpkg/core': 4.0.0-rc.45
+      '@yarnpkg/fslib': 3.0.0-rc.45
+      '@yarnpkg/pnp': 4.0.0-rc.45
     dev: false
 
   /@yarnpkg/parsers@2.5.1:
@@ -43465,11 +44380,12 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/parsers@3.0.0-rc.48.1:
-    resolution: {integrity: sha512-qEewJouhRvaecGjbkjz9kMKn96UASbDodNrE5MYy2TrXkHcisIkbMxZdGBYfAq+s1dFtCSx/5H4k5bEkfakM+A==}
+  /@yarnpkg/parsers@3.0.0-rc.45:
+    resolution: {integrity: sha512-Aj0aHBV/crFQTpKQvL6k1xNiOhnlfVLu06LunelQAvl1MTeWrSi8LD9UJJDCFJiG4kx8NysUE6Tx0KZyPQUzIw==}
+    engines: {node: '>=14.15.0'}
     dependencies:
       js-yaml: 3.14.1
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /@yarnpkg/plugin-compat@3.1.13(@yarnpkg/core@3.5.2)(@yarnpkg/plugin-patch@3.2.4):
@@ -43520,7 +44436,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.13.0
+      typanion: 3.12.1
     dev: false
 
   /@yarnpkg/plugin-file@2.3.1(@yarnpkg/core@3.5.2):
@@ -43640,7 +44556,7 @@ packages:
       micromatch: 4.0.5
       semver: 7.5.2
       tslib: 1.14.1
-      typanion: 3.13.0
+      typanion: 3.12.1
     dev: false
 
   /@yarnpkg/plugin-npm@2.7.4(@yarnpkg/core@3.5.2)(@yarnpkg/plugin-pack@3.2.0):
@@ -43757,12 +44673,12 @@ packages:
       '@yarnpkg/fslib': 2.10.3
     dev: false
 
-  /@yarnpkg/pnp@4.0.0-rc.48:
-    resolution: {integrity: sha512-veLzNrT9EUev/jEjZcZolw6KYbINN3UsBIVM0OlPNZhNBmHTdwO5dnNhhPoTQgauEye1zg7MEIUC9j5+5p1+mg==}
-    engines: {node: '>=18.12.0'}
+  /@yarnpkg/pnp@4.0.0-rc.45:
+    resolution: {integrity: sha512-3m1gsj+ptDH2aAmmfP6RqVU0cyLJDNT2QUIe7yIRVs0oX1d6YK3Xkacm8d/EwOfDvwliEP0t6boRp2NQGxGB8Q==}
+    engines: {node: '>=14.15.0'}
     dependencies:
-      '@types/node': 18.16.19
-      '@yarnpkg/fslib': 3.0.0-rc.48
+      '@types/node': 18.11.18
+      '@yarnpkg/fslib': 3.0.0-rc.45
     dev: false
 
   /@yarnpkg/shell@3.2.5:
@@ -43781,19 +44697,19 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /@yarnpkg/shell@4.0.0-rc.48:
-    resolution: {integrity: sha512-0FMPepj3C/hr6Vsbmcv3+/Go6fxn1imO25l2ctSem5fFKLPpH2vsYysyfG60tX+UgM3yysBwMKSFZTRUSYOmdQ==}
-    engines: {node: '>=18.12.0'}
+  /@yarnpkg/shell@4.0.0-rc.45:
+    resolution: {integrity: sha512-I8VxA7GKlf6Uov9XaAJR0Xgvoh5+6CRsAB0AhV+/x8HwZzhF2CN8sytpiMJ5v7MtZpYk9kRkZsPypIY+/tkj+A==}
+    engines: {node: '>=14.15.0'}
     hasBin: true
     dependencies:
-      '@yarnpkg/fslib': 3.0.0-rc.48
-      '@yarnpkg/parsers': 3.0.0-rc.48.1
+      '@yarnpkg/fslib': 3.0.0-rc.45
+      '@yarnpkg/parsers': 3.0.0-rc.45
       chalk: 3.0.0
       clipanion: 3.2.1
       cross-spawn: 7.0.3
       fast-glob: 3.3.0
       micromatch: 4.0.5
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /@zkochan/cmd-shim@5.4.1:
@@ -43902,12 +44818,12 @@ packages:
       acorn-walk: 7.2.0
     dev: false
 
-  /acorn-import-assertions@1.9.0(acorn@8.10.0):
+  /acorn-import-assertions@1.9.0(acorn@8.8.2):
     resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
     peerDependencies:
       acorn: ^8
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.8.2
 
   /acorn-jsx@3.0.1:
     resolution: {integrity: sha512-AU7pnZkguthwBjKgCg6998ByQNIMjbuDQZ8bb78QAFZwPfmKia8AIzgY/gWgqCjnht8JLdXmB4YxA0KaV60ncQ==}
@@ -43946,8 +44862,8 @@ packages:
     hasBin: true
     dev: false
 
-  /acorn@8.10.0:
-    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
+  /acorn@8.8.2:
+    resolution: {integrity: sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -44249,7 +45165,7 @@ packages:
     peerDependencies:
       graphql: ^14.2.1 || ^15.0.0
     dependencies:
-      core-js-pure: 3.31.1
+      core-js-pure: 3.27.2
       graphql: 15.8.0
       lodash.sortby: 4.7.0
       sha.js: 2.4.11
@@ -44301,7 +45217,7 @@ packages:
   /apollo-link@1.2.14(graphql@15.8.0):
     resolution: {integrity: sha512-p67CMEFP7kOG1JZ0ZkYZwRDa369w5PIjtMjvrQd/HnIV8FRsHRqLqK+oAZQnFa1DDdZtOtHTi+aMIW6EatC2jg==}
     peerDependencies:
-      graphql: '*'
+      graphql: ^0.11.3 || ^0.12.3 || ^0.13.0 || ^14.0.0 || ^15.0.0
     dependencies:
       apollo-utilities: 1.3.4(graphql@15.8.0)
       graphql: 15.8.0
@@ -44378,7 +45294,7 @@ packages:
     deprecated: The `apollo-server-env` package is part of Apollo Server v2 and v3, which are now deprecated (end-of-life October 22nd 2023). This package's functionality is now found in the `@apollo/utils.fetcher` package. See https://www.apollographql.com/docs/apollo-server/previous-versions/ for more details.
     dependencies:
       node-fetch: 2.6.7
-      util.promisify: 1.1.2
+      util.promisify: 1.1.1
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -44405,7 +45321,7 @@ packages:
       '@types/body-parser': 1.19.0
       '@types/cors': 2.8.10
       '@types/express': 4.17.13
-      '@types/express-serve-static-core': 4.17.35
+      '@types/express-serve-static-core': 4.17.33
       accepts: 1.3.8
       apollo-server-core: 2.26.1(bufferutil@4.0.3)(graphql@15.8.0)(utf-8-validate@5.0.5)
       apollo-server-types: 0.10.0(graphql@15.8.0)
@@ -44547,7 +45463,7 @@ packages:
       lodash.isplainobject: 4.0.6
       lodash.union: 4.6.0
       normalize-path: 3.0.0
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
 
   /archiver@5.3.1:
@@ -44557,8 +45473,8 @@ packages:
       archiver-utils: 2.1.0
       async: 3.2.4
       buffer-crc32: 0.2.13
-      readable-stream: 3.6.2
-      readdir-glob: 1.1.3
+      readable-stream: 3.6.0
+      readdir-glob: 1.1.2
       tar-stream: 2.2.0
       zip-stream: 4.1.0
     dev: false
@@ -44571,7 +45487,7 @@ packages:
     resolution: {integrity: sha512-nxwy40TuMiUGqMyRHgCSWZ9FM4VAoRP4xUYSTv5ImRog+h9yISPbVH7H8fASCIzYn9wlEv4zvFL7uKDMCFQm3g==}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
     optional: true
 
@@ -44580,7 +45496,7 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dependencies:
       delegates: 1.0.0
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /argparse@1.0.10:
@@ -44612,18 +45528,13 @@ packages:
     engines: {node: '>=6.0'}
     dependencies:
       '@babel/runtime': 7.20.0
-      '@babel/runtime-corejs3': 7.22.6
+      '@babel/runtime-corejs3': 7.20.13
     dev: false
 
   /aria-query@5.1.3:
     resolution: {integrity: sha512-R5iJ5lkuHybztUfuOAznmboyjWq8O6sqNqtK7CLOqdydi54VNbORp49mb14KbWgG1QD3JFO9hJdZ+y4KutfdOQ==}
     dependencies:
-      deep-equal: 2.2.2
-
-  /aria-query@5.3.0:
-    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
-    dependencies:
-      dequal: 2.0.3
+      deep-equal: 2.2.0
 
   /arr-diff@4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
@@ -44639,12 +45550,6 @@ packages:
     resolution: {integrity: sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==}
     engines: {node: '>=0.10.0'}
     dev: false
-
-  /array-buffer-byte-length@1.0.0:
-    resolution: {integrity: sha512-LPuwb2P+NrQw3XhxGc36+XSvuBPopovXYTR9Ew++Du9Yb/bx5AzBfrIsBoj0EZUifjQU+sHL21sseZ3jerWO/A==}
-    dependencies:
-      call-bind: 1.0.2
-      is-array-buffer: 3.0.2
 
   /array-differ@3.0.0:
     resolution: {integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==}
@@ -44675,9 +45580,9 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      get-intrinsic: 1.2.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
+      get-intrinsic: 1.2.0
       is-string: 1.0.7
     dev: false
 
@@ -44700,8 +45605,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -44710,8 +45615,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
       es-shim-unscopables: 1.0.0
     dev: false
 
@@ -44720,22 +45625,10 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
       es-array-method-boxes-properly: 1.0.0
       is-string: 1.0.7
-    dev: false
-
-  /arraybuffer.prototype.slice@1.0.1:
-    resolution: {integrity: sha512-09x0ZWFEjj4WD8PDbykUwo3t9arLn8NIzmmYEJFpYekOAQjpkGSyrQhNoRTcwwcFRu+ycWF78QZ63oWTqSjBcw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      array-buffer-byte-length: 1.0.0
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      get-intrinsic: 1.2.1
-      is-array-buffer: 3.0.2
-      is-shared-array-buffer: 1.0.2
     dev: false
 
   /arraybuffer.slice@0.0.7:
@@ -44830,7 +45723,7 @@ packages:
     resolution: {integrity: sha512-O0yuUDnZeQDL+ncNGlJ78BiO4jnYI3bvMsD5prT0/nsgijG/LpNBIr63gTjVTNsiGkgQhiyCShTgxt8oXOrklA==}
     engines: {node: '>=4'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /ast-types@0.9.6:
@@ -44854,7 +45747,7 @@ packages:
   /async-mutex@0.3.1:
     resolution: {integrity: sha512-vRfQwcqBnJTLzVQo72Sf7KIUbcSUP5hNchx6udI1U6LuPQpfePgdjJzlCe76yFZ8pxlLjn9lwcl/Ya0TSOv0Tw==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /async-retry@1.3.3:
@@ -44904,15 +45797,15 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /autoprefixer@10.4.14(postcss@8.4.18):
-    resolution: {integrity: sha512-FQzyfOsTlwVzjHxKEqRIAdJx9niO6VCBCoEwax/VLSoQF29ggECcPuBqUMZ+u8jCZOPSy8b8/8KnuFbp0SaFZQ==}
+  /autoprefixer@10.4.13(postcss@8.4.18):
+    resolution: {integrity: sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==}
     engines: {node: ^10 || ^12 || >=14}
     hasBin: true
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
-      browserslist: 4.21.9
-      caniuse-lite: 1.0.30001517
+      browserslist: 4.21.5
+      caniuse-lite: 1.0.30001450
       fraction.js: 4.2.0
       normalize-range: 0.1.2
       picocolors: 1.0.0
@@ -44947,8 +45840,8 @@ packages:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     dev: false
 
-  /axe-core@4.7.2:
-    resolution: {integrity: sha512-zIURGIS1E1Q4pcrMjp+nnEh+16G56eG/MUllJH8yEvw7asDo7Ac9uhC9KIH5jzpITueEZolfYglnCGIuSBz39g==}
+  /axe-core@4.6.3:
+    resolution: {integrity: sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==}
     engines: {node: '>=4'}
     dev: false
 
@@ -44992,7 +45885,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       find-cache-dir: 3.3.2
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
       webpack: 5.84.1(esbuild@0.14.29)
 
   /babel-plugin-apply-mdx-type-prop@1.6.21(@babel/core@7.11.6):
@@ -45021,7 +45914,7 @@ packages:
     resolution: {integrity: sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
       '@istanbuljs/load-nyc-config': 1.1.0
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-instrument: 5.2.1
@@ -45034,10 +45927,10 @@ packages:
     resolution: {integrity: sha512-50wCwD5EMNW4aRpOwtqzyZHIewTYNxLA4nhB+09d8BIssfNfzBRhkBIHiaPv1Si226TQSvp8gxAJm2iY2qs2hQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/template': 7.22.5
+      '@babel/template': 7.20.7
       '@babel/types': 7.22.3
       '@types/babel__core': 7.20.0
-      '@types/babel__traverse': 7.20.1
+      '@types/babel__traverse': 7.18.3
     dev: false
 
   /babel-plugin-macros@2.8.0:
@@ -45061,10 +45954,10 @@ packages:
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
-      '@babel/compat-data': 7.22.9
+      '@babel/compat-data': 7.20.14
       '@babel/core': 7.19.6
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.19.6)
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
 
@@ -45075,7 +45968,7 @@ packages:
     dependencies:
       '@babel/core': 7.19.6
       '@babel/helper-define-polyfill-provider': 0.3.3(@babel/core@7.19.6)
-      core-js-compat: 3.31.1
+      core-js-compat: 3.27.2
     transitivePeerDependencies:
       - supports-color
 
@@ -45092,7 +45985,7 @@ packages:
   /babel-plugin-ramda@2.1.1:
     resolution: {integrity: sha512-J/+7vUTTmwF47QFsLx7A1YjAg0ZS3kx5NtajMGuYEntwD+4jg8vFEos4sNsiEBj4LsXZNqpkQEa7/bbJ3IvEEg==}
     dependencies:
-      '@babel/helper-module-imports': 7.22.5
+      '@babel/helper-module-imports': 7.18.6
     dev: false
 
   /babel-plugin-transform-react-remove-prop-types@0.4.24:
@@ -45109,7 +46002,7 @@ packages:
         optional: true
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/helper-plugin-utils': 7.22.5
+      '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
   /babel-preset-current-node-syntax@1.0.1(@babel/core@7.19.6):
@@ -45152,7 +46045,7 @@ packages:
       '@babel/plugin-proposal-nullish-coalescing-operator': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-proposal-numeric-separator': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-proposal-optional-chaining': 7.12.1(@babel/core@7.12.3)
-      '@babel/plugin-proposal-private-property-in-object': 7.21.11(@babel/core@7.12.3)
+      '@babel/plugin-proposal-private-property-in-object': 7.20.5(@babel/core@7.12.3)
       '@babel/plugin-transform-flow-strip-types': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-transform-react-display-name': 7.12.1(@babel/core@7.12.3)
       '@babel/plugin-transform-runtime': 7.12.1(@babel/core@7.12.3)
@@ -45238,7 +46131,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       cmd-shim: 6.0.1
-      npm-normalize-package-bin: 3.0.1
+      npm-normalize-package-bin: 3.0.0
       read-cmd-shim: 4.0.0
       write-file-atomic: 5.0.0
     dev: false
@@ -45264,7 +46157,7 @@ packages:
     dependencies:
       buffer: 5.7.1
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /blob@0.0.5:
@@ -45274,7 +46167,7 @@ packages:
   /block-stream2@2.1.0:
     resolution: {integrity: sha512-suhjmLI57Ewpmq00qaygS8UgEq2ly2PCItenIyhMqVjo4t4pGzqMvfgJuX8iWTeSDdfSSqS6j38fL4ToNL7Pfg==}
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /bluebird@3.7.2:
@@ -45346,8 +46239,28 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /bole@5.0.6:
-    resolution: {integrity: sha512-HtZbVmxHqreaC29XVvGPShDtL2zSafkLe8vMdvFr4ppvtjrObVxtejoU/3jpRbxzxFeqDLXv5oIxUhSVw1NaAw==}
+  /body-parser@1.20.2:
+    resolution: {integrity: sha512-ml9pReCu3M61kGlqoTm2umSXTlRTuGTx0bfYj+uIUKKYycG5NtSbeetV3faSU6R7ajOPw0g/J1PvK4qNy7s5bA==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.0
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.11.0
+      raw-body: 2.5.2
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /bole@5.0.3:
+    resolution: {integrity: sha512-4o8wk9dlpU0e69sXhIsPIaFfXgOvj6en2GgZkG8hadkqNEqYKcz9Y70ijg7Kjq9hz2prJkWXljca5OBJZ451xg==}
     dependencies:
       fast-safe-stringify: 2.1.1
       individual: 3.0.0
@@ -45467,7 +46380,7 @@ packages:
     resolution: {integrity: sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==}
     dependencies:
       cipher-base: 1.0.4
-      des.js: 1.1.0
+      des.js: 1.0.1
       inherits: 2.0.4
       safe-buffer: 5.2.1
     dev: false
@@ -45489,7 +46402,7 @@ packages:
       elliptic: 6.5.4
       inherits: 2.0.4
       parse-asn1: 5.1.6
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       safe-buffer: 5.2.1
     dev: false
 
@@ -45510,8 +46423,8 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001517
-      electron-to-chromium: 1.4.466
+      caniuse-lite: 1.0.30001450
+      electron-to-chromium: 1.4.284
       escalade: 3.1.1
       node-releases: 1.1.77
     dev: false
@@ -45521,21 +46434,21 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001517
+      caniuse-lite: 1.0.30001450
       colorette: 1.4.0
-      electron-to-chromium: 1.4.466
+      electron-to-chromium: 1.4.284
       escalade: 3.1.1
       node-releases: 1.1.77
 
-  /browserslist@4.21.9:
-    resolution: {integrity: sha512-M0MFoZzbUrRU4KNfCrDLnvyE7gub+peetoTid3TBIqtunaDJyXlwhakT+/VkvSXcfIzFfK/nkCs4nmyTmxdNSg==}
+  /browserslist@4.21.5:
+    resolution: {integrity: sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==}
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
     dependencies:
-      caniuse-lite: 1.0.30001517
-      electron-to-chromium: 1.4.466
-      node-releases: 2.0.13
-      update-browserslist-db: 1.0.11(browserslist@4.21.9)
+      caniuse-lite: 1.0.30001450
+      electron-to-chromium: 1.4.284
+      node-releases: 2.0.9
+      update-browserslist-db: 1.0.10(browserslist@4.21.5)
 
   /bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -45562,7 +46475,7 @@ packages:
     resolution: {integrity: sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==}
     dependencies:
       base64-js: 1.5.1
-      ieee754: 1.1.13
+      ieee754: 1.2.1
       isarray: 1.0.0
     dev: false
 
@@ -45696,14 +46609,14 @@ packages:
     engines: {node: '>=10.6.0'}
     dev: false
 
-  /cacheable-request@7.0.4:
-    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
+  /cacheable-request@7.0.2:
+    resolution: {integrity: sha512-pouW8/FmiPQbuGpkXQ9BAPv/Mo5xDGANgSNXzTzJ8DrKGuXOssM4wIQRjfanNRh3Yu5cfYPvcorqbhg2KIJtew==}
     engines: {node: '>=8'}
     dependencies:
       clone-response: 1.0.3
       get-stream: 5.2.0
       http-cache-semantics: 4.1.1
-      keyv: 4.5.3
+      keyv: 4.5.2
       lowercase-keys: 2.0.0
       normalize-url: 6.1.0
       responselike: 2.0.1
@@ -45713,7 +46626,7 @@ packages:
     resolution: {integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==}
     dependencies:
       function-bind: 1.1.1
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
 
   /call-me-maybe@1.0.2:
     resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
@@ -45747,7 +46660,7 @@ packages:
     resolution: {integrity: sha512-gxGWBrTT1JuMx6R+o5PTXMmUnhnVzLQ9SNutD4YqKtI6ap897t3tKECYla6gCWEkplXnlNybEkZg9GEGxKFCgw==}
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /camelcase-css@2.0.1:
@@ -45793,20 +46706,20 @@ packages:
     resolution: {integrity: sha512-eOgiEWqjppB+3DN/5E82EQ8dTINus8d9GXMCbEsUnp2hcUIcXmBvzWmD3tXMk3CuBK0v+ddK9qw0EAF+JVRMjQ==}
     engines: {node: '>=10.13'}
     dependencies:
-      path-temp: 2.1.0
+      path-temp: 2.0.0
     dev: false
 
   /caniuse-api@3.0.0:
     resolution: {integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==}
     dependencies:
       browserslist: 4.16.3
-      caniuse-lite: 1.0.30001517
+      caniuse-lite: 1.0.30001450
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
     dev: false
 
-  /caniuse-lite@1.0.30001517:
-    resolution: {integrity: sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==}
+  /caniuse-lite@1.0.30001450:
+    resolution: {integrity: sha512-qMBmvmQmFXaSxexkjjfMvD5rnDL0+m+dUMZKoDYsGG8iZN29RuYh9eRoMvKsT6uMAWlyUUGDEQGJJYjzCIO9ew==}
 
   /capture-stack-trace@1.0.2:
     resolution: {integrity: sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==}
@@ -45966,6 +46879,21 @@ packages:
       regexp-to-ast: 0.5.0
     dev: false
 
+  /chokidar@3.5.1:
+    resolution: {integrity: sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==}
+    engines: {node: '>= 8.10.0'}
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.2
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.1
+      normalize-path: 3.0.0
+      readdirp: 3.5.0
+    optionalDependencies:
+      fsevents: 2.3.2
+    dev: false
+
   /chokidar@3.5.3:
     resolution: {integrity: sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==}
     engines: {node: '>= 8.10.0'}
@@ -46018,8 +46946,8 @@ packages:
     deprecated: CircularJSON is in maintenance only, flatted is its successor.
     dev: false
 
-  /cjs-module-lexer@1.2.3:
-    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+  /cjs-module-lexer@1.2.2:
+    resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
     dev: false
 
   /class-transformer@0.5.1:
@@ -46130,8 +47058,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /cli-spinners@2.9.0:
-    resolution: {integrity: sha512-4/aL9X3Wh0yiMQlE+eeRhWP6vclO3QRtw1JHKIT0FFUs5FjpFmESqtMvYZ0+lbzBw900b95mS0hohy+qn2VK/g==}
+  /cli-spinners@2.7.0:
+    resolution: {integrity: sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==}
     engines: {node: '>=6'}
     dev: false
 
@@ -46167,16 +47095,22 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
+  /clipanion@3.2.0:
+    resolution: {integrity: sha512-XaPQiJQZKbyaaDbv5yR/cAt/ORfZfENkr4wGQj+Go/Uf/65ofTQBCPirgWFeJctZW24V3mxrFiEnEmqBflrJYA==}
+    dependencies:
+      typanion: 3.12.1
+    dev: false
+
   /clipanion@3.2.0-rc.4:
     resolution: {integrity: sha512-wkW5IYIK63i2aSmFr8EoRjEpZmy3KFXezDn4K8dBct7pq0hWWDFUoqwXTMIXWyBIEJFekmZ9v5wX+JtRBMZbOA==}
     dependencies:
-      typanion: 3.13.0
+      typanion: 3.12.1
     dev: false
 
   /clipanion@3.2.1:
     resolution: {integrity: sha512-dYFdjLb7y1ajfxQopN05mylEpK9ZX0sO1/RfMXdfmwjlIsPkbh4p7A682x++zFPLDCo1x3p82dtljHf5cW2LKA==}
     dependencies:
-      typanion: 3.13.0
+      typanion: 3.12.1
     dev: false
 
   /cliui@6.0.0:
@@ -46234,7 +47168,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       process-nextick-args: 2.0.1
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
 
   /clsx@1.2.1:
@@ -46282,8 +47216,8 @@ packages:
     resolution: {integrity: sha512-jEovNnrhMuqyCcjfEJA56v0Xq8SkIoPKDyaHahwo3POf4qcSXqMYuwNcOTzp74vTsR9Tn08z4MxWqAhcekogkQ==}
     dev: false
 
-  /collect-v8-coverage@1.0.2:
-    resolution: {integrity: sha512-lHl4d5/ONEbLlJvaJNtsF/Lz+WvB07u2ycqTYbdrq7UypDXailES4valYb2eWiJFxZlVmpGekfqoxQhzyFdT4Q==}
+  /collect-v8-coverage@1.0.1:
+    resolution: {integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==}
     dev: false
 
   /collection-visit@1.0.0:
@@ -46336,6 +47270,9 @@ packages:
 
   /colorette@1.4.0:
     resolution: {integrity: sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==}
+
+  /colorette@2.0.19:
+    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
   /colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -46470,7 +47407,7 @@ packages:
       buffer-crc32: 0.2.13
       crc32-stream: 4.0.2
       normalize-path: 3.0.0
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /compressible@2.0.18:
@@ -46485,7 +47422,7 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
     dependencies:
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
       serialize-javascript: 6.0.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -46518,7 +47455,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
       typedarray: 0.0.6
     dev: false
 
@@ -46528,7 +47465,7 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       typedarray: 0.0.6
     dev: false
 
@@ -46633,13 +47570,13 @@ packages:
     dependencies:
       toggle-selection: 1.0.6
 
-  /core-js-compat@3.31.1:
-    resolution: {integrity: sha512-wIDWd2s5/5aJSdpOJHfSibxNODxoGoWOBHt8JSPB41NOE94M7kuTPZCYLOlTtuoXTsBPKobpJ6T+y0SSy5L9SA==}
+  /core-js-compat@3.27.2:
+    resolution: {integrity: sha512-welaYuF7ZtbYKGrIy7y3eb40d37rG1FvzEOfe7hSLd2iD6duMDqUhRfSvCGyC46HhR6Y8JXXdZ2lnRUMkPBpvg==}
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
 
-  /core-js-pure@3.31.1:
-    resolution: {integrity: sha512-w+C62kvWti0EPs4KPMCMVv9DriHSXfQOCQ94bGGBiEW5rrbtt/Rz8n5Krhfw9cpFyzXBjf3DB3QnPdEzGDY4Fw==}
+  /core-js-pure@3.27.2:
+    resolution: {integrity: sha512-Cf2jqAbXgWH3VVzjyaaFkY1EBazxugUepGymDoeteyYr9ByX51kD2jdHZlsEF/xnJMyN3Prua7mQuzwMg6Zc9A==}
     requiresBuild: true
     dev: false
 
@@ -46706,7 +47643,7 @@ packages:
     hasBin: true
     dependencies:
       graceful-fs: 4.2.10
-      minimist: 1.2.8
+      minimist: 1.2.7
       mkdirp: 0.5.6
       rimraf: 2.7.1
     dev: false
@@ -46731,7 +47668,7 @@ packages:
     engines: {node: '>= 10'}
     dependencies:
       crc-32: 1.2.2
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /create-ecdh@4.0.4:
@@ -46813,7 +47750,7 @@ packages:
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
-      semver: 5.7.2
+      semver: 5.7.1
       shebang-command: 1.2.0
       which: 1.3.1
     dev: false
@@ -46864,11 +47801,11 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
-  /css-declaration-sorter@6.4.1(postcss@8.4.18):
-    resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
+  /css-declaration-sorter@6.3.1(postcss@8.4.18):
+    resolution: {integrity: sha512-fBffmak0bPAnyqc/HO8C3n2sHrp9wcqQz6ES9koRF2/mLOVAx9zIQ3Y7R29sYCteTPqMCwns4WYQoCX91Xl3+w==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
@@ -46884,7 +47821,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /css-in-js-utils@2.0.1:
@@ -46911,11 +47848,11 @@ packages:
       loader-utils: 2.0.4
       postcss: 8.4.18
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.18)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.18)
+      postcss-modules-local-by-default: 4.0.0(postcss@8.4.18)
       postcss-modules-scope: 3.0.0(postcss@8.4.18)
       postcss-modules-values: 4.0.0(postcss@8.4.18)
       postcss-value-parser: 4.2.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       semver: 7.5.2
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -46929,7 +47866,7 @@ packages:
       icss-utils: 5.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-modules-extract-imports: 3.0.0(postcss@8.4.18)
-      postcss-modules-local-by-default: 4.0.3(postcss@8.4.18)
+      postcss-modules-local-by-default: 4.0.0(postcss@8.4.18)
       postcss-modules-scope: 3.0.0(postcss@8.4.18)
       postcss-modules-values: 4.0.0(postcss@8.4.18)
       postcss-value-parser: 4.2.0
@@ -46950,11 +47887,11 @@ packages:
       csso:
         optional: true
     dependencies:
-      cssnano: 5.1.15(postcss@8.4.18)
+      cssnano: 5.1.14(postcss@8.4.18)
       jest-worker: 27.5.1
       p-limit: 3.1.0
       postcss: 8.4.18
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       source-map: 0.6.1
       webpack: 5.84.1(esbuild@0.14.29)
@@ -47044,8 +47981,8 @@ packages:
       source-map: 0.6.1
       source-map-resolve: 0.6.0
 
-  /cssdb@7.6.0:
-    resolution: {integrity: sha512-Nna7rph8V0jC6+JBY4Vk4ndErUmfJfV6NJCaZdurL0omggabiy+QB2HCQtu5c/ACLZ0I7REv7A4QyPIoYzZx0w==}
+  /cssdb@7.4.1:
+    resolution: {integrity: sha512-0Q8NOMpXJ3iTDDbUv9grcmQAfdDx4qz+fN/+Md2FGbevT+6+bJNQ2LjB2YIUlLbpBTM32idU1Sb+tb/uGt6/XQ==}
     dev: false
 
   /cssesc@3.0.0:
@@ -47058,24 +47995,24 @@ packages:
     resolution: {integrity: sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==}
     dev: false
 
-  /cssnano-preset-default@5.2.14(postcss@8.4.18):
-    resolution: {integrity: sha512-t0SFesj/ZV2OTylqQVOrFgEh5uanxbO6ZAdeCrNsUQ6fVuXwYTxJPNAGvGTxHbD68ldIJNec7PyYZDBrfDQ+6A==}
+  /cssnano-preset-default@5.2.13(postcss@8.4.18):
+    resolution: {integrity: sha512-PX7sQ4Pb+UtOWuz8A1d+Rbi+WimBIxJTRyBdgGp1J75VU0r/HFQeLnMYgHiCAp6AR4rqrc7Y4R+1Rjk3KJz6DQ==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.4.18)
+      css-declaration-sorter: 6.3.1(postcss@8.4.18)
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-calc: 8.2.4(postcss@8.4.18)
-      postcss-colormin: 5.3.1(postcss@8.4.18)
+      postcss-colormin: 5.3.0(postcss@8.4.18)
       postcss-convert-values: 5.1.3(postcss@8.4.18)
       postcss-discard-comments: 5.1.2(postcss@8.4.18)
       postcss-discard-duplicates: 5.1.0(postcss@8.4.18)
       postcss-discard-empty: 5.1.1(postcss@8.4.18)
       postcss-discard-overridden: 5.1.0(postcss@8.4.18)
       postcss-merge-longhand: 5.1.7(postcss@8.4.18)
-      postcss-merge-rules: 5.1.4(postcss@8.4.18)
+      postcss-merge-rules: 5.1.3(postcss@8.4.18)
       postcss-minify-font-values: 5.1.0(postcss@8.4.18)
       postcss-minify-gradients: 5.1.1(postcss@8.4.18)
       postcss-minify-params: 5.1.4(postcss@8.4.18)
@@ -47090,7 +48027,7 @@ packages:
       postcss-normalize-url: 5.1.0(postcss@8.4.18)
       postcss-normalize-whitespace: 5.1.1(postcss@8.4.18)
       postcss-ordered-values: 5.1.3(postcss@8.4.18)
-      postcss-reduce-initial: 5.1.2(postcss@8.4.18)
+      postcss-reduce-initial: 5.1.1(postcss@8.4.18)
       postcss-reduce-transforms: 5.1.0(postcss@8.4.18)
       postcss-svgo: 5.1.0(postcss@8.4.18)
       postcss-unique-selectors: 5.1.1(postcss@8.4.18)
@@ -47105,14 +48042,14 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /cssnano@5.1.15(postcss@8.4.18):
-    resolution: {integrity: sha512-j+BKgDcLDQA+eDifLx0EO4XSA56b7uut3BQFH+wbSaSTuGLuiyTa/wbRYthUXX8LC9mLg+WWKe8h+qJuwTAbHw==}
+  /cssnano@5.1.14(postcss@8.4.18):
+    resolution: {integrity: sha512-Oou7ihiTocbKqi0J1bB+TRJIQX5RMR3JghA8hcWSw9mjBLQ5Y3RWqEDoYG3sRNlAbCIXpqMoZGbq5KDR3vdzgw==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-preset-default: 5.2.14(postcss@8.4.18)
-      lilconfig: 2.1.0
+      cssnano-preset-default: 5.2.13(postcss@8.4.18)
+      lilconfig: 2.0.6
       postcss: 8.4.18
       yaml: 1.10.2
     dev: false
@@ -47139,15 +48076,8 @@ packages:
       cssom: 0.3.8
     dev: false
 
-  /cssstyle@3.0.0:
-    resolution: {integrity: sha512-N4u2ABATi3Qplzf0hWbVCdjenim8F3ojEXpBDF5hBpjzW182MjNGLqfmQ0SkSPeQ+V86ZXgeH8aXj6kayd4jgg==}
-    engines: {node: '>=14'}
-    dependencies:
-      rrweb-cssom: 0.6.0
-    dev: false
-
-  /csstype@3.1.2:
-    resolution: {integrity: sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ==}
+  /csstype@3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
 
   /cycle@1.0.3:
     resolution: {integrity: sha512-TVF6svNzeQCOpjCqsy0/CSy8VgObG3wXusJ73xW2GbG5rGx7lC8zxDSURicsXI2UsGdi2L0QNRCi745/wUDvsA==}
@@ -47253,15 +48183,6 @@ packages:
       whatwg-url: 8.7.0
     dev: false
 
-  /data-urls@4.0.0:
-    resolution: {integrity: sha512-/mMTei/JXPqvFqQtfyTowxmJVwr2PVAeCcDxyFf6LhoOu/09TX2OX3kb2wzi4DMXcfj4OItwDOnhl5oziPnT6g==}
-    engines: {node: '>=14'}
-    dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
-    dev: false
-
   /date-format@0.0.2:
     resolution: {integrity: sha512-M4obuJx8jU5T91lcbwi0+QPNVaWOY1DQYz5xUuKYWO93osVzB2ZPqyDUc5T+mDjbA1X8VOb4JDZ+8r2MrSOp7Q==}
     deprecated: 0.x is no longer supported. Please upgrade to 4.x or higher.
@@ -47332,7 +48253,7 @@ packages:
       supports-color: 8.1.1
     dev: false
 
-  /debug@4.3.4(supports-color@9.4.0):
+  /debug@4.3.4(supports-color@9.3.1):
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
@@ -47342,7 +48263,7 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-      supports-color: 9.4.0
+      supports-color: 9.3.1
     dev: false
 
   /decamelize@1.2.0:
@@ -47398,15 +48319,14 @@ packages:
     resolution: {integrity: sha512-FXgye2Jr6oEk01S7gmSrHrPEQ1ontR7wwl+nYiZ8h4SXlHVm0DYda74BIPcHz2s2qPz4+375IcAz1vsWLwddgQ==}
     dev: false
 
-  /deep-equal@2.2.2:
-    resolution: {integrity: sha512-xjVyBf0w5vH0I42jdAZzOKVldmPgSulmiyPRywoyq7HXC9qdgo17kxJE+rdnif5Tz6+pIrpJI8dCpMNLIGkUiA==}
+  /deep-equal@2.2.0:
+    resolution: {integrity: sha512-RdpzE0Hv4lhowpIUKKMJfeH6C1pXdtT1/it80ubgWqwI3qpuxUBpC1S4hnHg+zjnuOoDkzUtUCEEkG+XG5l3Mw==}
     dependencies:
-      array-buffer-byte-length: 1.0.0
       call-bind: 1.0.2
       es-get-iterator: 1.1.3
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       is-arguments: 1.1.1
-      is-array-buffer: 3.0.2
+      is-array-buffer: 3.0.1
       is-date-object: 1.0.5
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
@@ -47414,11 +48334,11 @@ packages:
       object-is: 1.1.5
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.0
+      regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
       which-boxed-primitive: 1.0.2
       which-collection: 1.0.1
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.9
 
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -47431,6 +48351,11 @@ packages:
 
   /deepmerge@4.2.2:
     resolution: {integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==}
+    engines: {node: '>=0.10.0'}
+    dev: false
+
+  /deepmerge@4.3.0:
+    resolution: {integrity: sha512-z2wJZXrmeHdvYJp/Ux55wIjqo81G5Bp4c+oELTW+7ar6SogWHajt5a9gO3s3IDaGSAXjDk0vlQKN3rms8ab3og==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -47460,8 +48385,8 @@ packages:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
 
-  /define-properties@1.2.0:
-    resolution: {integrity: sha512-xvqAVKGfT1+UAvPwKTVw/njhdQ8ZhXK4lI0bCIuCMrp2up9nPnaDftrLtmpTazqd1o+UY4zgzU+avtMbDP+ldA==}
+  /define-properties@1.1.4:
+    resolution: {integrity: sha512-uckOqKcfaVvtBdsVkdPv3XjveQJsNQqmhXgRi8uhvWWuPYZCNlzT8qAyblUgNoXdHdjMTzAqeGjAoli8f+bzPA==}
     engines: {node: '>= 0.4'}
     dependencies:
       has-property-descriptors: 1.0.0
@@ -47537,12 +48462,8 @@ packages:
     engines: {node: '>=6'}
     dev: false
 
-  /dequal@2.0.3:
-    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
-    engines: {node: '>=6'}
-
-  /des.js@1.1.0:
-    resolution: {integrity: sha512-r17GxjhUCjSRy8aiJpr8/UadFIzMzJGexI3Nmz4ADi9LYSFx4gTBp80+NaX/YsXWWLhpZ7v/v/ubEc/bCNfKwg==}
+  /des.js@1.0.1:
+    resolution: {integrity: sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==}
     dependencies:
       inherits: 2.0.4
       minimalistic-assert: 1.0.1
@@ -47572,8 +48493,8 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /detect-libc@2.0.2:
-    resolution: {integrity: sha512-UX6sGumvvqSaXgdKGUsgZWqcUyIXZ/vZTrlRT/iobiKhGL0zL4d3osHj3uqllWJK+i+sixDS/3COVEOFbupFyw==}
+  /detect-libc@2.0.1:
+    resolution: {integrity: sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==}
     engines: {node: '>=8'}
     dev: false
 
@@ -47763,13 +48684,6 @@ packages:
       webidl-conversions: 5.0.0
     dev: false
 
-  /domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    dependencies:
-      webidl-conversions: 7.0.0
-    dev: false
-
   /domhandler@4.3.1:
     resolution: {integrity: sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==}
     engines: {node: '>= 4'}
@@ -47796,7 +48710,7 @@ packages:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /dot-prop@4.2.1:
@@ -47804,16 +48718,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       is-obj: 1.0.1
-    dev: false
-
-  /dotenv@16.3.1:
-    resolution: {integrity: sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /dset@3.1.2:
-    resolution: {integrity: sha512-g/M9sqy3oHe477Ar4voQxWtaPIFw1jTdKZuomOjhCcBx9nHUNn0pu6NopuFFrTh/TRZIKEj+76vLWFu9BNKk+Q==}
-    engines: {node: '>=4'}
     dev: false
 
   /duplexer2@0.0.2:
@@ -47835,7 +48739,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       inherits: 2.0.4
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
       stream-shift: 1.0.1
     dev: false
 
@@ -47844,7 +48748,7 @@ packages:
     dependencies:
       end-of-stream: 1.4.4
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       stream-shift: 1.0.1
     dev: false
 
@@ -47857,7 +48761,7 @@ packages:
     peerDependencies:
       react: ^16.8.0
     dependencies:
-      immer: 9.0.21
+      immer: 9.0.19
       is-plain-object: 5.0.0
       memoizerific: 1.11.3
       react: 17.0.2
@@ -47890,8 +48794,8 @@ packages:
     requiresBuild: true
     dev: false
 
-  /electron-to-chromium@1.4.466:
-    resolution: {integrity: sha512-TSkRvbXRXD8BwhcGlZXDsbI2lRoP8dvqR7LQnqQNk9KxXBc4tG8O+rTuXgTyIpEdiqSGKEBSqrxdqEntnjNncA==}
+  /electron-to-chromium@1.4.284:
+    resolution: {integrity: sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==}
 
   /elliptic@6.5.4:
     resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
@@ -47944,6 +48848,7 @@ packages:
 
   /encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
+    requiresBuild: true
     dependencies:
       iconv-lite: 0.6.3
     dev: false
@@ -47999,8 +48904,8 @@ packages:
       tapable: 1.1.3
     dev: false
 
-  /enhanced-resolve@5.15.0:
-    resolution: {integrity: sha512-LXYT42KJ7lpIKECr2mAXIaMldcNCh/7E0KBKOu4KSfkHmP+mZmSs+8V5gBAqisWBy0OO4W5Oyys0GO1Y8KtdKg==}
+  /enhanced-resolve@5.14.1:
+    resolution: {integrity: sha512-Vklwq2vDKtl0y/vtwjSesgJ5MYS7Etuk5txS8VdKL4AOS1aUlD96zqIfsOSLQsdv3xgMRbtkWM8eG9XDfKUPow==}
     engines: {node: '>=10.13.0'}
     dependencies:
       graceful-fs: 4.2.10
@@ -48044,8 +48949,8 @@ packages:
       through: 2.3.8
     dev: false
 
-  /envinfo@7.10.0:
-    resolution: {integrity: sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==}
+  /envinfo@7.8.1:
+    resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
     dev: false
@@ -48072,18 +48977,17 @@ packages:
     dependencies:
       stackframe: 1.3.4
 
-  /es-abstract@1.22.1:
-    resolution: {integrity: sha512-ioRRcXMO6OFyRpyzV3kE1IIBd4WG5/kltnzdxSCqoP8CMGs/Li+M1uF5o7lOkZVFjDs+NLesthnF66Pg/0q0Lw==}
+  /es-abstract@1.21.1:
+    resolution: {integrity: sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      array-buffer-byte-length: 1.0.0
-      arraybuffer.prototype.slice: 1.0.1
       available-typed-arrays: 1.0.5
       call-bind: 1.0.2
       es-set-tostringtag: 2.0.1
       es-to-primitive: 1.2.1
+      function-bind: 1.1.1
       function.prototype.name: 1.1.5
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       get-symbol-description: 1.0.0
       globalthis: 1.0.3
       gopd: 1.0.1
@@ -48091,30 +48995,25 @@ packages:
       has-property-descriptors: 1.0.0
       has-proto: 1.0.1
       has-symbols: 1.0.3
-      internal-slot: 1.0.5
-      is-array-buffer: 3.0.2
+      internal-slot: 1.0.4
+      is-array-buffer: 3.0.1
       is-callable: 1.2.7
       is-negative-zero: 2.0.2
       is-regex: 1.1.4
       is-shared-array-buffer: 1.0.2
       is-string: 1.0.7
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
       is-weakref: 1.0.2
       object-inspect: 1.12.3
       object-keys: 1.1.1
       object.assign: 4.1.4
-      regexp.prototype.flags: 1.5.0
-      safe-array-concat: 1.0.0
+      regexp.prototype.flags: 1.4.3
       safe-regex-test: 1.0.0
-      string.prototype.trim: 1.2.7
       string.prototype.trimend: 1.0.6
       string.prototype.trimstart: 1.0.6
-      typed-array-buffer: 1.0.0
-      typed-array-byte-length: 1.0.0
-      typed-array-byte-offset: 1.0.0
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.9
     dev: false
 
   /es-array-method-boxes-properly@1.0.0:
@@ -48125,7 +49024,7 @@ packages:
     resolution: {integrity: sha512-sPZmqHBe6JIiTfN5q2pEi//TwxmAFHwj/XEuYjTuse78i8KxaqMTTzxPoFKuzRpDpTJ+0NAbpfenkmH2rePtuw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       has-symbols: 1.0.3
       is-arguments: 1.1.1
       is-map: 2.0.2
@@ -48134,14 +49033,14 @@ packages:
       isarray: 2.0.5
       stop-iteration-iterator: 1.0.0
 
-  /es-module-lexer@1.3.0:
-    resolution: {integrity: sha512-vZK7T0N2CBmBOixhmjdqx2gWVbFZ4DXZ/NyRMZVlJXPa7CyFS+/a4QQsDGDQy9ZfEzxFuNEsMLeQJnKP2p5/JA==}
+  /es-module-lexer@1.2.1:
+    resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
 
   /es-set-tostringtag@2.0.1:
     resolution: {integrity: sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       has: 1.0.3
       has-tostringtag: 1.0.0
     dev: false
@@ -48428,14 +49327,15 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+  /escodegen@2.0.0:
+    resolution: {integrity: sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==}
     engines: {node: '>=6.0'}
     hasBin: true
     dependencies:
       esprima: 4.0.1
       estraverse: 5.3.0
       esutils: 2.0.3
+      optionator: 0.8.3
     optionalDependencies:
       source-map: 0.6.1
     dev: false
@@ -48446,20 +49346,6 @@ packages:
     peerDependencies:
       eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
       eslint-plugin-import: ^2.21.2
-    dependencies:
-      confusing-browser-globals: 1.0.11
-      eslint: 7.32.0
-      eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
-      object.assign: 4.1.4
-      object.entries: 1.1.6
-    dev: false
-
-  /eslint-config-airbnb-base@14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0):
-    resolution: {integrity: sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
     dependencies:
       confusing-browser-globals: 1.0.11
       eslint: 7.32.0
@@ -48491,8 +49377,8 @@ packages:
     resolution: {integrity: sha512-pzkOGX76OEd3AmxWPJUwasz4CY98KHNQgdwsiFpYd/M35vC33WiD9OaLq8eFYysy7+NVJtUuElgn879lrQ1rPw==}
     dependencies:
       '@typescript-eslint/parser': 2.34.0(eslint@7.32.0)(typescript@4.7.4)
-      eslint-config-airbnb: 18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)
-      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0)
+      eslint-config-airbnb: 18.2.0(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)
+      eslint-config-airbnb-base: 14.2.0(eslint-plugin-import@2.22.1)(eslint@7.32.0)
     transitivePeerDependencies:
       - eslint
       - eslint-plugin-import
@@ -48515,26 +49401,6 @@ packages:
     dependencies:
       eslint: 7.32.0
       eslint-config-airbnb-base: 14.2.0(eslint-plugin-import@2.22.1)(eslint@7.32.0)
-      eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
-      eslint-plugin-jsx-a11y: 6.4.1(eslint@7.32.0)
-      eslint-plugin-react: 7.22.0(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.2.0(eslint@7.32.0)
-      object.assign: 4.1.4
-      object.entries: 1.1.6
-    dev: false
-
-  /eslint-config-airbnb@18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0):
-    resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
-      eslint-plugin-jsx-a11y: ^6.4.1
-      eslint-plugin-react: ^7.21.5
-      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
-    dependencies:
-      eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0)
       eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
       eslint-plugin-jsx-a11y: 6.4.1(eslint@7.32.0)
       eslint-plugin-react: 7.22.0(eslint@7.32.0)
@@ -48572,14 +49438,14 @@ packages:
       remark-mdx: 1.6.22
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
-      tslib: 2.6.0
+      tslib: 2.5.0
       unified: 9.2.2
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.8.0(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0):
-    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0):
+    resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
       '@typescript-eslint/parser': '*'
@@ -48625,13 +49491,13 @@ packages:
       doctrine: 1.5.0
       eslint: 7.32.0
       eslint-import-resolver-node: 0.3.4
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.35.1)(eslint-import-resolver-node@0.3.4)(eslint@7.32.0)
       has: 1.0.3
       minimatch: 3.0.5
       object.values: 1.1.6
       read-pkg-up: 2.0.0
       resolve: 1.20.0
-      tsconfig-paths: 3.14.2
+      tsconfig-paths: 3.14.1
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -48661,14 +49527,14 @@ packages:
       aria-query: 4.2.2
       array-includes: 3.1.6
       ast-types-flow: 0.0.7
-      axe-core: 4.7.2
+      axe-core: 4.6.3
       axobject-query: 2.2.0
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       eslint: 7.32.0
       has: 1.0.3
-      jsx-ast-utils: 3.3.4
-      language-tags: 1.0.8
+      jsx-ast-utils: 3.3.3
+      language-tags: 1.0.7
     dev: false
 
   /eslint-plugin-markdown@2.2.1(eslint@7.32.0):
@@ -48697,7 +49563,7 @@ packages:
       remark-parse: 8.0.3
       remark-stringify: 8.1.1
       synckit: 0.1.6
-      tslib: 2.6.0
+      tslib: 2.5.0
       unified: 9.2.2
       vfile: 4.2.1
     transitivePeerDependencies:
@@ -48740,7 +49606,7 @@ packages:
       doctrine: 2.1.0
       eslint: 7.32.0
       has: 1.0.3
-      jsx-ast-utils: 3.3.4
+      jsx-ast-utils: 3.3.3
       object.entries: 1.1.6
       object.fromentries: 2.0.6
       object.values: 1.1.6
@@ -48798,8 +49664,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-visitor-keys@3.4.1:
-    resolution: {integrity: sha512-pZnmmLwYzf+kWaM/Qgrvpen51upAktaaiI01nsJD/Yr3lMOdNtq0cxkrrg16w64VtisN6okbs7Q8AfGqj4c9fA==}
+  /eslint-visitor-keys@3.3.0:
+    resolution: {integrity: sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
@@ -48818,7 +49684,7 @@ packages:
       eslint-scope: 3.7.3
       eslint-visitor-keys: 1.3.0
       espree: 3.5.4
-      esquery: 1.5.0
+      esquery: 1.4.0
       esutils: 2.0.3
       file-entry-cache: 2.0.0
       functional-red-black-tree: 1.0.1
@@ -48841,7 +49707,7 @@ packages:
       progress: 2.0.3
       regexpp: 1.1.0
       require-uncached: 1.0.3
-      semver: 5.7.2
+      semver: 5.7.1
       strip-ansi: 4.0.0
       strip-json-comments: 2.0.1
       table: 4.0.2
@@ -48855,7 +49721,7 @@ packages:
     engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
     hasBin: true
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       ajv: 6.12.6
       chalk: 2.4.2
       cross-spawn: 6.0.5
@@ -48865,7 +49731,7 @@ packages:
       eslint-utils: 1.4.3
       eslint-visitor-keys: 1.3.0
       espree: 6.2.1
-      esquery: 1.5.0
+      esquery: 1.4.0
       esutils: 2.0.3
       file-entry-cache: 5.0.1
       functional-red-black-tree: 1.0.1
@@ -48886,7 +49752,7 @@ packages:
       optionator: 0.8.3
       progress: 2.0.3
       regexpp: 2.0.1
-      semver: 6.3.1
+      semver: 6.3.0
       strip-ansi: 5.2.0
       strip-json-comments: 3.1.1
       table: 5.4.6
@@ -48915,7 +49781,7 @@ packages:
       eslint-utils: 2.1.0
       eslint-visitor-keys: 2.1.0
       espree: 7.3.1
-      esquery: 1.5.0
+      esquery: 1.4.0
       esutils: 2.0.3
       fast-deep-equal: 3.1.3
       file-entry-cache: 6.0.1
@@ -48932,7 +49798,7 @@ packages:
       lodash.merge: 4.6.2
       minimatch: 3.0.5
       natural-compare: 1.4.0
-      optionator: 0.9.3
+      optionator: 0.9.1
       progress: 2.0.3
       regexpp: 3.2.0
       semver: 7.5.2
@@ -48989,8 +49855,8 @@ packages:
     hasBin: true
     dev: false
 
-  /esquery@1.5.0:
-    resolution: {integrity: sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==}
+  /esquery@1.4.0:
+    resolution: {integrity: sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==}
     engines: {node: '>=0.10'}
     dependencies:
       estraverse: 5.3.0
@@ -49168,7 +50034,7 @@ packages:
       content-type: 1.0.5
       graphql: 15.8.0
       http-errors: 1.8.0
-      raw-body: 2.5.2
+      raw-body: 2.5.1
     dev: false
 
   /express-history-api-fallback@2.2.1:
@@ -49402,6 +50268,17 @@ packages:
     resolution: {integrity: sha512-XXA9RmlPatkFKUzqVZAFth18R4Wo+Xug/S+C7YlYA3xrXwfPlW3dqNwOb4hvQo7wZJ2cNDYhrYuPzVOfHy5/uQ==}
     dev: false
 
+  /fast-glob@3.2.12:
+    resolution: {integrity: sha512-DVj4CQIYYow0BlaelwK1pHl5n5cRSJfM60UA0zK891sVInoPri2Ekj7+e1CT3/3qxXenpI+nBBmQAcJPJgaj4w==}
+    engines: {node: '>=8.6.0'}
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.5
+    dev: false
+
   /fast-glob@3.3.0:
     resolution: {integrity: sha512-ChDuvbOypPuNjO8yIDf36x7BlZX1smcUMTTcyoIjycexOxd6DFsKsg21qVBzEmr3G7fUKIRy2/psii+CIUt7FA==}
     engines: {node: '>=8.6.0'}
@@ -49423,8 +50300,8 @@ packages:
   /fast-loops@1.1.3:
     resolution: {integrity: sha512-8EZzEP0eKkEEVX+drtd9mtuQ+/QrlfW/5MlwcwK5Nds6EkZ/tRzEexkzUY2mIssnAyVLT+TKHuRXmFNNXYUd6g==}
 
-  /fast-redact@3.2.0:
-    resolution: {integrity: sha512-zaTadChr+NekyzallAMXATXLOR8MNx3zqpZ0MUF2aGf4EathnG0f32VLODNlY8IuGY3HoRO2L6/6fSzNsLaHIw==}
+  /fast-redact@3.1.2:
+    resolution: {integrity: sha512-+0em+Iya9fKGfEQGcd62Yv6onjBmmhV1uh86XVfOU8VwAe6kaFdQCWI9s0/Nnugx5Vd9tdbZ7e6gE2tR9dzXdw==}
     engines: {node: '>=6'}
     dev: false
 
@@ -49498,8 +50375,8 @@ packages:
       ua-parser-js: 0.7.24
     dev: false
 
-  /fbjs@3.0.5:
-    resolution: {integrity: sha512-ztsSx77JBtkuMrEypfhgc3cI0+0h+svqeie7xHbh1k/IKdcydnvadp/mUaGgjAOXQmQSxsqgaRhS3q9fy+1kxg==}
+  /fbjs@3.0.4:
+    resolution: {integrity: sha512-ucV0tDODnGV3JCnnkmoszb5lf4bNpzjv80K41wd4k798Etq+UYD0y0TIfalLjZoKgjive6/adkRnszwapiDgBQ==}
     dependencies:
       cross-fetch: 3.1.5
       fbjs-css-vars: 1.0.2
@@ -49507,7 +50384,7 @@ packages:
       object-assign: 4.1.1
       promise: 7.3.1
       setimmediate: 1.0.5
-      ua-parser-js: 1.0.35
+      ua-parser-js: 0.7.33
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -49722,7 +50599,7 @@ packages:
     resolution: {integrity: sha512-X8Z+b/0L4lToKYq+lwnKqi9X/Zek0NibLpsJgVsSxpoYq7JtiCtRb5HqKVEjEw/qAb/4AKKRLOwwKHlWNpm2Eg==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
 
   /firstline@2.0.2:
@@ -49824,12 +50701,12 @@ packages:
       vue-template-compiler:
         optional: true
     dependencies:
-      '@babel/code-frame': 7.10.4
+      '@babel/code-frame': 7.18.6
       chalk: 2.4.2
       eslint: 7.32.0
       micromatch: 3.1.10
       minimatch: 3.0.5
-      semver: 5.7.2
+      semver: 5.7.1
       tapable: 1.1.3
       typescript: 4.7.4
       webpack: 5.84.1(esbuild@0.14.29)
@@ -49854,15 +50731,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-
-  /form-data@4.0.0:
-    resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
-    engines: {node: '>= 6'}
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    dev: false
 
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -49954,10 +50822,6 @@ packages:
 
   /fs-monkey@1.0.3:
     resolution: {integrity: sha512-cybjIfiiE+pTWicSCLFHSrXZ6EilF30oh91FDP9S2B051prEa7QWfrVTQm10/dDpswBDXZugPa1Ogu8Yh+HV0Q==}
-    dev: false
-
-  /fs-monkey@1.0.4:
-    resolution: {integrity: sha512-INM/fWAxMICjttnD0DX1rBvinKskj5G1w+oy/pnm9u/tSlnBrzFonJMcalKJ30P8RRsPzKcCG7Q8l0jx5Fh9YQ==}
 
   /fs-readdir-recursive@1.1.0:
     resolution: {integrity: sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==}
@@ -49981,8 +50845,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
       functions-have-names: 1.2.3
     dev: false
 
@@ -50050,12 +50914,11 @@ packages:
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
 
-  /get-intrinsic@1.2.1:
-    resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
+  /get-intrinsic@1.2.0:
+    resolution: {integrity: sha512-L049y6nFOuom5wGyRc3/gdTLO94dySVKRACj1RmJZBQXlbTMhtNIgkWkUHq+jYmZvKf14EW1EoJnnjbmoHij0Q==}
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
-      has-proto: 1.0.1
       has-symbols: 1.0.3
 
   /get-npm-tarball-url@2.0.3:
@@ -50100,7 +50963,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
     dev: false
 
   /get-tsconfig@4.2.0:
@@ -50119,8 +50982,8 @@ packages:
       isobject: 3.0.1
     dev: false
 
-  /get-xpath@3.1.0:
-    resolution: {integrity: sha512-R/52dpa+WO8bO/df5VivWIf+VoI++iPVEPrAKRUSQHOBEK1cxKMmTxbhCoGUNIH+znE9ZvU5rFd188QkV4Q6QA==}
+  /get-xpath@3.0.1:
+    resolution: {integrity: sha512-GWG+RbJ7VE40rn4/NYYGojQbgN3Eha0s223ZSz1IhHFcGlMU+X7H5Iyrbuz6csiWqedAKplpS3udLw9X1nqX5Q==}
     dev: false
 
   /getpass@0.1.7:
@@ -50265,17 +51128,6 @@ packages:
       path-is-absolute: 1.0.1
     dev: false
 
-  /glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-    dev: false
-
   /glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
@@ -50332,7 +51184,7 @@ packages:
     resolution: {integrity: sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==}
     engines: {node: '>= 0.4'}
     dependencies:
-      define-properties: 1.2.0
+      define-properties: 1.1.4
     dev: false
 
   /globby@11.0.1:
@@ -50341,7 +51193,7 @@ packages:
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
-      fast-glob: 3.3.0
+      fast-glob: 3.2.12
       ignore: 5.2.4
       merge2: 1.4.1
       slash: 3.0.0
@@ -50362,7 +51214,7 @@ packages:
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
 
   /got@11.8.6:
     resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
@@ -50373,7 +51225,7 @@ packages:
       '@types/cacheable-request': 6.0.3
       '@types/responselike': 1.0.0
       cacheable-lookup: 5.0.4
-      cacheable-request: 7.0.4
+      cacheable-request: 7.0.2
       decompress-response: 6.0.0
       http2-wrapper: 1.0.3
       lowercase-keys: 2.0.0
@@ -50490,7 +51342,7 @@ packages:
       graphql: ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
     dependencies:
       graphql: 15.8.0
-      tslib: 2.6.0
+      tslib: 2.5.0
 
   /graphql-tools@4.0.8(graphql@15.8.0):
     resolution: {integrity: sha512-MW+ioleBrwhRjalKjYaLQbr+920pHBgy9vM/n47sswtns8+96sRn5M/G+J1eu7IMeKWiN/9p6tmwCHU7552VJg==}
@@ -50589,7 +51441,7 @@ packages:
     engines: {node: '>=0.4.7'}
     hasBin: true
     dependencies:
-      minimist: 1.2.8
+      minimist: 1.2.7
       neo-async: 2.6.2
       source-map: 0.6.1
       wordwrap: 1.0.0
@@ -50651,11 +51503,12 @@ packages:
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
     engines: {node: '>= 0.4'}
+    dev: false
 
   /has-symbols@1.0.3:
     resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
@@ -50720,7 +51573,7 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       safe-buffer: 5.2.1
     dev: false
 
@@ -50734,7 +51587,7 @@ packages:
   /hast-to-hyperscript@9.0.1:
     resolution: {integrity: sha512-zQgLKqF+O2F72S1aa4y2ivxzSlko3MAvxkwG8ehGmNiqd98BIN3JM1rAJPmplEyLmGLO2QZYJtIneOSZ2YbJuA==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       comma-separated-tokens: 1.0.8
       property-information: 5.6.0
       space-separated-tokens: 1.1.5
@@ -50771,7 +51624,7 @@ packages:
   /hast-util-raw@6.0.1:
     resolution: {integrity: sha512-ZMuiYA+UF7BXBtsTBNcLBF5HzXzkyE6MLzJnL605LKE8GJylNjGc4jjxazAHUtcwT5/CEt6afRKViYB4X66dig==}
     dependencies:
-      '@types/hast': 2.3.5
+      '@types/hast': 2.3.4
       hast-util-from-parse5: 6.0.1
       hast-util-to-parse5: 6.0.0
       html-void-elements: 1.0.5
@@ -50805,7 +51658,7 @@ packages:
   /hastscript@6.0.0:
     resolution: {integrity: sha512-nDM6bvd7lIqDUiYEiu5Sl/+6ReP0BMk/2f4U/Rooccxkj0P5nm+acM5PrGJ/t5I8qPGiqZSE6hVAwZEdZIvP4w==}
     dependencies:
-      '@types/hast': 2.3.5
+      '@types/hast': 2.3.4
       comma-separated-tokens: 1.0.8
       hast-util-parse-selector: 2.2.5
       property-information: 5.6.0
@@ -50826,7 +51679,7 @@ packages:
     resolution: {integrity: sha512-TAOnTB8Tz5Dw8penUuzHVrKNKlCIbwwbHnXraNJxPwf8LRtE2HlM84RYuezMFcwOJmoYOCWVDyJ8TQGxn9PgxA==}
     dependencies:
       glob: 8.1.0
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /highlight.js@10.7.3:
@@ -50875,7 +51728,7 @@ packages:
     dependencies:
       inherits: 2.0.4
       obuf: 1.1.2
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
       wbuf: 1.7.3
 
   /html-encoding-sniffer@2.0.1:
@@ -50885,15 +51738,8 @@ packages:
       whatwg-encoding: 1.0.5
     dev: false
 
-  /html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
-    dependencies:
-      whatwg-encoding: 2.0.0
-    dev: false
-
-  /html-entities@2.4.0:
-    resolution: {integrity: sha512-igBTJcNNNhvZFRtm8uA6xMY6xYleeDwn3PeBCkDz7tHttv4F2hsDI2aPgNERWzvRcNYHNT3ymRaQzllmXj4YsQ==}
+  /html-entities@2.3.3:
+    resolution: {integrity: sha512-DV5Ln36z34NNTDgnz0EWGBLZENelNAtkiFA4kyNOG2tDI6Mz1uSWiq1wAKdyjnJwyDiDO7Fa2SO1CTxPXL8VxA==}
 
   /html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
@@ -51043,7 +51889,7 @@ packages:
     resolution: {integrity: sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==}
     engines: {node: '>=8.0.0'}
     dependencies:
-      '@types/http-proxy': 1.17.11
+      '@types/http-proxy': 1.17.9
       http-proxy: 1.18.1(debug@4.3.2)
       is-glob: 4.0.1
       is-plain-obj: 3.0.0
@@ -51062,7 +51908,7 @@ packages:
         optional: true
     dependencies:
       '@types/express': 4.17.13
-      '@types/http-proxy': 1.17.11
+      '@types/http-proxy': 1.17.9
       http-proxy: 1.18.1(debug@4.3.2)
       is-glob: 4.0.1
       is-plain-obj: 3.0.0
@@ -51253,12 +52099,12 @@ packages:
     resolution: {integrity: sha512-aqXhGP7//Gui2+UrEtvxZxSquQVXTpZ7KDxfCcKAF3Vysvw0CViVaW9RZ1j1xlIYqaaaipBoqdqeibkc18PNvA==}
     dev: false
 
-  /immer@9.0.21:
-    resolution: {integrity: sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==}
+  /immer@9.0.19:
+    resolution: {integrity: sha512-eY+Y0qcsB4TZKwgQzLaE/lqYMlKhv5J9dyd2RhhtGhNo2njPXDqU9XPfcNfa3MIDsdtZt5KlkIsirlo4dHsWdQ==}
     dev: false
 
-  /immutable@4.3.1:
-    resolution: {integrity: sha512-lj9cnmB/kVS0QHsJnYKD1uo3o39nrbKxszjnqS9Fr6NB7bZzW45U6WSGBPKXDL/CvDKqDNPA4r3DoDQ8GTxo2A==}
+  /immutable@4.2.2:
+    resolution: {integrity: sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==}
     dev: false
 
   /import-fresh@3.3.0:
@@ -51344,7 +52190,7 @@ packages:
     peerDependencies:
       html-webpack-plugin: ^5.3.1
     dependencies:
-      debug: 4.3.2
+      debug: 4.3.4(supports-color@9.3.1)
       html-webpack-plugin: 5.3.2(webpack@5.84.1)
       insert-string-after: 1.0.0
       insert-string-before: 1.0.0
@@ -51359,7 +52205,7 @@ packages:
       ink: '>=3.0.5'
       react: '>=16.8.2'
     dependencies:
-      cli-spinners: 2.9.0
+      cli-spinners: 2.7.0
       ink: 3.2.0(@types/react@17.0.8)(bufferutil@4.0.3)(react@17.0.2)(utf-8-validate@5.0.5)
       react: 17.0.2
     dev: false
@@ -51387,7 +52233,7 @@ packages:
       lodash: 4.17.21
       patch-console: 1.0.0
       react: 17.0.2
-      react-devtools-core: 4.28.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      react-devtools-core: 4.27.1(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       react-reconciler: 0.26.2(react@17.0.2)
       scheduler: 0.20.2
       signal-exit: 3.0.7
@@ -51510,11 +52356,11 @@ packages:
     resolution: {integrity: sha512-Z3sKgwLX+x22HyEUjHJe05GdetR3aYtJy17cXRaym57AwXwI8Z7dCbAiYB+3d8u9NW/qi8ZLNhTev29H7QXnXw==}
     dev: false
 
-  /internal-slot@1.0.5:
-    resolution: {integrity: sha512-Y+R5hJrzs52QCG2laLn4udYVnxsfny9CpOhNhUvk/SSSVyF6T27FzRbF0sroPidSu3X8oEAkOn2K804mjpt6UQ==}
+  /internal-slot@1.0.4:
+    resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       has: 1.0.3
       side-channel: 1.0.4
 
@@ -51526,8 +52372,8 @@ packages:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
 
-  /ipaddr.js@2.1.0:
-    resolution: {integrity: sha512-LlbxQ7xKzfBusov6UMi4MFpEg0m+mAm9xyNGEduwXMEDuf4WfzB/RZwMVYEd7IKGvh4IUkEXYxtAVu9T3OelJQ==}
+  /ipaddr.js@2.0.1:
+    resolution: {integrity: sha512-1qTgH9NG+IIJ4yfKs2e6Pp1bZg8wbDbKHT21HrLIeYBTRLgMYKnMTPAuI3Lcs61nfx5h1xlXnbJtH1kX5/d/ng==}
     engines: {node: '>= 10'}
 
   /is-accessor-descriptor@0.1.6:
@@ -51567,12 +52413,12 @@ packages:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
 
-  /is-array-buffer@3.0.2:
-    resolution: {integrity: sha512-y+FyyR/w8vfIRq4eQcM1EYgSTnmHXPqaF+IgzgraytCFq5Xh8lllDVmAZolPJiZttZLeFSINPYMaEJ7/vWUa1w==}
+  /is-array-buffer@3.0.1:
+    resolution: {integrity: sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      is-typed-array: 1.1.12
+      get-intrinsic: 1.2.0
+      is-typed-array: 1.1.10
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
@@ -51634,8 +52480,8 @@ packages:
       ci-info: 2.0.0
     dev: false
 
-  /is-core-module@2.12.1:
-    resolution: {integrity: sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==}
+  /is-core-module@2.11.0:
+    resolution: {integrity: sha512-RRjxlvLDkD1YJwDbroBHMb+cukurkDWNyHx7D3oNB5x9rb5ogcksMC5wHCadcXoo67gVr/+3GFySh3134zi6rw==}
     dependencies:
       has: 1.0.3
 
@@ -51799,7 +52645,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.1.4
     dev: false
 
   /is-negative-zero@2.0.2:
@@ -51963,11 +52809,15 @@ packages:
     dependencies:
       has-symbols: 1.0.3
 
-  /is-typed-array@1.1.12:
-    resolution: {integrity: sha512-Z14TF2JNG8Lss5/HMqt0//T9JeHXttXy5pH/DBU4vi98ozO2btxzq9MwYDZYnKwU8nRsz/+GVFVRDq3DkVuSPg==}
+  /is-typed-array@1.1.10:
+    resolution: {integrity: sha512-PJqgEHiWZvMpaFZ3uTc8kHPM4+4ADTlDniuQL7cU/UDA0Ql7F70yGfHph3cLNe+c9toaigv+DFzTJKhc2CtO6A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      which-typed-array: 1.1.11
+      available-typed-arrays: 1.0.5
+      call-bind: 1.0.2
+      for-each: 0.3.3
+      gopd: 1.0.1
+      has-tostringtag: 1.0.0
 
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
@@ -51999,7 +52849,7 @@ packages:
     resolution: {integrity: sha512-t2yVvttHkQktwnNNmBQ98AhENLdPUTDTE21uPqAQ0ARwQfGeQKRVS0NNurH7bTf7RrvcVn1OOge45CnBeHCSmg==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
 
   /is-what@3.14.1:
     resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
@@ -52066,7 +52916,7 @@ packages:
     resolution: {integrity: sha512-9c4TNAKYXM5PRyVcwUZrF3W09nQ+sO7+jydgs4ZGW9dhsLG2VOlISJABombdQqQRXCwuYG3sYV/puGf5rp0qmA==}
     dependencies:
       node-fetch: 1.7.3
-      whatwg-fetch: 3.6.16
+      whatwg-fetch: 3.6.2
     dev: false
 
   /isstream@0.1.2:
@@ -52083,10 +52933,10 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.22.4
       '@istanbuljs/schema': 0.1.3
       istanbul-lib-coverage: 3.2.0
-      semver: 6.3.1
+      semver: 6.3.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -52402,7 +53252,7 @@ packages:
     resolution: {integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==}
     engines: {node: '>= 10.14.2'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       '@jest/types': 26.6.2
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -52417,7 +53267,7 @@ packages:
     resolution: {integrity: sha512-rMyFe1+jnyAAf+NHwTclDz0eAaLkVDdKVHHBFWsBWHnnh5YeJMNWWsv7AbFYXfK3oTqvL7VTWkhNLu1jX24D+g==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       '@jest/types': 27.5.1
       '@types/stack-utils': 2.0.1
       chalk: 4.1.2
@@ -52524,8 +53374,8 @@ packages:
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
       chalk: 4.1.2
-      cjs-module-lexer: 1.2.3
-      collect-v8-coverage: 1.0.2
+      cjs-module-lexer: 1.2.2
+      collect-v8-coverage: 1.0.1
       execa: 5.1.1
       glob: 7.1.6
       graceful-fs: 4.2.10
@@ -52555,13 +53405,13 @@ packages:
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
     dependencies:
       '@babel/core': 7.19.6
-      '@babel/generator': 7.22.9
-      '@babel/plugin-syntax-typescript': 7.22.5(@babel/core@7.19.6)
-      '@babel/traverse': 7.22.8
+      '@babel/generator': 7.20.14
+      '@babel/plugin-syntax-typescript': 7.20.0(@babel/core@7.19.6)
+      '@babel/traverse': 7.20.13
       '@babel/types': 7.22.3
       '@jest/transform': 27.5.1
       '@jest/types': 27.5.1
-      '@types/babel__traverse': 7.20.1
+      '@types/babel__traverse': 7.18.3
       '@types/prettier': 2.3.2
       babel-preset-current-node-syntax: 1.0.1(@babel/core@7.19.6)
       chalk: 4.1.2
@@ -52629,7 +53479,7 @@ packages:
       jest-watcher: 27.5.1
       slash: 4.0.0
       string-length: 5.0.1
-      strip-ansi: 7.1.0
+      strip-ansi: 7.0.1
     dev: false
 
   /jest-watcher@27.5.1:
@@ -52733,24 +53583,24 @@ packages:
         optional: true
     dependencies:
       abab: 2.0.6
-      acorn: 8.10.0
+      acorn: 8.8.2
       acorn-globals: 6.0.0
       cssom: 0.4.4
       cssstyle: 2.3.0
       data-urls: 2.0.0
       decimal.js: 10.4.3
       domexception: 2.0.1
-      escodegen: 2.1.0
+      escodegen: 2.0.0
       form-data: 3.0.1
       html-encoding-sniffer: 2.0.1
       http-proxy-agent: 4.0.1
       https-proxy-agent: 5.0.0
       is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.7
+      nwsapi: 2.2.2
       parse5: 6.0.1
       saxes: 5.0.1
       symbol-tree: 3.2.4
-      tough-cookie: 4.1.3
+      tough-cookie: 4.1.2
       w3c-hr-time: 1.0.2
       w3c-xmlserializer: 2.0.0
       webidl-conversions: 6.1.0
@@ -52759,44 +53609,6 @@ packages:
       whatwg-url: 8.7.0
       ws: 7.5.9(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       xml-name-validator: 3.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    dev: false
-
-  /jsdom@22.1.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
-    resolution: {integrity: sha512-/9AVW7xNbsBv6GfWho4TTNjEo9fe6Zhf9O7s0Fhhr3u+awPwAJMKwAMXnkk5vBxflqLW9hTHX/0cs+P3gW+cQw==}
-    engines: {node: '>=16'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    dependencies:
-      abab: 2.0.6
-      cssstyle: 3.0.0
-      data-urls: 4.0.0
-      decimal.js: 10.4.3
-      domexception: 4.0.0
-      form-data: 4.0.0
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.7
-      parse5: 7.1.2
-      rrweb-cssom: 0.6.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.3
-      w3c-xmlserializer: 4.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 12.0.1
-      ws: 8.13.0(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      xml-name-validator: 4.0.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -52875,7 +53687,7 @@ packages:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
     hasBin: true
     dependencies:
-      minimist: 1.2.8
+      minimist: 1.2.7
     dev: false
 
   /json5@2.2.3:
@@ -52916,16 +53728,6 @@ packages:
       semver: 7.5.2
     dev: false
 
-  /jsonwebtoken@9.0.1:
-    resolution: {integrity: sha512-K8wx7eJ5TPvEjuiVSkv167EVboBDv9PZdDoF7BgeQnBLVvZWW9clr2PsQHVJDTKaEIH5JBIwHujGcHp7GgI2eg==}
-    engines: {node: '>=12', npm: '>=6'}
-    dependencies:
-      jws: 3.2.2
-      lodash: 4.17.21
-      ms: 2.1.3
-      semver: 7.5.2
-    dev: false
-
   /jsprim@1.4.2:
     resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
     engines: {node: '>=0.6.0'}
@@ -52948,20 +53750,18 @@ packages:
       source-map: 0.4.4
     dev: false
 
-  /jsx-ast-utils@3.3.4:
-    resolution: {integrity: sha512-fX2TVdCViod6HwKEtSWGHs57oFhVfCMwieb9PuRDgjDPh5XeqJiHFFFJCHxU5cnTc3Bu/GRL+kPiFmw8XWOfKw==}
+  /jsx-ast-utils@3.3.3:
+    resolution: {integrity: sha512-fYQHZTZ8jSfmWZ0iyzfwiU4WDX4HpHbMCZ3gPlWYiCl3BoeOTsqKBqnTVfH2rYT7eP5c3sVbeSPHnnJOaTrWiw==}
     engines: {node: '>=4.0'}
     dependencies:
       array-includes: 3.1.6
-      array.prototype.flat: 1.3.1
       object.assign: 4.1.4
-      object.values: 1.1.6
     dev: false
 
   /jsx-to-string@1.4.0:
     resolution: {integrity: sha512-BmDM0gMngtBcjET7iEDuMxU+ZA4fTFWhMWAfbJeZP0X0VIaN7+At3wa64v48hzuE9rf77VAwlI/aMJrR+9LEZA==}
     dependencies:
-      immutable: 4.3.1
+      immutable: 4.2.2
       json-stringify-pretty-compact: 1.2.0
       react: 0.14.10
     dev: false
@@ -53002,8 +53802,8 @@ packages:
       tsscmp: 1.0.6
     dev: false
 
-  /keyv@4.5.3:
-    resolution: {integrity: sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==}
+  /keyv@4.5.2:
+    resolution: {integrity: sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==}
     dependencies:
       json-buffer: 3.0.1
     dev: false
@@ -53061,8 +53861,8 @@ packages:
     resolution: {integrity: sha512-tN0MCzyWnoz/4nHS6uxdlFWoUZT7ABptwKPQ52Ea7URk6vll88bWBVhodtnlfEuCcKWNGoc+uGbw1cwa9IKh/w==}
     dev: false
 
-  /language-tags@1.0.8:
-    resolution: {integrity: sha512-aWAZwgPLS8hJ20lNPm9HNVs4inexz6S2sQa3wx/+ycuutMNE5/IfYxiWYBbi+9UWCQVaXYCOPUl6gFrPR7+jGg==}
+  /language-tags@1.0.7:
+    resolution: {integrity: sha512-bSytju1/657hFjgUzPAPqszxH62ouE8nQFoFaVlIQfne4wO/wXC9A4+m8jYve7YBBvi59eq0SUpcshvG8h5Usw==}
     dependencies:
       language-subtag-registry: 0.3.22
     dev: false
@@ -53078,13 +53878,13 @@ packages:
     resolution: {integrity: sha512-JpDCcQnyAAzZZaZ7vEiSqL690w7dAEyLao+KC96zBplnYbJS7TYNjvM3M7y3dGz+v7aIsJk3hllWuc0kWAjyRQ==}
     dependencies:
       picocolors: 1.0.0
-      shell-quote: 1.8.1
+      shell-quote: 1.8.0
 
   /lazystream@1.0.1:
     resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
     engines: {node: '>= 0.6.3'}
     dependencies:
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
 
   /less-loader@10.0.0(less@4.1.3)(webpack@5.84.1):
@@ -53118,7 +53918,7 @@ packages:
     dependencies:
       copy-anything: 2.0.6
       parse-node-version: 1.0.1
-      tslib: 2.6.0
+      tslib: 2.5.0
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.10
@@ -53157,8 +53957,8 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /lilconfig@2.1.0:
-    resolution: {integrity: sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==}
+  /lilconfig@2.0.6:
+    resolution: {integrity: sha512-9JROoBW7pobfsx+Sq2JsASvCo6Pfo6WWoUW79HuB1BCoBXD4PLWJPqDF6fNj67pqBYTbAHkE57M1kS/+L1neOg==}
     engines: {node: '>=10'}
     dev: false
 
@@ -53183,9 +53983,9 @@ packages:
     hasBin: true
     dependencies:
       cli-truncate: 3.1.0
-      colorette: 2.0.20
+      colorette: 2.0.19
       commander: 9.5.0
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       execa: 5.1.1
       lilconfig: 2.0.5
       listr2: 4.0.5(enquirer@2.3.6)
@@ -53193,8 +53993,8 @@ packages:
       normalize-path: 3.0.0
       object-inspect: 1.12.3
       pidtree: 0.5.0
-      string-argv: 0.3.2
-      supports-color: 9.4.0
+      string-argv: 0.3.1
+      supports-color: 9.3.1
       yaml: 1.10.2
     transitivePeerDependencies:
       - enquirer
@@ -53445,15 +54245,14 @@ packages:
       wrap-ansi: 6.2.0
     dev: false
 
-  /logform@2.5.1:
-    resolution: {integrity: sha512-9FyqAm9o9NKKfiAKfZoYo9bGXXuwMkxQiQttkT4YjjVtQVIQtK6LmVtlxmCaFswo6N4AfEkHqZTV0taDtPotNg==}
+  /logform@2.4.2:
+    resolution: {integrity: sha512-W4c9himeAwXEdZ05dQNerhFz2XG80P9Oj0loPUMV23VC2it0orMHQhJm4hdnnor3rd1HsGf6a2lPwBM1zeXHGw==}
     dependencies:
       '@colors/colors': 1.5.0
-      '@types/triple-beam': 1.3.2
       fecha: 4.2.3
       ms: 2.1.3
-      safe-stable-stringify: 2.4.3
-      triple-beam: 1.4.1
+      safe-stable-stringify: 2.4.2
+      triple-beam: 1.3.0
     dev: false
 
   /loglevel-colored-level-prefix@1.0.0:
@@ -53506,7 +54305,7 @@ packages:
   /lower-case@2.0.2:
     resolution: {integrity: sha512-7fm3l3NAF9WfN6W3JOmf5drwpVqX78JtoGJ3A6W0a6ZnldM41w2fV5D490psKFTpMds8TJse/eHLFFsNHHjHgg==}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /lowercase-keys@1.0.1:
@@ -53565,8 +54364,8 @@ packages:
       es5-ext: 0.10.62
     dev: false
 
-  /lz-string@1.5.0:
-    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+  /lz-string@1.4.4:
+    resolution: {integrity: sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==}
     hasBin: true
 
   /magic-string@0.25.9:
@@ -53587,14 +54386,14 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pify: 4.0.1
-      semver: 5.7.2
+      semver: 5.7.1
     dev: false
 
   /make-dir@3.1.0:
     resolution: {integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==}
     engines: {node: '>=8'}
     dependencies:
-      semver: 6.3.1
+      semver: 6.3.0
 
   /make-empty-dir@2.0.0:
     resolution: {integrity: sha512-kKvqQBL0LzLd6tmG1TwGTxAS8kgS0LPtKMlH5M0awKGixPo6EEaE2i0gHpXXoywoSjYOvZpdWrxln6NdgQ3q4g==}
@@ -53621,7 +54420,7 @@ packages:
       minipass-pipeline: 1.2.4
       negotiator: 0.6.3
       promise-retry: 2.0.1
-      socks-proxy-agent: 6.2.1
+      socks-proxy-agent: 6.1.1
       ssri: 8.0.1
     transitivePeerDependencies:
       - bluebird
@@ -53709,7 +54508,7 @@ packages:
   /mdast-util-from-markdown@0.8.5:
     resolution: {integrity: sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==}
     dependencies:
-      '@types/mdast': 3.0.12
+      '@types/mdast': 3.0.10
       mdast-util-to-string: 2.0.0
       micromark: 2.11.4
       parse-entities: 2.0.0
@@ -53721,8 +54520,8 @@ packages:
   /mdast-util-to-hast@9.1.2:
     resolution: {integrity: sha512-OpkFLBC2VnNAb2FNKcKWu9FMbJhQKog+FCT8nuKmQNIKXyT1n3SIskE7uWDep6x+cA20QXlK5AETHQtYmQmxtQ==}
     dependencies:
-      '@types/mdast': 3.0.12
-      '@types/unist': 2.0.7
+      '@types/mdast': 3.0.10
+      '@types/unist': 2.0.6
       mdast-util-definitions: 3.0.1
       mdurl: 1.0.1
       unist-builder: 2.0.3
@@ -53784,11 +54583,11 @@ packages:
       fs-monkey: 1.0.3
     dev: false
 
-  /memfs@3.5.3:
-    resolution: {integrity: sha512-UERzLsxzllchadvbPs5aolHh65ISpKpM+ccLbOJ8/vvpBKmAWf+la7dXFy7Mr0ySHbdHrFv5kGFCUHHe6GFEmw==}
+  /memfs@3.4.13:
+    resolution: {integrity: sha512-omTM41g3Skpvx5dSYeZIbXKcXoAVc/AoMNwn9TKx++L/gaen/+4TTttmu8ZSch5vfVJ8uJvGbroTsIlslRg6lg==}
     engines: {node: '>= 4.0.0'}
     dependencies:
-      fs-monkey: 1.0.4
+      fs-monkey: 1.0.3
 
   /memoize-one@6.0.0:
     resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
@@ -53818,7 +54617,7 @@ packages:
     engines: {node: '>=4.3.0 <5.0.0 || >=5.10'}
     dependencies:
       errno: 0.1.8
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
     dev: false
 
   /memorystream@0.3.1:
@@ -53957,7 +54756,7 @@ packages:
     peerDependencies:
       webpack: ^5.0.0
     dependencies:
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
@@ -53992,13 +54791,6 @@ packages:
       brace-expansion: 2.0.1
     dev: false
 
-  /minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    dependencies:
-      brace-expansion: 2.0.1
-    dev: false
-
   /minimist@0.0.10:
     resolution: {integrity: sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==}
     dev: false
@@ -54007,8 +54799,8 @@ packages:
     resolution: {integrity: sha512-miQKw5Hv4NS1Psg2517mV4e4dYNaO3++hjAvLOAzKqZ61rH8NS1SK+vbfBWZ5PY/Me/bEWhUwqMghEW5Fb9T7Q==}
     dev: false
 
-  /minimist@1.2.8:
-    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+  /minimist@1.2.7:
+    resolution: {integrity: sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==}
     dev: false
 
   /minio@7.0.32:
@@ -54022,7 +54814,7 @@ packages:
       crypto-browserify: 3.12.0
       es6-error: 4.1.1
       fast-xml-parser: 3.21.1
-      ipaddr.js: 2.1.0
+      ipaddr.js: 2.0.1
       json-stream: 1.0.0
       lodash: 4.17.21
       mime-types: 2.1.35
@@ -54080,8 +54872,8 @@ packages:
       yallist: 4.0.0
     dev: false
 
-  /minipass@4.2.8:
-    resolution: {integrity: sha512-fNzuVyifolSLFL4NzpF+wEF4qrgqaaKX0haXPQEdQ7NKAN+WecoKMHV09YcuL/DHxrUsYQOK3MiuDf7Ip2OXfQ==}
+  /minipass@4.0.1:
+    resolution: {integrity: sha512-V9esFpNbK0arbN3fm2sxDKqMYgIp7XtVdE4Esj+PE4Qaaxdg1wIw48ITQIOn1sc8xXSmUviVL3cyjMqPlrVkiA==}
     engines: {node: '>=8'}
     dev: false
 
@@ -54122,7 +54914,7 @@ packages:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
     hasBin: true
     dependencies:
-      minimist: 1.2.8
+      minimist: 1.2.7
     dev: false
 
   /mkdirp@1.0.4:
@@ -54325,7 +55117,7 @@ packages:
       react-dom: '*'
     dependencies:
       css-tree: 1.1.2
-      csstype: 3.1.2
+      csstype: 3.1.1
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 6.0.4
       react: 17.0.2
@@ -54333,7 +55125,7 @@ packages:
       rtl-css-js: 1.16.1
       sourcemap-codec: 1.4.8
       stacktrace-js: 2.0.2
-      stylis: 4.3.0
+      stylis: 4.1.3
     dev: true
 
   /nanoclone@0.2.1:
@@ -54352,8 +55144,8 @@ packages:
     hasBin: true
     dev: false
 
-  /nanoid@3.3.6:
-    resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
+  /nanoid@3.3.4:
+    resolution: {integrity: sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
     dev: false
@@ -54407,8 +55199,8 @@ packages:
     hasBin: true
     dependencies:
       json-stringify-safe: 5.0.1
-      minimist: 1.2.8
-      readable-stream: 3.6.2
+      minimist: 1.2.7
+      readable-stream: 3.6.0
       split2: 3.2.2
       through2: 4.0.2
     dev: false
@@ -54474,7 +55266,7 @@ packages:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /node-dir@0.1.17:
@@ -54548,35 +55340,35 @@ packages:
   /node-releases@1.1.77:
     resolution: {integrity: sha512-rB1DUFUNAN4Gn9keO2K1efO35IDK7yKHCdCaIMvFO7yUYmmZYeDjnGKle26G4rwj+LKRQpjyUUvMkPglwGCYNQ==}
 
-  /node-releases@2.0.13:
-    resolution: {integrity: sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==}
+  /node-releases@2.0.9:
+    resolution: {integrity: sha512-2xfmOrRkGogbTK9R6Leda0DGiXeY3p2NJpy4+gNCffdUvV6mdEJnaDEic1i3Ec2djAo8jWYoJMR5PB0MSMpxUA==}
 
   /node-source-walk@4.2.0:
     resolution: {integrity: sha512-hPs/QMe6zS94f5+jG3kk9E7TNm4P2SulrKiLWMzKszBfNZvL/V6wseHlTd7IvfW0NZWqPtK3+9yYNr+3USGteA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.20.13
     dev: false
 
   /node-source-walk@4.3.0:
     resolution: {integrity: sha512-8Q1hXew6ETzqKRAs3jjLioSxNfT1cx74ooiF8RlAONwVMcfq+UdzLC2eB5qcPldUxaE5w3ytLkrmV1TGddhZTA==}
     engines: {node: '>=6.0'}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.22.4
     dev: false
 
-  /node-source-walk@5.0.2:
-    resolution: {integrity: sha512-Y4jr/8SRS5hzEdZ7SGuvZGwfORvNsSsNRwDXx5WisiqzsVfeftDvRgfeqWNgZvWSJbgubTRVRYBzK6UO+ErqjA==}
+  /node-source-walk@5.0.1:
+    resolution: {integrity: sha512-fe5rFjPqkWQb4CLfsOf10fZAJvImfLpcVx+Nqbozaj6PBoAEjyEK1HZGCGvQNyre2HdL1HnZG6mxBf2UHSzr/w==}
     engines: {node: '>=12'}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.20.13
     dev: false
 
   /node-source-walk@6.0.2:
     resolution: {integrity: sha512-jn9vOIK/nfqoFCcpK89/VCVaLg1IHE6UVfDOzvqmANaJ/rWCTEdH8RZ1V278nv2jr36BJdyQXIAavBLXpzdlag==}
     engines: {node: '>=14'}
     dependencies:
-      '@babel/parser': 7.22.7
+      '@babel/parser': 7.22.4
     dev: false
 
   /node.extend@2.0.2:
@@ -54611,7 +55403,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       resolve: 1.20.0
-      semver: 5.7.2
+      semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: false
 
@@ -54620,7 +55412,7 @@ packages:
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
       hosted-git-info: 6.1.1
-      is-core-module: 2.12.1
+      is-core-module: 2.11.0
       semver: 7.5.2
       validate-npm-package-license: 3.0.4
     dev: false
@@ -54655,8 +55447,8 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     dev: false
 
-  /npm-normalize-package-bin@3.0.1:
-    resolution: {integrity: sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==}
+  /npm-normalize-package-bin@3.0.0:
+    resolution: {integrity: sha512-g+DPQSkusnk7HYXr75NtzkIP4+N81i3RPsGFidF3DzHd9MT9wWngmqoeg/fnHFz5MNdtG4w03s+QnhewSLTT2Q==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dev: false
 
@@ -54665,7 +55457,7 @@ packages:
     dependencies:
       hosted-git-info: 2.8.9
       osenv: 0.1.5
-      semver: 5.7.2
+      semver: 5.7.1
       validate-npm-package-name: 3.0.0
     dev: false
 
@@ -54692,7 +55484,7 @@ packages:
       minimatch: 3.0.5
       pidtree: 0.3.1
       read-pkg: 3.0.0
-      shell-quote: 1.8.1
+      shell-quote: 1.8.0
       string.prototype.padend: 3.1.4
     dev: false
 
@@ -54884,8 +55676,8 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
-  /nwsapi@2.2.7:
-    resolution: {integrity: sha512-ub5E4+FBPKwAZx0UwIQOjYWGHTEq5sPqHQNRN8Z9e4A7u3Tj1weLJsL59yH9vmvqEtBHaOmT6cYQKIZOxp35FQ==}
+  /nwsapi@2.2.2:
+    resolution: {integrity: sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==}
     dev: false
 
   /oauth-sign@0.9.0:
@@ -54932,7 +55724,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.1.4
 
   /object-keys@1.1.1:
     resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
@@ -54955,7 +55747,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.1.4
       has-symbols: 1.0.3
       object-keys: 1.1.1
 
@@ -54964,8 +55756,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /object.fromentries@2.0.6:
@@ -54973,19 +55765,18 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
-  /object.getownpropertydescriptors@2.1.6:
-    resolution: {integrity: sha512-lq+61g26E/BgHv0ZTFgRvi7NMEPuAxLkFU7rukXjc/AlwH4Am5xXVnIXy3un1bg/JPbXHrixRkK1itUzzPiIjQ==}
+  /object.getownpropertydescriptors@2.1.5:
+    resolution: {integrity: sha512-yDNzckpM6ntyQiGTik1fKV1DcVDRS+w8bvpWNCBanvH5LfRX9O8WTHqQzG4RZwRAM4I0oU7TV11Lj5v0g20ibw==}
     engines: {node: '>= 0.8'}
     dependencies:
       array.prototype.reduce: 1.0.5
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      safe-array-concat: 1.0.0
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /object.pick@1.3.0:
@@ -55000,8 +55791,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /objnest@5.1.1:
@@ -55089,8 +55880,8 @@ packages:
       is-wsl: 2.2.0
     dev: false
 
-  /open@8.4.2:
-    resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
+  /open@8.4.0:
+    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
     engines: {node: '>=12'}
     dependencies:
       define-lazy-prop: 2.0.0
@@ -55100,7 +55891,7 @@ packages:
   /optimism@0.16.2:
     resolution: {integrity: sha512-zWNbgWj+3vLEjZNIh/okkY2EUfX+vB9TJopzIZwT1xxaMqC5hRLLraePod4c5n4He08xuXNH+zhKFFCu390wiQ==}
     dependencies:
-      '@wry/context': 0.7.3
+      '@wry/context': 0.7.0
       '@wry/trie': 0.3.2
 
   /optimist@0.3.7:
@@ -55125,19 +55916,19 @@ packages:
       levn: 0.3.0
       prelude-ls: 1.1.2
       type-check: 0.3.2
-      word-wrap: 1.2.4
+      word-wrap: 1.2.3
     dev: false
 
-  /optionator@0.9.3:
-    resolution: {integrity: sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==}
+  /optionator@0.9.1:
+    resolution: {integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==}
     engines: {node: '>= 0.8.0'}
     dependencies:
-      '@aashutoshrathi/word-wrap': 1.2.6
       deep-is: 0.1.4
       fast-levenshtein: 2.0.6
       levn: 0.4.1
       prelude-ls: 1.2.1
       type-check: 0.4.0
+      word-wrap: 1.2.3
     dev: false
 
   /ora@5.4.1:
@@ -55147,7 +55938,7 @@ packages:
       bl: 4.1.0
       chalk: 4.1.2
       cli-cursor: 3.1.0
-      cli-spinners: 2.9.0
+      cli-spinners: 2.7.0
       is-interactive: 1.0.0
       is-unicode-supported: 0.1.0
       log-symbols: 4.1.0
@@ -55367,7 +56158,7 @@ packages:
       got: 6.7.1
       registry-auth-token: 3.4.0
       registry-url: 3.1.0
-      semver: 5.7.2
+      semver: 5.7.1
     dev: false
 
   /pad-right@0.2.2:
@@ -55389,7 +56180,7 @@ packages:
     resolution: {integrity: sha512-RXlj7zCYokReqWpOPH9oYivUzLYZ5vAPIfEmCTNViosC78F8F0H9y7T7gG2M39ymgutxF5gcFEsyZQSph9Bp3A==}
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /parent-module@1.0.1:
@@ -55444,7 +56235,7 @@ packages:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
@@ -55464,7 +56255,7 @@ packages:
     resolution: {integrity: sha512-InpdgIdNe5xWMEUcrVQUniQKwnggBtJ7+SCwh7zQAZwbbIYZV9XdgJyhtmDSSvykFyQXoe4BINnzKTfCwWLs5g==}
     engines: {node: '>=8.15'}
     dependencies:
-      semver: 6.3.1
+      semver: 6.3.0
     dev: false
 
   /parse-package-name@0.1.0:
@@ -55520,7 +56311,7 @@ packages:
     resolution: {integrity: sha512-uWlGT3YSnK9x3BQJaOdcZwrnV6hPpd8jFH1/ucpiLRPh/2zCVJKS19E4GvYHvaCcACn3foXZ0cLB9Wrx1KGe5g==}
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: false
 
   /pascalcase@0.1.1:
@@ -55697,33 +56488,33 @@ packages:
     resolution: {integrity: sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==}
     dependencies:
       duplexify: 4.1.2
-      split2: 4.2.0
+      split2: 4.1.0
     dev: false
 
   /pino-abstract-transport@1.0.0:
     resolution: {integrity: sha512-c7vo5OpW4wIS42hUVcT5REsL8ZljsUfBjqV/e2sFxmFEFZiq1XLUp5EYLtuDH6PEHq9W1egWqRbnLUP5FuZmOA==}
     dependencies:
-      readable-stream: 4.4.2
-      split2: 4.2.0
+      readable-stream: 4.3.0
+      split2: 4.1.0
     dev: false
 
   /pino-pretty@9.1.0:
     resolution: {integrity: sha512-IM6NY9LLo/dVgY7/prJhCh4rAJukafdt0ibxeNOWc2fxKMyTk90SOB9Ao2HfbtShT9QPeP0ePpJktksMhSQMYA==}
     hasBin: true
     dependencies:
-      colorette: 2.0.20
+      colorette: 2.0.19
       dateformat: 4.6.3
       fast-copy: 2.1.7
       fast-safe-stringify: 2.1.1
       help-me: 4.2.0
       joycon: 3.1.1
-      minimist: 1.2.8
+      minimist: 1.2.7
       on-exit-leak-free: 2.1.0
       pino-abstract-transport: 1.0.0
       pump: 3.0.0
-      readable-stream: 4.4.2
+      readable-stream: 4.3.0
       secure-json-parse: 2.7.0
-      sonic-boom: 3.3.0
+      sonic-boom: 3.2.1
       strip-json-comments: 3.1.1
     dev: false
 
@@ -55731,8 +56522,8 @@ packages:
     resolution: {integrity: sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q==}
     dev: false
 
-  /pino-std-serializers@6.2.2:
-    resolution: {integrity: sha512-cHjPPsE+vhj/tnhCy/wiMh3M3z3h/j15zHQX+S9GkTBgqJuTuJzYJ4gUyACLhDaJ7kk9ba9iRDmbH2tJU03OiA==}
+  /pino-std-serializers@6.1.0:
+    resolution: {integrity: sha512-KO0m2f1HkrPe9S0ldjx7za9BJjeHqBku5Ch8JyxETxT8dEFGz1PwgrHaOQupVYitpzbFSYm7nnljxD8dik2c+g==}
     dev: false
 
   /pino@7.11.0:
@@ -55740,14 +56531,14 @@ packages:
     hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.2.0
+      fast-redact: 3.1.2
       on-exit-leak-free: 0.2.0
       pino-abstract-transport: 0.5.0
       pino-std-serializers: 4.0.0
       process-warning: 1.0.0
       quick-format-unescaped: 4.0.4
       real-require: 0.1.0
-      safe-stable-stringify: 2.4.3
+      safe-stable-stringify: 2.4.2
       sonic-boom: 2.8.0
       thread-stream: 0.15.2
     dev: false
@@ -55757,20 +56548,20 @@ packages:
     hasBin: true
     dependencies:
       atomic-sleep: 1.0.0
-      fast-redact: 3.2.0
+      fast-redact: 3.1.2
       on-exit-leak-free: 2.1.0
       pino-abstract-transport: 1.0.0
-      pino-std-serializers: 6.2.2
-      process-warning: 2.2.0
+      pino-std-serializers: 6.1.0
+      process-warning: 2.1.0
       quick-format-unescaped: 4.0.4
       real-require: 0.2.0
-      safe-stable-stringify: 2.4.3
-      sonic-boom: 3.3.0
+      safe-stable-stringify: 2.4.2
+      sonic-boom: 3.2.1
       thread-stream: 2.3.0
     dev: false
 
-  /pirates@4.0.6:
-    resolution: {integrity: sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg==}
+  /pirates@4.0.5:
+    resolution: {integrity: sha512-8V9+HQPupnaXMA23c5hvl69zXvTwTzyAYasnkb0Tts4XvO4CliqONMOnvlq26rkhLC3nWDFBJf73LU1e1VZLaQ==}
     engines: {node: '>= 6'}
     dev: false
 
@@ -55832,7 +56623,7 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-browser-comments@4.0.0(browserslist@4.16.3)(postcss@8.4.18):
@@ -55852,7 +56643,7 @@ packages:
       postcss: ^8.2.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
     dev: false
 
@@ -55896,13 +56687,13 @@ packages:
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-colormin@5.3.1(postcss@8.4.18):
-    resolution: {integrity: sha512-UsWQG0AqTFQmpBegeLLc1+c3jIqBNB0zlDGRWR+dQ3pRKJL1oeMzyqmH3o2PIfn9MBdNrVPWhDbT769LxCTLJQ==}
+  /postcss-colormin@5.3.0(postcss@8.4.18):
+    resolution: {integrity: sha512-WdDO4gOFG2Z8n4P8TWBpshnL3JpmNmJwdnfP2gbk2qBA8PWwOYcmjmI/t3CmMeL72a7Hkd+x/Mg9O2/0rD54Pg==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       caniuse-api: 3.0.0
       colord: 2.9.3
       postcss: 8.4.18
@@ -55915,7 +56706,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
     dev: false
@@ -55947,7 +56738,7 @@ packages:
       postcss: ^8.3
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-dir-pseudo-class@6.0.5(postcss@8.4.18):
@@ -55957,7 +56748,7 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-discard-comments@5.1.2(postcss@8.4.18):
@@ -56032,7 +56823,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-focus-within@5.0.4(postcss@8.4.18):
@@ -56042,7 +56833,7 @@ packages:
       postcss: ^8.4
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-font-variant@5.0.0(postcss@8.4.18):
@@ -56134,17 +56925,17 @@ packages:
       stylehacks: 5.1.1(postcss@8.4.18)
     dev: false
 
-  /postcss-merge-rules@5.1.4(postcss@8.4.18):
-    resolution: {integrity: sha512-0R2IuYpgU93y9lhVbO/OylTtKMVcHb67zjWIfCiKR9rWL3GUk1677LAqD/BcHizukdZEjT8Ru3oHRoAYoJy44g==}
+  /postcss-merge-rules@5.1.3(postcss@8.4.18):
+    resolution: {integrity: sha512-LbLd7uFC00vpOuMvyZop8+vvhnfRGpp2S+IMQKeuOZZapPRY4SMq5ErjQeHbHsjCUgJkRNrlU+LmxsKIqPKQlA==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       caniuse-api: 3.0.0
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-minify-font-values@5.1.0(postcss@8.4.18):
@@ -56175,7 +56966,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       cssnano-utils: 3.1.0(postcss@8.4.18)
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
@@ -56188,7 +56979,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-modules-extract-imports@3.0.0(postcss@8.4.18):
@@ -56200,15 +56991,15 @@ packages:
       postcss: 8.4.18
     dev: false
 
-  /postcss-modules-local-by-default@4.0.3(postcss@8.4.18):
-    resolution: {integrity: sha512-2/u2zraspoACtrbFRnTijMiQtb4GW4BvatjaG/bCjYQo8kLTdevCUlwuBHx2sCnSyrI3x3qj4ZK1j5LQBgzmwA==}
+  /postcss-modules-local-by-default@4.0.0(postcss@8.4.18):
+    resolution: {integrity: sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==}
     engines: {node: ^10 || ^12 || >= 14}
     peerDependencies:
       postcss: ^8.1.0
     dependencies:
       icss-utils: 5.1.0(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
       postcss-value-parser: 4.2.0
     dev: false
 
@@ -56219,7 +57010,7 @@ packages:
       postcss: ^8.1.0
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-modules-values@4.0.0(postcss@8.4.18):
@@ -56238,9 +57029,9 @@ packages:
     peerDependencies:
       postcss: ^8.2
     dependencies:
-      '@csstools/selector-specificity': 2.2.0(postcss-selector-parser@6.0.13)
+      '@csstools/selector-specificity': 2.1.1(postcss-selector-parser@6.0.11)(postcss@8.4.18)
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-normalize-charset@5.1.0(postcss@8.4.18):
@@ -56308,7 +57099,7 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       postcss: 8.4.18
       postcss-value-parser: 4.2.0
     dev: false
@@ -56416,12 +57207,12 @@ packages:
       '@csstools/postcss-text-decoration-shorthand': 1.0.0(postcss@8.4.18)
       '@csstools/postcss-trigonometric-functions': 1.0.2(postcss@8.4.18)
       '@csstools/postcss-unset-value': 1.0.2(postcss@8.4.18)
-      autoprefixer: 10.4.14(postcss@8.4.18)
-      browserslist: 4.21.9
+      autoprefixer: 10.4.13(postcss@8.4.18)
+      browserslist: 4.21.5
       css-blank-pseudo: 3.0.3(postcss@8.4.18)
       css-has-pseudo: 3.0.4(postcss@8.4.18)
       css-prefers-color-scheme: 6.0.3(postcss@8.4.18)
-      cssdb: 7.6.0
+      cssdb: 7.4.1
       postcss: 8.4.18
       postcss-attribute-case-insensitive: 5.0.2(postcss@8.4.18)
       postcss-clamp: 4.1.0(postcss@8.4.18)
@@ -56461,16 +57252,16 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
-  /postcss-reduce-initial@5.1.2(postcss@8.4.18):
-    resolution: {integrity: sha512-dE/y2XRaqAi6OvjzD22pjTUQ8eOfc6m/natGHgKFBK9DxFmIm69YmaRVQrGgFlEfc1HePIurY0TmDeROK05rIg==}
+  /postcss-reduce-initial@5.1.1(postcss@8.4.18):
+    resolution: {integrity: sha512-//jeDqWcHPuXGZLoolFrUXBDyuEGbr9S2rMo19bkTIjBQ4PqkaO+oI8wua5BOUxpfi97i3PCoInsiFIEBfkm9w==}
     engines: {node: ^10 || ^12 || >=14.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       caniuse-api: 3.0.0
       postcss: 8.4.18
     dev: false
@@ -56500,11 +57291,11 @@ packages:
       postcss: ^8.2
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
-  /postcss-selector-parser@6.0.13:
-    resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
+  /postcss-selector-parser@6.0.11:
+    resolution: {integrity: sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==}
     engines: {node: '>=4'}
     dependencies:
       cssesc: 3.0.0
@@ -56529,7 +57320,7 @@ packages:
       postcss: ^8.2.15
     dependencies:
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
   /postcss-value-parser@4.2.0:
@@ -56548,7 +57339,7 @@ packages:
     resolution: {integrity: sha512-Wi8mWhncLJm11GATDaQKobXSNEYGUHeQLiQqDFG1qQ5UTDPTEvKw0Xt5NsTpktGTwLps3ByrWsBrG0rB8YQ9oA==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
-      nanoid: 3.3.6
+      nanoid: 3.3.4
       picocolors: 1.0.0
       source-map-js: 1.0.2
     dev: false
@@ -56714,8 +57505,8 @@ packages:
     resolution: {integrity: sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==}
     dev: false
 
-  /process-warning@2.2.0:
-    resolution: {integrity: sha512-/1WZ8+VQjR6avWOgHeEPd7SDQmFQ1B5mC1eRXsCm5TarlNmx/wCsa5GEaxGm05BORRtyG/Ex/3xq3TuRvq57qg==}
+  /process-warning@2.1.0:
+    resolution: {integrity: sha512-9C20RLxrZU/rFnxWncDkuF6O999NdIf3E1ws4B0ZeY3sRVPzWBMsYDE2lxjxhiXxg464cQTgKUGm8/i6y2YGXg==}
     dev: false
 
   /process@0.11.10:
@@ -56908,19 +57699,14 @@ packages:
     resolution: {integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==}
     engines: {node: '>=6'}
 
-  /punycode@2.3.0:
-    resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
-    engines: {node: '>=6'}
-    dev: false
-
   /puppeteer@13.7.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
     resolution: {integrity: sha512-U1uufzBjz3+PkpCxFrWzh4OrMIdIb2ztzCu0YEPfRHjHswcSwHZswnK+WdsOQJsRV8WeTg3jLhJR4D867+fjsA==}
     engines: {node: '>=10.18.1'}
-    deprecated: < 19.4.0 is no longer supported
+    deprecated: < 18.1.0 is no longer supported
     requiresBuild: true
     dependencies:
       cross-fetch: 3.1.5
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       devtools-protocol: 0.0.981744
       extract-zip: 2.0.1
       https-proxy-agent: 5.0.1
@@ -57088,7 +57874,7 @@ packages:
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
-      minimist: 1.2.8
+      minimist: 1.2.7
       strip-json-comments: 2.0.1
     dev: false
 
@@ -57113,8 +57899,8 @@ packages:
       object-assign: 4.1.1
       promise: 8.3.0
       raf: 3.4.1
-      regenerator-runtime: 0.13.7
-      whatwg-fetch: 3.6.16
+      regenerator-runtime: 0.13.11
+      whatwg-fetch: 3.6.2
     dev: false
 
   /react-create-ref@1.0.1(react@17.0.2):
@@ -57167,10 +57953,10 @@ packages:
       - vue-template-compiler
     dev: false
 
-  /react-devtools-core@4.28.0(bufferutil@4.0.3)(utf-8-validate@5.0.5):
-    resolution: {integrity: sha512-E3C3X1skWBdBzwpOUbmXG8SgH6BtsluSMe+s6rRcujNKG1DGi8uIfhdhszkgDpAsMoE55hwqRUzeXCmETDBpTg==}
+  /react-devtools-core@4.27.1(bufferutil@4.0.3)(utf-8-validate@5.0.5):
+    resolution: {integrity: sha512-qXhcxxDWiFmFAOq48jts9YQYe1+wVoUXzJTlY4jbaATzyio6dd6CUGu3dXBhREeVgpZ+y4kg6vFJzIOZh6vY2w==}
     dependencies:
-      shell-quote: 1.8.1
+      shell-quote: 1.8.0
       ws: 7.4.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     transitivePeerDependencies:
       - bufferutil
@@ -57264,7 +58050,7 @@ packages:
       prism-react-renderer: 1.3.5(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      sucrase: 3.34.0
+      sucrase: 3.32.0
       use-editable: 2.3.3(react@17.0.2)
     dev: false
 
@@ -57278,7 +58064,7 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       react-use: 17.4.0(react-dom@17.0.2)(react@17.0.2)
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: true
 
   /react-native-web@0.14.13(react-dom@17.0.2)(react@17.0.2):
@@ -57309,7 +58095,7 @@ packages:
     dependencies:
       array-find-index: 1.0.2
       create-react-class: 15.7.0
-      fbjs: 3.0.5
+      fbjs: 3.0.4
       hyphenate-style-name: 1.0.4
       inline-style-prefixer: 6.0.4
       normalize-css-color: 1.0.2
@@ -57384,7 +58170,7 @@ packages:
   /react-syntax-highlighter@15.4.3(react@17.0.2):
     resolution: {integrity: sha512-TnhGgZKXr5o8a63uYdRTzeb8ijJOgRGe0qjrE0eK/gajtdyqnSO6LqB3vW16hHB0cFierYSoy/AOJw8z1Dui8g==}
     peerDependencies:
-      react: '*'
+      react: '>= 0.14.0'
     dependencies:
       '@babel/runtime': 7.20.0
       highlight.js: 10.7.3
@@ -57420,14 +58206,14 @@ packages:
     resolution: {integrity: sha512-4+ow23tp/Tv7hBM5Az5/Be/eKKF7DIvJ09voz5LyHGQaqqz9WV8YMs31eFvcYQs7d451LSg7kDJV70XYN/Ug/Q==}
     dev: false
 
-  /react-universal-interface@0.6.2(react@17.0.2)(tslib@2.6.0):
+  /react-universal-interface@0.6.2(react@17.0.2)(tslib@2.5.0):
     resolution: {integrity: sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==}
     peerDependencies:
       react: '*'
       tslib: '*'
     dependencies:
       react: 17.0.2
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: true
 
   /react-use-dimensions@1.2.1(@types/react@17.0.8)(react@17.0.2)(typescript@4.7.4):
@@ -57457,13 +58243,13 @@ packages:
       nano-css: 5.3.5(react-dom@17.0.2)(react@17.0.2)
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      react-universal-interface: 0.6.2(react@17.0.2)(tslib@2.6.0)
+      react-universal-interface: 0.6.2(react@17.0.2)(tslib@2.5.0)
       resize-observer-polyfill: 1.5.1
       screenfull: 5.2.0
       set-harmonic-interval: 1.0.1
       throttle-debounce: 3.0.1
       ts-easing: 0.2.0
-      tslib: 2.6.0
+      tslib: 2.5.0
     dev: true
 
   /react-xarrows@2.0.2(react@17.0.2):
@@ -57601,8 +58387,8 @@ packages:
       util-deprecate: 1.0.2
     dev: false
 
-  /readable-stream@2.3.8:
-    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+  /readable-stream@2.3.7:
+    resolution: {integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==}
     dependencies:
       core-util-is: 1.0.3
       inherits: 2.0.4
@@ -57612,23 +58398,22 @@ packages:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
 
-  /readable-stream@3.6.2:
-    resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
+  /readable-stream@3.6.0:
+    resolution: {integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==}
     engines: {node: '>= 6'}
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
-  /readable-stream@4.4.2:
-    resolution: {integrity: sha512-Lk/fICSyIhodxy1IDK2HazkeGjSmezAWX2egdtJnYhtzKEsBPJowlI6F6LPb5tqIQILrMbx22S5o3GuJavPusA==}
+  /readable-stream@4.3.0:
+    resolution: {integrity: sha512-MuEnA0lbSi7JS8XM+WNJlWZkHAAdm7gETHdFK//Q/mChGyj2akEFtdLZh32jSdkWGbRwCW9pn6g3LWDdDeZnBQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       abort-controller: 3.0.0
       buffer: 6.0.3
       events: 3.3.0
       process: 0.11.10
-      string_decoder: 1.3.0
     dev: false
 
   /readdir-enhanced@1.5.2:
@@ -57639,10 +58424,17 @@ packages:
       glob-to-regexp: 0.3.0
     dev: false
 
-  /readdir-glob@1.1.3:
-    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
+  /readdir-glob@1.1.2:
+    resolution: {integrity: sha512-6RLVvwJtVwEDfPdn6X6Ille4/lxGl0ATOY4FN/B9nxQcgOazvvI0nodiD19ScKq0PvA/29VpaOQML36o5IzZWA==}
     dependencies:
       minimatch: 5.1.6
+    dev: false
+
+  /readdirp@3.5.0:
+    resolution: {integrity: sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==}
+    engines: {node: '>=8.10.0'}
+    dependencies:
+      picomatch: 2.3.1
     dev: false
 
   /readdirp@3.6.0:
@@ -57764,12 +58556,12 @@ packages:
     resolution: {integrity: sha512-tlbJqcMHnPKI9zSrystikWKwHkBqu2a/Sgw01h3zFjvYrMxEDYHzzoMZnUrbIfpTFEsoRnnviOXNCzFiSc54Qw==}
     dev: false
 
-  /regexp.prototype.flags@1.5.0:
-    resolution: {integrity: sha512-0SutC3pNudRKgquxGoRGIz946MZVHqbNfPjBdxeOhBrdgDKlRoXmYLQN9xRbrR09ZXWeGAdPuif7egofn6v5LA==}
+  /regexp.prototype.flags@1.4.3:
+    resolution: {integrity: sha512-fjggEOO3slI6Wvgjwflkc4NFRCTZAu5CnNfBd5qOMYhWdn67nJBBu34/TkD++eeFmd8C9r9jfXJ27+nSiRkSUA==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.1.4
       functions-have-names: 1.2.3
 
   /regexpp@1.1.0:
@@ -57787,13 +58579,13 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /regexpu-core@5.3.2:
-    resolution: {integrity: sha512-RAM5FlZz+Lhmo7db9L298p2vHP5ZywrVXmVXpmAD9GuL5MPH6t9ROw1iA/wfHkQ76Qe7AaPF0nGuim96/IrQMQ==}
+  /regexpu-core@5.2.2:
+    resolution: {integrity: sha512-T0+1Zp2wjF/juXMrMxHxidqGYn8U4R+zleSJhX9tQ1PUsS8a9UtYfbsF9LdiVgNX3kiX8RNaKM42nfSgvFJjmw==}
     engines: {node: '>=4'}
     dependencies:
-      '@babel/regjsgen': 0.8.0
       regenerate: 1.4.2
       regenerate-unicode-properties: 10.1.0
+      regjsgen: 0.7.1
       regjsparser: 0.9.1
       unicode-match-property-ecmascript: 2.0.0
       unicode-match-property-value-ecmascript: 2.1.0
@@ -57811,6 +58603,9 @@ packages:
     dependencies:
       rc: 1.2.8
     dev: false
+
+  /regjsgen@0.7.1:
+    resolution: {integrity: sha512-RAt+8H2ZEzHeYWxZ3H2z6tF18zyyOnlcdaafLrm21Bguj7uZy6ULibiAFdXEtKQY4Sy7wDTwDiOazasMLc4KPA==}
 
   /regjsparser@0.9.1:
     resolution: {integrity: sha512-dQUtn90WanSNl+7mQKcXAgZxvUe7Z0SqXlgzv0za4LwiUhyzBC58yQO3liFoUgu8GiJVInAhJjkj1N0EtQ5nkQ==}
@@ -58112,14 +58907,14 @@ packages:
   /resolve@1.20.0:
     resolution: {integrity: sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==}
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.11.0
       path-parse: 1.0.7
 
   /resolve@1.22.2:
     resolution: {integrity: sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==}
     hasBin: true
     dependencies:
-      is-core-module: 2.12.1
+      is-core-module: 2.11.0
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
     dev: false
@@ -58231,11 +59026,11 @@ packages:
     peerDependencies:
       rollup: ^2.0.0
     dependencies:
-      '@babel/code-frame': 7.22.5
+      '@babel/code-frame': 7.18.6
       jest-worker: 26.6.2
       rollup: 2.79.1
       serialize-javascript: 4.0.0
-      terser: 5.19.1
+      terser: 5.17.3
     dev: false
 
   /rollup@2.79.1:
@@ -58253,10 +59048,6 @@ packages:
       can-link: 2.0.0
       next-path: 1.0.0
       path-temp: 2.0.0
-    dev: false
-
-  /rrweb-cssom@0.6.0:
-    resolution: {integrity: sha512-APM0Gt1KoXBz0iIkkdB/kfvGOwC4UuJFeG/c+yV7wSc7q96cG/kJ0HiYCnzivD9SB53cLV1MlHFNfOuPaadYSw==}
     dev: false
 
   /rtl-css-js@1.16.1:
@@ -58303,17 +59094,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.6.0
-    dev: false
-
-  /safe-array-concat@1.0.0:
-    resolution: {integrity: sha512-9dVEFruWIsnie89yym+xWTAYASdpw3CJV7Li/6zBewGf9z2i1j31rP6jnY0pHEO4QZh6N0K11bFjWmdR8UGdPQ==}
-    engines: {node: '>=0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      has-symbols: 1.0.3
-      isarray: 2.0.5
+      tslib: 2.5.0
     dev: false
 
   /safe-buffer@5.1.2:
@@ -58351,7 +59132,7 @@ packages:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       is-regex: 1.1.4
     dev: false
 
@@ -58361,8 +59142,8 @@ packages:
       ret: 0.1.15
     dev: false
 
-  /safe-stable-stringify@2.4.3:
-    resolution: {integrity: sha512-e2bDA2WJT0wxseVd4lsDP4+3ONX6HpMXQa1ZhFQ7SU+GjvORCmShbCMltrtIDfkYhVHrOcPtj+KhmDBdPdZD1g==}
+  /safe-stable-stringify@2.4.2:
+    resolution: {integrity: sha512-gMxvPJYhP0O9n2pvcfYfIuYgbledAOJFcqRThtPRmjscaipiwcwPPKLytpVzMkG2HAN87Qmo2d4PtGiri1dSLA==}
     engines: {node: '>=10'}
     dev: false
 
@@ -58429,8 +59210,8 @@ packages:
     engines: {node: '>=14.0.0'}
     hasBin: true
     dependencies:
-      chokidar: 3.5.3
-      immutable: 4.3.1
+      chokidar: 3.5.1
+      immutable: 4.2.2
       source-map-js: 1.0.2
     dev: false
 
@@ -58449,24 +59230,26 @@ packages:
       xmlchars: 2.2.0
     dev: false
 
-  /saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
-    dependencies:
-      xmlchars: 2.2.0
-    dev: false
-
   /scheduler@0.20.2:
     resolution: {integrity: sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==}
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
 
-  /schema-utils@3.3.0:
-    resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
+  /schema-utils@3.1.1:
+    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
     engines: {node: '>= 10.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
+      ajv: 6.12.6
+      ajv-keywords: 3.5.2(ajv@6.12.6)
+    dev: false
+
+  /schema-utils@3.1.2:
+    resolution: {integrity: sha512-pvjEHOgWc9OWA/f/DE3ohBWTD6EleVLf7iFUkoSwAxttdBhB9QUebQgxER2kWueOvRJXPHNnyrvvh9eZINB8Eg==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.11
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
 
@@ -58474,17 +59257,7 @@ packages:
     resolution: {integrity: sha512-1edyXKgh6XnJsJSQ8mKWXnN/BVaIbFMLpouRUrXgVq7WYne5kw3MW7UPhO44uRXQSIpTSXoJbmrR2X0w9kUTyg==}
     engines: {node: '>= 12.13.0'}
     dependencies:
-      '@types/json-schema': 7.0.12
-      ajv: 8.12.0
-      ajv-formats: 2.1.1
-      ajv-keywords: 5.1.0(ajv@8.12.0)
-    dev: false
-
-  /schema-utils@4.2.0:
-    resolution: {integrity: sha512-L0jRsrPpjdckP3oPug3/VxNKt2trR8TcabrM6FOAAlvC/9Phcmm+cuAgTlxBqdBR1WJx7Naj9WHw+aOmheSVbw==}
-    engines: {node: '>= 12.13.0'}
-    dependencies:
-      '@types/json-schema': 7.0.12
+      '@types/json-schema': 7.0.11
       ajv: 8.12.0
       ajv-formats: 2.1.1
       ajv-keywords: 5.1.0(ajv@8.12.0)
@@ -58515,13 +59288,13 @@ packages:
     resolution: {integrity: sha512-gL8F8L4ORwsS0+iQ34yCYv///jsOq0ZL7WP55d1HnJ32o7tyFYEFQZQA22mrLIacZdU6xecaBBZ+uEiffGNyXw==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      semver: 5.7.2
+      semver: 5.7.1
     dev: false
 
   /semver-intersect@1.4.0:
     resolution: {integrity: sha512-d8fvGg5ycKAq0+I6nfWeCx6ffaWJCsBYU0H2Rq56+/zFePYfT8mXkB3tWBSjR5BerkHNZ5eTPIk1/LBYas35xQ==}
     dependencies:
-      semver: 5.7.2
+      semver: 5.7.1
     dev: false
 
   /semver-range-intersect@0.3.1:
@@ -58529,7 +59302,7 @@ packages:
     engines: {node: '>=8.3.0'}
     dependencies:
       '@types/semver': 6.2.3
-      semver: 6.3.1
+      semver: 6.3.0
     dev: false
 
   /semver-regex@3.1.4:
@@ -58541,7 +59314,7 @@ packages:
     resolution: {integrity: sha512-JicVlQKz/C//4BiPmbHEDou6HihXxo5xqB/8Hm9FaLJ6HHkRRvYgCECq4u/z0XF8kyJQ/KAZt++A/kYz/oOSSg==}
     engines: {node: '>=0.10.0'}
     dependencies:
-      semver: 5.7.2
+      semver: 5.7.1
       semver-regex: 3.1.4
     dev: false
 
@@ -58549,13 +59322,13 @@ packages:
     resolution: {integrity: sha512-EjnoLE5OGmDAVV/8YDoN5KiajNadjzIp9BAHOhYeQHt7j0UWxjmgsx4YD48wp4Ue1Qogq38F1GNUJNqF1kKKxA==}
     dev: false
 
-  /semver@5.7.2:
-    resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
+  /semver@5.7.1:
+    resolution: {integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==}
     hasBin: true
     dev: false
 
-  /semver@6.3.1:
-    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+  /semver@6.3.0:
+    resolution: {integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==}
     hasBin: true
 
   /semver@7.3.4:
@@ -58572,6 +59345,22 @@ packages:
     dependencies:
       lru-cache: 6.0.0
     dev: true
+
+  /semver@7.5.0:
+    resolution: {integrity: sha512-+XC0AD/R7Q2mPSRuy2Id0+CGTZ98+8f+KvwirxOKIEyid+XSx6HbC63p+O4IndTHuX5Z+JxQ0TghCkO5Cg/2HA==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
+
+  /semver@7.5.1:
+    resolution: {integrity: sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      lru-cache: 6.0.0
+    dev: false
 
   /semver@7.5.2:
     resolution: {integrity: sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==}
@@ -58772,8 +59561,8 @@ packages:
     resolution: {integrity: sha512-mRz/m/JVscCrkMyPqHc/bczi3OQHkLTqXHEFu0zDhK/qfv3UcOA4SVmRCLmos4bhjr9ekVQubj/R7waKapmiQg==}
     dev: false
 
-  /shell-quote@1.8.1:
-    resolution: {integrity: sha512-6j1W9l1iAs/4xYBI1SYOVZyFcCis9b4KCLQ8fgAGG07QvzaRLVVRQvAy85yNmmZSjYjg4MWh4gNvlPujU/5LpA==}
+  /shell-quote@1.8.0:
+    resolution: {integrity: sha512-QHsz8GgQIGKlRi24yFc6a6lN69Idnx634w49ay6+jA5yFh7a1UY+4Rp6HPx/L/1zcEDPEij8cIsiqR6bQsE5VQ==}
 
   /shelljs@0.3.0:
     resolution: {integrity: sha512-Ny0KN4dyT8ZSCE0frtcbAJGoM/HTArpyPkeli1/00aYfm0sbD/Gk/4x7N2DP9QKGpBsiQH7n6rpm1L79RtviEQ==}
@@ -58785,7 +59574,7 @@ packages:
     resolution: {integrity: sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==}
     dependencies:
       call-bind: 1.0.2
-      get-intrinsic: 1.2.1
+      get-intrinsic: 1.2.0
       object-inspect: 1.12.3
 
   /signal-exit@3.0.7:
@@ -58975,17 +59764,6 @@ packages:
       - supports-color
     dev: false
 
-  /socks-proxy-agent@6.2.1:
-    resolution: {integrity: sha512-a6KW9G+6B3nWZ1yB8G7pJwL3ggLy1uTzKAgCb7ttblwqdz9fMGJUuTy3uFzEP48FAs9FLILlmzDlE2JJhVQaXQ==}
-    engines: {node: '>= 10'}
-    dependencies:
-      agent-base: 6.0.2
-      debug: 4.3.4(supports-color@9.4.0)
-      socks: 2.7.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
   /socks@2.7.1:
     resolution: {integrity: sha512-7maUZy1N7uo6+WVEX6psASxtNlKaNVMlGQKkG/63nEDdLOWNbiUMoLK7X4uYoLhQstau72mLgfEWcXcwsaHbYQ==}
     engines: {node: '>= 10.13.0', npm: '>= 3.0.0'}
@@ -58996,6 +59774,12 @@ packages:
 
   /sonic-boom@2.8.0:
     resolution: {integrity: sha512-kuonw1YOYYNOve5iHdSahXPOK49GqwA+LZhI6Wz/l0rP57iKyXXIHaRagOBHAPmGwJC6od2Z9zgvZ5loSgMlVg==}
+    dependencies:
+      atomic-sleep: 1.0.0
+    dev: false
+
+  /sonic-boom@3.2.1:
+    resolution: {integrity: sha512-iITeTHxy3B9FGu8aVdiDXUVAcHMF9Ss0cCsAOo2HfCrmVGT3/DT5oYaeu0M/YKZDlKTvChEyPq0zI9Hf33EX6A==}
     dependencies:
       atomic-sleep: 1.0.0
     dev: false
@@ -59114,11 +59898,11 @@ packages:
       proc-output: 1.0.8
     dev: false
 
-  /spdx-correct@3.2.0:
-    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+  /spdx-correct@3.1.1:
+    resolution: {integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==}
     dependencies:
       spdx-expression-parse: 3.0.1
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.12
     dev: false
 
   /spdx-exceptions@2.3.0:
@@ -59129,11 +59913,11 @@ packages:
     resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
     dependencies:
       spdx-exceptions: 2.3.0
-      spdx-license-ids: 3.0.13
+      spdx-license-ids: 3.0.12
     dev: false
 
-  /spdx-license-ids@3.0.13:
-    resolution: {integrity: sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==}
+  /spdx-license-ids@3.0.12:
+    resolution: {integrity: sha512-rr+VVSXtRhO4OHbXUiAF7xW3Bo9DuuF6C5jH+q/x15j2jniycgKbxU09Hr0WqlSLUs4i4ltHGXqTe7VHclYWyA==}
     dev: false
 
   /spdy-transport@3.0.0:
@@ -59143,7 +59927,7 @@ packages:
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       wbuf: 1.7.3
     transitivePeerDependencies:
       - supports-color
@@ -59184,11 +59968,11 @@ packages:
   /split2@3.2.2:
     resolution: {integrity: sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==}
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
-  /split2@4.2.0:
-    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+  /split2@4.1.0:
+    resolution: {integrity: sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==}
     engines: {node: '>= 10.x'}
     dev: false
 
@@ -59228,7 +60012,7 @@ packages:
     resolution: {integrity: sha512-WVy6di9DlPOeBWEjMScpNipeSX2jIZBGEn5Uuo8Q7aIuFEuDX0pw8RxcOjlD1TWP4obi24ki7m/13+nFpcbXrw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
     dependencies:
-      minipass: 4.2.8
+      minipass: 4.0.1
     dev: false
 
   /ssri@10.0.4:
@@ -59332,7 +60116,7 @@ packages:
     resolution: {integrity: sha512-iCGQj+0l0HOdZ2AEeBADlsRC+vsnDsZsbdSiH1yNSjcfKM7fdpCMfqAL/dwF5BLiw/XhRft/Wax6zQbhq2BcjQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      internal-slot: 1.0.5
+      internal-slot: 1.0.4
 
   /stoppable@1.1.0:
     resolution: {integrity: sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==}
@@ -59343,7 +60127,7 @@ packages:
     resolution: {integrity: sha512-H73RAHsVBapbim0tU2JwwOiXUj+fikfiaoYAKHF3VJfA0pe2BCzkhAHBlLG6REzE+2WNZcxOXjK7lkso+9euLA==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /stream-buffers@3.0.2:
@@ -59356,7 +60140,7 @@ packages:
     dependencies:
       builtin-status-codes: 3.0.0
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       xtend: 4.0.2
     dev: false
 
@@ -59388,8 +60172,8 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
+  /string-argv@0.3.1:
+    resolution: {integrity: sha512-a1uQGz7IyVy9YwhqjZIZu1c8JO8dNIe20xBmSS6qu9kv++k3JGzCVmprbNN5Kn+BgzD5E7YYwg1CcjuJMRNsvg==}
     engines: {node: '>=0.6.19'}
     dev: false
 
@@ -59410,7 +60194,7 @@ packages:
     engines: {node: '>=12.20'}
     dependencies:
       char-regex: 2.0.1
-      strip-ansi: 7.1.0
+      strip-ansi: 7.0.1
     dev: false
 
   /string-width@1.0.2:
@@ -59454,19 +60238,19 @@ packages:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.1.0
+      strip-ansi: 7.0.1
     dev: false
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-      get-intrinsic: 1.2.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
+      get-intrinsic: 1.2.0
       has-symbols: 1.0.3
-      internal-slot: 1.0.5
-      regexp.prototype.flags: 1.5.0
+      internal-slot: 1.0.4
+      regexp.prototype.flags: 1.4.3
       side-channel: 1.0.4
     dev: false
 
@@ -59475,33 +60259,24 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
-    dev: false
-
-  /string.prototype.trim@1.2.7:
-    resolution: {integrity: sha512-p6TmeT1T3411M8Cgg9wBTMRtY2q9+PNy9EV1i2lIXUN/btt763oIfxwN3RR8VU6wHX8j/1CFy0L+YuThm6bgOg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /string.prototype.trimend@1.0.6:
     resolution: {integrity: sha512-JySq+4mrPf9EsDBEDYMOb/lM7XQLulwg5R/m1r0PXEFqrV0qHvl58sdTilSXtKOflCsK2E8jxf+GKC0T07RWwQ==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /string.prototype.trimstart@1.0.6:
     resolution: {integrity: sha512-omqjMDaY92pbn5HOX7f9IccLA+U1tA9GvtU4JrodiXFfYB7jPzzHpRzpglLAjtUV6bB557zwClJezTqnAiYnQA==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
     dev: false
 
   /string_decoder@0.10.31:
@@ -59580,8 +60355,8 @@ packages:
       ansi-regex: 5.0.1
     dev: false
 
-  /strip-ansi@7.1.0:
-    resolution: {integrity: sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==}
+  /strip-ansi@7.0.1:
+    resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
     engines: {node: '>=12'}
     dependencies:
       ansi-regex: 6.0.1
@@ -59676,7 +60451,7 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       loader-utils: 2.0.4
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
@@ -59692,13 +60467,13 @@ packages:
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       postcss: 8.4.18
-      postcss-selector-parser: 6.0.13
+      postcss-selector-parser: 6.0.11
     dev: false
 
-  /stylis@4.3.0:
-    resolution: {integrity: sha512-E87pIogpwUsUwXw7dNyU4QDjdgVMy52m+XEOPEKUn161cCzWjjhPSQhByfd1CcNvrOLnXQ6OnnZDwnJrz/Z4YQ==}
+  /stylis@4.1.3:
+    resolution: {integrity: sha512-GP6WDNWf+o403jrEp9c5jibKavrtLW+/qYGhFxFrG8maXhwTBI7gLLhiBb0o7uFccWN+EOS9aMO6cGHWAO07OA==}
     dev: true
 
   /stylus-lookup@3.0.2:
@@ -59707,7 +60482,7 @@ packages:
     hasBin: true
     dependencies:
       commander: 2.20.3
-      debug: 4.3.2
+      debug: 4.3.4(supports-color@9.3.1)
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -59745,17 +60520,17 @@ packages:
       - utf-8-validate
     dev: false
 
-  /sucrase@3.34.0:
-    resolution: {integrity: sha512-70/LQEZ07TEcxiU2dz51FKaE6hCTWC6vr7FOk3Gr0U60C3shtAN+H+BFr9XlYe5xqf3RA8nrc+VIwzCfnxuXJw==}
+  /sucrase@3.32.0:
+    resolution: {integrity: sha512-ydQOU34rpSyj2TGyz4D2p8rbktIOZ8QY9s+DGLvFU1i5pWJE8vkpruCjGCMHsdXwnD7JDcS+noSwM/a7zyNFDQ==}
     engines: {node: '>=8'}
     hasBin: true
     dependencies:
-      '@jridgewell/gen-mapping': 0.3.3
+      '@jridgewell/gen-mapping': 0.3.2
       commander: 4.1.1
       glob: 7.1.6
       lines-and-columns: 1.2.4
       mz: 2.7.0
-      pirates: 4.0.6
+      pirates: 4.0.5
       ts-interface-checker: 0.1.13
     dev: false
 
@@ -59789,8 +60564,8 @@ packages:
     dependencies:
       has-flag: 4.0.0
 
-  /supports-color@9.4.0:
-    resolution: {integrity: sha512-VL+lNrEoIXww1coLPOmiEmK/0sGigko5COxI09KzHc2VJXJsQ37UaQ+8quuxjDeA7+KnLGTWRyOXSLLR2Wb4jw==}
+  /supports-color@9.3.1:
+    resolution: {integrity: sha512-knBY82pjmnIzK3NifMo3RxEIRD9E0kIzV4BKcyTZ9+9kWgLMxd4PrsTSMoFQUabgRBbF8KOLRDCyKgNV+iK44Q==}
     engines: {node: '>=12'}
     dev: false
 
@@ -59876,7 +60651,7 @@ packages:
     resolution: {integrity: sha512-5pk9meINInVUZ4nKn5942/x/mY5OE9SVzkOFIxiCDnellaz1cwTd4m7Xl1ibz1F3AxnZ8NxQMEbF7eMWMGECGg==}
     engines: {node: '>=4.0'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
       uuid: 8.3.2
     dev: false
 
@@ -59938,7 +60713,7 @@ packages:
       end-of-stream: 1.4.4
       fs-constants: 1.0.0
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /tar@6.1.11:
@@ -60018,15 +60793,15 @@ packages:
       esbuild: 0.14.29
       jest-worker: 27.5.1
       p-limit: 3.1.0
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       serialize-javascript: 6.0.1
       source-map: 0.6.1
-      terser: 5.19.1
+      terser: 5.16.2
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.14.29)(webpack@5.84.1):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
+  /terser-webpack-plugin@5.3.8(esbuild@0.14.29)(webpack@5.84.1):
+    resolution: {integrity: sha512-WiHL3ElchZMsK27P8uIUh4604IgJyAW47LVXGbEoB21DbQcZ+OuMpGjVYnEUaqcWM6dO8uS2qUbA7LSCWqvsbg==}
     engines: {node: '>= 10.13.0'}
     peerDependencies:
       '@swc/core': '*'
@@ -60041,12 +60816,12 @@ packages:
       uglify-js:
         optional: true
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.18
+      '@jridgewell/trace-mapping': 0.3.17
       esbuild: 0.14.29
       jest-worker: 27.5.1
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       serialize-javascript: 6.0.1
-      terser: 5.19.1
+      terser: 5.17.3
       webpack: 5.84.1(esbuild@0.14.29)
 
   /terser@4.8.1:
@@ -60054,19 +60829,30 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      acorn: 8.10.0
+      acorn: 8.8.2
       commander: 2.20.3
       source-map: 0.6.1
       source-map-support: 0.5.21
     dev: false
 
-  /terser@5.19.1:
-    resolution: {integrity: sha512-27hxBUVdV6GoNg1pKQ7Z5cbR6V9txPVyBA+FQw3BaZ1Wuzvztce5p156DaP0NVZNrMZZ+6iG9Syf7WgMNKDg2Q==}
+  /terser@5.16.2:
+    resolution: {integrity: sha512-JKuM+KvvWVqT7muHVyrwv7FVRPnmHDwF6XwoIxdbF5Witi0vu99RYpxDexpJndXt3jbZZmmWr2/mQa6HvSNdSg==}
     engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      '@jridgewell/source-map': 0.3.5
-      acorn: 8.10.0
+      '@jridgewell/source-map': 0.3.2
+      acorn: 8.8.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
+    dev: false
+
+  /terser@5.17.3:
+    resolution: {integrity: sha512-AudpAZKmZHkG9jueayypz4duuCFJMMNGRMwaPvQKWfxKedh8Z2x3OCoDqIIi1xx5+iwx1u6Au8XQcc9Lke65Yg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.2
+      acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
 
@@ -60131,7 +60917,7 @@ packages:
   /through2@2.0.5:
     resolution: {integrity: sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==}
     dependencies:
-      readable-stream: 2.3.8
+      readable-stream: 2.3.7
       xtend: 4.0.2
     dev: false
 
@@ -60139,13 +60925,13 @@ packages:
     resolution: {integrity: sha512-enaDQ4MUyP2W6ZyT6EsMzqBPZaM/avg8iuo+l2d3QCs0J+6RaqkHV/2/lOwDTueBHeJ/2LG9lrLW3d5rWPucuQ==}
     dependencies:
       inherits: 2.0.4
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /through2@4.0.2:
     resolution: {integrity: sha512-iOqSav00cVxEEICeD7TjLB1sueEL+81Wpzp2bY17uZjZN0pWZPuo4suZ/61VujxmqSGFfgOcNuTZ85QJwNZQpw==}
     dependencies:
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /through@2.3.8:
@@ -60187,7 +60973,7 @@ packages:
   /tippy.js@6.2.7:
     resolution: {integrity: sha512-k+kWF9AJz5xLQHBi3K/XlmJiyu+p9gsCyc5qZhxxGaJWIW8SMjw1R+C7saUnP33IM8gUhDA2xX//ejRSwqR0tA==}
     dependencies:
-      '@popperjs/core': 2.11.8
+      '@popperjs/core': 2.11.6
     dev: false
 
   /tmp@0.0.33:
@@ -60271,8 +61057,8 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /tough-cookie@4.1.3:
-    resolution: {integrity: sha512-aX/y5pVRkfRnfmuX+OdbSdXvPe6ieKX/G2s7e98f4poJHnqH3281gDPm/metm6E/WRamfx7WC4HUqkWHfQHprw==}
+  /tough-cookie@4.1.2:
+    resolution: {integrity: sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==}
     engines: {node: '>=6'}
     dependencies:
       psl: 1.9.0
@@ -60298,13 +61084,6 @@ packages:
       punycode: 2.1.1
     dev: false
 
-  /tr46@4.1.1:
-    resolution: {integrity: sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==}
-    engines: {node: '>=14'}
-    dependencies:
-      punycode: 2.3.0
-    dev: false
-
   /treeify@1.1.0:
     resolution: {integrity: sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==}
     engines: {node: '>=0.6'}
@@ -60323,12 +61102,10 @@ packages:
 
   /trim@0.0.1:
     resolution: {integrity: sha512-YzQV+TZg4AxpKxaTHK3c3D+kRDCGVEE7LemdlQZoQXn0iennk10RsIoY6ikzAqJTc9Xjl9C1/waHom/J86ziAQ==}
-    deprecated: Use String.prototype.trim() instead
     dev: false
 
-  /triple-beam@1.4.1:
-    resolution: {integrity: sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==}
-    engines: {node: '>= 14.0.0'}
+  /triple-beam@1.3.0:
+    resolution: {integrity: sha512-XrHUvV5HpdLmIj4uVMxHggLbFSZYIn7HEWsqePZcI50pco+MPqJ50wMGY794X7AOOhxOBAjbkqfAbEe/QMp2Lw==}
     dev: false
 
   /trough@1.0.5:
@@ -60341,8 +61118,8 @@ packages:
       utf8-byte-length: 1.0.4
     dev: false
 
-  /ts-deepmerge@6.2.0:
-    resolution: {integrity: sha512-2qxI/FZVDPbzh63GwWIZYE7daWKtwXZYuyc8YNq0iTmMUwn4mL0jRLsp6hfFlgbdRSR4x2ppe+E86FnvEpN7Nw==}
+  /ts-deepmerge@6.0.3:
+    resolution: {integrity: sha512-MBBJL0UK/mMnZRONMz4J1CRu5NsGtsh+gR1nkn8KLE9LXo/PCzeHhQduhNary8m5/m9ryOOyFwVKxq81cPlaow==}
     engines: {node: '>=14.13.1'}
     dev: false
 
@@ -60358,7 +61135,7 @@ packages:
     resolution: {integrity: sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==}
     engines: {node: '>=8'}
     dependencies:
-      tslib: 2.6.0
+      tslib: 2.5.0
 
   /ts-invariant@0.4.4:
     resolution: {integrity: sha512-uEtWkFM/sdZvRNNDL3Ehu4WVpwaulhwQszV8mrtcdeE8nN00BV9mAmQ88RkrBhFgl9gMgvjJLAQcZbnPXI9mlA==}
@@ -60370,12 +61147,12 @@ packages:
     resolution: {integrity: sha512-hnGJXIgC49ZuF5g5oDthoge8t4cvT0dYg2pYO5C6yV/HmUUy1koooU2U/5K2N+Uw++hcXQpJAToLRa+GRp28Sg==}
     dev: false
 
-  /tsconfig-paths@3.14.2:
-    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
+  /tsconfig-paths@3.14.1:
+    resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
     dependencies:
       '@types/json5': 0.0.29
       json5: 1.0.2
-      minimist: 1.2.8
+      minimist: 1.2.7
       strip-bom: 3.0.0
     dev: false
 
@@ -60390,8 +61167,8 @@ packages:
     resolution: {integrity: sha512-lTqkx847PI7xEDYJntxZH89L2/aXInsyF2luSafe/+0fHOMjlBNXdH6th7f70qxLDhul7KZK0zC8V5ZIyHl0/g==}
     dev: false
 
-  /tslib@2.6.0:
-    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
+  /tslib@2.5.0:
+    resolution: {integrity: sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==}
 
   /tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -60437,8 +61214,8 @@ packages:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     dev: false
 
-  /typanion@3.13.0:
-    resolution: {integrity: sha512-AkZMjMIW8MGeQwBxu1bixzu/2Zk7rH6ILrI/9zBoW0sAiVaWwHjXSnmPBomfY2t7tSG6m5bIE+OYYyyuGnFVHA==}
+  /typanion@3.12.1:
+    resolution: {integrity: sha512-3SJF/czpzqq6G3lprGFLa6ps12yb1uQ1EmitNnep2fDMNh1aO/Zbq9sWY+3lem0zYb2oHJnQWyabTGUZ+L1ScQ==}
     dev: false
 
   /type-check@0.3.2:
@@ -60455,15 +61232,15 @@ packages:
       prelude-ls: 1.2.1
     dev: false
 
-  /type-coverage-core@2.26.0(typescript@4.7.4):
-    resolution: {integrity: sha512-/9VQ0ySU1CKbWd/BNnbVYMJ67oOt7qdXXxm4W5VIM07AUB5eelcDjrWG7qdIj0ZafnNkpv+v5qcD68ExOVK+Sw==}
+  /type-coverage-core@2.24.1(typescript@4.7.4):
+    resolution: {integrity: sha512-HZCiVINVnrekaEQuq/lKEerAZO/L7rR9vMDs+QRhTfb7HrD2OO6JDQKxJiKLJGAoGhjjQY5248mmX3t/+zLXxg==}
     peerDependencies:
-      typescript: 2 || 3 || 4 || 5
+      typescript: 2 || 3 || 4
     dependencies:
-      fast-glob: 3.3.0
-      minimatch: 9.0.3
+      fast-glob: 3.2.12
+      minimatch: 3.0.5
       normalize-path: 3.0.0
-      tslib: 2.6.0
+      tslib: 2.5.0
       tsutils: 3.21.0(typescript@4.7.4)
       typescript: 4.7.4
     dev: false
@@ -60472,8 +61249,8 @@ packages:
     resolution: {integrity: sha512-HvqD19WtsUlmbSCY3De/HcKUyohjgtQoNHdlVjed8WcySGVgEjGpjF4pZUiLZDVsZf3+VwNvkHoLewLEWXWdQQ==}
     hasBin: true
     dependencies:
-      minimist: 1.2.8
-      type-coverage-core: 2.26.0(typescript@4.7.4)
+      minimist: 1.2.7
+      type-coverage-core: 2.24.1(typescript@4.7.4)
     transitivePeerDependencies:
       - typescript
     dev: false
@@ -60532,42 +61309,12 @@ packages:
     resolution: {integrity: sha512-dzlvlNlt6AXU7EBSfpAscydQ7gXB+pPGsPnfJnZpiNJBDj7IaJzQlBZYGdEi4R9HmPdBv2XmWJ6YUtoTa7lmCw==}
     dev: false
 
-  /typed-array-buffer@1.0.0:
-    resolution: {integrity: sha512-Y8KTSIglk9OZEr8zywiIHG/kmQ7KWyjseXs1CbSo8vC42w7hg2HgYTxSWwP0+is7bWDc1H+Fo026CpHFwm8tkw==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      get-intrinsic: 1.2.1
-      is-typed-array: 1.1.12
-    dev: false
-
-  /typed-array-byte-length@1.0.0:
-    resolution: {integrity: sha512-Or/+kvLxNpeQ9DtSydonMxCx+9ZXOswtwJn17SNLvhptaXYDJvkFFP5zbfU/uLmvnBJlI4yrnXRxpdWH/M5tNA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      has-proto: 1.0.1
-      is-typed-array: 1.1.12
-    dev: false
-
-  /typed-array-byte-offset@1.0.0:
-    resolution: {integrity: sha512-RD97prjEt9EL8YgAgpOkf3O4IF9lhJFr9g0htQkm0rchFp/Vx7LW5Q8fSXXub7BXAODyUQohRMyOc3faCPd0hg==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      available-typed-arrays: 1.0.5
-      call-bind: 1.0.2
-      for-each: 0.3.3
-      has-proto: 1.0.1
-      is-typed-array: 1.1.12
-    dev: false
-
   /typed-array-length@1.0.4:
     resolution: {integrity: sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==}
     dependencies:
       call-bind: 1.0.2
       for-each: 0.3.3
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
     dev: false
 
   /typedarray-to-buffer@3.1.5:
@@ -60610,18 +61357,12 @@ packages:
     hasBin: true
     dev: false
 
-  /typescript@5.1.6:
-    resolution: {integrity: sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==}
-    engines: {node: '>=14.17'}
-    hasBin: true
-    dev: false
-
   /ua-parser-js@0.7.24:
     resolution: {integrity: sha512-yo+miGzQx5gakzVK3QFfN0/L9uVhosXBBO7qmnk7c2iw1IhL212wfA3zbnI54B0obGwC/5NWub/iT9sReMx+Fw==}
     dev: false
 
-  /ua-parser-js@1.0.35:
-    resolution: {integrity: sha512-fKnGuqmTBnIE+/KXSzCn4db8RTigUzw1AN0DmdU6hJovUTbYJKyqj+8Mt1c4VfRDnOVJnENmfYkIPZ946UrSAA==}
+  /ua-parser-js@0.7.33:
+    resolution: {integrity: sha512-s8ax/CeZdK9R/56Sui0WM6y9OFREJarMRHqLB2EwkovemBxNQ+Bqu8GAsUnVcXKgphb++ghr/B2BZx4mahujPw==}
     dev: false
 
   /uglify-js@3.17.4:
@@ -60685,7 +61426,7 @@ packages:
   /unified@8.4.2:
     resolution: {integrity: sha512-JCrmN13jI4+h9UAyKEoGcDZV+i1E7BLFuG7OsaDvTXI5P0qhHX+vZO/kOhz9jn8HGENDKbwSeB0nVOg4gVStGA==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-plain-obj: 2.1.0
@@ -60696,7 +61437,7 @@ packages:
   /unified@9.2.0:
     resolution: {integrity: sha512-vx2Z0vY+a3YoTj8+pttM3tiJHCwY5UFbYdiWrwBEbHmK8pvsPj2rtAX2BFfgXen8T39CJWblWRDT4L5WGXtDdg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -60708,7 +61449,7 @@ packages:
   /unified@9.2.2:
     resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       bail: 1.0.5
       extend: 3.0.2
       is-buffer: 2.0.5
@@ -60796,20 +61537,20 @@ packages:
   /unist-util-stringify-position@2.0.3:
     resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
     dev: false
 
   /unist-util-visit-parents@3.1.1:
     resolution: {integrity: sha512-1KROIZWo6bcMrZEwiH2UrXDyalAa0uqzWCxCJj6lPOvTve2WkfgCytoDTPaMnodXh1WrXOq0haVYHj99ynJlsg==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       unist-util-is: 4.1.0
     dev: false
 
   /unist-util-visit@2.0.3:
     resolution: {integrity: sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       unist-util-is: 4.1.0
       unist-util-visit-parents: 3.1.1
     dev: false
@@ -60858,13 +61599,13 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /update-browserslist-db@1.0.11(browserslist@4.21.9):
-    resolution: {integrity: sha512-dCwEFf0/oT85M1fHBg4F0jtLwJrutGoHSQXCh7u4o2t1drG+c0a9Flnqww6XUKSfQMPpJBRjU8d4RXB09qtvaA==}
+  /update-browserslist-db@1.0.10(browserslist@4.21.5):
+    resolution: {integrity: sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==}
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
     dependencies:
-      browserslist: 4.21.9
+      browserslist: 4.21.5
       escalade: 3.1.1
       picocolors: 1.0.0
 
@@ -61036,7 +61777,7 @@ packages:
     dependencies:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-      tslib: 2.6.0
+      tslib: 2.5.0
       use-constant: 1.1.1(react@17.0.2)
     dev: false
 
@@ -61072,22 +61813,20 @@ packages:
   /util.promisify@1.0.1:
     resolution: {integrity: sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==}
     dependencies:
-      define-properties: 1.2.0
-      es-abstract: 1.22.1
+      define-properties: 1.1.4
+      es-abstract: 1.21.1
       has-symbols: 1.0.3
-      object.getownpropertydescriptors: 2.1.6
+      object.getownpropertydescriptors: 2.1.5
     dev: false
 
-  /util.promisify@1.1.2:
-    resolution: {integrity: sha512-PBdZ03m1kBnQ5cjjO0ZvJMJS+QsbyIcFwi4hY4U76OQsCO9JrOYjbCFgIF76ccFg9xnJo7ZHPkqyj1GqmdS7MA==}
+  /util.promisify@1.1.1:
+    resolution: {integrity: sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==}
     dependencies:
       call-bind: 1.0.2
-      define-properties: 1.2.0
+      define-properties: 1.1.4
       for-each: 0.3.3
-      has-proto: 1.0.1
       has-symbols: 1.0.3
-      object.getownpropertydescriptors: 2.1.6
-      safe-array-concat: 1.0.0
+      object.getownpropertydescriptors: 2.1.5
     dev: false
 
   /util@0.12.3:
@@ -61096,9 +61835,9 @@ packages:
       inherits: 2.0.4
       is-arguments: 1.1.1
       is-generator-function: 1.0.10
-      is-typed-array: 1.1.12
+      is-typed-array: 1.1.10
       safe-buffer: 5.2.1
-      which-typed-array: 1.1.11
+      which-typed-array: 1.1.9
     dev: false
 
   /utila@0.4.0:
@@ -61162,7 +61901,7 @@ packages:
   /validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
     dependencies:
-      spdx-correct: 3.2.0
+      spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: false
 
@@ -61200,12 +61939,12 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
-  /verdaccio-audit@11.0.0-6-next.37:
-    resolution: {integrity: sha512-hzQq90HmKwy327PueS58V720MRDycSCmo7DNgOy+h8dvITG6XAQ6bSsiTgQScjmwImdp3tkl3bqu9kXh33bPxA==}
+  /verdaccio-audit@11.0.0-6-next.34:
+    resolution: {integrity: sha512-TF+gnJJveEI4TGJTsVBCNwbfx5WBvlP7QoaDDxSmJQlmhzrsJ2MjhagWgAA/OoLV7p45bJ7e00v391Frv0pwnw==}
     engines: {node: '>=12'}
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.74
-      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/config': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.71
       express: 4.18.2
       https-proxy-agent: 5.0.1
       node-fetch: 2.6.7
@@ -61214,53 +61953,54 @@ packages:
       - supports-color
     dev: false
 
-  /verdaccio-htpasswd@11.0.0-6-next.44:
-    resolution: {integrity: sha512-ZKCpZ5KhcHXjAlYkCI6CM6O8KO/Pr/x5C89zqjRR7OMaPyOAu0psIJjvhTycn1efZub4pT6Tlj7rCRlmvIbR0w==}
+  /verdaccio-htpasswd@11.0.0-6-next.41:
+    resolution: {integrity: sha512-HS1/3No2W7Dhl9DJ3tXUDgSOIL3do5tW2O2OvRVPc6aNKbqXFg22FIqjzpn1yG2sydTuBFKUSjMvmk/1oliKPg==}
     engines: {node: '>=14', npm: '>=6'}
     dependencies:
-      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/core': 6.0.0-6-next.71
       '@verdaccio/file-locking': 11.0.0-6-next.7
       apache-md5: 1.1.8
       bcryptjs: 2.4.3
       core-js: 3.30.2
-      debug: 4.3.4(supports-color@9.4.0)
+      debug: 4.3.4(supports-color@9.3.1)
       http-errors: 2.0.0
       unix-crypt-td-js: 1.1.4
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /verdaccio@5.26.0:
-    resolution: {integrity: sha512-XuVUL5TYwMrky0w6wjgWhgviXmjbLluYy29vjJT9hByLa7TX3zBsqyBWIm+ncb5SxaiYLIEv8fJCrNXujpvUsA==}
+  /verdaccio@5.25.0:
+    resolution: {integrity: sha512-h/BDAudOZtwC52waErxCjZA+YKuUi7Ojt3haRGxZ1ZTL26BkbjaKkzt0Y72Z2bauRLxmwtGevJWm2LV7ZTeIug==}
     engines: {node: '>=12.18'}
     hasBin: true
     dependencies:
-      '@verdaccio/config': 6.0.0-6-next.74
-      '@verdaccio/core': 6.0.0-6-next.74
+      '@verdaccio/config': 6.0.0-6-next.71
+      '@verdaccio/core': 6.0.0-6-next.71
       '@verdaccio/local-storage': 10.3.3
-      '@verdaccio/logger-7': 6.0.0-6-next.19
-      '@verdaccio/middleware': 6.0.0-6-next.53
+      '@verdaccio/logger-7': 6.0.0-6-next.16
+      '@verdaccio/middleware': 6.0.0-6-next.50
       '@verdaccio/search': 6.0.0-6-next.2
       '@verdaccio/signature': 6.0.0-6-next.2
       '@verdaccio/streams': 10.2.1
-      '@verdaccio/tarball': 11.0.0-6-next.43
-      '@verdaccio/ui-theme': 6.0.0-6-next.74
-      '@verdaccio/url': 11.0.0-6-next.40
-      '@verdaccio/utils': 6.0.0-6-next.42
+      '@verdaccio/tarball': 11.0.0-6-next.40
+      '@verdaccio/ui-theme': 6.0.0-6-next.71
+      '@verdaccio/url': 11.0.0-6-next.37
+      '@verdaccio/utils': 6.0.0-6-next.39
       JSONStream: 1.3.5
       async: 3.2.4
-      clipanion: 3.2.1
+      body-parser: 1.20.2
+      clipanion: 3.2.0
       compression: 1.7.4
       cookies: 0.8.0
       cors: 2.8.5
-      debug: 4.3.4(supports-color@9.4.0)
-      envinfo: 7.10.0
+      debug: 4.3.4(supports-color@9.3.1)
+      envinfo: 7.8.1
       express: 4.18.2
       express-rate-limit: 5.5.1
       fast-safe-stringify: 2.1.1
       handlebars: 4.7.7
       js-yaml: 4.1.0
-      jsonwebtoken: 9.0.1
+      jsonwebtoken: 9.0.0
       kleur: 4.1.5
       lodash: 4.17.21
       lru-cache: 7.18.3
@@ -61269,10 +62009,10 @@ packages:
       mv: 2.1.1
       pkginfo: 0.4.1
       request: 2.88.2
-      semver: 7.5.4
+      semver: 7.5.1
       validator: 13.9.0
-      verdaccio-audit: 11.0.0-6-next.37
-      verdaccio-htpasswd: 11.0.0-6-next.44
+      verdaccio-audit: 11.0.0-6-next.34
+      verdaccio-htpasswd: 11.0.0-6-next.41
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -61301,14 +62041,14 @@ packages:
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       unist-util-stringify-position: 2.0.3
     dev: false
 
   /vfile@4.2.0:
     resolution: {integrity: sha512-a/alcwCvtuc8OX92rqqo7PflxiCgXRFjdyoGVuYV+qbgCb0GgZJRvIgCD4+U/Kl1yhaRsaTwksF88xbPyGsgpw==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       is-buffer: 2.0.5
       replace-ext: 1.0.0
       unist-util-stringify-position: 2.0.3
@@ -61318,7 +62058,7 @@ packages:
   /vfile@4.2.1:
     resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
     dependencies:
-      '@types/unist': 2.0.7
+      '@types/unist': 2.0.6
       is-buffer: 2.0.5
       unist-util-stringify-position: 2.0.3
       vfile-message: 2.0.4
@@ -61354,7 +62094,7 @@ packages:
   /vscode-icons-js@11.0.0:
     resolution: {integrity: sha512-Rx/vgLY3KSCPp53RXPY/t/jk8sOrBUEDDQlLoTaTzxwnsKyrorUXfrtw9UlG5D97z5DRxERn1ek0KB9RTuPxmQ==}
     dependencies:
-      '@types/jasmine': 3.10.11
+      '@types/jasmine': 3.10.7
 
   /vscode-jsonrpc@6.0.0:
     resolution: {integrity: sha512-wnJA4BnEjOSyFMvjZdpiOwhSq9uDoK8e/kpRJDTaMYzwlkrhG1fwDIZI94CLsLzlCK5cIbMMtFlJlfR57Lavmg==}
@@ -61376,7 +62116,7 @@ packages:
       eslint-scope: 5.1.1
       eslint-visitor-keys: 1.3.0
       espree: 6.2.1
-      esquery: 1.5.0
+      esquery: 1.4.0
       lodash: 4.17.21
     transitivePeerDependencies:
       - supports-color
@@ -61394,13 +62134,6 @@ packages:
     engines: {node: '>=10'}
     dependencies:
       xml-name-validator: 3.0.0
-    dev: false
-
-  /w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
-    dependencies:
-      xml-name-validator: 4.0.0
     dev: false
 
   /walker@1.0.8:
@@ -61457,11 +62190,6 @@ packages:
     engines: {node: '>=10.4'}
     dev: false
 
-  /webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-    dev: false
-
   /webpack-assets-manifest@5.1.0(webpack@5.84.1):
     resolution: {integrity: sha512-kPuTMEjBrqZQVJ5M6yXNBCEdFbQQn7p+loNXt8NOeDFaAbsNFWqqwR0YL1mfG5LbwhK5FLXWXpuK3GuIIZ46rg==}
     engines: {node: '>=10.13.0'}
@@ -61469,11 +62197,11 @@ packages:
       webpack: ^5.2.0
     dependencies:
       chalk: 4.1.2
-      deepmerge: 4.3.1
+      deepmerge: 4.3.0
       lockfile: 1.0.4
       lodash.get: 4.4.2
       lodash.has: 4.5.2
-      schema-utils: 3.3.0
+      schema-utils: 3.1.1
       tapable: 2.2.1
       webpack: 5.84.1(esbuild@0.14.29)
     dev: false
@@ -61485,10 +62213,10 @@ packages:
       webpack: ^4.0.0 || ^5.0.0
     dependencies:
       colorette: 2.0.20
-      memfs: 3.5.3
+      memfs: 3.4.13
       mime-types: 2.1.35
       range-parser: 1.2.1
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
       webpack: 5.84.1(esbuild@0.14.29)
 
   /webpack-dev-server@4.15.0(bufferutil@4.0.3)(debug@4.3.2)(utf-8-validate@5.0.5)(webpack@5.84.1):
@@ -61505,29 +62233,29 @@ packages:
         optional: true
     dependencies:
       '@types/bonjour': 3.5.10
-      '@types/connect-history-api-fallback': 1.5.0
+      '@types/connect-history-api-fallback': 1.3.5
       '@types/express': 4.17.13
       '@types/serve-index': 1.9.1
-      '@types/serve-static': 1.15.2
+      '@types/serve-static': 1.15.0
       '@types/sockjs': 0.3.33
-      '@types/ws': 8.5.5
+      '@types/ws': 8.5.4
       ansi-html-community: 0.0.8
       bonjour-service: 1.1.1
       chokidar: 3.5.3
-      colorette: 2.0.20
+      colorette: 2.0.19
       compression: 1.7.4
       connect-history-api-fallback: 2.0.0
       default-gateway: 6.0.3
       express: 4.18.2
       graceful-fs: 4.2.10
-      html-entities: 2.4.0
+      html-entities: 2.3.3
       http-proxy-middleware: 2.0.6(@types/express@4.17.13)(debug@4.3.2)
-      ipaddr.js: 2.1.0
+      ipaddr.js: 2.0.1
       launch-editor: 2.6.0
-      open: 8.4.2
+      open: 8.4.0
       p-retry: 4.6.2
       rimraf: 3.0.2
-      schema-utils: 4.2.0
+      schema-utils: 4.0.0
       selfsigned: 2.1.1
       serve-index: 1.9.1
       sockjs: 0.3.24
@@ -61557,7 +62285,7 @@ packages:
     engines: {node: '>=10.0.0'}
     dependencies:
       clone-deep: 4.0.1
-      wildcard: 2.0.1
+      wildcard: 2.0.0
     dev: false
 
   /webpack-sources@1.4.3:
@@ -61590,16 +62318,16 @@ packages:
         optional: true
     dependencies:
       '@types/eslint-scope': 3.7.4
-      '@types/estree': 1.0.1
+      '@types/estree': 1.0.0
       '@webassemblyjs/ast': 1.11.6
       '@webassemblyjs/wasm-edit': 1.11.6
       '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.10.0
-      acorn-import-assertions: 1.9.0(acorn@8.10.0)
+      acorn: 8.8.2
+      acorn-import-assertions: 1.9.0(acorn@8.8.2)
       browserslist: 4.16.3
       chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.3.0
+      enhanced-resolve: 5.14.1
+      es-module-lexer: 1.2.1
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
@@ -61608,9 +62336,9 @@ packages:
       loader-runner: 4.3.0
       mime-types: 2.1.35
       neo-async: 2.6.2
-      schema-utils: 3.3.0
+      schema-utils: 3.1.2
       tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.14.29)(webpack@5.84.1)
+      terser-webpack-plugin: 5.3.8(esbuild@0.14.29)(webpack@5.84.1)
       watchpack: 2.4.0
       webpack-sources: 3.2.3
     transitivePeerDependencies:
@@ -61636,36 +62364,16 @@ packages:
       iconv-lite: 0.4.24
     dev: false
 
-  /whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
-    engines: {node: '>=12'}
-    dependencies:
-      iconv-lite: 0.6.3
-    dev: false
-
   /whatwg-fetch@0.9.0:
     resolution: {integrity: sha512-DIuh7/cloHxHYwS/oRXGgkALYAntijL63nsgMQsNSnBj825AysosAqA2ZbYXGRqpPRiNH7335dTqV364euRpZw==}
     dev: false
 
-  /whatwg-fetch@3.6.16:
-    resolution: {integrity: sha512-83avoGbZ0qtjtNrU3UTT3/Xd3uZ7DyfSYLuc1fL5iYs+93P+UkIVF6/6xpRVWeQcvbc7kSnVybSAVbd6QFW5Fg==}
+  /whatwg-fetch@3.6.2:
+    resolution: {integrity: sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==}
     dev: false
 
   /whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
-    dev: false
-
-  /whatwg-mimetype@3.0.0:
-    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
-    engines: {node: '>=12'}
-    dev: false
-
-  /whatwg-url@12.0.1:
-    resolution: {integrity: sha512-Ed/LrqB8EPlGxjS+TrsXcpUond1mhccS3pchLhzSgPCnTimUCKj3IZE75pAs5m6heB2U2TMerKFUXheyHY+VDQ==}
-    engines: {node: '>=14'}
-    dependencies:
-      tr46: 4.1.1
-      webidl-conversions: 7.0.0
     dev: false
 
   /whatwg-url@5.0.0:
@@ -61709,8 +62417,8 @@ packages:
       is-weakmap: 2.0.1
       is-weakset: 2.0.2
 
-  /which-module@2.0.1:
-    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+  /which-module@2.0.0:
+    resolution: {integrity: sha512-B+enWhmw6cjfVC7kS8Pj9pCrKSc5txArRyaYGe088shv/FGWH+0Rjx/xPgtsWfsUtS27FkP697E4DDhgrgoc0Q==}
     dev: false
 
   /which-pm@2.0.0:
@@ -61721,8 +62429,8 @@ packages:
       path-exists: 4.0.0
     dev: false
 
-  /which-typed-array@1.1.11:
-    resolution: {integrity: sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==}
+  /which-typed-array@1.1.9:
+    resolution: {integrity: sha512-w9c4xkx6mPidwp7180ckYWfMmvxpjlZuIudNtDf4N/tTAUB8VJbX25qZoAsrtGuYNnGw3pa0AXgbGKRB8/EceA==}
     engines: {node: '>= 0.4'}
     dependencies:
       available-typed-arrays: 1.0.5
@@ -61730,6 +62438,7 @@ packages:
       for-each: 0.3.3
       gopd: 1.0.1
       has-tostringtag: 1.0.0
+      is-typed-array: 1.1.10
 
   /which@1.3.1:
     resolution: {integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==}
@@ -61756,7 +62465,7 @@ packages:
   /wide-align@1.1.5:
     resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
     dependencies:
-      string-width: 1.0.2
+      string-width: 4.2.3
     dev: false
 
   /widest-line@2.0.1:
@@ -61773,17 +62482,17 @@ packages:
       string-width: 4.2.3
     dev: false
 
-  /wildcard@2.0.1:
-    resolution: {integrity: sha512-CC1bOL87PIWSBhDcTrdeLo6eGT7mCFtrg0uIJtqJUFyK+eJnzl8A1niH56uu7KMa5XFrtiV+AQuHO3n7DsHnLQ==}
+  /wildcard@2.0.0:
+    resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
     dev: false
 
   /winston-transport@4.5.0:
     resolution: {integrity: sha512-YpZzcUzBedhlTAfJg6vJDlyEai/IFMIVcaEZZyl3UXIl4gmqRpU7AE89AHLkbzLUsv0NVmw7ts+iztqKxxPW1Q==}
     engines: {node: '>= 6.4.0'}
     dependencies:
-      logform: 2.5.1
-      readable-stream: 3.6.2
-      triple-beam: 1.4.1
+      logform: 2.4.2
+      readable-stream: 3.6.0
+      triple-beam: 1.3.0
     dev: false
 
   /winston@2.4.7:
@@ -61805,16 +62514,16 @@ packages:
       '@dabh/diagnostics': 2.0.3
       async: 3.2.4
       is-stream: 2.0.1
-      logform: 2.5.1
+      logform: 2.4.2
       one-time: 1.0.0
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
       stack-trace: 0.0.10
-      triple-beam: 1.4.1
+      triple-beam: 1.3.0
       winston-transport: 4.5.0
     dev: false
 
-  /word-wrap@1.2.4:
-    resolution: {integrity: sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==}
+  /word-wrap@1.2.3:
+    resolution: {integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==}
     engines: {node: '>=0.10.0'}
     dev: false
 
@@ -61993,7 +62702,7 @@ packages:
   /workbox-window@6.2.4:
     resolution: {integrity: sha512-9jD6THkwGEASj1YP56ZBHYJ147733FoGpJlMamYk38k/EBFE75oc6K3Vs2tGOBx5ZGq54+mHSStnlrtFG3IiOg==}
     dependencies:
-      '@types/trusted-types': 2.0.3
+      '@types/trusted-types': 2.0.2
       workbox-core: 6.2.4
     dev: false
 
@@ -62190,15 +62899,10 @@ packages:
     resolution: {integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==}
     dev: false
 
-  /xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
-    dev: false
-
   /xml2js@0.4.19:
     resolution: {integrity: sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==}
     dependencies:
-      sax: 1.2.1
+      sax: 1.2.4
       xmlbuilder: 9.0.7
     dev: false
 
@@ -62325,7 +63029,7 @@ packages:
       require-main-filename: 2.0.0
       set-blocking: 2.0.0
       string-width: 4.2.3
-      which-module: 2.0.1
+      which-module: 2.0.0
       y18n: 4.0.3
       yargs-parser: 18.1.3
     dev: false
@@ -62428,7 +63132,7 @@ packages:
     dependencies:
       archiver-utils: 2.1.0
       compress-commons: 4.1.1
-      readable-stream: 3.6.2
+      readable-stream: 3.6.0
     dev: false
 
   /zwitch@1.0.5:
@@ -62461,10 +63165,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.code-snippet': 4.2.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -62487,7 +63191,7 @@ packages:
       '@react-hook/previous': 1.0.1(react@17.0.2)
       '@teambit/base-react.hooks.use-1d-nav': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.hooks.use-queued-execution': 0.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.item': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -62511,7 +63215,7 @@ packages:
     dependencies:
       '@teambit/component-id': 0.0.427
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -62591,6 +63295,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/component-id': 0.0.427
+      '@teambit/component.ui.component-compare.models.component-compare-state': 0.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -62634,8 +63339,8 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -62652,8 +63357,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.dark-theme': 1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
@@ -62688,7 +63393,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
-      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -62834,7 +63539,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       react: 17.0.2
@@ -62948,8 +63653,8 @@ packages:
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/explorer.ui.gallery.component-grid': 0.0.496(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/lanes.ui.models': 0.0.79(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -62972,7 +63677,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -62990,10 +63695,14 @@ packages:
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.dropdown': 1.2.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.input-text': 1.0.21(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.inputs.selectors.checkbox-item': 1.1.11(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.inputs.toggle-button': 0.0.9(@testing-library/react@12.1.5)(react@17.0.2)
+      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63013,7 +63722,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63069,7 +63778,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63086,7 +63795,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63245,7 +63954,7 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -63512,12 +64221,12 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -63595,21 +64304,24 @@ packages:
     dependencies:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.queries.get-file-content': 0.0.504(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
+      '@teambit/component.ui.component-compare.context': 0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.status-resolver': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.inputs.selectors.checkbox-item': 1.1.11(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.dark-theme': 1.91.4(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.radio': 1.1.13(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -63631,14 +64343,15 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/code.ui.code-view': 0.0.508(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.queries.get-component-code': 0.0.502(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label': registry.npmjs.org/@teambit/documenter.ui.label@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label': 4.0.3(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -63697,6 +64410,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63711,6 +64425,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63725,6 +64440,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63823,6 +64539,7 @@ packages:
     name: '@teambit/compilation.modules.babel-compiler'
     dependencies:
       '@babel/core': 7.19.6
+      json-formatter-js: 2.3.4
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -63852,6 +64569,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -63866,10 +64584,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/component.instructions.exporting-components': registry.npmjs.org/@teambit/component.instructions.exporting-components@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.instructions.exporting-components': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -63908,7 +64626,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.code-compare-section': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
@@ -63935,15 +64653,15 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/any-fs': 0.0.5
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.navigation.responsive-navbar': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.separator': registry.npmjs.org/@teambit/documenter.ui.separator@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.separator': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -63997,6 +64715,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
+      '@teambit/code.ui.object-formatter': 0.0.1(react@17.0.2)
+      '@teambit/component-id': 0.0.427
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64010,7 +64730,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.muted-italic': 0.0.44(react-dom@17.0.2)(react@17.0.2)
@@ -64120,6 +64840,8 @@ packages:
   file:scopes/component/component-package-version:
     resolution: {directory: scopes/component/component-package-version, type: directory}
     name: '@teambit/component-package-version'
+    dependencies:
+      '@teambit/component-version': 0.0.406
     dev: false
 
   file:scopes/component/component-sizer(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2):
@@ -64162,8 +64884,9 @@ packages:
     peerDependencies:
       react: 17.0.2
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
+      chai: 4.3.0
       query-string: 7.0.0
       react: 17.0.2
     transitivePeerDependencies:
@@ -64174,6 +64897,7 @@ packages:
     resolution: {directory: scopes/component/component-version, type: directory}
     name: '@teambit/component-version'
     dependencies:
+      chai: 4.3.0
       semver: 7.5.2
     dev: false
 
@@ -64268,15 +64992,15 @@ packages:
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.routing.nav-link': registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.not-found': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.server-error': 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.input.checkbox.label': registry.npmjs.org/@teambit/evangelist.input.checkbox.label@1.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.input.checkbox.label': 1.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
@@ -64381,6 +65105,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
+      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
@@ -64502,11 +65227,13 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
+      '@teambit/component-version': 0.0.406
       '@teambit/graph.cleargraph': 0.0.1
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
       core-js: 3.13.0
+      fs-extra: 10.0.0
       lodash: 4.17.21
       node-fetch: 2.6.7
       p-map: 4.0.0
@@ -64550,6 +65277,7 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/component-id': 0.0.427
+      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
@@ -64614,12 +65342,12 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/code.ui.hooks.use-code-params': 0.0.496(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
       '@teambit/design.ui.skeletons.sidebar-loader': 0.0.4(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       is-binary-path: 2.1.0
@@ -64691,15 +65419,15 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.layout.row': 0.0.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.layout.page-frame': registry.npmjs.org/@teambit/base-ui.layout.page-frame@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.page-frame': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.navigation.content-tabs': 0.0.5(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.label-list': registry.npmjs.org/@teambit/documenter.ui.label-list@4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.label-list': 4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64781,10 +65509,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -64833,9 +65561,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.contributors': 0.0.514(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -64856,11 +65585,12 @@ packages:
       react-router-dom: ^6.0.0
     dependencies:
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -64898,6 +65628,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64914,7 +65645,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/base-ui.loaders.skeleton': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -64932,18 +65663,18 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.status-message-card': 0.0.17(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-context': 4.0.3(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -64965,6 +65696,7 @@ packages:
     resolution: {directory: scopes/compositions/model/composition-id, type: directory}
     name: '@teambit/compositions.model.composition-id'
     dependencies:
+      chai: 4.3.0
       humanize-string: 2.1.0
     dev: false
 
@@ -65005,10 +65737,11 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.themed-text': registry.npmjs.org/@teambit/base-ui.text.themed-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.accent-color': registry.npmjs.org/@teambit/base-ui.theme.accent-color@1.1.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.themed-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.accent-color': 1.1.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65024,10 +65757,13 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      '@teambit/component.ui.component-compare.context': 0.0.22(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.hooks.use-component-compare-url': 0.0.3(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       query-string: 7.0.0
       react: 17.0.2
@@ -65248,6 +65984,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       core-js: 3.13.0
+      fs-extra: 10.0.0
       p-map-series: 2.1.0
       prettier: 2.3.2
       react: 17.0.2
@@ -65339,6 +66076,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.round-loader': 0.0.355(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65358,7 +66096,7 @@ packages:
       '@teambit/design.ui.alert-card': 0.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.separator': 0.0.354(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65388,7 +66126,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -65404,6 +66142,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65418,6 +66157,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65432,6 +66172,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65667,6 +66408,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65737,7 +66479,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
@@ -65795,6 +66537,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65935,6 +66678,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -65949,6 +66693,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66041,9 +66786,11 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       cacache: 15.0.5(bluebird@3.7.2)
+      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+      uuid: 8.3.2
     transitivePeerDependencies:
       - bluebird
     dev: false
@@ -66303,7 +67050,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.copied-message': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0
@@ -66338,6 +67085,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66507,6 +67255,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       lodash: 4.17.21
@@ -66527,6 +67276,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/design.ui.empty-box': 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
+      chai: 4.3.0
       core-js: 3.13.0
       fs-extra: 10.0.0
       minimatch: 3.0.5
@@ -66595,6 +67345,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.markdown.mdx': 0.1.13(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/mdx.ui.docs.link': 0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -66628,6 +67379,8 @@ packages:
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/documenter.markdown.hybrid-live-code-snippet': 0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66645,6 +67398,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66694,6 +67448,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
+      chai: 4.3.0
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66715,6 +67470,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66759,6 +67515,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66824,7 +67581,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.string.affix': registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      chai: 4.3.0
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -66841,7 +67599,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66856,6 +67614,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66870,6 +67629,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -66958,9 +67718,9 @@ packages:
       '@babel/runtime': 7.20.0
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
-      '@prerenderer/prerenderer': 1.2.3(@types/express@4.17.13)(debug@4.3.2)
-      '@prerenderer/renderer-jsdom': 1.1.6(bufferutil@4.0.3)(utf-8-validate@5.0.5)
-      '@prerenderer/webpack-plugin': 5.3.6(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
+      '@prerenderer/prerenderer': 1.2.0(@types/express@4.17.13)(debug@4.3.2)
+      '@prerenderer/renderer-jsdom': 1.1.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
+      '@prerenderer/webpack-plugin': 5.2.0(@types/express@4.17.13)(debug@4.3.2)(html-webpack-plugin@5.3.2)(puppeteer@13.7.0)(webpack@5.84.1)
       '@svgr/webpack': 5.5.0
       '@teambit/component-id': 0.0.427
       '@teambit/defender.eslint-linter': 1.0.1(@teambit/legacy@node_modules+@teambit+legacy)
@@ -66968,8 +67728,8 @@ packages:
       '@teambit/design.ui.input.option-button': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
-      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-tests': registry.npmjs.org/@teambit/react.instructions.react.adding-tests@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-tests': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/react.rendering.ssr': 0.0.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/typescript.typescript-compiler': 2.0.1(@teambit/legacy@node_modules+@teambit+legacy)
       '@testing-library/jest-dom': 5.16.2
@@ -67136,7 +67896,7 @@ packages:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
       '@teambit/react.instructions.react-native.adding-tests': 0.0.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/react.instructions.react.adding-compositions': registry.npmjs.org/@teambit/react.instructions.react.adding-compositions@0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/react.instructions.react.adding-compositions': 0.0.6(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/jest-native': 4.0.4
       comment-json: 3.0.3
       core-js: 3.13.0
@@ -67149,6 +67909,7 @@ packages:
     transitivePeerDependencies:
       - '@babel/core'
       - '@teambit/legacy'
+      - supports-color
     dev: false
 
   file:scopes/react/ui/compositions-app(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2):
@@ -67159,7 +67920,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.pages.standalone-not-found-page': 0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -67181,7 +67942,7 @@ packages:
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.code.react-playground': 4.1.9(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       jsx-to-string: 1.4.0
@@ -67202,7 +67963,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67218,7 +67979,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67232,7 +67993,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       lodash: 4.17.21
       react: 17.0.2
@@ -67250,7 +68011,7 @@ packages:
     dependencies:
       '@teambit/documenter.ui.linked-heading': 4.1.6(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.property-table': 4.1.3(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
-      '@teambit/documenter.ui.section': registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.section': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67267,7 +68028,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.styles.flex-center': registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.styles.flex-center': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.icon-button': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -67303,7 +68064,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
@@ -67367,9 +68128,9 @@ packages:
       react-router-dom: ^6.0.0
     dependencies:
       '@babel/runtime': 7.20.0
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.composer': registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.composer': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -67378,7 +68139,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.3
+      chokidar: 3.5.1
       classnames: 2.2.6
       core-js: 3.13.0
       fs-extra: 10.0.0
@@ -67406,6 +68167,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
+      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       chalk: 2.4.2
       core-js: 3.13.0
@@ -67422,7 +68184,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67464,7 +68227,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/documenter.ui.sub-title': registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.sub-title': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash: 4.17.21
@@ -67495,8 +68259,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.heading': registry.npmjs.org/@teambit/documenter.ui.heading@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.ui.scope-icon': 0.0.91(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -67515,6 +68279,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@babel/runtime': 7.20.0
+      '@teambit/component-version': 0.0.406
       '@teambit/harmony': 0.4.6
       chalk: 2.4.2
       core-js: 3.13.0
@@ -67562,6 +68327,7 @@ packages:
     resolution: {directory: scopes/toolbox/fs/hard-link-directory, type: directory}
     name: '@teambit/toolbox.fs.hard-link-directory'
     dependencies:
+      '@teambit/defender.fs.global-bit-temp-dir': 0.0.1
       fs-extra: 10.0.0
       resolve-link-target: 1.0.1
       symlink-dir: 5.1.1
@@ -67588,6 +68354,8 @@ packages:
   file:scopes/toolbox/network/get-port:
     resolution: {directory: scopes/toolbox/network/get-port, type: directory}
     name: '@teambit/toolbox.network.get-port'
+    dependencies:
+      chai: 4.3.0
     dev: false
 
   file:scopes/toolbox/path/is-path-inside:
@@ -67599,6 +68367,7 @@ packages:
     resolution: {directory: scopes/toolbox/path/match-patterns, type: directory}
     name: '@teambit/toolbox.path.match-patterns'
     dependencies:
+      chai: 4.3.0
       minimatch: 3.0.5
     dev: false
 
@@ -67671,6 +68440,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67680,6 +68450,7 @@ packages:
     resolution: {directory: scopes/typescript/modules/ts-config-mutator, type: directory}
     name: '@teambit/typescript.modules.ts-config-mutator'
     dependencies:
+      json-formatter-js: 2.3.4
       lodash: 4.17.21
       typescript: 4.7.4
     dev: false
@@ -67706,7 +68477,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
+      chai: 4.3.0
       chalk: 2.4.2
+      comment-json: 3.0.3
       core-js: 3.13.0
       fs-extra: 10.0.0
       get-tsconfig: 4.2.0
@@ -67759,7 +68532,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -67775,9 +68549,10 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.text-sizes': registry.npmjs.org/@teambit/base-ui.text.text-sizes@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.text-sizes': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/community.constants.links': 0.0.2
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -67795,7 +68570,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.constants.storage': registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.constants.storage': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -67842,7 +68617,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -67873,8 +68648,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.surfaces.card': registry.npmjs.org/@teambit/base-ui.surfaces.card@1.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.text.muted-text': registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.card': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.text.muted-text': 1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.theme-provider': registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.elements.level-icon': 0.0.20(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.time-ago': 0.0.366(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.x-button': 1.0.7(react-dom@17.0.2)(react@17.0.2)
@@ -67894,7 +68671,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.theme.dark-theme': registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@teambit/evangelist.elements.button': 1.0.6(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68031,7 +68808,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68046,12 +68824,14 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.root-node': registry.npmjs.org/@teambit/base-ui.graph.tree.root-node@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.root-node': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/code.ui.utils.get-file-icon': 0.0.495(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68066,10 +68846,11 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.graph.tree.collapsable-tree-node': 0.0.4(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.elements.icon': 1.0.5(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68085,9 +68866,9 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68110,8 +68891,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
-      '@teambit/base-ui.loaders.loader-ribbon': registry.npmjs.org/@teambit/base-ui.loaders.loader-ribbon@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.fonts.roboto': registry.npmjs.org/@teambit/base-ui.theme.fonts.roboto@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.loaders.loader-ribbon': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.fonts.roboto': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.theme.icons-font': 2.0.26(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.themes.theme-toggler': 0.1.3(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
@@ -68207,7 +68988,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
       react-router-dom: ^6.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/design.ui.avatar': 1.0.16(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68349,8 +69131,8 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.tooltip': registry.npmjs.org/@teambit/evangelist.surfaces.tooltip@1.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.tooltip': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68413,14 +69195,14 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': registry.npmjs.org/@teambit/base-ui.graph.tree.inflate-paths@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': registry.npmjs.org/@teambit/base-ui.graph.tree.recursive-tree@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': registry.npmjs.org/@teambit/base-ui.graph.tree.tree-context@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': registry.npmjs.org/@teambit/base-ui.theme.colors@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68453,7 +69235,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68471,7 +69253,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68501,9 +69283,10 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.layout.breakpoints': registry.npmjs.org/@teambit/base-ui.layout.breakpoints@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.surfaces.dropdown': registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.layout.breakpoints': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.surfaces.dropdown': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68522,8 +69305,8 @@ packages:
       '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.content.documentation-links': 4.1.3(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.highlighted-text': registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.highlighted-text': 4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       lodash.flatten: 4.4.0
@@ -68545,7 +69328,7 @@ packages:
     dependencies:
       '@teambit/design.ui.styles.ellipsis': 0.0.357(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.copy-box': 4.1.6(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68575,7 +69358,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -68652,6 +69435,8 @@ packages:
   file:scopes/webpack/modules/generate-externals:
     resolution: {directory: scopes/webpack/modules/generate-externals, type: directory}
     name: '@teambit/webpack.modules.generate-externals'
+    dependencies:
+      json-formatter-js: 2.3.4
     dev: false
 
   file:scopes/webpack/modules/generate-style-loaders:
@@ -68746,6 +69531,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68828,6 +69614,7 @@ packages:
     resolution: {directory: scopes/workspace/modules/match-pattern, type: directory}
     name: '@teambit/workspace.modules.match-pattern'
     dependencies:
+      chai: 4.3.0
       lodash: 4.17.21
       minimatch: 3.0.5
       ramda: 0.27.1
@@ -68839,7 +69626,9 @@ packages:
     dependencies:
       '@teambit/legacy-bit-id': 0.0.423
       fs-extra: 10.0.0
+      glob: 7.1.6
       p-map-series: 2.1.0
+      ramda: 0.27.1
     dev: false
 
   file:scopes/workspace/testing/mock-workspace:
@@ -68858,6 +69647,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      '@teambit/documenter.theme.theme-compositions': registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -68872,7 +69662,7 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       '@testing-library/react': 12.1.5(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -68940,7 +69730,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 0.0.423
       chalk: 2.4.2
-      chokidar: 3.5.3
+      chokidar: 3.5.1
       core-js: 3.13.0
       fs-extra: 10.0.0
       lodash: 4.17.21
@@ -68964,8 +69754,8 @@ packages:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
       '@babel/runtime': 7.20.0
       '@react-hook/latest': 1.0.3(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.hover-splitter': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.surfaces.split-pane.split-pane': registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.split-pane@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.hover-splitter': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.surfaces.split-pane.split-pane': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/component-id': 0.0.427
       '@teambit/design.ui.surfaces.menu.link-item': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
@@ -69009,7 +69799,9 @@ packages:
     dependencies:
       '@babel/runtime': 7.20.0
       '@teambit/harmony': 0.4.6
+      chai: 4.3.0
       chalk: 2.4.2
+      cli-table: 0.3.6
       core-js: 3.13.0
       fs-extra: 10.0.0
       globby: 11.0.1
@@ -69041,8 +69833,8 @@ packages:
     name: '@teambit/base-ui.css-components.elevation'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69055,8 +69847,8 @@ packages:
     name: '@teambit/base-ui.css-components.roundness'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69077,6 +69869,21 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
+
+  registry.npmjs.org/@teambit/base-ui.elements.image@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-33kB66RvIaSRipV7mwL/IMwwOEThFRF4myHPFBSaF8rXmmJLKInm6bN1dWZ77gKcRlOtwJWq/UJMStC/EWtksA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.elements.image/-/base-ui.elements.image-1.0.0.tgz}
+    id: registry.npmjs.org/@teambit/base-ui.elements.image/1.0.0
+    name: '@teambit/base-ui.elements.image'
+    version: 1.0.0
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      classnames: 2.2.6
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: true
 
   registry.npmjs.org/@teambit/base-ui.graph.tree.indent@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-I1b8AryymAz574SX8FoVAwfCwPU6r0PMkJ6MvonSazXjYvG2ZBQmIlFb4/3O1d9p/aHiD82IF+D3nce6NJwdHQ==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.graph.tree.indent/-/base-ui.graph.tree.indent-1.0.0.tgz}
@@ -69158,8 +69965,8 @@ packages:
     name: '@teambit/base-ui.hook.use-click-outside'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69284,6 +70091,23 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
       url-parse: 1.5.1
+    dev: false
+
+  registry.npmjs.org/@teambit/base-ui.routing.link@1.0.0(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-kJkoNmZqsrXWFyDBM8DXH5IKa7GumBvm9l7mcs8kjawFmBtP+LnunV/KJozwQtuNTjmizMYwq8+6IWAV365RLA==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.link/-/base-ui.routing.link-1.0.0.tgz}
+    id: registry.npmjs.org/@teambit/base-ui.routing.link/1.0.0
+    name: '@teambit/base-ui.routing.link'
+    version: 1.0.0
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.routing-provider': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+    dev: true
 
   registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-yrkm02UxkeCBWyLQC9MG7Jl6JbQrsIBz+9c57mZqAjEcVvQWY2mB3lEY+pNZAuIyOg55/DTqKR1bKQKl6ZAdzg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.native-link/-/base-ui.routing.native-link-1.0.0.tgz}
@@ -69291,8 +70115,8 @@ packages:
     name: '@teambit/base-ui.routing.native-link'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69307,13 +70131,14 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.compare-url': registry.npmjs.org/@teambit/base-ui.routing.compare-url@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.compare-url': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-B6r0oNgTs/tR7v8MiOrwCQko/Vpjb1Zo/XmcgGMYEFe7UpTeD29pTM8DvCw9QU/VOnRnurUVGbrNfkrKfDrXdw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.routing.nav-link/-/base-ui.routing.nav-link-1.0.0.tgz}
@@ -69340,12 +70165,13 @@ packages:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
-      '@teambit/base-ui.routing.native-link': registry.npmjs.org/@teambit/base-ui.routing.native-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.routing.native-nav-link': registry.npmjs.org/@teambit/base-ui.routing.native-nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.utils.is-browser': registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.routing.native-nav-link': 1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/base-ui.utils.is-browser': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
+    dev: false
 
   registry.npmjs.org/@teambit/base-ui.styles.flex-center@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-kO9scMrQ5AI2+vi9Xc/VMQryBhlcR+RAAsM32mmPQ6cEbE4R1clN9SIASj2BZ2gTca+nQI37+sFvXdefviz4iw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.styles.flex-center/-/base-ui.styles.flex-center-1.0.0.tgz}
@@ -69353,8 +70179,8 @@ packages:
     name: '@teambit/base-ui.styles.flex-center'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -69397,8 +70223,8 @@ packages:
     name: '@teambit/base-ui.surfaces.card'
     version: 1.0.1
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.css-components.elevation': registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.css-components.roundness': registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -69415,8 +70241,8 @@ packages:
     name: '@teambit/base-ui.surfaces.drawer'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.hook.use-click-outside': registry.npmjs.org/@teambit/base-ui.hook.use-click-outside@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.surfaces.abs-container': registry.npmjs.org/@teambit/base-ui.surfaces.abs-container@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -69497,8 +70323,8 @@ packages:
     name: '@teambit/base-ui.surfaces.split-pane.splitter'
     version: 1.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69526,8 +70352,8 @@ packages:
     name: '@teambit/base-ui.text.muted-text'
     version: 1.0.1
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -69763,19 +70589,6 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  registry.npmjs.org/@teambit/base-ui.utils.is-browser@1.0.0(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-xvMmDLJFXqO0WwEYtM+zipMFQ7yaQLxDWmUynehfrBERSA8ZaeVfR8DiTPV/X3nRM/OD2Cym4f6UZPhcXLXJeg==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.is-browser/-/base-ui.utils.is-browser-1.0.0.tgz}
-    id: registry.npmjs.org/@teambit/base-ui.utils.is-browser/1.0.0
-    name: '@teambit/base-ui.utils.is-browser'
-    version: 1.0.0
-    peerDependencies:
-      react: '*'
-      react-dom: '*'
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-
   registry.npmjs.org/@teambit/base-ui.utils.string.affix@1.0.0(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-cuXL6MNfP7XPJtJZUVUCj50JJpzF/+pS0RRlnWE1B/rNB9tKyu+QfdZQ+kmSAGwQMT1ZfTufo50Gow/suzZavw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/base-ui.utils.string.affix/-/base-ui.utils.string.affix-1.0.0.tgz}
     id: registry.npmjs.org/@teambit/base-ui.utils.string.affix/1.0.0
@@ -69836,7 +70649,6 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: true
 
   registry.npmjs.org/@teambit/design.ui.styles.ellipsis@0.0.344(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-SwTlVagmcCvedxD9hrq+1pt9MxkYY+GfYAyF4BUsTjKYAv37ZqOX8dqNgmkKhKlTBXSAw70rfGDQ5BBE8Ptipw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/design.ui.styles.ellipsis/-/design.ui.styles.ellipsis-0.0.344.tgz}
@@ -69854,6 +70666,21 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
+  registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-5XbZTdEgwo05Qsu7+NO635JU6yRS6Z6fKwQGg/zjbOTouetsyeXgmu01NMAAEyEYFZvyjxZE1RRoIA9hx7H1zw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-compositions/-/documenter.theme.theme-compositions-4.1.1.tgz}
+    id: registry.npmjs.org/@teambit/documenter.theme.theme-compositions/4.1.1
+    name: '@teambit/documenter.theme.theme-compositions'
+    version: 4.1.1
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
+    dependencies:
+      '@teambit/design.theme.icons-font': registry.npmjs.org/@teambit/design.theme.icons-font@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.theme.theme-context': registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2)
+      core-js: 3.13.0
+      react: 17.0.2
+      react-dom: 17.0.2(react@17.0.2)
+
   registry.npmjs.org/@teambit/documenter.theme.theme-context@4.0.3(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-y3A4sldyzVLvaOQX0rOg9LAVWUx1OwjzIiBCyAwiNSTTsl42emPChOWePDGycBkN+fPkQVokAUKimqMk/h/aNw==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.theme.theme-context/-/documenter.theme.theme-context-4.0.3.tgz}
     id: registry.npmjs.org/@teambit/documenter.theme.theme-context/4.0.3
@@ -69870,15 +70697,18 @@ packages:
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
 
-  registry.npmjs.org/@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-gbfQTP1HRL5bkg1+mc94UTrGgI6tFkR4h7fkgQuxH+53JOLF6odEwLYhfJ2qZFju5dtL1Ag0rsCIGdeM9fP04A==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.copied-message/-/documenter.ui.copied-message-4.0.1.tgz}
-    id: registry.npmjs.org/@teambit/documenter.ui.copied-message/4.0.1
-    name: '@teambit/documenter.ui.copied-message'
-    version: 4.0.1
+  registry.npmjs.org/@teambit/documenter.ui.consumable-link@4.0.3(react-dom@17.0.2)(react@17.0.2):
+    resolution: {integrity: sha512-htTNbT54hIBaF7sCXMLus56Rw3AfZpJwgS1B2K8UQg4hBN93/iEFAP6ZOhfR9xYoA7ejImhdxyMUxYJmrwPF2w==, registry: https://node-registry.v2.bit.cloud/, tarball: https://registry.npmjs.org/@teambit/documenter.ui.consumable-link/-/documenter.ui.consumable-link-4.0.3.tgz}
+    id: registry.npmjs.org/@teambit/documenter.ui.consumable-link/4.0.3
+    name: '@teambit/documenter.ui.consumable-link'
+    version: 4.0.3
     peerDependencies:
       react: ^16.8.0 || ^17.0.0
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
+      '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.copy-box': registry.npmjs.org/@teambit/documenter.ui.copy-box@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.paragraph': registry.npmjs.org/@teambit/documenter.ui.paragraph@4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
       react: 17.0.2
@@ -69910,8 +70740,8 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.layout.grid-component': registry.npmjs.org/@teambit/base-ui.layout.grid-component@1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/documenter.ui.copied-message': registry.npmjs.org/@teambit/documenter.ui.copied-message@4.0.1(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/documenter.ui.copied-message': 4.0.1(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       copy-to-clipboard: 3.3.1
       core-js: 3.13.0
@@ -70083,8 +70913,8 @@ packages:
     name: '@teambit/documenter.ui.table-column'
     version: 4.0.0
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
       core-js: 3.13.0
@@ -70160,8 +70990,8 @@ packages:
     name: '@teambit/evangelist.surfaces.dropdown'
     version: 1.0.2
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@teambit/base-ui.css-components.elevation': registry.npmjs.org/@teambit/base-ui.css-components.elevation@1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.css-components.roundness': registry.npmjs.org/@teambit/base-ui.css-components.roundness@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -70217,8 +71047,8 @@ packages:
     name: '@teambit/react.instructions.react.adding-compositions'
     version: 0.0.6
     peerDependencies:
-      react: '*'
-      react-dom: '*'
+      react: ^16.8.0 || ^17.0.0
+      react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/mdx.ui.mdx-scope-context': registry.npmjs.org/@teambit/mdx.ui.mdx-scope-context@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -398,19 +398,9 @@ export class Watcher {
   private async createWatcher(pathsToWatch: string[]) {
     this.fsWatcher = chokidar.watch(pathsToWatch, {
       ignoreInitial: true,
-      // Using the function way since the regular way not working as expected
-      // It might be solved when upgrading to chokidar > 3.0.0
-      // See:
-      // https://github.com/paulmillr/chokidar/issues/773
-      // https://github.com/paulmillr/chokidar/issues/492
-      // https://github.com/paulmillr/chokidar/issues/724
-      ignored: (path) => {
-        // Ignore package.json temporarily since it cerates endless loop since it's re-written after each build
-        if (path.includes(`${sep}node_modules${sep}`) || path.includes(`${sep}package.json`)) {
-          return true;
-        }
-        return false;
-      },
+      // `chokidar` matchers have Bash-parity, so Windows-style backslackes are not supported as separators.
+      // (windows-style backslashes are converted to forward slashes)
+      ignored: ['**/node_modules/**', '**/package.json'],
       persistent: true,
       useFsEvents: false,
     });

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -1,6 +1,6 @@
 import { PubsubMain } from '@teambit/pubsub';
 import fs from 'fs-extra';
-import { dirname, sep, basename } from 'path';
+import { dirname, basename } from 'path';
 import { compact, difference, partition } from 'lodash';
 import { ComponentID } from '@teambit/component';
 import { BitId } from '@teambit/legacy-bit-id';


### PR DESCRIPTION
## Proposed Changes

- Update chokidar to latest version 3.5.3
- Update chokidar ignored paths to support multiple operating systems (including Windows)
- Use of chokidar ignored regexes
