### PR TITLE
move the check for missing-dist from onLoad slot to status and snap/tag only

### DIFF
--- a/scopes/compilation/compiler/compiler.main.runtime.ts
+++ b/scopes/compilation/compiler/compiler.main.runtime.ts
@@ -4,6 +4,7 @@ import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import { BuilderAspect, BuilderMain } from '@teambit/builder';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { IssuesClasses } from '@teambit/component-issues';
+import IssuesAspect, { IssuesMain } from '@teambit/issues';
 import { Component, ComponentID } from '@teambit/component';
 import { DEFAULT_DIST_DIRNAME } from '@teambit/legacy/dist/constants';
 import WatcherAspect, { WatcherMain } from '@teambit/watcher';
@@ -96,13 +97,16 @@ export class CompilerMain {
     return new DistArtifact(artifacts);
   }
 
-  async addMissingDistsIssue(component: Component) {
-    const exist = await this.isDistDirExists(component);
-    if (!exist) {
-      component.state.issues.getOrCreate(IssuesClasses.MissingDists).data = true;
-    }
-    // we don't want to add any data to the compiler aspect, only to add issues on the component
-    return undefined;
+  async addMissingDistsIssue(components: Component[], issuesToIgnore: string[]): Promise<void> {
+    if (issuesToIgnore.includes(IssuesClasses.MissingDists.name)) return;
+    await Promise.all(
+      components.map(async (component) => {
+        const exist = await this.isDistDirExists(component);
+        if (!exist) {
+          component.state.issues.getOrCreate(IssuesClasses.MissingDists).data = true;
+        }
+      })
+    );
   }
 
   static runtime = MainRuntime;
@@ -119,6 +123,7 @@ export class CompilerMain {
     GeneratorAspect,
     DependencyResolverAspect,
     WatcherAspect,
+    IssuesAspect,
   ];
 
   static async provider([
@@ -133,6 +138,7 @@ export class CompilerMain {
     generator,
     dependencyResolver,
     watcher,
+    issues,
   ]: [
     CLIMain,
     Workspace,
@@ -144,7 +150,8 @@ export class CompilerMain {
     UiMain,
     GeneratorMain,
     DependencyResolverMain,
-    WatcherMain
+    WatcherMain,
+    IssuesMain
   ]) {
     const logger = loggerMain.createLogger(CompilerAspect.id);
     const compilerService = new CompilerService();
@@ -170,8 +177,8 @@ export class CompilerMain {
       compilerService
     );
     cli.register(new CompileCmd(workspaceCompiler, logger, pubsub));
-    if (workspace) {
-      workspace.onComponentLoad(compilerMain.addMissingDistsIssue.bind(compilerMain));
+    if (issues) {
+      issues.registerAddComponentsIssues(compilerMain.addMissingDistsIssue.bind(compilerMain));
     }
     if (generator) generator.registerComponentTemplate([compilerTemplate]);
 


### PR DESCRIPTION
It's better for performance as it's not needed every time the component is loaded. 
Also, in some edge cases, this check throws an error if it gets called during installation/compilation. 