### PR TITLE
restore first argument to lane rename/change-scope commands

### DIFF
--- a/e2e/harmony/lanes/rename-lane.e2e.ts
+++ b/e2e/harmony/lanes/rename-lane.e2e.ts
@@ -13,6 +13,61 @@ describe('rename lanes', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
+  describe('rename current lane when one argument provided', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.switchLocalLane('main');
+      helper.command.createLane('dev2');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.command.renameLane('new-dev');
+    });
+    it('should rename current lane when only one argument provided', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap[LANE_KEY].id.name).to.equal('new-dev');
+    });
+    it('should not throw on any command', () => {
+      expect(() => helper.command.status()).to.not.throw();
+    });
+    it('should update .bitmap with the new name', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap[LANE_KEY].id.name).to.equal('new-dev');
+    });
+  });
+  describe('rename specified lane when second argument provided', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.switchLocalLane('main');
+      helper.command.createLane('dev2');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.command.renameLane('dev', 'new-dev');
+    });
+    it('should rename current lane when only one argument provided', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap[LANE_KEY].id.name).to.equal('dev2'); // ensure didnt change current lane
+      // expect to not be able to switch to old name of 'dev' lane
+      expect(() => helper.command.switchLocalLane('dev')).to.throw();
+      // and to be able to switch to the new lane name of 'dev'
+      expect(() => helper.command.switchLocalLane('new-dev')).to.not.throw();
+    });
+    it('should not throw on any command', () => {
+      expect(() => helper.command.status()).to.not.throw();
+    });
+    it('.bitmap should now be on the "new-dev" (formerly "dev") branch', () => {
+      helper.command.switchLocalLane('new-dev');
+      const bitMap = helper.bitMap.read();
+      expect(bitMap[LANE_KEY].id.name).to.equal('new-dev');
+    });
+  });
   describe('rename lane using the alias', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -254,9 +254,9 @@ it is useful e.g. when having multiple lanes with the same name, but with differ
 }
 
 export class LaneChangeScopeCmd implements Command {
-  name = 'change-scope <lane-name-or-remote-scope> <remote-scope-name>';
+  name = 'change-scope <lane-name-or-remote-scope> [remote-scope-name]';
   description = `changes the remote scope of a lane`;
-  extendedDescription = `If no lane is specified (i.e. only one argument provided) this will update the current lane.
+  extendedDescription = `If no lane is specified (i.e. only one argument provided) this will update the scope of the current lane.
 NOTE: available only before the lane is exported to the remote`;
   alias = '';
   options = [] as CommandOptions;
@@ -275,10 +275,9 @@ NOTE: available only before the lane is exported to the remote`;
 
   constructor(private lanes: LanesMain) {}
 
-  async report([laneNameOrRemoteScope, remoteScope]: [string, string]): Promise<string> {
-    const remoteScopeName = remoteScope ?? laneNameOrRemoteScope;
-    const laneToChange = remoteScope ? laneNameOrRemoteScope : undefined;
-    const { remoteScopeBefore, localName } = await this.lanes.changeScope(remoteScopeName, laneToChange);
+  async report([laneNameOrRemoteScope, remoteScope = laneNameOrRemoteScope]: [string, string]): Promise<string> {
+    const laneToChange = remoteScope === laneNameOrRemoteScope ? undefined : laneNameOrRemoteScope;
+    const { remoteScopeBefore, localName } = await this.lanes.changeScope(remoteScope, laneToChange);
     return `the remote-scope of ${chalk.bold(localName)} has been changed from ${chalk.bold(
       remoteScopeBefore
     )} to ${chalk.bold(remoteScope)}`;
@@ -286,10 +285,10 @@ NOTE: available only before the lane is exported to the remote`;
 }
 
 export class LaneRenameCmd implements Command {
-  name = 'rename <existing-name-or-new-name> <new-name>';
+  name = 'rename <existing-name-or-new-name> [new-name]';
   description = `EXPERIMENTAL. change the lane-name locally and on the remote (if exported)`;
   extendedDescription =
-    'If no lane is specified (i.e. only a single argument provided) this will change the current lane';
+    'If no lane is specified (i.e. only a single argument is provided) this will change the current lane';
   alias = '';
   options = [] as CommandOptions;
   loader = true;
@@ -301,15 +300,14 @@ export class LaneRenameCmd implements Command {
     },
     {
       cmd: 'lane rename my-lane new-my-lane';
-      description: "change the scope of lane 'my-lane' to 'new-my-lane'";
+      description: "change the name of lane 'my-lane' to 'new-my-lane'";
     }
   ];
   constructor(private lanes: LanesMain) {}
 
-  async report([existingNameOrNewName, newName]: [string, string]): Promise<string> {
-    const newLaneName = newName ?? existingNameOrNewName;
-    const currentLaneName = newName ? existingNameOrNewName : undefined;
-    const { exported, exportErr, currentName } = await this.lanes.rename(newLaneName, currentLaneName);
+  async report([existingNameOrNewName, newName = existingNameOrNewName]: [string, string]): Promise<string> {
+    const currentLaneName = newName === existingNameOrNewName ? undefined : existingNameOrNewName;
+    const { exported, exportErr, currentName } = await this.lanes.rename(newName, currentLaneName);
     const exportedStr = exported
       ? `and have been exported successfully to the remote`
       : `however failed exporting the renamed lane to the remote, due to an error: ${exportErr?.message || 'unknown'}`;

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -312,8 +312,8 @@ export default class CommandHelper {
   createLane(laneName = 'dev', options = '') {
     return this.runCmd(`bit lane create ${laneName} ${options}`);
   }
-  changeLaneScope(newScope: string) {
-    return this.runCmd(`bit lane change-scope ${newScope}`);
+  changeLaneScope(laneNameOrNewScope: string, newScope?: string) {
+    return this.runCmd(`bit lane change-scope ${laneNameOrNewScope} ${newScope ?? ''}`);
   }
   clearCache() {
     return this.runCmd('bit clear-cache');
@@ -443,8 +443,8 @@ export default class CommandHelper {
   fetchAllComponents() {
     return this.runCmd(`bit fetch --components`);
   }
-  renameLane(newName: string) {
-    return this.runCmd(`bit lane rename ${newName}`);
+  renameLane(existingLaneOrNewName: string, newName?: string) {
+    return this.runCmd(`bit lane rename ${existingLaneOrNewName} ${newName ?? ''}`);
   }
   importManyComponents(ids: string[], flag = '') {
     const idsWithRemote = ids.map((id) => `${this.scopes.remote}/${id}`);


### PR DESCRIPTION
lane rename/change-scope commands

## Proposed Changes

- restore initial lane-name argument to lane rename and change-scope commands to better align with how the command works
- remove lane-name flag for both
-
