### PR TITLE
fix(lanes): fix fetching historical snaps on lane from bare scope

### DIFF
--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -70,18 +70,13 @@ export function useLaneComponentIdFromUrl(): ComponentID | undefined | null {
   if (compIdFromLocation) return compIdFromLocation;
   if (loading) return undefined;
 
-  return (lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) as any | undefined) ?? null;
+  const lanesComp = (lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) as any | undefined) ?? null;
 
-  // if (componentVersion && laneFromUrl) {
-  //   const componentId = ComponentID.tryFromString(`${idFromLocation}@${componentVersion}`);
-  //   return componentId;
-  // }
+  if (componentVersion) {
+    return lanesComp?.changeVersion(componentVersion);
+  }
 
-  // const laneComponentId =
-  //   idFromLocation && !laneFromUrl?.isDefault()
-  //     ? lanesModel?.resolveComponentFromUrl(idFromLocation, laneFromUrl) ?? null
-  //     : null;
-  // return loading ? undefined : laneComponentId;
+  return lanesComp;
 }
 
 export function useComponentId() {


### PR DESCRIPTION
This PR fixes the issue with not being able to navigate to a historical snap on a lane from scope. 