### PR TITLE
fix(ui server): open dev server in the default browser

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -96,6 +96,7 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
     },
 
     devServer: {
+      open: true,
       allowedHosts: 'all',
 
       static: [


### PR DESCRIPTION
This PR fixes the issue where the dev server **won't** open the app in the default browser of the user. 