### PR TITLE
change(registry) - use new registry by default (node-registry.bit.cloud)

### DIFF
--- a/e2e/harmony/pkg-manager-errors.e2e.ts
+++ b/e2e/harmony/pkg-manager-errors.e2e.ts
@@ -30,7 +30,7 @@ describe('bit checkout command', function () {
         const output = helper.command.checkoutVersion('0.0.1', 'comp1');
         expect(output).to.have.string('Installation Error');
         // this is the actual error coming from the package-manager
-        // the full error is: `GET https://node.bit.cloud/bit-non-exist-pkg: Not Found - 404`
+        // the full error is: `GET https://node-registry.bit.cloud/bit-non-exist-pkg: Not Found - 404`
         expect(output).to.have.string('404');
       });
     });

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -970,7 +970,7 @@ export class DependencyResolverMain {
 
       const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig();
 
-      const alwaysAuth = bitAuthHeaderValue !== undefined;
+      const alwaysAuth = !!bitAuthHeaderValue;
       const bitDefaultRegistry = new Registry(
         bitRegistry,
         alwaysAuth,

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -90,11 +90,7 @@ import { DependencyDetector } from './dependency-detector';
 import { DependenciesService } from './dependencies.service';
 import { EnvPolicy } from './policy/env-policy';
 
-/**
- * @deprecated use BIT_CLOUD_REGISTRY instead
- */
-export const BIT_DEV_REGISTRY = 'https://node.bit.dev/';
-export const BIT_CLOUD_REGISTRY = `https://node.${getCloudDomain()}/`;
+export const BIT_CLOUD_REGISTRY = `https://node-registry.${getCloudDomain()}/`;
 export const NPM_REGISTRY = 'https://registry.npmjs.org/';
 
 export { ProxyConfig, NetworkConfig } from '@teambit/legacy/dist/scope/network/http';
@@ -968,13 +964,11 @@ export class DependencyResolverMain {
       registries = await systemPm.getRegistries();
     }
 
-    const bitScope = registries.scopes.bit;
-
     const getDefaultBitRegistry = (): Registry => {
       const bitGlobalConfigRegistry = this.globalConfig.getSync(CFG_REGISTRY_URL_KEY);
-      const bitRegistry = bitGlobalConfigRegistry || bitScope?.uri || BIT_DEV_REGISTRY;
+      const bitRegistry = bitGlobalConfigRegistry || BIT_CLOUD_REGISTRY;
 
-      const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig(bitScope);
+      const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig();
 
       const alwaysAuth = bitAuthHeaderValue !== undefined;
       const bitDefaultRegistry = new Registry(
@@ -1005,24 +999,20 @@ export class DependencyResolverMain {
       // then in the registry server it should be use it when proxies
       registries = registries.setDefaultRegistry(bitDefaultRegistry);
     }
-    // Make sure @bit scope is register with alwaysAuth
-    if (!bitScope || (bitScope && !bitScope.alwaysAuth)) {
-      registries = registries.updateScopedRegistry('bit', bitDefaultRegistry);
-    }
 
-    registries = this.addAuthToScopedBitRegistries(registries, bitScope);
+    registries = this.addAuthToScopedBitRegistries(registries);
     return registries;
   }
 
   /**
    * This will mutate any registry which point to BIT_DEV_REGISTRY to have the auth config from the @bit scoped registry or from the user.token in bit's config
    */
-  private addAuthToScopedBitRegistries(registries: Registries, bitScopeRegistry: Registry): Registries {
-    const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig(bitScopeRegistry);
+  private addAuthToScopedBitRegistries(registries: Registries): Registries {
+    const { bitOriginalAuthType, bitAuthHeaderValue, bitOriginalAuthValue } = this.getBitAuthConfig();
     const alwaysAuth = bitAuthHeaderValue !== undefined;
     let updatedRegistries = registries;
     Object.entries(registries.scopes).map(([name, registry]) => {
-      if (!registry.authHeaderValue && BIT_DEV_REGISTRY.includes(registry.uri)) {
+      if (!registry.authHeaderValue && BIT_CLOUD_REGISTRY.includes(registry.uri)) {
         const registryWithAuth = new Registry(
           registry.uri,
           alwaysAuth,
@@ -1037,26 +1027,26 @@ export class DependencyResolverMain {
     return updatedRegistries;
   }
 
-  private getBitAuthConfig(
-    bitScopeRegistry: Registry
-  ): Partial<{ bitOriginalAuthType: string; bitAuthHeaderValue: string; bitOriginalAuthValue: string }> {
+  private getBitAuthConfig(): Partial<{
+    bitOriginalAuthType: string;
+    bitAuthHeaderValue: string;
+    bitOriginalAuthValue: string;
+  }> {
     const bitGlobalConfigToken = this.globalConfig.getSync(CFG_USER_TOKEN_KEY);
-    let bitAuthHeaderValue = bitScopeRegistry?.authHeaderValue;
-    let bitOriginalAuthType = bitScopeRegistry?.originalAuthType;
-    let bitOriginalAuthValue = bitScopeRegistry?.originalAuthValue;
+    const res = {
+      bitOriginalAuthType: '',
+      bitAuthHeaderValue: '',
+      bitOriginalAuthValue: '',
+    };
 
     // In case there is no auth configuration in the npmrc, but there is token in bit config, take it from the config
-    if ((!bitScopeRegistry || !bitScopeRegistry.authHeaderValue) && bitGlobalConfigToken) {
-      bitOriginalAuthType = 'authToken';
-      bitAuthHeaderValue = `Bearer ${bitGlobalConfigToken}`;
-      bitOriginalAuthValue = bitGlobalConfigToken;
+    if (bitGlobalConfigToken) {
+      res.bitOriginalAuthType = 'authToken';
+      res.bitAuthHeaderValue = `Bearer ${bitGlobalConfigToken}`;
+      res.bitOriginalAuthValue = bitGlobalConfigToken;
     }
 
-    return {
-      bitOriginalAuthType,
-      bitAuthHeaderValue,
-      bitOriginalAuthValue,
-    };
+    return res;
   }
 
   get packageManagerName(): string {

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -21,13 +21,12 @@ export type {
   DependencyResolverMain,
   DependencyResolverWorkspaceConfig,
   DependencyResolverVariantConfig,
-  BIT_CLOUD_REGISTRY,
   MergedOutdatedPkg,
   NodeLinker,
 } from './dependency-resolver.main.runtime';
 export {
-  BIT_DEV_REGISTRY,
   NPM_REGISTRY,
+  BIT_CLOUD_REGISTRY,
   ProxyConfig as PackageManagerProxyConfig,
   NetworkConfig as PackageManagerNetworkConfig,
 } from './dependency-resolver.main.runtime';

--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
@@ -3,13 +3,13 @@ import { pnpmErrorToBitError } from './pnpm-error-to-bit-error';
 
 test('the hint from the fetch error is used', () => {
   const bitError = pnpmErrorToBitError(
-    new PnpmError('FETCH_404', 'GET https://node.bit.cloud/dsffsdf: Not Found - 404', {
+    new PnpmError('FETCH_404', 'GET https://node-registry.bit.cloud/dsffsdf: Not Found - 404', {
       hint: `dsffsdf is not in the npm registry, or you have no permission to fetch it.
 
 An authorization header was used: Bearer df96[hidden]`,
     })
   );
-  expect(bitError.report()).toEqual(`GET https://node.bit.cloud/dsffsdf: Not Found - 404
+  expect(bitError.report()).toEqual(`GET https://node-registry.bit.cloud/dsffsdf: Not Found - 404
 
 dsffsdf is not in the npm registry, or you have no permission to fetch it.
 

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -8,7 +8,7 @@ import {
   ResolvedPackageVersion,
   Registries,
   Registry,
-  BIT_DEV_REGISTRY,
+  BIT_CLOUD_REGISTRY,
   PackageManagerProxyConfig,
   PackageManagerNetworkConfig,
 } from '@teambit/dependency-resolver';
@@ -204,7 +204,7 @@ export class PnpmPackageManager implements PackageManager {
 
     // Add bit registry server if not exist
     if (!scopesRegistries.bit) {
-      scopesRegistries.bit = new Registry(BIT_DEV_REGISTRY, true);
+      scopesRegistries.bit = new Registry(BIT_CLOUD_REGISTRY, true);
     }
 
     return new Registries(defaultRegistry, scopesRegistries);

--- a/scopes/dependencies/pnpm/pnpm.ui.runtime.tsx
+++ b/scopes/dependencies/pnpm/pnpm.ui.runtime.tsx
@@ -35,7 +35,7 @@ export class PnpmUI {
       Title: <img style={{ height: '16px', marginTop: '-2px' }} src="https://static.bit.dev/brands/pnpm.svg" />,
       Component: !options?.hide ? (
         <Install
-          config={`npm config set '${registry}:registry' https://node.bit.cloud`}
+          config={`npm config set '${registry}:registry' https://node-registry.bit.cloud`}
           componentName={componentId.name}
           packageManager="pnpm"
           copyString={`pnpm i ${packageName}${packageVersion}`}

--- a/scopes/dependencies/yarn/yarn.ui.runtime.tsx
+++ b/scopes/dependencies/yarn/yarn.ui.runtime.tsx
@@ -37,7 +37,7 @@ export class YarnUI {
       ),
       Component: !options?.hide ? (
         <Install
-          config={`npm config set '${registry}:registry' https://node.bit.cloud`}
+          config={`npm config set '${registry}:registry' https://node-registry.bit.cloud`}
           componentName={componentId.name}
           packageManager="yarn"
           copyString={`yarn add ${packageName}${packageVersion}`}

--- a/scopes/pkg/pkg/pkg.ui.runtime.tsx
+++ b/scopes/pkg/pkg/pkg.ui.runtime.tsx
@@ -36,7 +36,7 @@ export class PkgUI {
       Title: <img style={{ width: '30px' }} src="https://static.bit.dev/brands/logo-npm-new.svg" />,
       Component: !options?.hide ? (
         <Install
-          config={`npm config set '${registry}:registry' https://node.bit.cloud`}
+          config={`npm config set '${registry}:registry' https://node-registry.bit.cloud`}
           componentName={componentId.name}
           packageManager="npm"
           copyString={`npm i ${packageName}${packageVersion}`}

--- a/scopes/toolbox/network/agent/agent.spec.ts
+++ b/scopes/toolbox/network/agent/agent.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { getAgent } from './agent';
 
 test('getAgent reads cafile', () => {
-  const agent = getAgent('https://node.bit.cloud', {
+  const agent = getAgent('https://node-registry.bit.cloud', {
     cafile: path.join(__dirname, 'fixtures/cafile.txt'),
   });
   // @ts-ignore

--- a/scopes/ui-foundation/use-box/menu/menu.compositions.tsx
+++ b/scopes/ui-foundation/use-box/menu/menu.compositions.tsx
@@ -8,7 +8,7 @@ const methods = [
     Title: <img style={{ width: '30px' }} src="https://static.bit.dev/brands/logo-npm-new.svg" />,
     Component: (
       <Install
-        config={`npm config set @teambit:registry' https://node.bit.dev`}
+        config={`npm config set @teambit:registry' https://node-registry.bit.dev`}
         componentName="radio"
         packageManager="npm"
         copyString="npm i @teambit/design.ui.radio"

--- a/scopes/ui-foundation/use-box/menu/menu.docs.mdx
+++ b/scopes/ui-foundation/use-box/menu/menu.docs.mdx
@@ -19,7 +19,7 @@ The menu has some more concrete components available for the most common usages,
       Title: <img style={{ width: '30px' }} src="https://static.bit.dev/brands/logo-npm-new.svg" />,
       Component: (
         <Install
-          config={`npm config set @teambit:registry' https://node.bit.dev`}
+          config={`npm config set @teambit:registry' https://node-registry.bit.dev`}
           componentName="radio"
           packageManager="npm"
           copyString="npm i @teambit/design.ui.radio"

--- a/scripts/docker-teambit-bit/Dockerfile-symphony
+++ b/scripts/docker-teambit-bit/Dockerfile-symphony
@@ -11,7 +11,7 @@ ENV NODE_OPTIONS=--max-old-space-size=${MAX_OLD_SPACE_SIZE}
 # RUN bvm link bbit
 # ENV PATH=$PATH:/home/user/bin
 RUN npm i -g npm@9
-RUN npm config set @teambit:registry=https://node.bit.dev
+RUN npm config set @teambit:registry=https://node-registry.bit.dev
 RUN npm i @teambit/bit -g --unsafe-perm=true
 RUN bbit config set analytics_reporting false
 RUN bbit config set no_warnings false

--- a/src/api/consumer/lib/login.ts
+++ b/src/api/consumer/lib/login.ts
@@ -3,10 +3,8 @@ import loginToCloud from '../../../consumer/login/login';
 export default (async function loginAction(
   port: string,
   suppressBrowserLaunch: boolean,
-  npmrcPath: string,
-  skipRegistryConfig: boolean,
   machineName: string | null | undefined,
   cloudDomain?: string
 ): Promise<{ isAlreadyLoggedIn?: boolean; username?: string; npmrcPath?: string }> {
-  return loginToCloud(port, suppressBrowserLaunch, npmrcPath, skipRegistryConfig, machineName, cloudDomain);
+  return loginToCloud(port, suppressBrowserLaunch, machineName, cloudDomain);
 });

--- a/src/cli/commands/public-cmds/login-cmd.ts
+++ b/src/cli/commands/public-cmds/login-cmd.ts
@@ -1,7 +1,6 @@
 import chalk from 'chalk';
 
 import { login } from '../../../api/consumer';
-import { getCloudDomain } from '../../../constants';
 import { Group } from '../../command-groups';
 import { CommandOptions, LegacyCommand } from '../../legacy-command';
 
@@ -15,8 +14,6 @@ export default class Login implements LegacyCommand {
     ['d', 'cloud-domain <domain>', 'login cloud domain (default bit.cloud)'],
     ['p', 'port <port>', 'port number to open for localhost server (default 8085)'],
     ['', 'suppress-browser-launch', 'do not open a browser for authentication'],
-    ['', 'npmrc-path <path>', `path to npmrc file to configure ${getCloudDomain()} registry`],
-    ['', 'skip-registry-config', `don't configure ${getCloudDomain()} registry`],
     [
       '',
       'machine-name <name>',
@@ -29,47 +26,29 @@ export default class Login implements LegacyCommand {
       cloudDomain,
       port,
       suppressBrowserLaunch = false,
-      npmrcPath,
-      skipRegistryConfig = false,
       machineName,
     }: {
       cloudDomain?: string;
       port: string;
       suppressBrowserLaunch?: boolean;
-      npmrcPath: string;
-      skipRegistryConfig: boolean;
       machineName?: string;
     }
   ): Promise<any> {
-    return login(port, suppressBrowserLaunch, npmrcPath, skipRegistryConfig, machineName, cloudDomain).then(
-      (results) => ({
-        ...results,
-        skipRegistryConfig,
-      })
-    );
+    return login(port, suppressBrowserLaunch, machineName, cloudDomain).then((results) => ({
+      ...results,
+    }));
   }
   report({
     isAlreadyLoggedIn = false,
     username,
-    npmrcPath,
-    skipRegistryConfig,
-    writeToNpmrcError,
   }: {
     isAlreadyLoggedIn: boolean;
     username: string;
-    npmrcPath: string;
-    skipRegistryConfig: boolean;
     writeToNpmrcError: boolean;
   }): string {
     if (isAlreadyLoggedIn) return chalk.yellow('already logged in');
     const successLoginMessage = chalk.green(`success! logged in as ${username}`);
-    let writeToNpmrcMessage = '\n';
-    if (!skipRegistryConfig) {
-      writeToNpmrcMessage = writeToNpmrcError
-        ? chalk.yellow(`\nunable to add @bit as a scoped registry at "${chalk.bold(npmrcPath)}"\n`)
-        : chalk.green(`\nsuccessfully added @bit as a scoped registry at ${npmrcPath}\n`);
-    }
-    const finalMessage = `${writeToNpmrcMessage}${successLoginMessage}`;
+    const finalMessage = successLoginMessage;
     return finalMessage;
   }
 }


### PR DESCRIPTION
## Proposed Changes

- Use the new registry (`https://node-registry.bit.cloud`) by default 
- Remove all old registries - (`https://node.bit.cloud` and `https://node.bit.dev`)
- Do not write the `@bit` to the npmrc during bit login
- Do not take the token from npmrc (from the `@bit` entry) but from the bit's config (`user.token`) 
- Remove bit login flags that affect the changes to npmrc (they are not needed anymore now that we don't change the npmrc at bit login)
  - `npmrc-path`
  - `skip-registry-config`
- Update the use box in the UI to guide the user to run `npm config set` with the new registry url
