### PR TITLE
Improve rename lane command

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -329,7 +329,7 @@ describe('bit lane command', function () {
       const { scopePath, scopeName } = helper.scopeHelper.getNewBareScope();
       helper.scopeHelper.addRemoteScope(scopePath);
       helper.command.createLane('dev');
-      helper.command.changeLaneScope('dev', scopeName);
+      helper.command.changeLaneScope(scopeName);
       helper.fs.outputFile('comp1/comp1.spec.js');
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
@@ -632,7 +632,7 @@ describe('bit lane command', function () {
     before(() => {
       helper.scopeHelper.reInitLocalScope();
       helper.command.createLane();
-      output = helper.command.changeLaneScope('dev', 'my-remote');
+      output = helper.command.changeLaneScope('my-remote');
     });
     it('should output the changes', () => {
       expect(removeChalkCharacters(output)).to.have.string(
@@ -1232,7 +1232,7 @@ describe('bit lane command', function () {
       helper.fixtures.populateComponents(1);
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
-      helper.command.renameLane('dev', 'new-lane');
+      helper.command.renameLane('new-lane');
     });
     it('should rename the lane locally', () => {
       const lanes = helper.command.listLanes();
@@ -1517,7 +1517,7 @@ describe('bit lane command', function () {
         helper.command.export();
       });
       it('should block the rename', () => {
-        expect(() => helper.command.changeLaneScope('dev', 'new-scope')).to.throw(
+        expect(() => helper.command.changeLaneScope('new-scope')).to.throw(
           'changing lane scope-name is allowed for new lanes only'
         );
       });
@@ -1530,7 +1530,7 @@ describe('bit lane command', function () {
       });
       it('should throw InvalidScopeName error', () => {
         const err = new InvalidScopeName('invalid.scope.name');
-        const cmd = () => helper.command.changeLaneScope('dev', 'invalid.scope.name');
+        const cmd = () => helper.command.changeLaneScope('invalid.scope.name');
         helper.general.expectToThrow(cmd, err);
       });
     });

--- a/e2e/harmony/lanes/rename-lane.e2e.ts
+++ b/e2e/harmony/lanes/rename-lane.e2e.ts
@@ -21,7 +21,7 @@ describe('rename lanes', function () {
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
 
-      helper.command.renameLane('d', 'new-dev');
+      helper.command.renameLane('new-dev');
     });
     it('should not throw on any command', () => {
       expect(() => helper.command.status()).to.not.throw();

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -254,18 +254,20 @@ it is useful e.g. when having multiple lanes with the same name, but with differ
 }
 
 export class LaneChangeScopeCmd implements Command {
-  name = 'change-scope <lane-name> <remote-scope-name>';
+  name = 'change-scope <remote-scope-name>';
   description = `changes the remote scope of a lane`;
   extendedDescription = 'NOTE: available only before the lane is exported to the remote';
   alias = '';
-  options = [] as CommandOptions;
+  options = [
+    ['lane-name', '', 'the name of the lane to change its remote scope. if not specified, the current lane is used'],
+  ] as CommandOptions;
   loader = true;
   migration = true;
 
   constructor(private lanes: LanesMain) {}
 
-  async report([localName, remoteScope]: [string, string]): Promise<string> {
-    const { remoteScopeBefore } = await this.lanes.changeScope(localName, remoteScope);
+  async report([remoteScope]: [string], { laneName }: { laneName?: string }): Promise<string> {
+    const { remoteScopeBefore, localName } = await this.lanes.changeScope(remoteScope, laneName);
     return `the remote-scope of ${chalk.bold(localName)} has been changed from ${chalk.bold(
       remoteScopeBefore
     )} to ${chalk.bold(remoteScope)}`;

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -275,10 +275,12 @@ export class LaneChangeScopeCmd implements Command {
 }
 
 export class LaneRenameCmd implements Command {
-  name = 'rename <current-name> <new-name>';
+  name = 'rename <new-name>';
   description = `EXPERIMENTAL. change the lane-name locally and on the remote (if exported)`;
   alias = '';
-  options = [] as CommandOptions;
+  options = [
+    ['l', 'lane-name <lane-name>', 'the name of the lane to rename. if not specified, the current lane is used'],
+  ] as CommandOptions;
   loader = true;
   migration = true;
   constructor(private lanes: LanesMain) {}

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -259,7 +259,11 @@ export class LaneChangeScopeCmd implements Command {
   extendedDescription = 'NOTE: available only before the lane is exported to the remote';
   alias = '';
   options = [
-    ['lane-name', '', 'the name of the lane to change its remote scope. if not specified, the current lane is used'],
+    [
+      'l',
+      'lane-name <lane-name>',
+      'the name of the lane to change its remote scope. if not specified, the current lane is used',
+    ],
   ] as CommandOptions;
   loader = true;
   migration = true;
@@ -285,8 +289,8 @@ export class LaneRenameCmd implements Command {
   migration = true;
   constructor(private lanes: LanesMain) {}
 
-  async report([currentName, newName]: [string, string]): Promise<string> {
-    const { exported, exportErr } = await this.lanes.rename(currentName, newName);
+  async report([newName]: [string], { laneName }: { laneName?: string }): Promise<string> {
+    const { exported, exportErr, currentName } = await this.lanes.rename(newName, laneName);
     const exportedStr = exported
       ? `and have been exported successfully to the remote`
       : `however failed exporting the renamed lane to the remote, due to an error: ${exportErr?.message || 'unknown'}`;

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -401,11 +401,15 @@ please create a new lane instead, which will include all components of this lane
   /**
    * change a lane-name and if possible, export the lane to the remote
    */
-  async rename(currentName: string, newName: string): Promise<{ exported: boolean; exportErr?: Error }> {
+  async rename(
+    newName: string,
+    laneName?: string
+  ): Promise<{ exported: boolean; exportErr?: Error; currentName: string }> {
     if (!this.workspace) {
       throw new BitError(`unable to rename a lane outside of Bit workspace`);
     }
     throwForInvalidLaneName(newName);
+    const currentName = laneName || this.workspace.getCurrentLaneId().name;
     const existingAliasWithNewName = this.scope.legacyScope.lanes.getRemoteTrackedDataByLocalLane(newName);
     if (existingAliasWithNewName) {
       const remoteIdStr = `${existingAliasWithNewName.remoteLane}/${existingAliasWithNewName.remoteScope}`;
@@ -459,7 +463,7 @@ please create a new lane instead, which will include all components of this lane
 
     await this.workspace.consumer.onDestroy();
 
-    return { exported, exportErr };
+    return { exported, exportErr, currentName };
   }
 
   async exportLane(lane: Lane) {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -312,8 +312,8 @@ export default class CommandHelper {
   createLane(laneName = 'dev', options = '') {
     return this.runCmd(`bit lane create ${laneName} ${options}`);
   }
-  changeLaneScope(laneName: string, newScope: string) {
-    return this.runCmd(`bit lane change-scope ${laneName} ${newScope}`);
+  changeLaneScope(newScope: string) {
+    return this.runCmd(`bit lane change-scope ${newScope}`);
   }
   clearCache() {
     return this.runCmd('bit clear-cache');
@@ -443,8 +443,8 @@ export default class CommandHelper {
   fetchAllComponents() {
     return this.runCmd(`bit fetch --components`);
   }
-  renameLane(oldName: string, newName: string) {
-    return this.runCmd(`bit lane rename ${oldName} ${newName}`);
+  renameLane(newName: string) {
+    return this.runCmd(`bit lane rename ${newName}`);
   }
   importManyComponents(ids: string[], flag = '') {
     const idsWithRemote = ids.map((id) => `${this.scopes.remote}/${id}`);


### PR DESCRIPTION
---

###  Enhancement of `LaneRenameCmd` Command Functionality

**Description:**

Building upon the changes made in the previous PR ([#7852](https://github.com/teambit/bit/pull/7852)), this PR proposes updates to the `LaneRenameCmd` command:

1. **Re-evaluation of Required Parameters**:
   - Current command definition:
     ```typescript
     name = 'rename <current-name> <new-name>';
     ```
   - The necessity of the `current-name` parameter is being questioned. The idea is to streamline the renaming process by potentially omitting the need to specify the current name.

2. **Command Context**:
   - This command is responsible for renaming a lane both locally and on the remote, provided the lane has been exported.
   - Definition:
     ```typescript
     description = `EXPERIMENTAL. change the lane-name locally and on the remote (if exported)`;
     ```

The intention behind these updates is to refine and simplify the user experience when renaming lanes.

---

