### PR TITLE
fix(bit new) - compile components again once all envs and their dependencies are in place

### DIFF
--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -59,6 +59,7 @@ export class WorkspaceGenerator {
       await this.setupGitBitmapMergeDriver();
       await this.forkComponentsFromRemote();
       await this.importComponentsFromRemote();
+      await this.workspace.clearCache();
       await this.install.install(undefined, {
         dedupe: true,
         import: false,
@@ -66,6 +67,9 @@ export class WorkspaceGenerator {
         copyPeerToRuntimeOnComponents: false,
         updateExisting: false,
       });
+      console.log('compiling components');
+      // compile the components again now that we have the dependencies installed
+      await this.compileComponents(true);
       // await this.wsConfigFiles.writeConfigFiles({});
       // await this.buildUI(); // disabled for now. it takes too long
     } catch (err: any) {
@@ -154,8 +158,6 @@ export class WorkspaceGenerator {
       refactor: true,
       install: false,
     });
-    await this.workspace.clearCache();
-    await this.compileComponents();
   }
 
   private async importComponentsFromRemote() {
@@ -177,11 +179,12 @@ export class WorkspaceGenerator {
     });
 
     await this.workspace.bitMap.write();
-    await this.workspace.clearCache();
-    await this.compileComponents();
   }
 
-  private async compileComponents() {
+  private async compileComponents(clearCache = true) {
+    if (clearCache) {
+      await this.workspace.clearCache();
+    }
     const compiler = this.harmony.get<CompilerMain>(CompilerAspect.id);
     await compiler.compileOnWorkspace();
   }

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -67,7 +67,6 @@ export class WorkspaceGenerator {
         copyPeerToRuntimeOnComponents: false,
         updateExisting: false,
       });
-      console.log('compiling components');
       // compile the components again now that we have the dependencies installed
       await this.compileComponents(true);
       // await this.wsConfigFiles.writeConfigFiles({});


### PR DESCRIPTION
## Proposed Changes

- this fixes a case when the first compilation (as part of the bit new) is done incorrectly as the envs are not loaded yet.

### background

an example of this is when using:
```
bit new hello-world my-hello-world --env teambit.community/starters/hello-world
```
then looking at the compiled code, you will see - `React.createElement` which is invalid as it should use the new jsx runtime.
(for example `cat my-hello-world/node_modules/@org/scope-name.ui.hello-world/dist/hello-world.js`)
So it should be `_jsx` 
compiling again fixes the issue.
but this leaves the workspace just after the new command in an invalid state (the app will not run for example)
