### PR TITLE
delete invalid objects when running bit reset --never-exported

### DIFF
--- a/src/scope/exceptions/bit-id-comp-id-err.ts
+++ b/src/scope/exceptions/bit-id-comp-id-err.ts
@@ -4,7 +4,7 @@ import { VERSION_CHANGED_BIT_ID_TO_COMP_ID } from '../../constants';
 export class BitIdCompIdError extends BitError {
   constructor(readonly id: string) {
     super(`components in your workspace (e.g. "${id}") were tagged/snapped with older bit version (before v${VERSION_CHANGED_BIT_ID_TO_COMP_ID}), please bit-export with the same bit version.
-alternatively, if local (unexported) tags/snaps are not relevant for you anymore, reset them by running "bit reset --never-exported".
+alternatively, if local (unexported) tags/snaps/lanes are not relevant for you anymore, reset them by running "bit reset --never-exported".
 in case "bit reset" fails with this error, clear your local scope by running "bit init --reset-scope", and then run "bit status"`);
   }
 }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -207,7 +207,23 @@ export default class Repository {
     await pMapPool(
       refs,
       async (ref) => {
-        const object = await this.load(ref);
+        let object: BitObject;
+        try {
+          object = await this.load(ref);
+        } catch (err: any) {
+          // this is needed temporarily to allow `bit reset --never-exported` to fix the bit-id-comp-id error.
+          // in a few months, we can remove this condition (around min 2024)
+          if (
+            process.argv.includes('--never-exported') &&
+            (err.constructor.name === 'BitIdCompIdError' || err.constructor.name === 'MissingScope')
+          ) {
+            logger.debug(`bit-id-comp-id error, moving an object to trash ${ref.toString()}`);
+            await this.moveOneObjectToTrash(ref);
+            return;
+          }
+          throw err;
+        }
+
         types.forEach((type) => {
           if (
             object instanceof type ||
@@ -309,7 +325,7 @@ export default class Repository {
       return scopeIndex;
     } catch (err: any) {
       if (err.code === 'ENOENT') {
-        const bitObjects: BitObject[] = await this.list([ModelComponent, Symlink, Lane]);
+        const bitObjects: BitObject[] = await this.list([ModelComponent, Lane]);
         const scopeIndex = ScopeIndex.create(this.scopePath);
         const added = scopeIndex.addMany(bitObjects);
         if (added) await scopeIndex.write();

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -26,7 +26,7 @@ import { concurrentIOLimit } from '../../utils/concurrency';
 import { createInMemoryCache } from '../../cache/cache-factory';
 import { getMaxSizeForObjects, InMemoryCache } from '../../cache/in-memory-cache';
 import { Types } from '../object-registrar';
-import { Lane, ModelComponent, Symlink } from '../models';
+import { Lane, ModelComponent } from '../models';
 import { ComponentFsCache } from '../../consumer/component/component-fs-cache';
 import { pMapPool } from '../../utils/promise-with-concurrent';
 


### PR DESCRIPTION
As a result of upgrading to > 1.2.10, local tags/snaps/lanes created by an older version can be invalid. For the most cases, the suggested solution: `bit reset --never-exported` fixes the issue. This PR covers the case when the command fails in the bootstrap phase.