### PR TITLE
fix(schema): custom syntax highlighter theme + node summary style fixes

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1113,6 +1113,13 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/schema-nodes-index"
     },
+    "renderers/this": {
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.api-reference",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/api-reference/renderers/this"
+    },
     "renderers/type": {
         "scope": "teambit.api-reference",
         "version": "0.0.27",
@@ -2246,6 +2253,13 @@
         "version": "0.0.13",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/utils/copy-schema-node"
+    },
+    "utils/custom-prism-syntax-highlighter-theme": {
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.api-reference",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/api-reference/utils/custom-prism-syntax-highlighter-theme"
     },
     "utils/group-schema-node-by-signature": {
         "scope": "teambit.api-reference",

--- a/scopes/api-reference/api-reference/api-reference.ui.runtime.tsx
+++ b/scopes/api-reference/api-reference/api-reference.ui.runtime.tsx
@@ -19,6 +19,7 @@ import { typeLiteralRenderer } from '@teambit/api-reference.renderers.type-liter
 import { parameterRenderer } from '@teambit/api-reference.renderers.parameter';
 import { inferenceTypeRenderer } from '@teambit/api-reference.renderers.inference-type';
 import { typeArrayRenderer } from '@teambit/api-reference.renderers.type-array';
+import { thisRenderer } from '@teambit/api-reference.renderers.this';
 import { SchemaNodeConstructor, SchemaRegistry, Schemas } from '@teambit/semantics.entities.semantic-schema';
 import CodeAspect, { CodeUI } from '@teambit/code';
 
@@ -68,6 +69,7 @@ export class APIReferenceUI {
     typeLiteralRenderer,
     inferenceTypeRenderer,
     typeArrayRenderer,
+    thisRenderer,
   ];
 
   static async provider(

--- a/scopes/api-reference/renderers/grouped-schema-nodes-summary/grouped-schema-nodes-summary.tsx
+++ b/scopes/api-reference/renderers/grouped-schema-nodes-summary/grouped-schema-nodes-summary.tsx
@@ -34,20 +34,15 @@ const DEFAULT_HEADINGS = {
   default: ['name', 'type', 'description'],
 };
 
-export function GroupedSchemaNodesSummary({
-  nodes,
-  apiNodeRendererProps,
-  headings: headingsFromProps = {},
-  skipNode,
-  skipGrouping,
-  renderTable = (type, member, _headings = []) => {
+const defaultTableRenderer = function DefaultTableRendererWrapper(apiNodeRendererProps: APINodeRenderProps) {
+  return function DefaultTableRenderer(type: string, member: SchemaNode, headings: string[]) {
     const typeId = type && encodeURIComponent(type);
 
     if (type === 'enum members') {
       return (
         <EnumMemberSummary
           key={`${member.__schema}-${member.name}`}
-          headings={_headings}
+          headings={headings}
           apiNodeRendererProps={apiNodeRendererProps}
           groupElementClassName={typeId}
           name={(member as EnumMemberSchema).name}
@@ -60,7 +55,7 @@ export function GroupedSchemaNodesSummary({
       <VariableNodeSummary
         key={`${member.__schema}-${member.name}`}
         node={member}
-        headings={_headings}
+        headings={headings}
         groupElementClassName={typeId}
         apiNodeRendererProps={apiNodeRendererProps}
         name={member.name || member.signature || ''}
@@ -69,7 +64,16 @@ export function GroupedSchemaNodesSummary({
         defaultValue={(member as any).defaultValue}
       />
     );
-  },
+  };
+};
+
+export function GroupedSchemaNodesSummary({
+  nodes,
+  apiNodeRendererProps,
+  headings: headingsFromProps = {},
+  skipNode,
+  skipGrouping,
+  renderTable = defaultTableRenderer(apiNodeRendererProps),
   className,
   ...rest
 }: GroupedSchemaNodesSummaryProps) {

--- a/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.module.scss
+++ b/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.module.scss
@@ -1,13 +1,15 @@
 .summaryContainer {
-  padding: 0px 12px 2px 12px;
-  margin-bottom: 8px;
-  border-radius: var(--bit-p-sm);
-  background-color: var(--primary-surface-color);
+  padding: 0px 16px;
+  margin-bottom: 16px;
+  border-radius: 8px;
+  background-color: #f7f7f5;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
 }
 
 .signatureTitle {
   color: var(--on-background-color);
-  margin-bottom: 16px;
 
   > pre {
     > code {
@@ -19,7 +21,8 @@
 
 .description {
   font-size: 14px;
-  margin: 20px 0px;
+  margin-bottom: 16px;
+  font-style: italic;
 }
 
 .subtitle {
@@ -30,7 +33,6 @@
   margin-bottom: 12px;
 }
 
-.paramsContainer,
 .returnContainer {
   margin-bottom: 16px;
 }
@@ -38,5 +40,9 @@
 .functionName {
   font-size: var(--bit-p-md);
   font-weight: 500;
-  padding: 8px 0px;
+  padding: 16px 0px;
+}
+
+.hide {
+  padding: 8px 0px !important;
 }

--- a/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
+++ b/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
@@ -1,12 +1,12 @@
 import React, { HTMLAttributes, useMemo } from 'react';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import defaultTheme from 'react-syntax-highlighter/dist/esm/styles/prism/vsc-dark-plus';
 import { SchemaNode, SetAccessorSchema } from '@teambit/semantics.entities.semantic-schema';
 import { transformSignature } from '@teambit/api-reference.utils.schema-node-signature-transform';
 import { APIReferenceModel } from '@teambit/api-reference.models.api-reference-model';
 import { APINodeRenderProps, nodeStyles } from '@teambit/api-reference.models.api-node-renderer';
 import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
 import classNames from 'classnames';
+import defaultTheme from '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme';
 
 import styles from './function-node-summary.module.scss';
 
@@ -53,22 +53,21 @@ export function FunctionNodeSummary({
     <div className={styles.summaryContainer}>
       <div className={styles.signatureTitle}>
         {<div className={classNames(styles.functionName, hideName && styles.hide)}>{hideName ? '' : name}</div>}
+        {doc?.comment && <div className={styles.description}>{doc?.comment || ''}</div>}
         {signature && (
           <SyntaxHighlighter
             language={lang}
             style={defaultTheme}
             customStyle={{
               borderRadius: '8px',
-              marginTop: '8px',
-              padding: '8px',
+              marginTop: '4px',
+              padding: '6px',
             }}
           >
             {signature}
           </SyntaxHighlighter>
         )}
       </div>
-      <p className={styles.description}>{doc?.comment || ''}</p>
-
       {params.length > 0 && (
         <div className={styles.paramsContainer}>
           <h3 className={styles.subtitle}>Parameters</h3>

--- a/scopes/api-reference/renderers/this/index.ts
+++ b/scopes/api-reference/renderers/this/index.ts
@@ -1,0 +1,1 @@
+export { thisRenderer } from './this.renderer';

--- a/scopes/api-reference/renderers/this/this.renderer.tsx
+++ b/scopes/api-reference/renderers/this/this.renderer.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { APINodeRenderProps, APINodeRenderer } from '@teambit/api-reference.models.api-node-renderer';
+import { ThisTypeSchema } from '@teambit/semantics.entities.semantic-schema';
+import { TypeRefName } from '@teambit/api-reference.renderers.type-ref';
+import { useUpdatedUrlFromQuery } from '@teambit/api-reference.hooks.use-api-ref-url';
+
+export const thisRenderer: APINodeRenderer = {
+  predicate: (node) => node.__schema === ThisTypeSchema.name,
+  Component: ThisComponent,
+  nodeType: 'This',
+  default: true,
+};
+
+function ThisComponent(props: APINodeRenderProps) {
+  const {
+    apiNode: { api },
+    apiRefModel,
+  } = props;
+
+  const thisType = api as ThisTypeSchema;
+  const typeRef = thisType.name !== 'this' ? apiRefModel.apiByName.get(thisType.name) : undefined;
+
+  if (!typeRef) return <>{api.name}</>;
+
+  return (
+    <TypeRefName name={typeRef.api.name as string} url={useUpdatedUrlFromQuery({ selectedAPI: typeRef.api.name })} />
+  );
+}

--- a/scopes/api-reference/renderers/type-ref/index.ts
+++ b/scopes/api-reference/renderers/type-ref/index.ts
@@ -1,1 +1,1 @@
-export { typeRefRenderer } from './type-ref.renderer';
+export { typeRefRenderer, TypeRefName } from './type-ref.renderer';

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
@@ -125,7 +125,7 @@ function TypeRefComponent(props: APINodeRenderProps) {
 
 const LinkContext = React.createContext(false);
 
-function TypeRefName({
+export function TypeRefName({
   name,
   url,
   external,

--- a/scopes/api-reference/utils/custom-prism-syntax-highlighter-theme/custom-theme.js
+++ b/scopes/api-reference/utils/custom-prism-syntax-highlighter-theme/custom-theme.js
@@ -1,0 +1,198 @@
+export default {
+  'code[class*="language-"]': {
+    fontFamily: '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+    fontSize: '14px',
+    lineHeight: '1.5',
+    direction: 'ltr',
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    MozTabSize: '2',
+    OTabSize: '2',
+    tabSize: '2',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+    background: '#ededed',
+    color: '#6c5ce7',
+  },
+  'pre[class*="language-"]': {
+    fontFamily: '"Fira Code", "Fira Mono", Menlo, Consolas, "DejaVu Sans Mono", monospace',
+    fontSize: '14px',
+    lineHeight: '1.5',
+    direction: 'ltr',
+    textAlign: 'left',
+    whiteSpace: 'pre',
+    wordSpacing: 'normal',
+    wordBreak: 'normal',
+    MozTabSize: '2',
+    OTabSize: '2',
+    tabSize: '2',
+    WebkitHyphens: 'none',
+    MozHyphens: 'none',
+    msHyphens: 'none',
+    hyphens: 'none',
+    background: '#ededed',
+    color: '#6c5ce7',
+    padding: '1em',
+    margin: '.5em 0',
+    borderRadius: '.3em',
+    overflow: 'auto',
+  },
+  'pre > code[class*="language-"]': {
+    fontSize: '1em',
+  },
+  'code[class*="language-"] ::-moz-selection': {
+    textShadow: 'none',
+    background: 'hsl(230, 1%, 90%)',
+  },
+  'pre[class*="language-"]::selection': {
+    textShadow: 'none',
+    background: 'hsl(230, 1%, 90%)',
+  },
+  ':not(pre) > code[class*="language-"]': {
+    padding: '0.2em 0.3em',
+    borderRadius: '.3em',
+  },
+  comment: {
+    color: 'hsl(230, 4%, 64%)',
+  },
+  prolog: {
+    color: 'hsl(230, 4%, 64%)',
+  },
+  doctype: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  cdata: {
+    color: 'hsl(230, 4%, 64%)',
+  },
+  punctuation: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  namespace: {
+    Opacity: '.7',
+  },
+  tag: {
+    color: 'hsl(5, 74%, 59%)',
+  },
+  operator: {
+    color: 'hsl(221, 87%, 60%)',
+  },
+  number: {
+    color: '#b800b8',
+  },
+  property: {
+    color: '#111b27',
+  },
+  function: {
+    color: '#b800b8',
+  },
+  'tag-id': {
+    color: '#2d2006',
+  },
+  selector: {
+    color: '#2d2006',
+  },
+  'atrule-id': {
+    color: '#2d2006',
+  },
+  'code.language-javascript': {
+    color: '#896724',
+  },
+  'attr-name': {
+    color: '#896724',
+  },
+  'code.language-css': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  'code.language-scss': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  boolean: {
+    color: '#b800b8',
+  },
+  string: {
+    color: 'hsl(119, 34%, 47%)',
+  },
+  entity: {
+    color: 'hsl(230, 8%, 24%)',
+    cursor: 'help',
+  },
+  url: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  '.language-css .token.string': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  '.language-scss .token.string': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  '.style .token.string': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  'attr-value': {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  builtin: {
+    color: 'hsla(301, 63%, 40%, 1)',
+  },
+  keyword: {
+    color: 'hsla(301, 63%, 40%, 1)',
+  },
+  control: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  directive: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  unit: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  statement: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  regex: {
+    color: 'hsl(230, 8%, 24%)',
+  },
+  atrule: {
+    color: '#b800b8',
+  },
+  placeholder: {
+    color: '#93abdc',
+  },
+  variable: {
+    color: 'hsl(221, 87%, 60%);',
+  },
+  deleted: {
+    textDecoration: 'line-through',
+  },
+  inserted: {
+    borderBottom: '1px dotted #2d2006',
+    textDecoration: 'none',
+  },
+  italic: {
+    fontStyle: 'italic',
+  },
+  important: {
+    fontWeight: 'bold',
+    color: '#896724',
+  },
+  bold: {
+    fontWeight: 'bold',
+  },
+  'pre > code.highlight': {
+    Outline: '.4em solid #896724',
+    OutlineOffset: '.4em',
+  },
+  '.line-numbers .line-numbers-rows': {
+    borderRightColor: '#ece8de',
+  },
+  '.line-numbers-rows > span:before': {
+    color: '#cdc4b1',
+  },
+  '.line-highlight': {
+    background: 'linear-gradient(to right, rgba(45, 32, 6, 0.2) 70%, rgba(45, 32, 6, 0))',
+  },
+};

--- a/scopes/api-reference/utils/custom-prism-syntax-highlighter-theme/index.ts
+++ b/scopes/api-reference/utils/custom-prism-syntax-highlighter-theme/index.ts
@@ -1,0 +1,3 @@
+import DefaultBitPrismTheme from './custom-theme';
+
+export default DefaultBitPrismTheme;


### PR DESCRIPTION
This PR is part (1) of style fixes in API Reference

It adds the following

- a custom Bit flavoured Prism Syntax Highlighter theme for node summary signatures
- thisType renderer to handle self referenced types
- style fixes for function node summary 

<img width="903" alt="Screenshot 2023-09-27 at 3 29 22 PM" src="https://github.com/teambit/bit/assets/8999604/d5a301f2-f256-4000-b450-0d096d43f2ba">