### PR TITLE
support resolving components with no snaps in common between two lanes

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -724,6 +724,68 @@ describe('merge lanes', function () {
       });
     });
   });
+  describe('merge unrelated between two lanes with --resolve-unrelated', () => {
+    let headOnLaneA: string;
+    let headOnLaneB: string;
+    let beforeMerge: string;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false, 'lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      headOnLaneA = helper.command.getHeadOfLane('lane-a', 'comp1');
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane('lane-b');
+      helper.fixtures.populateComponents(1, false, 'lane-b');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      headOnLaneB = helper.command.getHeadOfLane('lane-b', 'comp1');
+      beforeMerge = helper.scopeHelper.cloneLocalScope();
+    });
+    describe('without specifying strategy, which defaults to "ours"', () => {
+      before(() => {
+        helper.command.mergeLane('lane-a', '--resolve-unrelated -x');
+      });
+      it('should resolve by default by ours', () => {
+        const fileContent = helper.fs.readFile('comp1/index.js');
+        expect(fileContent).to.have.string('lane-b');
+        expect(fileContent).to.not.have.string('lane-a');
+      });
+      it('should populate the unrelated property correctly on the Version object', () => {
+        const ver = helper.command.catComponent('comp1@latest');
+        expect(ver.unrelated.head).to.equal(headOnLaneA);
+        expect(ver.unrelated.laneId.name).to.equal('lane-a');
+      });
+      it('should populate the parents according to the current lane', () => {
+        const ver = helper.command.catComponent('comp1@latest');
+        expect(ver.parents[0]).to.equal(headOnLaneB);
+      });
+    });
+    describe('with strategy theirs', () => {
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(beforeMerge);
+        helper.command.mergeLane('lane-a', '--resolve-unrelated=theirs -x');
+      });
+      it('should get the file content according to their', () => {
+        const fileContent = helper.fs.readFile('comp1/index.js');
+        expect(fileContent).to.have.string('lane-a');
+        expect(fileContent).to.not.have.string('lane-b');
+      });
+      it('should populate the unrelated property correctly on the Version object', () => {
+        const ver = helper.command.catComponent('comp1@latest');
+        expect(ver.unrelated.head).to.equal(headOnLaneB);
+        expect(ver.unrelated.laneId.name).to.equal('lane-b');
+      });
+      it('should populate the parents according to the other lane', () => {
+        const ver = helper.command.catComponent('comp1@latest');
+        expect(ver.parents[0]).to.equal(headOnLaneA);
+      });
+    });
+  });
   describe('merge lanes when local-lane has soft-removed components and the other lane is behind', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -1,0 +1,403 @@
+import { Workspace } from '@teambit/workspace';
+import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
+import mapSeries from 'p-map-series';
+import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
+import { DEFAULT_LANE, LaneId } from '@teambit/lane-id';
+import { getDivergeData } from '@teambit/legacy/dist/scope/component-ops/get-diverge-data';
+import { Lane, ModelComponent, Version } from '@teambit/legacy/dist/scope/models';
+import { Ref } from '@teambit/legacy/dist/scope/objects';
+import { Tmp } from '@teambit/legacy/dist/scope/repositories';
+import ConsumerComponent from '@teambit/legacy/dist/consumer/component/consumer-component';
+import { ImporterMain } from '@teambit/importer';
+import { Logger } from '@teambit/logger';
+import { compact } from 'lodash';
+import threeWayMerge from '@teambit/legacy/dist/consumer/versions-ops/merge-version/three-way-merge';
+import { SnapsDistance } from '@teambit/legacy/dist/scope/component-ops/snaps-distance';
+import { NoCommonSnap } from '@teambit/legacy/dist/scope/exceptions/no-common-snap';
+import { ConfigMerger } from './config-merger';
+import { ComponentMergeStatus, ComponentMergeStatusBeforeMergeAttempt } from './merging.main.runtime';
+
+export class MergeStatusProvider {
+  constructor(
+    private workspace: Workspace,
+    private logger: Logger,
+    private importer: ImporterMain,
+    private currentLane?: Lane, // currently checked out lane. if on main, then it's null.
+    private otherLane?: Lane, // the lane we want to merged to our lane. (null if it's "main").
+    private options?: { resolveUnrelated?: MergeStrategy; ignoreConfigChanges?: boolean }
+  ) {}
+
+  async getStatus(
+    bitIds: BitId[] // the id.version is the version we want to merge to the current component
+  ): Promise<ComponentMergeStatus[]> {
+    if (!this.currentLane && this.otherLane) {
+      await this.importer.importObjectsFromMainIfExist(this.otherLane.toBitIds().toVersionLatest());
+    }
+    const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
+      this.getComponentStatusBeforeMergeAttempt(id)
+    );
+    const toImport = componentStatusBeforeMergeAttempt
+      .map((compStatus) => {
+        if (!compStatus.divergeData) return [];
+        const versionsToImport = compact([
+          ...compStatus.divergeData.snapsOnTargetOnly,
+          compStatus.divergeData.commonSnapBeforeDiverge,
+        ]);
+        return versionsToImport.map((v) => compStatus.id.changeVersion(v.toString()));
+      })
+      .flat();
+
+    await this.workspace.consumer.scope.scopeImporter.importWithoutDeps(BitIds.fromArray(toImport), {
+      lane: this.otherLane,
+      cache: true,
+      includeVersionHistory: false,
+    });
+
+    const compStatusNotNeedMerge = componentStatusBeforeMergeAttempt.filter(
+      (c) => !c.mergeProps
+    ) as ComponentMergeStatus[];
+    const compStatusNeedMerge = componentStatusBeforeMergeAttempt.filter((c) => c.mergeProps);
+
+    const getComponentsStatusNeedMerge = async (): Promise<ComponentMergeStatus[]> => {
+      const tmp = new Tmp(this.workspace.consumer.scope);
+      try {
+        const componentsStatus = await Promise.all(
+          compStatusNeedMerge.map((compStatus) => this.getComponentMergeStatus(compStatus))
+        );
+        await tmp.clear();
+        return componentsStatus;
+      } catch (err: any) {
+        await tmp.clear();
+        throw err;
+      }
+    };
+    const results = await getComponentsStatusNeedMerge();
+
+    results.push(...compStatusNotNeedMerge);
+    return results;
+  }
+
+  private async getComponentMergeStatus(
+    componentMergeStatusBeforeMergeAttempt: ComponentMergeStatusBeforeMergeAttempt
+  ) {
+    const { id, divergeData, currentComponent, mergeProps } = componentMergeStatusBeforeMergeAttempt;
+    if (!mergeProps) throw new Error(`getDivergedMergeStatus, mergeProps is missing for ${id.toString()}`);
+    const { otherLaneHead, currentId, modelComponent } = mergeProps;
+    const repo = this.workspace.consumer.scope.objects;
+    if (!divergeData) throw new Error(`getDivergedMergeStatus, divergeData is missing for ${id.toString()}`);
+    if (!currentComponent) throw new Error(`getDivergedMergeStatus, currentComponent is missing for ${id.toString()}`);
+
+    const baseSnap = divergeData.commonSnapBeforeDiverge as Ref; // must be set when isTrueMerge
+    this.logger.debug(`merging snaps details:
+id:      ${id.toStringWithoutVersion()}
+base:    ${baseSnap.toString()}
+current: ${currentId.version}
+other:   ${otherLaneHead.toString()}`);
+    const baseComponent: Version = await modelComponent.loadVersion(baseSnap.toString(), repo);
+    const otherComponent: Version = await modelComponent.loadVersion(otherLaneHead.toString(), repo);
+
+    const currentLaneName = this.currentLane?.toLaneId().toString() || 'main';
+    const otherLaneName = this.otherLane ? this.otherLane.toLaneId().toString() : DEFAULT_LANE;
+    const currentLabel = `${currentId.version} (${currentLaneName === otherLaneName ? 'current' : currentLaneName})`;
+    const otherLabel = `${otherLaneHead.toString()} (${
+      otherLaneName === currentLaneName ? 'incoming' : otherLaneName
+    })`;
+    const workspaceIds = await this.workspace.listIds();
+    const configMerger = new ConfigMerger(
+      id.toStringWithoutVersion(),
+      workspaceIds,
+      this.otherLane,
+      currentComponent.extensions,
+      baseComponent.extensions,
+      otherComponent.extensions,
+      currentLabel,
+      otherLabel,
+      this.logger
+    );
+    const configMergeResult = configMerger.merge();
+
+    const mergeResults = await threeWayMerge({
+      consumer: this.workspace.consumer,
+      otherComponent,
+      otherLabel,
+      currentComponent,
+      currentLabel,
+      baseComponent,
+    });
+    return { currentComponent, id, mergeResults, divergeData, configMergeResult };
+  }
+
+  private returnUnmerged(id: BitId, msg: string, unmergedLegitimately = false): ComponentMergeStatusBeforeMergeAttempt {
+    const componentStatus: ComponentMergeStatusBeforeMergeAttempt = { id };
+    componentStatus.unmergedMessage = msg;
+    componentStatus.unmergedLegitimately = unmergedLegitimately;
+    return componentStatus;
+  }
+
+  private async getComponentStatusBeforeMergeAttempt(
+    id: BitId // the id.version is the version we want to merge to the current component
+  ): Promise<ComponentMergeStatusBeforeMergeAttempt> {
+    const consumer = this.workspace.consumer;
+    const componentStatus: ComponentMergeStatusBeforeMergeAttempt = { id };
+    const modelComponent = await consumer.scope.getModelComponentIfExist(id);
+    if (!modelComponent) {
+      return this.returnUnmerged(
+        id,
+        `component ${id.toString()} is on the lane/main but its objects were not found, please re-import the lane`
+      );
+    }
+    const unmerged = consumer.scope.objects.unmergedComponents.getEntry(id.name);
+    if (unmerged) {
+      return this.returnUnmerged(
+        id,
+        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort/ bit lane merge-abort)`
+      );
+    }
+    const repo = consumer.scope.objects;
+    const version = id.version as string;
+    const otherLaneHead = modelComponent.getRef(version);
+    const existingBitMapId = consumer.bitMap.getBitIdIfExist(id, { ignoreVersion: true });
+    const componentOnOther: Version = await modelComponent.loadVersion(version, consumer.scope.objects);
+    const idOnCurrentLane = this.currentLane?.getComponent(id);
+
+    if (componentOnOther.isRemoved()) {
+      // if exist in current lane, we want the current lane to get the soft-remove update.
+      // or if it was removed with --update-main, we want to merge it so then main will get the update.
+      const shouldMerge = idOnCurrentLane || componentOnOther.shouldRemoveFromMain();
+      if (shouldMerge) {
+        // remove the component from the workspace if exist.
+        componentStatus.shouldBeRemoved = true;
+      } else {
+        // on main, don't merge soft-removed components unless it's marked with removeOnMain.
+        // on lane, if it's not part of the current lane, don't merge it.
+        return this.returnUnmerged(id, `component has been removed`, true);
+      }
+    }
+    const getCurrentId = () => {
+      if (existingBitMapId) return existingBitMapId;
+      if (this.currentLane) {
+        if (!idOnCurrentLane) return null;
+        return idOnCurrentLane.id.changeVersion(idOnCurrentLane.head.toString());
+      }
+      // it's on main
+      const head = modelComponent.getHeadAsTagIfExist();
+      if (head) {
+        return id.changeVersion(head);
+      }
+      return null;
+    };
+    const currentId = getCurrentId();
+    if (!currentId) {
+      const divergeData = await getDivergeData({ repo, modelComponent, targetHead: otherLaneHead, throws: false });
+      return { ...componentStatus, componentFromModel: componentOnOther, divergeData };
+    }
+    const getCurrentComponent = () => {
+      if (existingBitMapId) return consumer.loadComponent(existingBitMapId);
+      return consumer.scope.getConsumerComponent(currentId);
+    };
+    const currentComponent = await getCurrentComponent();
+    if (currentComponent.isRemoved()) {
+      // we have a few options:
+      // 1. other is ahead. in this case, other recovered the component. so we can continue with the merge.
+      // it is possible that it is diverged, in which case, still continue with the merge, and later on, the
+      // merge-config will show a config conflict of the remove aspect.
+      // 2. other is not ahead. in this case, just ignore this component, no point to merge it, we want it removed.
+      // 3. there are errors when calculating the divergeData, e.g. no snap in common. in such cases, we assume
+      // there are issues with this component, and is better not to merge it.
+      const divergeData = await getDivergeData({ repo, modelComponent, targetHead: otherLaneHead, throws: false });
+      if (divergeData.err || !divergeData.isTargetAhead()) {
+        return this.returnUnmerged(id, `component has been removed`, true);
+      }
+    }
+
+    const isModified = async (): Promise<undefined | 'code' | 'config'> => {
+      const componentModificationStatus = await consumer.getComponentStatusById(currentComponent.id);
+      if (!componentModificationStatus.modified) return undefined;
+      if (!existingBitMapId) return undefined;
+      const baseComponent = await modelComponent.loadVersion(
+        existingBitMapId.version as string,
+        consumer.scope.objects
+      );
+      const isSourceCodeModified = await consumer.isComponentSourceCodeModified(baseComponent, currentComponent);
+      if (isSourceCodeModified) return 'code';
+      return 'config';
+    };
+
+    const modifiedType = await isModified();
+    if (modifiedType === 'config' && !this.options?.ignoreConfigChanges) {
+      return this.returnUnmerged(
+        id,
+        `component has config changes, please snap/tag it first. alternatively, use --ignore-config-changes flag to bypass`
+      );
+    }
+    if (modifiedType === 'code') {
+      return this.returnUnmerged(id, `component is modified, please snap/tag it first`);
+    }
+
+    if (!otherLaneHead) {
+      throw new Error(`merging: unable finding a hash for the version ${version} of ${id.toString()}`);
+    }
+    const divergeData = await getDivergeData({
+      repo,
+      modelComponent,
+      targetHead: otherLaneHead,
+      throws: false,
+    });
+    if (divergeData.err) {
+      if (!(divergeData.err instanceof NoCommonSnap) || !this.options?.resolveUnrelated) {
+        return this.returnUnmerged(
+          id,
+          `unable to traverse ${currentComponent.id.toString()} history. error: ${divergeData.err.message}`
+        );
+      }
+      return this.handleNoCommonSnap(
+        modelComponent,
+        id,
+        otherLaneHead,
+        currentComponent,
+        componentOnOther,
+        divergeData
+      );
+    }
+    if (!divergeData.isDiverged()) {
+      if (divergeData.isSourceAhead()) {
+        // do nothing!
+        return this.returnUnmerged(id, `component ${currentComponent.id.toString()} is ahead, nothing to merge`, true);
+      }
+      if (divergeData.isTargetAhead()) {
+        // just override with the model data
+        return {
+          ...componentStatus,
+          currentComponent,
+          componentFromModel: componentOnOther,
+          divergeData,
+        };
+      }
+      // we know that localHead and remoteHead are set, so if none of them is ahead they must be equal
+      return this.returnUnmerged(id, `component ${currentComponent.id.toString()} is already merged`, true);
+    }
+
+    // it's diverged and needs merge operation
+    const mergeProps = {
+      otherLaneHead,
+      currentId,
+      modelComponent,
+    };
+
+    return { ...componentStatus, currentComponent, mergeProps, divergeData };
+  }
+
+  private async handleNoCommonSnap(
+    modelComponent: ModelComponent,
+    id: BitId,
+    otherLaneHead: Ref,
+    currentComponent: ConsumerComponent,
+    componentOnOther?: Version,
+    divergeData?: SnapsDistance
+  ): Promise<ComponentMergeStatusBeforeMergeAttempt> {
+    const { resolveUnrelated } = this.options || {};
+    if (!resolveUnrelated) throw new Error(`handleNoCommonSnap expects resolveUnrelated to be set`);
+    const consumer = this.workspace.consumer;
+    const repo = consumer.scope.objects;
+    const mainHead = modelComponent.head;
+    if (mainHead) {
+      const hasResolvedFromMain = async (hashToCompare: Ref | null) => {
+        const divergeDataFromMain = await getDivergeData({
+          repo,
+          modelComponent,
+          sourceHead: hashToCompare,
+          targetHead: mainHead,
+          throws: false,
+        });
+        if (!divergeDataFromMain.err) return true;
+        return !(divergeDataFromMain.err instanceof NoCommonSnap);
+      };
+      const hasResolvedLocally = await hasResolvedFromMain(modelComponent.getHeadRegardlessOfLane() as Ref);
+      const hasResolvedRemotely = await hasResolvedFromMain(otherLaneHead);
+      if (!hasResolvedLocally && !hasResolvedRemotely) {
+        return this.returnUnmerged(
+          id,
+          `unable to traverse ${currentComponent.id.toString()} history. the main-head ${mainHead.toString()} doesn't appear in both lanes, it was probably created in each lane separately`
+        );
+      }
+      const versionToSaveInLane = hasResolvedLocally ? currentComponent.id.version : id.version;
+      const resolvedRef = modelComponent.getRef(versionToSaveInLane as string);
+      if (!resolvedRef) throw new Error(`unable to get ref of "${versionToSaveInLane}" for "${id.toString()}"`);
+      const unrelatedHead = hasResolvedLocally ? id.version : currentComponent.id.version;
+      const unrelatedHeadRef = modelComponent.getRef(unrelatedHead as string);
+      if (!unrelatedHeadRef) throw new Error(`unable to get ref of "${unrelatedHead}" for "${id.toString()}"`);
+      if (this.options?.resolveUnrelated === 'ours') {
+        return {
+          currentComponent,
+          id,
+          divergeData,
+          resolvedUnrelated: {
+            strategy: 'ours',
+            headOnLane: resolvedRef,
+            unrelatedHead: unrelatedHeadRef,
+            unrelatedLaneId: this.currentLane?.toLaneId() as LaneId,
+            futureParent: resolvedRef,
+          },
+        };
+      }
+      if (this.options?.resolveUnrelated === 'theirs') {
+        // just override with the model data
+        return {
+          currentComponent,
+          componentFromModel: componentOnOther,
+          id,
+          divergeData,
+          resolvedUnrelated: {
+            strategy: 'theirs',
+            headOnLane: resolvedRef,
+            unrelatedHead: unrelatedHeadRef,
+            unrelatedLaneId: this.currentLane?.toLaneId() as LaneId,
+            futureParent: resolvedRef,
+          },
+        };
+      }
+      throw new Error(
+        `unsupported strategy "${this.options?.resolveUnrelated}" of resolve-unrelated. supported strategies are: [ours, theirs]`
+      );
+    }
+    const versionToSaveInLane = resolveUnrelated === 'ours' ? currentComponent.id.version : id.version;
+    const unrelatedHead = resolveUnrelated === 'ours' ? id.version : currentComponent.id.version;
+    const resolvedRef = modelComponent.getRef(versionToSaveInLane as string);
+    if (!resolvedRef) throw new Error(`unable to get ref of "${versionToSaveInLane}" for "${id.toString()}"`);
+    const unrelatedHeadRef = modelComponent.getRef(unrelatedHead as string);
+    if (!unrelatedHeadRef) throw new Error(`unable to get ref of "${unrelatedHead}" for "${id.toString()}"`);
+    if (resolveUnrelated === 'ours') {
+      return {
+        currentComponent,
+        id,
+        divergeData,
+        resolvedUnrelated: {
+          headOnLane: resolvedRef,
+          strategy: 'ours',
+          unrelatedHead: unrelatedHeadRef,
+          unrelatedLaneId: this.otherLane?.toLaneId() as LaneId,
+          futureParent: resolvedRef,
+        },
+      };
+    }
+    if (resolveUnrelated === 'theirs') {
+      // just override with the model data
+      return {
+        currentComponent,
+        componentFromModel: componentOnOther,
+        id,
+        divergeData,
+        resolvedUnrelated: {
+          headOnLane: resolvedRef,
+          strategy: 'theirs',
+          unrelatedHead: unrelatedHeadRef,
+          unrelatedLaneId: this.currentLane?.toLaneId() as LaneId,
+          futureParent: resolvedRef,
+        },
+      };
+    }
+    throw new Error(
+      `unsupported strategy "${this.options?.resolveUnrelated}" of resolve-unrelated. supported strategies are: [ours, theirs]`
+    );
+  }
+}

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -17,26 +17,21 @@ import mapSeries from 'p-map-series';
 import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
 import { BitError } from '@teambit/bit-error';
 import GeneralError from '@teambit/legacy/dist/error/general-error';
-import { DEFAULT_LANE, LaneId } from '@teambit/lane-id';
+import { LaneId } from '@teambit/lane-id';
 import { AutoTagResult } from '@teambit/legacy/dist/scope/component-ops/auto-tag';
-import { getDivergeData } from '@teambit/legacy/dist/scope/component-ops/get-diverge-data';
 import { UnmergedComponent } from '@teambit/legacy/dist/scope/lanes/unmerged-components';
-import { Lane, ModelComponent, Version } from '@teambit/legacy/dist/scope/models';
+import { Lane, ModelComponent } from '@teambit/legacy/dist/scope/models';
 import { Ref } from '@teambit/legacy/dist/scope/objects';
 import chalk from 'chalk';
 import { ConfigAspect, ConfigMain } from '@teambit/config';
 import RemoveAspect, { RemoveMain } from '@teambit/remove';
-import { Tmp } from '@teambit/legacy/dist/scope/repositories';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 import { ComponentWriterAspect, ComponentWriterMain } from '@teambit/component-writer';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component/consumer-component';
 import ImporterAspect, { ImporterMain } from '@teambit/importer';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { compact, isEmpty } from 'lodash';
-import threeWayMerge, {
-  MergeResultsThreeWay,
-} from '@teambit/legacy/dist/consumer/versions-ops/merge-version/three-way-merge';
-import { NoCommonSnap } from '@teambit/legacy/dist/scope/exceptions/no-common-snap';
+import { MergeResultsThreeWay } from '@teambit/legacy/dist/consumer/versions-ops/merge-version/three-way-merge';
 import { DependencyResolverAspect, WorkspacePolicyConfigKeysNames } from '@teambit/dependency-resolver';
 import {
   ApplyVersionWithComps,
@@ -53,8 +48,8 @@ import { SnapsDistance } from '@teambit/legacy/dist/scope/component-ops/snaps-di
 import { InstallMain, InstallAspect } from '@teambit/install';
 import { MergeCmd } from './merge-cmd';
 import { MergingAspect } from './merging.aspect';
-import { ConfigMerger } from './config-merger';
 import { ConfigMergeResult } from './config-merge-result';
+import { MergeStatusProvider } from './merge-status-provider';
 
 type ResolveUnrelatedData = {
   strategy: MergeStrategy;
@@ -521,354 +516,15 @@ export class MergingMain {
     otherLane?: Lane | null, // the lane we want to merged to our lane. (null if it's "main").
     options?: { resolveUnrelated?: MergeStrategy; ignoreConfigChanges?: boolean }
   ): Promise<ComponentMergeStatus[]> {
-    if (!currentLane && otherLane) {
-      await this.importer.importObjectsFromMainIfExist(otherLane.toBitIds().toVersionLatest());
-    }
-    const componentStatusBeforeMergeAttempt = await mapSeries(bitIds, (id) =>
-      this.getComponentStatusBeforeMergeAttempt(id, currentLane, otherLane || null, options)
+    const mergeStatusProvider = new MergeStatusProvider(
+      this.workspace,
+      this.logger,
+      this.importer,
+      currentLane || undefined,
+      otherLane || undefined,
+      options
     );
-    const toImport = componentStatusBeforeMergeAttempt
-      .map((compStatus) => {
-        if (!compStatus.divergeData) return [];
-        const versionsToImport = compact([
-          ...compStatus.divergeData.snapsOnTargetOnly,
-          compStatus.divergeData.commonSnapBeforeDiverge,
-        ]);
-        return versionsToImport.map((v) => compStatus.id.changeVersion(v.toString()));
-      })
-      .flat();
-
-    await this.workspace.consumer.scope.scopeImporter.importWithoutDeps(BitIds.fromArray(toImport), {
-      lane: otherLane || undefined,
-      cache: true,
-      includeVersionHistory: false,
-    });
-
-    const compStatusNotNeedMerge = componentStatusBeforeMergeAttempt.filter(
-      (c) => !c.mergeProps
-    ) as ComponentMergeStatus[];
-    const compStatusNeedMerge = componentStatusBeforeMergeAttempt.filter((c) => c.mergeProps);
-
-    const getComponentsStatusNeedMerge = async (): Promise<ComponentMergeStatus[]> => {
-      const tmp = new Tmp(this.workspace.consumer.scope);
-      try {
-        const componentsStatus = await Promise.all(
-          compStatusNeedMerge.map((compStatus) =>
-            this.getComponentMergeStatus(currentLane, otherLane || undefined, compStatus)
-          )
-        );
-        await tmp.clear();
-        return componentsStatus;
-      } catch (err: any) {
-        await tmp.clear();
-        throw err;
-      }
-    };
-    const results = await getComponentsStatusNeedMerge();
-
-    results.push(...compStatusNotNeedMerge);
-    return results;
-  }
-
-  // eslint-disable-next-line complexity
-  private async getComponentStatusBeforeMergeAttempt(
-    id: BitId, // the id.version is the version we want to merge to the current component
-    localLane: Lane | null, // currently checked out lane. if on main, then it's null.
-    otherLane: Lane | null, // the lane we want to merged to our lane. (null if it's "main").
-    options?: { resolveUnrelated?: MergeStrategy; ignoreConfigChanges?: boolean }
-  ): Promise<ComponentMergeStatusBeforeMergeAttempt> {
-    const consumer = this.workspace.consumer;
-    const componentStatus: ComponentMergeStatusBeforeMergeAttempt = { id };
-    const returnUnmerged = (msg: string, unmergedLegitimately = false) => {
-      componentStatus.unmergedMessage = msg;
-      componentStatus.unmergedLegitimately = unmergedLegitimately;
-      return componentStatus;
-    };
-    const modelComponent = await consumer.scope.getModelComponentIfExist(id);
-    if (!modelComponent) {
-      return returnUnmerged(
-        `component ${id.toString()} is on the lane/main but its objects were not found, please re-import the lane`
-      );
-    }
-    const unmerged = consumer.scope.objects.unmergedComponents.getEntry(id.name);
-    if (unmerged) {
-      return returnUnmerged(
-        `component ${id.toStringWithoutVersion()} is in during-merge state a previous merge, please snap/tag it first (or use bit merge --resolve/--abort/ bit lane merge-abort)`
-      );
-    }
-    const repo = consumer.scope.objects;
-    const version = id.version as string;
-    const otherLaneHead = modelComponent.getRef(version);
-    const existingBitMapId = consumer.bitMap.getBitIdIfExist(id, { ignoreVersion: true });
-    const componentOnOther: Version = await modelComponent.loadVersion(version, consumer.scope.objects);
-    const idOnCurrentLane = localLane?.getComponent(id);
-
-    if (componentOnOther.isRemoved()) {
-      // if exist in current lane, we want the current lane to get the soft-remove update.
-      // or if it was removed with --update-main, we want to merge it so then main will get the update.
-      const shouldMerge = idOnCurrentLane || componentOnOther.shouldRemoveFromMain();
-      if (shouldMerge) {
-        // remove the component from the workspace if exist.
-        componentStatus.shouldBeRemoved = true;
-      } else {
-        // on main, don't merge soft-removed components unless it's marked with removeOnMain.
-        // on lane, if it's not part of the current lane, don't merge it.
-        return returnUnmerged(`component has been removed`, true);
-      }
-    }
-    const getCurrentId = () => {
-      if (existingBitMapId) return existingBitMapId;
-      if (localLane) {
-        if (!idOnCurrentLane) return null;
-        return idOnCurrentLane.id.changeVersion(idOnCurrentLane.head.toString());
-      }
-      // it's on main
-      const head = modelComponent.getHeadAsTagIfExist();
-      if (head) {
-        return id.changeVersion(head);
-      }
-      return null;
-    };
-    const currentId = getCurrentId();
-    if (!currentId) {
-      const divergeData = await getDivergeData({ repo, modelComponent, targetHead: otherLaneHead, throws: false });
-      return { ...componentStatus, componentFromModel: componentOnOther, divergeData };
-    }
-    const getCurrentComponent = () => {
-      if (existingBitMapId) return consumer.loadComponent(existingBitMapId);
-      return consumer.scope.getConsumerComponent(currentId);
-    };
-    const currentComponent = await getCurrentComponent();
-    if (currentComponent.isRemoved()) {
-      // we have a few options:
-      // 1. other is ahead. in this case, other recovered the component. so we can continue with the merge.
-      // it is possible that it is diverged, in which case, still continue with the merge, and later on, the
-      // merge-config will show a config conflict of the remove aspect.
-      // 2. other is not ahead. in this case, just ignore this component, no point to merge it, we want it removed.
-      // 3. there are errors when calculating the divergeData, e.g. no snap in common. in such cases, we assume
-      // there are issues with this component, and is better not to merge it.
-      const divergeData = await getDivergeData({ repo, modelComponent, targetHead: otherLaneHead, throws: false });
-      if (divergeData.err || !divergeData.isTargetAhead()) {
-        return returnUnmerged(`component has been removed`, true);
-      }
-    }
-
-    const isModified = async (): Promise<undefined | 'code' | 'config'> => {
-      const componentModificationStatus = await consumer.getComponentStatusById(currentComponent.id);
-      if (!componentModificationStatus.modified) return undefined;
-      if (!existingBitMapId) return undefined;
-      const baseComponent = await modelComponent.loadVersion(
-        existingBitMapId.version as string,
-        consumer.scope.objects
-      );
-      const isSourceCodeModified = await consumer.isComponentSourceCodeModified(baseComponent, currentComponent);
-      if (isSourceCodeModified) return 'code';
-      return 'config';
-    };
-
-    const modifiedType = await isModified();
-    if (modifiedType === 'config' && !options?.ignoreConfigChanges) {
-      return returnUnmerged(
-        `component has config changes, please snap/tag it first. alternatively, use --ignore-config-changes flag to bypass`
-      );
-    }
-    if (modifiedType === 'code') {
-      return returnUnmerged(`component is modified, please snap/tag it first`);
-    }
-
-    if (!otherLaneHead) {
-      throw new Error(`merging: unable finding a hash for the version ${version} of ${id.toString()}`);
-    }
-    const divergeData = await getDivergeData({
-      repo,
-      modelComponent,
-      targetHead: otherLaneHead,
-      throws: false,
-    });
-    if (divergeData.err) {
-      const mainHead = modelComponent.head;
-      if (divergeData.err instanceof NoCommonSnap && options?.resolveUnrelated) {
-        if (mainHead) {
-          const hasResolvedFromMain = async (hashToCompare: Ref | null) => {
-            const divergeDataFromMain = await getDivergeData({
-              repo,
-              modelComponent,
-              sourceHead: hashToCompare,
-              targetHead: mainHead,
-              throws: false,
-            });
-            if (!divergeDataFromMain.err) return true;
-            return !(divergeDataFromMain.err instanceof NoCommonSnap);
-          };
-          const hasResolvedLocally = await hasResolvedFromMain(modelComponent.getHeadRegardlessOfLane() as Ref);
-          const hasResolvedRemotely = await hasResolvedFromMain(otherLaneHead);
-          if (!hasResolvedLocally && !hasResolvedRemotely) {
-            return returnUnmerged(
-              `unable to traverse ${currentComponent.id.toString()} history. the main-head ${mainHead.toString()} doesn't appear in both lanes, it was probably created in each lane separately`
-            );
-          }
-          const versionToSaveInLane = hasResolvedLocally ? currentComponent.id.version : id.version;
-          const resolvedRef = modelComponent.getRef(versionToSaveInLane as string);
-          if (!resolvedRef) throw new Error(`unable to get ref of "${versionToSaveInLane}" for "${id.toString()}"`);
-          const unrelatedHead = hasResolvedLocally ? id.version : currentComponent.id.version;
-          const unrelatedHeadRef = modelComponent.getRef(unrelatedHead as string);
-          if (!unrelatedHeadRef) throw new Error(`unable to get ref of "${unrelatedHead}" for "${id.toString()}"`);
-          if (options?.resolveUnrelated === 'ours') {
-            return {
-              currentComponent,
-              id,
-              divergeData,
-              resolvedUnrelated: {
-                strategy: 'ours',
-                headOnLane: resolvedRef,
-                unrelatedHead: unrelatedHeadRef,
-                unrelatedLaneId: localLane?.toLaneId() as LaneId,
-                futureParent: resolvedRef,
-              },
-            };
-          }
-          if (options?.resolveUnrelated === 'theirs') {
-            // just override with the model data
-            return {
-              currentComponent,
-              componentFromModel: componentOnOther,
-              id,
-              divergeData,
-              resolvedUnrelated: {
-                strategy: 'theirs',
-                headOnLane: resolvedRef,
-                unrelatedHead: unrelatedHeadRef,
-                unrelatedLaneId: localLane?.toLaneId() as LaneId,
-                futureParent: resolvedRef,
-              },
-            };
-          }
-          throw new Error(
-            `unsupported strategy "${options?.resolveUnrelated}" of resolve-unrelated. supported strategies are: [ours, theirs]`
-          );
-        }
-        const versionToSaveInLane = options.resolveUnrelated === 'ours' ? currentComponent.id.version : id.version;
-        const unrelatedHead = options.resolveUnrelated === 'ours' ? id.version : currentComponent.id.version;
-        const resolvedRef = modelComponent.getRef(versionToSaveInLane as string);
-        if (!resolvedRef) throw new Error(`unable to get ref of "${versionToSaveInLane}" for "${id.toString()}"`);
-        const unrelatedHeadRef = modelComponent.getRef(unrelatedHead as string);
-        if (!unrelatedHeadRef) throw new Error(`unable to get ref of "${unrelatedHead}" for "${id.toString()}"`);
-        if (options.resolveUnrelated === 'ours') {
-          return {
-            currentComponent,
-            id,
-            divergeData,
-            resolvedUnrelated: {
-              headOnLane: resolvedRef,
-              strategy: 'ours',
-              unrelatedHead: unrelatedHeadRef,
-              unrelatedLaneId: otherLane?.toLaneId() as LaneId,
-              futureParent: resolvedRef,
-            },
-          };
-        }
-        if (options.resolveUnrelated === 'theirs') {
-          // just override with the model data
-          return {
-            currentComponent,
-            componentFromModel: componentOnOther,
-            id,
-            divergeData,
-            resolvedUnrelated: {
-              headOnLane: resolvedRef,
-              strategy: 'theirs',
-              unrelatedHead: unrelatedHeadRef,
-              unrelatedLaneId: localLane?.toLaneId() as LaneId,
-              futureParent: resolvedRef,
-            },
-          };
-        }
-        throw new Error(
-          `unsupported strategy "${options?.resolveUnrelated}" of resolve-unrelated. supported strategies are: [ours, theirs]`
-        );
-      }
-      return returnUnmerged(
-        `unable to traverse ${currentComponent.id.toString()} history. error: ${divergeData.err.message}`
-      );
-    }
-    if (!divergeData.isDiverged()) {
-      if (divergeData.isSourceAhead()) {
-        // do nothing!
-        return returnUnmerged(`component ${currentComponent.id.toString()} is ahead, nothing to merge`, true);
-      }
-      if (divergeData.isTargetAhead()) {
-        // just override with the model data
-        return {
-          ...componentStatus,
-          currentComponent,
-          componentFromModel: componentOnOther,
-          divergeData,
-        };
-      }
-      // we know that localHead and remoteHead are set, so if none of them is ahead they must be equal
-      return returnUnmerged(`component ${currentComponent.id.toString()} is already merged`, true);
-    }
-
-    // it's diverged and needs merge operation
-    const mergeProps = {
-      otherLaneHead,
-      currentId,
-      modelComponent,
-    };
-
-    return { ...componentStatus, currentComponent, mergeProps, divergeData };
-  }
-
-  private async getComponentMergeStatus(
-    localLane: Lane | null, // currently checked out lane. if on main, then it's null.
-    otherLane: Lane | undefined, // the lane name we want to merged to our lane. (can be also "main").
-    componentMergeStatusBeforeMergeAttempt: ComponentMergeStatusBeforeMergeAttempt
-  ) {
-    const { id, divergeData, currentComponent, mergeProps } = componentMergeStatusBeforeMergeAttempt;
-    if (!mergeProps) throw new Error(`getDivergedMergeStatus, mergeProps is missing for ${id.toString()}`);
-    const { otherLaneHead, currentId, modelComponent } = mergeProps;
-    const repo = this.workspace.consumer.scope.objects;
-    if (!divergeData) throw new Error(`getDivergedMergeStatus, divergeData is missing for ${id.toString()}`);
-    if (!currentComponent) throw new Error(`getDivergedMergeStatus, currentComponent is missing for ${id.toString()}`);
-
-    const baseSnap = divergeData.commonSnapBeforeDiverge as Ref; // must be set when isTrueMerge
-    this.logger.debug(`merging snaps details:
-id:      ${id.toStringWithoutVersion()}
-base:    ${baseSnap.toString()}
-current: ${currentId.version}
-other:   ${otherLaneHead.toString()}`);
-    const baseComponent: Version = await modelComponent.loadVersion(baseSnap.toString(), repo);
-    const otherComponent: Version = await modelComponent.loadVersion(otherLaneHead.toString(), repo);
-
-    const currentLaneName = localLane?.toLaneId().toString() || 'main';
-    const otherLaneName = otherLane ? otherLane.toLaneId().toString() : DEFAULT_LANE;
-    const currentLabel = `${currentId.version} (${currentLaneName === otherLaneName ? 'current' : currentLaneName})`;
-    const otherLabel = `${otherLaneHead.toString()} (${
-      otherLaneName === currentLaneName ? 'incoming' : otherLaneName
-    })`;
-    const workspaceIds = await this.workspace.listIds();
-    const configMerger = new ConfigMerger(
-      id.toStringWithoutVersion(),
-      workspaceIds,
-      otherLane,
-      currentComponent.extensions,
-      baseComponent.extensions,
-      otherComponent.extensions,
-      currentLabel,
-      otherLabel,
-      this.logger
-    );
-    const configMergeResult = configMerger.merge();
-
-    const mergeResults = await threeWayMerge({
-      consumer: this.workspace.consumer,
-      otherComponent,
-      otherLabel,
-      currentComponent,
-      currentLabel,
-      baseComponent,
-    });
-    return { currentComponent, id, mergeResults, divergeData, configMergeResult };
+    return mergeStatusProvider.getStatus(bitIds);
   }
 
   private async applyVersion({

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -53,10 +53,9 @@ import { MergeStatusProvider } from './merge-status-provider';
 
 type ResolveUnrelatedData = {
   strategy: MergeStrategy;
-  headOnLane: Ref;
+  headOnCurrentLane: Ref;
   unrelatedHead: Ref;
   unrelatedLaneId: LaneId;
-  futureParent: Ref;
 };
 type PkgEntry = { name: string; version: string; force: boolean };
 
@@ -565,10 +564,10 @@ export class MergingMain {
       // first and then merge with --resolve-unrelated
       if (!localLane) throw new Error('localLane must be defined when resolvedUnrelated');
       if (!resolvedUnrelated) throw new Error('resolvedUnrelated must be populated');
-      localLane.addComponent({ id, head: resolvedUnrelated.headOnLane });
+      localLane.addComponent({ id, head: resolvedUnrelated.headOnCurrentLane });
       unmergedComponent.unrelated = {
         unrelatedHead: resolvedUnrelated.unrelatedHead,
-        futureParent: resolvedUnrelated.futureParent,
+        headOnCurrentLane: resolvedUnrelated.headOnCurrentLane,
         unrelatedLaneId: resolvedUnrelated.unrelatedLaneId,
       };
       consumer.scope.objects.unmergedComponents.addEntry(unmergedComponent);

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -814,9 +814,16 @@ another option, in case this dependency is not in main yet is to remove all refe
             `source.previouslyUsedVersion must be set for ${component.name} because it's unrelated resolved.`
           );
         }
-        const unrelatedHead = Ref.from(source.previouslyUsedVersion);
-        version.unrelated = { head: unrelatedHead, laneId: unmergedComponent.laneId };
-        version.addAsOnlyParent(unmergedComponent.head);
+        if (unmergedComponent.unrelated === true) {
+          // backward compatibility
+          const unrelatedHead = Ref.from(source.previouslyUsedVersion);
+          version.setUnrelated({ head: unrelatedHead, laneId: unmergedComponent.laneId });
+          version.addAsOnlyParent(unmergedComponent.head);
+        } else {
+          const unrelated = unmergedComponent.unrelated;
+          version.setUnrelated({ head: unrelated.unrelatedHead, laneId: unrelated.unrelatedLaneId });
+          version.addAsOnlyParent(unrelated.futureParent);
+        }
       } else {
         // this is adding a second parent to the version. the order is important. the first parent is coming from the current-lane.
         version.addParent(unmergedComponent.head);

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -822,7 +822,7 @@ another option, in case this dependency is not in main yet is to remove all refe
         } else {
           const unrelated = unmergedComponent.unrelated;
           version.setUnrelated({ head: unrelated.unrelatedHead, laneId: unrelated.unrelatedLaneId });
-          version.addAsOnlyParent(unrelated.futureParent);
+          version.addAsOnlyParent(unrelated.headOnCurrentLane);
         }
       } else {
         // this is adding a second parent to the version. the order is important. the first parent is coming from the current-lane.

--- a/src/scope/lanes/unmerged-components.ts
+++ b/src/scope/lanes/unmerged-components.ts
@@ -11,24 +11,25 @@ export type UnmergedComponent = {
     scope?: string;
     name: string;
   };
+  /**
+   * the head of the other lane we merged from.
+   * this head will be the second parent of the snap-merge.
+   * an exception is when it's "unrelated", where it is using the unrelated props.
+   */
   head: Ref;
+  /**
+   * not in use anymore
+   */
   unmergedPaths?: string[];
-  /**
-   * @deprecated use laneId.remote instead
-   */
-  remote?: string;
-  /**
-   * @deprecated use laneId.name instead
-   */
-  lane: string;
   /**
    * can be main as well
    */
   laneId: LaneId;
   /**
-   * the head is coming from a component with the same name and scope but has no snap in common
+   * before 0.2.32 this was boolean. now it's an object with more data.
+   * it should be safe to remove the "boolean" around 11/2023
    */
-  unrelated?: boolean;
+  unrelated?: boolean | { unrelatedHead: Ref; unrelatedLaneId: LaneId; futureParent: Ref };
   /**
    * aspects config that were merged successfully
    */
@@ -48,12 +49,22 @@ export default class UnmergedComponents {
   static async load(scopePath: string): Promise<UnmergedComponents> {
     const filePath = path.join(scopePath, UNMERGED_FILENAME);
     let unmerged: UnmergedComponent[];
+    const loadUnrelated = (item) => {
+      if (item.unrelated === undefined) return undefined;
+      if (typeof item.unrelated === 'boolean') return item.unrelated;
+      return {
+        unrelatedHead: Ref.from(item.unrelated.unrelatedHead),
+        unrelatedLaneId: new LaneId(item.unrelated.unrelatedLaneId),
+        futureParent: Ref.from(item.unrelated.futureParent),
+      };
+    };
     try {
       const fileContent = await fs.readJson(filePath);
       unmerged = fileContent.map((item) => ({
         ...item,
         head: Ref.from(item.head),
         laneId: item.laneId ? new LaneId(item.laneId) : undefined,
+        unrelated: loadUnrelated(item),
       }));
     } catch (err: any) {
       if (err.code === 'ENOENT') {
@@ -110,7 +121,21 @@ export default class UnmergedComponents {
   }
 
   toObject() {
-    return this.unmerged.map((item) => ({ ...item, head: item.head.toString(), laneId: item.laneId.toObject() }));
+    const getUnrelated = (item: UnmergedComponent) => {
+      if (item.unrelated === undefined) return undefined;
+      if (typeof item.unrelated === 'boolean') return item.unrelated;
+      return {
+        unrelatedHead: item.unrelated.unrelatedHead.toString(),
+        unrelatedLaneId: item.unrelated.unrelatedLaneId.toObject(),
+        futureParent: item.unrelated.futureParent.toString(),
+      };
+    };
+    return this.unmerged.map((item) => ({
+      ...item,
+      head: item.head.toString(),
+      laneId: item.laneId.toObject(),
+      unrelated: getUnrelated(item),
+    }));
   }
 
   static buildSnapMessage(unmergedComponent: UnmergedComponent): string {

--- a/src/scope/lanes/unmerged-components.ts
+++ b/src/scope/lanes/unmerged-components.ts
@@ -29,7 +29,23 @@ export type UnmergedComponent = {
    * before 0.2.33 this was boolean. now it's an object with more data.
    * it should be safe to remove the "boolean" around 11/2023
    */
-  unrelated?: boolean | { unrelatedHead: Ref; unrelatedLaneId: LaneId; futureParent: Ref };
+  unrelated?:
+    | boolean
+    | {
+        /**
+         * this will be saved in the Version.unrelated.head
+         */
+        unrelatedHead: Ref;
+        /**
+         * this will be saved in the Version.unrelated.laneId
+         */
+        unrelatedLaneId: LaneId;
+        /**
+         * this will be the parent of the snap-merge.
+         * (so basically, the history of the component is determined by this ref)
+         */
+        headOnCurrentLane: Ref;
+      };
   /**
    * aspects config that were merged successfully
    */
@@ -55,7 +71,7 @@ export default class UnmergedComponents {
       return {
         unrelatedHead: Ref.from(item.unrelated.unrelatedHead),
         unrelatedLaneId: new LaneId(item.unrelated.unrelatedLaneId),
-        futureParent: Ref.from(item.unrelated.futureParent),
+        headOnCurrentLane: Ref.from(item.unrelated.headOnCurrentLane),
       };
     };
     try {
@@ -127,7 +143,7 @@ export default class UnmergedComponents {
       return {
         unrelatedHead: item.unrelated.unrelatedHead.toString(),
         unrelatedLaneId: item.unrelated.unrelatedLaneId.toObject(),
-        futureParent: item.unrelated.futureParent.toString(),
+        headOnCurrentLane: item.unrelated.headOnCurrentLane.toString(),
       };
     };
     return this.unmerged.map((item) => ({

--- a/src/scope/lanes/unmerged-components.ts
+++ b/src/scope/lanes/unmerged-components.ts
@@ -26,7 +26,7 @@ export type UnmergedComponent = {
    */
   laneId: LaneId;
   /**
-   * before 0.2.32 this was boolean. now it's an object with more data.
+   * before 0.2.33 this was boolean. now it's an object with more data.
    * it should be safe to remove the "boolean" around 11/2023
    */
   unrelated?: boolean | { unrelatedHead: Ref; unrelatedLaneId: LaneId; futureParent: Ref };

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -713,6 +713,10 @@ export default class Version extends BitObject {
     }
   }
 
+  setUnrelated(externalHead: ExternalHead) {
+    this.unrelated = externalHead;
+  }
+
   addModifiedLog(log: Log) {
     this.modified.push(log);
   }

--- a/src/scope/version-validator.ts
+++ b/src/scope/version-validator.ts
@@ -280,7 +280,7 @@ ${duplicationStr}`);
   }
   const unrelatedHead = version.unrelated?.head;
   if (unrelatedHead && version.parents.some((p) => p.isEqual(unrelatedHead))) {
-    if (version.bitVersion && gt(version.bitVersion, '0.2.31'))
+    if (version.bitVersion && gt(version.bitVersion, '0.2.33'))
       throw new VersionInvalid(`${message}, the unrelated.head is the same as the parent: ${unrelatedHead.toString()}`);
   }
   const schema = version.schema || SchemaName.Legacy;

--- a/src/scope/version-validator.ts
+++ b/src/scope/version-validator.ts
@@ -278,6 +278,11 @@ ${duplicationStr}`);
       }
     });
   }
+  const unrelatedHead = version.unrelated?.head;
+  if (unrelatedHead && version.parents.some((p) => p.isEqual(unrelatedHead))) {
+    if (version.bitVersion && gt(version.bitVersion, '0.2.31'))
+      throw new VersionInvalid(`${message}, the unrelated.head is the same as the parent: ${unrelatedHead.toString()}`);
+  }
   const schema = version.schema || SchemaName.Legacy;
   if (!version.isLegacy) {
     const fieldsForSchemaCheck = ['compiler', 'tester', 'dists', 'mainDistFile'];


### PR DESCRIPTION
Until now, this `--resolve-unrelated` flag was working only when the component was on main, because in this scenario we know what history to keep (the one from main).
This PR handles the case where two lanes created the same component, but that component is not on main.
To decide which history to keep, we use the strategy passed to the `--resolve-unrelated` flag, which can be either `ours` or `theirs`.