### PR TITLE
make the compilation during watch configurable

### DIFF
--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -91,7 +91,7 @@ export class NewComponentHelperMain {
     await this.workspace.bitMap.write();
     await this.workspace.clearCache();
     // this takes care of compiling the component as well
-    await this.workspace.triggerOnComponentAdd(targetId);
+    await this.workspace.triggerOnComponentAdd(targetId, { compile: true });
   }
 
   private async throwForExistingPath(targetPath: string) {

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -31,7 +31,7 @@ export class ApiServerMain {
     private importer: ImporterMain
   ) {}
 
-  async runApiServer(options: { port: number }) {
+  async runApiServer(options: { port: number; compile: boolean }) {
     if (!this.workspace) {
       throw new Error(`unable to run bit-server, the current directory ${process.cwd()} is not a workspace`);
     }
@@ -70,6 +70,7 @@ export class ApiServerMain {
     this.watcher
       .watch({
         preCompile: false,
+        compile: true, // todo: once a stable release is out, change vscode to support this and change to: `options.compile`,
       })
       .catch((err) => {
         // don't throw an error, we don't want to break the "run" process

--- a/scopes/harmony/api-server/server.cmd.ts
+++ b/scopes/harmony/api-server/server.cmd.ts
@@ -8,11 +8,14 @@ export class ServerCmd implements Command {
   alias = '';
   commands: Command[] = [];
   group = 'general';
-  options = [['p', 'port [port]', 'port to run the server on']] as CommandOptions;
+  options = [
+    ['p', 'port [port]', 'port to run the server on'],
+    ['c', 'compile', 'compile components during the watch process'],
+  ] as CommandOptions;
 
   constructor(private apiServer: ApiServerMain) {}
 
-  async report(args, options: { port: number }): Promise<string> {
+  async report(args, options: { port: number; compile: boolean }): Promise<string> {
     await this.apiServer.runApiServer(options);
     return 'server is running successfully'; // should never get here, the previous line is blocking
   }

--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -315,6 +315,7 @@ export class ApplicationMain {
       this.watcher
         .watch({
           preCompile: false,
+          compile: true,
         })
         .catch((err) => {
           // don't throw an error, we don't want to break the "run" process

--- a/scopes/preview/preview/preview.start-plugin.tsx
+++ b/scopes/preview/preview/preview.start-plugin.tsx
@@ -39,6 +39,7 @@ export class PreviewStartPlugin implements StartPlugin {
         spawnTSServer: true,
         checkTypes: CheckTypes.None,
         preCompile: false,
+        compile: true,
         initiator: CompilationInitiator.Start,
       })
       .catch((err) => {

--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -88,6 +88,7 @@ if this doesn't work well for you, run "bit config set watch_use_polling true" t
     const watchOpts: WatchOptions = {
       msgs: getMessages(this.logger),
       verbose,
+      compile: true,
       preCompile: !watchCmdOpts.skipPreCompilation,
       spawnTSServer: Boolean(checkTypes), // if check-types is enabled, it must spawn the tsserver.
       checkTypes: getCheckTypesEnum(),

--- a/scopes/workspace/watcher/watcher.main.runtime.ts
+++ b/scopes/workspace/watcher/watcher.main.runtime.ts
@@ -27,8 +27,8 @@ export class WatcherMain {
   ) {}
 
   async watch(opts: WatchOptions) {
-    const watcher = new Watcher(this.workspace, this.pubsub, this);
-    await watcher.watchAll(opts);
+    const watcher = new Watcher(this.workspace, this.pubsub, this, opts);
+    await watcher.watch();
   }
 
   async watchScopeInternalFiles() {

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -54,6 +54,7 @@ export type WatchOptions = {
   spawnTSServer?: boolean; // needed for check types and extract API/docs.
   checkTypes?: CheckTypes; // if enabled, the spawnTSServer becomes true.
   preCompile?: boolean; // whether compile all components before start watching
+  compile?: boolean; // whether compile modified/added components during watch process
 };
 
 const DEBOUNCE_WAIT_MS = 100;
@@ -68,17 +69,22 @@ export class Watcher {
   private trackDirs: { [dir: PathLinux]: ComponentID } = {};
   private verbose = false;
   private multipleWatchers: WatcherProcessData[] = [];
-  constructor(private workspace: Workspace, private pubsub: PubsubMain, private watcherMain: WatcherMain) {
+  constructor(
+    private workspace: Workspace,
+    private pubsub: PubsubMain,
+    private watcherMain: WatcherMain,
+    private options: WatchOptions
+  ) {
     this.ipcEventsDir = this.watcherMain.ipcEvents.eventsDir;
+    this.verbose = this.options.verbose || false;
   }
 
   get consumer(): Consumer {
     return this.workspace.consumer;
   }
 
-  async watchAll(opts: WatchOptions) {
-    const { msgs, ...watchOpts } = opts;
-    this.verbose = opts.verbose || false;
+  async watch() {
+    const { msgs, ...watchOpts } = this.options;
     const componentIds = Object.values(this.trackDirs);
     await this.watcherMain.triggerOnPreWatch(componentIds, watchOpts);
     await this.setTrackDirs();
@@ -102,10 +108,7 @@ export class Watcher {
       watcher.on('all', async (event, filePath) => {
         if (event !== 'change' && event !== 'add' && event !== 'unlink') return;
         const startTime = new Date().getTime();
-        const { files, results, debounced, irrelevant, failureMsg } = await this.handleChange(
-          filePath,
-          opts?.initiator
-        );
+        const { files, results, debounced, irrelevant, failureMsg } = await this.handleChange(filePath);
         if (debounced || irrelevant) {
           return;
         }
@@ -154,10 +157,7 @@ export class Watcher {
    * this way we can also ensure that if compA was started before the .bitmap execution, it will complete before the
    * .bitmap execution starts.
    */
-  private async handleChange(
-    filePath: string,
-    initiator?: CompilationInitiator
-  ): Promise<{
+  private async handleChange(filePath: string): Promise<{
     results: OnComponentEventResult[];
     files: string[];
     failureMsg?: string;
@@ -203,7 +203,7 @@ export class Watcher {
       const files = this.changedFilesPerComponent[compIdStr];
       delete this.changedFilesPerComponent[compIdStr];
 
-      const buildResults = await this.watchQueue.add(() => this.triggerCompChanges(componentId, files, initiator));
+      const buildResults = await this.watchQueue.add(() => this.triggerCompChanges(componentId, files));
       const failureMsg = buildResults.length
         ? undefined
         : `files ${files.join(', ')} are inside the component ${compIdStr} but configured to be ignored`;
@@ -224,8 +224,7 @@ export class Watcher {
 
   private async triggerCompChanges(
     componentId: ComponentID,
-    files: PathOsBasedAbsolute[],
-    initiator?: CompilationInitiator
+    files: PathOsBasedAbsolute[]
   ): Promise<OnComponentEventResult[]> {
     let updatedComponentId: ComponentID | undefined = componentId;
     if (!(await this.workspace.hasId(componentId))) {
@@ -274,8 +273,7 @@ export class Watcher {
       updatedComponentId,
       compFiles,
       removedFiles,
-      true,
-      initiator
+      true
     );
     return buildResults;
   }
@@ -306,7 +304,7 @@ export class Watcher {
 
   private async executeWatchOperationsOnRemove(componentId: ComponentID) {
     logger.debug(`running OnComponentRemove hook for ${chalk.bold(componentId.toString())}`);
-    this.pubsub.pub(WorkspaceAspect.id, this.creatOnComponentRemovedEvent(componentId.toString()));
+    this.pubsub.pub(WorkspaceAspect.id, this.createOnComponentRemovedEvent(componentId.toString()));
     await this.workspace.triggerOnComponentRemove(componentId);
   }
 
@@ -314,8 +312,7 @@ export class Watcher {
     componentId: ComponentID,
     files: PathOsBasedAbsolute[],
     removedFiles: PathOsBasedAbsolute[] = [],
-    isChange = true,
-    initiator?: CompilationInitiator
+    isChange = true
   ): Promise<OnComponentEventResult[]> {
     if (this.isComponentWatchedExternally(componentId)) {
       // update capsule, once done, it automatically triggers the external watcher
@@ -326,28 +323,28 @@ export class Watcher {
 
     if (isChange) {
       logger.debug(`running OnComponentChange hook for ${chalk.bold(idStr)}`);
-      this.pubsub.pub(WorkspaceAspect.id, this.creatOnComponentChangeEvent(idStr, 'OnComponentChange'));
+      this.pubsub.pub(WorkspaceAspect.id, this.createOnComponentChangeEvent(idStr, 'OnComponentChange'));
     } else {
       logger.debug(`running OnComponentAdd hook for ${chalk.bold(idStr)}`);
-      this.pubsub.pub(WorkspaceAspect.id, this.creatOnComponentAddEvent(idStr, 'OnComponentAdd'));
+      this.pubsub.pub(WorkspaceAspect.id, this.createOnComponentAddEvent(idStr, 'OnComponentAdd'));
     }
 
     const buildResults = isChange
-      ? await this.workspace.triggerOnComponentChange(componentId, files, removedFiles, initiator)
-      : await this.workspace.triggerOnComponentAdd(componentId);
+      ? await this.workspace.triggerOnComponentChange(componentId, files, removedFiles, this.options)
+      : await this.workspace.triggerOnComponentAdd(componentId, this.options);
 
     return buildResults;
   }
 
-  private creatOnComponentRemovedEvent(idStr) {
+  private createOnComponentRemovedEvent(idStr) {
     return new OnComponentRemovedEvent(Date.now(), idStr);
   }
 
-  private creatOnComponentChangeEvent(idStr, hook) {
+  private createOnComponentChangeEvent(idStr, hook) {
     return new OnComponentChangeEvent(Date.now(), idStr, hook);
   }
 
-  private creatOnComponentAddEvent(idStr, hook) {
+  private createOnComponentAddEvent(idStr, hook) {
     return new OnComponentAddEvent(Date.now(), idStr, hook);
   }
 
@@ -413,7 +410,7 @@ export class Watcher {
     }
   }
 
-  async setTrackDirs() {
+  private async setTrackDirs() {
     this.trackDirs = {};
     const componentsFromBitMap = this.consumer.bitMap.getAllComponents();
     await Promise.all(

--- a/scopes/workspace/workspace/on-component-events.ts
+++ b/scopes/workspace/workspace/on-component-events.ts
@@ -1,16 +1,20 @@
 import { Component, ComponentID, AspectData } from '@teambit/component';
-import { CompilationInitiator } from '@teambit/compiler';
 import { ComponentLoadOptions } from '@teambit/legacy/dist/consumer/component/component-loader';
 import type { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
+import { WatchOptions } from '@teambit/watcher';
 
 export type SerializableResults = { results: any; toString: () => string };
 export type OnComponentChange = (
   component: Component,
   files: PathOsBasedAbsolute[],
-  removedFiles?: PathOsBasedAbsolute[],
-  initiator?: CompilationInitiator
+  removedFiles: PathOsBasedAbsolute[],
+  watchOpts: WatchOptions
 ) => Promise<SerializableResults | void>;
-export type OnComponentAdd = (component: Component, files: string[]) => Promise<SerializableResults>;
+export type OnComponentAdd = (
+  component: Component,
+  files: string[],
+  watchOpts: WatchOptions
+) => Promise<SerializableResults | void>;
 export type OnComponentRemove = (componentId: ComponentID) => Promise<SerializableResults>;
 export type OnComponentEventResult = { extensionId: string; results: SerializableResults };
 


### PR DESCRIPTION
In some scenarios there are multiple watchers running in the background (e.g. `bit start` and vscode-ext), in which case it's best to let only one of them compile the components to avoid race condition between them.