### PR TITLE
ci: release Bit CLI for Windows from Windows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -629,7 +629,7 @@ jobs:
     steps:
       - run: sleep 300;
 
-  bundle_version:
+  bundle_version_posix:
     <<: *defaults
     environment:
       # do not download chromium when installing puppeteer
@@ -735,27 +735,6 @@ jobs:
       - run:
           name: move to macos-arm64 folder
           command: mv bit-${BIT_VERSION}.tar.gz macos-arm64/bit-${BIT_VERSION}.tar.gz
-      - run:
-          name: install bit for Windows x64
-          command: >
-            cd bit-${BIT_VERSION}-install &&
-            yarn config set supportedArchitectures --json '{"os":["win32"],"cpu":["x64"]}' &&
-            yarn
-      - run:
-          name: copy node_modules
-          command: cp -r bit-${BIT_VERSION}-install/node_modules bit-${BIT_VERSION}/node_modules
-      - run:
-          name: create windows
-          command: mkdir windows
-      - run:
-          name: compress bit for Windows x64
-          command: tar -cvf bit-${BIT_VERSION}.tar.gz bit-${BIT_VERSION}
-      - run:
-          name: remove leftovers
-          command: rm -rf bit-${BIT_VERSION}/node_modules
-      - run:
-          name: move to windows folder
-          command: mv bit-${BIT_VERSION}.tar.gz windows/bit-${BIT_VERSION}.tar.gz
 
       - persist_to_workspace:
           root: .
@@ -764,7 +743,6 @@ jobs:
             - linux-arm64
             - macos
             - macos-arm64
-            - windows
       - store_artifacts:
           path: linux
       - store_artifacts:
@@ -773,6 +751,50 @@ jobs:
           path: macos
       - store_artifacts:
           path: macos-arm64
+
+  bundle_version_windows:
+    <<: *windows_defaults
+    environment:
+      # do not download chromium when installing puppeteer
+      PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+    steps:
+      # We can't use Node.js newer than 16.13.2 due to this issue with npm: https://github.com/npm/cli/issues/4234
+      - windows_set_node_version
+      - run: corepack enable; corepack prepare yarn@3.6.4 --activate
+      - run: 'yarn -v'
+      - set_bit_cloud_registry
+      - run:
+          name: print bit version
+          command: npm view @teambit/bit version
+      - run:
+          name: create version file
+          command: npm view @teambit/bit version | Out-File -FilePath .\version.txt
+      - run:
+          name: create folder
+          command: New-Item -ItemType "directory" -Path ".\bundle"
+      - run: 'node -v'
+      - run:
+          name: install bit
+          command: cd bundle; npm init -y; corepack enable; corepack prepare yarn@3.6.4 --activate; yarn config set nodeLinker node-modules; yarn config set npmRegistryServer https://node-registry.bit.cloud; yarn add @teambit/bit
+      - run:
+          name: remove leftovers
+          command: Remove-Item .\bundle\package.json; Remove-Item .\bundle\yarn.lock
+      - run:
+          name: rename folder
+          command: $BIT_VERSION = Get-Content -Path .\version.txt; Rename-Item .\bundle ".\bit-$BIT_VERSION"
+      - run:
+          name: compress bit
+          command: $BIT_VERSION = Get-Content -Path .\version.txt; tar -cvf bit-${BIT_VERSION}.tar.gz bit-${BIT_VERSION}
+      - run:
+          name: create folder
+          command: New-Item -ItemType "directory" -Path ".\windows"
+      - run:
+          name: move to windows folder
+          command: $BIT_VERSION = Get-Content -Path .\version.txt;Move-Item -Path .\bit-${BIT_VERSION}.tar.gz -Destination .\windows\bit-${BIT_VERSION}.tar.gz
+      - persist_to_workspace:
+          root: .
+          paths:
+            - windows
       - store_artifacts:
           path: windows
 
@@ -1318,7 +1340,13 @@ workflows:
           requires:
             - bit_tag
             - bit_export
-      - bundle_version:
+      - bundle_version_posix:
+          <<: *master_only_filter
+          requires:
+            - bit_tag
+            - bit_export
+            - sleep_5_minutes
+      - bundle_version_windows:
           <<: *master_only_filter
           requires:
             - bit_tag
@@ -1327,7 +1355,8 @@ workflows:
       - harmony_publish_to_gcloud:
           <<: *master_only_filter
           requires:
-            - bundle_version
+            - bundle_version_posix
+            - bundle_version_windows
             - checkout_code # This is needed to generate index.json
       - bit_export:
           <<: *master_only_filter
@@ -1447,7 +1476,14 @@ workflows:
             - harmony_deploy_approval_job
             - bit_tag
             - bit_export
-      - bundle_version:
+      - bundle_version_posix:
+          <<: *master_only_filter
+          requires:
+            - harmony_deploy_approval_job
+            - bit_tag
+            - bit_export
+            - sleep_5_minutes
+      - bundle_version_windows:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
@@ -1458,7 +1494,8 @@ workflows:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
-            - bundle_version
+            - bundle_version_posix
+            - bundle_version_windows
             - checkout_code # This is needed to generate index.json
       - bit_export:
           <<: *master_only_filter
@@ -1538,7 +1575,11 @@ workflows:
   #         filters:
   #           branches:
   #             only: fix-circle-yarn3
-  #     - bundle_version:
+  #     - bundle_version_posix:
+  #         filters:
+  #           branches:
+  #             only: fix-circle-yarn3
+  #     - bundle_version_windows:
   #         filters:
   #           branches:
   #             only: fix-circle-yarn3
@@ -1547,7 +1588,8 @@ workflows:
   #           branches:
   #             only: fix-circle-yarn3
   #         requires:
-  #           - bundle_version
+  #           - bundle_version_posix
+  #           - bundle_version_windows
   #           - checkout_code # This is needed to generate index.json
   #     # - docker_build:
   #     #     requires:


### PR DESCRIPTION
## Proposed Changes

- The reason we should publish the artefact for Windows from Windows is that Windows doesn't support symlinks. If we create the tarball on Linux, yarn will create symlinks in `node_modules/.bin` directories, which will fail during extraction on Windows. However, if we run install on Windows, Yarn will create command shims (not symlinks) in `node_modules/.bin`