### PR TITLE
replace --ours,--theirs,--manual flags with --auto-merge-resolve<merge-strategy> flag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -562,7 +562,7 @@ jobs:
       - run: cd bit && npm run generate-cli-reference-json
       - run: cd bit && npm run generate-cli-reference-docs
       - run: cd bit && bit status # just to make sure that the new cli-reference.mdx file is valid
-      - run: cd bit && bit checkout head teambit.harmony/content/cli-reference --ours --skip-dependency-installation
+      - run: cd bit && bit checkout head teambit.harmony/content/cli-reference --auto-merge-resolve ours --skip-dependency-installation
       - run: cd bit && bit checkout head --skip-dependency-installation
       - run: cd bit && git diff
       # - run: cd bit && rm -rf node_modules/@teambit/legacy

--- a/e2e/harmony/binary-files.e2e.ts
+++ b/e2e/harmony/binary-files.e2e.ts
@@ -30,7 +30,7 @@ describe('handling binary files in Bit', function () {
         helper.scopeHelper.getClonedLocalScope(afterFirstTag);
         helper.fixtures.copyFixtureFile('png/png-fixture3.png', 'comp1/icon.png');
         helper.command.import();
-        checkoutOutput = helper.command.checkoutHead('--all --manual');
+        checkoutOutput = helper.command.checkoutHead('--all --auto-merge-resolve manual');
       });
       it('should checkout with no errors and leave the file as is indicating there was a conflict', () => {
         expect(checkoutOutput).to.include(FileStatusWithoutChalk.binaryConflict);

--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -354,7 +354,7 @@ describe('bit checkout command', function () {
       let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
-        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--ours');
+        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve ours');
       });
       it('should indicate that the version was switched', () => {
         expect(output).to.have.string(successOutput);
@@ -416,7 +416,7 @@ describe('bit checkout command', function () {
         let output;
         before(() => {
           helper.scopeHelper.getClonedLocalScope(scopeWithAddedFile);
-          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--ours');
+          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve ours');
         });
         it('should indicate that the new file was not changed', () => {
           expect(output).to.have.string(FileStatusWithoutChalk.unchanged);

--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -282,7 +282,7 @@ describe('bit checkout command', function () {
     describe('using manual strategy', () => {
       let output;
       before(() => {
-        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--manual');
+        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve manual');
       });
       it('should indicate that the file has conflicts', () => {
         expect(output).to.have.string(successOutput);
@@ -328,7 +328,7 @@ describe('bit checkout command', function () {
       let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
-        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--theirs');
+        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve theirs');
       });
       it('should indicate that the file has updated', () => {
         expect(output).to.have.string(successOutput);
@@ -388,7 +388,7 @@ describe('bit checkout command', function () {
       describe('using manual strategy', () => {
         let output;
         before(() => {
-          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--manual');
+          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve manual');
         });
         it('should indicate that a new file was added', () => {
           expect(output).to.have.string(FileStatusWithoutChalk.added);

--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -402,7 +402,7 @@ describe('bit checkout command', function () {
         let output;
         before(() => {
           helper.scopeHelper.getClonedLocalScope(scopeWithAddedFile);
-          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--theirs');
+          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve theirs');
         });
         it('should indicate that the new file was removed', () => {
           expect(output).to.have.string(FileStatusWithoutChalk.removed);

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -580,7 +580,7 @@ describe('bit lane command', function () {
           helper.scopeHelper.getClonedRemoteScope(afterSwitchingRemote);
           helper.fixtures.populateComponents(2, undefined, 'v3');
           helper.command.snapAllComponentsWithoutBuild();
-          helper.command.mergeLane('dev', '--ours --no-squash');
+          helper.command.mergeLane('dev', '--auto-merge-resolve ours --no-squash');
         });
         it('should merge the lane', () => {
           const mergedLanes = helper.command.listLanes('--merged');
@@ -1215,7 +1215,7 @@ describe('bit lane command', function () {
         expect(status.mergePendingComponents).to.have.lengthOf(1);
       });
       it('bit merge with no args should merge them', () => {
-        const output = helper.command.merge(`--manual`);
+        const output = helper.command.merge(`--auto-merge-resolve manual`);
         expect(output).to.have.string('successfully merged');
         expect(output).to.have.string('CONFLICT');
       });

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -431,7 +431,7 @@ describe('merge lanes', function () {
     describe('merge the lane without snapping', () => {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(beforeMerge);
-        helper.command.mergeLane('main', '--theirs --no-snap -x');
+        helper.command.mergeLane('main', '--auto-merge-resolve theirs --no-snap -x');
       });
       it('should show the during-merge as modified', () => {
         const status = helper.command.statusJson();

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -386,7 +386,7 @@ describe('merge lanes', function () {
     describe('merging the lane', () => {
       let status;
       before(() => {
-        helper.command.mergeLane('main', '--theirs');
+        helper.command.mergeLane('main', '--auto-merge-resolve theirs');
         status = helper.command.statusJson();
         afterMergeToMain = helper.scopeHelper.cloneLocalScope();
       });

--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -52,7 +52,7 @@ describe('merge config scenarios', function () {
     });
     describe('merging the lane to main', () => {
       before(() => {
-        helper.command.mergeLane(`${helper.scopes.remote}/dev`, '--manual --no-squash');
+        helper.command.mergeLane(`${helper.scopes.remote}/dev`, '--auto-merge-resolve manual --no-squash');
         // fixes the conflicts
         helper.fs.outputFile(`${helper.scopes.remoteWithoutOwner}/comp1/index.js`);
         helper.fs.outputFile(`${helper.scopes.remoteWithoutOwner}/comp2/index.js`);
@@ -94,7 +94,7 @@ describe('merge config scenarios', function () {
       });
       describe('merge from main to the lane', () => {
         before(() => {
-          helper.command.mergeLane('main', '--manual');
+          helper.command.mergeLane('main', '--auto-merge-resolve manual');
         });
         // previous bug, showed only comp1 as componentsDuringMergeState, but the rest, because they're not in the
         // workspace, it didn't merge them correctly.

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -295,7 +295,7 @@ describe('bit snap command', function () {
           let mergeOutput;
           before(() => {
             helper.scopeHelper.getClonedLocalScope(beforeMergeScope);
-            mergeOutput = helper.command.merge('bar/foo --ours --no-snap');
+            mergeOutput = helper.command.merge('bar/foo --auto-merge-resolve ours --no-snap');
           });
           it('should succeed and indicate that the files were not changed', () => {
             expect(mergeOutput).to.have.string('unchanged');

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -263,7 +263,7 @@ describe('bit snap command', function () {
         describe('without --no-snap flag', () => {
           let mergeOutput;
           before(() => {
-            mergeOutput = helper.command.merge('bar/foo --ours');
+            mergeOutput = helper.command.merge('bar/foo --auto-merge-resolve ours');
           });
           it('should succeed and indicate that the files were not changed', () => {
             expect(mergeOutput).to.have.string('unchanged');
@@ -352,7 +352,7 @@ describe('bit snap command', function () {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScope);
           helper.command.importComponent('bar/foo --objects');
-          mergeOutput = helper.command.merge('bar/foo --theirs');
+          mergeOutput = helper.command.merge('bar/foo --auto-merge-resolve theirs');
         });
         it('should succeed and indicate that the files were updated', () => {
           expect(mergeOutput).to.have.string('updated');
@@ -383,7 +383,7 @@ describe('bit snap command', function () {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScope);
           helper.command.importComponent('bar/foo --objects');
-          mergeOutput = helper.command.merge('bar/foo --manual');
+          mergeOutput = helper.command.merge('bar/foo --auto-merge-resolve manual');
           scopeWithConflicts = helper.scopeHelper.cloneLocalScope();
         });
         it('should succeed and indicate that the files were left in a conflict state', () => {
@@ -412,7 +412,7 @@ describe('bit snap command', function () {
           expect(status.mergePendingComponents).to.have.lengthOf(0);
         });
         it('should block checking out the component', () => {
-          const output = helper.command.checkoutVersion(firstSnap, 'bar/foo', '--manual');
+          const output = helper.command.checkoutVersion(firstSnap, 'bar/foo', '--auto-merge-resolve manual');
           expect(output).to.have.string('is in during-merge state');
         });
         describe('tagging or snapping the component', () => {

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -10,7 +10,7 @@ import {
   getAddedOutput,
 } from '@teambit/merging';
 import { COMPONENT_PATTERN_HELP, HEAD, LATEST } from '@teambit/legacy/dist/constants';
-import { getMergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
+import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
 import { BitId } from '@teambit/legacy-bit-id';
 import { BitError } from '@teambit/bit-error';
 import { CheckoutMain, CheckoutProps } from './checkout.main.runtime';
@@ -43,9 +43,18 @@ export class CheckoutCmd implements Command {
       'interactive-merge',
       'when a component is modified and the merge process found conflicts, display options to resolve them',
     ],
-    ['o', 'ours', 'in case of a conflict, override the used version with the current modification'],
-    ['t', 'theirs', 'in case of a conflict, override the current modification with the specified version'],
-    ['m', 'manual', 'in case of a conflict, leave the files with a conflict state to resolve them manually later'],
+    ['', 'ours', 'DEPRECATED. use --auto-merge-resolve. In the future, this flag will leave the current code intact'],
+    [
+      '',
+      'theirs',
+      'DEPRECATED. use --auto-merge-resolve. In the future, this flag will override the current code with the incoming code',
+    ],
+    ['', 'manual', 'DEPRECATED. use --auto-merge-resolve'],
+    [
+      '',
+      'auto-merge-resolve <merge-strategy>',
+      'in case of a conflict, resolve according to the strategy: [ours, theirs, manual]',
+    ],
     ['r', 'reset', 'revert changes that were not snapped/tagged'],
     ['a', 'all', 'all components'],
     [
@@ -67,6 +76,7 @@ export class CheckoutCmd implements Command {
       ours = false,
       theirs = false,
       manual = false,
+      autoMergeResolve,
       all = false,
       workspaceOnly = false,
       verbose = false,
@@ -77,6 +87,7 @@ export class CheckoutCmd implements Command {
       ours?: boolean;
       theirs?: boolean;
       manual?: boolean;
+      autoMergeResolve?: MergeStrategy;
       all?: boolean;
       workspaceOnly?: boolean;
       verbose?: boolean;
@@ -84,9 +95,22 @@ export class CheckoutCmd implements Command {
       revert?: boolean;
     }
   ) {
+    if (ours || theirs || manual) {
+      throw new BitError(
+        'the "--ours", "--theirs" and "--manual" flags are deprecated. use "--auto-merge-resolve" instead.'
+      );
+    }
+    if (
+      autoMergeResolve &&
+      autoMergeResolve !== 'ours' &&
+      autoMergeResolve !== 'theirs' &&
+      autoMergeResolve !== 'manual'
+    ) {
+      throw new BitError('--auto-merge-resolve must be one of the following: [ours, theirs, manual]');
+    }
     const checkoutProps: CheckoutProps = {
       promptMergeOptions: interactiveMerge,
-      mergeStrategy: getMergeStrategy(ours, theirs, manual),
+      mergeStrategy: autoMergeResolve,
       all,
       verbose,
       isLane: false,

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -42,6 +42,8 @@ import { MergeAbortLaneCmd } from './merge-abort.cmd';
 
 export type MergeLaneOptions = {
   mergeStrategy: MergeStrategy;
+  ours?: boolean;
+  theirs?: boolean;
   noSnap: boolean;
   snapMessage: string;
   existingOnWorkspaceOnly: boolean;


### PR DESCRIPTION
This is a preparation for new flags functionality that replaces the code according to the strategy [ours, theirs] regardless of a conflict. 

The change is for the following commands: `bit merge`, `bit checkout` and `bit lane merge`.