### PR TITLE
feature(import) - new filter-envs flag for bit import command

### DIFF
--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -26,6 +26,7 @@ type ImportFlags = {
   skipDependencyInstallation?: boolean;
   skipWriteConfigFiles?: boolean;
   merge?: MergeStrategy;
+  filterEnvs?: string;
   saveInLane?: boolean;
   dependencies?: boolean;
   dependents?: boolean;
@@ -76,6 +77,11 @@ export class ImportCmd implements Command {
       '',
       'dependents',
       'import components found while traversing from the imported components upwards to the workspace components',
+    ],
+    [
+      '',
+      'filter-envs <envs>',
+      'only import components that have the specified environment (e.g., "teambit.react/react-env")',
     ],
     [
       '',
@@ -172,6 +178,7 @@ export class ImportCmd implements Command {
       skipDependencyInstallation = false,
       skipWriteConfigFiles = false,
       merge,
+      filterEnvs,
       saveInLane = false,
       dependencies = false,
       dependents = false,
@@ -205,10 +212,13 @@ export class ImportCmd implements Command {
       mergeStrategy = merge;
     }
 
+    const envsToFilter = filterEnvs ? filterEnvs.split(',').map((p) => p.trim()) : undefined;
+
     const importOptions: ImportOptions = {
       ids,
       verbose,
       merge: Boolean(merge),
+      filterEnvs: envsToFilter,
       mergeStrategy,
       writeToPath: path,
       objectsOnly: objects,


### PR DESCRIPTION
## Proposed Changes

- Now you can use new flag `--filter-envs` for bit import.
This is useful in case you import many unknown components for example when using `**` in the pattern, or when using `--dependencies` or `--dependents` flag.
- The new flag supports multiple envs at the same time wrapped by quotes, separated by `,`, for example:
```
bit import <comp-id> --filter-envs "<env-id1>, <env-id2>"
```
- The new flag supports getting `env-id` with version: `env-id@version` in that case it will only bring components using that specific version of the env.
- The new flag supports getting `env-id` without a version: `env-id` in that case it will bring components using and version of the env.
- In case you mention specific components (for example `comp-id` in the example above, it won't be filter out (so bit will import it even if it uses a different env).
- The filter is done at the end, so if you have the following components dependency structure:
compA@env1 -> compB@env2 -> compC->env3
and you run 
`bit import compA --dependencies --filter-envs env3`
you will get compC even that it's accessed from compB which was filtered out.

