### PR TITLE
fix: the generated package.json files should never be in a broken state

### DIFF
--- a/src/consumer/component/package-json-vinyl.ts
+++ b/src/consumer/component/package-json-vinyl.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import { dirname } from 'path';
 import fs from 'fs-extra';
 import stringifyPackage from 'stringify-package';
 import writeFileAtomic from 'write-file-atomic';
@@ -32,7 +32,7 @@ export default class PackageJsonVinyl extends AbstractVinyl {
     }
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     logger.debug(`package-json-vinyl.write, path ${this.path}`);
-    await fs.mkdirp(path.dirname(this.path));
+    await fs.mkdirp(dirname(this.path));
     await writeFileAtomic(this.path, this.contents);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;

--- a/src/consumer/component/package-json-vinyl.ts
+++ b/src/consumer/component/package-json-vinyl.ts
@@ -1,5 +1,5 @@
-import fs from 'fs-extra';
 import stringifyPackage from 'stringify-package';
+import writeFileAtomic from 'write-file-atomic';
 
 import ValidationError from '../../error/validation-error';
 import logger from '../../logger/logger';
@@ -30,8 +30,7 @@ export default class PackageJsonVinyl extends AbstractVinyl {
     }
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     logger.debug(`package-json-vinyl.write, path ${this.path}`);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    await fs.outputFile(this.path, this.contents);
+    await writeFileAtomic(this.path, this.contents);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;
   }

--- a/src/consumer/component/package-json-vinyl.ts
+++ b/src/consumer/component/package-json-vinyl.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+import fs from 'fs-extra';
 import stringifyPackage from 'stringify-package';
 import writeFileAtomic from 'write-file-atomic';
 
@@ -30,6 +32,7 @@ export default class PackageJsonVinyl extends AbstractVinyl {
     }
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     logger.debug(`package-json-vinyl.write, path ${this.path}`);
+    await fs.mkdirp(path.dirname(this.path));
     await writeFileAtomic(this.path, this.contents);
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;


### PR DESCRIPTION
## Proposed Changes

- Use an atomic write to avoid broken package.json files
