### PR TITLE
fix, delete merge-conflict file upon snap/tag even when it has workspace entries

### DIFF
--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -559,6 +559,15 @@ describe('merge config scenarios', function () {
               const status = helper.command.statusJson();
               expect(status.workspaceIssues).to.have.lengthOf(0);
             });
+            describe('snapping all', () => {
+              before(() => {
+                helper.command.snapAllComponentsWithoutBuild();
+              });
+              it('should delete the config-merge file although it has the Workspace section', () => {
+                const conflictFile = helper.general.getConfigMergePath();
+                expect(conflictFile).to.not.be.a.path();
+              });
+            });
           });
         });
         describe('when the dep is not in the workspace.jsonc', () => {


### PR DESCRIPTION
Currently, this file is deleted only once it's empty. However, it's possible that this file still has the (relatively new) "WORKSPACE" section, and as a result, it keeps the file, which makes it very confusing later on to understand why some dependencies have specific versions. 
This PR checks whether all unmerged-components are now merged and if so deletes the file.