### PR TITLE
fix(lane-merge), merge recovered components

### DIFF
--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -12,6 +12,7 @@ import { ComponentID } from '@teambit/component-id';
 import { BitError } from '@teambit/bit-error';
 import deleteComponentsFiles from '@teambit/legacy/dist/consumer/component-ops/delete-component-files';
 import ComponentAspect, { Component, ComponentMain } from '@teambit/component';
+import { VersionNotFound } from '@teambit/legacy/dist/scope/exceptions';
 import { removeComponentsFromNodeModules } from '@teambit/legacy/dist/consumer/component/package-json-utils';
 import { RemoveCmd } from './remove-cmd';
 import { removeComponents } from './remove-components';
@@ -163,11 +164,24 @@ export class RemoveMain {
       return true;
     }
     const compId = await this.workspace.scope.resolveComponentId(compIdStr);
-    const compFromScope = await this.workspace.scope.get(compId);
+    const currentLane = await this.workspace.getCurrentLaneObject();
+    const idOnLane = currentLane?.getComponent(compId._legacy);
+    const compIdWithPossibleVer = idOnLane ? compId.changeVersion(idOnLane.head.toString()) : compId;
+    let compFromScope: Component | undefined;
+    try {
+      compFromScope = await this.workspace.scope.get(compIdWithPossibleVer);
+    } catch (err: any) {
+      if (err instanceof VersionNotFound && err.version === '0.0.0') {
+        throw new BitError(
+          `unable to find the component ${compIdWithPossibleVer.toString()} in the current lane or main`
+        );
+      }
+      throw err;
+    }
     if (compFromScope && this.isRemoved(compFromScope)) {
       // case #2 and #3
-      await importComp(compId._legacy.toString());
-      await setAsRemovedFalse(compId);
+      await importComp(compIdWithPossibleVer._legacy.toString());
+      await setAsRemovedFalse(compIdWithPossibleVer);
       return true;
     }
     // case #5

--- a/src/scope/exceptions/version-not-found.ts
+++ b/src/scope/exceptions/version-not-found.ts
@@ -6,7 +6,7 @@ import chalk from 'chalk';
  * @see VersionNotFoundOnFS for cases when the Version object is missing from the filesystem.
  */
 export default class VersionNotFound extends BitError {
-  constructor(version: string, componentId: string) {
+  constructor(readonly version: string, componentId: string) {
     super(`error: version "${chalk.bold(version)}" of component ${chalk.bold(componentId)} was not found.`);
   }
 }


### PR DESCRIPTION
Currently, if the checked out lane has a removed component and it is merging a lane where in that lane the component has been recovered, it won't merge the component, just skip it with a message saying the component is removed. 
This PR checks whether the other lane is ahead, in which case, we know that the other lane recovered the removed component, and we bring it back.