### PR TITLE
fix: replace app plugin file for React to `.cjs`

### DIFF
--- a/scopes/react/react/templates/react-app/files/app-plugin.ts
+++ b/scopes/react/react/templates/react-app/files/app-plugin.ts
@@ -1,13 +1,9 @@
 import { ComponentContext } from '@teambit/generator';
 
-export function appPlugin({ name, namePascalCase: Name }: ComponentContext) {
-  return `import { ReactAppOptions } from '@teambit/react';
-
-export const ${Name}App: ReactAppOptions = {
-  name: '${name}',
-  entry: [require.resolve('./${name}.app-root')]
-};
-
-export default ${Name}App;
-`;
+export function appPlugin({ name }: ComponentContext) {
+  return `/** @type {import("@teambit/react.apps.react-app-types").ReactAppOptions} */
+module.exports.default = {
+  name: "${name}",
+  entry: [require.resolve("./${name}.app-root")],
+};`;
 }

--- a/scopes/react/react/templates/react-app/index.ts
+++ b/scopes/react/react/templates/react-app/index.ts
@@ -22,7 +22,7 @@ export const reactAppTemplate: ComponentTemplate = {
         content: docFile(context),
       },
       {
-        relativePath: `${context.name}.react-app.ts`,
+        relativePath: `${context.name}.react-app.cjs`,
         content: appPlugin(context),
       },
       {


### PR DESCRIPTION
## Proposed Changes

- In the legacy React app template, change the filename for the plugin file from `{name}.react-app.ts` to `{name}.react-app.cjs`.
