### PR TITLE
chore(eslint) - upgrade eslint-config-airbnb-typescript from v5 to v12 (for legacy code)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,11 +54,13 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'off',
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': ['error'],
+    // ERRORS OF plugin:@typescript-eslint as a result of upgrade eslint-config-airbnb-typescript from v5 to v12
     '@typescript-eslint/lines-between-class-members': 'off',
     '@typescript-eslint/naming-convention': 'off',
     '@typescript-eslint/no-unused-expressions': 'off',
-    'no-shadow': 'off',
-    '@typescript-eslint/no-shadow': ['error'],
+    // END ERRORS OF plugin:@typescript-eslint as a result of upgrade eslint-config-airbnb-typescript from v5 to v12
     // ERRORS OF plugin:@typescript-eslint/recommended
     '@typescript-eslint/no-var-requires': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,6 +54,9 @@ module.exports = {
     '@typescript-eslint/explicit-module-boundary-types': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
     '@typescript-eslint/ban-types': 'off',
+    '@typescript-eslint/lines-between-class-members': 'off',
+    '@typescript-eslint/naming-convention': 'off',
+    '@typescript-eslint/no-unused-expressions': 'off',
     'no-shadow': 'off',
     '@typescript-eslint/no-shadow': ['error'],
     // ERRORS OF plugin:@typescript-eslint/recommended

--- a/components/ui/component-compare/changelog/component-compare-changelog.tsx
+++ b/components/ui/component-compare/changelog/component-compare-changelog.tsx
@@ -8,7 +8,7 @@ import { sortByDateDsc } from '@teambit/component.ui.component-compare.utils.sor
 
 import styles from './component-compare-changelog.module.scss';
 
-export type ComponentCompareChangelog = {} & HTMLAttributes<HTMLDivElement>;
+export type ComponentCompareChangelogType = {} & HTMLAttributes<HTMLDivElement>;
 
 const orderByDateDsc: (
   logA?: LegacyComponentLog,
@@ -43,7 +43,7 @@ const getLogsBetweenVersions: (
   return allLogs.filter((_, index) => index >= startingVersionIndex && index <= endingVersionIndex);
 };
 
-export function ComponentCompareChangelog({ className }: ComponentCompareChangelog) {
+export function ComponentCompareChangelog({ className }: ComponentCompareChangelogType) {
   const component = useContext(ComponentContext);
   const componentCompareContext = useComponentCompare();
   const { base, compare, logsByVersion } = componentCompareContext || {};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@babel/register':
         specifier: 7.18.9
         version: 7.18.9(@babel/core@7.19.6)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@babel/types':
         specifier: 7.22.3
         version: 7.22.3
@@ -898,8 +901,8 @@ importers:
         specifier: 7.32.0
         version: 7.32.0
       eslint-config-airbnb-typescript:
-        specifier: 5.1.0
-        version: 5.1.0(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)(typescript@4.7.4)
+        specifier: 12.0.0
+        version: 12.0.0(@typescript-eslint/eslint-plugin@5.35.1)(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)(typescript@4.7.4)
       eslint-config-prettier:
         specifier: 8.5.0
         version: 8.5.0(eslint@7.32.0)
@@ -1672,9 +1675,6 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
     devDependencies:
-      '@babel/runtime':
-        specifier: 7.20.0
-        version: 7.20.0
       '@teambit/base-ui.theme.theme-provider':
         specifier: 1.0.1
         version: registry.npmjs.org/@teambit/base-ui.theme.theme-provider@1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -1900,6 +1900,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -1907,6 +1910,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -1946,6 +1952,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -1956,6 +1965,9 @@ importers:
         specifier: 15.4.3
         version: 15.4.3(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2001,6 +2013,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fuse.js:
         specifier: 6.6.2
         version: 6.6.2
@@ -2023,6 +2038,9 @@ importers:
         specifier: 1.2.0
         version: 1.2.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@testing-library/jest-dom':
         specifier: 5.16.2
         version: 5.16.2
@@ -2062,6 +2080,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -2075,6 +2096,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2114,6 +2138,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2124,6 +2151,9 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2157,6 +2187,9 @@ importers:
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2164,6 +2197,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2191,6 +2227,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2198,6 +2237,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2222,6 +2264,9 @@ importers:
 
   components/ui/compare/lane-compare-page:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2229,6 +2274,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2253,6 +2301,9 @@ importers:
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2260,6 +2311,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2284,6 +2338,9 @@ importers:
       '@teambit/design.ui.empty-box':
         specifier: 0.0.363
         version: 0.0.363(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2291,6 +2348,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2315,6 +2375,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2322,6 +2385,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2361,6 +2427,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2368,6 +2437,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2407,6 +2479,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -2417,6 +2492,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2444,6 +2522,9 @@ importers:
 
   components/ui/component-compare/compare-aspects/context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2451,6 +2532,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2481,6 +2565,9 @@ importers:
       '@teambit/design.ui.tree':
         specifier: 0.0.15
         version: 0.0.15(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2488,6 +2575,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2509,6 +2599,9 @@ importers:
 
   components/ui/component-compare/compare-aspects/models/component-compare-aspects-model:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2516,6 +2609,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2546,6 +2642,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2553,6 +2652,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2577,6 +2679,9 @@ importers:
 
   components/ui/component-compare/context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2584,6 +2689,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2608,6 +2716,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2615,6 +2726,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2639,6 +2753,9 @@ importers:
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2646,6 +2763,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2670,6 +2790,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2677,6 +2800,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2701,6 +2827,9 @@ importers:
 
   components/ui/component-compare/models/component-compare-change-type:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2708,6 +2837,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2729,6 +2861,9 @@ importers:
 
   components/ui/component-compare/models/component-compare-hooks:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2736,6 +2871,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2757,6 +2895,9 @@ importers:
 
   components/ui/component-compare/models/component-compare-model:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2764,6 +2905,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2791,6 +2935,9 @@ importers:
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2801,6 +2948,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2822,6 +2972,9 @@ importers:
 
   components/ui/component-compare/models/component-compare-state:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2829,6 +2982,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2856,6 +3012,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2863,6 +3022,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -2887,6 +3049,9 @@ importers:
 
   components/ui/component-compare/utils/group-by-version:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2894,6 +3059,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2915,6 +3083,9 @@ importers:
 
   components/ui/component-compare/utils/lazy-loading:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -2925,6 +3096,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2949,6 +3123,9 @@ importers:
 
   components/ui/component-compare/utils/sort-logs:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2956,6 +3133,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -2977,6 +3157,9 @@ importers:
 
   components/ui/component-compare/utils/sort-tabs:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -2984,6 +3167,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3008,6 +3194,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3018,6 +3207,9 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3069,6 +3261,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -3079,6 +3274,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3109,6 +3307,9 @@ importers:
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3116,6 +3317,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3161,6 +3365,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -3174,6 +3381,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3207,6 +3417,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3214,6 +3427,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3244,6 +3460,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -3254,6 +3473,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3287,6 +3509,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -3300,6 +3525,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3339,6 +3567,9 @@ importers:
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3346,6 +3577,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3373,6 +3607,9 @@ importers:
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -3386,6 +3623,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3419,6 +3659,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3426,6 +3669,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -3450,6 +3696,9 @@ importers:
 
   components/ui/readme:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -3463,6 +3712,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -3487,6 +3739,9 @@ importers:
 
   components/ui/surfaces/menu/section:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -3494,6 +3749,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15029,9 +15287,15 @@ importers:
 
   scopes/api-reference/api-reference:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15069,6 +15333,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15076,6 +15343,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15103,6 +15373,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15110,6 +15383,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15134,6 +15410,9 @@ importers:
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15141,6 +15420,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15165,6 +15447,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15172,6 +15457,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15193,6 +15481,9 @@ importers:
 
   scopes/api-reference/models/api-node-renderer:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15200,6 +15491,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15224,6 +15518,9 @@ importers:
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15231,6 +15528,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15264,6 +15564,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       monaco-editor:
         specifier: 0.33.0
         version: 0.33.0
@@ -15277,6 +15580,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15301,6 +15607,9 @@ importers:
 
   scopes/api-reference/renderers/class:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15308,6 +15617,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15329,6 +15641,9 @@ importers:
 
   scopes/api-reference/renderers/enum:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15336,6 +15651,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15360,6 +15678,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15367,6 +15688,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15397,6 +15721,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15404,6 +15731,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15431,6 +15761,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15441,6 +15774,9 @@ importers:
         specifier: 15.4.3
         version: 15.4.3(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15465,6 +15801,9 @@ importers:
 
   scopes/api-reference/renderers/interface:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15472,6 +15811,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15499,6 +15841,9 @@ importers:
       '@teambit/documenter.ui.table-row':
         specifier: 4.1.13
         version: 4.1.13(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15506,6 +15851,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15530,6 +15878,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15537,6 +15888,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15567,6 +15921,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15577,6 +15934,9 @@ importers:
         specifier: 15.4.3
         version: 15.4.3(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15613,6 +15973,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -15623,6 +15986,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15650,6 +16016,9 @@ importers:
 
   scopes/api-reference/renderers/type:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15657,6 +16026,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15678,6 +16050,9 @@ importers:
 
   scopes/api-reference/renderers/type-array:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15685,6 +16060,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15709,6 +16087,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15716,6 +16097,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15740,6 +16124,9 @@ importers:
 
   scopes/api-reference/renderers/type-literal:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15747,6 +16134,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15777,6 +16167,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15784,6 +16177,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15811,6 +16207,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15818,6 +16217,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15842,6 +16244,9 @@ importers:
 
   scopes/api-reference/renderers/unresolved:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15849,6 +16254,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15870,6 +16278,9 @@ importers:
 
   scopes/api-reference/renderers/variable:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15877,6 +16288,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -15922,6 +16336,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -15932,6 +16349,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -15959,6 +16379,9 @@ importers:
 
   scopes/api-reference/sections/api-reference-section:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -15966,6 +16389,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -16073,9 +16499,15 @@ importers:
 
   scopes/cloud/cloud:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16158,6 +16590,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -16171,6 +16606,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -16210,6 +16648,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       monaco-editor:
         specifier: 0.33.0
         version: 0.33.0
@@ -16220,6 +16661,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -16271,6 +16715,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       is-binary-path:
         specifier: 2.1.0
         version: 2.1.0
@@ -16284,6 +16731,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -16323,6 +16773,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16330,6 +16783,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -16354,9 +16810,15 @@ importers:
 
   scopes/community/community:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16388,6 +16850,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16395,6 +16860,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -16422,6 +16890,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16429,6 +16900,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -16456,6 +16930,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16463,6 +16940,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -16490,9 +16970,15 @@ importers:
       '@babel/core':
         specifier: 7.19.6
         version: 7.19.6
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -16542,12 +17028,18 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       ink:
         specifier: 3.2.0
         version: 3.2.0(@types/react@17.0.8)(bufferutil@4.0.3)(react@17.0.2)(utf-8-validate@5.0.5)
@@ -16610,6 +17102,9 @@ importers:
 
   scopes/compilation/compiler:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -16622,6 +17117,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -16699,9 +17197,15 @@ importers:
 
   scopes/compilation/multi-compiler:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       p-map-series:
         specifier: 2.1.0
         version: 2.1.0
@@ -16736,6 +17240,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16743,6 +17250,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -16767,6 +17277,9 @@ importers:
 
   scopes/component/changelog:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component.instructions.exporting-components':
         specifier: 0.0.7
         version: 0.0.7(react-dom@17.0.2)(react@17.0.2)
@@ -16785,6 +17298,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16816,6 +17332,9 @@ importers:
 
   scopes/component/checkout:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -16828,6 +17347,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -16865,6 +17387,9 @@ importers:
 
   scopes/component/code:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.constants.storage':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -16877,6 +17402,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -16908,6 +17436,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/any-fs':
         specifier: 0.0.5
         version: 0.0.5
@@ -16956,6 +17487,9 @@ importers:
       copy-to-clipboard:
         specifier: 3.3.1
         version: 3.3.1
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17026,12 +17560,18 @@ importers:
 
   scopes/component/component-compare:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       '@teambit/legacy-bit-id':
         specifier: 1.0.0
         version: 1.0.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17072,6 +17612,12 @@ importers:
 
   scopes/component/component-descriptor:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -17127,6 +17673,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -17137,6 +17686,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -17164,6 +17716,9 @@ importers:
 
   scopes/component/component-filters/component-filter-context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -17174,6 +17729,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -17204,6 +17762,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -17211,6 +17772,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -17250,6 +17814,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -17257,6 +17824,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -17287,6 +17857,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -17294,6 +17867,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -17337,6 +17913,9 @@ importers:
 
   scopes/component/component-log:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/graph.cleargraph':
         specifier: 0.0.1
         version: 0.0.1
@@ -17352,6 +17931,9 @@ importers:
       cli-table:
         specifier: 0.3.6
         version: 0.3.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -17410,9 +17992,15 @@ importers:
 
   scopes/component/component-sizer:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17444,9 +18032,15 @@ importers:
 
   scopes/component/component-tree:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -17537,9 +18131,15 @@ importers:
 
   scopes/component/component-writer:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -17577,6 +18177,9 @@ importers:
 
   scopes/component/deprecation:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -17586,6 +18189,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17617,12 +18223,18 @@ importers:
 
   scopes/component/dev-files:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       comment-json:
         specifier: 3.0.3
         version: 3.0.3
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17669,6 +18281,9 @@ importers:
 
   scopes/component/forking:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -17681,6 +18296,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -17724,6 +18342,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.routing.nav-link':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.routing.nav-link@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -17766,6 +18387,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       dagre:
         specifier: 0.8.5
         version: 0.8.5
@@ -17827,6 +18451,9 @@ importers:
 
   scopes/component/isolator:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/any-fs':
         specifier: 0.0.5
         version: 0.0.5
@@ -17845,6 +18472,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       debug:
         specifier: 4.3.2
         version: 4.3.2
@@ -17924,12 +18554,18 @@ importers:
 
   scopes/component/issues:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       p-map-series:
         specifier: 2.1.0
         version: 2.1.0
@@ -17973,6 +18609,9 @@ importers:
 
   scopes/component/lister:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -17985,6 +18624,9 @@ importers:
       cli-table:
         specifier: 0.3.6
         version: 0.3.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       ramda:
         specifier: 0.27.1
         version: 0.27.1
@@ -18025,6 +18667,9 @@ importers:
 
   scopes/component/merging:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18037,6 +18682,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -18083,12 +18731,18 @@ importers:
 
   scopes/component/mover:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -18126,6 +18780,9 @@ importers:
 
   scopes/component/new-component-helper:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18135,6 +18792,9 @@ importers:
       '@teambit/legacy-bit-id':
         specifier: 1.0.0
         version: 1.0.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -18169,6 +18829,9 @@ importers:
 
   scopes/component/refactoring:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -18178,6 +18841,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       isbinaryfile:
         specifier: 4.0.6
         version: 4.0.6
@@ -18215,6 +18881,9 @@ importers:
 
   scopes/component/remove:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18227,6 +18896,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       group-array:
         specifier: 1.0.0
         version: 1.0.0
@@ -18276,6 +18948,9 @@ importers:
 
   scopes/component/renaming:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -18285,6 +18960,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -18322,6 +19000,9 @@ importers:
 
   scopes/component/snapping:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18337,6 +19018,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -18404,6 +19088,9 @@ importers:
 
   scopes/component/stash:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18413,6 +19100,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -18456,6 +19146,9 @@ importers:
 
   scopes/component/status:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -18468,6 +19161,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -18533,6 +19229,9 @@ importers:
 
   scopes/component/tracker:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -18542,6 +19241,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -18594,6 +19296,9 @@ importers:
       '@teambit/design.ui.pill-label':
         specifier: 0.0.356
         version: 0.0.356(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18601,6 +19306,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -18643,6 +19351,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       is-binary-path:
         specifier: 2.1.0
         version: 2.1.0
@@ -18656,6 +19367,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -18680,6 +19394,9 @@ importers:
 
   scopes/component/ui/component-artifacts/models/component-artifacts-model:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18687,6 +19404,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -18711,6 +19431,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18718,6 +19441,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -18757,6 +19483,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18764,6 +19493,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -18818,6 +19550,9 @@ importers:
       '@teambit/documenter.ui.sub-title':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.sub-title@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18825,6 +19560,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -18852,6 +19590,9 @@ importers:
       '@teambit/design.ui.tooltip':
         specifier: 0.0.361
         version: 0.0.361(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       pretty-bytes:
         specifier: 5.6.0
         version: 5.6.0
@@ -18862,6 +19603,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -18889,6 +19633,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18896,6 +19643,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -18935,6 +19685,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18942,6 +19695,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -18987,6 +19743,9 @@ importers:
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -18994,6 +19753,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19048,6 +19810,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19055,6 +19820,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19097,6 +19865,9 @@ importers:
       '@teambit/graphql.hooks.use-query-light':
         specifier: 1.0.0
         version: 1.0.0(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19104,6 +19875,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19128,6 +19902,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19135,6 +19912,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19171,6 +19951,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19178,6 +19961,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -19226,6 +20012,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19239,6 +20028,9 @@ importers:
         specifier: 7.5.2
         version: 7.5.2
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19290,6 +20082,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19297,6 +20092,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19339,6 +20137,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19346,6 +20147,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19370,6 +20174,9 @@ importers:
 
   scopes/compositions/composition-card:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.loaders.skeleton':
         specifier: 1.0.1
         version: 1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -19382,6 +20189,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19413,6 +20223,9 @@ importers:
 
   scopes/compositions/compositions:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -19458,6 +20271,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -19612,6 +20428,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19622,6 +20441,9 @@ importers:
         specifier: ^3.0.0
         version: 3.1.4(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -19661,6 +20483,9 @@ importers:
       '@teambit/evangelist.surfaces.dropdown':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.surfaces.dropdown@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -19674,6 +20499,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19698,6 +20526,9 @@ importers:
 
   scopes/compositions/ui/composition-compare-section:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19705,6 +20536,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19729,6 +20563,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -19739,6 +20576,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -19766,6 +20606,9 @@ importers:
 
   scopes/compositions/ui/compositions-overview:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19773,6 +20616,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19794,6 +20640,9 @@ importers:
 
   scopes/compositions/ui/hooks/use-composition:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -19801,6 +20650,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -19822,9 +20674,15 @@ importers:
 
   scopes/defender/eslint:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       eslint:
         specifier: 7.32.0
         version: 7.32.0
@@ -19905,6 +20763,9 @@ importers:
 
   scopes/defender/formatter:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -19914,6 +20775,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -19957,6 +20821,9 @@ importers:
 
   scopes/defender/jest:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@jest/test-result':
         specifier: 26.6.2
         version: 26.6.2
@@ -19966,6 +20833,9 @@ importers:
       comlink:
         specifier: 4.3.0
         version: 4.3.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       flatted:
         specifier: 3.1.0
         version: 3.1.0
@@ -20021,6 +20891,9 @@ importers:
 
   scopes/defender/linter:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -20030,6 +20903,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -20079,9 +20955,15 @@ importers:
       '@babel/register':
         specifier: 7.18.9
         version: 7.18.9(@babel/core@7.19.6)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -20122,9 +21004,15 @@ importers:
 
   scopes/defender/multi-tester:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -20165,9 +21053,15 @@ importers:
 
   scopes/defender/prettier:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       p-map-series:
         specifier: 2.1.0
         version: 2.1.0
@@ -20233,6 +21127,9 @@ importers:
 
   scopes/defender/tester:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -20242,6 +21139,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -20333,6 +21233,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20340,6 +21243,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -20364,6 +21270,9 @@ importers:
 
   scopes/defender/ui/test-compare-section:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20371,6 +21280,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -20398,6 +21310,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20405,6 +21320,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -20450,6 +21368,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20457,6 +21378,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -20487,6 +21411,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20494,6 +21421,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -20524,6 +21454,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20531,6 +21464,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -20558,6 +21494,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20565,6 +21504,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -20592,6 +21534,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20599,6 +21544,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -20626,6 +21574,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -20633,6 +21584,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -20657,6 +21611,9 @@ importers:
 
   scopes/dependencies/dependencies:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -20675,6 +21632,9 @@ importers:
       cli-table:
         specifier: 0.3.6
         version: 0.3.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -20718,6 +21678,9 @@ importers:
 
   scopes/dependencies/dependency-resolver:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pnpm/core':
         specifier: 12.1.1
         version: 12.1.1(@pnpm/logger@5.0.0)(@pnpm/worker@0.3.0)(@yarnpkg/core@3.5.2)(bluebird@3.7.2)
@@ -20739,6 +21702,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       execa:
         specifier: 2.1.0
         version: 2.1.0
@@ -20861,6 +21827,9 @@ importers:
 
   scopes/dependencies/pnpm:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pnpm/client':
         specifier: 10.0.24
         version: 10.0.24(@pnpm/logger@5.0.0)(@pnpm/worker@0.3.0)(bluebird@3.7.2)
@@ -20915,6 +21884,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       credentials-by-uri:
         specifier: 2.0.0
         version: 2.0.0
@@ -20970,6 +21942,9 @@ importers:
 
   scopes/dependencies/yarn:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pnpm/parse-overrides':
         specifier: 4.0.2
         version: 4.0.2
@@ -20994,6 +21969,9 @@ importers:
       '@yarnpkg/plugin-npm':
         specifier: 2.7.4
         version: 2.7.4(@yarnpkg/core@3.5.2)(@yarnpkg/plugin-pack@3.2.0)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -21046,6 +22024,9 @@ importers:
 
   scopes/docs/docs:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.loaders.skeleton':
         specifier: 1.0.1
         version: 1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -21064,6 +22045,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -21110,6 +22094,9 @@ importers:
       '@teambit/design.ui.round-loader':
         specifier: 0.0.355
         version: 0.0.355(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21117,6 +22104,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21138,6 +22128,9 @@ importers:
 
   scopes/docs/ui/overview-compare-section:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21145,6 +22138,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21169,6 +22165,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21176,6 +22175,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21200,6 +22202,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21207,6 +22212,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -21231,9 +22239,15 @@ importers:
 
   scopes/envs/env:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21262,6 +22276,9 @@ importers:
 
   scopes/envs/envs:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -21274,6 +22291,9 @@ importers:
       comment-json:
         specifier: 3.0.3
         version: 3.0.3
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -21320,6 +22340,9 @@ importers:
 
   scopes/envs/ui/env-icon:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21327,6 +22350,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21348,6 +22374,9 @@ importers:
 
   scopes/explorer/command-bar:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.text.muted-text':
         specifier: 1.0.1
         version: registry.npmjs.org/@teambit/base-ui.text.muted-text@1.0.1(react-dom@17.0.2)(react@17.0.2)
@@ -21360,6 +22389,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       is-primitive:
         specifier: 3.0.1
         version: 3.0.1
@@ -21406,6 +22438,9 @@ importers:
 
   scopes/explorer/insights:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -21415,6 +22450,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -21464,6 +22502,9 @@ importers:
       '@teambit/explorer.ui.gallery.base-component-card':
         specifier: 0.0.503
         version: 0.0.503(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21471,6 +22512,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -21495,6 +22539,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21502,6 +22549,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -21526,6 +22576,9 @@ importers:
 
   scopes/generator/generator:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -21538,6 +22591,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       execa:
         specifier: 2.1.0
         version: 2.1.0
@@ -21590,12 +22646,18 @@ importers:
 
   scopes/git/git:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -21633,9 +22695,15 @@ importers:
 
   scopes/harmony/api-server:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -21682,12 +22750,18 @@ importers:
 
   scopes/harmony/application:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       ink:
         specifier: 3.2.0
         version: 3.2.0(@types/react@17.0.8)(bufferutil@4.0.3)(react@17.0.2)(utf-8-validate@5.0.5)
@@ -21758,6 +22832,9 @@ importers:
       '@babel/preset-typescript':
         specifier: 7.22.15
         version: 7.22.15(@babel/core@7.19.6)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -21782,6 +22859,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -21831,6 +22911,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21838,6 +22921,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -21865,6 +22951,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -21872,6 +22961,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -21896,6 +22988,9 @@ importers:
 
   scopes/harmony/aspect-loader:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/bvm.config':
         specifier: 0.2.2
         version: 0.2.2
@@ -21911,6 +23006,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -21957,6 +23055,9 @@ importers:
       '@apollo/client':
         specifier: 3.6.9
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -22057,9 +23158,15 @@ importers:
 
   scopes/harmony/bit-custom-aspect:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -22100,12 +23207,18 @@ importers:
 
   scopes/harmony/cache:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       cacache:
         specifier: 15.0.5
         version: 15.0.5(bluebird@3.7.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -22149,12 +23262,18 @@ importers:
 
   scopes/harmony/cli:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       didyoumean:
         specifier: 1.2.1
         version: 1.2.1
@@ -22213,6 +23332,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -22220,6 +23342,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -22241,6 +23366,9 @@ importers:
 
   scopes/harmony/config:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -22250,6 +23378,9 @@ importers:
       comment-json:
         specifier: 3.0.3
         version: 3.0.3
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -22290,9 +23421,15 @@ importers:
 
   scopes/harmony/diagnostic:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       graphql-tag:
         specifier: 2.12.1
         version: 2.12.1(graphql@15.8.0)
@@ -22324,12 +23461,18 @@ importers:
 
   scopes/harmony/express:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       body-parser:
         specifier: 1.19.0
         version: 1.19.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       express:
         specifier: 4.17.1
         version: 4.17.1
@@ -22370,12 +23513,18 @@ importers:
 
   scopes/harmony/global-config:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -22416,6 +23565,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@graphql-modules/core':
         specifier: 0.7.17
         version: 0.7.17(graphql@15.8.0)(reflect-metadata@0.1.13)
@@ -22446,6 +23598,9 @@ importers:
       bufferutil:
         specifier: 4.0.3
         version: 4.0.3
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       cors:
         specifier: 2.8.5
         version: 2.8.5
@@ -22522,9 +23677,15 @@ importers:
 
   scopes/harmony/ipc-events:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -22562,12 +23723,18 @@ importers:
 
   scopes/harmony/logger:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       pretty-time:
         specifier: 1.1.0
         version: 1.1.0
@@ -22629,12 +23796,18 @@ importers:
 
   scopes/harmony/node:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/design.ui.empty-box':
         specifier: 0.0.363
         version: 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       jest-environment-node:
         specifier: 27.5.1
         version: 27.5.1
@@ -22669,9 +23842,15 @@ importers:
 
   scopes/harmony/pubsub:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       eventemitter2:
         specifier: 6.4.4
         version: 6.4.4
@@ -22737,6 +23916,9 @@ importers:
       copy-to-clipboard:
         specifier: 3.3.1
         version: 3.3.1
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       json-formatter-js:
         specifier: 2.3.4
         version: 2.3.4
@@ -22750,6 +23932,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -22777,12 +23962,18 @@ importers:
 
   scopes/harmony/worker:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       comlink:
         specifier: 4.3.0
         version: 4.3.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -22814,6 +24005,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -22821,6 +24015,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -22845,12 +24042,18 @@ importers:
 
   scopes/html/html:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       '@teambit/html.modules.render-template':
         specifier: 0.0.104
         version: 0.0.104
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       map-obj:
         specifier: 4.2.1
         version: 4.2.1
@@ -23003,6 +24206,9 @@ importers:
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -23013,6 +24219,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -23071,6 +24280,9 @@ importers:
 
   scopes/lanes/lanes:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/design.ui.pages.not-found':
         specifier: 0.0.366
         version: 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -23086,6 +24298,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fuse.js:
         specifier: 6.6.2
         version: 6.6.2
@@ -23141,6 +24356,9 @@ importers:
 
   scopes/lanes/merge-lanes:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -23153,6 +24371,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -23208,6 +24429,9 @@ importers:
       '@teambit/evangelist.elements.button':
         specifier: 1.0.6
         version: 1.0.6(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -23218,6 +24442,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23248,12 +24475,18 @@ importers:
       '@babel/helper-plugin-test-runner':
         specifier: 7.16.7
         version: 7.16.7
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/design.ui.empty-box':
         specifier: 0.0.363
         version: 0.0.363(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -23395,9 +24628,15 @@ importers:
 
   scopes/mdx/readme:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23432,6 +24671,9 @@ importers:
       '@teambit/mdx.ui.docs.link':
         specifier: 0.0.500
         version: 0.0.500(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23439,6 +24681,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23463,6 +24708,9 @@ importers:
 
   scopes/mdx/ui/mdx-scope-context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23470,6 +24718,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -23497,6 +24748,9 @@ importers:
       '@teambit/documenter.markdown.hybrid-live-code-snippet':
         specifier: 0.1.12
         version: 0.1.12(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23504,6 +24758,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23540,6 +24797,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23547,6 +24807,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23571,6 +24834,9 @@ importers:
 
   scopes/pipelines/builder:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -23586,6 +24852,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       filenamify:
         specifier: 4.2.0
         version: 4.2.0
@@ -23662,6 +24931,12 @@ importers:
 
   scopes/pipelines/modules/builder-data:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23721,6 +24996,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23728,6 +25006,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23752,6 +25033,9 @@ importers:
 
   scopes/pkg/pkg:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pnpm/plugin-commands-publishing':
         specifier: 7.3.12
         version: 7.3.12(@pnpm/logger@5.0.0)(@pnpm/worker@0.3.0)(bluebird@3.7.2)
@@ -23764,6 +25048,9 @@ importers:
       cli-highlight:
         specifier: 2.1.9
         version: 2.1.9
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       execa:
         specifier: 2.1.0
         version: 2.1.0
@@ -23837,6 +25124,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -23844,6 +25134,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -23920,6 +25213,9 @@ importers:
 
   scopes/preview/preview:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -23929,6 +25225,9 @@ importers:
       camelcase:
         specifier: 6.2.0
         version: 6.2.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       cross-fetch:
         specifier: 3.1.5
         version: 3.1.5
@@ -24011,6 +25310,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -24024,6 +25326,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -24060,6 +25365,9 @@ importers:
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24067,6 +25375,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24091,6 +25402,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24098,6 +25412,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -24125,6 +25442,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24132,6 +25452,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -24156,6 +25479,9 @@ importers:
 
   scopes/react/bit-component-meta:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24163,6 +25489,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24388,6 +25717,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       css-loader:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.84.1)
@@ -24584,6 +25916,9 @@ importers:
       '@babel/preset-react':
         specifier: 7.22.15
         version: 7.22.15(@babel/core@7.19.6)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
@@ -24599,6 +25934,9 @@ importers:
       babel-preset-react-app:
         specifier: ^10.0.0
         version: 10.0.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       css-loader:
         specifier: 6.2.0
         version: 6.2.0(webpack@5.84.1)
@@ -24711,6 +26049,9 @@ importers:
       '@babel/preset-react':
         specifier: 7.22.15
         version: 7.22.15(@babel/core@7.19.6)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -24723,6 +26064,9 @@ importers:
       '@testing-library/jest-native':
         specifier: 4.0.4
         version: 4.0.4
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -24769,6 +26113,9 @@ importers:
       '@teambit/design.ui.pages.standalone-not-found-page':
         specifier: 0.0.369
         version: 0.0.369(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24776,6 +26123,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24815,6 +26165,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       jsx-to-string:
         specifier: 1.4.0
         version: 1.4.0
@@ -24828,6 +26181,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -24858,6 +26214,9 @@ importers:
       '@teambit/base-ui.utils.composer':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.utils.composer@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24868,6 +26227,9 @@ importers:
         specifier: ^3.0.0
         version: 3.1.4(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24895,6 +26257,9 @@ importers:
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24902,6 +26267,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24926,6 +26294,9 @@ importers:
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -24939,6 +26310,9 @@ importers:
         specifier: ^3.0.0
         version: 3.1.4(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -24972,6 +26346,9 @@ importers:
       '@teambit/documenter.ui.section':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.section@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -24979,6 +26356,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25009,6 +26389,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25019,6 +26402,9 @@ importers:
         specifier: ^3.0.0
         version: 3.1.4(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -25049,6 +26435,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       query-string:
         specifier: 7.0.0
         version: 7.0.0
@@ -25059,6 +26448,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -25089,6 +26481,9 @@ importers:
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25096,6 +26491,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25117,12 +26515,18 @@ importers:
 
   scopes/scope/export:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -25169,6 +26573,9 @@ importers:
 
   scopes/scope/importer:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -25178,6 +26585,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -25237,6 +26647,9 @@ importers:
 
   scopes/scope/scope:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.surfaces.split-pane.hover-splitter':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.surfaces.split-pane.hover-splitter@1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -25276,6 +26689,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -25343,12 +26759,18 @@ importers:
 
   scopes/scope/sign:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       p-map-series:
         specifier: 2.1.0
         version: 2.1.0
@@ -25383,6 +26805,9 @@ importers:
       '@teambit/documenter.ui.highlighted-text':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.ui.highlighted-text@4.1.1(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25390,6 +26815,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -25414,6 +26842,9 @@ importers:
 
   scopes/scope/ui/hooks/scope-context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25421,6 +26852,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25445,6 +26879,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25452,6 +26889,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -25479,6 +26919,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -25489,6 +26932,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -25519,6 +26965,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -25529,6 +26978,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -25568,6 +27020,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -25575,6 +27030,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -25599,12 +27057,18 @@ importers:
 
   scopes/scope/update-dependencies:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -25670,12 +27134,18 @@ importers:
 
   scopes/semantics/schema:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -26052,6 +27522,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26059,6 +27532,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -26145,12 +27621,18 @@ importers:
 
   scopes/typescript/typescript:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -26274,6 +27756,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26281,6 +27766,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -26323,6 +27811,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26330,6 +27821,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -26360,6 +27854,9 @@ importers:
       '@teambit/base-ui.constants.storage':
         specifier: 1.0.0
         version: registry.npmjs.org/@teambit/base-ui.constants.storage@1.0.0(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26370,6 +27867,9 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26391,9 +27891,15 @@ importers:
 
   scopes/ui-foundation/harmony-ui-app/harmony-ui-app:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26428,6 +27934,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -26438,6 +27947,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -26474,6 +27986,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26481,6 +27996,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -26505,9 +28023,15 @@ importers:
 
   scopes/ui-foundation/notifications/aspect:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26560,6 +28084,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26567,6 +28094,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-ui.theme.dark-theme':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/base-ui.theme.dark-theme@1.0.2(react-dom@17.0.2)(react@17.0.2)
@@ -26606,6 +28136,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26613,6 +28146,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -26637,6 +28173,9 @@ importers:
 
   scopes/ui-foundation/notifications/ui/notification-context:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26644,6 +28183,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26665,6 +28207,9 @@ importers:
 
   scopes/ui-foundation/notifications/ui/notification-store:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26672,6 +28217,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26693,12 +28241,18 @@ importers:
 
   scopes/ui-foundation/panels:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26736,6 +28290,9 @@ importers:
 
   scopes/ui-foundation/react-router/react-router:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
@@ -26745,6 +28302,9 @@ importers:
       '@teambit/ui-foundation.ui.navigation.react-router-adapter':
         specifier: 6.1.1
         version: 6.1.1(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react-router-dom@6.3.0)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26782,6 +28342,9 @@ importers:
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -26795,6 +28358,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26822,6 +28388,9 @@ importers:
       '@teambit/base-react.navigation.link':
         specifier: 2.0.27
         version: 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26829,6 +28398,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -26850,12 +28422,18 @@ importers:
 
   scopes/ui-foundation/sidebar:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -26899,6 +28477,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26906,6 +28487,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -26951,6 +28535,9 @@ importers:
       '@teambit/design.ui.tree':
         specifier: 0.0.15
         version: 0.0.15(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -26958,6 +28545,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/code.ui.utils.get-file-icon':
         specifier: 0.0.495
         version: 0.0.495(react-dom@17.0.2)(react@17.0.2)
@@ -27003,6 +28593,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27010,6 +28603,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -27052,6 +28648,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27059,6 +28658,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27086,6 +28688,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: 0.5.4
         version: 0.5.4(@types/webpack@5.28.1)(react-refresh@0.10.0)(webpack-dev-server@4.15.0)(webpack@5.84.1)
@@ -27125,6 +28730,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       css-loader:
         specifier: 5.2.0
         version: 5.2.0(webpack@5.84.1)
@@ -27267,6 +28875,9 @@ importers:
 
   scopes/ui-foundation/uis/constants/z-indexes:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27274,6 +28885,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27301,6 +28915,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27311,6 +28928,9 @@ importers:
         specifier: ^6.0.0
         version: 6.3.0(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27335,6 +28955,9 @@ importers:
 
   scopes/ui-foundation/uis/full-loader:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27342,6 +28965,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27363,6 +28989,9 @@ importers:
 
   scopes/ui-foundation/uis/global-loader:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27373,6 +29002,9 @@ importers:
         specifier: 8.3.2
         version: 8.3.2
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27397,6 +29029,9 @@ importers:
 
   scopes/ui-foundation/uis/hooks/use-bind-key:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       mousetrap:
         specifier: 1.6.5
         version: 1.6.5
@@ -27407,6 +29042,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27434,6 +29072,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27441,6 +29082,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27462,6 +29106,9 @@ importers:
 
   scopes/ui-foundation/uis/hooks/use-in-out-transition:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27469,6 +29116,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27490,6 +29140,9 @@ importers:
 
   scopes/ui-foundation/uis/hooks/use-is-mobile:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27497,6 +29150,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27521,6 +29177,9 @@ importers:
       '@teambit/react.rendering.ssr':
         specifier: 0.0.3
         version: 0.0.3(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27531,6 +29190,9 @@ importers:
         specifier: 0.7.24
         version: 0.7.24
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27555,6 +29217,9 @@ importers:
 
   scopes/ui-foundation/uis/is-browser:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27562,6 +29227,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27586,6 +29254,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27593,6 +29264,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27629,6 +29303,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -27639,6 +29316,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27666,6 +29346,9 @@ importers:
 
   scopes/ui-foundation/uis/pages/preview-not-found:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27673,6 +29356,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27703,6 +29389,9 @@ importers:
       '@teambit/design.ui.pages.server-error':
         specifier: 0.0.366
         version: 0.0.366(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27710,6 +29399,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27731,6 +29423,9 @@ importers:
 
   scopes/ui-foundation/uis/rendering/html:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27738,6 +29433,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27789,6 +29487,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27799,6 +29500,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27826,6 +29530,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27833,6 +29540,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27863,6 +29573,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27870,6 +29583,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -27906,6 +29622,9 @@ importers:
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27913,6 +29632,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27934,6 +29656,9 @@ importers:
 
   scopes/ui-foundation/use-box/bottom-link:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27941,6 +29666,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -27974,6 +29702,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -27981,6 +29712,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -28029,6 +29763,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash.flatten:
         specifier: 4.4.0
         version: 4.4.0
@@ -28042,6 +29779,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28081,6 +29821,9 @@ importers:
       '@teambit/evangelist.elements.icon':
         specifier: 1.0.2
         version: registry.npmjs.org/@teambit/evangelist.elements.icon@1.0.2(react-dom@17.0.2)(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28088,6 +29831,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -28115,6 +29861,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28122,6 +29871,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28152,6 +29904,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28162,6 +29917,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -28186,9 +29944,15 @@ importers:
 
   scopes/ui-foundation/user-agent:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28223,6 +29987,9 @@ importers:
 
   scopes/web-components/elements:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
@@ -28232,6 +29999,9 @@ importers:
       camelcase:
         specifier: 6.2.0
         version: 6.2.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -28407,6 +30177,9 @@ importers:
 
   scopes/webpack/webpack:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -28428,6 +30201,9 @@ importers:
       constants-browserify:
         specifier: 1.0.0
         version: 1.0.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       crypto-browserify:
         specifier: 3.12.0
         version: 3.12.0
@@ -28552,6 +30328,9 @@ importers:
       '@mdx-js/react':
         specifier: 1.6.22
         version: 1.6.22(react@17.0.2)
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28559,6 +30338,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -28583,6 +30365,12 @@ importers:
 
   scopes/workspace/bit-roots:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -28617,12 +30405,18 @@ importers:
 
   scopes/workspace/clear-cache:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28651,12 +30445,18 @@ importers:
 
   scopes/workspace/eject:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/component-id':
         specifier: ^0.0.427
         version: 0.0.427
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28685,6 +30485,9 @@ importers:
 
   scopes/workspace/install:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@pnpm/colorize-semver-diff':
         specifier: 1.0.1
         version: 1.0.1
@@ -28700,6 +30503,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       enquirer:
         specifier: 2.3.6
         version: 2.3.6
@@ -28845,6 +30651,9 @@ importers:
 
   scopes/workspace/ui/empty-workspace:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28852,6 +30661,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -28885,6 +30697,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28892,6 +30707,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -28931,6 +30749,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28938,6 +30759,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/documenter.theme.theme-compositions':
         specifier: 4.1.1
         version: registry.npmjs.org/@teambit/documenter.theme.theme-compositions@4.1.1(react-dom@17.0.2)(react@17.0.2)
@@ -28971,6 +30795,9 @@ importers:
 
   scopes/workspace/ui/workspace-component-card:
     dependencies:
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       react:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2
@@ -28978,6 +30805,9 @@ importers:
         specifier: ^16.8.0 || ^17.0.0
         version: 17.0.2(react@17.0.2)
     devDependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@types/jest':
         specifier: ^26.0.0
         version: 26.0.20
@@ -28999,6 +30829,9 @@ importers:
 
   scopes/workspace/variants:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
@@ -29008,6 +30841,9 @@ importers:
       comment-json:
         specifier: 3.0.3
         version: 3.0.3
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       lodash:
         specifier: 4.17.21
         version: 4.17.21
@@ -29045,6 +30881,9 @@ importers:
 
   scopes/workspace/watcher:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/chokidar':
         specifier: 3.5.6
         version: 3.5.6
@@ -29060,6 +30899,9 @@ importers:
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -29112,6 +30954,9 @@ importers:
       '@apollo/client':
         specifier: ^3.6.0
         version: 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@react-hook/latest':
         specifier: 1.0.3
         version: 1.0.3(react@17.0.2)
@@ -29148,6 +30993,9 @@ importers:
       classnames:
         specifier: 2.2.6
         version: 2.2.6
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       detect-indent:
         specifier: 5.0.0
         version: 5.0.0
@@ -29242,12 +31090,18 @@ importers:
 
   scopes/workspace/workspace-config-files:
     dependencies:
+      '@babel/runtime':
+        specifier: 7.20.0
+        version: 7.20.0
       '@teambit/harmony':
         specifier: 0.4.6
         version: 0.4.6
       chalk:
         specifier: 2.4.2
         version: 2.4.2
+      core-js:
+        specifier: ^3.0.0
+        version: 3.13.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -41318,22 +43172,6 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils@2.34.0(eslint@7.32.0)(typescript@4.7.4):
-    resolution: {integrity: sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    peerDependencies:
-      eslint: '*'
-    dependencies:
-      '@types/json-schema': 7.0.12
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.7.4)
-      eslint: 7.32.0
-      eslint-scope: 5.1.1
-      eslint-utils: 2.1.0
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-    dev: false
-
   /@typescript-eslint/experimental-utils@3.10.1(eslint@6.8.0)(typescript@3.9.10):
     resolution: {integrity: sha512-DewqIgscDzmAfd5nOGe4zm6Bl7PKtMG2Ad0KG8CUZAHlXfAKTF9Ol5PXhiMh39yRL2ChRH1cuuUGOcVyyrhQIw==}
     engines: {node: ^10.12.0 || >=12.0.0}
@@ -41367,26 +43205,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - typescript
-    dev: false
-
-  /@typescript-eslint/parser@2.34.0(eslint@7.32.0)(typescript@4.7.4):
-    resolution: {integrity: sha512-03ilO0ucSD0EPTw2X4PntSIRFtDPWjrVq7C3/Z3VQHRC7+13YB55rcJI3Jt+YgeHbjUdJPcPa7b23rXCBokuyA==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    peerDependencies:
-      eslint: ^5.0.0 || ^6.0.0
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@types/eslint-visitor-keys': 1.0.0
-      '@typescript-eslint/experimental-utils': 2.34.0(eslint@7.32.0)(typescript@4.7.4)
-      '@typescript-eslint/typescript-estree': 2.34.0(typescript@4.7.4)
-      eslint: 7.32.0
-      eslint-visitor-keys: 1.3.0
-      typescript: 4.7.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@typescript-eslint/parser@3.10.1(eslint@6.8.0)(typescript@3.9.10):
@@ -41516,27 +43334,6 @@ packages:
   /@typescript-eslint/types@5.62.0:
     resolution: {integrity: sha512-87NVngcbVXUahrRTqIK27gD2t5Cu1yuCXxbLcFtCzZGlfyVWWh8mLHkoxzjsB6DDNnvdL+fW8MiwPEJyGJQDgQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
-    dev: false
-
-  /@typescript-eslint/typescript-estree@2.34.0(typescript@4.7.4):
-    resolution: {integrity: sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==}
-    engines: {node: ^8.10.0 || ^10.13.0 || >=11.10.1}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      debug: 4.3.2
-      eslint-visitor-keys: 1.3.0
-      glob: 7.1.6
-      is-glob: 4.0.1
-      lodash: 4.17.21
-      semver: 7.5.2
-      tsutils: 3.21.0(typescript@4.7.4)
-      typescript: 4.7.4
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@typescript-eslint/typescript-estree@3.10.1(typescript@3.9.10):
@@ -47326,22 +49123,6 @@ packages:
       - typescript
     dev: false
 
-  /eslint-config-airbnb-typescript@5.1.0(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)(typescript@4.7.4):
-    resolution: {integrity: sha512-pzkOGX76OEd3AmxWPJUwasz4CY98KHNQgdwsiFpYd/M35vC33WiD9OaLq8eFYysy7+NVJtUuElgn879lrQ1rPw==}
-    dependencies:
-      '@typescript-eslint/parser': 2.34.0(eslint@7.32.0)(typescript@4.7.4)
-      eslint-config-airbnb: 18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0)
-      eslint-config-airbnb-base: 14.2.1(eslint-plugin-import@2.22.1)(eslint@7.32.0)
-    transitivePeerDependencies:
-      - eslint
-      - eslint-plugin-import
-      - eslint-plugin-jsx-a11y
-      - eslint-plugin-react
-      - eslint-plugin-react-hooks
-      - supports-color
-      - typescript
-    dev: false
-
   /eslint-config-airbnb@18.2.0(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0):
     resolution: {integrity: sha512-Fz4JIUKkrhO0du2cg5opdyPKQXOI2MvF8KUvN2710nJMT6jaRUpRE2swrJftAjVGL7T1otLM5ieo5RqS1v9Udg==}
     engines: {node: '>= 6'}
@@ -47350,26 +49131,6 @@ packages:
       eslint-plugin-import: ^2.21.2
       eslint-plugin-jsx-a11y: ^6.3.0
       eslint-plugin-react: ^7.20.0
-      eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
-    dependencies:
-      eslint: 7.32.0
-      eslint-config-airbnb-base: 14.2.0(eslint-plugin-import@2.22.1)(eslint@7.32.0)
-      eslint-plugin-import: 2.22.1(@typescript-eslint/parser@5.35.1)(eslint@7.32.0)
-      eslint-plugin-jsx-a11y: 6.4.1(eslint@7.32.0)
-      eslint-plugin-react: 7.22.0(eslint@7.32.0)
-      eslint-plugin-react-hooks: 4.2.0(eslint@7.32.0)
-      object.assign: 4.1.4
-      object.entries: 1.1.6
-    dev: false
-
-  /eslint-config-airbnb@18.2.1(eslint-plugin-import@2.22.1)(eslint-plugin-jsx-a11y@6.4.1)(eslint-plugin-react-hooks@4.2.0)(eslint-plugin-react@7.22.0)(eslint@7.32.0):
-    resolution: {integrity: sha512-glZNDEZ36VdlZWoxn/bUR1r/sdFKPd1mHPbqUtkctgNG4yT2DLLtJ3D+yCV+jzZCc2V1nBVkmdknOJBZ5Hc0fg==}
-    engines: {node: '>= 6'}
-    peerDependencies:
-      eslint: ^5.16.0 || ^6.8.0 || ^7.2.0
-      eslint-plugin-import: ^2.22.1
-      eslint-plugin-jsx-a11y: ^6.4.1
-      eslint-plugin-react: ^7.21.5
       eslint-plugin-react-hooks: ^4 || ^3 || ^2.3.0 || ^1.7.0
     dependencies:
       eslint: 7.32.0
@@ -62190,6 +63951,7 @@ packages:
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/documenter.ui.heading': 4.1.1(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
+      core-js: 3.13.0
       monaco-editor: 0.33.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -62307,6 +64069,7 @@ packages:
       react-dom: ^16.8.0 || ^17.0.0
     dependencies:
       classnames: 2.2.6
+      core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
     dev: false
@@ -62593,6 +64356,7 @@ packages:
       '@monaco-editor/react': 4.4.6(monaco-editor@0.33.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/base-ui.theme.dark-theme': 1.0.2(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
+      core-js: 3.13.0
       monaco-editor: 0.33.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
@@ -64971,6 +66735,7 @@ packages:
     name: '@teambit/bit'
     dependencies:
       '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
+      '@babel/runtime': 7.20.0
       '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.8)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/legacy-bit-id': 1.0.0

--- a/scopes/component/graph/ui/component-node/component-node.tsx
+++ b/scopes/component/graph/ui/component-node/component-node.tsx
@@ -15,12 +15,12 @@ import { ComponentGraphContext } from '../dependencies-graph/';
 import styles from './component-node.module.scss';
 import variants from './variants.module.scss';
 
-export interface ComponentNode extends CardProps {
+export interface IComponentNode extends CardProps {
   node: NodeModel;
   type: string;
 }
 
-export function ComponentNode({ node, type = 'defaultNode', ...rest }: ComponentNode) {
+export function ComponentNode({ node, type = 'defaultNode', ...rest }: IComponentNode) {
   const graphContext = useContext(ComponentGraphContext);
   const { component } = node;
   const { id } = component;

--- a/scopes/component/graph/ui/graph-page/graph-filters.tsx
+++ b/scopes/component/graph/ui/graph-page/graph-filters.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { Card, CardProps } from '@teambit/base-ui.surfaces.card';
 import { CheckboxLabel } from '@teambit/evangelist.input.checkbox.label';
 
-type GraphFilters = {
+type GraphFiltersType = {
   isFiltered: boolean;
   onChangeFilter: (isFiltered: boolean) => void;
   disable?: boolean;
 } & CardProps;
 
-export function GraphFilters({ onChangeFilter, isFiltered, disable, ...rest }: GraphFilters) {
+export function GraphFilters({ onChangeFilter, isFiltered, disable, ...rest }: GraphFiltersType) {
   return (
     <Card {...rest}>
       <div>

--- a/scopes/dependencies/dependency-resolver/apply-updates.ts
+++ b/scopes/dependencies/dependency-resolver/apply-updates.ts
@@ -59,7 +59,7 @@ export function applyUpdates(
           if (outdatedPkg.variantPattern) {
             const { variantPattern, targetField, name } = outdatedPkg;
             updatedVariants.add(outdatedPkg.variantPattern);
-            // eslint-disable-next-line dot-notation
+            // eslint-disable-next-line dot-notation, @typescript-eslint/dot-notation
             if (variantPoliciesByPatterns[variantPattern]?.[targetField]?.[name]?.['version']) {
               // eslint-disable-line
               variantPoliciesByPatterns[variantPattern][targetField]![name]['version'] = outdatedPkg.latestRange; // eslint-disable-line

--- a/scopes/react/modules/prerenderer-puppeteer/prerenderer-puppeteer.ts
+++ b/scopes/react/modules/prerenderer-puppeteer/prerenderer-puppeteer.ts
@@ -31,7 +31,7 @@ const waitForRender = function (options: { renderAfterDocumentEvent?: string; re
   return new Promise<void>((resolve) => {
     // Render when an event fires on the document.
     if (options.renderAfterDocumentEvent) {
-      // eslint-disable-next-line dot-notation
+      // eslint-disable-next-line dot-notation, @typescript-eslint/dot-notation
       if (window['__PRERENDER_STATUS'] && window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED) resolve();
       document.addEventListener(options.renderAfterDocumentEvent, () => resolve());
 
@@ -133,8 +133,10 @@ export default class CustomPuppeteerRenderer {
           if (options.renderAfterDocumentEvent) {
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
             page.evaluateOnNewDocument(function (_options: { renderAfterDocumentEvent: string }) {
+              // eslint-disable-next-line dot-notation, @typescript-eslint/dot-notation
               window['__PRERENDER_STATUS'] = {};
               document.addEventListener(_options.renderAfterDocumentEvent, () => {
+                // eslint-disable-next-line dot-notation, @typescript-eslint/dot-notation
                 window['__PRERENDER_STATUS'].__DOCUMENT_EVENT_RESOLVED = true;
               });
             }, this._rendererOptions);

--- a/scopes/scope/scope/ui/scope.tsx
+++ b/scopes/scope/scope/ui/scope.tsx
@@ -15,7 +15,7 @@ import { ScopeProvider } from '@teambit/scope.ui.hooks.scope-context';
 import { useScopeQuery } from '@teambit/scope.ui.hooks.use-scope';
 import { ScopeOverview } from './scope-overview';
 import styles from './scope.module.scss';
-import ScopeUI, { ScopeBadgeSlot, ScopeContextType, CornerSlot, OverviewLineSlot } from '../scope.ui.runtime';
+import { ScopeUI, ScopeBadgeSlot, ScopeContextType, CornerSlot, OverviewLineSlot } from '../scope.ui.runtime';
 import { ScopeModel } from '..';
 
 export type ScopeProps = {

--- a/scopes/workspace/workspace/ui/workspace/workspace.tsx
+++ b/scopes/workspace/workspace/ui/workspace/workspace.tsx
@@ -17,7 +17,7 @@ import { useWorkspace } from './use-workspace';
 import { WorkspaceOverview } from './workspace-overview';
 import { WorkspaceProvider } from './workspace-provider';
 import styles from './workspace.module.scss';
-import WorkspaceUI from '../../workspace.ui.runtime';
+import { WorkspaceUI } from '../../workspace.ui.runtime';
 
 export type WorkspaceProps = {
   routeSlot: RouteSlot;

--- a/src/consumer/component/sources/vinyl-types.ts
+++ b/src/consumer/component/sources/vinyl-types.ts
@@ -71,6 +71,7 @@ export interface FileConstructor {
 
 let File: FileConstructor;
 
+// eslint-disable-next-line @typescript-eslint/no-redeclare
 interface File {
   /**
    * Gets and sets the contents of the file. If set to a `Stream`, it is wrapped in

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -271,10 +271,7 @@
         "dagre": "0.8.5",
         "didyoumean": "1.2.1",
         "enquirer": "2.3.6",
-        "eslint-config-airbnb-typescript": {
-          "version": "5.1.0",
-          "preserve": true
-        },
+        "eslint-config-airbnb-typescript": "12.0.0",
         "eslint-import-resolver-node": "0.3.4",
         "eventemitter2": "6.4.4",
         "expose-loader": "3.1.0",


### PR DESCRIPTION
## Proposed Changes

- Upgrade eslint-config-airbnb-typescript from v5 to v12 (for legacy code only)
- Update some new rules in the eslint config (to prevent the need of fixing thousands of files) 
- Fix some left overs lint errors
- This also fixes this warning when running bit from the repo 
```
⢀⠀ running command "status"...(node:51416) [DEP0128] DeprecationWarning: Invalid 'main' field in '<repo path>/node_modules/eslint-config-airbnb-typescript/package.json' of 'dist/eslint-config-airbnb-typescript.js'. Please either fix that or report it to the module author
(Use `node --trace-deprecation ...` to show where the warning was created)
```

