### PR TITLE
fix(overview): re render entire overview when comp id changes

### DIFF
--- a/scopes/docs/docs/overview/overview.tsx
+++ b/scopes/docs/docs/overview/overview.tsx
@@ -73,7 +73,7 @@ export function Overview({ titleBadges, overviewOptions, previewProps }: Overvie
   );
 
   return (
-    <div className={styles.overviewWrapper}>
+    <div className={styles.overviewWrapper} key={`${component.id.toString()}`}>
       {showHeader && (
         <ComponentOverview
           className={classNames(styles.componentOverviewBlock, !isScaling && styles.legacyPreview)}


### PR DESCRIPTION
This PR fixes an issue when navigating between components and viewing their Overview Page. 
When the component Id changes, the overview iframe mounts and unmounts, but the Component Overview is updated immediately
which leads to the prev iframe being rendered for a few milliseconds before the new one mounts

This PR adds an explicit key to the parent `ComponentOverview` page which unmounts the entire Overview when the component id changes