### PR TITLE
fix: don't include the version of a local env or app in its root directory

### DIFF
--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -514,7 +514,7 @@ export class InstallMain {
       await Promise.all(
         envs.map(async (envId) => {
           return [
-            getRootComponentDir(this.workspace.path, envId.toString()),
+            await this.getRootComponentDirByRootId(this.workspace.path, envId),
             {
               dependencies: {
                 ...(await this._getEnvDependencies(envId)),
@@ -576,7 +576,7 @@ export class InstallMain {
             if (!appManifest) return null;
             const envId = await this.envs.calculateEnvId(app);
             return [
-              getRootComponentDir(this.workspace.path, app.id.toString()),
+              await this.getRootComponentDirByRootId(this.workspace.path, app.id),
               {
                 ...omit(appManifest, ['name', 'version']),
                 dependencies: {
@@ -770,16 +770,26 @@ export class InstallMain {
 
   private async _linkAllComponentsToBitRoots(compDirMap: ComponentMap<string>) {
     const envs = await this._getAllUsedEnvIds();
-    const apps = (await this.app.listAppsComponents()).map((component) => component.id.toString());
+    const apps = (await this.app.listAppsComponents()).map((component) => component.id);
     await Promise.all(
       [...envs, ...apps].map(async (id) => {
-        await fs.mkdirp(getRootComponentDir(this.workspace.path, id.toString()));
+        const dir = await this.getRootComponentDirByRootId(this.workspace.path, id);
+        await fs.mkdirp(dir);
       })
     );
     await linkPkgsToBitRoots(
       this.workspace.path,
       compDirMap.components.map((component) => this.dependencyResolver.getPackageName(component))
     );
+  }
+
+  private async getRootComponentDirByRootId(workspacePath: string, rootComponentId: ComponentID): Promise<string> {
+    // Root directories for local envs and apps are created without their version number.
+    // This is done in order to avoid changes to the lockfile after such components are tagged.
+    const id = (await this.workspace.hasId(rootComponentId))
+      ? rootComponentId.toStringWithoutVersion()
+      : rootComponentId.toString();
+    return getRootComponentDir(workspacePath, id);
   }
 
   /**


### PR DESCRIPTION
## Proposed Changes

- local envs & apps will not have their version numbers in their respective directory names inside `node_modules/.bit_roots`

