### PR TITLE
introduce "bit version" to show bit version

### DIFF
--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -14,6 +14,7 @@ import { CLIParser } from './cli-parser';
 import { CompletionCmd } from './completion.cmd';
 import { CliCmd, CliGenerateCmd } from './cli.cmd';
 import { HelpCmd } from './help.cmd';
+import { VersionCmd } from './version.cmd';
 
 export type CommandList = Array<Command>;
 export type OnStart = (hasWorkspace: boolean, currentCommand: string) => Promise<void>;
@@ -166,7 +167,7 @@ export class CLIMain {
     const cliCmd = new CliCmd(cliMain);
     const helpCmd = new HelpCmd(cliMain);
     cliCmd.commands.push(cliGenerateCmd);
-    cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd, helpCmd);
+    cliMain.register(...legacyCommandsAdapters, new CompletionCmd(), cliCmd, helpCmd, new VersionCmd());
     return cliMain;
   }
 }

--- a/scopes/harmony/cli/version.cmd.ts
+++ b/scopes/harmony/cli/version.cmd.ts
@@ -1,0 +1,21 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
+
+export class VersionCmd implements Command {
+  name = 'version';
+  description = 'shows bit version';
+  alias = '';
+  loader = false;
+  group = 'general';
+  options = [['j', 'json', 'return the version in json format']] as CommandOptions;
+
+  async report() {
+    const results = await this.json();
+    return results.bit;
+  }
+
+  async json() {
+    const bit = getHarmonyVersion(true);
+    return { bit };
+  }
+}


### PR DESCRIPTION
Currently the way to get bit-version is by running `bit -v`.  This PR introduces a dedicated command for this, which can be used for IDEs and also can be extended later to include remote-version and so on.