### PR TITLE
fix(renaming): scope rename - handle when there are no env components to rename

### DIFF
--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -158,7 +158,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     await Promise.all(
       envs.map(async (env) => {
         const componentIds = compsUsingEnv[env.id.toString()];
-        if (!componentIds.length) return;
+        if (!componentIds?.length) return;
         await this.workspace.setEnvToComponents(env.id.changeScope(newScope), componentIds);
       })
     );


### PR DESCRIPTION
This PR fixes the issue when there are no env components to rename. 

Previously, if there were no env components it throws during scope rename

```
unable to import the following component(s): org.scope-name/examples/sample-app.
the remote scope "org.scope-name" was not found
```