### PR TITLE
fix(schema/api-ref): support extracting schema for react comps without props

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -10,1561 +10,1344 @@
 
 {
     "api-reference": {
-        "name": "api-reference",
         "scope": "teambit.api-reference",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/api-reference"
     },
     "api-server": {
-        "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/api-server"
     },
     "application": {
-        "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/application"
     },
     "aspect": {
-        "name": "aspect",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect"
     },
     "aspect-docs/babel": {
-        "name": "aspect-docs/babel",
         "scope": "teambit.compilation",
         "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/aspect-docs/babel"
     },
     "aspect-docs/builder": {
-        "name": "aspect-docs/builder",
         "scope": "teambit.pipelines",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/aspect-docs/builder"
     },
     "aspect-docs/compiler": {
-        "name": "aspect-docs/compiler",
         "scope": "teambit.compilation",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/aspect-docs/compiler"
     },
     "aspect-docs/component": {
-        "name": "aspect-docs/component",
         "scope": "teambit.component",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/aspect-docs/component"
     },
     "aspect-docs/compositions": {
-        "name": "aspect-docs/compositions",
         "scope": "teambit.compositions",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/aspect-docs/compositions"
     },
     "aspect-docs/dependency-resolver": {
-        "name": "aspect-docs/dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "0.0.171",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/aspect-docs/dependency-resolver"
     },
     "aspect-docs/envs": {
-        "name": "aspect-docs/envs",
         "scope": "teambit.envs",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/aspect-docs/envs"
     },
     "aspect-docs/generator": {
-        "name": "aspect-docs/generator",
         "scope": "teambit.generator",
         "version": "0.0.166",
         "mainFile": "index.ts",
         "rootDir": "scopes/generator/aspect-docs/generator"
     },
     "aspect-docs/html": {
-        "name": "aspect-docs/html",
         "scope": "teambit.html",
         "version": "0.0.119",
         "mainFile": "index.ts",
         "rootDir": "scopes/html/aspect-docs/html"
     },
     "aspect-docs/logger": {
-        "name": "aspect-docs/logger",
         "scope": "teambit.harmony",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-docs/logger"
     },
     "aspect-docs/mdx": {
-        "name": "aspect-docs/mdx",
         "scope": "teambit.mdx",
         "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/aspect-docs/mdx"
     },
     "aspect-docs/multi-compiler": {
-        "name": "aspect-docs/multi-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/aspect-docs/multi-compiler"
     },
     "aspect-docs/node": {
-        "name": "aspect-docs/node",
         "scope": "teambit.harmony",
         "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-docs/node"
     },
     "aspect-docs/pkg": {
-        "name": "aspect-docs/pkg",
         "scope": "teambit.pkg",
         "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/pkg/aspect-docs/pkg"
     },
     "aspect-docs/pnpm": {
-        "name": "aspect-docs/pnpm",
         "scope": "teambit.dependencies",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/aspect-docs/pnpm"
     },
     "aspect-docs/preview": {
-        "name": "aspect-docs/preview",
         "scope": "teambit.preview",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/aspect-docs/preview"
     },
     "aspect-docs/react": {
-        "name": "aspect-docs/react",
         "scope": "teambit.react",
         "version": "0.0.163",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/aspect-docs/react"
     },
     "aspect-docs/react-native": {
-        "name": "aspect-docs/react-native",
         "scope": "teambit.react",
         "version": "0.0.165",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/aspect-docs/react-native"
     },
     "aspect-docs/typescript": {
-        "name": "aspect-docs/typescript",
         "scope": "teambit.typescript",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/aspect-docs/typescript"
     },
     "aspect-docs/variants": {
-        "name": "aspect-docs/variants",
         "scope": "teambit.workspace",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/aspect-docs/variants"
     },
     "aspect-docs/yarn": {
-        "name": "aspect-docs/yarn",
         "scope": "teambit.dependencies",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/aspect-docs/yarn"
     },
     "aspect-loader": {
-        "name": "aspect-loader",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-loader"
     },
     "babel": {
-        "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/babel"
     },
     "babel/bit-react-transformer": {
-        "name": "babel/bit-react-transformer",
         "scope": "teambit.react",
         "version": "1.0.6",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/bit-react-transformer"
     },
     "bit": {
-        "name": "bit",
         "scope": "teambit.harmony",
         "version": "1.1.3",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit"
     },
     "bit-custom-aspect": {
-        "name": "bit-custom-aspect",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit-custom-aspect"
     },
     "bit-error": {
-        "name": "bit-error",
         "scope": "teambit.harmony",
         "version": "0.0.404",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit-error"
     },
     "bit-roots": {
-        "name": "bit-roots",
         "scope": "teambit.workspace",
         "version": "0.0.129",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/bit-roots"
     },
     "builder": {
-        "name": "builder",
         "scope": "teambit.pipelines",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/builder"
     },
     "builder-data": {
-        "name": "builder-data",
         "scope": "teambit.pipelines",
         "version": "0.0.344",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/modules/builder-data"
     },
     "bundler": {
-        "name": "bundler",
         "scope": "teambit.compilation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/bundler"
     },
     "cache": {
-        "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.888",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cache"
     },
     "changelog": {
-        "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/changelog"
     },
     "checkout": {
-        "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/checkout"
     },
     "clear-cache": {
-        "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.351",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/clear-cache"
     },
     "cli": {
-        "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.795",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli"
     },
     "cli-table": {
-        "name": "cli-table",
         "scope": "teambit.toolbox",
         "version": "0.0.43",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/tables/cli-table"
     },
     "cli/preview-server-status": {
-        "name": "cli/preview-server-status",
         "scope": "teambit.preview",
         "version": "0.0.501",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/cli/preview-server-status"
     },
     "cli/ui-server-console": {
-        "name": "cli/ui-server-console",
         "scope": "teambit.ui-foundation",
         "version": "0.0.501",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/cli/ui-server-console"
     },
     "cli/ui-server-loader": {
-        "name": "cli/ui-server-loader",
         "scope": "teambit.ui-foundation",
         "version": "0.0.499",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/cli/ui-server-loader"
     },
     "cli/webpack-events-listener": {
-        "name": "cli/webpack-events-listener",
         "scope": "teambit.preview",
         "version": "0.0.170",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/cli/webpack-events-listener"
     },
     "cli/webpack/error": {
-        "name": "cli/webpack/error",
         "scope": "teambit.compilation",
         "version": "0.0.498",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/cli/webpack/error"
     },
     "cloud": {
-        "name": "cloud",
         "scope": "teambit.cloud",
         "version": "0.0.343",
         "mainFile": "index.ts",
         "rootDir": "scopes/cloud/cloud"
     },
     "code": {
-        "name": "code",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/code"
     },
     "command-bar": {
-        "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/command-bar"
     },
     "community": {
-        "name": "community",
         "scope": "teambit.community",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/community/community"
     },
     "compiler": {
-        "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/compiler"
     },
     "component": {
-        "name": "component",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component"
     },
     "component-compare": {
-        "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-compare"
     },
     "component-descriptor": {
-        "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.361",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-descriptor"
     },
     "component-issues": {
-        "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.97",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-issues"
     },
     "component-log": {
-        "name": "component-log",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-log"
     },
     "component-package-version": {
-        "name": "component-package-version",
         "scope": "teambit.component",
         "version": "0.0.427",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-package-version"
     },
     "component-sizer": {
-        "name": "component-sizer",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-sizer"
     },
     "component-tree": {
-        "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-tree"
     },
     "component-version": {
-        "name": "component-version",
         "scope": "teambit.component",
         "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-version"
     },
     "component-writer": {
-        "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-writer"
     },
     "composition-card": {
-        "name": "composition-card",
         "scope": "teambit.compositions",
         "version": "0.0.154",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/composition-card"
     },
     "compositions": {
-        "name": "compositions",
         "scope": "teambit.compositions",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/compositions"
     },
     "config": {
-        "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.810",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/config"
     },
     "content/cli-reference": {
-        "name": "content/cli-reference",
         "scope": "teambit.harmony",
         "version": "2.0.17",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli-reference"
     },
     "dependencies": {
-        "name": "dependencies",
         "scope": "teambit.dependencies",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependencies"
     },
     "dependency-resolver": {
-        "name": "dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver"
     },
     "deprecation": {
-        "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/deprecation"
     },
     "dev-files": {
-        "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/dev-files"
     },
     "diagnostic": {
-        "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/diagnostic"
     },
     "docs": {
-        "name": "docs",
         "scope": "teambit.docs",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/docs"
     },
     "eject": {
-        "name": "eject",
         "scope": "teambit.workspace",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/eject"
     },
     "elements": {
-        "name": "elements",
         "scope": "teambit.web-components",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/web-components/elements"
     },
     "entities/lane-diff": {
-        "name": "entities/lane-diff",
         "scope": "teambit.lanes",
         "version": "0.0.152",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/entities/lane-diff"
     },
     "env": {
-        "name": "env",
         "scope": "teambit.envs",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/env"
     },
     "envs": {
-        "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/envs"
     },
     "eslint": {
-        "name": "eslint",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/eslint"
     },
     "eslint-config-bit-react": {
-        "name": "eslint-config-bit-react",
         "scope": "teambit.react",
         "version": "1.0.39",
         "mainFile": "index.js",
         "rootDir": "scopes/react/eslint-config-bit-react"
     },
     "eslint/config-mutator": {
-        "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.94",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/eslint-config-mutator"
     },
     "explorer/api-reference-explorer": {
-        "name": "explorer/api-reference-explorer",
         "scope": "teambit.api-reference",
         "version": "0.0.19",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/explorer/api-reference-explorer"
     },
     "export": {
-        "name": "export",
         "scope": "teambit.scope",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/export"
     },
     "express": {
-        "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.894",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/express"
     },
     "forking": {
-        "name": "forking",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/forking"
     },
     "formatter": {
-        "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/formatter"
     },
     "fs/hard-link-directory": {
-        "name": "fs/hard-link-directory",
         "scope": "teambit.toolbox",
         "version": "0.0.17",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/fs/hard-link-directory"
     },
     "fs/linked-dependencies": {
-        "name": "fs/linked-dependencies",
         "scope": "teambit.dependencies",
         "version": "0.0.4",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/fs/linked-dependencies"
     },
     "generator": {
-        "name": "generator",
         "scope": "teambit.generator",
         "version": "1.0.17",
         "mainFile": "index.ts",
         "rootDir": "scopes/generator/generator"
     },
     "git": {
-        "name": "git",
         "scope": "teambit.git",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/git/git"
     },
     "global-config": {
-        "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.797",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/global-config"
     },
     "graph": {
-        "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/graph"
     },
     "graphql": {
-        "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/graphql"
     },
     "harmony-ui-app": {
-        "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
     },
     "hooks/use-api": {
-        "name": "hooks/use-api",
         "scope": "teambit.api-reference",
         "version": "0.0.12",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/hooks/use-api"
     },
     "hooks/use-api-ref-url": {
-        "name": "hooks/use-api-ref-url",
         "scope": "teambit.api-reference",
         "version": "0.0.9",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/hooks/use-api-ref-url"
     },
     "hooks/use-schema": {
-        "name": "hooks/use-schema",
         "scope": "teambit.api-reference",
         "version": "0.0.17",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/hooks/use-schema"
     },
     "html": {
-        "name": "html",
         "scope": "teambit.html",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/html/html"
     },
     "importer": {
-        "name": "importer",
         "scope": "teambit.scope",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/importer"
     },
     "insights": {
-        "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/insights"
     },
     "install": {
-        "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/install"
     },
     "ipc-events": {
-        "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/ipc-events"
     },
     "isolator": {
-        "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/isolator"
     },
     "issues": {
-        "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/issues"
     },
     "jest": {
-        "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/jest"
     },
     "lane-id": {
-        "name": "lane-id",
         "scope": "teambit.lanes",
         "version": "0.0.307",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lane-id"
     },
     "lanes": {
-        "name": "lanes",
         "scope": "teambit.lanes",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lanes"
     },
     "legacy-component-log": {
-        "name": "legacy-component-log",
         "scope": "teambit.component",
         "version": "0.0.402",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/legacy-component-log"
     },
     "linter": {
-        "name": "linter",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/linter"
     },
     "lister": {
-        "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/lister"
     },
     "logger": {
-        "name": "logger",
         "scope": "teambit.harmony",
         "version": "0.0.888",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/logger"
     },
     "mdx": {
-        "name": "mdx",
         "scope": "teambit.mdx",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/mdx"
     },
     "merge-lanes": {
-        "name": "merge-lanes",
         "scope": "teambit.lanes",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/merge-lanes"
     },
     "merging": {
-        "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/merging"
     },
     "mocha": {
-        "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/mocha"
     },
     "model/composition-id": {
-        "name": "model/composition-id",
         "scope": "teambit.compositions",
         "version": "0.0.498",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/model/composition-id"
     },
     "model/composition-type": {
-        "name": "model/composition-type",
         "scope": "teambit.compositions",
         "version": "0.0.499",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/model/composition-type"
     },
     "models/scope-model": {
-        "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.450",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/models/scope-model"
     },
     "modules/babel-compiler": {
-        "name": "modules/babel-compiler",
         "scope": "teambit.compilation",
         "version": "0.0.135",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/modules/babel-compiler"
     },
     "modules/component-url": {
-        "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.153",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-url"
     },
     "modules/config-mutator": {
-        "name": "modules/config-mutator",
         "scope": "teambit.webpack",
         "version": "0.0.162",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/config-mutator"
     },
     "modules/create-element-from-string": {
-        "name": "modules/create-element-from-string",
         "scope": "teambit.html",
         "version": "0.0.106",
         "mainFile": "index.ts",
         "rootDir": "scopes/html/modules/create-element-from-string"
     },
     "modules/diff": {
-        "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.425",
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/diff"
     },
     "modules/fetch-html-from-url": {
-        "name": "modules/fetch-html-from-url",
         "scope": "teambit.html",
         "version": "0.0.106",
         "mainFile": "index.ts",
         "rootDir": "scopes/html/modules/fetch-html-from-url"
     },
     "modules/generate-expose-loaders": {
-        "name": "modules/generate-expose-loaders",
         "scope": "teambit.webpack",
         "version": "0.0.12",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/modules/generate-expose-loaders"
     },
     "modules/generate-externals": {
-        "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.13",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/modules/generate-externals"
     },
     "modules/generate-style-loaders": {
-        "name": "modules/generate-style-loaders",
         "scope": "teambit.webpack",
         "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/modules/generate-style-loaders"
     },
     "modules/match-pattern": {
-        "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.500",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/modules/match-pattern"
     },
     "modules/mdx-compiler": {
-        "name": "modules/mdx-compiler",
         "scope": "teambit.mdx",
         "version": "0.0.502",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/modules/compiler"
     },
     "modules/mdx-loader": {
-        "name": "modules/mdx-loader",
         "scope": "teambit.mdx",
         "version": "1.0.7",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/modules/loader"
     },
     "modules/merge-component-results": {
-        "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.494",
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/modules/merge-component-results"
     },
     "modules/module-resolver": {
-        "name": "modules/module-resolver",
         "scope": "teambit.toolbox",
         "version": "0.0.3",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/modules/module-resolver"
     },
     "modules/node-modules-linker": {
-        "name": "modules/node-modules-linker",
         "scope": "teambit.workspace",
         "version": "0.0.136",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/modules/node-modules-linker"
     },
     "modules/packages-excluder": {
-        "name": "modules/packages-excluder",
         "scope": "teambit.dependencies",
         "version": "1.0.4",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/modules/packages-excluder"
     },
     "modules/prerenderer-puppeteer": {
-        "name": "modules/prerenderer-puppeteer",
         "scope": "teambit.react",
         "version": "0.0.12",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/modules/prerenderer-puppeteer"
     },
     "modules/requireable-component": {
-        "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.493",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/modules/requireable-component"
     },
     "modules/resolved-component": {
-        "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.493",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/modules/resolved-component"
     },
     "modules/style-regexps": {
-        "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/style-regexps"
     },
     "modules/ts-config-mutator": {
-        "name": "modules/ts-config-mutator",
         "scope": "teambit.typescript",
         "version": "0.0.78",
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/modules/ts-config-mutator"
     },
     "mover": {
-        "name": "mover",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/mover"
     },
     "multi-compiler": {
-        "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/multi-compiler"
     },
     "multi-tester": {
-        "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/multi-tester"
     },
     "network/agent": {
-        "name": "network/agent",
         "scope": "teambit.toolbox",
         "version": "0.0.554",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/network/agent"
     },
     "network/get-port": {
-        "name": "network/get-port",
         "scope": "teambit.toolbox",
         "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/network/get-port"
     },
     "new-component-helper": {
-        "name": "new-component-helper",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/new-component-helper"
     },
     "node": {
-        "name": "node",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/node"
     },
     "notifications": {
-        "name": "notifications",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/notifications/aspect"
     },
     "panels": {
-        "name": "panels",
         "scope": "teambit.ui-foundation",
         "version": "0.0.796",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/panels"
     },
     "panels/composition-gallery": {
-        "name": "panels/composition-gallery",
         "scope": "teambit.compositions",
         "version": "0.0.154",
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/panels/composition-gallery"
     },
     "path/is-path-inside": {
-        "name": "path/is-path-inside",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/path/is-path-inside"
     },
     "path/match-patterns": {
-        "name": "path/match-patterns",
         "scope": "teambit.toolbox",
         "version": "0.0.11",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/path/match-patterns"
     },
     "path/to-windows-compatible-path": {
-        "name": "path/to-windows-compatible-path",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/path/to-windows-compatible-path"
     },
     "performance/v8-cache": {
-        "name": "performance/v8-cache",
         "scope": "teambit.toolbox",
         "version": "0.0.29",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/performance/v8-cache"
     },
     "pkg": {
-        "name": "pkg",
         "scope": "teambit.pkg",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/pkg/pkg"
     },
     "plugins/inject-head-webpack-plugin": {
-        "name": "plugins/inject-head-webpack-plugin",
         "scope": "teambit.webpack",
         "version": "0.0.5",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
     },
     "pnpm": {
-        "name": "pnpm",
         "scope": "teambit.dependencies",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/pnpm"
     },
     "prettier": {
-        "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/prettier"
     },
     "prettier/config-mutator": {
-        "name": "prettier/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.92",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/prettier-config-mutator"
     },
     "preview": {
-        "name": "preview",
         "scope": "teambit.preview",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/preview"
     },
     "pubsub": {
-        "name": "pubsub",
         "scope": "teambit.harmony",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/pubsub"
     },
     "react": {
-        "name": "react",
         "scope": "teambit.react",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react"
     },
     "react-elements": {
-        "name": "react-elements",
         "scope": "teambit.react",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react-elements"
     },
     "react-native": {
-        "name": "react-native",
         "scope": "teambit.react",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/react-native"
     },
     "react-router": {
-        "name": "react-router",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/react-router/react-router"
     },
     "readme": {
-        "name": "readme",
         "scope": "teambit.mdx",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/mdx/readme"
     },
     "refactoring": {
-        "name": "refactoring",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/refactoring"
     },
     "remove": {
-        "name": "remove",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/remove"
     },
     "renaming": {
-        "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/renaming"
     },
     "renderers/function": {
-        "name": "renderers/function",
         "scope": "teambit.api-reference",
         "version": "0.0.29",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/function"
     },
     "renderers/grouped-schema-nodes-summary": {
-        "name": "renderers/grouped-schema-nodes-summary",
         "scope": "teambit.api-reference",
         "version": "0.0.28",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/grouped-schema-nodes-summary"
     },
     "renderers/parameter": {
-        "name": "renderers/parameter",
         "scope": "teambit.api-reference",
         "version": "0.0.24",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/parameter"
     },
+    "renderers/react": {
+        "scope": "teambit.api-reference",
+        "version": "0.0.11",
+        "mainFile": "index.ts",
+        "rootDir": "components/renderers/react"
+    },
     "renderers/schema-node-member-summary": {
-        "name": "renderers/schema-node-member-summary",
         "scope": "teambit.api-reference",
         "version": "0.0.27",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/schema-node-member-summary"
     },
     "renderers/this": {
-        "name": "renderers/this",
         "scope": "teambit.api-reference",
         "version": "0.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/this"
     },
     "renderers/type-ref": {
-        "name": "renderers/type-ref",
         "scope": "teambit.api-reference",
         "version": "0.0.30",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/type-ref"
     },
     "schema": {
-        "name": "schema",
         "scope": "teambit.semantics",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/semantics/schema"
     },
     "scope": {
-        "name": "scope",
         "scope": "teambit.scope",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/scope"
     },
     "sections/api-reference-page": {
-        "name": "sections/api-reference-page",
         "scope": "teambit.api-reference",
         "version": "0.0.37",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/sections/api-reference-page"
     },
     "sections/api-reference-section": {
-        "name": "sections/api-reference-section",
         "scope": "teambit.api-reference",
         "version": "0.0.9",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/sections/api-reference-section"
     },
     "sidebar": {
-        "name": "sidebar",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/sidebar"
     },
     "sign": {
-        "name": "sign",
         "scope": "teambit.scope",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/sign"
     },
     "snapping": {
-        "name": "snapping",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/snapping"
     },
     "stash": {
-        "name": "stash",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/stash"
     },
     "status": {
-        "name": "status",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/status"
     },
     "string/capitalize": {
-        "name": "string/capitalize",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/string/capitalize"
     },
     "string/ellipsis": {
-        "name": "string/ellipsis",
         "scope": "teambit.toolbox",
         "version": "0.0.183",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/string/ellipsis"
     },
     "string/get-initials": {
-        "name": "string/get-initials",
         "scope": "teambit.toolbox",
         "version": "0.0.493",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/string/get-initials"
     },
     "string/strip-trailing-char": {
-        "name": "string/strip-trailing-char",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/string/strip-trailing-char"
     },
     "tester": {
-        "name": "tester",
         "scope": "teambit.defender",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/tester"
     },
     "testing/load-aspect": {
-        "name": "testing/load-aspect",
         "scope": "teambit.harmony",
         "version": "0.0.155",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/testing/load-aspect"
     },
     "testing/mock-components": {
-        "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.156",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/testing/mock-components"
     },
     "testing/mock-workspace": {
-        "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/testing/mock-workspace"
     },
     "tests-results": {
-        "name": "tests-results",
         "scope": "teambit.defender",
         "version": "1.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/tests-results"
     },
     "time/time-format": {
-        "name": "time/time-format",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/time/time-format"
     },
     "tracker": {
-        "name": "tracker",
         "scope": "teambit.component",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/component/tracker"
     },
     "ts-server": {
-        "name": "ts-server",
         "scope": "teambit.typescript",
         "version": "0.0.50",
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/ts-server"
     },
     "types/serializable": {
-        "name": "types/serializable",
         "scope": "teambit.toolbox",
         "version": "0.0.493",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/types/serializable"
     },
     "typescript": {
-        "name": "typescript",
         "scope": "teambit.typescript",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/typescript"
     },
     "ui": {
-        "name": "ui",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/ui"
     },
     "ui/aspect-box": {
-        "name": "ui/aspect-box",
         "scope": "teambit.harmony",
         "version": "0.0.502",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/ui/aspect-box"
     },
     "ui/component-preview": {
-        "name": "ui/component-preview",
         "scope": "teambit.preview",
         "version": "1.0.0",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/ui/component-preview"
     },
     "ui/compositions-app": {
-        "name": "ui/compositions-app",
         "scope": "teambit.react",
         "version": "0.0.17",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/compositions-app"
     },
     "ui/docs-app": {
-        "name": "ui/docs-app",
         "scope": "teambit.react",
         "version": "1.0.6",
         "mainFile": "index.tsx",
         "rootDir": "scopes/react/ui/docs-app"
     },
     "ui/docs/apply-providers": {
-        "name": "ui/docs/apply-providers",
         "scope": "teambit.react",
         "version": "0.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/docs/apply-providers"
     },
     "ui/docs/compositions-carousel": {
-        "name": "ui/docs/compositions-carousel",
         "scope": "teambit.react",
         "version": "0.0.21",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/docs/compositions-carousel"
     },
     "ui/docs/docs-content": {
-        "name": "ui/docs/docs-content",
         "scope": "teambit.react",
         "version": "0.0.22",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/docs/docs-content"
     },
     "ui/docs/properties-table": {
-        "name": "ui/docs/properties-table",
         "scope": "teambit.react",
         "version": "0.0.18",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/docs/properties-table"
     },
     "ui/env-icon": {
-        "name": "ui/env-icon",
         "scope": "teambit.envs",
         "version": "0.0.500",
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/ui/env-icon"
     },
     "ui/error-fallback": {
-        "name": "ui/error-fallback",
         "scope": "teambit.react",
         "version": "0.0.125",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/error-fallback"
     },
     "ui/highlighter-provider": {
-        "name": "ui/highlighter-provider",
         "scope": "teambit.react",
         "version": "0.0.205",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/highlighter-provider"
     },
     "ui/highlighter/component-metadata/bit-component-meta": {
-        "name": "ui/highlighter/component-metadata/bit-component-meta",
         "scope": "teambit.react",
         "version": "0.0.36",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/bit-component-meta"
     },
     "ui/loader-fallback": {
-        "name": "ui/loader-fallback",
         "scope": "teambit.react",
         "version": "0.0.105",
         "mainFile": "index.ts",
         "rootDir": "scopes/react/ui/loader-fallback"
     },
     "ui/preview-placeholder": {
-        "name": "ui/preview-placeholder",
         "scope": "teambit.preview",
         "version": "0.0.501",
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/ui/preview-placeholder"
     },
     "ui/queries/get-docs": {
-        "name": "ui/queries/get-docs",
         "scope": "teambit.docs",
         "version": "0.0.503",
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/ui/queries/get-docs"
     },
     "update-dependencies": {
-        "name": "update-dependencies",
         "scope": "teambit.scope",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/update-dependencies"
     },
     "url/add-avatar-query-params": {
-        "name": "url/add-avatar-query-params",
         "scope": "teambit.toolbox",
         "version": "0.0.494",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/url/add-avatar-query-params"
     },
     "url/query-string": {
-        "name": "url/query-string",
         "scope": "teambit.toolbox",
         "version": "0.0.492",
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/url/query-string"
     },
     "user-agent": {
-        "name": "user-agent",
         "scope": "teambit.ui-foundation",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent"
     },
     "utils/custom-prism-syntax-highlighter-theme": {
-        "name": "utils/custom-prism-syntax-highlighter-theme",
         "scope": "teambit.api-reference",
         "version": "0.0.2",
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/utils/custom-prism-syntax-highlighter-theme"
     },
     "variants": {
-        "name": "variants",
         "scope": "teambit.workspace",
         "version": "0.0.902",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/variants"
     },
     "watcher": {
-        "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/watcher"
     },
     "webpack": {
-        "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/webpack"
     },
     "worker": {
-        "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1099",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/worker"
     },
     "workspace": {
-        "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace"
     },
     "workspace-config-files": {
-        "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.16",
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace-config-files"
     },
     "yarn": {
-        "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.16",
         "mainFile": "index.ts",

--- a/components/renderers/react/index.ts
+++ b/components/renderers/react/index.ts
@@ -1,0 +1,1 @@
+export { reactRenderer } from './react.renderer';

--- a/components/renderers/react/react.renderer.module.scss
+++ b/components/renderers/react/react.renderer.module.scss
@@ -1,0 +1,63 @@
+.container {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  padding-bottom: 16px;
+  font-size: var(--bit-p-lg);
+  font-weight: 600;
+}
+
+.value {
+  font-size: var(--bit-p-xs);
+  background: var(--bit-bg-dent);
+  padding: 16px;
+  border-radius: 6px;
+  font-family: Roboto mono;
+}
+
+.topPad {
+  padding: 16px 0px;
+  border-top: 1px solid var(--border-medium-color);
+}
+
+.typeParams {
+  padding-top: 16px;
+  border-top: 1px solid var(--border-medium-color);
+}
+
+.bold {
+  font-weight: 500;
+}
+
+.table {
+  padding: 16px 8px;
+
+  > div {
+    grid-gap: 16px 24px;
+  }
+}
+
+.returnType {
+  font-size: var(--bit-p-xxs);
+  // color: #397300;
+  display: flex;
+  color: #4646c6;
+}
+
+.node {
+  display: flex;
+  font-size: var(--bit-p-xxs);
+  word-break: normal;
+}
+
+.paramRef {
+  padding-bottom: 16px;
+  font-size: var(--bit-p-md);
+}
+
+.docComment {
+  font-size: var(--bit-p-xs);
+  padding-bottom: 16px;
+}

--- a/components/renderers/react/react.renderer.tsx
+++ b/components/renderers/react/react.renderer.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import type { ReactSchema } from '@teambit/react';
+import { APINodeRenderProps, APINodeRenderer, nodeStyles } from '@teambit/api-reference.models.api-node-renderer';
+import { APINodeDetails } from '@teambit/api-reference.renderers.api-node-details';
+import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
+import classnames from 'classnames';
+import { TagName } from '@teambit/semantics.entities.semantic-schema';
+
+import styles from './react.renderer.module.scss';
+
+export const reactRenderer: APINodeRenderer = {
+  predicate: (node) => node.__schema === 'ReactSchema',
+  Component: ReactComponent,
+  nodeType: 'React',
+  icon: { name: 'React', url: 'https://static.bit.dev/extensions-icons/react.svg' },
+  default: true,
+};
+
+function ReactComponent(props: APINodeRenderProps) {
+  const {
+    apiNode: { api },
+    renderers,
+    // apiRefModel,
+  } = props;
+  const reactNode = api as ReactSchema;
+  const { returnType, props: reactProps, typeParams } = reactNode;
+  const returnTypeRenderer = renderers.find((renderer) => renderer.predicate(returnType));
+
+  if (props.metadata?.[api.__schema]?.columnView) {
+    return <div className={nodeStyles.node}>{api.toString()}</div>;
+  }
+
+  const paramRenderer = reactProps && renderers.find((renderer) => renderer.predicate(reactProps));
+  const paramRef = reactProps?.type;
+  const paramRefRenderer = paramRef && renderers.find((renderer) => renderer.predicate(paramRef));
+  const PropsRefComponent =
+    paramRef && paramRefRenderer?.Component ? (
+      <paramRefRenderer.Component
+        {...props}
+        key={`props-ref-${reactProps.name}`}
+        depth={(props.depth ?? 0) + 1}
+        apiNode={{ ...props.apiNode, renderer: paramRefRenderer, api: paramRef }}
+        metadata={{ [paramRef.__schema]: { columnView: true } }}
+      />
+    ) : null;
+
+  const ParamComponent =
+    reactProps && paramRenderer?.Component ? (
+      <paramRenderer.Component
+        {...props}
+        key={`props-${reactProps.name}`}
+        depth={(props.depth ?? 0) + 1}
+        apiNode={{ ...props.apiNode, renderer: paramRenderer, api: reactProps }}
+        metadata={{ [reactProps.__schema]: { columnView: true } }}
+      />
+    ) : (
+      (reactProps && (
+        <defaultParamRenderer.Component
+          {...props}
+          key={`props-${reactProps.name}`}
+          depth={(props.depth ?? 0) + 1}
+          apiNode={{ ...props.apiNode, renderer: defaultParamRenderer, api: reactProps }}
+          metadata={{ [reactProps.__schema]: { columnView: true } }}
+        />
+      )) ||
+      null
+    );
+
+  const docComment = api.doc?.findTag(TagName.return)?.comment;
+
+  return (
+    <APINodeDetails {...props} options={{ hideIndex: true }}>
+      {typeParams && (
+        <div className={classnames(styles.container, styles.typeParams, styles.topPad)}>
+          <div className={styles.title}>Type Parameters</div>
+          <div className={styles.values}>
+            {typeParams.map((typeParam) => {
+              return (
+                <div className={classnames(styles.value)} key={typeParam}>
+                  {typeParam}
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+      {ParamComponent && (
+        <div className={classnames(styles.container, styles.topPad)}>
+          <div className={styles.title}>Props</div>
+          <div className={styles.paramRef}>{PropsRefComponent}</div>
+          {ParamComponent}
+        </div>
+      )}
+      <div className={styles.container}>
+        <div className={styles.title}>Returns</div>
+        {docComment && <div className={styles.docComment}>{docComment}</div>}
+        <div className={styles.returnType}>
+          {(returnTypeRenderer && (
+            <returnTypeRenderer.Component
+              {...props}
+              apiNode={{ ...props.apiNode, api: returnType, renderer: returnTypeRenderer }}
+              depth={(props.depth ?? 0) + 1}
+            />
+          )) || <div className={nodeStyles.node}>{returnType.toString()}</div>}
+        </div>
+      </div>
+    </APINodeDetails>
+  );
+}

--- a/scopes/react/react/react.api.transformer.ts
+++ b/scopes/react/react/react.api.transformer.ts
@@ -18,9 +18,7 @@ export class ReactAPITransformer implements SchemaNodeTransformer {
     const isReactFile = REACT_FILE_EXT.some((r) => functionNode.location.filePath.includes(r));
     if (!isReactFile) return false;
     const params = functionNode.params;
-    if (params.length !== 1) return false;
-    const isParamTypeRef = params[0] instanceof ParameterSchema;
-    if (!isParamTypeRef) return false;
+    if (params.length > 1) return false;
     const returnsPotentialReactElement = [
       'JSX.Element',
       'React.ReactNode',
@@ -29,6 +27,7 @@ export class ReactAPITransformer implements SchemaNodeTransformer {
       'React.ReactChild',
       'React.ReactFragment',
       'React.ReactPortal',
+      'React.JSX.Element',
     ].includes(this.getReturnTypeName(node));
     if (!returnsPotentialReactElement) return false;
     return true;
@@ -38,8 +37,8 @@ export class ReactAPITransformer implements SchemaNodeTransformer {
     return new ReactSchema(
       node.location,
       node.name,
-      node.params[0] as ParameterSchema<TypeRefSchema>,
       new TypeRefSchema(node.returnType.location, this.getReturnTypeName(node), undefined, 'react'),
+      node.params[0] as ParameterSchema<TypeRefSchema>,
       node.signature,
       node.modifiers,
       node.doc,

--- a/scopes/react/react/react.schema.ts
+++ b/scopes/react/react/react.schema.ts
@@ -10,6 +10,7 @@ import {
   TypeRefSchema,
 } from '@teambit/semantics.entities.semantic-schema';
 import chalk from 'chalk';
+import { compact } from 'lodash';
 
 /**
  * function-like can be a function, method, arrow-function, variable-function, etc.
@@ -17,7 +18,7 @@ import chalk from 'chalk';
 export class ReactSchema extends SchemaNode {
   readonly returnType: SchemaNode;
 
-  readonly props: ParameterSchema;
+  readonly props?: ParameterSchema;
 
   readonly doc?: DocSchema;
 
@@ -26,8 +27,8 @@ export class ReactSchema extends SchemaNode {
   constructor(
     readonly location: Location,
     readonly name: string,
-    props: ParameterSchema<TypeRefSchema>,
     returnType: TypeRefSchema,
+    props?: ParameterSchema<TypeRefSchema>,
     signature?: string,
     readonly modifiers: Modifier[] = [],
     doc?: DocSchema,
@@ -37,15 +38,15 @@ export class ReactSchema extends SchemaNode {
     this.props = props;
     this.returnType = returnType;
     this.doc = doc;
-    this.signature = signature || FunctionLikeSchema.createSignature(name, [props], returnType);
+    this.signature = signature || FunctionLikeSchema.createSignature(name, compact([props]), returnType);
   }
 
   getNodes() {
-    return [this.props, this.returnType];
+    return compact([this.props, this.returnType]);
   }
 
   toString() {
-    const paramsStr = this.props.toString();
+    const paramsStr = this.props?.toString();
     const typeParamsStr = this.typeParams ? `<${this.typeParams.join(', ')}>` : '';
     return `${this.modifiersToString()}${typeParamsStr}${chalk.bold(
       this.name
@@ -69,7 +70,7 @@ export class ReactSchema extends SchemaNode {
     return {
       ...super.toObject(),
       name: this.name,
-      props: this.props.toObject(),
+      props: this.props?.toObject(),
       returnType: this.returnType.toObject(),
       signature: this.signature,
       modifiers: this.modifiers,
@@ -81,12 +82,12 @@ export class ReactSchema extends SchemaNode {
   static fromObject(obj: Record<string, any>): ReactSchema {
     const location = obj.location;
     const name = obj.name;
-    const props = ParameterSchema.fromObject<TypeRefSchema>(obj.props);
+    const props = obj.props ? ParameterSchema.fromObject<TypeRefSchema>(obj.props) : undefined;
     const returnType = SchemaRegistry.fromObject(obj.returnType);
     const signature = obj.signature;
     const modifiers = obj.modifiers;
     const doc = obj.doc ? DocSchema.fromObject(obj.doc) : undefined;
     const typeParams = obj.typeParams;
-    return new ReactSchema(location, name, props, returnType, signature, modifiers, doc, typeParams);
+    return new ReactSchema(location, name, returnType, props, signature, modifiers, doc, typeParams);
   }
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -60,7 +60,6 @@
         "@teambit/api-reference.renderers.enum": "^0.0.29",
         "@teambit/api-reference.renderers.inference-type": "^0.0.19",
         "@teambit/api-reference.renderers.interface": "^0.0.29",
-        "@teambit/api-reference.renderers.react": "^0.0.11",
         "@teambit/api-reference.renderers.schema-nodes-index": "^0.0.25",
         "@teambit/api-reference.renderers.type": "^0.0.28",
         "@teambit/api-reference.renderers.type-array": "^0.0.19",


### PR DESCRIPTION
This PR fixes the React API Transformer and Renderer to support extracting and rendering schema for a react component without any props. 