### PR TITLE
fix(typescript): AST transform: handle namespace export renaming

### DIFF
--- a/scopes/typescript/typescript/sourceFileTransformers/export.ts
+++ b/scopes/typescript/typescript/sourceFileTransformers/export.ts
@@ -11,6 +11,7 @@ export const exportTransformer: SourceFileTransformer = (mapping: Record<string,
             moduleSpecifier = moduleSpecifier.replace(oldName, newName);
           }
         }
+        let updatedExportClause;
 
         if (node.exportClause && ts.isNamedExports(node.exportClause)) {
           const transformedElements = node.exportClause.elements.map((element) => {
@@ -30,18 +31,18 @@ export const exportTransformer: SourceFileTransformer = (mapping: Record<string,
             );
           });
 
-          const updatedExportClause = ts.factory.updateNamedExports(node.exportClause, transformedElements);
-
-          return ts.factory.updateExportDeclaration(
-            node,
-            node.decorators,
-            node.modifiers,
-            node.isTypeOnly,
-            updatedExportClause,
-            node.moduleSpecifier ? ts.factory.createStringLiteral(moduleSpecifier || '') : undefined,
-            undefined
-          );
+          updatedExportClause = ts.factory.updateNamedExports(node.exportClause, transformedElements);
         }
+
+        return ts.factory.updateExportDeclaration(
+          node,
+          node.decorators,
+          node.modifiers,
+          node.isTypeOnly,
+          updatedExportClause,
+          node.moduleSpecifier ? ts.factory.createStringLiteral(moduleSpecifier || '') : undefined,
+          undefined
+        );
       }
 
       if (ts.isExportAssignment(node)) {

--- a/scopes/typescript/typescript/transform-source-file.spec.ts
+++ b/scopes/typescript/typescript/transform-source-file.spec.ts
@@ -7,6 +7,7 @@ import {
   interfaceNamesTransformer,
   typeAliasNamesTransformer,
   variableNamesTransformer,
+  exportTransformer,
 } from './sourceFileTransformers';
 
 function normalizeFormatting(code: string): string {
@@ -70,6 +71,48 @@ describe('transformSourceFile', () => {
       sourceCode: 'let testVariable = "test";',
       nameMapping: { testVariable: 'newVariableName' },
       expectedCode: 'let newVariableName = "test";',
+    },
+    {
+      transformer: importTransformer,
+      sourceCode: 'import { Component } from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'import { Component } from "@abc/ui-library";',
+    },
+    {
+      transformer: importTransformer,
+      sourceCode: 'import * as UI from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'import * as UI from "@abc/ui-library";',
+    },
+    {
+      transformer: importTransformer,
+      sourceCode: 'import UI from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'import UI from "@abc/ui-library";',
+    },
+    {
+      transformer: importTransformer,
+      sourceCode: 'const UI = require("@xxx/ui-library");',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'const UI = require("@abc/ui-library");',
+    },
+    {
+      transformer: exportTransformer,
+      sourceCode: 'export { Component } from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'export { Component } from "@abc/ui-library";',
+    },
+    {
+      transformer: exportTransformer,
+      sourceCode: 'export * from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'export * from "@abc/ui-library";',
+    },
+    {
+      transformer: exportTransformer,
+      sourceCode: 'export { default as UI } from "@xxx/ui-library";',
+      nameMapping: { '@xxx/ui-library': '@abc/ui-library' },
+      expectedCode: 'export { default as UI } from "@abc/ui-library";',
     },
   ];
 


### PR DESCRIPTION
This pull request addresses a bug in the exportTransformer where namespace exports, specifically those using the "export * from 'module'" syntax, were not being correctly renamed according to the provided mapping.

