### PR TITLE
update VersionHistory object on export

### DIFF
--- a/e2e/functionalities/repository-hooks.e2e.ts
+++ b/e2e/functionalities/repository-hooks.e2e.ts
@@ -35,8 +35,8 @@ describe('repository-hooks', function () {
     it('should run the on persist hook', () => {
       const regex = new RegExp('on persist run', 'g');
       const count = exportOutput.match(regex);
-      // 4 objects - component, version, file and flattenedEdges
-      expect(count).to.have.lengthOf(4);
+      // 5 objects - component, version, file, VersionHistory and flattenedEdges
+      expect(count).to.have.lengthOf(5);
     });
 
     describe('import from remote scope with manipulation hook', () => {
@@ -47,15 +47,18 @@ describe('repository-hooks', function () {
         const regex = new RegExp('on read run', 'g');
         const count = importOutput.match(regex);
         // total 5 objects - component, version, version-history, file and flattened-edges
-        // the reason for the 6 reading is that it happens in two places.
-        // 1. repository.load(), it reads 2 files, the component and the version objects.
-        // 2. repository.loadRaw(), it reads 3 files, component, version and file.
+        // the reason for the 8 reading is that it happens in two places.
+        // 1. `repository.load()`, it reads 3 files, the component, version-history and the version objects.
+        // 2. `repository.loadRaw()`, it reads 5 files, component, version-history, source (file), source (flattened-edges) and version.
+        // all `loadRaw` are coming from "pushObjectsToReadable" method.
         // ideally, loadRaw could use the cached file from load. but it might be safer to not use the cache,
         // so we make sure the client get the exact file saved in the filesystem on the remote. need to think about it.
 
         // if this test fails, and the number is bigger than 5. this could indicate a serious performance issue,
         // because for components with large amount of versions, this could become a huge number.
-        expect(count).to.have.lengthOf(7);
+
+        // to debug this, uncomment the "console.log" after the "onRead" in repository.ts file.
+        expect(count).to.have.lengthOf(8);
       });
       it('should be able to import the component as usual', () => {
         expect(importOutput).to.have.string('successfully imported one component');

--- a/e2e/harmony/export-harmony.e2e.ts
+++ b/e2e/harmony/export-harmony.e2e.ts
@@ -46,6 +46,14 @@ describe('export functionality on Harmony', function () {
     it('should not delete the first version', () => {
       expect(() => helper.command.catComponent('comp1@0.0.1')).not.to.throw();
     });
+    it('should update the VersionHistory on the remote', () => {
+      const versionHistory = helper.command.catVersionHistory(
+        `${helper.scopes.remote}/comp1`,
+        helper.scopes.remotePath
+      );
+      expect(versionHistory).to.have.property('versions');
+      expect(versionHistory.versions).to.have.lengthOf(2);
+    });
     it('should enable un-tagging after a new tag', () => {
       // before it used to throw VersionNotFound
       helper.fixtures.populateComponents(1, undefined, '-v3');

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1025,6 +1025,10 @@ describe('bit lane command', function () {
   // on lane-b, getDivergeData compares its head to main, not to lane-a because they're different scopes.
   // as a result, although it traverses the "squash", it's unable to connect main to lane-b.
   // the missing history exists on lane-a only.
+
+  // update: after PR: https://github.com/teambit/bit/pull/7822, the version-history is created during
+  // export. as a result, the VersionHistory the client gets, has already the entire graph, with all the
+  // connections.
   describe('multiple scopes - fork the lane, then original lane progresses and squashed to main', () => {
     let anotherRemote: string;
     let laneB: string;
@@ -1056,7 +1060,8 @@ describe('bit lane command', function () {
     it('should not throw NoCommonSnap on bit status', () => {
       expect(() => helper.command.status()).not.to.throw();
     });
-    it('should show the component in the invalid component section', () => {
+    // see the update in the `describe` section.
+    it.skip('should show the component in the invalid component section', () => {
       const status = helper.command.statusJson();
       expect(status.invalidComponents).lengthOf(2);
       expect(status.invalidComponents[0].error.name).to.equal('NoCommonSnap');

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -109,14 +109,16 @@ async function _updateVersionHistoryForVersionsWithoutOrigin(
 ): Promise<VersionHistory[]> {
   const mutatedVersionObjects = versionWithoutOrigin.filter((v) => v.squashed || v.unrelated);
   if (!mutatedVersionObjects.length) return [];
-  logger.debug(`updateVersionHistoryIfNeeded, found ${mutatedVersionObjects.length} mutated version`);
+  logger.debug(`_updateVersionHistoryForVersionsWithoutOrigin, found ${mutatedVersionObjects.length} mutated version`);
   const versionsHistory = await Promise.all(
     mergedComponents.map(async (modelComp) =>
       modelComp.updateRebasedVersionHistory(scope.objects, mutatedVersionObjects)
     )
   );
   const versionsHistoryNoNull = compact(versionsHistory);
-  logger.debug(`updateVersionHistoryIfNeeded, found ${versionsHistoryNoNull.length} versionsHistory to update
+  logger.debug(`_updateVersionHistoryForVersionsWithoutOrigin, found ${
+    versionsHistoryNoNull.length
+  } versionsHistory to update
 ${versionsHistoryNoNull.map((v) => v.bitId.toString()).join(', ')}`);
 
   return versionsHistoryNoNull;
@@ -128,6 +130,7 @@ async function _updateVersionHistoryForVersionsWithOrigin(
   versionObjects: Version[]
 ): Promise<VersionHistory[]> {
   if (!versionObjects.length) return [];
+  logger.debug(`_updateVersionHistoryForVersionsWithOrigin, found ${versionObjects.length} versions with origin`);
   const componentVersionMap = new Map<ModelComponent, Version[]>();
   versionObjects.forEach((version) => {
     const component = mergedComponents.find(

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -108,6 +108,7 @@ async function _updateVersionHistoryForVersionsWithoutOrigin(
   versionWithoutOrigin: Version[]
 ): Promise<VersionHistory[]> {
   const mutatedVersionObjects = versionWithoutOrigin.filter((v) => v.squashed || v.unrelated);
+  if (!mutatedVersionObjects.length) return [];
   logger.debug(`updateVersionHistoryIfNeeded, found ${mutatedVersionObjects.length} mutated version`);
   const versionsHistory = await Promise.all(
     mergedComponents.map(async (modelComp) =>

--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -1,5 +1,5 @@
 import mapSeries from 'p-map-series';
-import { compact } from 'lodash';
+import { compact, partition } from 'lodash';
 import R from 'ramda';
 import { BitId, BitIds } from '../../bit-id';
 import logger from '../../logger/logger';
@@ -16,6 +16,8 @@ import { PersistFailed } from '../exceptions/persist-failed';
 import { MergeResult } from '../repositories/sources';
 import { Ref } from '../objects';
 import { BitObjectList } from '../objects/bit-object-list';
+import { pMapPool } from '../../utils/promise-with-concurrent';
+import { concurrentComponentsLimit } from '../../utils/concurrency';
 
 /**
  * ** Legacy and "bit sign" Only **
@@ -51,7 +53,7 @@ export async function saveObjects(scope: Scope, objectList: ObjectList): Promise
   const { mergedIds, mergedComponentsResults, mergedLanes } = await mergeObjects(scope, bitObjectList);
   const mergedComponents = mergedComponentsResults.map((_) => _.mergedComponent);
   const versionObjects = objectsNotRequireMerge.filter((o) => o instanceof Version) as Version[];
-  const versionsHistory = await updateVersionHistoryIfNeeded(scope, mergedComponents, versionObjects);
+  const versionsHistory = await updateVersionHistory(scope, mergedComponents, versionObjects);
   const allObjects = [...mergedComponents, ...mergedLanes, ...objectsNotRequireMerge, ...versionsHistory];
   scope.objects.validateObjects(true, allObjects);
   await scope.objects.writeObjectsToTheFS(allObjects);
@@ -61,19 +63,51 @@ export async function saveObjects(scope: Scope, objectList: ObjectList): Promise
 }
 
 /**
- * in case of rebase (squash / unrelated) where the version history is changed, make the necessary changes in the
- * VersionHistory. Because we only know about this from the Version object, and the Version object has no info about
- * what the component-id is, we have to iterate all model-components, grab their version-history and check whether
- * the version-hash is inside their VersionHistory.
- * it's not ideal performance wise. however, in most cases, this rebase is about squashing, and when squashing, it's
- * done for the entire lane, so all components need to be updated regardless.
+ * Previously, the VersionHistory was populated during fetch. However, we want the fetch operation to be more efficient
+ * so we move this logic to the export operation.
+ * Before version 0.2.22, the Version object didn't have any info about the component-id, so we do update only for
+ * rebase. For versions that tagged by > 0.2.22, we have the "origin.id" and we know to what component this version
+ * belongs to.
  */
-async function updateVersionHistoryIfNeeded(
+async function updateVersionHistory(
   scope: Scope,
   mergedComponents: ModelComponent[],
   versionObjects: Version[]
 ): Promise<VersionHistory[]> {
-  const mutatedVersionObjects = versionObjects.filter((v) => v.squashed || v.unrelated);
+  const versionsWithComponentId = versionObjects.filter((obj) => obj.origin?.id);
+
+  const [versionsWithOrigin, versionWithoutOrigin] = partition(versionsWithComponentId, (v) => v.origin?.id);
+
+  const versionHistoryOfVersionsWithOrigin = await _updateVersionHistoryForVersionsWithOrigin(
+    scope,
+    mergedComponents,
+    versionsWithOrigin
+  );
+
+  const versionHistoryOfVersionsWithoutOrigin = await _updateVersionHistoryForVersionsWithoutOrigin(
+    scope,
+    mergedComponents,
+    versionWithoutOrigin
+  );
+
+  return [...versionHistoryOfVersionsWithOrigin, ...versionHistoryOfVersionsWithoutOrigin];
+}
+
+/**
+ * In case of rebase (squash / unrelated) where the version history is changed, make the necessary changes in the
+ * VersionHistory.
+ * Because previously (bit-version < 0.2.22) we only knew about this from the Version object, and the Version object
+ * didn't have any info about what the component-id is, we have to iterate all model-components, grab their
+ * version-history and check whether the version-hash is inside their VersionHistory.
+ * it's not ideal performance wise. however, in most cases, this rebase is about squashing, and when squashing, it's
+ * done for the entire lane, so all components need to be updated regardless.
+ */
+async function _updateVersionHistoryForVersionsWithoutOrigin(
+  scope: Scope,
+  mergedComponents: ModelComponent[],
+  versionWithoutOrigin: Version[]
+): Promise<VersionHistory[]> {
+  const mutatedVersionObjects = versionWithoutOrigin.filter((v) => v.squashed || v.unrelated);
   logger.debug(`updateVersionHistoryIfNeeded, found ${mutatedVersionObjects.length} mutated version`);
   const versionsHistory = await Promise.all(
     mergedComponents.map(async (modelComp) =>
@@ -83,7 +117,40 @@ async function updateVersionHistoryIfNeeded(
   const versionsHistoryNoNull = compact(versionsHistory);
   logger.debug(`updateVersionHistoryIfNeeded, found ${versionsHistoryNoNull.length} versionsHistory to update
 ${versionsHistoryNoNull.map((v) => v.bitId.toString()).join(', ')}`);
+
   return versionsHistoryNoNull;
+}
+
+async function _updateVersionHistoryForVersionsWithOrigin(
+  scope: Scope,
+  mergedComponents: ModelComponent[],
+  versionObjects: Version[]
+): Promise<VersionHistory[]> {
+  if (!versionObjects.length) return [];
+  const componentVersionMap = new Map<ModelComponent, Version[]>();
+  versionObjects.forEach((version) => {
+    const component = mergedComponents.find(
+      (c) => c.scope === version.origin?.id.scope && c.name === version.origin?.id.name
+    );
+    if (!component) {
+      logger.error(`updateVersionHistoryIfNeeded, unable to find component for version ${version.hash().toString()}`);
+      return;
+    }
+    const versions = componentVersionMap.get(component) || [];
+    componentVersionMap.set(component, [...versions, version]);
+  });
+
+  const versionsHistory = await pMapPool(
+    mergedComponents,
+    async (modelComp) => {
+      const versions = componentVersionMap.get(modelComp);
+      if (!versions || !versions.length) return undefined;
+      return modelComp.updateVersionHistory(scope.objects, versions);
+    },
+    { concurrency: concurrentComponentsLimit() }
+  );
+
+  return compact(versionsHistory);
 }
 
 type MergeObjectsResult = { mergedIds: BitIds; mergedComponentsResults: MergeResult[]; mergedLanes: Lane[] };

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1103,6 +1103,11 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     return versionHistory;
   }
 
+  /**
+   * careful! the `versions` passed here can belong to other components, not necessarily to this one.
+   * that's why it checks whether the version-hash exists in the VersionHistory, and if it's not,
+   * it won't update it.
+   */
   async updateRebasedVersionHistory(repo: Repository, versions: Version[]): Promise<VersionHistory | undefined> {
     const versionHistory = await this.getVersionHistory(repo);
     const hasUpdated = versions.some((version) => {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1115,6 +1115,12 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
     return hasUpdated ? versionHistory : undefined;
   }
 
+  async updateVersionHistory(repo: Repository, versions: Version[]): Promise<VersionHistory> {
+    const versionHistory = await this.getVersionHistory(repo);
+    versionHistory.addFromVersionsObjects(versions);
+    return versionHistory;
+  }
+
   async populateVersionHistoryIfMissingGracefully(
     repo: Repository,
     versionHistory: VersionHistory,

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -180,7 +180,9 @@ export default class Repository {
       return null;
     }
     const size = fileContentsRaw.byteLength;
-    const fileContents = await this.onRead(fileContentsRaw);
+    const fileContents = this.onRead(fileContentsRaw);
+    // uncomment to debug the transformed objects by onRead
+    // console.log('transformedContent load', ref.toString(), BitObject.parseSync(fileContents).getType());
     const parsedObject = await BitObject.parseObject(fileContents, objectPath);
     const maxSizeToCache = 100 * 1024; // 100KB
     if (size < maxSizeToCache) {
@@ -302,6 +304,8 @@ export default class Repository {
     const raw = await fs.readFile(this.objectPath(ref));
     // Run hook to transform content pre reading
     const transformedContent = this.onRead(raw);
+    // uncomment to debug the transformed objects by onRead
+    // console.log('transformedContent loadRaw', ref.toString(), BitObject.parseSync(transformedContent).getType());
     return transformedContent;
   }
 


### PR DESCRIPTION
Until now, it was updated during import, which is not ideal. Now that we save the component-id inside the Version object, we can do it during export.