### PR TITLE
fix(cat-version-history), minor two fixes for the --graph flag

### DIFF
--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -118,7 +118,7 @@ export default class VisualDependencyGraph {
     const edges = clearGraph.edges;
 
     nodes.forEach((node) => {
-      graph.addNode(node);
+      graph.addNode(node.id);
     });
     edges.forEach((edge) => {
       const edgeType = edge.attr;

--- a/src/scope/models/version-history.ts
+++ b/src/scope/models/version-history.ts
@@ -158,7 +158,10 @@ export default class VersionHistory extends BitObject {
       .map((v) => {
         const verEdges = v.parents.map((p) => new Edge(v.hash.toString(), p.toString(), 'parent'));
         if (v.unrelated) verEdges.push(new Edge(v.hash.toString(), v.unrelated.toString(), 'unrelated'));
-        if (v.squashed) v.squashed.map((p) => verEdges.push(new Edge(v.hash.toString(), p.toString(), 'squashed')));
+        if (v.squashed) {
+          const squashed = v.squashed.filter((s) => !v.parents.find((p) => p.isEqual(s)));
+          squashed.map((p) => verEdges.push(new Edge(v.hash.toString(), p.toString(), 'squashed')));
+        }
         return verEdges;
       })
       .flat();


### PR DESCRIPTION
## Proposed Changes

- in case the `squash` has the same hash as the `parent`, avoid showing it as squashed.
- remove the `[object object]` in the graph
