### PR TITLE
feat: installation that only update the lockfile, not node_modules

### DIFF
--- a/e2e/harmony/install.e2e.ts
+++ b/e2e/harmony/install.e2e.ts
@@ -242,3 +242,28 @@ describe('named install', function () {
     expect(bitJsonc['teambit.dependencies/dependency-resolver'].policy.dependencies['is-positive']).to.equal('^3.1.0');
   });
 });
+
+describe('install with --lockfile-only', function () {
+  this.timeout(0);
+  let helper: Helper;
+  let bitJsonc;
+  before(() => {
+    helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+    helper.scopeHelper.setNewLocalAndRemoteScopes();
+    helper.extensions.bitJsonc.setPackageManager('teambit.dependencies/pnpm');
+    helper.command.install('is-positive@1.0.0 --lockfile-only');
+    bitJsonc = helper.bitJsonc.read();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  it('should update workspace.jsonc', () => {
+    expect(bitJsonc['teambit.dependencies/dependency-resolver'].policy.dependencies['is-positive']).to.equal('^1.0.0');
+  });
+  it('should create pnpm-lock.yaml', () => {
+    expect(fs.existsSync(path.join(helper.fixtures.scopes.localPath, 'pnpm-lock.yaml'))).to.equal(true);
+  });
+  it('should not write dependencies to node_modules', () => {
+    expect(fs.existsSync(path.join(helper.fixtures.scopes.localPath, 'node_modules/is-positive'))).to.equal(false);
+  });
+});

--- a/scopes/workspace/install/install.cmd.tsx
+++ b/scopes/workspace/install/install.cmd.tsx
@@ -17,6 +17,7 @@ type InstallCmdOptions = {
   addMissingPeers: boolean;
   noOptional: boolean;
   recurringInstall: boolean;
+  lockfileOnly: boolean;
 };
 
 type FormatOutputArgs = {
@@ -58,6 +59,7 @@ export default class InstallCmd implements Command {
       'automatically run install again if there are non loaded old envs in your workspace',
     ],
     ['', 'no-optional [noOptional]', 'do not install optional dependencies (works with pnpm only)'],
+    ['', 'lockfile-only', 'dependencies are not written to node_modules. Only the lockfile is updated'],
   ] as CommandOptions;
 
   constructor(
@@ -94,6 +96,7 @@ export default class InstallCmd implements Command {
       includeOptionalDeps: !options.noOptional,
       updateAll: options.update,
       recurringInstall: options.recurringInstall,
+      lockfileOnly: options.lockfileOnly,
     };
     const components = await this.install.install(packages, installOpts);
     const endTime = Date.now();

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -74,6 +74,7 @@ export type WorkspaceInstallOptions = {
   updateAll?: boolean;
   recurringInstall?: boolean;
   optimizeReportForNonTerminal?: boolean;
+  lockfileOnly?: boolean;
 };
 
 export type ModulesInstallOptions = Omit<WorkspaceInstallOptions, 'updateExisting' | 'lifecycleType' | 'import'>;
@@ -281,6 +282,7 @@ export class InstallMain {
       rootComponents: hasRootComponents,
       updateAll: options?.updateAll,
       optimizeReportForNonTerminal: options?.optimizeReportForNonTerminal,
+      lockfileOnly: options?.lockfileOnly,
     };
     const prevManifests = new Set<string>();
     // TODO: this make duplicate
@@ -342,9 +344,11 @@ export class InstallMain {
       current = await this._getComponentsManifests(installer, mergedRootPolicy, calcManifestsOpts);
       installCycle += 1;
     } while ((!prevManifests.has(manifestsHash(current.manifests)) || hasMissingLocalComponents) && installCycle < 5);
-    // We clean node_modules only after the last install.
-    // Otherwise, we might load an env from a location that we later remove.
-    await installer.pruneModules(this.workspace.path);
+    if (!options?.lockfileOnly) {
+      // We clean node_modules only after the last install.
+      // Otherwise, we might load an env from a location that we later remove.
+      await installer.pruneModules(this.workspace.path);
+    }
     await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
     /* eslint-enable no-await-in-loop */
     return current.componentDirectoryMap;


### PR DESCRIPTION
## Proposed Changes

- The `bit install` command will now accept the `--lockfile-only` flag.

