### PR TITLE
fix(diff), show diff of components during merge

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -354,6 +354,7 @@ describe('merge lanes', function () {
   describe('getting updates from main when lane is diverge', () => {
     let workspaceOnLane: string;
     let comp2HeadOnMain: string;
+    let beforeMerge: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(2);
@@ -371,6 +372,7 @@ describe('merge lanes', function () {
       helper.command.export();
       helper.scopeHelper.getClonedLocalScope(workspaceOnLane);
       helper.command.import();
+      beforeMerge = helper.scopeHelper.cloneLocalScope();
     });
     it('bit import should not bring the latest main objects', () => {
       const head = helper.command.getHead(`${helper.scopes.remote}/comp2`);
@@ -424,6 +426,21 @@ describe('merge lanes', function () {
           expect(cat.parents).to.have.lengthOf(1);
           expect(cat.parents[0]).to.equal(beforeMergeHead);
         });
+      });
+    });
+    describe('merge the lane without snapping', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(beforeMerge);
+        helper.command.mergeLane('main', '--theirs --no-snap -x');
+      });
+      it('should show the during-merge as modified', () => {
+        const status = helper.command.statusJson();
+        expect(status.modifiedComponents).to.have.lengthOf(2);
+      });
+      it('bit diff should show the diff between the .bitmap version and the currently merged version', () => {
+        const diff = helper.command.diff();
+        expect(diff).to.have.string(`-module.exports = () => 'comp1v2 and ' + comp2();`);
+        expect(diff).to.have.string(`+module.exports = () => 'comp1v3 and ' + comp2();`);
       });
     });
   });

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -404,10 +404,10 @@ describe('bit snap command', function () {
           const head = helper.command.getHead('bar/foo');
           expect(head).to.equal(localHead);
         });
-        it('bit status should show it as component with conflict and not as pending update or modified', () => {
+        it('bit status should show it as component with conflict and modified but not as pending update', () => {
           const status = helper.command.statusJson();
           expect(status.componentsDuringMergeState).to.have.lengthOf(1);
-          expect(status.modifiedComponents).to.have.lengthOf(0);
+          expect(status.modifiedComponents).to.have.lengthOf(1);
           expect(status.outdatedComponents).to.have.lengthOf(0);
           expect(status.mergePendingComponents).to.have.lengthOf(0);
         });

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -86,15 +86,14 @@ export default class ComponentsList {
   async listModifiedComponents(load = false, loadOpts?: ComponentLoadOptions): Promise<Array<BitId | Component>> {
     if (!this._modifiedComponents) {
       const fileSystemComponents = await this.getComponentsFromFS(loadOpts);
-      const unmergedComponents = this.listDuringMergeStateComponents();
+      // const unmergedComponents = this.listDuringMergeStateComponents();
       const componentStatuses = await this.consumer.getManyComponentsStatuses(fileSystemComponents.map((f) => f.id));
-      this._modifiedComponents = fileSystemComponents
-        .filter((component) => {
-          const status = componentStatuses.find((s) => s.id.isEqual(component.id));
-          if (!status) throw new Error(`listModifiedComponents unable to find status for ${component.id.toString()}`);
-          return status.status.modified;
-        })
-        .filter((component: Component) => !unmergedComponents.hasWithoutScopeAndVersion(component.id));
+      this._modifiedComponents = fileSystemComponents.filter((component) => {
+        const status = componentStatuses.find((s) => s.id.isEqual(component.id));
+        if (!status) throw new Error(`listModifiedComponents unable to find status for ${component.id.toString()}`);
+        return status.status.modified;
+      });
+      // .filter((component: Component) => !unmergedComponents.hasWithoutScopeAndVersion(component.id));
     }
     if (load) return this._modifiedComponents;
     return this._modifiedComponents.map((component) => component.id);
@@ -304,7 +303,7 @@ export default class ComponentsList {
     const removedComponents = await this.listLocallySoftRemoved();
     const duringMergeIds = this.listDuringMergeStateComponents();
 
-    return BitIds.fromArray([
+    return BitIds.uniqFromArray([
       ...(newComponents as BitId[]),
       ...(modifiedComponents as BitId[]),
       ...removedComponents,


### PR DESCRIPTION
Currently, components during-merge are filtered out from the list-modified. As a result, `bit diff` doesn't show them, which makes it hard after `bit lane merge` to figure out what changes were entered, especially if this process involves fixing conflicts.
This PR removes this filter, which also changes `bit status` to show these during-merge components as modified as well (which is fine).