### PR TITLE
fix(checkout-head), in case of not-available on main, checkout to main head after making it available

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -689,6 +689,20 @@ describe('merge lanes', function () {
         });
       });
     });
+    describe('switching to main and checking out to head', () => {
+      before(() => {
+        helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);
+        helper.scopeHelper.getClonedLocalScope(afterLaneExport);
+        helper.command.switchLocalLane('main', '-x');
+        helper.command.checkoutHead('comp1', '-x');
+      });
+      it('should make the component available and checkout to 0.0.1', () => {
+        const list = helper.command.listParsed();
+        expect(list).to.have.lengthOf(1);
+        expect(list[0].localVersion).to.equal('0.0.1');
+        expect(list[0].currentVersion).to.equal('0.0.1');
+      });
+    });
     describe('bit lane merge after soft-removed the unrelated component', () => {
       before(() => {
         helper.scopeHelper.getClonedRemoteScope(remoteScopeAfterExport);

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -224,7 +224,7 @@ export class BitMap {
   makeComponentsAvailableOnMain(ids: ComponentID[]) {
     ids.forEach((id) => {
       const componentMap = this.getBitmapEntry(id);
-      delete componentMap.isAvailableOnCurrentLane;
+      componentMap.isAvailableOnCurrentLane = true;
       delete componentMap.onLanesOnly;
     });
     this.legacyBitMap.markAsChanged();

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -645,8 +645,8 @@ export default class CommandHelper {
   checkout(values: string) {
     return this.runCmd(`bit checkout ${values}`);
   }
-  checkoutHead(values = '') {
-    return this.runCmd(`bit checkout head ${values}`);
+  checkoutHead(values = '', flags = '') {
+    return this.runCmd(`bit checkout head ${values} ${flags}`);
   }
   checkoutLatest(values = '') {
     return this.runCmd(`bit checkout latest ${values}`);


### PR DESCRIPTION
Currently, the first `bit checkout head` make it available and the second checks out to main-head. With this PR it's all done in one run.