### PR TITLE
fix(lane-merge-abort), restore components deleted by the last lane-merge

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -248,9 +248,21 @@ describe('bit lane command', function () {
         const staged = status.stagedComponents.map((c) => c.id);
         expect(staged).to.include(`${helper.scopes.remote}/comp2`);
       });
+      describe('abort the lane-merge', () => {
+        let abortOutput: string;
+        before(() => {
+          abortOutput = helper.command.mergeAbortLane('-x');
+        });
+        it('should indicate that a component has been added', () => {
+          expect(abortOutput).to.have.string('have been added');
+        });
+        it('should add the previously removed component', () => {
+          expect(path.join(helper.scopes.localPath, 'comp2')).to.be.a.directory();
+        });
+      });
     });
   });
-  describe('soft remove on lane when a forked lane changed it and is now merging this lane', () => {
+  describe('soft remove on lane when a forked lane changed it (diverged) and is now merging this lane', () => {
     let beforeRemoveScope: string;
     let beforeMerge: string;
     let output;

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -7,6 +7,7 @@ import {
   installationErrorOutput,
   compilationErrorOutput,
   getRemovedOutput,
+  getAddedOutput,
 } from '@teambit/merging';
 import { COMPONENT_PATTERN_HELP, HEAD, LATEST } from '@teambit/legacy/dist/constants';
 import { getMergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
@@ -113,6 +114,7 @@ export function checkoutOutput(checkoutResults: ApplyVersionResults, checkoutPro
     version,
     failedComponents,
     removedComponents,
+    addedComponents,
     leftUnresolvedConflicts,
     newFromLane,
     newFromLaneAdded,
@@ -222,6 +224,7 @@ once ready, snap/tag the components to persist the changes`;
     getNotCheckedOutOutput() +
     getSuccessfulOutput() +
     getRemovedOutput(removedComponents) +
+    getAddedOutput(addedComponents) +
     getNewOnLaneOutput() +
     getConflictSummary() +
     getSummary() +

--- a/scopes/component/merging/index.ts
+++ b/scopes/component/merging/index.ts
@@ -7,6 +7,7 @@ export {
   installationErrorOutput,
   compilationErrorOutput,
   getRemovedOutput,
+  getAddedOutput,
 } from './merge-cmd';
 export type { MergingMain, ComponentMergeStatus, ApplyVersionResults } from './merging.main.runtime';
 export { ConfigMergeResult } from './config-merge-result';

--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import { Command, CommandOptions } from '@teambit/cli';
 import { BitId } from '@teambit/legacy-bit-id';
+import { ComponentID } from '@teambit/component-id';
 import { compact } from 'lodash';
 import { WILDCARD_HELP, AUTO_SNAPPED_MSG, MergeConfigFilename } from '@teambit/legacy/dist/constants';
 import {
@@ -302,5 +303,12 @@ export function getRemovedOutput(removedComponents?: BitId[]) {
   if (!removedComponents?.length) return '';
   const title = `the following ${removedComponents.length} component(s) have been removed`;
   const body = removedComponents.join('\n');
+  return `\n\n${chalk.underline(title)}\n${body}\n\n`;
+}
+
+export function getAddedOutput(addedComponents?: ComponentID[]) {
+  if (!addedComponents?.length) return '';
+  const title = `the following ${addedComponents.length} component(s) have been added`;
+  const body = addedComponents.join('\n');
   return `\n\n${chalk.underline(title)}\n${body}\n\n`;
 }

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -89,6 +89,7 @@ export type ApplyVersionResults = {
   version?: string;
   failedComponents?: FailedComponents[];
   removedComponents?: BitId[];
+  addedComponents?: ComponentID[]; // relevant when restoreMissingComponents is true (e.g. bit lane merge-abort)
   resolvedComponents?: ConsumerComponent[]; // relevant for bit merge --resolve
   abortedComponents?: ApplyVersionResult[]; // relevant for bit merge --abort
   mergeSnapResults?: {

--- a/scopes/lanes/merge-lanes/merge-abort.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-abort.cmd.ts
@@ -44,13 +44,21 @@ also, checkout the workspace components according to the restored lane`;
       verbose,
       skipNpmInstall: skipDependencyInstallation,
     };
-    const { checkoutResults, restoredItems } = await this.mergeLanes.abortLaneMerge(checkoutProps);
+    const { checkoutResults, restoredItems, checkoutError } = await this.mergeLanes.abortLaneMerge(checkoutProps);
 
-    const checkoutOutputStr = checkoutOutput(checkoutResults, checkoutProps);
-    const restoredItemsTitle = chalk.underline('The following have been restored:');
-    const restoredItemsOutput = restoredItems.map((item) => `[-] ${item}`).join('\n');
+    const getCheckoutErrorStr = () => {
+      if (!checkoutError) return '';
+      const errMsg = `\n\nFailed changing the component files to the pre-merge due to an error:
+${checkoutError.message}
+please fix the error and then run "bit checkout reset --all" to revert the components to the pre-merge state`;
+      return chalk.red(errMsg);
+    };
 
-    return `${checkoutOutputStr}\n\n${restoredItemsTitle}\n${restoredItemsOutput}`;
+    const checkoutOutputStr = checkoutResults ? checkoutOutput(checkoutResults, checkoutProps) : '';
+    const restoredItemsTitle = chalk.green('The following have been restored successfully:');
+    const restoredItemsOutput = restoredItems.map((item) => `[√] ${item}`).join('\n');
+
+    return `${checkoutOutputStr}\n\n${restoredItemsTitle}\n${restoredItemsOutput}${getCheckoutErrorStr()}`;
   }
 
   private async prompt() {

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -617,7 +617,9 @@ async function getLoadedFiles(
   bitDir: string
 ): Promise<SourceFile[]> {
   if (componentMap.noFilesError) {
-    throw componentMap.noFilesError;
+    throw new Error(`unable to find component files of ${id.toString()} in ${componentMap.rootDir}`, {
+      cause: componentMap.noFilesError,
+    });
   }
   await componentMap.trackDirectoryChangesHarmony(consumer, id);
   const sourceFiles = componentMap.files.map((file) => {

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -617,9 +617,7 @@ async function getLoadedFiles(
   bitDir: string
 ): Promise<SourceFile[]> {
   if (componentMap.noFilesError) {
-    throw new Error(`unable to find component files of ${id.toString()} in ${componentMap.rootDir}`, {
-      cause: componentMap.noFilesError,
-    });
+    throw new ComponentNotFoundInPath(bitDir, componentMap.noFilesError);
   }
   await componentMap.trackDirectoryChangesHarmony(consumer, id);
   const sourceFiles = componentMap.files.map((file) => {

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -617,7 +617,8 @@ async function getLoadedFiles(
   bitDir: string
 ): Promise<SourceFile[]> {
   if (componentMap.noFilesError) {
-    throw new ComponentNotFoundInPath(bitDir, componentMap.noFilesError);
+    logger.error(`rethrowing an error of ${componentMap.noFilesError.message}`);
+    throw componentMap.noFilesError;
   }
   await componentMap.trackDirectoryChangesHarmony(consumer, id);
   const sourceFiles = componentMap.files.map((file) => {

--- a/src/consumer/component/exceptions/component-not-found-in-path.ts
+++ b/src/consumer/component/exceptions/component-not-found-in-path.ts
@@ -5,9 +5,10 @@ export default class ComponentNotFoundInPath extends BitError {
   path: string;
   code: number;
 
-  constructor(path: string) {
+  constructor(path: string, cause?: Error) {
     super(`error: component in path "${chalk.bold(path)}" was not found`);
     this.code = 127;
     this.path = path;
+    if (cause) this.cause = cause;
   }
 }


### PR DESCRIPTION
## Proposed Changes

- in case the last merge deleted components from the workspace (was soft-removed by the other lane), the abort-merge rewrites it back. 
- catch checkout errors during "bit lane merge-abort" and explain in the output the status. suggest to run "bit checkout reset" after fixing the error.

