### PR TITLE
fix(snap/tag), clear status-cache when a component is modified

### DIFF
--- a/e2e/commands/diff.e2e.1.ts
+++ b/e2e/commands/diff.e2e.1.ts
@@ -119,13 +119,13 @@ describe('bit diff command', function () {
         output = helper.command.diff();
       });
       it('should show diff for all modified components', () => {
-        expect(output).to.have.string('bar/foo');
-        expect(output).to.have.string('utils/is-type');
+        expect(output).to.have.string('showing diff for bar/foo');
+        expect(output).to.have.string('showing diff for utils/is-type');
         expect(output).to.have.string(barFooV1);
         expect(output).to.have.string(barFooV2);
       });
       it('should not show non modified components', () => {
-        expect(output).to.not.have.string('utils/is-string');
+        expect(output).to.not.have.string('showing diff for utils/is-string');
       });
     });
     describe('running bit diff with multiple ids', () => {

--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -385,6 +385,6 @@ export class WorkspaceCompiler {
     if (changed) {
       return this.workspace.getNewAndModifiedIds();
     }
-    return this.workspace.getAllComponentIds();
+    return this.workspace.listIds();
   }
 }

--- a/scopes/component/component-compare/component-compare.main.runtime.ts
+++ b/scopes/component/component-compare/component-compare.main.runtime.ts
@@ -147,14 +147,11 @@ export class ComponentCompareMain {
 
   private async parseValues(values: string[]): Promise<{ bitIds: BitId[]; version?: string; toVersion?: string }> {
     if (!this.workspace) throw new OutsideWorkspaceError();
-    const consumer = this.workspace.consumer;
     // option #1: bit diff
     // no arguments
     if (!values.length) {
-      const componentsList = new ComponentsList(consumer);
-      const bitIds = await componentsList.listTagPendingComponents();
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      return { bitIds };
+      const componentIds = await this.workspace.listTagPendingIds();
+      return { bitIds: componentIds.map((id) => id._legacy) };
     }
     const firstValue = values[0];
     const lastValue = values[values.length - 1];

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -47,7 +47,7 @@ import {
 } from '@teambit/legacy/dist/utils/path';
 import fs from 'fs-extra';
 import { CompIdGraph, DepEdgeType } from '@teambit/graph';
-import { slice, isEmpty, merge, compact } from 'lodash';
+import { slice, isEmpty, merge, compact, uniqBy } from 'lodash';
 import { MergeConfigFilename, CFG_DEFAULT_RESOLVE_ENVS_FROM_ROOTS } from '@teambit/legacy/dist/constants';
 import path from 'path';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
@@ -441,31 +441,69 @@ export class Workspace implements ComponentFactory {
    * list all modified components in the workspace.
    */
   async modified(): Promise<Component[]> {
-    const legacyComps = (await this.componentList.listModifiedComponents(true)) as ConsumerComponent[];
-    return this.getManyByLegacy(legacyComps);
+    const allComps = await this.list();
+    const modifiedIncludeNulls = await mapSeries(allComps, async (component) => {
+      const modified = await this.isModified(component);
+      return modified ? component : null;
+    });
+    return compact(modifiedIncludeNulls);
   }
 
   /**
    * list all new components in the workspace.
    */
   async newComponents() {
-    const ids: any = await this.componentList.listNewComponents(false);
-    const componentIds = ids.map(ComponentID.fromLegacy);
+    const componentIds = await this.newComponentIds();
     return this.getMany(componentIds);
   }
 
+  async newComponentIds(): Promise<ComponentID[]> {
+    const allIds = await this.listIds();
+    return allIds.filter((id) => !id.hasVersion());
+  }
+
+  async locallyDeletedIds(): Promise<ComponentID[]> {
+    const locallyDeleted = await this.componentList.listLocallySoftRemoved();
+    return this.resolveMultipleComponentIds(locallyDeleted);
+  }
+
+  async duringMergeIds(): Promise<ComponentID[]> {
+    const duringMerge = this.componentList.listDuringMergeStateComponents();
+    return this.resolveMultipleComponentIds(duringMerge);
+  }
+
   /**
-   * get all workspace component-ids, include vendor components.
-   * (exclude nested dependencies in case dependencies are saved as components and not packages)
+   * @deprecated use `listIds()` instead.
+   * get all workspace component-ids
    */
   getAllComponentIds(): Promise<ComponentID[]> {
     const bitIds = this.consumer.bitMap.getAllBitIds();
     return this.resolveMultipleComponentIds(bitIds);
   }
 
+  async listTagPendingIds(): Promise<ComponentID[]> {
+    const newComponents = await this.newComponentIds();
+    const modifiedComponents = (await this.modified()).map((c) => c.id);
+    const removedComponents = await this.locallyDeletedIds();
+    const duringMergeIds = await this.duringMergeIds();
+    const allIds = [...newComponents, ...modifiedComponents, ...removedComponents, ...duringMergeIds];
+    const allIdsUniq = uniqBy(allIds, (id) => id.toString());
+    return allIdsUniq;
+  }
+
+  /**
+   * list all components that can be tagged. (e.g. when tagging/snapping with --unmodified).
+   * which are all components in the workspace, include locally deleted components.
+   */
+  async listPotentialTagIds(): Promise<ComponentID[]> {
+    const deletedIds = await this.locallyDeletedIds();
+    const allIdsWithoutDeleted = await this.listIds();
+    return [...deletedIds, ...allIdsWithoutDeleted];
+  }
+
   async getNewAndModifiedIds(): Promise<ComponentID[]> {
-    const ids = await this.componentList.listTagPendingComponents();
-    return this.resolveMultipleComponentIds(ids);
+    const ids = await this.listTagPendingIds();
+    return ids;
   }
 
   async newAndModified(): Promise<Component[]> {
@@ -710,7 +748,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
 
   clearComponentCache(id: ComponentID) {
     this.componentLoader.clearComponentCache(id);
-    this.consumer.componentLoader.clearOneComponentCache(id._legacy);
+    this.consumer.clearOneComponentCache(id._legacy);
     this.componentList = new ComponentsList(this.consumer);
   }
 
@@ -1215,12 +1253,20 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   async isModified(component: Component): Promise<boolean> {
     const head = component.head;
     if (!head) {
-      return true; // it's a new component
+      return false; // it's a new component
     }
     const consumerComp = component.state._consumer as ConsumerComponent;
     if (typeof consumerComp._isModified === 'boolean') return consumerComp._isModified;
     const componentStatus = await this.consumer.getComponentStatusById(component.id._legacy);
     return componentStatus.modified === true;
+  }
+
+  async isModifiedOrNew(component: Component): Promise<boolean> {
+    const head = component.head;
+    if (!head) {
+      return true; // it's a new component
+    }
+    return this.isModified(component);
   }
 
   /**

--- a/src/consumer/component-ops/component-status-loader.ts
+++ b/src/consumer/component-ops/component-status-loader.ts
@@ -114,4 +114,8 @@ export class ComponentStatusLoader {
     status.modified = await this.consumer.isComponentModified(versionFromModel, componentFromFileSystem);
     return status;
   }
+
+  clearOneComponentCache(id: BitId) {
+    delete this._componentsStatusCache[id.toString()];
+  }
 }

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -282,34 +282,6 @@ export default class ComponentsList {
     return components;
   }
 
-  /**
-   * list all components that can be tagged.
-   */
-  async listPotentialTagAllWorkspace(): Promise<BitId[]> {
-    const removedIds = await this.listLocallySoftRemoved();
-    const allIdsExcludeRemoved = this.idsFromBitMap();
-    return [...removedIds, ...allIdsExcludeRemoved];
-  }
-
-  /**
-   * New and modified components are tag pending
-   *
-   * @return {Promise<string[]>}
-   */
-  async listTagPendingComponents(): Promise<BitIds> {
-    const newComponents = await this.listNewComponents();
-    const modifiedComponents = await this.listModifiedComponents();
-    const removedComponents = await this.listLocallySoftRemoved();
-    const duringMergeIds = this.listDuringMergeStateComponents();
-
-    return BitIds.uniqFromArray([
-      ...(newComponents as BitId[]),
-      ...(modifiedComponents as BitId[]),
-      ...removedComponents,
-      ...duringMergeIds,
-    ]);
-  }
-
   async listExportPendingComponentsIds(lane?: Lane | null): Promise<BitIds> {
     const fromBitMap = this.bitMap.getAllBitIds();
     const modelComponents = await this.getModelComponents();

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -129,6 +129,11 @@ export default class Consumer {
     await Promise.all(this.onCacheClear.map((func) => func()));
   }
 
+  clearOneComponentCache(id: BitId) {
+    this.componentLoader.clearOneComponentCache(id);
+    this.componentStatusLoader.clearOneComponentCache(id);
+  }
+
   getTmpFolder(fullPath = false): PathOsBased {
     if (!fullPath) {
       return BIT_WORKSPACE_TMP_DIRNAME;


### PR DESCRIPTION
Clear the in-memory status-cache, which says whether a component is modified. Otherwise, in-memory processes, such as, vscode-ext, get the wrong status data.