### PR TITLE
fix(watch), fix issues with watcher not watching files

### DIFF
--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -81,6 +81,7 @@ export class Watcher {
     this.verbose = opts.verbose || false;
     const componentIds = Object.values(this.trackDirs);
     await this.watcherMain.triggerOnPreWatch(componentIds, watchOpts);
+    await this.setTrackDirs();
     await this.createWatcher();
     const watcher = this.fsWatcher;
     msgs?.onStart(this.workspace);

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -79,10 +79,9 @@ export class Watcher {
   async watchAll(opts: WatchOptions) {
     const { msgs, ...watchOpts } = opts;
     this.verbose = opts.verbose || false;
-    const pathsToWatch = await this.getPathsToWatch();
     const componentIds = Object.values(this.trackDirs);
     await this.watcherMain.triggerOnPreWatch(componentIds, watchOpts);
-    await this.createWatcher(pathsToWatch);
+    await this.createWatcher();
     const watcher = this.fsWatcher;
     msgs?.onStart(this.workspace);
 
@@ -95,37 +94,22 @@ export class Watcher {
       }
       watcher.on('ready', () => {
         msgs?.onReady(this.workspace, this.trackDirs, this.verbose);
+        // console.log(this.fsWatcher.getWatched());
         loader.stop();
       });
       // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      watcher.on('change', async (filePath) => {
+      watcher.on('all', async (event, filePath) => {
+        if (event !== 'change' && event !== 'add' && event !== 'unlink') return;
         const startTime = new Date().getTime();
-        const { files, results, debounced, failureMsg } = await this.handleChange(filePath, opts?.initiator);
-        if (debounced) {
+        const { files, results, debounced, irrelevant, failureMsg } = await this.handleChange(
+          filePath,
+          opts?.initiator
+        );
+        if (debounced || irrelevant) {
           return;
         }
         const duration = new Date().getTime() - startTime;
         msgs?.onChange(files, results, this.verbose, duration, failureMsg);
-      });
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      watcher.on('add', async (filePath) => {
-        const startTime = new Date().getTime();
-        const { files, results, debounced, failureMsg } = await this.handleChange(filePath, opts?.initiator);
-        if (debounced) {
-          return;
-        }
-        const duration = new Date().getTime() - startTime;
-        msgs?.onAdd(files, results, this.verbose, duration, failureMsg);
-      });
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      watcher.on('unlink', async (filePath) => {
-        const startTime = new Date().getTime();
-        const { files, results, debounced, failureMsg } = await this.handleChange(filePath, opts?.initiator);
-        if (debounced) {
-          return;
-        }
-        const duration = new Date().getTime() - startTime;
-        msgs?.onUnlink(files, results, this.verbose, duration, failureMsg);
       });
       watcher.on('error', (err) => {
         msgs?.onError(err);
@@ -177,6 +161,7 @@ export class Watcher {
     files: string[];
     failureMsg?: string;
     debounced?: boolean;
+    irrelevant?: boolean; // file/dir is not part of any component
   }> {
     try {
       if (filePath.endsWith(BIT_MAP)) {
@@ -199,10 +184,8 @@ export class Watcher {
       }
       const componentId = this.getComponentIdByPath(filePath);
       if (!componentId) {
-        const failureMsg = `file ${filePath} is not part of any component, ignoring it`;
-        logger.debug(failureMsg);
         loader.stop();
-        return { results: [], files: [filePath], failureMsg };
+        return { results: [], files: [], irrelevant: true };
       }
       const compIdStr = componentId.toString();
       if (this.changedFilesPerComponent[compIdStr]) {
@@ -304,14 +287,12 @@ export class Watcher {
     const removedDirs: string[] = difference(Object.keys(previewsTrackDirs), Object.keys(this.trackDirs));
     const results: OnComponentEventResult[] = [];
     if (newDirs.length) {
-      this.fsWatcher.add(newDirs.map((dir) => this.consumer.toAbsolutePath(dir)));
       const addResults = await mapSeries(newDirs, async (dir) =>
         this.executeWatchOperationsOnComponent(this.trackDirs[dir], [], [], false)
       );
       results.push(...addResults.flat());
     }
     if (removedDirs.length) {
-      await this.fsWatcher.unwatch(removedDirs);
       await mapSeries(removedDirs, (dir) => this.executeWatchOperationsOnRemove(previewsTrackDirs[dir]));
     }
 
@@ -396,14 +377,20 @@ export class Watcher {
     return this.findTrackDirByFilePathRecursively(parentDir);
   }
 
-  private async createWatcher(pathsToWatch: string[]) {
+  private async createWatcher() {
     const usePollingConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_POLLING);
     const usePolling = usePollingConf === 'true';
-    this.fsWatcher = chokidar.watch(pathsToWatch, {
+    const ignoreLocalScope = (pathToCheck: string) => {
+      if (pathToCheck.startsWith(this.ipcEventsDir)) return false;
+      return (
+        pathToCheck.startsWith(`${this.workspace.path}/.git/`) || pathToCheck.startsWith(`${this.workspace.path}/.bit/`)
+      );
+    };
+    this.fsWatcher = chokidar.watch(this.workspace.path, {
       ignoreInitial: true,
-      // `chokidar` matchers have Bash-parity, so Windows-style backslackes are not supported as separators.
+      // `chokidar` matchers have Bash-parity, so Windows-style backslashes are not supported as separators.
       // (windows-style backslashes are converted to forward slashes)
-      ignored: ['**/node_modules/**', '**/package.json'],
+      ignored: ['**/node_modules/**', '**/package.json', ignoreLocalScope],
       usePolling,
       persistent: true,
     });
@@ -424,15 +411,5 @@ export class Watcher {
         this.trackDirs[rootDir] = componentId;
       })
     );
-  }
-
-  private async getPathsToWatch(): Promise<PathOsBasedAbsolute[]> {
-    await this.setTrackDirs();
-    const paths = [...Object.keys(this.trackDirs), BIT_MAP];
-    const pathsAbsolute = paths.map((dir) => this.consumer.toAbsolutePath(dir));
-    // otherwise, if the dir is not there, chokidar triggers 'onReady' event twice for some unclear reason.
-    await fs.ensureDir(this.ipcEventsDir);
-    pathsAbsolute.push(this.ipcEventsDir);
-    return pathsAbsolute;
   }
 }


### PR DESCRIPTION
Since the watcher has changed to use `fsEvents`, in some cases it stopped watching with no indication/reason as to why it's happening. (see also https://github.com/teambit/bit/pull/7828).
Today I got a clue why this might happen by getting an error "EMFILE, too many open files" when running vscode with bit extension using the watcher. 
By running `lsof` I noticed that bit watcher opens 4,000 file descriptors (FDs) when running on bit repo (381 components). Taking a closer look as to why this is happening, I figured that for each directory passed to `chokidar`, it opens around 10 FDs. See below.
Since the watcher was configured to get an array of all components-dir, it opened a lot of FDs. (fun fact: this is not happening when chokidar is configured to use polling. It only happens when using fsevents).
This PR fixes it by watching only one directory - the workspace root-path. Then when handling the filePath received from the watcher, the non-comp-files are ignored. By doing this change the number of open file descriptiors had dropped from 4,000 to 38.



```
node    12153 davidfirst  983r     DIR               1,18      544             1054597 /Users/davidfirst/teambit/bit2/scopes/defender/tester
node    12153 davidfirst  984r     DIR               1,18      448             1054525 /Users/davidfirst/teambit/bit2/scopes/defender
node    12153 davidfirst  985r     DIR               1,18     1024             1053703 /Users/davidfirst/teambit/bit2/scopes
node    12153 davidfirst  986r     DIR               1,18     1504             1031598 /Users/davidfirst/teambit/bit2
node    12153 davidfirst  987r     DIR               1,18      736              647803 /Users/davidfirst/teambit
node    12153 davidfirst  988r     DIR               1,18     2240              256107 /Users/davidfirst
node    12153 davidfirst  989r     DIR               1,18      160               23829 /Users
node    12153 davidfirst  990r     DIR               1,18      640 1152921500311879682 /System/Volumes/Data
node    12153 davidfirst  991r     DIR               1,18      448 1152921500312727483 /System/Volumes
node    12153 davidfirst  992r     DIR               1,18      288 1152921500311879701 /System
```