### PR TITLE
fix(refactoring): source file formatting after transform

### DIFF
--- a/scopes/component/refactoring/refactoring.main.runtime.ts
+++ b/scopes/component/refactoring/refactoring.main.runtime.ts
@@ -6,7 +6,6 @@ import replacePackageName from '@teambit/legacy/dist/utils/string/replace-packag
 import ComponentAspect, { Component, ComponentID, ComponentMain } from '@teambit/component';
 import { BitError } from '@teambit/bit-error';
 import PkgAspect, { PkgMain } from '@teambit/pkg';
-import { PrettierConfigMutator } from '@teambit/defender.prettier.config-mutator';
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import {
   SourceFileTransformer,

--- a/scopes/defender/formatter/formatter.ts
+++ b/scopes/defender/formatter/formatter.ts
@@ -38,6 +38,6 @@ export type FormatResults = {
 export interface Formatter {
   id: string;
   format(context: FormatterContext): Promise<FormatResults>;
-  formatSnippet(snippet: string): Promise<string>;
+  formatSnippet(snippet: string, filepath?: string): Promise<string>;
   check(context: FormatterContext): Promise<FormatResults>;
 }

--- a/scopes/defender/prettier/prettier.formatter.ts
+++ b/scopes/defender/prettier/prettier.formatter.ts
@@ -35,8 +35,24 @@ export class PrettierFormatter implements Formatter {
     return this.run(context);
   }
 
-  async formatSnippet(snippet: string): Promise<string> {
-    return this.prettierModule.format(snippet, this.options);
+  async formatSnippet(snippet: string, filePath?: string): Promise<string> {
+    let parser;
+
+    if (filePath) {
+      const ext = filePath.split('.').pop();
+      const supportInfo = this.prettierModule.getSupportInfo();
+      const language = supportInfo.languages.find((lang) => lang.extensions && lang.extensions.includes(`.${ext}`));
+
+      if (language) {
+        parser = language.parsers[0];
+      }
+    }
+
+    parser = parser || 'babel';
+
+    const optsWithFilePath = Object.assign({}, this.options, { filepath: filePath, parser: parser });
+
+    return this.prettierModule.format(snippet, optsWithFilePath);
   }
 
   async check(context: FormatterContext): Promise<FormatResults> {

--- a/scopes/defender/prettier/prettier.formatter.ts
+++ b/scopes/defender/prettier/prettier.formatter.ts
@@ -50,7 +50,7 @@ export class PrettierFormatter implements Formatter {
 
     parser = parser || 'babel';
 
-    const optsWithFilePath = Object.assign({}, this.options, { filepath: filePath, parser: parser });
+    const optsWithFilePath = Object.assign({}, this.options, { filepath: filePath, parser });
 
     return this.prettierModule.format(snippet, optsWithFilePath);
   }

--- a/scopes/typescript/typescript/sourceFileTransformers/empty-line-encoder.ts
+++ b/scopes/typescript/typescript/sourceFileTransformers/empty-line-encoder.ts
@@ -36,7 +36,7 @@ export function decodeEmptyLines(text: string, emptyLineMarker?: string, newLine
 
   const lines = text.split(/\r?\n/);
 
-  const uncommentedLines = lines.map((line) => (line.replace(marker, '').trim() === '' ? '' : line));
+  const uncommentedLines = lines.map((line) => (line.trim() === marker ? '' : line));
 
   return uncommentedLines.join(newLine || EmptyLineEncoder.defaultNewLine);
 }

--- a/scopes/typescript/typescript/sourceFileTransformers/transform.ts
+++ b/scopes/typescript/typescript/sourceFileTransformers/transform.ts
@@ -59,7 +59,7 @@ export async function transformSourceFile(
   transformedSourceFileStr = transformedSourceFileStr.replace(regex, '');
 
   try {
-    const formattedSourceFileStr = await formatter?.formatSnippet(transformedSourceFileStr);
+    const formattedSourceFileStr = await formatter?.formatSnippet(transformedSourceFileStr, sourceFilePath);
     return formattedSourceFileStr || transformedSourceFileStr;
   } catch {
     // We can ignore if the formatter fails


### PR DESCRIPTION
This PR fixes the issue where the prettier api would throw the error "Cannot find parser ... "
With this PR we don't use a formatter to re format the transformed source file
Since,
1) The source file is already formatted
2) We encode/decode empty lines when we transform AST
3) Only the matching AST nodes are transformed

hence preserving the formatting of the underlying code