### PR TITLE
fix(watch), fix high CPU by removing "useFsEvents: false" from chokidar

### DIFF
--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -402,7 +402,6 @@ export class Watcher {
       // (windows-style backslashes are converted to forward slashes)
       ignored: ['**/node_modules/**', '**/package.json'],
       persistent: true,
-      useFsEvents: false,
     });
   }
 


### PR DESCRIPTION
It's unclear why `useFsEvents: false,` was used. Removing this fixes the CPU load issue on big projects.