### PR TITLE
improvement(sidebar): allow overriding scope sidebar toggler

### DIFF
--- a/scopes/scope/scope/get-scope-options.ts
+++ b/scopes/scope/scope/get-scope-options.ts
@@ -10,4 +10,5 @@ export type GetScopeOptions = {
   TargetScopeOverview?: ComponentType;
   PaneWrapper?: ComponentType<{ children: ReactNode }>;
   overrideDrawers?: DrawerType[];
+  onSidebarToggle?: (callback: () => void) => void;
 };

--- a/scopes/scope/scope/scope.ui.runtime.tsx
+++ b/scopes/scope/scope/scope.ui.runtime.tsx
@@ -138,7 +138,7 @@ export class ScopeUI {
         badgeSlot={this.scopeBadgeSlot}
         overviewLineSlot={this.overviewSlot}
         context={this.getContext()}
-        onSidebarTogglerChange={this.setSidebarToggle}
+        onSidebarTogglerChange={options.onSidebarToggle || this.setSidebarToggle}
         cornerSlot={this.cornerSlot}
         paneClassName={options.paneClassName}
         PaneWrapper={options.PaneWrapper}


### PR DESCRIPTION
update `getScope` in `scope.ui.runtime` to allow overriding scope sidebar toggler