### PR TITLE
feat, support .bitignore within component dirs

### DIFF
--- a/src/utils/ignore/ignore.ts
+++ b/src/utils/ignore/ignore.ts
@@ -1,12 +1,20 @@
 import findUp from 'find-up';
 import fs from 'fs-extra';
+import path from 'path';
 import gitignore from 'parse-gitignore';
 
 import { GIT_IGNORE, IGNORE_LIST } from '../../constants';
 
-function getGitIgnoreFile(dir: string) {
+export const BIT_IGNORE = '.bitignore';
+
+function getGitIgnoreFile(dir: string): string[] {
   const gitIgnoreFile = findUp.sync([GIT_IGNORE], { cwd: dir });
   return gitIgnoreFile ? gitignore(fs.readFileSync(gitIgnoreFile)) : [];
+}
+
+export async function getBitIgnoreFile(dir: string): Promise<string[]> {
+  const fileContent = await fs.readFile(path.join(dir, BIT_IGNORE));
+  return gitignore(fileContent);
 }
 
 export default function retrieveIgnoreList(cwd: string) {


### PR DESCRIPTION
It helps to exclude files/patterns per component basis. This `.bitignore` file has the same syntax of `.gitignore`. The file is tracked by bit so then when importing the component, the ignored files are still ignored in case they were re-introduced. 