### PR TITLE
ignore builder aspect when merging config

### DIFF
--- a/scopes/component/merging/config-merger.ts
+++ b/scopes/component/merging/config-merger.ts
@@ -1,6 +1,7 @@
 import { ComponentID } from '@teambit/component-id';
 import semver from 'semver';
 import { Logger } from '@teambit/logger';
+import BuilderAspect from '@teambit/builder';
 import { isHash } from '@teambit/component-version';
 import {
   DependencyResolverAspect,
@@ -67,7 +68,7 @@ export class ConfigMerger {
   private currentEnv: EnvData;
   private otherEnv: EnvData;
   private baseEnv?: EnvData;
-  private handledExtIds: string[] = [];
+  private handledExtIds: string[] = [BuilderAspect.id]; // don't try to merge builder, it's possible that at one end it wasn't built yet, so it's empty
   private otherLaneIdsStr: string[];
   constructor(
     private compIdStr: string,


### PR DESCRIPTION
Otherwise, in some cases it generates this odd output:
```
<<<<<<< bd6a9262467c86932302a6c0a508b3dc1f476b3b (teambit.vscode/config-diff)
  "teambit.pipelines/builder": "-"
=======
  "teambit.pipelines/builder": {}
>>>>>>> d8770f855173e65609df08ac529b799443759760 (main)
}
```
This is happening when in one end the `Version` object was not built yet, so the builder aspect is empty.