### PR TITLE
remove legacy templates

### DIFF
--- a/e2e/harmony/app.e2e.ts
+++ b/e2e/harmony/app.e2e.ts
@@ -15,7 +15,7 @@ describe('app command', function () {
   describe('app run', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes({ addRemoteScopeAsDefaultScope: false });
-      helper.command.create('express-app', 'my-app');
+      helper.command.create('express-app', 'my-app', '--aspect teambit.node/node');
       helper.command.compile();
       helper.command.install();
       helper.bitJsonc.addKeyVal('my-scope/my-app', {});

--- a/e2e/harmony/build-cmd.e2e.ts
+++ b/e2e/harmony/build-cmd.e2e.ts
@@ -24,7 +24,7 @@ describe('build command', function () {
   describe('an mdx dependency of a react env', () => {
     before(() => {
       helper.scopeHelper.reInitLocalScope();
-      helper.command.create('mdx-component', 'my-mdx');
+      helper.command.create('mdx-component', 'my-mdx', '--aspect teambit.mdx/mdx-env');
       helper.command.create('react-env', 'my-env');
       const importStatement = `import { MyMdx } from '@${helper.scopes.remote}/my-mdx';\n`;
       helper.fs.prependFile(path.join(helper.scopes.remote, 'my-env/my-env.docs.mdx'), importStatement);
@@ -68,7 +68,7 @@ describe('build command', function () {
   describe('registering the publish task for the snap pipeline in a new-custom env', () => {
     before(() => {
       helper.scopeHelper.reInitLocalScope({ addRemoteScopeAsDefaultScope: false });
-      helper.command.create('node-env', 'my-env');
+      helper.command.create('node-env', 'my-env', '--aspect teambit.node/node');
       helper.fixtures.populateComponents(1);
       helper.fs.outputFile('my-scope/my-env/my-env.main.runtime.ts', getMyEnvMainRuntime());
       helper.bitJsonc.setVariant(undefined, 'my-scope/my-env', { 'teambit.envs/env': {} });

--- a/e2e/harmony/custom-aspects.e2e.ts
+++ b/e2e/harmony/custom-aspects.e2e.ts
@@ -52,7 +52,7 @@ describe('custom aspects', function () {
 
       helper.command.install(`@ci/${helper.scopes.remoteWithoutOwner}.main-aspect`);
 
-      helper.command.create('react-env', 'my-env', '--path my-env');
+      helper.command.create('react-env', 'my-env', '--path my-env --aspect teambit.react/react-env');
       helper.fs.outputFile('my-env/my-env.main.runtime.ts', getEnvRuntimeMain(helper.scopes.remoteWithoutOwner));
       helper.fixtures.populateComponents(1);
 

--- a/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
+++ b/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
@@ -69,7 +69,7 @@ describe.skip('env-jsonc-policies', function () {
     helper = new Helper();
     helper.scopeHelper.setNewLocalAndRemoteScopes();
     envId = `${helper.scopes.remote}/react-based-env`;
-    helper.command.create('react', 'button', '-p button');
+    helper.command.create('react', 'button', '-p button --aspect teambit.react/react-env');
     helper.fs.prependFile('button/button.tsx', 'import isPositive from "is-positive";\n');
     helper.env.setCustomNewEnv(undefined, undefined, { policy: ENV_POLICY });
     helper.command.setEnv('button', envId);

--- a/e2e/harmony/dependencies/policies-order.e2e.ts
+++ b/e2e/harmony/dependencies/policies-order.e2e.ts
@@ -11,7 +11,12 @@ describe('policies order', function () {
     before(() => {
       helper = new Helper();
       helper.scopeHelper.setNewLocalAndRemoteScopes();
-      helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1');
+      helper.command.create(
+        'react-env',
+        'custom-react/env1',
+        '-p custom-react/env1',
+        '--aspect teambit.react/react-env'
+      );
       helper.fixtures.populateEnvMainRuntime(`custom-react/env1/env1.main.runtime.ts`, {
         envName: 'env1',
         dependencies: {
@@ -48,7 +53,7 @@ describe('policies order', function () {
     before(() => {
       helper = new Helper();
       helper.scopeHelper.setNewLocalAndRemoteScopes();
-      helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1');
+      helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1 --aspect teambit.react/react-env');
       helper.fixtures.populateEnvMainRuntime(`custom-react/env1/env1.main.runtime.ts`, {
         envName: 'env1',
         dependencies: {

--- a/e2e/harmony/install-and-compile.e2e.ts
+++ b/e2e/harmony/install-and-compile.e2e.ts
@@ -12,7 +12,7 @@ describe('all custom envs are compiled during installation', function () {
   function prepare() {
     helper = new Helper();
     helper.scopeHelper.setNewLocalAndRemoteScopes();
-    helper.command.create('node-env', 'custom-env1');
+    helper.command.create('node-env', 'custom-env1', '--aspect teambit.node/node-env');
     helper.fixtures.generateEnvJsoncFile(`${helper.scopes.remoteWithoutOwner}/custom-env1`, {
       policy: {
         runtime: [
@@ -52,7 +52,7 @@ export class CustomEnv1Main {
 CustomEnv1Aspect.addRuntime(CustomEnv1Main);
 `
     );
-    helper.command.create('node-env', 'custom-env2');
+    helper.command.create('node-env', 'custom-env2', '--aspect teambit.node/node-env');
     helper.fixtures.generateEnvJsoncFile(`${helper.scopes.remoteWithoutOwner}/custom-env2`, {
       policy: {
         runtime: [
@@ -97,7 +97,7 @@ CustomEnv2Aspect.addRuntime(CustomEnv2Main);
 `
     );
     helper.command.setEnv(`custom-env2`, `custom-env1`);
-    helper.command.create('node', 'comp');
+    helper.command.create('node', 'comp', '--aspect teambit.node/node');
     helper.fs.outputFile(
       `${helper.scopes.remoteWithoutOwner}/comp/comp.ts`,
       `
@@ -158,7 +158,7 @@ export function comp() {
       npmCiRegistry = new NpmCiRegistry(helper);
       await npmCiRegistry.init();
       npmCiRegistry.configureCiInPackageJsonHarmony();
-      helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1');
+      helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1 --aspect teambit.react/react-env');
       helper.fixtures.populateEnvMainRuntime(`custom-react/env1/env1.main.runtime.ts`, {
         envName: 'env1',
         dependencies: {
@@ -180,8 +180,8 @@ export function comp() {
       helper.scopeHelper.reInitLocalScope();
       helper.scopeHelper.addRemoteScope();
       helper.bitJsonc.setupDefault();
-      helper.command.create('react', 'comp1');
-      helper.command.create('react', 'comp2');
+      helper.command.create('react', 'comp1', '--aspect teambit.react/react-env');
+      helper.command.create('react', 'comp2', '--aspect teambit.react/react-env');
       helper.command.setEnv('comp1', `${helper.scopes.remote}/custom-react/env1`);
     });
     it('should not run install indefinitely', () => {

--- a/e2e/harmony/install-angular.e2e.ts
+++ b/e2e/harmony/install-angular.e2e.ts
@@ -10,7 +10,7 @@ describe.skip('installing in an angular workspace', function () {
     helper = new Helper();
     helper.command.new('ng-workspace', '--aspect=teambit.angular/angular');
     workspaceDir = path.join(helper.scopes.localPath, 'my-workspace');
-    helper.command.create('ng-module', 'ui/my-button', undefined, workspaceDir);
+    helper.command.create('ng-module', 'ui/my-button', '--aspect teambit.angular/angular', workspaceDir);
   }
   describe('using yarn', function () {
     before(prepare);

--- a/e2e/harmony/root-components.e2e.ts
+++ b/e2e/harmony/root-components.e2e.ts
@@ -1564,7 +1564,7 @@ describe('env peer dependencies hoisting', function () {
       helper = new Helper();
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.extensions.bitJsonc.addKeyValToDependencyResolver('rootComponents', true);
-      helper.command.create('react', 'my-button', '-p my-button');
+      helper.command.create('react', 'my-button', '-p my-button --aspect teambit.react/react-env');
       helper.command.install();
     });
     after(() => {
@@ -1618,7 +1618,7 @@ describe('env peer dependencies hoisting when the env is in the workspace', func
     helper = new Helper();
     helper.scopeHelper.setNewLocalAndRemoteScopes();
     helper.extensions.bitJsonc.setPackageManager(`teambit.dependencies/${pm}`);
-    helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1');
+    helper.command.create('react-env', 'custom-react/env1', '-p custom-react/env1 --aspect teambit.react/react-env');
     helper.fixtures.populateEnvMainRuntime(`custom-react/env1/env1.main.runtime.ts`, {
       envName: 'env1',
       dependencies: {
@@ -1631,7 +1631,7 @@ describe('env peer dependencies hoisting when the env is in the workspace', func
         ],
       },
     });
-    helper.command.create('react-env', 'custom-react/env2', '-p custom-react/env2');
+    helper.command.create('react-env', 'custom-react/env2', '-p custom-react/env2 --aspect teambit.react/react-env');
     helper.fixtures.populateEnvMainRuntime(`custom-react/env2/env2.main.runtime.ts`, {
       envName: 'env2',
       dependencies: {
@@ -1666,9 +1666,9 @@ describe('create with root components on', function () {
     helper = new Helper();
     helper.scopeHelper.setNewLocalAndRemoteScopes();
     helper.extensions.bitJsonc.addKeyValToDependencyResolver('rootComponents', true);
-    helper.command.create('react', 'card');
+    helper.command.create('react', 'card', '--aspect teambit.react/react-env');
     helper.command.install();
-    helper.command.create('react', 'my-button');
+    helper.command.create('react', 'my-button', '--aspect teambit.react/react-env');
   });
   it('should create the runtime component directory for the created component', () => {
     expect(path.join(helper.env.rootCompDirDep('teambit.react/react', 'my-button'), 'index.ts')).to.be.a.path();

--- a/scopes/harmony/node/node.main.runtime.ts
+++ b/scopes/harmony/node/node.main.runtime.ts
@@ -13,11 +13,7 @@ import { EnvsAspect, EnvsMain, EnvTransformer, Environment } from '@teambit/envs
 import { ReactAspect, ReactEnv, ReactMain, UseTypescriptModifiers } from '@teambit/react';
 import { NodeAspect } from './node.aspect';
 import { NodeEnv } from './node.env';
-import { nodeEnvTemplate } from './templates/node-env';
-import { nodeTemplate } from './templates/node';
 import { NodeAppType } from './node.app-type';
-import { expressAppTemplate } from './templates/express-app';
-import { expressRouteTemplate } from './templates/express-route';
 
 export class NodeMain {
   constructor(
@@ -165,8 +161,6 @@ export class NodeMain {
     envs.registerEnv(nodeEnv);
     const nodeAppType = new NodeAppType('node-app', nodeEnv, logger);
     application.registerAppType(nodeAppType);
-    if (generator)
-      generator.registerComponentTemplate([nodeEnvTemplate, nodeTemplate, expressAppTemplate, expressRouteTemplate]);
     return new NodeMain(react, tsAspect, nodeEnv, envs);
   }
 }

--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -13,7 +13,6 @@ import { MDXAspect } from './mdx.aspect';
 import { MDXCompiler, MDXCompilerOpts } from './mdx.compiler';
 import { MDXDependencyDetector } from './mdx.detector';
 import { MDXDocReader } from './mdx.doc-reader';
-import { componentTemplates } from './mdx.templates';
 import { babelConfig } from './babel/babel.config';
 
 export type MDXConfig = {
@@ -111,7 +110,6 @@ export class MDXMain {
     envs.registerEnv(mdxEnv);
     depResolver.registerDetector(new MDXDependencyDetector(config.extensions));
     docs.registerDocReader(new MDXDocReader(config.extensions));
-    if (generator) generator.registerComponentTemplate(componentTemplates);
 
     mdx.mdxEnv = mdxEnv as ReactEnv;
     return mdx;

--- a/scopes/react/react-native/react-native.main.runtime.ts
+++ b/scopes/react/react-native/react-native.main.runtime.ts
@@ -11,7 +11,6 @@ import { PackageJsonProps } from '@teambit/pkg';
 import { EnvsAspect, EnvsMain, EnvTransformer, Environment } from '@teambit/envs';
 import { ReactAspect, ReactMain, ReactEnv, UseWebpackModifiers } from '@teambit/react';
 import { ReactNativeAspect } from './react-native.aspect';
-import { componentTemplates } from './react-native.templates';
 import { previewConfigTransformer, devServerConfigTransformer } from './webpack/webpack-transformers';
 import { ReactNativeEnv } from './react-native.env';
 
@@ -123,10 +122,6 @@ export class ReactNativeMain {
       react.compose([react.useWebpack(webpackModifiers), react.overrideJestConfig(jestConfig)])
     );
     envs.registerEnv(reactNativeComposedEnv);
-
-    if (generator) {
-      generator.registerComponentTemplate(componentTemplates);
-    }
 
     return new ReactNativeMain(react, reactNativeComposedEnv, envs);
   }

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -33,7 +33,6 @@ import { ReactAspect } from './react.aspect';
 import { ReactEnv } from './react.env';
 import { ReactAppType } from './apps/web';
 import { reactSchema } from './react.graphql';
-import { componentTemplates } from './react.templates';
 import { ReactAppOptions } from './apps/web/react-app-options';
 
 type ReactDeps = [
@@ -451,9 +450,6 @@ export class ReactMain {
     const react = new ReactMain(reactEnv, envs, application, appType, dependencyResolver, logger);
     graphql.register(reactSchema(react));
     envs.registerEnv(reactEnv);
-    if (generator) {
-      generator.registerComponentTemplate(componentTemplates);
-    }
 
     if (application) application.registerAppType(appType);
 


### PR DESCRIPTION
This should have been removed in this PR: #7804
Not sure why it was not removed.
This is a major issue because even if the template Is hidden when running bit create react it will create a component with the legacy env.