### PR TITLE
(wip), try not to ignore scope when comparing ids

### DIFF
--- a/scopes/component/isolator/capsule-list.ts
+++ b/scopes/component/isolator/capsule-list.ts
@@ -15,9 +15,6 @@ export default class CapsuleList extends Array<Capsule> {
   getCapsuleIgnoreVersion(id: ComponentID): Capsule | undefined {
     return this.find((capsule) => capsule.component.id.isEqual(id, { ignoreVersion: true }));
   }
-  getCapsuleIgnoreScopeAndVersion(id: ComponentID): Capsule | undefined {
-    return this.find((capsule) => capsule.component.id._legacy.isEqualWithoutScopeAndVersion(id._legacy));
-  }
   getAllCapsuleDirs(): string[] {
     return this.map((capsule) => capsule.path);
   }

--- a/scopes/component/isolator/symlink-dependencies-to-capsules.ts
+++ b/scopes/component/isolator/symlink-dependencies-to-capsules.ts
@@ -46,12 +46,12 @@ async function symlinkComponent(
   capsuleList: CapsuleList,
   logger: Logger
 ): Promise<[string, Record<string, string>]> {
-  const componentCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(new ComponentID(component.id));
+  const componentCapsule = capsuleList.getCapsuleIgnoreVersion(new ComponentID(component.id));
   if (!componentCapsule) throw new Error(`unable to find the capsule for ${component.id.toString()}`);
   const allDeps = component.getAllDependenciesIds();
   const linkResults = allDeps.reduce((acc, depId: BitId) => {
     // TODO: this is dangerous - we might have 2 capsules for the same component with different version, then we might link to the wrong place
-    const devCapsule = capsuleList.getCapsuleIgnoreScopeAndVersion(new ComponentID(depId));
+    const devCapsule = capsuleList.getCapsuleIgnoreVersion(new ComponentID(depId));
     if (!devCapsule) {
       // happens when a dependency is not in the workspace. (it gets installed via the package manager)
       logger.debug(

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -605,7 +605,7 @@ there are matching among unmodified components thought. consider using --unmodif
         : softTaggedComponentsIds;
       return compact(
         idsToRemoveSoftTags.map((componentId) => {
-          const componentMap = consumer.bitMap.getComponent(componentId._legacy, { ignoreScopeAndVersion: true });
+          const componentMap = consumer.bitMap.getComponent(componentId._legacy, { ignoreVersion: true });
           const removedVersion = componentMap.nextVersion?.version;
           if (!removedVersion) return null;
           componentMap.clearNextVersion();

--- a/scopes/component/tracker/add-components.ts
+++ b/scopes/component/tracker/add-components.ts
@@ -207,7 +207,7 @@ export default class AddComponents {
     const componentFromScope = await this._getComponentFromScopeIfExist(parsedBitId);
     const files: ComponentMapFile[] = component.files;
     const foundComponentFromBitMap = this.bitMap.getComponentIfExist(component.componentId, {
-      ignoreScopeAndVersion: true,
+      ignoreVersion: true,
     });
     const componentFilesP = files.map(async (file: ComponentMapFile) => {
       // $FlowFixMe null is removed later on

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -35,7 +35,7 @@ export class BitMap {
     shouldMergeConfig = false
   ): boolean {
     if (!aspectId || typeof aspectId !== 'string') throw new Error(`expect aspectId to be string, got ${aspectId}`);
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     const currentConfig = (bitMapEntry.config ||= {})[aspectId];
     if (isEqual(currentConfig, config)) {
       return false; // no changes
@@ -66,7 +66,7 @@ export class BitMap {
 
   removeComponentConfig(id: ComponentID, aspectId: string, markWithMinusIfNotExist: boolean): boolean {
     if (!aspectId || typeof aspectId !== 'string') throw new Error(`expect aspectId to be string, got ${aspectId}`);
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     const currentConfig = (bitMapEntry.config ||= {})[aspectId];
     if (currentConfig) {
       delete bitMapEntry.config[aspectId];
@@ -83,7 +83,7 @@ export class BitMap {
   }
 
   removeEntireConfig(id: ComponentID): boolean {
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     if (!bitMapEntry.config) return false;
     delete bitMapEntry.config;
     this.legacyBitMap.markAsChanged();
@@ -91,13 +91,13 @@ export class BitMap {
   }
 
   setEntireConfig(id: ComponentID, config: Record<string, any>) {
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     bitMapEntry.config = config;
     this.legacyBitMap.markAsChanged();
   }
 
   removeDefaultScope(id: ComponentID) {
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     if (bitMapEntry.defaultScope) {
       delete bitMapEntry.defaultScope;
       this.legacyBitMap.markAsChanged();
@@ -105,7 +105,7 @@ export class BitMap {
   }
 
   setDefaultScope(id: ComponentID, defaultScope: string) {
-    const bitMapEntry = this.getBitmapEntry(id, { ignoreScopeAndVersion: true });
+    const bitMapEntry = this.getBitmapEntry(id, { ignoreVersion: true });
     bitMapEntry.defaultScope = defaultScope;
     this.legacyBitMap.markAsChanged();
   }

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -125,7 +125,7 @@ export default class BitMap {
   }
 
   setOnLanesOnly(id: BitId, value: boolean) {
-    const componentMap = this.getComponent(id, { ignoreScopeAndVersion: true });
+    const componentMap = this.getComponent(id, { ignoreVersion: true });
     componentMap.onLanesOnly = value;
     this.markAsChanged();
     return componentMap;
@@ -137,7 +137,7 @@ export default class BitMap {
 
   // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
   removeComponentProp(id: BitId, propName: keyof ComponentMap) {
-    const componentMap = this.getComponent(id, { ignoreScopeAndVersion: true });
+    const componentMap = this.getComponent(id, { ignoreVersion: true });
     delete componentMap[propName];
     this.markAsChanged();
     return componentMap;
@@ -759,7 +759,7 @@ export default class BitMap {
   }
 
   removeComponent(bitId: BitId) {
-    const bitmapComponent = this.getBitIdIfExist(bitId, { ignoreScopeAndVersion: true });
+    const bitmapComponent = this.getBitIdIfExist(bitId, { ignoreVersion: true });
     if (bitmapComponent) this._removeFromComponentsArray(bitmapComponent);
     return bitmapComponent;
   }

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -146,6 +146,7 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
   }
 
   findExtension(extensionId: string, ignoreVersion = false, ignoreScope = false): ExtensionDataEntry | undefined {
+    ignoreScope = false;
     if (ExtensionDataList.coreExtensionsNames.has(extensionId)) {
       return this.findCoreExtension(extensionId);
     }


### PR DESCRIPTION
This is a preparation for a future fix of allowing same-name different-scope in the same workspace. 