### PR TITLE
fix(lane-merge), avoid squashing if the distance between the current-lane and the other lane is 1

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -264,6 +264,25 @@ describe('merge lanes', function () {
       expect(log[1].parents[0]).to.equal(headOnMain);
     });
   });
+  describe('merge with squash when other lane is ahead by only 1 snap, so no need to squash', () => {
+    let headOnLane: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('dev');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      headOnLane = helper.command.getHeadOfLane('dev', 'comp1');
+      helper.command.switchLocalLane('main');
+      helper.command.mergeLane('dev');
+    });
+    it('should not add the squashed prop into the version object', () => {
+      const head = helper.command.catComponent(`comp1@${headOnLane}`);
+      expect(head).to.not.have.property('squashed');
+      expect(head.modified).to.have.lengthOf(0);
+    });
+  });
   describe('merge with squash after exporting and importing the lane to a new workspace', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -775,17 +775,16 @@ alternatively, use "--no-squash" flag to keep the entire history of "${otherLane
       .join('\n');
     return `${messageTitle}\n${allMessageStr}`;
   };
-  // no need to check this case. even if it has only one snap ahead, we want to do the "squash", and run "addAsOnlyParent"
-  // to make sure it doesn't not have two parents.
-  // if (remoteSnaps.length === 1) {
-  //   // nothing to squash. it has only one commit.
-  //   return;
-  // }
   if (!componentFromModel) {
     throw new Error('unable to squash, the componentFromModel is missing');
   }
-
   const currentParents = componentFromModel.parents;
+
+  // if the remote has only one snap, there is nothing to squash.
+  // other checks here is to make sure `componentFromModel.addAsOnlyParent` call is not needed.
+  if (remoteSnaps.length === 1 && divergeData.commonSnapBeforeDiverge && currentParents.length === 1) {
+    return undefined;
+  }
 
   const doSquash = async () => {
     if (divergeData.commonSnapBeforeDiverge) {


### PR DESCRIPTION
It just makes the graph complex for no reason. 
It's also confusing when looking at the Version object to see the same `Ref` in both: `parents` and `squashed.previousParents` props.