### PR TITLE
perf(bootstrap), improve scanning components dir by ignoring node-modules

### DIFF
--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -400,6 +400,9 @@ export async function getFilesByDir(dir: string, consumerPath: string, gitIgnore
     cwd: consumerPath,
     dot: true,
     onlyFiles: true,
+    // must ignore node_modules at this stage, although we check for gitignore later on.
+    // otherwise, it hurts performance dramatically for components that have node_modules in the comp-dir.
+    ignore: [`${dir}/node_modules/`],
   });
   if (!matches.length) throw new ComponentNotFoundInPath(dir);
   const filteredMatches: string[] = gitIgnore.filter(matches);


### PR DESCRIPTION
Previously, this was done at a later stage, when comparing with gitignore. 
With this PR it is done in the first `glob`. 