### PR TITLE
fix(lane-merge), save versions in .bitmap as tags if exist when merging from main

### DIFF
--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -111,10 +111,13 @@ export class ComponentWriterMain {
     this.fixDirsIfNested(componentWriterInstances);
     // add componentMap entries into .bitmap before starting the process because steps like writing package-json
     // rely on .bitmap to determine whether a dependency exists and what's its origin
-    componentWriterInstances.forEach((componentWriter: ComponentWriter) => {
-      componentWriter.existingComponentMap =
-        componentWriter.existingComponentMap || componentWriter.addComponentToBitMap(componentWriter.writeToPath);
-    });
+    await Promise.all(
+      componentWriterInstances.map(async (componentWriter: ComponentWriter) => {
+        componentWriter.existingComponentMap =
+          componentWriter.existingComponentMap ||
+          (await componentWriter.addComponentToBitMap(componentWriter.writeToPath));
+      })
+    );
     if (opts.resetConfig) {
       componentWriterInstances.forEach((componentWriter: ComponentWriter) => {
         delete componentWriter.existingComponentMap?.config;

--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -118,6 +118,11 @@ export class APIForIDE {
     return results;
   }
 
+  async setDefaultScope(scopeName: string) {
+    await this.workspace.setDefaultScope(scopeName);
+    return scopeName;
+  }
+
   async getCompFilesDirPathFromLastSnapUsingCompFiles(
     compFiles: CompFiles
   ): Promise<{ [relativePath: string]: string }> {


### PR DESCRIPTION
Currently, when merging from main and main is ahead, it saves the components in .bitmap with the snap (hash) instead of the tags. As a result, the subsequent snap of a dependent, saves the dependency with a snap instead of a tag. 
Once this happens, the manifest generated for this component has the dependency version as `0.0.0-hash` instead of the tag and the installation fails. 
This PR fixes it by saving it with the tag to the .bitmap during the merge. 