### PR TITLE
handle errors of workspace tagged with older bit-version before ComponentID changes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,10 +17,11 @@ the setup process is more involving than expected because we write bit using bit
 
 the script does the following:
 
-1. runs `bit install` to install all dependencies
-2. runs `bit compile` to compile all components in the workspace (Harmony code).
-3. compiles bit-legacy code (by `npm run build`).
-4. generates the d.ts files for the bit-legacy code (by `npm run build:types`).
+1. runs `bit install` to install all dependencies.
+2. runs `npm run link-bit-legacy` to create a symlink for the bit-legacy package.
+3. runs `bit compile` to compile all components in the workspace (Harmony code).
+4. compiles bit-legacy code (by `npm run build`).
+5. generates the d.ts files for the bit-legacy code (by `npm run build:types`).
 
 install command globally and link (in order to use the "bit-dev" command globally and always use the
 latest development build)

--- a/components/component-id/exceptions/missing-scope.ts
+++ b/components/component-id/exceptions/missing-scope.ts
@@ -1,6 +1,7 @@
 export class MissingScope extends Error {
   constructor(src: any) {
-    super(`scope is missing from a component-id "${src.toString()}"`);
+    super(`scope is missing from a component-id "${src.toString()}".
+in case you just upgraded bit version to >= 1.2.10 and you're getting this error, please run "bit cc" and then "bit status" to fix it`);
   }
   report() {
     return this.message;

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -38,6 +38,7 @@ import ComponentOverrides from '@teambit/legacy/dist/consumer/config/component-o
 import { PackageJsonTransformer } from '@teambit/workspace.modules.node-modules-linker';
 import { satisfies } from 'semver';
 import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
+import ClearCacheAspect from '@teambit/clear-cache';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { ComponentIdList, ComponentID } from '@teambit/component-id';
@@ -203,8 +204,12 @@ function shouldLoadInSafeMode() {
     'remote',
   ];
   const hasSafeModeFlag = process.argv.includes('--safe-mode');
-  const isSafeModeCommand = safeModeCommands.includes(currentCommand);
+  const isSafeModeCommand = safeModeCommands.includes(currentCommand) || isClearCacheCommand();
   return isSafeModeCommand || hasSafeModeFlag;
+}
+
+function isClearCacheCommand() {
+  return process.argv[2] === 'clear-cache' || process.argv[2] === 'cc';
 }
 
 function shouldRunAsDaemon() {
@@ -224,6 +229,7 @@ export async function loadBit(path = process.cwd()) {
 
   const aspectsToLoad = [CLIAspect];
   const loadCLIOnly = shouldLoadInSafeMode();
+  if (isClearCacheCommand()) aspectsToLoad.push(ClearCacheAspect);
   if (!loadCLIOnly) {
     aspectsToLoad.push(BitAspect);
   }

--- a/scopes/scope/scope/clear-cache-action.ts
+++ b/scopes/scope/scope/clear-cache-action.ts
@@ -1,4 +1,4 @@
-import { ScopeMain } from '@teambit/scope';
+import { ScopeMain } from './scope.main.runtime';
 
 export class ClearCacheAction {
   name = ClearCacheAction.name;

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1,4 +1,5 @@
 import GlobalConfigAspect, { GlobalConfigMain } from '@teambit/global-config';
+import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
 import mapSeries from 'p-map-series';
 import path from 'path';
 import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
@@ -58,6 +59,7 @@ import { ScopeCmd } from './scope-cmd';
 import { StagedConfig } from './staged-config';
 import { NoIdMatchPattern } from './exceptions/no-id-match-pattern';
 import { ScopeAspectsLoader, ScopeLoadAspectsOptions } from './scope-aspects-loader';
+import { ClearCacheAction } from './clear-cache-action';
 
 type RemoteEventMetadata = { auth?: AuthData; headers?: {} };
 type RemoteEvent<Data> = (data: Data, metadata: RemoteEventMetadata, errors?: Array<string | Error>) => Promise<void>;
@@ -1107,6 +1109,7 @@ export class ScopeMain implements ComponentFactory {
     PostSign.onPutHook = onPutHook;
     Scope.onPostExport = onPostExportHook;
     Repository.onPostObjectsPersist = onPostObjectsPersistHook;
+    ExternalActions.externalActions.push(new ClearCacheAction(scope));
 
     express.register([
       new PutRoute(scope, postPutSlot),

--- a/scopes/workspace/clear-cache/clear-cache-cmd.ts
+++ b/scopes/workspace/clear-cache/clear-cache-cmd.ts
@@ -28,9 +28,19 @@ export default class ClearCacheCmd implements Command {
       }
       return chalk.red(`failed cleaning the cache of "${remote}"`);
     }
-    const cacheCleared = await this.clearCache.clearCache();
-    const title = 'the following cache(s) have been cleared:';
-    const output = cacheCleared.map((str) => `  ✔ ${str}`).join('\n');
-    return chalk.green(`${chalk.bold(title)}\n${output}`);
+    const { succeed, failed } = await this.clearCache.clearCache();
+    const getSuccessOutput = () => {
+      if (!succeed.length) return '';
+      const title = 'the following cache(s) have been cleared:';
+      const output = succeed.map((str) => `  ✔ ${str}`).join('\n');
+      return chalk.green(`${chalk.bold(title)}\n${output}`);
+    };
+    const getFailedOutput = () => {
+      if (!failed.length) return '';
+      const title = 'the following cache(s) failed to clear:';
+      const output = failed.map((str) => `  X ${str}`).join('\n');
+      return chalk.red(`${chalk.bold(title)}\n${output}`);
+    };
+    return `${getSuccessOutput()}\n${getFailedOutput()}`;
   }
 }

--- a/scopes/workspace/clear-cache/clear-cache.main.runtime.ts
+++ b/scopes/workspace/clear-cache/clear-cache.main.runtime.ts
@@ -1,34 +1,40 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
-import WorkspaceAspect, { Workspace } from '@teambit/workspace';
-import ScopeAspect, { ScopeMain } from '@teambit/scope';
-import { clearCache } from '@teambit/legacy/dist/api/consumer';
-import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
+import { clearCache, CacheClearResult } from '@teambit/legacy/dist/api/consumer/lib/clear-cache';
 import getRemoteByName from '@teambit/legacy/dist/remotes/get-remote-by-name';
+import { loadConsumerIfExist, Consumer } from '@teambit/legacy/dist/consumer';
 import ClearCacheCmd from './clear-cache-cmd';
 import { ClearCacheAspect } from './clear-cache.aspect';
-import { ClearCacheAction } from './clear-cache-action';
 
+/**
+ * avoid adding `workspace` / `scope` aspects as dependencies to this aspect.
+ * the clear-cache command is often being used when the workspace/scope is not working properly.
+ */
 export class ClearCacheMain {
-  constructor(private workspace?: Workspace) {}
-
-  async clearCache(): Promise<string[]> {
+  async clearCache(): Promise<CacheClearResult> {
     return clearCache();
   }
 
   async clearRemoteCache(remote: string) {
-    const remoteObj = await getRemoteByName(remote, this.workspace?.consumer);
-    const result = await remoteObj.action(ClearCacheAction.name, {});
+    const maybeConsumer = await this.getConsumerGracefully();
+    const remoteObj = await getRemoteByName(remote, maybeConsumer);
+    const result = await remoteObj.action('ClearCacheAction', {});
     return result;
   }
 
-  static slots = [];
-  static dependencies = [WorkspaceAspect, CLIAspect, ScopeAspect];
-  static runtime = MainRuntime;
-  static async provider([workspace, cli, scope]: [Workspace, CLIMain, ScopeMain]) {
-    const clearCacheMain = new ClearCacheMain(workspace);
-    cli.register(new ClearCacheCmd(clearCacheMain));
-    ExternalActions.externalActions.push(new ClearCacheAction(scope));
+  private async getConsumerGracefully(): Promise<Consumer | undefined> {
+    try {
+      return await loadConsumerIfExist();
+    } catch (err: any) {
+      return undefined;
+    }
+  }
 
+  static slots = [];
+  static dependencies = [CLIAspect];
+  static runtime = MainRuntime;
+  static async provider([cli]: [CLIMain]) {
+    const clearCacheMain = new ClearCacheMain();
+    cli.register(new ClearCacheCmd(clearCacheMain));
     return clearCacheMain;
   }
 }

--- a/src/api/consumer/lib/init.ts
+++ b/src/api/consumer/lib/init.ts
@@ -4,7 +4,7 @@ import { Consumer } from '../../../consumer';
 import { WorkspaceConfigProps } from '../../../consumer/config/workspace-config';
 import { Scope } from '../../../scope';
 import { Repository } from '../../../scope/objects';
-import { isDirEmpty } from '../../../utils';
+import { findScopePath, isDirEmpty } from '../../../utils';
 import ObjectsWithoutConsumer from './exceptions/objects-without-consumer';
 
 export default async function init(
@@ -21,6 +21,11 @@ export default async function init(
   if (reset || resetHard) {
     await Consumer.reset(absPath, resetHard, noGit);
   }
+  if (resetScope) {
+    const scopePath = findScopePath(process.cwd());
+    if (!scopePath) throw new Error(`fatal: scope not found in the path: ${process.cwd()}`);
+    await Scope.reset(scopePath, true);
+  }
   const consumer: Consumer = await Consumer.create(absPath, noGit, workspaceConfigProps);
   if (!force && !resetScope) {
     await throwForOutOfSyncScope(consumer);
@@ -30,9 +35,6 @@ export default async function init(
   }
   if (resetLaneNew) {
     await consumer.resetLaneNew();
-  }
-  if (resetScope) {
-    await Scope.reset(consumer.scope.path, true);
   }
   return consumer.write();
 }

--- a/src/scope/exceptions/bit-id-comp-id-err.ts
+++ b/src/scope/exceptions/bit-id-comp-id-err.ts
@@ -1,0 +1,10 @@
+import { BitError } from '@teambit/bit-error';
+import { VERSION_CHANGED_BIT_ID_TO_COMP_ID } from '../../constants';
+
+export class BitIdCompIdError extends BitError {
+  constructor(readonly id: string) {
+    super(`components in your workspace (e.g. "${id}") were tagged/snapped with older bit version (before v${VERSION_CHANGED_BIT_ID_TO_COMP_ID}), please bit-export with the same bit version.
+alternatively, if local (unexported) tags/snaps are not relevant for you anymore, reset them by running "bit reset --never-exported".
+in case "bit reset" fails with this error, clear your local scope by running "bit init --reset-scope", and then run "bit status"`);
+  }
+}

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -15,7 +15,6 @@ import {
   DEFAULT_BIT_VERSION,
   DEFAULT_LANGUAGE,
   Extensions,
-  VERSION_CHANGED_BIT_ID_TO_COMP_ID,
 } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { License, SourceFile } from '../../consumer/component/sources';
@@ -55,6 +54,7 @@ import { SchemaName } from '../../consumer/component/component-schema';
 import { NoHeadNoVersion } from '../exceptions/no-head-no-version';
 import { errorIsTypeOfMissingObject } from '../component-ops/scope-components-importer';
 import type Scope from '../scope';
+import { BitIdCompIdError } from '../exceptions/bit-id-comp-id-err';
 
 type State = {
   versions?: {
@@ -138,10 +138,7 @@ export default class Component extends BitObject {
     super();
     if (!props.name) throw new TypeError('Model Component constructor expects to get a name parameter');
     if (!props.scope) {
-      throw new Error(
-        `your component "${props.name}" was tagged/snapped with older bit version (before v${VERSION_CHANGED_BIT_ID_TO_COMP_ID}), please export it with the same bit version.
-alternatively, if local (unexported) tags/snaps are not relevant for you anymore, reset them by running "bit reset --never-exported"`
-      );
+      throw new BitIdCompIdError(props.name);
     }
     this.scope = props.scope;
     this.name = props.name;

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -22,6 +22,7 @@ import Repository from '../objects/repository';
 import validateVersionInstance from '../version-validator';
 import Source from './source';
 import { getHarmonyVersion } from '../../bootstrap';
+import { BitIdCompIdError } from '../exceptions/bit-id-comp-id-err';
 
 export type SourceFileModel = {
   name: string;
@@ -508,6 +509,9 @@ export default class Version extends BitObject {
       };
 
       return deps.map((dependency: any) => {
+        if (!dependency.id.scope) {
+          throw new BitIdCompIdError(dependency.id.name);
+        }
         return new Dependency(
           ComponentID.fromObject(dependency.id),
           Array.isArray(dependency.relativePaths)

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -28,6 +28,7 @@ import { getMaxSizeForObjects, InMemoryCache } from '../../cache/in-memory-cache
 import { Types } from '../object-registrar';
 import { Lane, ModelComponent, Symlink } from '../models';
 import { ComponentFsCache } from '../../consumer/component/component-fs-cache';
+import { pMapPool } from '../../utils/promise-with-concurrent';
 
 const OBJECTS_BACKUP_DIR = `${OBJECTS_DIR}.bak`;
 const TRASH_DIR = 'trash';
@@ -203,7 +204,7 @@ export default class Repository {
     const refs = await this.listRefs();
     const concurrency = concurrentIOLimit();
     const objects: BitObject[] = [];
-    await pMap(
+    await pMapPool(
       refs,
       async (ref) => {
         const object = await this.load(ref);


### PR DESCRIPTION
## Proposed Changes

- add a descriptive message when previously errored with "scope is missing from a component-id...". suggest running "bit cc".
- fix `bit cc` (clear-cache) command to not throw in case the consumer or scope failed to load. 
- fix `bit init --reset-scope` to work in case the consumer failed to load.
- add another suggestion in case the components were tagged with the old bit-version to run `bit init --reset-scope` if other options failed.
