### PR TITLE
refactor, change Config class to return extensions from ConsumerComponent instance

### DIFF
--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -9,7 +9,7 @@ import { slice } from 'lodash';
 import { ComponentFactory } from './component-factory';
 import ComponentFS from './component-fs';
 // import { NothingToSnap } from './exceptions';
-import ComponentConfig from './config';
+import { Config as ComponentConfig } from './config';
 // eslint-disable-next-line import/no-cycle
 import { Snap } from './snap';
 import { State } from './state';

--- a/scopes/component/component/config.ts
+++ b/scopes/component/component/config.ts
@@ -1,31 +1,24 @@
-import { ComponentOverridesData } from '@teambit/legacy/dist/consumer/config/component-overrides';
 import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config/extension-data';
-import { PathLinux } from '@teambit/legacy/dist/utils/path';
-// import { CustomResolvedPath } from '@teambit/legacy/dist/consumer/component/consumer-component';
-// import { ComponentOverridesData } from '@teambit/legacy/dist/consumer/config/component-overrides';
-
-type LegacyConfigProps = {
-  lang?: string;
-  bindingPrefix: string;
-  extensions?: ExtensionDataList;
-  overrides?: ComponentOverridesData;
-};
+import { PathLinuxRelative, PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
 
 /**
  * in-memory representation of the component configuration.
  */
-export default class Config {
-  constructor(
-    /**
-     * version main file
-     */
-    readonly main: PathLinux,
+export class Config {
+  constructor(private consumerComponent: any) {}
 
-    /**
-     * configured extensions
-     */
-    readonly extensions: ExtensionDataList,
+  /**
+   * component main file
+   * when loaded from the workspace, it's PathOsBasedRelative. otherwise, PathLinuxRelative.
+   */
+  get main(): PathLinuxRelative | PathOsBasedRelative {
+    return this.consumerComponent.mainFile;
+  }
 
-    readonly legacyProperties?: LegacyConfigProps
-  ) {}
+  /**
+   * configured extensions
+   */
+  get extensions(): ExtensionDataList {
+    return this.consumerComponent.extensions;
+  }
 }

--- a/scopes/component/component/index.ts
+++ b/scopes/component/component/index.ts
@@ -6,7 +6,7 @@ export { useComponentHost } from './host';
 export { Component, InvalidComponent } from './component';
 export { ComponentID } from '@teambit/component-id';
 export { default as ComponentFS } from './component-fs';
-export type { default as ComponentConfig } from './config';
+export type { Config as ComponentConfig } from './config';
 export type {
   ComponentFactory,
   ResolveAspectsOptions,
@@ -46,7 +46,7 @@ export { RegisteredComponentRoute, ComponentUrlParams } from './component.route'
 export { ComponentModel, ComponentModelProps } from './ui/component-model';
 export { TopBarNav } from './ui/top-bar-nav';
 export type { ShowFragment, ShowRow, ShowJSONRow } from './show';
-export { default as Config } from './config';
+export { Config } from './config';
 export { useComponent, useIdFromLocation, useComponentLogs, ComponentLogsResult, Filters } from './ui';
 
 // export { AspectList } from './aspect-list';

--- a/scopes/component/component/state.ts
+++ b/scopes/component/component/state.ts
@@ -1,7 +1,7 @@
 import { IssuesList } from '@teambit/component-issues';
 import { ComponentID } from '@teambit/component-id';
 import ComponentFS from './component-fs';
-import Config from './config';
+import { Config } from './config';
 import { AspectList } from './aspect-list';
 import { MainFileNotFound } from './exceptions';
 

--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -191,7 +191,7 @@ export class ScopeComponentLoader {
     const state = new State(
       // We use here the consumerComponent.extensions instead of version.extensions
       // because as part of the conversion to consumer component the artifacts are initialized as Artifact instances
-      new Config(version.mainFile, consumerComponent.extensions),
+      new Config(consumerComponent),
       // todo: see the comment of this "createAspectListFromLegacy" method. the aspect ids may be incorrect.
       // find a better way to get the ids correctly.
       this.scope.componentExtension.createAspectListFromLegacy(consumerComponent.extensions),

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -170,7 +170,7 @@ export class WorkspaceComponentLoader {
     consumerComponent.extensions = extensions;
 
     const state = new State(
-      new Config(consumerComponent.mainFile, extensions),
+      new Config(consumerComponent),
       await this.workspace.createAspectList(extensions),
       ComponentFS.fromVinyls(consumerComponent.files),
       consumerComponent.dependencies,


### PR DESCRIPTION
Currently, the `Config` class gets the `consumerComponent.extensions` into the constructor. Problem is that in some cases, after the component object is created, we replace the `consumerComponent.extensions` with another ExtensionDataList instance. (happens in snap-from-scope command). When this is happening, we get two unrelated instances of the extensions, which leads to a very hard to debug extension issues.

This PR passes the instance of consumerComponent itself into the Config constructor, and makes the `extensions` prop dynamic as a getter function, so it's always up to date.