### PR TITLE
fix(snap), don't check component-issues for deleted components

### DIFF
--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -180,6 +180,13 @@ export class Component implements IComponent {
   }
 
   /**
+   * whether a component is marked as deleted.
+   */
+  isDeleted(): boolean {
+    return this.state._consumer.isRemoved();
+  }
+
+  /**
    * is component isOutdated
    */
   isOutdated(): boolean {

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -182,9 +182,7 @@ export class SnappingMain {
     this.logger.debug(`tagging the following components: ${legacyBitIds.toString()}`);
     const components = await this.loadComponentsForTagOrSnap(legacyBitIds, !soft);
     const consumerComponents = components.map((c) => c.state._consumer) as ConsumerComponent[];
-    await this.throwForLegacyDependenciesInsideHarmony(consumerComponents);
-    await this.throwForComponentIssues(components, ignoreIssues);
-    this.throwForPendingImport(consumerComponents);
+    await this.throwForVariousIssues(components, ignoreIssues);
 
     const { taggedComponents, autoTaggedResults, publishedPackages, stagedConfig, removedComponents } =
       await tagModelComponent({
@@ -491,9 +489,7 @@ if you're willing to lose the history from the head to the specified version, us
     this.logger.debug(`snapping the following components: ${ids.toString()}`);
     const components = await this.loadComponentsForTagOrSnap(ids);
     const consumerComponents = components.map((c) => c.state._consumer) as ConsumerComponent[];
-    await this.throwForLegacyDependenciesInsideHarmony(consumerComponents);
-    await this.throwForComponentIssues(components, ignoreIssues);
-    this.throwForPendingImport(consumerComponents);
+    await this.throwForVariousIssues(components, ignoreIssues);
 
     const { taggedComponents, autoTaggedResults, stagedConfig, removedComponents } = await tagModelComponent({
       workspace: this.workspace,
@@ -672,6 +668,15 @@ there are matching among unmodified components thought. consider using --unmodif
       await this.throwForDepsFromAnotherLaneForComp(component, allIds, lane || undefined, true);
     });
   }
+
+  private async throwForVariousIssues(components: Component[], ignoreIssues?: string) {
+    const componentsToCheck = components.filter((c) => !c.isDeleted());
+    const consumerComponents = componentsToCheck.map((c) => c.state._consumer) as ConsumerComponent[];
+    await this.throwForLegacyDependenciesInsideHarmony(consumerComponents);
+    await this.throwForComponentIssues(componentsToCheck, ignoreIssues);
+    this.throwForPendingImport(consumerComponents);
+  }
+
   private async throwForDepsFromAnotherLaneForComp(
     component: ConsumerComponent,
     allIds: BitIds,
@@ -937,7 +942,6 @@ another option, in case this dependency is not in main yet is to remove all refe
 
   private throwForPendingImport(components: ConsumerComponent[]) {
     const componentsMissingFromScope = components
-      .filter((c) => !c.isRemoved())
       .filter((c) => !c.componentFromModel && c.id.hasScope())
       .map((c) => c.id.toString());
     if (componentsMissingFromScope.length) {


### PR DESCRIPTION
currently, when deleting multiple components, some are dependencies of others, it throw `RemovedDependencies` upon snap. This PR fixes it by filtering out all deleting components. 