### PR TITLE
adjust ImportNonMainFiles comp-issue for the future require.resolve detection

### DIFF
--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -808,6 +808,11 @@ either, use the ignore file syntax or change the require statement to have a mod
     }
     const nonMainFileSplit = depFullPath.split(`node_modules/`);
     const nonMainFileShort = nonMainFileSplit[1] || nonMainFileSplit[0];
+    if (nonMainFileShort.includes('eslintrc')) {
+      // a temporary workaround for envs that don't expose eslintrc config in their index file.
+      // this is needed for a future change of detecting require.resolve syntax
+      return;
+    }
     (this.issues.getOrCreate(IssuesClasses.ImportNonMainFiles).data[filePath] ||= []).push(nonMainFileShort);
   }
 


### PR DESCRIPTION
This is needed in order for users to not get errors in bit-status once this lane is merged.
https://bit.cloud/teambit/node/~lane/detect-require-resolve/~ripple-ci/job/teambit-detect-require-resolve-statements