### PR TITLE
add onLanesOnly when snapping on a lane

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1682,4 +1682,16 @@ describe('bit lane command', function () {
       expect(() => helper.command.createLane('dev', '--scope some-scope')).to.not.throw();
     });
   });
+  describe('creating components on lanes, that do not exist on main', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('should add "onLanesOnly" prop', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap.comp1.onLanesOnly).to.be.true;
+    });
+  });
 });

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -712,7 +712,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       components.map(async (comp) => {
         const existOnRemoteLane = idsFromRemoteLanes.has(comp.id);
         if (!existOnRemoteLane && !this.options.saveInLane) {
-          this.consumer.bitMap.setComponentProp(comp.id, 'onLanesOnly', false);
+          this.consumer.bitMap.setOnLanesOnly(comp.id, false);
           return;
         }
         const modelComponent = await this.scope.getModelComponent(comp.id);

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -119,9 +119,9 @@ export default class BitMap {
     });
   }
 
-  setComponentProp(id: BitId, propName: keyof ComponentMap, val: any) {
+  setOnLanesOnly(id: BitId, value: boolean) {
     const componentMap = this.getComponent(id, { ignoreScopeAndVersion: true });
-    (componentMap as any)[propName] = val;
+    componentMap.onLanesOnly = value;
     this.markAsChanged();
     return componentMap;
   }


### PR DESCRIPTION
This is related to https://github.com/teambit/bit/pull/7706, one case of onLanesOnly was missing. Added here.