### PR TITLE
fix(compile), allow compiling by specifying ids without their exact versions

### DIFF
--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -22,11 +22,14 @@ export type WatchCmdOpts = {
 export class WatchCommand implements Command {
   name = 'watch';
   description = 'automatically recompile modified components (on save)';
+  extendedDescription = `by default, the watcher doesn't use polling, to keep the CPU idle.
+in some rare cases, this could result in missing file events. to fix it, try to prefix this command with CHOKIDAR_USEPOLLING=true
+alternatively, restarting the computer could also help.`;
   helpUrl = 'reference/compiling/compiler-overview';
   alias = '';
   group = 'development';
   options = [
-    ['v', 'verbose', 'show npm verbose output for inspection and print the stack trace'],
+    ['v', 'verbose', 'show all watch events and compiler verbose output'],
     ['', 'skip-pre-compilation', 'skip the compilation step before starting to watch'],
     [
       't',
@@ -99,7 +102,7 @@ function getMessages(logger: Logger): EventMessages {
   return {
     onAll: (event: string, path: string) => logger.console(`Event: "${event}". Path: ${path}`),
     onStart: () => {},
-    onReady: (workspace, watchPathsSortByComponent, verbose) => {
+    onReady: (workspace, watchPathsSortByComponent, verbose?: boolean) => {
       clearOutdatedData();
       if (verbose) {
         logger.console(formatWatchPathsSortByComponent(watchPathsSortByComponent));

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -65,14 +65,10 @@ export class Watcher {
   private watchQueue = new WatchQueue();
   private bitMapChangesInProgress = false;
   private ipcEventsDir: string;
-  constructor(
-    private workspace: Workspace,
-    private pubsub: PubsubMain,
-    private watcherMain: WatcherMain,
-    private trackDirs: { [dir: PathLinux]: ComponentID } = {},
-    private verbose = false,
-    private multipleWatchers: WatcherProcessData[] = []
-  ) {
+  private trackDirs: { [dir: PathLinux]: ComponentID } = {};
+  private verbose = false;
+  private multipleWatchers: WatcherProcessData[] = [];
+  constructor(private workspace: Workspace, private pubsub: PubsubMain, private watcherMain: WatcherMain) {
     this.ipcEventsDir = this.watcherMain.ipcEvents.eventsDir;
   }
 
@@ -82,6 +78,7 @@ export class Watcher {
 
   async watchAll(opts: WatchOptions) {
     const { msgs, ...watchOpts } = opts;
+    this.verbose = opts.verbose || false;
     const pathsToWatch = await this.getPathsToWatch();
     const componentIds = Object.values(this.trackDirs);
     await this.watcherMain.triggerOnPreWatch(componentIds, watchOpts);
@@ -92,8 +89,7 @@ export class Watcher {
     await this.workspace.scope.watchScopeInternalFiles();
 
     return new Promise((resolve, reject) => {
-      // prefix your command with "BIT_LOG=*" to see all watch events
-      if (process.env.BIT_LOG) {
+      if (this.verbose) {
         // @ts-ignore
         if (msgs?.onAll) watcher.on('all', msgs?.onAll);
       }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -389,7 +389,7 @@ export class Workspace implements ComponentFactory {
    */
   async filterIds(ids: ComponentID[]): Promise<ComponentID[]> {
     const workspaceIds = await this.listIds();
-    return ids.filter((id) => workspaceIds.find((wsId) => wsId.isEqual(id)));
+    return ids.filter((id) => workspaceIds.find((wsId) => wsId.isEqual(id, { ignoreVersion: !id.hasVersion() })));
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- until now, `bit compile <id>` wasn't compile anything in case the id didn't have a version. This fixes it.
-  fix `bit watch --verbose` to show all events coming from Chokidar and the compiler output. 
