### PR TITLE
feat: add ignorePackageManifest option to the pnpm package manager aspect

### DIFF
--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -82,6 +82,11 @@ export type PackageManagerInstallOptions = {
   hideProgressPrefix?: boolean;
 
   hideLifecycleOutput?: boolean;
+
+  /**
+   * Do installation using lockfile only. Ignore the component manifests.
+   */
+  ignorePackageManifest?: boolean;
 };
 
 export type PackageManagerGetPeerDependencyIssuesOptions = PackageManagerInstallOptions;

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -198,6 +198,7 @@ export async function install(
     | 'excludeLinksFromLockfile'
     | 'peerDependencyRules'
     | 'neverBuiltDependencies'
+    | 'ignorePackageManifest'
   > &
     Pick<CreateStoreControllerOptions, 'packageImportMethod' | 'pnpmHomeDir' | 'preferOffline'>,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -77,6 +77,7 @@ export class PnpmPackageManager implements PackageManager {
         nodeLinker: installOptions.nodeLinker,
         nodeVersion: installOptions.nodeVersion ?? config.nodeVersion,
         includeOptionalDeps: installOptions.includeOptionalDeps,
+        ignorePackageManifest: installOptions.ignorePackageManifest,
         overrides: installOptions.overrides,
         hoistPattern: config.hoistPattern,
         publicHoistPattern: config.shamefullyHoist


### PR DESCRIPTION
## Proposed Changes

- Expose a setting is passed to pnpm: ignorePackageManifest. When set to `true` installation is done using information from the lockfile only. It doesn't matter if the lockfile is out of date.
