### PR TITLE
do not send new lanes to the remote-fetcher 

### DIFF
--- a/scopes/component/component-log/component-log.main.runtime.ts
+++ b/scopes/component/component-log/component-log.main.runtime.ts
@@ -67,13 +67,14 @@ export class ComponentLogMain {
     const filePathAsLinux = pathNormalizeToLinux(filePath);
     const filePathRelativeInComponent = filePathAsLinux.replace(`${rootDir}/`, '');
 
-    const modelComp = await workspace.scope.getBitObjectModelComponent(componentId, true);
+    const modelComp = await workspace.scope.getBitObjectModelComponent(componentId);
+    if (!modelComp) return []; // probably a new component
     const results: FileLog[] = [];
     await pMap(
       logs,
       async (logItem) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        const versionObj = await workspace.scope.getBitObjectVersion(modelComp!, logItem.hash);
+        const versionObj = await workspace.scope.getBitObjectVersion(modelComp!, logItem.hash, true);
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const fileInComp = versionObj!.files.find((f) => f.relativePath === filePathRelativeInComponent);
         if (!fileInComp) return;

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -3,6 +3,7 @@ import { CompilerAspect, CompilerMain } from '@teambit/compiler';
 import InstallAspect, { InstallMain } from '@teambit/install';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
+import { BitError } from '@teambit/bit-error';
 import fs from 'fs-extra';
 import mapSeries from 'p-map-series';
 import * as path from 'path';
@@ -242,10 +243,10 @@ to move all component files to a different directory, run bit remove and then bi
 
     if (fs.pathExistsSync(componentDir)) {
       if (!isDir(componentDir)) {
-        throw new GeneralError(`unable to import to ${componentDir} because it's a file`);
+        throw new BitError(`unable to import to ${componentDir} because it's a file`);
       }
       if (!isDirEmptySync(componentDir) && opts.throwForExistingDir) {
-        throw new GeneralError(
+        throw new BitError(
           `unable to import to ${componentDir}, the directory is not empty. use --override flag to delete the directory and then import`
         );
       }

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -277,6 +277,11 @@ export class Watcher {
       );
       return [];
     }
+    this.consumer.bitMap.updateComponentPaths(
+      componentId._legacy,
+      compFiles.map((f) => this.consumer.getPathRelativeToConsumer(f)),
+      removedFiles.map((f) => this.consumer.getPathRelativeToConsumer(f))
+    );
     const buildResults = await this.executeWatchOperationsOnComponent(
       updatedComponentId,
       compFiles,
@@ -321,8 +326,8 @@ export class Watcher {
 
   private async executeWatchOperationsOnComponent(
     componentId: ComponentID,
-    files: string[],
-    removedFiles: string[] = [],
+    files: PathOsBasedAbsolute[],
+    removedFiles: PathOsBasedAbsolute[] = [],
     isChange = true,
     initiator?: CompilationInitiator
   ): Promise<OnComponentEventResult[]> {

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -20,7 +20,7 @@ import {
 import ShowDoctorError from '../../error/show-doctor-error';
 import logger from '../../logger/logger';
 import { isDir, pathJoinLinux, pathNormalizeToLinux, sortObject } from '../../utils';
-import { PathLinux, PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative } from '../../utils/path';
+import { PathLinux, PathLinuxRelative, PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative } from '../../utils/path';
 import ComponentMap, {
   ComponentMapFile,
   Config,
@@ -849,6 +849,17 @@ export default class BitMap {
         });
       });
     }
+  }
+
+  updateComponentPaths(id: BitId, files: PathLinuxRelative[], removedFiles: PathLinuxRelative[]) {
+    removedFiles.forEach((removedFile) => {
+      delete this.paths[removedFile];
+      delete this.pathsLowerCase[removedFile.toLowerCase()];
+    });
+    files.forEach((file) => {
+      this.paths[file] = id;
+      this.pathsLowerCase[file.toLowerCase()] = id;
+    });
   }
 
   getAllTrackDirs() {

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -866,10 +866,10 @@ export default class ScopeComponentsImporter {
   }
 
   private async getLaneForFetcher(lane?: Lane): Promise<Lane | undefined> {
-    if (lane) return lane;
+    if (lane && !lane.isNew) return lane;
     if (!this.shouldOnlyFetchFromCurrentLane) return undefined;
     const currentLane = await this.scope.getCurrentLaneObject();
-    return currentLane || undefined;
+    return currentLane && !currentLane.isNew ? currentLane : undefined;
   }
 
   private async _getComponentVersion(id: BitId): Promise<ComponentVersion> {


### PR DESCRIPTION
## Proposed Changes

- for non-exported lanes, remove the lane prop from the fetch-options sent to the remote.
- fix log-file-history to not throw for new-components
- fix watcher to update file paths 
