### PR TITLE
introduce --head-only flag for bit-export

### DIFF
--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -44,6 +44,11 @@ export class ExportCmd implements Command {
     ],
     [
       '',
+      'head-only',
+      'EXPERIMENTAL. in case previous export failed and locally it shows exported and only one snap/tag was created, try using this flag',
+    ],
+    [
+      '',
       'ignore-missing-artifacts',
       "EXPERIMENTAL. don't throw an error when artifact files are missing. not recommended, unless you're sure the artifacts are in the remote",
     ],
@@ -66,6 +71,7 @@ export class ExportCmd implements Command {
       originDirectly = false,
       ignoreMissingArtifacts = false,
       resume,
+      headOnly,
       forkLaneNewScope = false,
     }: any
   ): Promise<string> {
@@ -77,6 +83,7 @@ export class ExportCmd implements Command {
         allVersions: allVersions || all,
         originDirectly,
         resumeExportId: resume,
+        headOnly,
         ignoreMissingArtifacts,
         forkLaneNewScope,
       });

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -76,6 +76,7 @@ type ExportParams = {
   originDirectly?: boolean;
   includeNonStaged?: boolean;
   resumeExportId?: string | undefined;
+  headOnly?: boolean;
   ignoreMissingArtifacts?: boolean;
   forkLaneNewScope?: boolean;
 };
@@ -112,7 +113,13 @@ export class ExportMain {
     return exportResults;
   }
 
-  private async exportComponents({ ids, includeNonStaged, originDirectly, ...params }: ExportParams): Promise<{
+  private async exportComponents({
+    ids,
+    includeNonStaged,
+    headOnly,
+    originDirectly,
+    ...params
+  }: ExportParams): Promise<{
     updatedIds: BitId[];
     nonExistOnBitMap: BitId[];
     removedIds: BitIds;
@@ -125,7 +132,7 @@ export class ExportMain {
     const consumer: Consumer = this.workspace.consumer;
     const { idsToExport, missingScope, idsWithFutureScope, laneObject } = await this.getComponentsToExport(
       ids,
-      includeNonStaged
+      includeNonStaged || headOnly
     );
 
     if (R.isEmpty(idsToExport)) {
@@ -167,6 +174,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     const isOnMain = consumer.isOnMain();
     const { exported, updatedLocally, newIdsOnRemote } = await this.exportMany({
       ...params,
+      exportHeadsOnly: headOnly,
       scope: consumer.scope,
       ids: idsToExport,
       laneObject,


### PR DESCRIPTION
To help in some edge cases when the export failed on some components, but the status is not "staged" anymore. 
Similar to `--all-versions` flag, it's running on all components regardless of "staged" status, however, this one only export the head version, not all history.