### PR TITLE
improvement(merge-from-scope), enable squashing the messages and providing a title

### DIFF
--- a/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
@@ -10,6 +10,7 @@ type Flags = {
   keepReadme?: boolean;
   noSquash: boolean;
   includeDeps?: boolean;
+  title?: string;
 };
 
 /**
@@ -34,6 +35,11 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
   alias = '';
   options = [
     ['', 'pattern <string>', 'partially merge the lane with the specified component-pattern'],
+    [
+      '',
+      'title <string>',
+      'if provided, it replaces the original message with this title and append squashed snaps messages',
+    ],
     ['', 'push', 'export the updated objects to the original scopes once done'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
     ['', 'no-squash', 'relevant for merging lanes into main, which by default squash.'],
@@ -49,7 +55,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
 
   async report(
     [fromLane, toLane]: [string, string],
-    { pattern, push = false, keepReadme = false, noSquash = false, includeDeps = false }: Flags
+    { pattern, push = false, keepReadme = false, noSquash = false, includeDeps = false, title }: Flags
   ): Promise<string> {
     if (includeDeps && !pattern) {
       throw new BitError(`"--include-deps" flag is relevant only for --pattern flag`);
@@ -64,6 +70,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
         noSquash,
         pattern,
         includeDeps,
+        snapMessage: title,
       }
     );
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -692,9 +692,18 @@ export default class Version extends BitObject {
     this.parents.push(ref);
   }
 
-  setSquashed(squashData: SquashData, log: Log) {
+  setSquashed(squashData: SquashData, log: Log, replaceMessage?: string) {
     this.squashed = squashData;
     this.addModifiedLog(log);
+    if (replaceMessage) {
+      this.addModifiedLog({
+        username: undefined,
+        email: undefined,
+        date: Date.now().toString(),
+        message: `squashing: replacing the original log.message, which was: "${this.log.message || '<empty>'}"`,
+      });
+      this.log.message = replaceMessage;
+    }
   }
 
   addModifiedLog(log: Log) {


### PR DESCRIPTION
This only works with `--title` was provided. It replaces the head snap message with this title and appends the squashed snaps messages.