### PR TITLE
dont show removed components in the "change components" list

### DIFF
--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -744,8 +744,11 @@ describe('bit snap command', function () {
       helper.command.softRemoveComponent('comp1');
       output = helper.command.snapAllComponentsWithoutBuild('--unmodified');
     });
-    it('should indicate that the component was snapped successfully', () => {
-      expect(output).to.have.string('changed components');
+    it('should indicate that the component was removed successfully', () => {
+      expect(output).to.have.string('removed components');
+    });
+    it('should not show the component as changed (because the new snap isnt relevant for a deleted component', () => {
+      expect(output).to.not.have.string('changed components');
     });
   });
 });

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -146,9 +146,11 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
     if (!results) return chalk.yellow(NOTHING_TO_SNAP_MSG);
     const { snappedComponents, autoSnappedResults, warnings, newComponents, laneName, removedComponents }: SnapResults =
       results;
-    const changedComponents = snappedComponents.filter(
-      (component) => !newComponents.searchWithoutVersion(component.id)
-    );
+    const changedComponents = snappedComponents.filter((component) => {
+      return (
+        !newComponents.searchWithoutVersion(component.id) && !removedComponents?.searchWithoutVersion(component.id)
+      );
+    });
     const addedComponents = snappedComponents.filter((component) => newComponents.searchWithoutVersion(component.id));
     const autoTaggedCount = autoSnappedResults ? autoSnappedResults.length : 0;
 


### PR DESCRIPTION


## Proposed Changes

- removed components dont need to be shown in the "changed components" list 
- the user has deleted/removed the component, they're not bothered with how bit manages that in the background and info on version bumps only confuses the removed status
-
