### PR TITLE
fix(Schema): handle parsing arrow function declarations

### DIFF
--- a/scopes/semantics/schema/mock/button-schemas.json
+++ b/scopes/semantics/schema/mock/button-schemas.json
@@ -479,7 +479,7 @@
               "line": 6,
               "character": 14
             },
-            "signature": "const BasicButton: () => any",
+            "signature": "function(): any",
             "name": "BasicButton",
             "params": [],
             "returnType": {
@@ -487,7 +487,7 @@
               "location": {
                 "filePath": "button.composition.tsx",
                 "line": 6,
-                "character": 14
+                "character": 28
               },
               "type": "any"
             },
@@ -548,10 +548,12 @@
                     "location": {
                       "filePath": "button.composition.tsx",
                       "line": 14,
-                      "character": 24
+                      "character": 26
                     },
                     "name": "children",
-                    "type": "any"
+                    "type": "any",
+                    "defaultValue": "<BasicButton />",
+                    "isSpread": false
                   }
                 ],
                 "isSpread": false
@@ -577,7 +579,7 @@
               "line": 18,
               "character": 14
             },
-            "signature": "const ButtonWithCustomStyles: () => any",
+            "signature": "function(): any",
             "name": "ButtonWithCustomStyles",
             "params": [],
             "returnType": {
@@ -585,7 +587,7 @@
               "location": {
                 "filePath": "button.composition.tsx",
                 "line": 18,
-                "character": 14
+                "character": 39
               },
               "type": "any"
             },
@@ -598,7 +600,7 @@
               "line": 22,
               "character": 14
             },
-            "signature": "const ButtonWithIcon: () => any",
+            "signature": "function(): any",
             "name": "ButtonWithIcon",
             "params": [],
             "returnType": {
@@ -606,7 +608,7 @@
               "location": {
                 "filePath": "button.composition.tsx",
                 "line": 22,
-                "character": 14
+                "character": 31
               },
               "type": "any"
             },
@@ -619,7 +621,7 @@
               "line": 31,
               "character": 14
             },
-            "signature": "const ButtonAsALink: () => any",
+            "signature": "function(): any",
             "name": "ButtonAsALink",
             "params": [],
             "returnType": {
@@ -627,7 +629,7 @@
               "location": {
                 "filePath": "button.composition.tsx",
                 "line": 31,
-                "character": 14
+                "character": 30
               },
               "type": "any"
             },
@@ -665,7 +667,7 @@
           "line": 30,
           "character": 14
         },
-        "signature": "const Function: () => void",
+        "signature": "function(): void",
         "name": "Function",
         "params": [],
         "returnType": {
@@ -673,7 +675,7 @@
           "location": {
             "filePath": "index.ts",
             "line": 30,
-            "character": 14
+            "character": 25
           },
           "type": "void"
         },
@@ -1051,7 +1053,7 @@
           "line": 69,
           "character": 14
         },
-        "signature": "const getBar: (bar: Bar) => Bar",
+        "signature": "function(bar: Bar): Bar",
         "name": "getBar",
         "params": [
           {
@@ -1081,7 +1083,7 @@
           "location": {
             "filePath": "index.ts",
             "line": 69,
-            "character": 14
+            "character": 23
           },
           "name": "Bar",
           "internalFilePath": "index.ts"
@@ -1095,7 +1097,7 @@
           "line": 71,
           "character": 14
         },
-        "signature": "const tuple: ([a, b, c]: [string, Function, Record<string, any>]) => void",
+        "signature": "function([a, b, c]: [string, Function, Record<string, any>]): void",
         "name": "tuple",
         "params": [
           {
@@ -1153,7 +1155,7 @@
           "location": {
             "filePath": "index.ts",
             "line": 71,
-            "character": 14
+            "character": 22
           },
           "type": "void"
         },
@@ -1488,10 +1490,12 @@
                 "location": {
                   "filePath": "index.ts",
                   "line": 96,
-                  "character": 45
+                  "character": 47
                 },
                 "name": "prop",
-                "type": "number"
+                "type": "number",
+                "defaultValue": "1",
+                "isSpread": false
               }
             ],
             "isSpread": false

--- a/scopes/typescript/typescript/transformers/parameter.ts
+++ b/scopes/typescript/typescript/transformers/parameter.ts
@@ -32,17 +32,17 @@ export class ParameterTransformer implements SchemaTransformer {
     const type = await this.getType(node, context);
     return new ParameterSchema(
       context.getLocation(node),
-      this.getName(node),
+      ParameterTransformer.getName(node),
       type,
       Boolean(node.questionToken),
       node.initializer ? node.initializer.getText() : undefined,
       undefined,
-      await this.getObjectBindingNodes(node, type, context),
+      await ParameterTransformer.getObjectBindingNodes(node, type, context),
       Boolean(node.dotDotDotToken)
     );
   }
 
-  getName(param: ParameterDeclaration): string {
+  static getName(param: ParameterDeclaration): string {
     if (isIdentifier(param.name)) {
       return param.name.getText();
     }
@@ -86,7 +86,7 @@ export class ParameterTransformer implements SchemaTransformer {
     throw new Error(`unknown param type`);
   }
 
-  async getObjectBindingNodes(
+  static async getObjectBindingNodes(
     param: ParameterDeclaration,
     paramType: SchemaNode,
     context: SchemaExtractorContext
@@ -96,7 +96,9 @@ export class ParameterTransformer implements SchemaTransformer {
       const existing = paramType.findNode?.((node) => {
         return node.name === elem.name.getText().trim();
       });
-      if (existing) return existing;
+      if (existing && existing.__schema !== 'InferenceTypeSchema') {
+        return existing;
+      }
       const info = await context.getQuickInfo(elem.name);
       const parsed = info ? parseTypeFromQuickInfo(info) : elem.getText();
       const defaultValue = elem.initializer ? elem.initializer.getText() : undefined;

--- a/scopes/typescript/typescript/transformers/variable-declaration.ts
+++ b/scopes/typescript/typescript/transformers/variable-declaration.ts
@@ -4,13 +4,15 @@ import {
   FunctionLikeSchema,
   Modifier,
   ParameterSchema,
+  TypeRefSchema,
 } from '@teambit/semantics.entities.semantic-schema';
 import ts, { Node, VariableDeclaration as VariableDeclarationNode, ArrowFunction } from 'typescript';
 import pMapSeries from 'p-map-series';
 import { SchemaTransformer } from '../schema-transformer';
 import { SchemaExtractorContext } from '../schema-extractor-context';
-import { parseReturnTypeFromQuickInfo, parseTypeFromQuickInfo } from './utils/parse-type-from-quick-info';
+import { parseTypeFromQuickInfo } from './utils/parse-type-from-quick-info';
 import { Identifier } from '../identifier';
+import { ParameterTransformer } from './parameter';
 
 export class VariableDeclaration implements SchemaTransformer {
   predicate(node: Node) {
@@ -33,9 +35,8 @@ export class VariableDeclaration implements SchemaTransformer {
     const doc = await context.jsDocToDocSchema(varDec);
     const modifiers = varDec.modifiers?.map((modifier) => modifier.getText()) || [];
     if (varDec.initializer?.kind === ts.SyntaxKind.ArrowFunction) {
-      const args = (await pMapSeries((varDec.initializer as ArrowFunction).parameters, async (param) =>
-        context.computeSchema(param)
-      )) as ParameterSchema[];
+      const functionLikeInfo = await context.getQuickInfo((varDec.initializer as ArrowFunction).equalsGreaterThanToken);
+      const returnTypeStr = functionLikeInfo ? parseTypeFromQuickInfo(functionLikeInfo) : 'any';
       // example => export const useLanesContext: () => LanesContextModel | undefined = () => {
       if (varDec.type) {
         const funcType = await context.resolveType(varDec, '');
@@ -45,15 +46,56 @@ export class VariableDeclaration implements SchemaTransformer {
             name,
             funcType.params,
             funcType.returnType,
-            displaySig,
+            functionLikeInfo?.body?.displayString || '',
+            modifiers as Modifier[],
+            doc
+          );
+        }
+        // e.g. export const MyComponent: React.FC<T> = ({}) => {}
+        if (funcType instanceof TypeRefSchema) {
+          const paramTypes = funcType.typeArgs;
+          const params = (varDec.initializer as ArrowFunction).parameters;
+          const paramsSchema = await pMapSeries(params, async (param, index) => {
+            const objectBindingNodes = await ParameterTransformer.getObjectBindingNodes(
+              param,
+              paramTypes?.[index] ?? funcType,
+              context
+            );
+            return new ParameterSchema(
+              location,
+              ParameterTransformer.getName(param),
+              paramTypes?.[index] ?? funcType,
+              Boolean(param.questionToken),
+              param.initializer ? param.initializer.getText() : undefined,
+              undefined,
+              objectBindingNodes,
+              Boolean(param.dotDotDotToken)
+            );
+          });
+
+          return new FunctionLikeSchema(
+            location,
+            name,
+            paramsSchema,
+            await context.resolveType(varDec.initializer, returnTypeStr),
+            functionLikeInfo?.body?.displayString || '',
             modifiers as Modifier[],
             doc
           );
         }
       }
-      const typeStr = parseReturnTypeFromQuickInfo(info);
-      const returnType = await context.resolveType(varDec, typeStr);
-      return new FunctionLikeSchema(location, name, args, returnType, displaySig, modifiers as Modifier[], doc);
+      const args = (await pMapSeries((varDec.initializer as ArrowFunction).parameters, async (param) =>
+        context.computeSchema(param)
+      )) as ParameterSchema[];
+      return new FunctionLikeSchema(
+        location,
+        name,
+        args,
+        await context.resolveType(varDec.initializer, returnTypeStr),
+        functionLikeInfo?.body?.displayString || '',
+        modifiers as Modifier[],
+        doc
+      );
     }
     const typeStr = parseTypeFromQuickInfo(info);
     const type = await context.resolveType(varDec, typeStr);


### PR DESCRIPTION
This PR fixes the issue of incorrectly parsing schema for arrow function declaration. 
Previously the schema extractor used the type information from the variable declaration, instead of the function initializer (`= () => {}`) which yields incorrectly extracted signature, return type, and parameter information.
e.g.
`const MyComponent: React.FC<ParamType> = ({p1, p2, ...rest}) => {}`

<img width="1912" alt="Screenshot 2023-09-22 at 3 23 21 PM" src="https://github.com/teambit/bit/assets/8999604/583c4067-5b48-460c-a4eb-691736a43650">
