### PR TITLE
chore(ui): remove legacy sass loader syntax

### DIFF
--- a/components/ui/command-bar/command-bar/command-bar.module.scss
+++ b/components/ui/command-bar/command-bar/command-bar.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .commandBar {
   flex-direction: column;

--- a/components/ui/component-compare/compare-aspects/compare-aspects/compare-aspects.module.scss
+++ b/components/ui/component-compare/compare-aspects/compare-aspects/compare-aspects.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .componentCompareAspectContainer {
   display: flex;

--- a/components/ui/component-compare/version-picker/component-compare-version-picker.module.scss
+++ b/components/ui/component-compare/version-picker/component-compare-version-picker.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .componentCompareVersionPicker {
   display: flex;

--- a/components/ui/inputs/lane-selector/lane-selector.module.scss
+++ b/components/ui/inputs/lane-selector/lane-selector.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .dropdown {
   // otherwise when the dropdown is open it clashes with the content of the tree

--- a/scopes/api-reference/sections/api-reference-page/api-reference-page.module.scss
+++ b/scopes/api-reference/sections/api-reference-page/api-reference-page.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 $panelBg: #fafafa;
 
 .apiRefPageContainer {

--- a/scopes/code/ui/code-compare/code-compare-navigation/code-compare-navigation.module.scss
+++ b/scopes/code/ui/code-compare/code-compare-navigation/code-compare-navigation.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .codeCompareTab {
   display: flex;

--- a/scopes/code/ui/code-compare/code-compare-view/code-compare-view.module.scss
+++ b/scopes/code/ui/code-compare/code-compare-view/code-compare-view.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .componentCompareCodeViewContainer {
   width: 100%;

--- a/scopes/code/ui/code-compare/code-compare.module.scss
+++ b/scopes/code/ui/code-compare/code-compare.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .componentCompareCodeContainer {
   display: flex;

--- a/scopes/code/ui/code-tab-page/code-tab-page.module.scss
+++ b/scopes/code/ui/code-tab-page/code-tab-page.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 $panelBg: #fafafa;
 
 .codePage {

--- a/scopes/component/component-filters/env-filter/envs-filter.module.scss
+++ b/scopes/component/component-filters/env-filter/envs-filter.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 .envsFilterContainer {
   > div {
     line-height: 16px;

--- a/scopes/component/component/ui/menu/menu.module.scss
+++ b/scopes/component/component/ui/menu/menu.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
+@import '@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
 
 .topBar {
   display: flex;

--- a/scopes/component/ui/component-meta/component-overview.module.scss
+++ b/scopes/component/ui/component-meta/component-overview.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
+@import '@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
 
 .componentTitle {
   > h1 {

--- a/scopes/component/ui/version-dropdown/version-dropdown.module.scss
+++ b/scopes/component/ui/version-dropdown/version-dropdown.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .versionDropdown {
   height: 100%;

--- a/scopes/compositions/compositions/compositions.module.scss
+++ b/scopes/compositions/compositions/compositions.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 $panelBg: #fafafa;
 
 .compositionsPage {

--- a/scopes/compositions/ui/composition-compare/composition-dropdown.module.scss
+++ b/scopes/compositions/ui/composition-compare/composition-dropdown.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .placeholder {
   display: flex;

--- a/scopes/scope/scope/ui/scope.module.scss
+++ b/scopes/scope/scope/ui/scope.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .scope {
   display: flex;

--- a/scopes/ui-foundation/collapser-button/collapser-button.module.scss
+++ b/scopes/ui-foundation/collapser-button/collapser-button.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .collapser {
   position: absolute;

--- a/scopes/ui-foundation/notifications/ui/notification-center/notification-center.module.scss
+++ b/scopes/ui-foundation/notifications/ui/notification-center/notification-center.module.scss
@@ -1,6 +1,6 @@
 @use "sass:math";
 
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 $animationTime: 300ms;
 $header-height: 56px;

--- a/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.module.scss
+++ b/scopes/ui-foundation/tree/folder-tree-node/folder-tree-node.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.theme.colors/colors.module.scss';
+@import '@teambit/base-ui.theme.colors/colors.module.scss';
 
 .folder {
   position: relative;

--- a/scopes/ui-foundation/tree/tree-node/tree-node.module.scss
+++ b/scopes/ui-foundation/tree/tree-node/tree-node.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.theme.colors/colors.module.scss';
+@import '@teambit/base-ui.theme.colors/colors.module.scss';
 
 .fileNode {
   height: 32px;

--- a/scopes/ui-foundation/uis/corner/corner.module.scss
+++ b/scopes/ui-foundation/uis/corner/corner.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
+@import '@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
 
 $topbarHeight: 56px;
 

--- a/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.module.scss
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/component-view/component-view.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.theme.colors/colors.module.scss';
+@import '@teambit/base-ui.theme.colors/colors.module.scss';
 
 .component {
   height: 32px;

--- a/scopes/ui-foundation/uis/side-bar/component-tree/namespace-tree-node/namespace-tree-node.module.scss
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/namespace-tree-node/namespace-tree-node.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.theme.colors/colors.module.scss';
+@import '@teambit/base-ui.theme.colors/colors.module.scss';
 
 .namespace {
   position: relative;

--- a/scopes/ui-foundation/uis/side-bar/component-tree/scope-tree-node/scope-tree-node.module.scss
+++ b/scopes/ui-foundation/uis/side-bar/component-tree/scope-tree-node/scope-tree-node.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/base-ui.theme.colors/colors.module.scss';
+@import '@teambit/base-ui.theme.colors/colors.module.scss';
 
 .scope {
   position: relative;

--- a/scopes/ui-foundation/uis/top-bar/top-bar.module.scss
+++ b/scopes/ui-foundation/uis/top-bar/top-bar.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 $topbarHeight: 56px;
 
 .topbar {

--- a/scopes/ui-foundation/use-box/dropdown/dropdown.module.scss
+++ b/scopes/ui-foundation/use-box/dropdown/dropdown.module.scss
@@ -1,5 +1,5 @@
-@import '~@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/base-ui.layout.breakpoints/_breakpoints.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .menu {
   padding: 0;

--- a/scopes/ui-foundation/use-box/menu/menu.module.scss
+++ b/scopes/ui-foundation/use-box/menu/menu.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .container {
   z-index: $modal-z-index;

--- a/scopes/workspace/workspace/ui/workspace/workspace.module.scss
+++ b/scopes/workspace/workspace/ui/workspace/workspace.module.scss
@@ -1,4 +1,4 @@
-@import '~@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
 
 .emptyContainer {
   height: 100vh;


### PR DESCRIPTION
This PR removes the legacy sass loader syntax, (`~`) from all sass imports 