### PR TITLE
fixes(UI): sync UI fixes from cloud

### DIFF
--- a/components/ui/compare/lane-compare-drawer/lane-compare-drawer-name.module.scss
+++ b/components/ui/compare/lane-compare-drawer/lane-compare-drawer-name.module.scss
@@ -7,6 +7,10 @@
   justify-content: space-between;
 }
 
+.closed {
+  visibility: hidden;
+}
+
 .versionContainer {
   display: flex;
   align-items: center;
@@ -77,4 +81,16 @@
     height: 14px;
     width: 14px;
   }
+}
+
+.fullHeight {
+  height: 100%;
+}
+
+.autoHeight {
+  height: auto;
+}
+
+.noHeight {
+  height: 0;
 }

--- a/components/ui/compare/lane-compare-drawer/lane-compare-drawer-name.tsx
+++ b/components/ui/compare/lane-compare-drawer/lane-compare-drawer-name.tsx
@@ -20,6 +20,7 @@ const shortenVersion = (version?: string) => (semver.valid(version) ? version : 
 export function LaneCompareDrawerName({ baseId, compareId, open, leftWidget }: LaneCompareDrawerNameProps) {
   const status = !baseId ? 'new' : (!compareId?.isEqual(baseId) && 'modified') || undefined;
   const key = `drawer-name-${baseId}-${compareId}`;
+
   return (
     <div key={key} className={classnames(styles.drawerNameContainer, open && styles.open)}>
       <div className={styles.left}>
@@ -27,9 +28,9 @@ export function LaneCompareDrawerName({ baseId, compareId, open, leftWidget }: L
         <div className={styles.status}>{status && <CompareStatusResolver status={status} />}</div>
         <div className={classnames(styles.compId, ellipsis)}>{compareId?.toStringWithoutVersion()}</div>
         <div className={styles.versionContainer}>
-          {compareId && (
-            <Tooltip content={compareId.version} placement={'bottom'}>
-              <div className={styles.version}>{shortenVersion(compareId?.version)}</div>
+          {baseId && (
+            <Tooltip content={baseId.version} placement={'bottom'}>
+              <div className={styles.version}>{shortenVersion(baseId?.version)}</div>
             </Tooltip>
           )}
           {baseId && (
@@ -37,9 +38,9 @@ export function LaneCompareDrawerName({ baseId, compareId, open, leftWidget }: L
               <img src="https://static.bit.dev/bit-icons/arrow-right.svg"></img>
             </div>
           )}
-          {baseId && (
-            <Tooltip content={baseId.version} placement={'bottom'}>
-              <div className={styles.version}>{shortenVersion(baseId?.version)}</div>
+          {compareId && (
+            <Tooltip content={compareId.version} placement={'bottom'}>
+              <div className={styles.version}>{shortenVersion(compareId?.version)}</div>
             </Tooltip>
           )}
         </div>

--- a/components/ui/compare/lane-compare-drawer/lane-compare-drawer.tsx
+++ b/components/ui/compare/lane-compare-drawer/lane-compare-drawer.tsx
@@ -1,9 +1,9 @@
 import React, { HTMLAttributes } from 'react';
-import AnimateHeight from 'react-animate-height';
 import { ComponentCompareProps } from '@teambit/component.ui.component-compare.models.component-compare-props';
 import { DrawerProps, DrawerUI } from '@teambit/ui-foundation.ui.tree.drawer';
 import { ComponentCompare } from '@teambit/component.ui.component-compare.component-compare';
 import { computeStateKey } from '@teambit/lanes.ui.compare.lane-compare-state';
+import classnames from 'classnames';
 
 import styles from './lane-compare-drawer-name.module.scss';
 
@@ -11,6 +11,8 @@ export type LaneCompareDrawerProps = {
   compareProps: ComponentCompareProps;
   drawerProps: DrawerProps;
   isFullScreen?: boolean;
+  lastInteracted?: boolean;
+  onInteract?: (e: React.MouseEvent<HTMLDivElement>) => void;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function LaneCompareDrawer({ drawerProps, compareProps, isFullScreen }: LaneCompareDrawerProps) {
@@ -18,14 +20,19 @@ export function LaneCompareDrawer({ drawerProps, compareProps, isFullScreen }: L
   const { baseId, compareId } = compareProps;
   const key = computeStateKey(baseId, compareId);
 
+  const fullScreenStyles = isFullScreen ? styles.fullScreenDrawer : undefined;
+  const heightStyles = open ? (isFullScreen && styles.fullHeight) || styles.autoHeight : styles.noHeight || undefined;
+
   return (
-    <DrawerUI key={`${key}-lane-drawer`} {...drawerProps}>
-      <AnimateHeight
-        height={open ? (isFullScreen && '100%') || 'auto' : 0}
-        className={(isFullScreen && styles.fullScreenDrawer) || undefined}
-      >
-        {(!!open && <ComponentCompare key={`lane-compare-component-compare-${key}`} {...compareProps} />) || <></>}
-      </AnimateHeight>
-    </DrawerUI>
+    <div className={classnames(styles.drawerRoot)} key={key}>
+      <DrawerUI key={`${key}-lane-drawer`} {...drawerProps}>
+        <ComponentCompare
+          hidden={!open}
+          className={classnames(!open && styles.closed, fullScreenStyles, heightStyles)}
+          key={`lane-compare-component-compare-${key}`}
+          {...compareProps}
+        />
+      </DrawerUI>
+    </div>
   );
 }

--- a/components/ui/compare/lane-compare-page/lane-compare-page.tsx
+++ b/components/ui/compare/lane-compare-page/lane-compare-page.tsx
@@ -18,11 +18,15 @@ export function LaneComparePage({
   useLanes = defaultUseLanes,
   ...rest
 }: LaneComparePageProps) {
-  const { lanesModel, loading, fetchMoreLanes, hasMore, offset, limit } = useLanes();
+  const { lanesModel, loading, fetchMoreLanes, hasMore, offset, limit } = useLanes(undefined, undefined, {
+    offset: 0,
+    limit: 10,
+  });
   const [base, setBase] = useState<LaneModel | undefined>();
   const defaultLane = lanesModel?.getDefaultLane();
   const compare = lanesModel?.viewedLane;
   const nonMainLanes = lanesModel?.getNonMainLanes() || [];
+
   useEffect(() => {
     if (!base && !compare?.id.isDefault() && defaultLane) {
       setBase(defaultLane);
@@ -36,7 +40,7 @@ export function LaneComparePage({
 
   const lanes: Array<LaneModel> = useMemo(() => {
     return nonMainLanes.filter((l) => l.toString() !== compare?.id.toString());
-  }, [base?.id.toString(), compare?.id.toString(), lanesModel?.lanes.length]);
+  }, [base?.id.toString(), compare?.id.toString(), nonMainLanes.length]);
 
   if (!lanesModel) return null;
   if (!lanesModel.viewedLane) return null;

--- a/components/ui/compare/lane-compare/lane-compare.context.ts
+++ b/components/ui/compare/lane-compare/lane-compare.context.ts
@@ -1,0 +1,31 @@
+import { createContext, useContext } from 'react';
+import { LaneCompareState } from '@teambit/lanes.ui.compare.lane-compare-state';
+import { LaneComponentDiff, LaneDiff } from '@teambit/lanes.entities.lane-diff';
+import { ComponentID } from '@teambit/component-id';
+import { DefaultLaneState, LaneFilter } from './lane-compare';
+
+export type LaneCompareContextModel = {
+  laneCompareState: LaneCompareState;
+  setLaneCompareState: React.Dispatch<React.SetStateAction<LaneCompareState>>;
+  fullScreenDrawerKey: string | undefined;
+  setFullScreen: React.Dispatch<React.SetStateAction<string | undefined>>;
+  openDrawerList: string[];
+  setOpenDrawerList: React.Dispatch<React.SetStateAction<string[]>>;
+  lastDrawerInteractedWith?: string;
+  setLastDrawerInteractedWith: React.Dispatch<React.SetStateAction<string | undefined>>;
+  filters?: LaneFilter[];
+  groupBy?: 'scope' | 'status';
+  defaultLaneState: DefaultLaneState;
+  laneDiff?: LaneDiff;
+  loadingLaneDiff?: boolean;
+  componentsToDiff: [ComponentID | undefined, ComponentID | undefined][];
+  groupedComponentsToDiff: Map<string, [ComponentID | undefined, ComponentID | undefined][]> | null;
+  laneComponentDiffByCompId: Map<string, LaneComponentDiff>;
+};
+
+export const LaneCompareContext = createContext<LaneCompareContextModel | undefined>(undefined);
+
+export const useLaneCompareContext = (): LaneCompareContextModel | undefined => {
+  const context = useContext(LaneCompareContext);
+  return context;
+};

--- a/components/ui/compare/lane-compare/lane-compare.provider.tsx
+++ b/components/ui/compare/lane-compare/lane-compare.provider.tsx
@@ -1,0 +1,239 @@
+import React, { ReactNode, useCallback, useEffect, useMemo, useState } from 'react';
+import { LaneCompareState, computeStateKey } from '@teambit/lanes.ui.compare.lane-compare-state';
+import { ComponentCompareState } from '@teambit/component.ui.component-compare.models.component-compare-state';
+import { MaybeLazyLoaded, extractLazyLoadedData } from '@teambit/component.ui.component-compare.utils.lazy-loading';
+import { sortTabs } from '@teambit/component.ui.component-compare.utils.sort-tabs';
+import { compact, isEqual } from 'lodash';
+import { TabItem } from '@teambit/component.ui.component-compare.models.component-compare-props';
+import { LaneId } from '@teambit/lane-id';
+import {
+  useLaneDiffStatus as defaultUseLaneDiffStatus,
+  UseLaneDiffStatus,
+} from '@teambit/lanes.ui.compare.lane-compare-hooks.use-lane-diff-status';
+import { LaneComponentDiff } from '@teambit/lanes.entities.lane-diff';
+import { ComponentID } from '@teambit/component-id';
+import { LaneFilter, extractCompsToDiff, filterDepKey } from './lane-compare';
+import { LaneCompareContext, LaneCompareContextModel } from './lane-compare.context';
+
+export type LaneCompareGroupBy = 'scope' | 'status';
+
+export type LaneCompareProviderProps = {
+  children: ReactNode;
+  /**
+   * default state of all component compare drawers
+   */
+  defaultComponentCompareState?: LaneCompareState;
+  /**
+   * default open drawers - comp ids keys
+   */
+  defaultOpenDrawers?: string[];
+  /**
+   * default full screen drawer
+   */
+  defaultFullScreen?: string;
+  /**
+   * filters to apply to component diffs
+   */
+  filters?: Array<LaneFilter>;
+  /**
+   * filter out component diffs by type
+   */
+  filter?: (laneComponentDiff?: LaneComponentDiff, filters?: Array<LaneFilter>) => boolean;
+  /**
+   * group component diffs by diff status or scope
+   */
+  groupBy?: LaneCompareGroupBy;
+  /**
+   * hook to override fetching lane diff status for base and compare
+   */
+  useLaneDiffStatus?: UseLaneDiffStatus;
+  base?: LaneId;
+  compare?: LaneId;
+  tabs?: MaybeLazyLoaded<TabItem[]>;
+};
+
+function _LaneCompareProvider({
+  defaultComponentCompareState,
+  tabs,
+  children,
+  defaultOpenDrawers,
+  defaultFullScreen,
+  useLaneDiffStatus = defaultUseLaneDiffStatus,
+  base,
+  compare,
+  filters,
+  groupBy,
+  filter,
+}: LaneCompareProviderProps) {
+  const { loading: loadingLaneDiff, laneDiff } = useLaneDiffStatus({
+    baseId: base?.toString(),
+    compareId: compare?.toString(),
+    options: {
+      skipUpToDate: true,
+    },
+  });
+
+  const componentsToDiff = useMemo(
+    () => extractCompsToDiff(laneDiff),
+    [loadingLaneDiff, base?.toString(), compare?.toString()]
+  );
+
+  const defaultLaneState = useCallback(
+    (compId?: string) => {
+      const _tabs = extractLazyLoadedData(tabs)?.sort(sortTabs);
+
+      const defaultState = (compId && defaultComponentCompareState?.get(compId)) || {};
+
+      const value: ComponentCompareState = {
+        tabs: {
+          controlled: true,
+          id: _tabs && _tabs[0].id,
+          element: _tabs && _tabs[0].element,
+        },
+        code: {
+          controlled: true,
+        },
+        aspects: {
+          controlled: true,
+        },
+        preview: {
+          controlled: true,
+        },
+        versionPicker: {
+          element: null,
+        },
+        ...defaultState,
+      };
+      return value;
+    },
+    [defaultComponentCompareState]
+  );
+
+  const [laneCompareState, setLaneCompareState] = useState<LaneCompareState>(() => {
+    const state = new Map();
+    componentsToDiff.forEach(([_base, _compare]) => {
+      const key = computeStateKey(_base, _compare);
+      const baseKey = computeStateKey(_base);
+      const compareKey = computeStateKey(undefined, _compare);
+      state.set(key, defaultLaneState(key));
+      state.set(baseKey, defaultLaneState(baseKey));
+      state.set(compareKey, defaultLaneState(compareKey));
+    });
+    return state;
+  });
+
+  const [openDrawerList, setOpenDrawerList] = useState<string[]>(
+    defaultOpenDrawers ??
+      compact(
+        componentsToDiff.map(([_base, _compare]) => {
+          const drawerKey = _compare?.toStringWithoutVersion() ?? _base?.toStringWithoutVersion();
+          return drawerKey;
+        })
+      )
+  );
+
+  const [fullScreenDrawerKey, setFullScreen] = useState<string | undefined>(defaultFullScreen);
+
+  useEffect(() => {
+    if (componentsToDiff.length > 0) {
+      const compareState: LaneCompareState = new Map(defaultComponentCompareState);
+      const drawerKeys: string[] = [];
+
+      componentsToDiff.forEach(([_base, _compare]) => {
+        const key = computeStateKey(_base, _compare);
+        const baseKey = computeStateKey(_base);
+        const compareKey = computeStateKey(undefined, _compare);
+        compareState.set(key, defaultLaneState(key));
+        compareState.set(baseKey, defaultLaneState(baseKey));
+        compareState.set(compareKey, defaultLaneState(compareKey));
+        // const drawerKey = _compare?.toStringWithoutVersion() ?? _base?.toStringWithoutVersion();
+        // if (drawerKey) drawerKeys.push(drawerKey);
+      });
+
+      setLaneCompareState(compareState);
+      setFullScreen(defaultFullScreen);
+      setOpenDrawerList(defaultOpenDrawers ?? drawerKeys);
+    }
+  }, [loadingLaneDiff, componentsToDiff.length, base?.toString(), compare?.toString(), defaultComponentCompareState]);
+
+  useEffect(() => {
+    if (defaultOpenDrawers && !isEqual(openDrawerList, defaultOpenDrawers)) {
+      setOpenDrawerList(defaultOpenDrawers);
+    }
+  }, [defaultOpenDrawers?.join('')]);
+
+  useEffect(() => {
+    if (defaultFullScreen && fullScreenDrawerKey !== defaultFullScreen) {
+      setFullScreen(defaultFullScreen);
+    }
+  }, [defaultFullScreen]);
+
+  const laneComponentDiffByCompId = useMemo(() => {
+    if (!laneDiff) return new Map<string, LaneComponentDiff>();
+    return laneDiff.diff.reduce((accum, next) => {
+      accum.set(next.componentId.toStringWithoutVersion(), next as any);
+      return accum;
+    }, new Map<string, LaneComponentDiff>());
+  }, [base?.toString(), compare?.toString(), loadingLaneDiff]);
+
+  const groupedComponentsToDiff = useMemo(() => {
+    if (laneComponentDiffByCompId.size === 0) return null;
+    return componentsToDiff
+      .filter((comps) => {
+        if (!filter) return comps;
+        const comp = comps[1] || comps[0];
+        if (!comp) return comps;
+        return filter(laneComponentDiffByCompId.get(comp.toStringWithoutVersion()), filters);
+      })
+      .reduce((accum, [baseId, compareId]) => {
+        const compareIdStrWithoutVersion = compareId?.toStringWithoutVersion();
+        const laneCompDiff = !compareIdStrWithoutVersion
+          ? undefined
+          : laneComponentDiffByCompId.get(compareIdStrWithoutVersion);
+
+        const changeType = laneCompDiff?.changeType;
+
+        const key = !groupBy ? compareIdStrWithoutVersion : (groupBy === 'status' && changeType) || compareId?.scope;
+
+        if (!key) {
+          return accum;
+        }
+
+        const existing = accum.get(key) || [];
+        accum.set(key, existing.concat([[baseId, compareId]]));
+        return accum;
+      }, new Map<string, Array<[ComponentID | undefined, ComponentID | undefined]>>());
+  }, [
+    base?.toString(),
+    compare?.toString(),
+    laneComponentDiffByCompId.size,
+    loadingLaneDiff,
+    laneDiff,
+    filterDepKey(filters),
+  ]);
+
+  const [lastDrawerInteractedWith, setLastDrawerInteractedWith] = React.useState<string | undefined>();
+
+  const laneCompareContextModel: LaneCompareContextModel = {
+    laneCompareState,
+    setLaneCompareState,
+    openDrawerList,
+    setOpenDrawerList,
+    fullScreenDrawerKey,
+    setFullScreen,
+    filters,
+    groupBy,
+    defaultLaneState,
+    laneDiff,
+    loadingLaneDiff,
+    componentsToDiff,
+    groupedComponentsToDiff,
+    laneComponentDiffByCompId,
+    lastDrawerInteractedWith,
+    setLastDrawerInteractedWith,
+  };
+
+  return <LaneCompareContext.Provider value={laneCompareContextModel}>{children}</LaneCompareContext.Provider>;
+}
+
+export const LaneCompareProvider = React.memo(_LaneCompareProvider);

--- a/components/ui/component-compare/component-compare/component-compare.module.scss
+++ b/components/ui/component-compare/component-compare/component-compare.module.scss
@@ -16,6 +16,10 @@
   overflow: hidden;
   flex-direction: column;
   flex: 1;
+
+  &.hidden {
+    display: none;
+  }
   // padding-bottom: 16px;
 }
 

--- a/components/ui/component-compare/component-compare/component-compare.tsx
+++ b/components/ui/component-compare/component-compare/component-compare.tsx
@@ -1,7 +1,14 @@
 import React, { useContext, useMemo, HTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { LegacyComponentLog } from '@teambit/legacy-component-log';
-import { CollapsibleMenuNav, ComponentContext, ComponentID, NavPlugin, useComponent } from '@teambit/component';
+import {
+  CollapsibleMenuNav,
+  ComponentContext,
+  ComponentDescriptorContext,
+  ComponentID,
+  NavPlugin,
+  useComponent,
+} from '@teambit/component';
 import { ComponentCompareContext } from '@teambit/component.ui.component-compare.context';
 import { useComponentCompareQuery } from '@teambit/component.ui.component-compare.hooks.use-component-compare';
 import {
@@ -52,10 +59,12 @@ export function ComponentCompare(props: ComponentCompareProps) {
     baseContext,
     compareContext,
     isFullScreen,
+    hidden = false,
     ...rest
   } = props;
   const baseVersion = useCompareQueryParam('baseVersion');
   const component = useContext(ComponentContext);
+  const componentDescriptor = useContext(ComponentDescriptorContext);
   const location = useLocation();
   const isWorkspace = host === 'teambit.workspace/workspace';
 
@@ -63,8 +72,8 @@ export function ComponentCompare(props: ComponentCompareProps) {
     component: compareComponent,
     loading: loadingCompare,
     componentDescriptor: compareComponentDescriptor,
-  } = useComponent(host, _compareId?.toString() || '', {
-    skip: !_compareId,
+  } = useComponent(host, _compareId?.toString(), {
+    skip: hidden || !_compareId,
     customUseComponent,
     logFilters: {
       log: {
@@ -103,7 +112,7 @@ export function ComponentCompare(props: ComponentCompareProps) {
     componentDescriptor: baseComponentDescriptor,
   } = useComponent(host, baseId?.toString(), {
     customUseComponent,
-    skip: !baseId,
+    skip: hidden || !baseId,
     logFilters: {
       log: {
         limit: 3,
@@ -122,7 +131,7 @@ export function ComponentCompare(props: ComponentCompareProps) {
   }, [compare?.id.toString()]);
 
   const skipComponentCompareQuery =
-    compareIsLocalChanges || base?.id.version?.toString() === compare?.id.version?.toString();
+    hidden || compareIsLocalChanges || base?.id.version?.toString() === compare?.id.version?.toString();
 
   const { loading: compCompareLoading, componentCompareData } = useComponentCompareQuery(
     base?.id.toString(),
@@ -165,7 +174,7 @@ export function ComponentCompare(props: ComponentCompareProps) {
   const componentCompareModel = {
     compare: compare && {
       model: compare,
-      descriptor: compareComponentDescriptor,
+      descriptor: compareComponentDescriptor || componentDescriptor,
       hasLocalChanges: compareIsLocalChanges,
     },
     base: base && {
@@ -182,6 +191,7 @@ export function ComponentCompare(props: ComponentCompareProps) {
     fileCompareDataByName,
     testCompareDataByName,
     isFullScreen,
+    hidden,
   };
 
   const changes =
@@ -229,7 +239,9 @@ function RenderCompareScreen(
     compareVersion,
     compareHasLocalChanges,
     componentId,
+    hidden,
   } = props;
+
   const showVersionPicker = state?.versionPicker?.element !== null;
 
   return (
@@ -250,7 +262,7 @@ function RenderCompareScreen(
       )}
       {loading && <Loader className={classnames(styles.loader)} />}
       {!loading && (
-        <div className={styles.bottom}>
+        <div className={classnames(styles.bottom, hidden && styles.hidden)}>
           <CompareMenuNav {...props} />
           {(extractLazyLoadedData(routes) || []).length > 0 && (
             <SlotRouter routes={extractLazyLoadedData(routes) || []} />

--- a/components/ui/component-compare/context/component-compare-context.ts
+++ b/components/ui/component-compare/context/component-compare-context.ts
@@ -12,7 +12,9 @@ export type ComponentCompareContextType = ComponentCompareModel &
   StateAndHooks & {
     baseContext?: StateAndHooks;
     compareContext?: StateAndHooks;
+  } & {
     isFullScreen?: boolean;
+    hidden?: boolean;
   };
 
 export const ComponentCompareContext = createContext<ComponentCompareContextType | undefined>(undefined);

--- a/components/ui/component-compare/layouts/compare-split-layout-preset/compare-split-layout-preset.module.scss
+++ b/components/ui/component-compare/layouts/compare-split-layout-preset/compare-split-layout-preset.module.scss
@@ -1,19 +1,21 @@
 .mainContainer {
   display: flex;
   height: 100%;
-  overflow: hidden;
 }
 
 .subContainerLeft {
   flex: 1;
-  background-color: #ededed;
+  background-color: var(--border-medium-color);
   padding-right: 4px;
+  padding-left: 1px;
+  padding-top: 1px;
+  padding-bottom: 1px;
 }
 
 .subContainerRight {
   flex: 1;
-  background-color: #ededed;
-  padding-left: 4px;
+  background-color: var(--border-medium-color);
+  padding: 1px 1px 1px 1px;
 }
 
 .loader {

--- a/components/ui/component-compare/version-picker/component-compare-version-picker.tsx
+++ b/components/ui/component-compare/version-picker/component-compare-version-picker.tsx
@@ -2,7 +2,7 @@ import React, { HTMLAttributes } from 'react';
 import { DetailedVersion, VersionDropdown } from '@teambit/component.ui.version-dropdown';
 import { useUpdatedUrlFromQuery } from '@teambit/component.ui.component-compare.hooks.use-component-compare-url';
 import { useComponentCompare } from '@teambit/component.ui.component-compare.context';
-import { UseComponentType, useComponent } from '@teambit/component';
+import { UseComponentType } from '@teambit/component';
 import classNames from 'classnames';
 import * as semver from 'semver';
 
@@ -36,6 +36,7 @@ export function ComponentCompareVersionPicker({
   const useVersions = React.useCallback(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     (filter: (version: string) => boolean = (version) => true) =>
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       (props?: { skip?: boolean }) => {
         return {
           loading: loadingLogs,

--- a/components/ui/inputs/lane-selector/lane-grouped-menu-item.module.scss
+++ b/components/ui/inputs/lane-selector/lane-grouped-menu-item.module.scss
@@ -4,6 +4,10 @@
   // min-width: 120px;
 }
 
+.scopeName {
+  font-size: var(--bit-p-xs);
+}
+
 .scope {
   padding: 8px 16px;
   color: var(--on-surface-medium-color, #707279);

--- a/components/ui/navigation/lane-switcher/lane-switcher.tsx
+++ b/components/ui/navigation/lane-switcher/lane-switcher.tsx
@@ -1,4 +1,4 @@
-import React, { HTMLAttributes, useRef } from 'react';
+import React, { HTMLAttributes } from 'react';
 import { UseLanes, useLanes as defaultUseLanes } from '@teambit/lanes.hooks.use-lanes';
 import { LaneSelector } from '@teambit/lanes.ui.inputs.lane-selector';
 import { LanesModel } from '@teambit/lanes.ui.models.lanes-model';
@@ -41,8 +41,10 @@ export function LaneSwitcher({
   getHref = LanesModel.getLaneUrl,
   ...rest
 }: LaneSwitcherProps) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const { lanesModel, loading, fetchMoreLanes, hasMore, offset, limit } = useLanes();
+  const { lanesModel, loading, fetchMoreLanes, hasMore, offset, limit } = useLanes(undefined, undefined, {
+    offset: 0,
+    limit: 10,
+  });
 
   const mainLane = lanesModel?.getDefaultLane();
   const nonMainLanes = lanesModel?.getNonMainLanes() || [];
@@ -60,7 +62,7 @@ export function LaneSwitcher({
   const selectedLaneGalleryHref = selectedLane && getHref(selectedLane.id);
 
   return (
-    <div className={classnames(styles.laneSwitcherContainer, className)} ref={containerRef}>
+    <div className={classnames(styles.laneSwitcherContainer, className)}>
       <div className={styles.laneSelectorContainer}>
         {loading && <WordSkeleton className={styles.loader} length={24} />}
         {

--- a/components/ui/surfaces/menu/section/section.module.scss
+++ b/components/ui/surfaces/menu/section/section.module.scss
@@ -3,11 +3,11 @@
   // border-bottom: 1px solid var(--bit-border-color-lightest, #ededed);
   margin: 12px 0;
   font-size: var(--bit-p-xs);
+  overflow: hidden;
 }
 
 // `> *` doesn't add specificity, so adding 'div' instead
 // could use a --menu-indention variable instead
 div.menuSection > * {
   padding-left: 30px;
-  overflow: hidden;
 }

--- a/components/ui/surfaces/menu/section/section.module.scss
+++ b/components/ui/surfaces/menu/section/section.module.scss
@@ -3,7 +3,9 @@
   // border-bottom: 1px solid var(--bit-border-color-lightest, #ededed);
   margin: 12px 0;
   font-size: var(--bit-p-xs);
-  overflow: hidden;
+  > a {
+    overflow: hidden;
+  }
 }
 
 // `> *` doesn't add specificity, so adding 'div' instead

--- a/scopes/code/ui/code-compare/code-compare-tree/code-compare-tree.tsx
+++ b/scopes/code/ui/code-compare/code-compare-tree/code-compare-tree.tsx
@@ -19,6 +19,7 @@ export type CodeCompareTreeProps = {
   widgets?: ComponentType<WidgetProps<any>>[];
   getHref?: (node: TreeNode) => string;
   onTreeNodeSelected?: (id: string, event?: React.MouseEvent) => void;
+  open?: boolean;
 } & HTMLAttributes<HTMLDivElement>;
 
 export function CodeCompareTree({
@@ -29,6 +30,7 @@ export function CodeCompareTree({
   drawerName,
   widgets,
   getHref,
+  open,
   onTreeNodeSelected,
 }: CodeCompareTreeProps) {
   const fileIconMatchers: FileIconMatch[] = useMemo(() => flatten(fileIconSlot?.values()), [fileIconSlot]);
@@ -46,6 +48,8 @@ export function CodeCompareTree({
     }
     onToggleDrawer((list) => list.concat(id));
   };
+
+  if (!open) return null;
 
   return (
     <div className={classNames(styles.componentCompareCodeTreeContainer, className)}>

--- a/scopes/code/ui/code-compare/code-compare.module.scss
+++ b/scopes/code/ui/code-compare/code-compare.module.scss
@@ -4,6 +4,10 @@
   display: flex;
   height: 100%;
   width: 100%;
+
+  &.hidden {
+    display: none;
+  }
 }
 
 .right {
@@ -16,15 +20,16 @@
     //cannot assign max-width directly to right side
     max-width: calc(100% - 32px);
   }
+  background: var(--on-surface-neutral-low-color, #282828) !important;
 }
 
 .left {
   position: relative;
   background: var(--on-surface-neutral-low-color, #282828);
-  overflow-y: auto;
   // this is to fix the right panel when it gets too big or too small
   min-width: 200px;
   max-width: calc(100% - 200px);
+
   &.collapsed {
     min-width: 32px;
     //cannot assign max-width directly to right side
@@ -34,8 +39,8 @@
 
 .splitter {
   position: relative;
-  // @todo get token for this color
   background: var(--on-surface-neutral-low-color, #282828);
+  // display: none;
 
   > :first-child {
     z-index: $pane-splitter-zIndex;

--- a/scopes/code/ui/code-compare/code-compare.tsx
+++ b/scopes/code/ui/code-compare/code-compare.tsx
@@ -32,7 +32,7 @@ export function CodeCompare({ fileIconSlot, className, CodeView = CodeCompareVie
   const query = useQuery();
   const location = useLocation() || { pathname: '/' };
 
-  const { base, compare, state: compareState, hooks: compareHooks, hidden, loading } = componentCompareContext || {};
+  const { base, compare, state: compareState, hooks: compareHooks, hidden } = componentCompareContext || {};
 
   const state = compareState?.code;
   const hook = compareHooks?.code;

--- a/scopes/code/ui/code-compare/code-compare.tsx
+++ b/scopes/code/ui/code-compare/code-compare.tsx
@@ -32,20 +32,21 @@ export function CodeCompare({ fileIconSlot, className, CodeView = CodeCompareVie
   const query = useQuery();
   const location = useLocation() || { pathname: '/' };
 
-  const { base, compare, state: compareState, hooks: compareHooks } = componentCompareContext || {};
+  const { base, compare, state: compareState, hooks: compareHooks, hidden, loading } = componentCompareContext || {};
+
   const state = compareState?.code;
   const hook = compareHooks?.code;
 
   const [isSidebarOpen, setSidebarOpenness] = useState(false);
 
-  const { fileTree: baseFileTree = [], mainFile } = useCode(base?.model.id);
-  const { fileTree: compareFileTree = [] } = useCode(compare?.model.id);
-  const fileCompareDataByName = componentCompareContext?.fileCompareDataByName;
+  const { fileTree: baseFileTree = [], mainFile } = useCode(hidden ? undefined : base?.model.id);
+  const { fileTree: compareFileTree = [] } = useCode(hidden ? undefined : compare?.model.id);
 
+  const fileCompareDataByName = componentCompareContext?.fileCompareDataByName;
   const anyFileHasDiffStatus = useRef<boolean>(false);
 
   const fileTree = useMemo(() => {
-    const allFiles = uniq<string>(baseFileTree.concat(compareFileTree));
+    const allFiles = uniq(baseFileTree.concat(compareFileTree));
     anyFileHasDiffStatus.current = false;
     // sort by diff status
     return !fileCompareDataByName
@@ -64,18 +65,15 @@ export function CodeCompare({ fileIconSlot, className, CodeView = CodeCompareVie
           if (bStatus?.toLowerCase() === 'new') return 1;
           return 0;
         });
-  }, [
-    fileCompareDataByName,
-    baseFileTree.length,
-    compareFileTree.length,
-    base?.model.id.toString(),
-    compare?.model.id.toString(),
-  ]);
+  }, [fileCompareDataByName?.size, baseFileTree.length, compareFileTree.length, hidden]);
 
   const selectedFileFromParams = useCompareQueryParam('file');
 
-  const selectedFile =
-    state?.id || selectedFileFromParams || (anyFileHasDiffStatus.current ? fileTree[0] : mainFile || DEFAULT_FILE);
+  const selectedFile = React.useMemo(
+    () =>
+      state?.id || selectedFileFromParams || (anyFileHasDiffStatus.current ? fileTree[0] : mainFile || DEFAULT_FILE),
+    [state?.id, selectedFileFromParams, fileTree, mainFile]
+  );
 
   const controlledHref = useUpdatedUrlFromQuery({});
   const getHref = (node) => {
@@ -103,13 +101,19 @@ export function CodeCompare({ fileIconSlot, className, CodeView = CodeCompareVie
       <SplitPane
         layout={sidebarOpenness}
         size={200}
-        className={classNames(styles.componentCompareCodeContainer, className)}
+        className={classNames(
+          styles.componentCompareCodeContainer,
+          className,
+          componentCompareContext?.hidden && styles.hidden
+        )}
       >
         <Pane className={classNames(styles.left, !isSidebarOpen && styles.collapsed)}>
-          <div className={styles.codeCompareTreeCollapse} onClick={() => setSidebarOpenness((value) => !value)}>
-            <img src={sidebarIconUrl} />
-          </div>
-          {isSidebarOpen && (
+          {
+            <div className={styles.codeCompareTreeCollapse} onClick={() => setSidebarOpenness((value) => !value)}>
+              <img src={sidebarIconUrl} />
+            </div>
+          }
+          {
             <CodeCompareTree
               className={styles.codeCompareTree}
               fileIconSlot={fileIconSlot}
@@ -119,18 +123,21 @@ export function CodeCompare({ fileIconSlot, className, CodeView = CodeCompareVie
               widgets={[Widget]}
               getHref={getHref}
               onTreeNodeSelected={hook?.onClick}
+              open={isSidebarOpen}
             />
-          )}
+          }
         </Pane>
         <HoverSplitter className={styles.splitter}></HoverSplitter>
         <Pane className={classNames(styles.right, styles.dark, !isSidebarOpen && styles.collapsed)}>
-          <CodeView
-            widgets={[Widget]}
-            fileName={selectedFile}
-            files={fileTree}
-            getHref={getHref}
-            onTabClicked={hook?.onClick}
-          />
+          {
+            <CodeView
+              widgets={[Widget]}
+              fileName={selectedFile}
+              files={fileTree}
+              getHref={getHref}
+              onTabClicked={hook?.onClick}
+            />
+          }
         </Pane>
       </SplitPane>
     </ThemeSwitcher>

--- a/scopes/code/ui/code-compare/use-code-compare/use-code-compare.ts
+++ b/scopes/code/ui/code-compare/use-code-compare/use-code-compare.ts
@@ -36,12 +36,12 @@ export function useCodeCompare({ fileName }: useCodeCompareProps): useCodeCompar
   const { fileContent: downloadedCompareFileContent, loading: loadingDownloadedCompareFileContent } = useFileContent(
     compareId,
     fileName,
-    loadingFromContext || !!codeCompareDataForFile?.compareContent
+    componentCompareContext?.hidden || loadingFromContext || !!codeCompareDataForFile?.compareContent
   );
   const { fileContent: downloadedBaseFileContent, loading: loadingDownloadedBaseFileContent } = useFileContent(
     baseId,
     fileName,
-    loadingFromContext || !!codeCompareDataForFile?.baseContent
+    componentCompareContext?.hidden || loadingFromContext || !!codeCompareDataForFile?.baseContent
   );
   const loading =
     loadingFromContext ||

--- a/scopes/compositions/ui/composition-compare/composition-compare.context.tsx
+++ b/scopes/compositions/ui/composition-compare/composition-compare.context.tsx
@@ -1,0 +1,14 @@
+import { CompositionContentProps } from '@teambit/compositions';
+import { useContext, createContext } from 'react';
+
+export type CompositionCompareContextModel = {
+  compositionProps?: CompositionContentProps;
+  isBase?: boolean;
+  isCompare?: boolean;
+};
+
+export const CompositionCompareContext: React.Context<CompositionCompareContextModel | undefined> = createContext<
+  CompositionCompareContextModel | undefined
+>(undefined);
+
+export const useCompositionCompare = () => useContext(CompositionCompareContext);

--- a/scopes/compositions/ui/composition-compare/composition-compare.module.scss
+++ b/scopes/compositions/ui/composition-compare/composition-compare.module.scss
@@ -1,17 +1,20 @@
 .toolbar {
   display: flex;
-  background-color: var(--bit-bg-heaviest, #ededed);
-  padding: 8px;
+  padding: 4px;
 }
 
 .left,
 .right {
   display: flex;
   flex: 1;
-  padding: 8px;
-  background-color: #fff;
+  padding: 4px;
+  background-color: var(--background-color);
   align-items: center;
   justify-content: space-between;
+}
+
+.right {
+  justify-content: flex-end;
 }
 
 .mainContainer {
@@ -30,8 +33,7 @@
 
 .subView {
   height: 100%;
-  background-color: white;
-  overflow-y: auto;
+  background-color: var(--background-color);
 }
 
 .loader {
@@ -42,6 +44,7 @@
 
 .widgets {
   display: flex;
+  padding: 4px;
 }
 
 .dropdown {

--- a/scopes/compositions/ui/composition-compare/composition-dropdown.tsx
+++ b/scopes/compositions/ui/composition-compare/composition-dropdown.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useRef } from 'react';
 import { MenuLinkItem } from '@teambit/design.ui.surfaces.menu.link-item';
-import { Icon } from '@teambit/evangelist.elements.icon';
+import { Icon } from '@teambit/design.elements.icon';
 import { Dropdown } from '@teambit/evangelist.surfaces.dropdown';
 
 import styles from './composition-dropdown.module.scss';
@@ -41,14 +41,7 @@ type MenuItemProps = {
 function MenuItem(props: MenuItemProps) {
   const { selected, current } = props;
 
-  const isCurrent = selected?.id === current.id;
   const currentVersionRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (isCurrent) {
-      currentVersionRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-    }
-  }, [isCurrent]);
 
   const onClick = (!!current.onClick && ((e) => current.onClick?.(current.id, e))) || undefined;
 

--- a/scopes/compositions/ui/composition-compare/index.ts
+++ b/scopes/compositions/ui/composition-compare/index.ts
@@ -1,1 +1,2 @@
 export { CompositionCompare } from './composition-compare';
+export { useCompositionCompare, CompositionCompareContext } from './composition-compare.context';

--- a/scopes/docs/ui/overview-compare/index.ts
+++ b/scopes/docs/ui/overview-compare/index.ts
@@ -1,1 +1,3 @@
-export { OverviewCompare, OverviewCompareProps } from './overview-compare';
+export { OverviewCompare } from './overview-compare';
+export { useOverviewCompare } from './overview-compare.context';
+export type { OverviewCompareProps } from './overview-compare';

--- a/scopes/docs/ui/overview-compare/overview-compare.context.tsx
+++ b/scopes/docs/ui/overview-compare/overview-compare.context.tsx
@@ -1,0 +1,13 @@
+import { useContext, createContext } from 'react';
+import { OverviewViewProps } from './overview-compare';
+
+export type OverviewCompareContextModel = OverviewViewProps & {
+  isBase?: boolean;
+  isCompare?: boolean;
+};
+
+export const OverviewViewCompareContext: React.Context<OverviewCompareContextModel | undefined> = createContext<
+  OverviewViewProps | undefined
+>(undefined);
+
+export const useOverviewCompare = () => useContext(OverviewViewCompareContext);

--- a/scopes/docs/ui/overview-compare/overview-compare.module.scss
+++ b/scopes/docs/ui/overview-compare/overview-compare.module.scss
@@ -1,6 +1,9 @@
-.checkboxContainer {
-  margin-top: 16px;
-  padding-left: 16px;
+.subContainerLeft {
+  flex: 1;
+}
+
+.subContainerRight {
+  flex: 1;
 }
 
 .subView {
@@ -15,26 +18,34 @@
   height: 100%;
 }
 
-.toolbar {
+.toggleContainer {
   display: flex;
-  background-color: var(--bit-bg-heaviest, #ededed);
-  padding: 8px;
+  align-items: center;
+
+  .toggle {
+    position: relative;
+  }
 }
 
-.widgets {
+.toolbar {
   display: flex;
+  padding: 4px;
 }
 
 .left,
 .right {
   display: flex;
   flex: 1;
-  padding: 8px;
-  background-color: #fff;
+  background-color: var(--background-color);
   align-items: center;
   justify-content: space-between;
 }
 
-.splitLayout {
-  margin-top: 8px;
+.right {
+  justify-content: flex-end;
+}
+
+.widgets {
+  display: flex;
+  padding: 4px;
 }

--- a/scopes/docs/ui/overview-compare/overview-compare.tsx
+++ b/scopes/docs/ui/overview-compare/overview-compare.tsx
@@ -1,4 +1,4 @@
-import { ComponentProvider } from '@teambit/component';
+import { ComponentDescriptorProvider, ComponentProvider } from '@teambit/component';
 import { CompareSplitLayoutPreset } from '@teambit/component.ui.component-compare.layouts.compare-split-layout-preset';
 import { useComponentCompare } from '@teambit/component.ui.component-compare.context';
 import { RoundLoader } from '@teambit/design.ui.round-loader';
@@ -6,21 +6,29 @@ import { Overview } from '@teambit/docs';
 import type { TitleBadgeSlot, OverviewOptionsSlot } from '@teambit/docs';
 import React, { useMemo, useRef } from 'react';
 import { ComponentPreviewProps } from '@teambit/preview.ui.component-preview';
+import { OverviewViewCompareContext } from './overview-compare.context';
 
 import styles from './overview-compare.module.scss';
+
+export type OverviewViewProps = {
+  titleBadges: TitleBadgeSlot;
+  overviewOptions: OverviewOptionsSlot;
+  previewProps?: Partial<ComponentPreviewProps>;
+};
 
 export type OverviewCompareProps = {
   titleBadges: TitleBadgeSlot;
   overviewOptions: OverviewOptionsSlot;
-  previewProps?: ComponentPreviewProps;
+  previewProps?: Partial<ComponentPreviewProps>;
   Widgets?: {
     Right?: React.ReactNode;
     Left?: React.ReactNode;
   };
+  OverviewView?: React.ComponentType<OverviewViewProps>;
 };
 
 export function OverviewCompare(props: OverviewCompareProps) {
-  const { titleBadges, overviewOptions, previewProps, Widgets } = props;
+  const { titleBadges, overviewOptions, previewProps, Widgets, OverviewView = Overview } = props;
   const componentCompare = useComponentCompare();
 
   const leftPanelRef = useRef<HTMLDivElement>(null);
@@ -33,9 +41,13 @@ export function OverviewCompare(props: OverviewCompareProps) {
 
     return (
       <div className={styles.subView} ref={leftPanelRef}>
-        <ComponentProvider component={componentCompare.base.model}>
-          <Overview titleBadges={titleBadges} overviewOptions={overviewOptions} previewProps={previewProps} />
-        </ComponentProvider>
+        <OverviewViewCompareContext.Provider value={{ titleBadges, overviewOptions, previewProps, isBase: true }}>
+          <ComponentDescriptorProvider componentDescriptor={componentCompare?.base.descriptor}>
+            <ComponentProvider component={componentCompare.base.model}>
+              <OverviewView titleBadges={titleBadges} overviewOptions={overviewOptions} previewProps={previewProps} />
+            </ComponentProvider>
+          </ComponentDescriptorProvider>
+        </OverviewViewCompareContext.Provider>
       </div>
     );
   }, [componentCompare?.base]);
@@ -47,9 +59,13 @@ export function OverviewCompare(props: OverviewCompareProps) {
 
     return (
       <div className={styles.subView} ref={rightPanelRef}>
-        <ComponentProvider component={componentCompare.compare.model}>
-          <Overview titleBadges={titleBadges} overviewOptions={overviewOptions} previewProps={previewProps} />
-        </ComponentProvider>
+        <OverviewViewCompareContext.Provider value={{ titleBadges, overviewOptions, previewProps, isCompare: true }}>
+          <ComponentDescriptorProvider componentDescriptor={componentCompare?.compare?.descriptor}>
+            <ComponentProvider component={componentCompare.compare.model}>
+              <OverviewView titleBadges={titleBadges} overviewOptions={overviewOptions} previewProps={previewProps} />
+            </ComponentProvider>
+          </ComponentDescriptorProvider>
+        </OverviewViewCompareContext.Provider>
       </div>
     );
   }, [componentCompare?.compare]);
@@ -89,7 +105,7 @@ export function OverviewCompare(props: OverviewCompareProps) {
         </div>
       </div> */}
       <OverviewToolbar />
-      <CompareSplitLayoutPreset base={BaseLayout} compare={CompareLayout} className={styles.splitLayout} />
+      <CompareSplitLayoutPreset base={BaseLayout} compare={CompareLayout} />
     </React.Fragment>
   );
 }

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -53,6 +53,7 @@ export function useComponentFilters() {
     },
   };
 }
+
 export function useLaneComponentIdFromUrl(): ComponentID | undefined | null {
   const idFromLocation = useIdFromLocation();
   const { lanesModel, loading } = useLanes();
@@ -60,16 +61,27 @@ export function useLaneComponentIdFromUrl(): ComponentID | undefined | null {
   const query = useQuery();
   const componentVersion = query.get('version');
 
-  if (componentVersion && laneFromUrl) {
-    const componentId = ComponentID.fromString(`${idFromLocation}@${componentVersion}`);
-    return componentId;
-  }
-  const laneComponentId =
-    idFromLocation && !laneFromUrl?.isDefault()
-      ? lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) ?? null
-      : null;
+  if (!idFromLocation) return null;
 
-  return loading ? undefined : laneComponentId;
+  const compIdFromLocation = ComponentID.tryFromString(
+    `${idFromLocation}${componentVersion ? `@${componentVersion}` : ''}`
+  );
+
+  if (compIdFromLocation) return compIdFromLocation;
+  if (loading) return undefined;
+
+  return lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) ?? null;
+
+  // if (componentVersion && laneFromUrl) {
+  //   const componentId = ComponentID.tryFromString(`${idFromLocation}@${componentVersion}`);
+  //   return componentId;
+  // }
+
+  // const laneComponentId =
+  //   idFromLocation && !laneFromUrl?.isDefault()
+  //     ? lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) ?? null
+  //     : null;
+  // return loading ? undefined : laneComponentId;
 }
 
 export function useComponentId() {


### PR DESCRIPTION
This PR fixes the following issues,

1. Resolving `Lane Component Ids` in the `Workspace` when the component belongs to the same scope as the lane and has a version

2. Ensuring the `Lane Switcher` and the `Lane Compare dropdown` always query lanes from `offset: 0`

3. `Lane Compare` now allows lifting its state up via LaneCompareContext and Provider for a fully controlled experience.

4. `Component Compare` fixes - add `Component Descriptor` data, handle hidden state better

5. `Code Compare` style fixes

6. `Composition Compare` now has (1) composition selector for both base and compare component compositions

7. `Overview Compare` style fixes

8. Remove syncronized scrolling from all Compare screens (Drawers, Composition dropdown, Composition/Overview Content Viewers)

 