### PR TITLE
decouple ignore-build-errors and disable-snap/tag-pipeline flags

### DIFF
--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -5,7 +5,6 @@ import { IssuesClasses } from '@teambit/component-issues';
 import { Command, CommandOptions } from '@teambit/cli';
 import { isFeatureEnabled, BUILD_ON_CI } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
 import { NOTHING_TO_SNAP_MSG, AUTO_SNAPPED_MSG, COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
-import { BitError } from '@teambit/bit-error';
 import { Logger } from '@teambit/logger';
 import { SnappingMain, SnapResults } from './snapping.main.runtime';
 import { outputIdsIfExists } from './tag-cmd';
@@ -114,9 +113,6 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     if (forceDeploy) {
       this.logger.consoleWarning(`--force-deploy is deprecated, use --ignore-build-errors instead`);
       ignoreBuildErrors = true;
-    }
-    if (disableTagAndSnapPipelines && ignoreBuildErrors) {
-      throw new BitError('you can use either ignore-build-error or disable-snap-pipeline, but not both');
     }
 
     const results = await this.snapping.snap({

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -150,9 +150,6 @@ export class SnappingMain {
     failFast?: boolean;
   } & Partial<BasicTagParams>): Promise<TagResults | null> {
     if (soft) build = false;
-    if (disableTagAndSnapPipelines && ignoreBuildErrors) {
-      throw new BitError('you can use either ignore-build-errors or disable-tag-pipeline, but not both');
-    }
     if (editor && persist) {
       throw new BitError('you can use either --editor or --persist, but not both');
     }


### PR DESCRIPTION


## Proposed Changes

- enable running snap or tag with both the above flags, as they are unrelated (previously they were coupled)
-
-
