### PR TITLE
fix: yarn's peer deps should always be installed as deps of bit

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3631,7 +3631,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -5540,7 +5540,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -7449,7 +7449,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -9358,7 +9358,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -11267,7 +11267,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -13176,7 +13176,7 @@ importers:
         version: file:scopes/compilation/babel(react-dom@17.0.2)(react@17.0.2)
       '@teambit/bit':
         specifier: workspace:*
-        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18)
+        version: file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18)
       '@teambit/bit-custom-aspect':
         specifier: workspace:*
         version: file:scopes/harmony/bit-custom-aspect(react-dom@17.0.2)(react@17.0.2)
@@ -21817,6 +21817,12 @@ importers:
       '@teambit/ui-foundation.ui.navigation.react-router-adapter':
         specifier: 6.1.1
         version: 6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
+      '@yarnpkg/cli':
+        specifier: 3.6.1
+        version: 3.6.1(@yarnpkg/core@3.5.2)
+      '@yarnpkg/core':
+        specifier: 3.5.2
+        version: 3.5.2
       '@yarnpkg/plugin-pack':
         specifier: 3.2.0
         version: 3.2.0(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)
@@ -39000,7 +39006,7 @@ packages:
     dev: false
 
   /@teambit/html.modules.create-element-from-string@0.0.104:
-    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=}
+    resolution: {integrity: sha1-yk2HNfv5z+0qh75v4SL0qkRNP9U=, tarball: https://node-registry.bit.cloud/@teambit/html.modules.create-element-from-string/-/@teambit-html.modules.create-element-from-string-0.0.104.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -39781,7 +39787,7 @@ packages:
     dev: true
 
   /@teambit/toolbox.string.ellipsis@0.0.181:
-    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=}
+    resolution: {integrity: sha1-85eglHHFlGiDBGQi9V5m4z9Tr+w=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.string.ellipsis/-/@teambit-toolbox.string.ellipsis-0.0.181.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -39801,7 +39807,7 @@ packages:
     dev: true
 
   /@teambit/toolbox.types.serializable@0.0.491:
-    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=}
+    resolution: {integrity: sha1-VTrj6yH43qYR2efWo5lAnh4dizI=, tarball: https://node-registry.bit.cloud/@teambit/toolbox.types.serializable/-/@teambit-toolbox.types.serializable-0.0.491.tgz}
     engines: {node: '>=12.22.0'}
     dev: false
 
@@ -64645,17 +64651,18 @@ packages:
       react-dom: 17.0.2(react@17.0.2)
     dev: false
 
-  file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)(subscriptions-transport-ws@0.9.18):
+  file:scopes/harmony/bit(@testing-library/react@12.1.5)(@types/react@17.0.8)(subscriptions-transport-ws@0.9.18):
     resolution: {directory: scopes/harmony/bit, type: directory}
     id: file:scopes/harmony/bit
     name: '@teambit/bit'
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
-      '@babel/runtime': 7.20.0
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 1.0.0
       '@teambit/ui-foundation.ui.navigation.react-router-adapter': 6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
+      '@yarnpkg/cli': 3.6.1(@yarnpkg/core@3.5.2)
+      '@yarnpkg/core': 3.5.2
       '@yarnpkg/plugin-pack': 3.2.0(@yarnpkg/cli@3.6.1)(@yarnpkg/core@3.5.2)
       browserslist: 4.16.3
       buffer: 6.0.3
@@ -64676,8 +64683,6 @@ packages:
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
-      - '@yarnpkg/cli'
-      - '@yarnpkg/core'
       - graphql-ws
       - subscriptions-transport-ws
     dev: false

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -844,6 +844,9 @@
             "@teambit/ui-foundation.ui.navigation.react-router-adapter": "6.1.1",
             "@apollo/client": "3.6.9",
             "@teambit/legacy": "1.0.559",
+            // These are the peer dependencies of Yarn
+            "@yarnpkg/cli": "3.6.1",
+            "@yarnpkg/core": "3.5.2",
             "@yarnpkg/plugin-pack": "3.2.0",
             "graphql": "15.8.0",
             "browserslist": "4.16.3",


### PR DESCRIPTION
close #7907

## Proposed Changes

-
-
-
