### PR TITLE
scope aspects capsule cache fixes

### DIFF
--- a/scopes/dependencies/fs/linked-dependencies/linked-dependencies.ts
+++ b/scopes/dependencies/fs/linked-dependencies/linked-dependencies.ts
@@ -1,11 +1,23 @@
 import path from 'path';
 import { createSymlinkOrCopy } from '@teambit/legacy/dist/utils';
 
-export async function createLinks(rootDir: string, linkedDeps: Record<string, string>) {
+type CreateLinksOpts = {
+  componentId?: string | null | undefined;
+  avoidHardLink?: boolean;
+  skipIfSymlinkValid?: boolean;
+};
+
+export async function createLinks(rootDir: string, linkedDeps: Record<string, string>, opts: CreateLinksOpts = {}) {
   const modulesDir = path.join(rootDir, 'node_modules');
   await Promise.all(
     Object.entries(linkedDeps).map(([packageName, linkPath]) =>
-      createSymlinkOrCopy(linkPath.substring(5), path.join(modulesDir, packageName))
+      createSymlinkOrCopy(
+        linkPath.substring(5),
+        path.join(modulesDir, packageName),
+        opts.componentId,
+        opts.avoidHardLink,
+        opts.skipIfSymlinkValid
+      )
     )
   );
 }

--- a/src/utils/fs/create-symlink-or-copy.ts
+++ b/src/utils/fs/create-symlink-or-copy.ts
@@ -16,8 +16,16 @@ export default function createSymlinkOrCopy(
   destPath: PathOsBased,
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   componentId?: string | null | undefined = '',
-  avoidHardLink = false
+  avoidHardLink = false,
+  skipIfSymlinkValid = false
 ) {
+  if (skipIfSymlinkValid && fs.existsSync(destPath)) {
+    const realDestination = fs.realpathSync(destPath);
+    if (realDestination === srcPath) {
+      logger.trace(`createSymlinkOrCopy, skip creating symlink, it already exists on ${destPath}`);
+      return;
+    }
+  }
   logger.trace(`createSymlinkOrCopy, deleting ${destPath}`);
   fs.removeSync(destPath); // in case a symlink already generated or when linking a component, when a component has been moved
   fs.ensureDirSync(path.dirname(destPath));


### PR DESCRIPTION
## Proposed Changes

- mark capsule as ready when creation is done (a new file named `.bit-capsule-ready` will be created at the capsule root)
- do not re-create symlinks to core aspects in scope aspects cache dir if they already exist and valid
- mark capsule as ready after it was moved from dated capsule to cache
- better logs for scope aspects isolation
- move capsule from dated capsule to cache if it already exists but not valid (ready)
- improve moving capsules from dated dir to cache dir
