### PR TITLE
fix(scope-rename), rename scope of envs in .bitmap config

### DIFF
--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -9,6 +9,7 @@ import ComponentAspect, { Component, ComponentID, ComponentMain } from '@teambit
 import { DeprecationAspect, DeprecationMain } from '@teambit/deprecation';
 import GraphqlAspect, { GraphqlMain } from '@teambit/graphql';
 import { CompilerAspect, CompilerMain } from '@teambit/compiler';
+import EnvsAspect, { EnvsMain } from '@teambit/envs';
 import NewComponentHelperAspect, { NewComponentHelperMain } from '@teambit/new-component-helper';
 import RefactoringAspect, { MultipleStringsReplacement, RefactoringMain } from '@teambit/refactoring';
 import ComponentWriterAspect, { ComponentWriterMain } from '@teambit/component-writer';
@@ -26,7 +27,6 @@ import { OldScopeNotFound } from './exceptions/old-scope-not-found';
 import { OldScopeExported } from './exceptions/old-scope-exported';
 import { OldScopeTagged } from './exceptions/old-scope-tagged';
 import { ScopeRenameOwnerCmd } from './scope-rename-owner.cmd';
-import EnvsAspect, { EnvsMain } from '@teambit/envs';
 
 export class RenamingMain {
   constructor(

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -26,6 +26,7 @@ import { OldScopeNotFound } from './exceptions/old-scope-not-found';
 import { OldScopeExported } from './exceptions/old-scope-exported';
 import { OldScopeTagged } from './exceptions/old-scope-tagged';
 import { ScopeRenameOwnerCmd } from './scope-rename-owner.cmd';
+import EnvsAspect, { EnvsMain } from '@teambit/envs';
 
 export class RenamingMain {
   constructor(
@@ -37,7 +38,8 @@ export class RenamingMain {
     private config: ConfigMain,
     private componentWriter: ComponentWriterMain,
     private compiler: CompilerMain,
-    private logger: Logger
+    private logger: Logger,
+    private envs: EnvsMain
   ) {}
 
   async rename(sourceIdStr: string, targetName: string, options: RenameOptions): Promise<RenameDependencyNameResult> {
@@ -119,6 +121,17 @@ make sure this argument is the name only, without the scope-name. to change the 
     if (!componentsUsingOldScope.length && this.workspace.defaultScope !== oldScope) {
       throw new OldScopeNotFound(oldScope);
     }
+    const envs = componentsUsingOldScope.filter((c) => this.envs.isEnv(c));
+    const compsUsingEnv = {};
+    await Promise.all(
+      envs.map(async (env) => {
+        const components = await this.workspace.getComponentsUsingEnv(env.id.toString(), true);
+        if (!components.length) return;
+        const componentIds = components.map((comp) => comp.id);
+        compsUsingEnv[env.id.toString()] = componentIds;
+      })
+    );
+
     // verify they're all new.
     const exported = componentsUsingOldScope.filter((comp) => comp.id._legacy.hasScope());
     if (exported.length) {
@@ -137,6 +150,16 @@ make sure this argument is the name only, without the scope-name. to change the 
       componentsUsingOldScope.forEach((comp) => this.workspace.bitMap.setDefaultScope(comp.id, newScope));
     }
     await this.workspace.bitMap.write();
+    await this.workspace.clearCache();
+
+    await Promise.all(
+      envs.map(async (env) => {
+        const componentIds = compsUsingEnv[env.id.toString()];
+        if (!componentIds.length) return;
+        await this.workspace.setEnvToComponents(env.id.changeScope(newScope), componentIds);
+      })
+    );
+
     const refactoredIds: ComponentID[] = [];
     if (options.refactor) {
       const legacyComps = componentsUsingOldScope.map((c) => c.state._consumer);
@@ -339,6 +362,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     ComponentWriterAspect,
     CompilerAspect,
     LoggerAspect,
+    EnvsAspect,
   ];
   static runtime = MainRuntime;
   static async provider([
@@ -354,6 +378,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     componentWriter,
     compiler,
     loggerMain,
+    envs,
   ]: [
     CLIMain,
     Workspace,
@@ -366,7 +391,8 @@ make sure this argument is the name only, without the scope-name. to change the 
     ConfigMain,
     ComponentWriterMain,
     CompilerMain,
-    LoggerMain
+    LoggerMain,
+    EnvsMain
   ]) {
     const logger = loggerMain.createLogger(RenamingAspect.id);
     const renaming = new RenamingMain(
@@ -378,7 +404,8 @@ make sure this argument is the name only, without the scope-name. to change the 
       config,
       componentWriter,
       compiler,
-      logger
+      logger,
+      envs
     );
     cli.register(new RenameCmd(renaming));
 


### PR DESCRIPTION
Fixes an issue when scope-renaming multiple components and some of them are envs of others. It was throwing ScopeNotFound. 
This PR fixes it by replacing the env ids inside `config` prop in the .bitmap file.