### PR TITLE
feat(lane-remove-comp), implement --update-main flag

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -468,50 +468,69 @@ describe('bit lane command', function () {
       expect(lane.components).to.have.lengthOf(1);
     });
   });
-  //   'soft remove on lane then tagging the dependent without removing the references to the removed component',
-  //   () => {
-  //     let npmCiRegistry: NpmCiRegistry;
-  //     before(async () => {
-  //       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
-  //       helper.scopeHelper.setNewLocalAndRemoteScopes();
-  //       // helper.command.createLane();
-  //       helper.fixtures.populateComponents(2);
-  //       npmCiRegistry = new NpmCiRegistry(helper);
-  //       npmCiRegistry.configureCiInPackageJsonHarmony();
-  //       await npmCiRegistry.init();
-  //       helper.command.tagAllComponents();
-  //       helper.command.export();
+  describe('remove on lane with --update-main then merge to main', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.removeLaneComp('comp1', '--update-main');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.mergeLane('dev', '-x');
+    });
+    it('should be marked as removed on main', () => {
+      const removeData = helper.command.showAspectConfig('comp1', Extensions.remove);
+      expect(removeData.config.removed).to.be.true;
+    });
+    it('bit status should show the component as staged', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents).to.have.lengthOf(1);
+    });
+    it('bitmap should not have the component', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.not.have.property('comp1');
+    });
+    describe('export and import the component to a new workspace', () => {
+      before(() => {
+        helper.command.export();
+        helper.scopeHelper.reInitLocalScope();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.importComponent('comp1', '-x');
+      });
+      it('should show the component as removed', () => {
+        const removeData = helper.command.showAspectConfig('comp1', Extensions.remove);
+        expect(removeData.config.removed).to.be.true;
+      });
+    });
+  });
+  describe('remove on lane with --update-main then merge to another lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.removeLaneComp('comp1', '--update-main');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
 
-  //       helper.command.softRemoveComponent('comp2');
-  //       // this installs comp2 as a package
-  //       helper.command.install();
-
-  //       // const pkgName = helper.general.getPackageNameByCompName('bar/foo');
-
-  //       // helper.scopeHelper.reInitLocalScope();
-  //       // helper.scopeHelper.addRemoteScope();
-  //       // helper.command.createLane('lane-a');
-  //       // helper.fs.outputFile('comp1/comp1.js', `import '${pkgName}';`);
-  //       // helper.command.addComponent('comp1');
-  //       // helper.command.install(pkgName);
-  //       // helper.command.snapAllComponentsWithoutBuild();
-  //       // helper.command.export();
-
-  //       // helper.command.createLane('lane-b');
-  //       // npmCiRegistry.setResolver();
-  //       // helper.command.importComponent('bar/foo');
-  //       // helper.command.snapAllComponentsWithoutBuild('--unmodified');
-  //       // helper.command.export();
-
-  //       // helper.command.switchLocalLane('lane-a', '-x');
-  //       // helper.fs.appendFile('comp1/comp1.js');
-  //     });
-  //     after(() => {
-  //       // npmCiRegistry.destroy();
-  //     });
-  //     it.only('should ', () => {
-
-  //     });
-  //   }
-  // );
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane('lane-b');
+      helper.command.mergeLane('lane-a', '-x');
+    });
+    it('should bring the removed component into the other lane', () => {
+      const laneComps = helper.command.catLane('lane-b');
+      const comps = laneComps.components.map((c) => c.id.name);
+      expect(comps).to.include('comp1');
+    });
+    it('should be marked with removed on main', () => {
+      const removeData = helper.command.showAspectConfig(`${helper.scopes.remote}/comp1`, Extensions.remove);
+      expect(removeData.config.removeOnMain).to.be.true;
+    });
+  });
 });

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -569,6 +569,7 @@ export class MergingMain {
     return results;
   }
 
+  // eslint-disable-next-line complexity
   private async getComponentStatusBeforeMergeAttempt(
     id: BitId, // the id.version is the version we want to merge to the current component
     localLane: Lane | null, // currently checked out lane. if on main, then it's null.
@@ -598,23 +599,26 @@ export class MergingMain {
     const otherLaneHead = modelComponent.getRef(version);
     const existingBitMapId = consumer.bitMap.getBitIdIfExist(id, { ignoreVersion: true });
     const componentOnOther: Version = await modelComponent.loadVersion(version, consumer.scope.objects);
+    const idOnCurrentLane = localLane?.getComponent(id);
+
     if (componentOnOther.isRemoved()) {
-      if (existingBitMapId && localLane) {
-        // continue with merging the component, so then the current lane will get the soft-remove update.
-        // also, remove the component from the workspace.
+      // if exist in current lane, we want the current lane to get the soft-remove update.
+      // or if it was removed with --update-main, we want to merge it so then main will get the update.
+      const shouldMerge = idOnCurrentLane || componentOnOther.shouldRemoveFromMain();
+      if (shouldMerge) {
+        // remove the component from the workspace if exist.
         componentStatus.shouldBeRemoved = true;
       } else {
-        // on main, don't merge soft-removed components.
-        // on lane, if it's not part of the current lane (!existingBitMapId), don't merge it.
+        // on main, don't merge soft-removed components unless it's marked with removeOnMain.
+        // on lane, if it's not part of the current lane, don't merge it.
         return returnUnmerged(`component has been removed`, true);
       }
     }
     const getCurrentId = () => {
       if (existingBitMapId) return existingBitMapId;
       if (localLane) {
-        const idOnLane = localLane.getComponent(id);
-        if (!idOnLane) return null;
-        return idOnLane.id.changeVersion(idOnLane.head.toString());
+        if (!idOnCurrentLane) return null;
+        return idOnCurrentLane.id.changeVersion(idOnCurrentLane.head.toString());
       }
       // it's on main
       const head = modelComponent.getHeadAsTagIfExist();
@@ -634,7 +638,7 @@ export class MergingMain {
     };
     const currentComponent = await getCurrentComponent();
     if (currentComponent.isRemoved()) {
-      // we made sure before that the component is not removed on the "other". so we have a few options:
+      // we have a few options:
       // 1. other is ahead. in this case, other recovered the component. so we can continue with the merge.
       // it is possible that it is diverged, in which case, still continue with the merge, and later on, the
       // merge-config will show a config conflict of the remove aspect.

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -347,7 +347,7 @@ in case the components are not part of the lane or the lane is new, it simply re
   alias = 'rc';
   options = [
     ['', 'workspace-only', 'do not mark the components as removed. instead, remove them from the workspace only'],
-    ['', 'update-main', 'NOT IMPLEMENTED YET. mark as removed on main after merging this lane into main'],
+    ['', 'update-main', 'EXPERIMENTAL. mark as removed on main after merging this lane into main'],
   ] as CommandOptions;
   loader = true;
   migration = true;
@@ -355,7 +355,6 @@ in case the components are not part of the lane or the lane is new, it simply re
   constructor(private workspace: Workspace, private lanes: LanesMain) {}
 
   async report([componentsPattern]: [string], removeCompsOpts: RemoveCompsOpts): Promise<string> {
-    if (removeCompsOpts.updateMain) throw new Error('not implemented yet');
     if (!this.workspace) throw new OutsideWorkspaceError();
     if (this.workspace.isOnMain()) {
       throw new Error(`error: you're checked out to main, please use "bit remove" instead`);

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -666,6 +666,7 @@ export default class CommandHelper {
     return this.runCmd(`bit merge ${values}`);
   }
   mergeLane(laneName: string, options = '') {
+    if (!laneName.includes('/')) laneName = `${this.scopes.remote}/${laneName}`;
     return this.runCmd(`bit lane merge ${laneName} ${options}`);
   }
   mergeAbortLane(options = '') {

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -726,6 +726,9 @@ export default class Version extends BitObject {
   isRemoved(): boolean {
     return Boolean(this.extensions.findCoreExtension(Extensions.remove)?.config?.removed);
   }
+  shouldRemoveFromMain(): boolean {
+    return Boolean(this.extensions.findCoreExtension(Extensions.remove)?.config?.removeOnMain);
+  }
 
   /**
    * Validate the version model properties, to make sure we are not inserting something


### PR DESCRIPTION
Similar to how "deprecate" works on lanes, where it marks the component as deprecated and once merged to main, the component is deprecated on main.
This PR introduces this functionality for `bit lane remove-comp`, where by default it only marks as removed on the lane, and the component is not merged. 