### PR TITLE
hide templates from old-style envs

### DIFF
--- a/scopes/harmony/node/templates/express-app/index.ts
+++ b/scopes/harmony/node/templates/express-app/index.ts
@@ -12,6 +12,7 @@ import { route } from './files/route';
 export const expressAppTemplate: ComponentTemplate = {
   name: 'express-app',
   description: 'a bit express application',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       indexFile(context),

--- a/scopes/harmony/node/templates/express-route/index.ts
+++ b/scopes/harmony/node/templates/express-route/index.ts
@@ -8,6 +8,7 @@ import { mainFile } from './files/main';
 export const expressRouteTemplate: ComponentTemplate = {
   name: 'express-route',
   description: 'an express route',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       indexFile(context),

--- a/scopes/harmony/node/templates/node-env/index.ts
+++ b/scopes/harmony/node/templates/node-env/index.ts
@@ -13,6 +13,7 @@ import { jestConfigFile } from './files/jest.config';
 export const nodeEnvTemplate: ComponentTemplate = {
   name: 'node-env',
   description: 'customize the base Node env with your configs and tools',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/harmony/node/templates/node/index.ts
+++ b/scopes/harmony/node/templates/node/index.ts
@@ -8,6 +8,7 @@ import { compositionFile } from './files/composition';
 export const nodeTemplate: ComponentTemplate = {
   name: 'node',
   description: 'a Node.js module',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [indexFile(context), docFile(context), mainFile(context), compositionFile(context), testFile(context)];
   },

--- a/scopes/html/html/templates/html-component/index.ts
+++ b/scopes/html/html/templates/html-component/index.ts
@@ -7,7 +7,7 @@ import { testFile } from './files/test';
 export const htmlComponentTemplate: ComponentTemplate = {
   name: 'html',
   description: 'a basic html component',
-
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;
     const indexFile = {

--- a/scopes/html/html/templates/html-env/index.ts
+++ b/scopes/html/html/templates/html-env/index.ts
@@ -6,6 +6,7 @@ import { extensionFile } from './files/extension';
 export const htmlEnvTemplate: ComponentTemplate = {
   name: 'html-env',
   description: 'customize the base Html env with your configs and tools',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/mdx/mdx/templates/mdx-component/index.ts
+++ b/scopes/mdx/mdx/templates/mdx-component/index.ts
@@ -8,7 +8,7 @@ import { docsFile } from './files/docs';
 export const MDXComponent: ComponentTemplate = {
   name: 'mdx',
   description: 'MDX-file compiled by Bit to a reuseable component',
-
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;
     const indexFile = {

--- a/scopes/react/react-native/templates/react-native-component/index.ts
+++ b/scopes/react/react-native/templates/react-native-component/index.ts
@@ -8,6 +8,7 @@ import { indexFile } from './files/index';
 export const reactNativeComponent: ComponentTemplate = {
   name: 'react-native',
   description: 'a basic react native component',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [indexFile(context), componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
   },

--- a/scopes/react/react-native/templates/react-native-env/index.ts
+++ b/scopes/react/react-native/templates/react-native-env/index.ts
@@ -11,6 +11,7 @@ import { jestConfigFile } from './files/jest.config';
 export const reactNativeEnvTemplate: ComponentTemplate = {
   name: 'react-native-env',
   description: 'customize the base React Native env with your configs and tools',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/react/react-native/templates/react-workspace/index.ts
+++ b/scopes/react/react-native/templates/react-workspace/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceTemplate: WorkspaceTemplate = {
   name: 'react-native',
   description: 'React workspace with demo components',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-component-js/index.ts
+++ b/scopes/react/react/templates/react-component-js/index.ts
@@ -7,7 +7,7 @@ import { testFile } from './files/test';
 export const reactComponentJS: ComponentTemplate = {
   name: 'react-js',
   description: 'a basic react component in js',
-
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     const { name, namePascalCase: Name } = context;
     const indexFile = {

--- a/scopes/react/react/templates/react-component/index.ts
+++ b/scopes/react/react/templates/react-component/index.ts
@@ -8,6 +8,7 @@ import { indexFile } from './files/index-file';
 export const reactComponent: ComponentTemplate = {
   name: 'react',
   description: 'a basic react component',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [indexFile(context), componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
   },

--- a/scopes/react/react/templates/react-context/index.ts
+++ b/scopes/react/react/templates/react-context/index.ts
@@ -9,7 +9,7 @@ import { indexFile } from './files/index-file';
 export const reactContext: ComponentTemplate = {
   name: 'react-context',
   description: 'a react context component',
-
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       indexFile(context),

--- a/scopes/react/react/templates/react-env/index.ts
+++ b/scopes/react/react/templates/react-env/index.ts
@@ -13,6 +13,7 @@ import { jestConfigFile } from './files/jest.config';
 export const reactEnvTemplate: ComponentTemplate = {
   name: 'react-env',
   description: 'customize the base React env with your configs and tools',
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [
       {

--- a/scopes/react/react/templates/react-hook/index.ts
+++ b/scopes/react/react/templates/react-hook/index.ts
@@ -8,7 +8,7 @@ import { indexFile } from './files/index-file';
 export const reactHook: ComponentTemplate = {
   name: 'react-hook',
   description: 'a react hook component',
-
+  hidden: true,
   generateFiles: (context: ComponentContext) => {
     return [indexFile(context), componentFile(context), compositionFile(context), docsFile(context), testFile(context)];
   },

--- a/scopes/react/react/templates/react-workspace-analytics/index.ts
+++ b/scopes/react/react/templates/react-workspace-analytics/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceAnalyticsTemplate: WorkspaceTemplate = {
   name: 'react-analytics',
   description: 'React workspace with components for an Analytics Application',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-workspace-blog/index.ts
+++ b/scopes/react/react/templates/react-workspace-blog/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceBlogTemplate: WorkspaceTemplate = {
   name: 'react-blog',
   description: 'React workspace with components for a Blog',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-workspace-data-fetching/index.ts
+++ b/scopes/react/react/templates/react-workspace-data-fetching/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceDataFetchingTemplate: WorkspaceTemplate = {
   name: 'react-data-fetching',
   description: 'React workspace with components to show data fetching',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-workspace-design-system/index.ts
+++ b/scopes/react/react/templates/react-workspace-design-system/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceDesignSystemTemplate: WorkspaceTemplate = {
   name: 'react-design-system',
   description: 'React workspace with components for a Design System',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-workspace-wiki/index.ts
+++ b/scopes/react/react/templates/react-workspace-wiki/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceWikiTemplate: WorkspaceTemplate = {
   name: 'react-wiki',
   description: 'React workspace with components for a Wiki',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },

--- a/scopes/react/react/templates/react-workspace/index.ts
+++ b/scopes/react/react/templates/react-workspace/index.ts
@@ -4,6 +4,7 @@ import { generateFiles as generateCommonFiles } from '../workspace-common';
 export const reactWorkspaceTemplate: WorkspaceTemplate = {
   name: 'react',
   description: 'React workspace with demo components',
+  hidden: true,
   generateFiles: async (context: WorkspaceContext) => {
     return generateCommonFiles(context);
   },


### PR DESCRIPTION
## Proposed Changes

- hide all tech-stack specific templates that come from core bit, i.e. from the old-style envs still in core bit
-
-
