### PR TITLE
fix(Component Tree): custom url matching 

### DIFF
--- a/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.tsx
@@ -11,6 +11,7 @@ import { TreeContext } from '@teambit/base-ui.graph.tree.tree-context';
 import { indentClass } from '@teambit/base-ui.graph.tree.indent';
 import { TreeNodeProps } from '@teambit/base-ui.graph.tree.recursive-tree';
 import { useLanes } from '@teambit/lanes.hooks.use-lanes';
+import { useScope } from '@teambit/scope.ui.hooks.scope-context';
 import { LanesModel } from '@teambit/lanes.ui.models.lanes-model';
 import { PayloadType } from '../payload-type';
 import { getName } from '../utils/get-name';
@@ -34,9 +35,12 @@ export function ComponentView(props: ComponentViewProps<PayloadType>) {
     },
     [onSelect, node.id]
   );
+
   const location = useLocation();
+  const scope = useScope();
 
   if (!(component instanceof ComponentModel)) return null;
+
   const envId = ComponentID.fromString(component.environment?.id as string);
 
   const envTooltip = (
@@ -74,28 +78,80 @@ export function ComponentView(props: ComponentViewProps<PayloadType>) {
     <span>{getName(node.id)}</span>
   );
 
+  /**
+   * this covers the following use cases when matching the active component's href with location
+   *
+   * 1. viewing main component
+   *
+   *  - /<component-id>/
+   *  - /<component-id>/~sub-route
+   *  - /<component-id>/~sub-route/another-sub-route
+   *  - /<component-id>/~sub-route?version=<version>
+   *
+   * 2. viewing a lane component
+   *
+   *  - /~lane/<lane-id>/<component-id>/
+   *  - /~lane/<lane-id>/<component-id>/~sub-route
+   *  - /~lane/<lane-id>/<component-id>/~sub-route/another-sub-route
+   *  - /~lane/<lane-id>/<component-id>/~sub-route?version=<version>
+   *
+   * 3. viewing a main component when on a lane
+   *
+   *  - /?lane=<lane-id>/<component-id>/
+   *  - /?lane=<lane-id>/<component-id>/~sub-route
+   *  - /?lane=<lane-id>/<component-id>/~sub-route/another-sub-route
+   *  - /?lane=<lane-id>/<component-id>/~sub-route?version=<version>
+   *
+   * 4. viewing currently checked out lane component on workspace
+   *
+   *  - /<component-id-without-scope>/
+   *
+   * 5. viewing lane component from the same scope as the lane on a workspace
+   *
+   * - /~lane/<lane-id>/<component-id-without-scope>/
+   *
+   * @todo - move this logic to a util function
+   */
   const isActive = React.useMemo(() => {
     if (!href || !location) return false;
-    const pathname = location.pathname.substring(1);
-    const hrefWithoutLaneMetadata = href.split('?lane')[0];
-    const sanitizedHref = (
-      hrefWithoutLaneMetadata.startsWith('/') ? hrefWithoutLaneMetadata.substring(1) : hrefWithoutLaneMetadata
-    ).split('?')[0];
-    if (pathname === sanitizedHref) return true;
-    // viewing main component
-    if (viewingMainCompOnLane || lanesModel?.viewedLane?.id.isDefault()) {
-      const locationWithoutSubRoutes = pathname.split('/~')[0];
-      return locationWithoutSubRoutes === sanitizedHref;
+
+    const pathname = location.pathname.substring(1).split('?')[0];
+    const compIdStr = component.id.toStringWithoutVersion();
+    const compIdName = component.id.fullName;
+
+    const sanitizedHref = (href.startsWith('/') ? href.substring(1) : href).split('?')[0];
+    // if you are in a workspace, the componentId might not have a scopeId, if you are viewing
+    // a component on the checked out lane
+    const viewingCheckedOutLaneComp =
+      lanesModel?.currentLane && lanesModel.currentLane.id.toString() === lanesModel?.viewedLane?.id.toString();
+
+    if (lanesModel?.viewedLane?.id.isDefault() || viewingMainCompOnLane || viewingCheckedOutLaneComp) {
+      // split out any sub routes if exist
+      const compUrl = pathname.split('/~')[0];
+      // may or may not contain scope
+      const scopeUrl = scope.name ? `${scope.name.replace('.', '/')}/` : '';
+      return sanitizedHref === compUrl.replace(scopeUrl, '');
     }
-    // viewing a lane component
-    const lastIndexOfSubRoute = pathname.lastIndexOf('/~');
-    const noSubRoutes =
-      pathname.substring(lastIndexOfSubRoute + 1).includes(LanesModel.baseLaneComponentRoute) ||
-      pathname.substring(lastIndexOfSubRoute + 1).includes(LanesModel.lanesPrefix);
-    if (noSubRoutes) return pathname === sanitizedHref;
-    const pathnameWithoutSubRoute = pathname.substring(0, lastIndexOfSubRoute);
-    return pathnameWithoutSubRoute === sanitizedHref;
-  }, [href, viewingMainCompOnLane, location?.pathname, component.id.toString()]);
+
+    const laneCompUrlWithSubRoutes = pathname.split(LanesModel.baseLaneComponentRoute)[1] ?? '';
+
+    const _laneCompUrl = laneCompUrlWithSubRoutes.split('/~')[0] ?? '';
+    const laneCompUrl = _laneCompUrl.startsWith('/') ? _laneCompUrl.substring(1) : _laneCompUrl;
+
+    const laneCompIdFromUrl = ComponentID.tryFromString(laneCompUrl);
+
+    // viewing lane component from the same scope as the lane on a workspace
+    const laneAndCompFromSameScopeOnWs =
+      !scope.name && lanesModel?.viewedLane?.id && component.id.scope === lanesModel?.viewedLane?.id.scope;
+
+    if (laneAndCompFromSameScopeOnWs) {
+      return compIdName === laneCompUrl;
+    }
+
+    if (!laneCompIdFromUrl) return false;
+
+    return laneCompIdFromUrl?.toString() === compIdStr || laneCompIdFromUrl.fullName === compIdName;
+  }, [href, viewingMainCompOnLane, location?.pathname, component.id.toString(), scope]);
 
   return (
     <Link


### PR DESCRIPTION
https://github.com/teambit/bit/pull/7668

The above linked PR fixed the component id selection in the case when the namespace name and the component name is the same

But resulted in a regression where it will **only match exact routes**, resulting in any sub route of the component page to unselect the component from the sidebar tree

This PR introduces custom URL matching to support both cases,

(1) when the namespace name and the component name is the same
(2) when the selected href is a subroute of the component

This also fixes an issue on the workspace where the Component Tree showed stale statuses since it didn't refresh when the viewed lane changed. 