### PR TITLE
fix workspace.jsonc links

### DIFF
--- a/scopes/harmony/config/workspace-template.jsonc
+++ b/scopes/harmony/config/workspace-template.jsonc
@@ -1,6 +1,6 @@
 /**
  * this is the main configuration file of your bit workspace.
- * for full documentation, please see: https://bit.dev/docs/workspace/workspace-configuration
+ * for full documentation, please see: https://bit.dev/reference/workspace/workspace-json
  **/
 {
   "$schema": "https://static.bit.dev/teambit/schemas/schema.json",
@@ -55,7 +55,7 @@
    * workspace. this is extremely useful for upgrading, aligning and building components with a new
    * set of dependencies. a rule can be a directory or a component-id/namespace, in which case,
    * wrap the rule with curly brackets (e.g. `"{ui/*}": {}`)
-   * see https://bit.dev/docs/workspace/variants for more info.
+   * see https://bit.dev/reference/workspace/variants for more info.
    **/
   "teambit.workspace/variants": {
     /**


### PR DESCRIPTION
## Proposed Changes

- Fix the links to the docs on the workspace.jsonc file generated when running  `bit init`

