### PR TITLE
fix(ui/component): Update package manager order in use box dropdown

### DIFF
--- a/scopes/dependencies/pnpm/pnpm.ui.runtime.tsx
+++ b/scopes/dependencies/pnpm/pnpm.ui.runtime.tsx
@@ -43,7 +43,7 @@ export class PnpmUI {
           isInstallable={!options?.disableInstall}
         />
       ) : null,
-      order: 30,
+      order: 10,
     };
   };
 }

--- a/scopes/pkg/pkg/pkg.ui.runtime.tsx
+++ b/scopes/pkg/pkg/pkg.ui.runtime.tsx
@@ -44,7 +44,7 @@ export class PkgUI {
           isInstallable={!options?.disableInstall}
         />
       ) : null,
-      order: 10,
+      order: 30,
     };
   };
 }


### PR DESCRIPTION
This PR updates the order of package managers in the use box dropdown on the component page. 

Previous order;
Bit, NPM, Yarn, PNPM

Updated order;
Bit, PNPM, Yarn, NPM

