### PR TITLE
add a new line at the end of the workspace.jsonc file

### DIFF
--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -311,7 +311,7 @@ export class WorkspaceConfig implements HostConfig {
 
   async toVinyl(workspaceDir: PathOsBasedAbsolute): Promise<AbstractVinyl[] | undefined> {
     if (this.data) {
-      const jsonStr = stringify(this.data, undefined, 2);
+      const jsonStr = `${stringify(this.data, undefined, 2)}\n`;
       const base = workspaceDir;
       const fullPath = workspaceDir ? WorkspaceConfig.composeWorkspaceJsoncPath(workspaceDir) : this.path;
       const jsonFile = new AbstractVinyl({ base, path: fullPath, contents: Buffer.from(jsonStr) });


### PR DESCRIPTION
Many IDEs adds the newline at the end of the file automatically, so if we write this file without the "\n" at the end, the file is modified whenever bit writes the file and the user is opening it with the IDE.