### PR TITLE
fix(aspect-merger | merging): make sure consumer reference is not stale

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -89,6 +89,7 @@ export type ApplyVersionResults = {
   version?: string;
   failedComponents?: FailedComponents[];
   removedComponents?: BitId[];
+  addedComponents?: ComponentID[]; // relevant when restoreMissingComponents is true (e.g. bit lane merge-abort)
   resolvedComponents?: ConsumerComponent[]; // relevant for bit merge --resolve
   abortedComponents?: ApplyVersionResult[]; // relevant for bit merge --abort
   mergeSnapResults?: {
@@ -588,7 +589,8 @@ export class MergingMain {
     const unmerged = consumer.scope.objects.unmergedComponents.getEntry(id.name);
     if (unmerged) {
       return returnUnmerged(
-        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort)`
+        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort/ 
+        bit lane merge-abort)`
       );
     }
     const repo = consumer.scope.objects;

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -589,8 +589,7 @@ export class MergingMain {
     const unmerged = consumer.scope.objects.unmergedComponents.getEntry(id.name);
     if (unmerged) {
       return returnUnmerged(
-        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort/ 
-        bit lane merge-abort)`
+        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort/ bit lane merge-abort)`
       );
     }
     const repo = consumer.scope.objects;

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -4,7 +4,6 @@ import { UnmergedComponent } from '@teambit/legacy/dist/scope/lanes/unmerged-com
 import { BitId } from '@teambit/legacy-bit-id';
 import { EnvsAspect } from '@teambit/envs';
 import { DependencyResolverAspect } from '@teambit/dependency-resolver';
-import { Consumer } from '@teambit/legacy/dist/consumer';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { partition, mergeWith, merge } from 'lodash';
 import { MergeConfigConflict } from './exceptions/merge-config-conflict';
@@ -13,12 +12,10 @@ import { MergeConflictFile } from './merge-conflict-file';
 import { WorkspaceLoadAspectsOptions } from './workspace-aspects-loader';
 
 export class AspectsMerger {
-  private consumer: Consumer;
   private warnedAboutMisconfiguredEnvs: string[] = []; // cache env-ids that have been errored about not having "env" type
   readonly mergeConflictFile: MergeConflictFile;
   private mergeConfigDepsResolverDataCache: { [compIdStr: string]: Record<string, any> } = {};
   constructor(private workspace: Workspace, private harmony: Harmony) {
-    this.consumer = workspace.consumer;
     this.mergeConflictFile = new MergeConflictFile(workspace.path);
   }
 
@@ -51,7 +48,7 @@ export class AspectsMerger {
     const mergeFromScope = true;
     const errors: Error[] = [];
 
-    const bitMapEntry = this.consumer.bitMap.getComponentIfExist(componentId._legacy);
+    const bitMapEntry = this.workspace.consumer.bitMap.getComponentIfExist(componentId._legacy);
     const bitMapExtensions = bitMapEntry?.config;
 
     let configMerge: Record<string, any> | undefined;


### PR DESCRIPTION
This PR fixes the issue with stale consumer references in aspect merger and merging main runtime

This specifically fixes the issue of making sure newly loaded components have the correct config loaded when accessed from another process