### PR TITLE
fix(schema): allow overriding context and tsserver path when extracting 

### DIFF
--- a/scopes/semantics/schema/index.ts
+++ b/scopes/semantics/schema/index.ts
@@ -2,6 +2,7 @@ import { SchemaAspect } from './schema.aspect';
 
 export { Parser } from './parser';
 export { SchemaExtractor } from './schema-extractor';
+export type { SchemaExtractorOptions } from './schema-extractor';
 export {
   SchemaTask,
   SCHEMA_ARTIFACT_NAME,

--- a/scopes/semantics/schema/schema-extractor.ts
+++ b/scopes/semantics/schema/schema-extractor.ts
@@ -6,7 +6,12 @@ export interface SchemaExtractor {
   /**
    * extract a semantic schema from a component.
    */
-  extract(component: Component, formatter?: Formatter): Promise<APISchema>;
+  extract(
+    component: Component,
+    formatter?: Formatter,
+    overrideRootTsserverPath?: string,
+    overrideContextPath?: string
+  ): Promise<APISchema>;
   /**
    * release resources if no schemas are needed for this process.
    * for typescript, this will kill the tsserver process.

--- a/scopes/semantics/schema/schema-extractor.ts
+++ b/scopes/semantics/schema/schema-extractor.ts
@@ -6,12 +6,7 @@ export interface SchemaExtractor {
   /**
    * extract a semantic schema from a component.
    */
-  extract(
-    component: Component,
-    formatter?: Formatter,
-    overrideRootTsserverPath?: string,
-    overrideContextPath?: string
-  ): Promise<APISchema>;
+  extract(component: Component, options?: SchemaExtractorOptions): Promise<APISchema>;
   /**
    * release resources if no schemas are needed for this process.
    * for typescript, this will kill the tsserver process.
@@ -20,3 +15,9 @@ export interface SchemaExtractor {
    */
   dispose(): void;
 }
+
+export type SchemaExtractorOptions = {
+  formatter?: Formatter;
+  tsserverPath?: string;
+  contextPath?: string;
+};

--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -110,7 +110,7 @@ export class SchemaMain {
       }
       const schemaExtractor: SchemaExtractor = env.getSchemaExtractor(undefined, tsserverPath, contextPath);
 
-      const result = await schemaExtractor.extract(component, formatter, tsserverPath, contextPath);
+      const result = await schemaExtractor.extract(component, { formatter, tsserverPath, contextPath });
       if (shouldDisposeResourcesOnceDone) schemaExtractor.dispose();
 
       return result;

--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -110,7 +110,7 @@ export class SchemaMain {
       }
       const schemaExtractor: SchemaExtractor = env.getSchemaExtractor(undefined, tsserverPath, contextPath);
 
-      const result = await schemaExtractor.extract(component, formatter);
+      const result = await schemaExtractor.extract(component, formatter, tsserverPath, contextPath);
       if (shouldDisposeResourcesOnceDone) schemaExtractor.dispose();
 
       return result;

--- a/scopes/typescript/typescript/typescript.extractor.ts
+++ b/scopes/typescript/typescript/typescript.extractor.ts
@@ -52,7 +52,19 @@ export class TypeScriptExtractor implements SchemaExtractor {
   /**
    * extract a component schema.
    */
-  async extract(component: Component, formatter?: Formatter): Promise<APISchema> {
+  async extract(
+    component: Component,
+    formatter?: Formatter,
+    overrideRootTsserverPath?: string,
+    overrideContextPath?: string
+  ): Promise<APISchema> {
+    // override the rootTsserverPath and rootContextPath if passed
+    if (overrideRootTsserverPath) {
+      this.rootTsserverPath = overrideRootTsserverPath;
+    }
+    if (overrideContextPath) {
+      this.rootContextPath = overrideContextPath;
+    }
     const tsserver = await this.getTsServer();
     const mainFile = component.mainFile;
     const compatibleExts = ['.tsx', '.ts'];

--- a/scopes/typescript/typescript/typescript.extractor.ts
+++ b/scopes/typescript/typescript/typescript.extractor.ts
@@ -1,6 +1,6 @@
 import ts, { Node, SourceFile, SyntaxKind } from 'typescript';
 import { getTsconfig } from 'get-tsconfig';
-import { SchemaExtractor } from '@teambit/schema';
+import { SchemaExtractor, SchemaExtractorOptions } from '@teambit/schema';
 import { TsserverClient } from '@teambit/ts-server';
 import type { Workspace } from '@teambit/workspace';
 import { ComponentDependency, DependencyResolverMain } from '@teambit/dependency-resolver';
@@ -52,18 +52,13 @@ export class TypeScriptExtractor implements SchemaExtractor {
   /**
    * extract a component schema.
    */
-  async extract(
-    component: Component,
-    formatter?: Formatter,
-    overrideRootTsserverPath?: string,
-    overrideContextPath?: string
-  ): Promise<APISchema> {
-    // override the rootTsserverPath and rootContextPath if passed
-    if (overrideRootTsserverPath) {
-      this.rootTsserverPath = overrideRootTsserverPath;
+  async extract(component: Component, options: SchemaExtractorOptions = {}): Promise<APISchema> {
+    // override the rootTsserverPath and rootContextPath if passed via options
+    if (options.tsserverPath) {
+      this.rootTsserverPath = options.tsserverPath;
     }
-    if (overrideContextPath) {
-      this.rootContextPath = overrideContextPath;
+    if (options.contextPath) {
+      this.rootContextPath = options.contextPath;
     }
     const tsserver = await this.getTsServer();
     const mainFile = component.mainFile;
@@ -73,7 +68,7 @@ export class TypeScriptExtractor implements SchemaExtractor {
     );
     const allFiles = [mainFile, ...internalFiles];
 
-    const context = await this.createContext(tsserver, component, formatter);
+    const context = await this.createContext(tsserver, component, options.formatter);
 
     await pMapSeries(allFiles, async (file) => {
       const ast = this.parseSourceFile(file);


### PR DESCRIPTION
This PR updates the extract method in the Schema Extractor to allow overriding context and tsserver paths
Previously, this was only possible when initializing the context from the env. This allows to override it ad hoc during the extract call. 

This PR specifically fixes the issue where all the components with the new env signed from a bare scope, had all APIs extracted as `UnResolvedSchema`