### PR TITLE
generate a unique name to a local-scope when created from the workspace

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -395,7 +395,7 @@
     },
     "content/cli-reference": {
         "scope": "teambit.harmony",
-        "version": "2.0.7",
+        "version": "2.0.8",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli-reference"
     },

--- a/e2e/harmony/load-bit.e2e.ts
+++ b/e2e/harmony/load-bit.e2e.ts
@@ -31,9 +31,9 @@ describe('loadBit()', function () {
     const scopeB = await createScope(helper.scopes.remotePath);
     const scopeC = await createScope(helper.scopes.localPath);
     // expect(workspace.path).to.eq(helper.scopes.localPath);
-    expect(scopeA.name).to.eq(scopeName);
-    expect(scopeB.name).to.eq(helper.scopes.remote);
-    expect(scopeC.name).to.eq(helper.scopes.local);
+    expect(scopeA.name).to.startWith(scopeName);
+    expect(scopeB.name).to.startWith(helper.scopes.remote);
+    expect(scopeC.name).to.startWith(helper.scopes.local);
   });
 
   it('should throw when defaultScope is invalid', async () => {

--- a/e2e/harmony/load-bit.e2e.ts
+++ b/e2e/harmony/load-bit.e2e.ts
@@ -31,9 +31,9 @@ describe('loadBit()', function () {
     const scopeB = await createScope(helper.scopes.remotePath);
     const scopeC = await createScope(helper.scopes.localPath);
     // expect(workspace.path).to.eq(helper.scopes.localPath);
-    expect(scopeA.name).to.startWith(scopeName);
-    expect(scopeB.name).to.startWith(helper.scopes.remote);
-    expect(scopeC.name).to.startWith(helper.scopes.local);
+    expect(scopeA.name.startsWith(scopeName)).to.be.true;
+    expect(scopeB.name.startsWith(helper.scopes.remote)).to.be.true;
+    expect(scopeC.name.startsWith(helper.scopes.local)).to.be.true;
   });
 
   it('should throw when defaultScope is invalid', async () => {

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -23,7 +23,7 @@ import { Scope } from '../scope';
 import { getAutoTagPending } from '../scope/component-ops/auto-tag';
 import { ComponentNotFound } from '../scope/exceptions';
 import { Lane, ModelComponent, Version } from '../scope/models';
-import { pathNormalizeToLinux, sortObject } from '../utils';
+import { generateRandomStr, pathNormalizeToLinux, sortObject } from '../utils';
 import { composeComponentPath, composeDependencyPath } from '../utils/bit/compose-component-path';
 import { packageNameToComponentId } from '../utils/bit/package-name-to-component-id';
 import {
@@ -540,7 +540,10 @@ export default class Consumer {
   ): Promise<Consumer> {
     const resolvedScopePath = Consumer._getScopePath(projectPath, standAlone);
     let existingGitHooks;
-    const scope = await Scope.ensure(resolvedScopePath);
+    // avoid using the default scope-name `path.basename(process.cwd())` when generated from the workspace.
+    // otherwise, components with the same scope-name will get ComponentNotFound on import
+    const scopeName = `${path.basename(process.cwd())}-local-${generateRandomStr()}`;
+    const scope = await Scope.ensure(resolvedScopePath, scopeName);
     const config = await WorkspaceConfig.ensure(projectPath, standAlone, workspaceConfigProps);
     const consumer = new Consumer({
       projectPath,


### PR DESCRIPTION
Otherwise, in case the components have the same scope-name, bit throws ComponentNotFound upon import, because it assumes the local scope is the remote scope.