### PR TITLE
fix(node-app), utilize the AppBuildResult.metadata 

### DIFF
--- a/scopes/harmony/application/app-build-result.ts
+++ b/scopes/harmony/application/app-build-result.ts
@@ -15,6 +15,12 @@ export interface AppBuildResult {
 
   /**
    * metadata to persist.
+   * this is the only property that actually gets saved into the objects (in builder aspect, aspectsData.buildDeployContexts[deployContext]).
+   * in some scenarios, the build and deploy pipelines run in different processes, and then the only data the deploy
+   * gets is what saved into the objects.
+   * examples of data that gets save here:
+   * React: { publicDir, ssrPublicDir }.
+   * Node: { mainFile, artifactsDir }.
    */
   metadata?: Record<string, any>;
 }

--- a/scopes/harmony/node/node-app-options.ts
+++ b/scopes/harmony/node/node-app-options.ts
@@ -1,10 +1,25 @@
-import { AppDeployContext, DeployFn } from '@teambit/application';
+import { DeployFn, AppBuildResult } from '@teambit/application';
 
-export interface DeployContext extends AppDeployContext {
+export interface DeployContext extends AppBuildResult {
+  metadata: NodeAppMetadata;
+
   /**
-   * the main file file of the app e.g: dist/app.js
+   * @todo: remove this. it's already part of `metadata`.
+   * it's here only for backward compatibility.
    */
   mainFile?: string;
+}
+
+export interface NodeAppMetadata {
+  /**
+   * the main file of the app e.g: dist/app.js
+   */
+  mainFile: string;
+
+  /**
+   * the directory where the artifacts are saved.
+   */
+  artifactsDir: string;
 }
 
 export type NodeAppOptions = {

--- a/scopes/harmony/node/node.application.ts
+++ b/scopes/harmony/node/node.application.ts
@@ -5,7 +5,7 @@ import { ReactEnv } from '@teambit/react';
 import { Application, DeployFn, AppBuildContext, AppContext } from '@teambit/application';
 import { Port } from '@teambit/toolbox.network.get-port';
 import { NodeEnv } from './node.env';
-import { DeployContext } from './node-app-options';
+import { DeployContext, NodeAppMetadata } from './node-app-options';
 
 export class NodeApp implements Application {
   constructor(
@@ -40,7 +40,15 @@ export class NodeApp implements Application {
     const { base } = parse(this.entry);
     const { distDir } = this.nodeEnv.getCompiler();
     const mainFile = join(distDir, base);
-    const _context = Object.assign(context, { mainFile });
-    return _context;
+    const metadata: NodeAppMetadata = {
+      mainFile,
+      artifactsDir: context.artifactsDir,
+    };
+    const deployContext: DeployContext = {
+      ...context, // @todo: is this needed?
+      mainFile, // @todo: remove this when possible. only metadata should be used.
+      metadata,
+    };
+    return deployContext;
   }
 }


### PR DESCRIPTION
to save the mainFile and artifactsDir into the objects.

Until now, it was saving the entire `BuildContext` object, which includes all capsules and components objects.