### PR TITLE
ipc-events, clear sse client cache after install

### DIFF
--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -896,6 +896,8 @@ export class InstallMain {
     const logger = loggerExt.createLogger(InstallAspect.id);
     ipcEvents.registerGotEventSlot(async (eventName) => {
       if (eventName !== 'onPostInstall') return;
+      logger.debug('got onPostInstall event, clear workspace and all components cache');
+      await workspace.clearCache();
       workspace.clearAllComponentsCache();
       await pMapSeries(postInstallSlot.values(), (fn) => fn());
     });


### PR DESCRIPTION
Otherwise, when one process runs `bit install`, other processes (that are running the watcher) have the old components objects.