### PR TITLE
fix(ui/ComponentCompare): Viewing diffs in a workspace

### DIFF
--- a/components/ui/component-compare/compare-aspects/compare-aspects/compare-aspects.tsx
+++ b/components/ui/component-compare/compare-aspects/compare-aspects/compare-aspects.tsx
@@ -64,6 +64,7 @@ export function ComponentCompareAspects({ host, className }: ComponentCompareAsp
               widgets={[Widget]}
               getHref={getHref}
               onTreeNodeSelected={hook?.onClick}
+              open={isSidebarOpen}
             />
           </Pane>
         </SplitPane>

--- a/components/ui/component-compare/component-compare/component-compare.tsx
+++ b/components/ui/component-compare/component-compare/component-compare.tsx
@@ -91,7 +91,7 @@ export function ComponentCompare(props: ComponentCompareProps) {
   );
   const isNew = useMemo(() => allVersionInfo.length === 0, [allVersionInfo]);
   const compareVersion =
-    isWorkspace && !isNew && !location?.search.includes('version') ? 'workspace' : component.id.version;
+    isWorkspace && !isNew && !location?.search.includes('version') && !_compareId ? 'workspace' : component.id.version;
   const compareIsLocalChanges = compareVersion === 'workspace';
 
   const lastVersionInfo = useMemo(() => {

--- a/scopes/code/ui/code-compare/use-code-compare/use-code-compare.ts
+++ b/scopes/code/ui/code-compare/use-code-compare/use-code-compare.ts
@@ -21,14 +21,16 @@ export function useCodeCompare({ fileName }: useCodeCompareProps): useCodeCompar
   const comparingLocalChanges = componentCompareContext?.compare?.hasLocalChanges;
   const codeCompareDataForFile = componentCompareContext?.fileCompareDataByName?.get(fileName);
   const loadingFromContext =
-    componentCompareContext?.loading || componentCompareContext?.fileCompareDataByName === undefined;
-
+    !componentCompareContext ||
+    componentCompareContext?.loading ||
+    componentCompareContext?.fileCompareDataByName === undefined;
   /**
    * when comparing with workspace changes, query without id
    */
   const compareId = comparingLocalChanges
     ? componentCompareContext?.compare?.model.id.changeVersion(undefined)
     : componentCompareContext?.compare?.model.id;
+
   const baseId = componentCompareContext?.base?.model.id;
   /**
    * when there is no component to compare with, fetch file content

--- a/scopes/component/graph/ui/dependencies-compare/dependencies-compare.module.scss
+++ b/scopes/component/graph/ui/dependencies-compare/dependencies-compare.module.scss
@@ -2,7 +2,9 @@ $d30: #878c9a;
 $b70: #0d2de3;
 
 .page {
-  margin-top: 16px; // not exported
+  margin-top: 16px;
+  // this is temporary until we get ride of this graph compare for deps and align it with cloud
+  height: 50vh;
 }
 
 .loader {


### PR DESCRIPTION
This PR fixes the following issues in Component Compare

- Previously, the workspace will always try to fetch the latest when comparing components in a lane, which ends up fetching the data for the wrong version. This PR fixes it by only fetching the latest when there is no explicit compareId passed, otherwise it uses the component version to fetch
- Aspects Compare page now renders the aspect tree navigation - this was a regression introduced when aligning cloud and OSS review fixes
- Dependencies Compare Graph on workspace rendering is fixed, previously the graph had no height - which resulted in it not being rendered correctly
- Fix Code Review to correctly switch view modes 