### PR TITLE
don't cache currentLaneId when a workspace is available

### DIFF
--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -32,11 +32,7 @@ export class SnapCmd implements Command {
     ['m', 'message <message>', 'snap message describing the latest changes - will appear in component history log'],
     ['u', 'unmodified', 'include unmodified components (by default, only new and modified components are snapped)'],
     ['', 'unmerged', 'complete a merge process by snapping the unmerged components'],
-    [
-      'b',
-      'build',
-      'not needed for now. run the build pipeline locally in case the feature-flag build-on-ci is enabled',
-    ],
+    ['b', 'build', 'locally run the build pipeline (i.e. not via rippleCI) and complete the snap'],
     [
       '',
       'editor [editor]',

--- a/scopes/pipelines/builder/builder.service.tsx
+++ b/scopes/pipelines/builder/builder.service.tsx
@@ -133,7 +133,7 @@ export class BuilderService implements EnvService<BuildServiceResults, string> {
         previousTasksResults: [],
         pipeName: this.displayPipeName,
         dev: options.dev,
-        laneId: this.scope.legacyScope.currentLaneId,
+        laneId: this.scope.legacyScope.getCurrentLaneId(),
       });
       envsBuildContext[executionContext.id] = buildContext;
     });

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -759,7 +759,7 @@ export class ScopeMain implements ComponentFactory {
   }
 
   async getStagedConfig() {
-    const currentLaneId = this.legacyScope.currentLaneId;
+    const currentLaneId = this.legacyScope.getCurrentLaneId();
     return StagedConfig.load(this.path, this.logger, currentLaneId);
   }
 

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -138,8 +138,12 @@ export default class Consumer {
     return path.join(this.getPath(), BIT_WORKSPACE_TMP_DIRNAME);
   }
 
+  getCurrentLaneIdIfExist() {
+    return this.bitMap.laneId;
+  }
+
   getCurrentLaneId(): LaneId {
-    return this.bitMap.laneId || this.getDefaultLaneId();
+    return this.getCurrentLaneIdIfExist() || this.getDefaultLaneId();
   }
 
   getDefaultLaneId() {
@@ -167,7 +171,6 @@ export default class Consumer {
 
   setCurrentLane(laneId: LaneId, exported = true) {
     this.bitMap.setCurrentLane(laneId, exported);
-    this.scope.setCurrentLaneId(laneId);
   }
 
   async cleanTmpFolder() {
@@ -599,7 +602,7 @@ export default class Consumer {
       scope,
     });
     await consumer.setBitMap();
-    scope.setCurrentLaneId(consumer.bitMap.laneId || consumer.getDefaultLaneId());
+    scope.currentLaneIdFunc = consumer.getCurrentLaneIdIfExist.bind(consumer);
     logger.commandHistory.fileBasePath = scope.getPath();
     return consumer;
   }

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -599,7 +599,7 @@ export default class Consumer {
       scope,
     });
     await consumer.setBitMap();
-    scope.setCurrentLaneId(consumer.bitMap.laneId);
+    scope.setCurrentLaneId(consumer.bitMap.laneId || consumer.getDefaultLaneId());
     logger.commandHistory.fileBasePath = scope.getPath();
     return consumer;
   }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -113,11 +113,18 @@ export default class Scope {
   _dependencyGraph: DependencyGraph; // cache DependencyGraph instance
   lanes: Lanes;
   /**
+   * important! never use this function directly, even inside this class. Only use getCurrentLaneId().
+   *
    * normally, the data about the current-lane is saved in .bitmap. the reason for having this prop here is that we
    * need this data when loading model-component, which gets called in multiple places where the consumer is not passed.
    * another instance this is needed is for bit-sign, this way when loading aspects and fetching dists, it'll go to lane-scope.
    */
-  currentLaneId?: LaneId;
+  private currentLaneId?: LaneId;
+  /**
+   * when the consumer is available, this function is set with the consumer.getCurrentLaneIdIfExist, so then we guarantee
+   * that it's always in sync with the consumer.
+   */
+  currentLaneIdFunc?: () => LaneId | undefined;
   stagedSnaps: StagedSnaps;
   constructor(scopeProps: ScopeProps) {
     this.path = scopeProps.path;
@@ -136,6 +143,11 @@ export default class Scope {
 
   public async refreshScopeIndex(force = false) {
     await this.objects.reloadScopeIndexIfNeed(force);
+  }
+
+  getCurrentLaneId(): LaneId | undefined {
+    if (this.currentLaneIdFunc) return this.currentLaneIdFunc();
+    return this.currentLaneId;
   }
 
   async getDependencyGraph(): Promise<DependencyGraph> {
@@ -464,7 +476,8 @@ once done, to continue working, please run "bit cc"`
   }
 
   async getCurrentLaneObject(): Promise<Lane | null> {
-    return this.currentLaneId ? this.loadLane(this.currentLaneId) : null;
+    const currentLaneId = this.getCurrentLaneId();
+    return currentLaneId ? this.loadLane(currentLaneId) : null;
   }
 
   /**

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -163,7 +163,7 @@ export default class Scope {
   setCurrentLaneId(laneId?: LaneId) {
     if (!laneId) return;
     if (laneId.isDefault()) this.currentLaneId = undefined;
-    this.currentLaneId = laneId;
+    else this.currentLaneId = laneId;
   }
 
   getPath() {


### PR DESCRIPTION
this is important especially for long-running process (e.g. watch/start) to have the scope lane-id in sync with the consumer.