### PR TITLE
fixed env config renaming

### DIFF
--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -59,6 +59,9 @@ make sure this argument is the name only, without the scope-name. to change the 
       await this.refactoring.refactorVariableAndClasses(sourceComp, sourceId, targetId);
       this.refactoring.refactorFilenames(sourceComp, sourceId, targetId);
     }
+    if (isSourceCompEnv) {
+      await this.workspace.replaceEnvForAllComponents(sourceId, targetId);
+    }
     if (isTagged) {
       const config = await this.getConfig(sourceComp);
       await this.newComponentHelper.writeAndAddNewComp(sourceComp, targetId, options, config);
@@ -92,7 +95,6 @@ make sure this argument is the name only, without the scope-name. to change the 
         writeToPath: this.newComponentHelper.getNewComponentPath(targetId),
       });
     }
-    isSourceCompEnv && (await this.workspace.replaceEnvForAllComponents(sourceId, targetId));
     await this.workspace.bitMap.write();
 
     await linkToNodeModulesByComponents([targetComp], this.workspace); // link the new-name to node-modules

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -54,6 +54,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     const sourceComp = await this.workspace.get(sourceId);
     const sourcePackageName = this.workspace.componentPackageName(sourceComp);
     const targetId = this.newComponentHelper.getNewComponentId(targetName, undefined, options?.scope);
+    const isSourceCompEnv = this.envs.isEnv(sourceComp);
     if (!options.preserve) {
       await this.refactoring.refactorVariableAndClasses(sourceComp, sourceId, targetId);
       this.refactoring.refactorFilenames(sourceComp, sourceId, targetId);
@@ -91,8 +92,7 @@ make sure this argument is the name only, without the scope-name. to change the 
         writeToPath: this.newComponentHelper.getNewComponentPath(targetId),
       });
     }
-
-    this.workspace.bitMap.renameAspectInConfig(sourceId, targetId);
+    isSourceCompEnv && (await this.workspace.replaceEnvForAllComponents(sourceId, targetId));
     await this.workspace.bitMap.write();
 
     await linkToNodeModulesByComponents([targetComp], this.workspace); // link the new-name to node-modules

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -193,6 +193,7 @@ export class BitMap {
       if (!config) return;
       Object.keys(config).forEach((aspectId) => {
         const fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
+        const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
         if (aspectId === fullSourceId) {
           config[targetId.toString()] = config[aspectId];
           delete config[aspectId];
@@ -200,7 +201,7 @@ export class BitMap {
         }
         if (aspectId === EnvsAspect.id) {
           const envConfig = config[aspectId];
-          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env !== sourceId.toString()) {
+          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === fullSourceId) {
             envConfig.env = targetId.toString();
             this.markAsChanged();
           }

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -191,14 +191,23 @@ export class BitMap {
     this.legacyBitMap.components.forEach((componentMap) => {
       const config = componentMap.config;
       if (!config) return;
+
       Object.keys(config).forEach((aspectId) => {
-        const fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
+        let fullSourceId: string;
+        try {
+          fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
+        } catch (error) {
+          // If entry not found it's probably new, keep the sourceId as is
+          fullSourceId = sourceId.toString();
+        }
+
         const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
         if (aspectIdWithoutVersion === fullSourceId) {
           config[targetId.toString()] = config[aspectId];
           delete config[aspectId];
           this.markAsChanged();
         }
+
         if (aspectId === EnvsAspect.id) {
           const envConfig = config[aspectId];
           if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === fullSourceId) {
@@ -207,6 +216,7 @@ export class BitMap {
           }
         }
       });
+
       componentMap.config = config;
     });
   }

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -194,7 +194,7 @@ export class BitMap {
       Object.keys(config).forEach((aspectId) => {
         const fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
         const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
-        if (aspectId === fullSourceId) {
+        if (aspectIdWithoutVersion === fullSourceId) {
           config[targetId.toString()] = config[aspectId];
           delete config[aspectId];
           this.markAsChanged();

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -192,10 +192,9 @@ export class BitMap {
       const config = componentMap.config;
       if (!config) return;
       Object.keys(config).forEach((aspectId) => {
-        const fullSourceId = sourceId.toStringWithoutVersion();
-
+        const sourceIdwithoutVersion = sourceId.toStringWithoutVersion();
         const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
-        if (aspectIdWithoutVersion === fullSourceId) {
+        if (aspectIdWithoutVersion === sourceIdwithoutVersion) {
           config[targetId.toString()] = config[aspectId];
           delete config[aspectId];
           this.markAsChanged();
@@ -203,7 +202,7 @@ export class BitMap {
 
         if (aspectId === EnvsAspect.id) {
           const envConfig = config[aspectId];
-          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === fullSourceId) {
+          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === sourceIdwithoutVersion) {
             envConfig.env = targetId.toString();
             this.markAsChanged();
           }

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -7,7 +7,6 @@ import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 import { REMOVE_EXTENSION_SPECIAL_SIGN } from '@teambit/legacy/dist/consumer/config';
 import { BitError } from '@teambit/bit-error';
 import { LaneId } from '@teambit/lane-id';
-import EnvsAspect from '@teambit/envs';
 
 export type MergeOptions = {
   mergeStrategy?: 'theirs' | 'ours' | 'manual';

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -184,35 +184,6 @@ export class BitMap {
     }
   }
 
-  /**
-   * helpful when reaming an aspect and this aspect is used in the config of other components.
-   */
-  renameAspectInConfig(sourceId: ComponentID, targetId: ComponentID) {
-    this.legacyBitMap.components.forEach((componentMap) => {
-      const config = componentMap.config;
-      if (!config) return;
-      Object.keys(config).forEach((aspectId) => {
-        const sourceIdwithoutVersion = sourceId.toStringWithoutVersion();
-        const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
-        if (aspectIdWithoutVersion === sourceIdwithoutVersion) {
-          config[targetId.toString()] = config[aspectId];
-          delete config[aspectId];
-          this.markAsChanged();
-        }
-
-        if (aspectId === EnvsAspect.id) {
-          const envConfig = config[aspectId];
-          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === sourceIdwithoutVersion) {
-            envConfig.env = targetId.toString();
-            this.markAsChanged();
-          }
-        }
-      });
-
-      componentMap.config = config;
-    });
-  }
-
   removeComponent(id: ComponentID) {
     this.legacyBitMap.removeComponent(id._legacy);
   }

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -192,14 +192,15 @@ export class BitMap {
       const config = componentMap.config;
       if (!config) return;
       Object.keys(config).forEach((aspectId) => {
-        if (aspectId === sourceId.toString()) {
+        const fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
+        if (aspectId === fullSourceId) {
           config[targetId.toString()] = config[aspectId];
           delete config[aspectId];
           this.markAsChanged();
         }
         if (aspectId === EnvsAspect.id) {
           const envConfig = config[aspectId];
-          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env === sourceId.toString()) {
+          if (envConfig !== REMOVE_EXTENSION_SPECIAL_SIGN && envConfig.env !== sourceId.toString()) {
             envConfig.env = targetId.toString();
             this.markAsChanged();
           }

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -191,15 +191,8 @@ export class BitMap {
     this.legacyBitMap.components.forEach((componentMap) => {
       const config = componentMap.config;
       if (!config) return;
-
       Object.keys(config).forEach((aspectId) => {
-        let fullSourceId: string;
-        try {
-          fullSourceId = this.getBitmapEntry(sourceId).id.toStringWithoutVersion();
-        } catch (error) {
-          // If entry not found it's probably new, keep the sourceId as is
-          fullSourceId = sourceId.toString();
-        }
+        const fullSourceId = sourceId.toStringWithoutVersion();
 
         const aspectIdWithoutVersion = ComponentID.fromString(aspectId).toStringWithoutVersion();
         if (aspectIdWithoutVersion === fullSourceId) {

--- a/scopes/workspace/workspace/envs-subcommands/envs-replace.cmd.ts
+++ b/scopes/workspace/workspace/envs-subcommands/envs-replace.cmd.ts
@@ -20,12 +20,11 @@ export class EnvsReplaceCmd implements Command {
 
   constructor(private workspace: Workspace) {}
 
-  async report([oldEnv, env]: [string, string]) {
-    const envId = await this.workspace.resolveComponentId(env);
-    const components = await this.workspace.getComponentsUsingEnv(oldEnv, true, true);
-    const componentIds = components.map((comp) => comp.id);
-    await this.workspace.setEnvToComponents(envId, componentIds);
-    return `added ${chalk.bold(envId.toString())} env to the following component(s):
-${componentIds.map((compId) => compId.toString()).join('\n')}`;
+  async report([currentEnv, newEnv]: [string, string]) {
+    const currentEnvId = await this.workspace.resolveComponentId(currentEnv);
+    const newEnvId = await this.workspace.resolveComponentId(newEnv);
+    const changedComponentIds = await this.workspace.replaceEnvForAllComponents(currentEnvId, newEnvId);
+    return `added ${chalk.bold(newEnvId.toString())} env to the following component(s):
+${changedComponentIds.map((compId) => compId.toString()).join('\n')}`;
   }
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1698,6 +1698,18 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   }
 
   /**
+   * replace the env for all components in the workspace that are using it
+   * returns the components ids that were changed.
+   */
+
+  async replaceEnvForAllComponents(currentEnv: ComponentID, newEnv: ComponentID) {
+    const components = await this.getComponentsUsingEnv(currentEnv.toString(), true, true);
+    const componentIds = components.map((comp) => comp.id);
+    await this.setEnvToComponents(newEnv, componentIds);
+    return componentIds;
+  }
+
+  /**
    * helpful when a user provides an env-string to be set and this env has no version.
    * in the workspace config, a custom-env needs to be set with a version unless it's part of the workspace.
    * (inside envs/envs it's set without a version).

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1717,12 +1717,16 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   async resolveEnvIdWithPotentialVersionForConfig(envId: ComponentID): Promise<string> {
     const isCore = this.aspectLoader.isCoreAspect(envId.toStringWithoutVersion());
     const existsOnWorkspace = await this.hasId(envId);
+    const isNew = !envId.hasVersion();
+    if (isNew) {
+      return envId.toString();
+    }
     if (isCore || existsOnWorkspace) {
       // the env needs to be without version
       return envId.toStringWithoutVersion();
     }
     // the env must include a version
-    if (envId.hasVersion()) {
+    if (!isNew) {
       return envId.toString();
     }
     const extensions = this.harmony.get<ConfigMain>('teambit.harmony/config').extensions;


### PR DESCRIPTION
### Fix
- **Update `teambit.envs/envs` Property**: Ensures the `teambit.envs/envs` prop in `bitmap` is updated when renaming an environment. This correction handles the property in components using that environment.
- **Partial Name Handling**: Now effectively manages scenarios where developers might use a partial name. For instance, transforming `teambit.react/react-env` to just `react-env` during a rename operation.

### Changes
1. **New Method in Workspace Aspect**:
   - Introduced the `replaceEnvForAllComponents` method within the Workspace aspect. This method allows for the substitution of an environment for all components reliant on the old environment, returning the IDs of affected components.

2. **Updates to Rename Method**:
   - Adjustments made to the `rename` method ensure that it checks if a component is an environment component and then uses the new `replaceEnvForAllComponents` method.

3. **Bit Env Replace Command Update**:
   - Extracted the logic from the original Bit env replace command and integrated it into a new method, enhancing its functionality.

4. **Refactoring**:
   - Logic from the `replace env` command was extracted and moved to a new method on the workspace aspect. Both the `replace` and `rename` methods utilize this.

5. **Removed Method**: 
   - The `renameAspectInConfig` method, previously used for renaming aspects in component configs, has been removed.

---

**Kindly review the changes and share your feedback.**
