### PR TITLE
feature(isolator) - support caching of the lock file only for scope aspects capsules

### DIFF
--- a/scopes/scope/scope/scope-aspects-loader.ts
+++ b/scopes/scope/scope/scope-aspects-loader.ts
@@ -8,6 +8,7 @@ import {
   CFG_CAPSULES_SCOPES_ASPECTS_BASE_DIR,
   CFG_CAPSULES_GLOBAL_SCOPE_ASPECTS_BASE_DIR,
   CFG_USE_DATED_CAPSULES,
+  CFG_CACHE_LOCK_ONLY_CAPSULES,
 } from '@teambit/legacy/dist/constants';
 import { Compiler, TranspileFileOutputOneFile } from '@teambit/compiler';
 import { Capsule, IsolateComponentsOptions, IsolatorMain } from '@teambit/isolator';
@@ -332,6 +333,12 @@ needed-for: ${neededFor || '<unknown>'}`);
     return globalConfig === true || globalConfig === 'true';
   }
 
+  shouldCacheLockFileOnly(): boolean {
+    const globalConfig = this.globalConfig.getSync(CFG_CACHE_LOCK_ONLY_CAPSULES);
+    // @ts-ignore
+    return globalConfig === true || globalConfig === 'true';
+  }
+
   getAspectCapsulePath() {
     const defaultPath = `${this.scope.path}-aspects`;
     if (this.scope.isGlobalScope) {
@@ -456,6 +463,7 @@ needed-for: ${neededFor || '<unknown>'}`);
   getDefaultIsolateOpts() {
     const useHash = this.shouldUseHashForCapsules();
     const useDatedDirs = this.shouldUseDatedCapsules();
+    const cacheLockFileOnly = this.shouldCacheLockFileOnly();
     const nodeLinker = this.getAspectsNodeLinker();
 
     const opts = {
@@ -465,6 +473,7 @@ needed-for: ${neededFor || '<unknown>'}`);
       packageManager: this.getAspectsPackageManager(),
       nodeLinker,
       useDatedDirs,
+      cacheLockFileOnly,
       skipIfExists: true,
       seedersOnly: true,
       includeFromNestedHosts: true,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -383,6 +383,8 @@ export const CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS = 'default_resolve_envs_from_ro
  */
 export const CFG_USE_DATED_CAPSULES = 'use_dated_capsules';
 
+export const CFG_CACHE_LOCK_ONLY_CAPSULES = 'cache_lock_only_capsules';
+
 export const CFG_PROXY = 'proxy';
 export const CFG_HTTPS_PROXY = 'https_proxy';
 export const CFG_PROXY_NO_PROXY = 'proxy.no_proxy';


### PR DESCRIPTION
## Proposed Changes

- add new bit config named: `cache_lock_only_capsules`
- if it's true the isolator will do a few things:
   * in the end of the process it will only move the lock file (pnpm-lock.yaml) into the capsule cache
   * in the beginning of the process it will check if there is a lock file in the capsule cache, if yes it will move it to the temp dated dir
   * it will write env's file into the dated dir (as it only contain the lock file)
   * it will run install in the dated dir (as there is no node_modules there yet)

