### PR TITLE
fix(watch), use forked @teambit/chokidar and switch back to FsEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "cacache": "15.0.5",
     "chalk": "2.4.2",
     "checksum": "0.1.1",
-    "chokidar": "3.5.3",
+    "@teambit/chokidar": "3.5.6",
     "cli-spinners": "1.3.1",
     "comment-json": "3.0.3",
     "core-js": "3.9.0",

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -41,7 +41,7 @@ import { Remotes } from '@teambit/legacy/dist/remotes';
 import { isMatchNamespacePatternItem } from '@teambit/workspace.modules.match-pattern';
 import { Scope } from '@teambit/legacy/dist/scope';
 import { CompIdGraph, DepEdgeType } from '@teambit/graph';
-import chokidar from 'chokidar';
+import chokidar from '@teambit/chokidar';
 import { Types } from '@teambit/legacy/dist/scope/object-registrar';
 import { FETCH_OPTIONS } from '@teambit/legacy/dist/api/scope/lib/fetch';
 import { ObjectList } from '@teambit/legacy/dist/scope/objects/object-list';

--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -22,10 +22,8 @@ export type WatchCmdOpts = {
 export class WatchCommand implements Command {
   name = 'watch';
   description = 'automatically recompile modified components (on save)';
-  extendedDescription = `by default, the watcher use polling, although it causes a high CPU usage.
-it's needed due to a bug (fixed in master but not released yet) in Chokidar package, which is used by Bit watcher.
-for small projects though it should be ok to use the fsevents.
-to use fsevents, run "bit config set watch_use_fsevents true".`;
+  extendedDescription = `by default, the watcher doesn't use polling, to keep the CPU idle.
+if this doesn't work well for you, run "bit config set watch_use_polling true" to use polling.`;
   helpUrl = 'reference/compiling/compiler-overview';
   alias = '';
   group = 'development';

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -5,14 +5,14 @@ import { compact, difference, partition } from 'lodash';
 import { ComponentID } from '@teambit/component';
 import { BitId } from '@teambit/legacy-bit-id';
 import loader from '@teambit/legacy/dist/cli/loader';
-import { BIT_MAP, CFG_WATCH_USE_FS_EVENTS } from '@teambit/legacy/dist/constants';
+import { BIT_MAP, CFG_WATCH_USE_POLLING } from '@teambit/legacy/dist/constants';
 import { Consumer } from '@teambit/legacy/dist/consumer';
 import logger from '@teambit/legacy/dist/logger/logger';
 import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 import mapSeries from 'p-map-series';
 import chalk from 'chalk';
 import { ChildProcess } from 'child_process';
-import chokidar, { FSWatcher } from 'chokidar';
+import chokidar, { FSWatcher } from '@teambit/chokidar';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 import { PathLinux, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import { CompilationInitiator } from '@teambit/compiler';
@@ -379,10 +379,10 @@ export class Watcher {
   }
 
   private async createWatcher() {
-    // const usePollingConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_POLLING);
-    // const usePolling = usePollingConf === 'true';
-    const useFsEventsConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_FS_EVENTS);
-    const useFsEvents = useFsEventsConf === 'true';
+    const usePollingConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_POLLING);
+    const usePolling = usePollingConf === 'true';
+    // const useFsEventsConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_FS_EVENTS);
+    // const useFsEvents = useFsEventsConf === 'true';
     const ignoreLocalScope = (pathToCheck: string) => {
       if (pathToCheck.startsWith(this.ipcEventsDir)) return false;
       return (
@@ -400,7 +400,8 @@ export class Watcher {
        * there is a fix for this in master. once a new version of Chokidar is released, we can upgrade it and then
        * default to true.
        */
-      useFsEvents,
+      usePolling,
+      // useFsEvents,
       persistent: true,
     });
     if (this.verbose) {


### PR DESCRIPTION
This is a continuation of the watcher saga. See last update here: https://github.com/teambit/bit/pull/7902
It may take some time for Chokidar owners to release a new version (the last one was released Jan 22), so this repo was forked and a new version was released under `@teambit/chokidar`. 
With this new version it's possible to work with the FsEvents and avoid the high CPU load.