### PR TITLE
feature(scope aspects) - allow specify specific node linker to be used for scope aspects capsules

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -22,6 +22,7 @@ import {
   ComponentDependency,
   KEY_NAME_BY_LIFECYCLE_TYPE,
   PackageManagerInstallOptions,
+  NodeLinker,
 } from '@teambit/dependency-resolver';
 import { Logger, LoggerAspect, LoggerMain, LongProcessLogger } from '@teambit/logger';
 import { BitId, BitIds } from '@teambit/legacy/dist/bit-id';
@@ -199,6 +200,11 @@ export type IsolateComponentsOptions = CreateGraphOptions & {
    * Use specific package manager for the isolation process (override the package manager from the dep resolver config)
    */
   packageManager?: string;
+
+  /**
+   * Use specific node linker for the isolation process (override the package manager from the dep resolver config)
+   */
+  nodeLinker?: NodeLinker;
 
   /**
    * Dir where to read the package manager config from
@@ -568,6 +574,7 @@ export class IsolatorMain {
               cachePackagesOnCapsulesRoot,
               linkedDependencies,
               packageManager: opts.packageManager,
+              nodeLinker: opts.nodeLinker,
             });
           })
         );
@@ -651,6 +658,7 @@ export class IsolatorMain {
       cachePackagesOnCapsulesRoot?: boolean;
       linkedDependencies?: Record<string, Record<string, string>>;
       packageManager?: string;
+      nodeLinker?: NodeLinker;
     }
   ) {
     const installer = this.dependencyResolver.getInstaller({
@@ -658,6 +666,7 @@ export class IsolatorMain {
       cacheRootDirectory: opts.cachePackagesOnCapsulesRoot ? capsulesDir : undefined,
       installingContext: { inCapsule: true },
       packageManager: opts.packageManager,
+      nodeLinker: opts.nodeLinker,
     });
     // When using isolator we don't want to use the policy defined in the workspace directly,
     // we only want to instal deps from components and the peer from the workspace

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -99,6 +99,8 @@ export const NPM_REGISTRY = 'https://registry.npmjs.org/';
 
 export { ProxyConfig, NetworkConfig } from '@teambit/legacy/dist/scope/network/http';
 
+export type NodeLinker = 'hoisted' | 'isolated';
+
 export interface DependencyResolverComponentData {
   packageName: string;
   policy: SerializedVariantPolicy;
@@ -232,7 +234,7 @@ export interface DependencyResolverWorkspaceConfig {
    * Defines what linker should be used for installing Node.js packages.
    * Supported values are hoisted and isolated.
    */
-  nodeLinker?: 'hoisted' | 'isolated';
+  nodeLinker?: NodeLinker;
 
   /*
    * Controls the way packages are imported from the store.
@@ -306,6 +308,7 @@ export type GetInstallerOptions = {
   packageManager?: string;
   cacheRootDirectory?: string;
   installingContext?: DepInstallerContext;
+  nodeLinker?: NodeLinker;
 };
 
 export type GetLinkerOptions = {
@@ -416,7 +419,7 @@ export class DependencyResolverMain {
     return rootPolicy.entries.some(({ dependencyId }) => dependencyId === '@teambit/harmony');
   }
 
-  nodeLinker(): 'hoisted' | 'isolated' {
+  nodeLinker(): NodeLinker {
     if (this.config.nodeLinker) return this.config.nodeLinker;
     if (this.config.packageManager === 'teambit.dependencies/pnpm') return 'isolated';
     return 'hoisted';
@@ -713,7 +716,7 @@ export class DependencyResolverMain {
       cacheRootDir,
       preInstallSubscribers,
       postInstallSubscribers,
-      this.config.nodeLinker,
+      options.nodeLinker || this.nodeLinker(),
       this.config.packageImportMethod,
       this.config.sideEffectsCache,
       this.config.nodeVersion,

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -23,6 +23,7 @@ export type {
   DependencyResolverVariantConfig,
   BIT_CLOUD_REGISTRY,
   MergedOutdatedPkg,
+  NodeLinker,
 } from './dependency-resolver.main.runtime';
 export {
   BIT_DEV_REGISTRY,

--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -20,6 +20,7 @@ import { Component, ComponentID, LoadAspectsOptions, ResolveAspectsOptions } fro
 import { ScopeMain } from '@teambit/scope';
 import { Logger } from '@teambit/logger';
 import { EnvsMain } from '@teambit/envs';
+import { NodeLinker } from '@teambit/dependency-resolver';
 
 type ManifestOrAspect = ExtensionManifest | Aspect;
 
@@ -350,6 +351,10 @@ needed-for: ${neededFor || '<unknown>'}`);
     return this.scope.aspectsPackageManager;
   }
 
+  getAspectsNodeLinker(): NodeLinker | undefined {
+    return this.scope.aspectsNodeLinker;
+  }
+
   private async resolveUserAspects(
     runtimeName?: string,
     userAspectsIds?: ComponentID[],
@@ -451,12 +456,14 @@ needed-for: ${neededFor || '<unknown>'}`);
   getDefaultIsolateOpts() {
     const useHash = this.shouldUseHashForCapsules();
     const useDatedDirs = this.shouldUseDatedCapsules();
+    const nodeLinker = this.getAspectsNodeLinker();
 
     const opts = {
       datedDirId: this.scope.name,
       baseDir: this.getAspectCapsulePath(),
       useHash,
       packageManager: this.getAspectsPackageManager(),
+      nodeLinker,
       useDatedDirs,
       skipIfExists: true,
       seedersOnly: true,

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -35,7 +35,7 @@ import { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component'
 import { loadScopeIfExist } from '@teambit/legacy/dist/scope/scope-loader';
 import { PersistOptions } from '@teambit/legacy/dist/scope/types';
 import { ExportPersist, PostSign } from '@teambit/legacy/dist/scope/actions';
-import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
+import { DependencyResolverAspect, DependencyResolverMain, NodeLinker } from '@teambit/dependency-resolver';
 import { getScopeRemotes } from '@teambit/legacy/dist/scope/scope-remotes';
 import { Remotes } from '@teambit/legacy/dist/remotes';
 import { isMatchNamespacePatternItem } from '@teambit/workspace.modules.match-pattern';
@@ -104,6 +104,10 @@ export type ScopeConfig = {
    * Set a different package manager for the aspects capsules
    */
   aspectsPackageManager?: string;
+  /**
+   * Set a different node linker for the aspects capsules
+   */
+  aspectsNodeLinker?: NodeLinker;
 };
 
 export class ScopeMain implements ComponentFactory {
@@ -191,6 +195,10 @@ export class ScopeMain implements ComponentFactory {
 
   get aspectsPackageManager(): string | undefined {
     return this.config.aspectsPackageManager;
+  }
+
+  get aspectsNodeLinker(): NodeLinker | undefined {
+    return this.config.aspectsNodeLinker;
   }
 
   // We need to reload the aspects with their new version since:


### PR DESCRIPTION
## Proposed Changes

- Added a new config for the scope aspect:
```
"teambit.scope/scope": {
   "aspectsNodeLinker": "hoisted"
}
```
- This `aspectsNodeLinker` will allow mentioning a specific node linker to be used when creating capsules for scope aspects (like envs for example). 
If not specified the aspects will be installed using the node linker that is configured by the `dependency resolver` aspect.

