### PR TITLE
fix(watch), default to not use fsevents until a new chokidar release

### DIFF
--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -22,10 +22,10 @@ export type WatchCmdOpts = {
 export class WatchCommand implements Command {
   name = 'watch';
   description = 'automatically recompile modified components (on save)';
-  extendedDescription = `by default, the watcher doesn't use polling, to keep the CPU idle.
-in some rare cases, this could result in missing file events (files are not watched).
-to fix it, try to stop other watchers on the same machine.
-alternatively, to use polling, run "bit config set watch_use_polling true".`;
+  extendedDescription = `by default, the watcher use polling, although it causes a high CPU usage.
+it's needed due to a bug (fixed in master but not released yet) in Chokidar package, which is used by Bit watcher.
+for small projects though it should be ok to use the fsevents.
+to use fsevents, run "bit config set watch_use_fsevents true".`;
   helpUrl = 'reference/compiling/compiler-overview';
   alias = '';
   group = 'development';

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -196,6 +196,7 @@ export const getSymphonyUrl = (): string => {
 export const CFG_CLOUD_DOMAIN_LOGIN_KEY = 'cloud_domain_login';
 
 export const CFG_WATCH_USE_POLLING = 'watch_use_polling';
+export const CFG_WATCH_USE_FS_EVENTS = 'watch_use_fsevents';
 
 export const getLoginUrl = (domain?: string): string => {
   const finalDomain = domain || getSync(CFG_CLOUD_DOMAIN_LOGIN_KEY) || getCloudDomain();


### PR DESCRIPTION
This is related to this bug: https://github.com/paulmillr/chokidar/issues/1196#issuecomment-1711033539.
A fix was merged to master on chokidar repo. Once a new version is released, we can default to FsEvents again. 