### PR TITLE
make lane name optional on change scope

### DIFF
--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -254,18 +254,20 @@ it is useful e.g. when having multiple lanes with the same name, but with differ
 }
 
 export class LaneChangeScopeCmd implements Command {
-  name = 'change-scope <lane-name> <remote-scope-name>';
+  name = 'change-scope <remote-scope-name>';
   description = `changes the remote scope of a lane`;
   extendedDescription = 'NOTE: available only before the lane is exported to the remote';
   alias = '';
-  options = [] as CommandOptions;
+  options = [
+    ['lane-name', '', 'the name of the lane to change its remote scope. if not specified, the current lane is used'],
+  ] as CommandOptions;
   loader = true;
   migration = true;
 
   constructor(private lanes: LanesMain) {}
 
-  async report([localName, remoteScope]: [string, string]): Promise<string> {
-    const { remoteScopeBefore } = await this.lanes.changeScope(localName, remoteScope);
+  async report([remoteScope]: [string], { laneName }: { laneName?: string }): Promise<string> {
+    const { remoteScopeBefore, localName } = await this.lanes.changeScope(remoteScope, laneName);
     return `the remote-scope of ${chalk.bold(localName)} has been changed from ${chalk.bold(
       remoteScopeBefore
     )} to ${chalk.bold(remoteScope)}`;


### PR DESCRIPTION
---

### Enhancement of `bit lane change-scope` Command Functionality

**Description:**

Proposed updates to the `bit lane change-scope` command based on recent feedback:

1. **Optional Lane Name Parameter**: 
   - The current implementation requires a mandatory lane name when using the `bit lane change-scope` command. This proposal suggests making the `<lane-name>` parameter optional. 
   - Modified command syntax: 
     ```shell
     bit lane change-scope <remote-scope-name> --lane-name [optional]
     ```
   - This change will allow users to modify the scope for another lane without needing to specify the lane name.

2. **Scope Change Restriction**: 
   - It has been clarified that the scope for a lane can only be modified before it is exported to the remote. This mirrors the behavior of component renaming, which restricts renaming unless the component hasn't been imported.

The proposed enhancements aim to improve the user experience and clarity of the `bit lane change-scope` command.

---
