### PR TITLE
fix(schema): add class name to ThisType schema

### DIFF
--- a/scopes/semantics/entities/semantic-schema/schemas/this-type.ts
+++ b/scopes/semantics/entities/semantic-schema/schemas/this-type.ts
@@ -4,16 +4,17 @@ import { SchemaLocation, SchemaNode } from '../schema-node';
  * e.g. `class A { createA(): this {} }`
  */
 export class ThisTypeSchema extends SchemaNode {
-  constructor(readonly location: SchemaLocation) {
+  constructor(readonly location: SchemaLocation, readonly name: string) {
     super();
   }
 
   toString() {
-    return 'this';
+    return this.name;
   }
 
   static fromObject(obj: Record<string, any>): ThisTypeSchema {
     const location = obj.location;
-    return new ThisTypeSchema(location);
+    const name = obj.name;
+    return new ThisTypeSchema(location, name);
   }
 }

--- a/scopes/semantics/schema/mock/button-schemas.json
+++ b/scopes/semantics/schema/mock/button-schemas.json
@@ -770,7 +770,8 @@
                 "filePath": "index.ts",
                 "line": 36,
                 "character": 1
-              }
+              },
+              "name": "ClassSomething"
             },
             "modifiers": []
           },
@@ -2011,7 +2012,8 @@
                 "filePath": "index.ts",
                 "line": 36,
                 "character": 1
-              }
+              },
+              "name": "ClassSomething"
             },
             "modifiers": []
           },

--- a/scopes/typescript/typescript/transformers/constructor.ts
+++ b/scopes/typescript/typescript/transformers/constructor.ts
@@ -23,8 +23,8 @@ export class ConstructorTransformer implements SchemaTransformer {
     const args = await pMapSeries(node.parameters, async (param) => context.computeSchema(param));
     const info = await context.getQuickInfo(node);
     const displaySig = info?.body?.displayString || '';
-
-    const returns = new ThisTypeSchema(context.getLocation(node.parent));
+    const name = node.parent?.name?.getText() || '';
+    const returns = new ThisTypeSchema(context.getLocation(node.parent), name);
     const modifiers = node.modifiers?.map((modifier) => modifier.getText()) || [];
     const doc = await context.jsDocToDocSchema(node);
 

--- a/scopes/typescript/typescript/transformers/this-type.ts
+++ b/scopes/typescript/typescript/transformers/this-type.ts
@@ -14,6 +14,6 @@ export class ThisTypeTransformer implements SchemaTransformer {
   }
 
   async transform(node: ThisTypeNode, context: SchemaExtractorContext) {
-    return new ThisTypeSchema(context.getLocation(node));
+    return new ThisTypeSchema(context.getLocation(node), 'this');
   }
 }


### PR DESCRIPTION
Previously, all `this` (self) reference schema's only rendered `this` as their type. This PR adds the parent class's name to provide more metadata of the self referenced type, specifically in the case of constructors 