### PR TITLE
fix(CompositionGallerySkeleton): duplicate render key 

### DIFF
--- a/scopes/compositions/panels/composition-gallery/composition-gallery-skeleton/composition-gallery-skeleton.tsx
+++ b/scopes/compositions/panels/composition-gallery/composition-gallery-skeleton/composition-gallery-skeleton.tsx
@@ -18,9 +18,9 @@ export function CompositionGallerySkeleton({
     <div {...rest} className={classnames(styles.compositionGallerySkeleton, className)}>
       <LineSkeleton width="100px" className={styles.title} />
       <div className={classnames(styles.compositionGalleryGrid)}>
-        {length.map((i) => (
-          <CompositionCardSkeleton key={i} />
-        ))}
+        {length.map((_, index) => {
+          return <CompositionCardSkeleton key={`comp-card-skeleton-${index}`} />;
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
This PR fixes duplicate render keys in CompositionGallerySkeleton when rendering a list of CompositionGallerySkeleton components