### PR TITLE
handle path for multiply components

### DIFF
--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -33,21 +33,6 @@ export class NewComponentHelperMain {
   }
 
   /**
-   * Synchronously checks if the given directory contains any files.
-   */
-  private dirContainsFiles(dirPath: string): boolean {
-    if (!fs.existsSync(dirPath)) return false;
-
-    const contents = fs.readdirSync(dirPath);
-    for (const item of contents) {
-      if (fs.statSync(path.join(dirPath, item)).isFile()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
    * when creating/forking a component, the user may or may not provide a path.
    * if not provided, generate the path based on the component-id.
    * the component will be written to that path.
@@ -58,9 +43,9 @@ export class NewComponentHelperMain {
       const componentPath = componentId.namespace?.length
         ? path.join(componentId.namespace, componentId.name)
         : componentId.name;
-      const dirHasFiles = this.dirContainsFiles(fullPath);
+      const dirExists = fs.readdirSync(fullPath);
       if (componentsToCreate && componentsToCreate === 1) {
-        return dirHasFiles ? pathFromUser : path.join(pathFromUser, componentPath);
+        return dirExists ? path.join(pathFromUser, componentPath) : pathFromUser;
       }
       if (componentsToCreate && componentsToCreate > 1) {
         return path.join(pathFromUser, componentPath);

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -40,9 +40,7 @@ export class NewComponentHelperMain {
   getNewComponentPath(componentId: ComponentID, pathFromUser?: string, componentsToCreate?: number): PathLinuxRelative {
     if (pathFromUser) {
       const fullPath = path.join(this.workspace.path, pathFromUser);
-      const componentPath = componentId.namespace?.length
-        ? path.join(componentId.namespace, componentId.name)
-        : componentId.name;
+      const componentPath = componentId.fullName;
       const dirExists = fs.readdirSync(fullPath);
       if (componentsToCreate && componentsToCreate === 1) {
         return dirExists ? path.join(pathFromUser, componentPath) : pathFromUser;

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -41,7 +41,7 @@ export class NewComponentHelperMain {
     if (pathFromUser) {
       const fullPath = path.join(this.workspace.path, pathFromUser);
       const componentPath = componentId.fullName;
-      const dirExists = fs.readdirSync(fullPath);
+      const dirExists = fs.pathExistsSync(fullPath);
       if (componentsToCreate && componentsToCreate === 1) {
         return dirExists ? path.join(pathFromUser, componentPath) : pathFromUser;
       }

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -52,7 +52,11 @@ export class ComponentGenerator {
     const dirsToDeleteIfFailed: string[] = [];
     const generateResults = await pMapSeries(this.componentIds, async (componentId) => {
       try {
-        const componentPath = this.newComponentHelper.getNewComponentPath(componentId, this.options.path);
+        const componentPath = this.newComponentHelper.getNewComponentPath(
+          componentId,
+          this.options.path,
+          this.componentIds.length
+        );
         if (fs.existsSync(path.join(this.workspace.path, componentPath))) {
           throw new BitError(`unable to create a component at "${componentPath}", this path already exist`);
         }


### PR DESCRIPTION
## Proposed Changes

**Context**:
We identified an issue with the `new-component-helper` when a path was provided for multiple components. This led to a potential conflict, causing failures for subsequent components due to existing paths.

**Enhancements**:
1. **Parameter Addition**: The `getNewComponentPath` function has been extended with a third parameter to account for the number of components being created. This ensures that the path returned is unique when multiple components are being generated.

2. **Path Adjustments**: Depending on the number of components to create and the existence of the dir, a path is created from the --path flag alone or joined with the full name of the component.

3. **Synchronous Approach**: Made a conscious effort to keep the new helper method synchronous to ensure that it doesn't inadvertently affect or break functionality in other places where it might be used.

4. **Method Accessibility**: Considering the specific functionality and intent of the `getNewComponentPath` method, I suggest that this method should be private. It serves a very specific internal purpose, and marking it as private would prevent unintended external access or misuse.

