### PR TITLE
feat: add more info messages to the update command output

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -1412,7 +1412,7 @@ export class DependencyResolverMain {
     components: Component[];
     patterns?: string[];
     forceVersionBump?: 'major' | 'minor' | 'patch' | 'compatible';
-  }): Promise<MergedOutdatedPkg[]> {
+  }): Promise<MergedOutdatedPkg[] | null> {
     const localComponentPkgNames = new Set(components.map((component) => this.getPackageName(component)));
     const componentModelVersions: ComponentModelVersion[] = (
       await Promise.all(
@@ -1452,6 +1452,9 @@ export class DependencyResolverMain {
         )
       );
       allPkgs = allPkgs.filter(({ name }) => selectedPkgNames.has(name));
+      if (!allPkgs.length) {
+        return null;
+      }
     }
     const outdatedPkgs = await this.getOutdatedPkgs({ rootDir, forceVersionBump }, allPkgs);
     return mergeOutdatedPkgs(outdatedPkgs);

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -636,6 +636,10 @@ export class InstallMain {
       patterns: options.patterns,
       forceVersionBump: options.forceVersionBump,
     });
+    if (outdatedPkgs == null) {
+      this.logger.consoleFailure('No dependencies found that match the patterns');
+      return null;
+    }
     let outdatedPkgsToUpdate!: MergedOutdatedPkg[];
     if (options.all) {
       outdatedPkgsToUpdate = outdatedPkgs;
@@ -646,6 +650,9 @@ export class InstallMain {
     }
     if (outdatedPkgsToUpdate.length === 0) {
       this.logger.consoleSuccess('No outdated dependencies found');
+      if (options.forceVersionBump === 'compatible') {
+        this.logger.console("If you want to find new versions that don't match the current version ranges, retry with the --latest flag");
+      }
       return null;
     }
     const { updatedVariants, updatedComponents } = this.dependencyResolver.applyUpdates(outdatedPkgsToUpdate, {


### PR DESCRIPTION
## Proposed Changes

- Print out an error message if there are no dependencies matching the patterns used with `bit update`.
- Print a hint about using the `--latest` flag, if no outdated dependencies are found.