### PR TITLE
fix(ws-config) - do not delete config files that are going to be written as part of the write op

### DIFF
--- a/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
+++ b/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
@@ -131,15 +131,29 @@ export class WorkspaceConfigFilesMain {
     const optionsWithDefaults = defaults(options, defaultOpts);
     const execContext = await this.getExecContext();
 
-    let cleanResults: string[] | undefined;
+    let pathsToClean: string[] | undefined = [];
     if (optionsWithDefaults.clean) {
-      cleanResults = await this.clean(options);
+      pathsToClean = await this.calcPathsToClean({ writers: optionsWithDefaults.writers });
     }
 
     let writeErr;
-    let writeResults;
+    let writeResults: WriteResults;
     try {
       writeResults = await this.write(execContext, optionsWithDefaults);
+      const allWrittenFiles = writeResults.writersResult.flatMap((writerResult) => {
+        return writerResult.extendingConfigFiles.flatMap((extendingConfigFile) => {
+          return extendingConfigFile.extendingConfigFile.filePaths;
+        });
+      });
+      // Avoid delete and re-create files that were written by other config writers
+      // instead of deleting at the beginning then write all
+      // we write all and then delete the files that were not written by the config writers
+      // This reduces the config files that re-created (as many times no changes needed)
+      // which prevent issues with needing to restart the ts-server in the ide
+      pathsToClean = pathsToClean.filter(
+        (pathToClean) => !allWrittenFiles.includes(join(this.workspace.path, pathToClean))
+      );
+      await this.deleteFiles(pathsToClean);
     } catch (err) {
       this.logger.info('writeConfigFiles failed', err);
       if (optionsWithDefaults.throw) {
@@ -148,7 +162,7 @@ export class WorkspaceConfigFilesMain {
       writeErr = err;
     }
 
-    return { writeResults, cleanResults, wsDir: this.workspace.path, err: writeErr };
+    return { writeResults, cleanResults: pathsToClean, wsDir: this.workspace.path, err: writeErr };
   }
 
   /**
@@ -321,6 +335,14 @@ export class WorkspaceConfigFilesMain {
    * @returns Array of paths of deleted config files
    */
   async clean({ dryRun, silent, writers }: WriteConfigFilesOptions): Promise<string[]> {
+    const paths = await this.calcPathsToClean({ writers });
+    if (dryRun) return paths;
+    if (!silent) await this.promptForCleaning(paths);
+    await this.deleteFiles(paths);
+    return paths;
+  }
+
+  private async calcPathsToClean({ writers }: WriteConfigFilesOptions): Promise<string[]> {
     const execContext = await this.getExecContext();
     const configWriters = this.getFlatConfigWriters(execContext);
     const filteredConfigWriters = writers
@@ -345,9 +367,6 @@ export class WorkspaceConfigFilesMain {
         })
         .flat()
     );
-    if (dryRun) return paths;
-    if (!silent) await this.promptForCleaning(paths);
-    await this.deleteFiles(paths);
     return paths;
   }
 

--- a/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
+++ b/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
@@ -4,6 +4,7 @@ import globby from 'globby';
 import chalk from 'chalk';
 import { PromptCanceled } from '@teambit/legacy/dist/prompts/exceptions';
 import pMapSeries from 'p-map-series';
+import { ConsumerNotFound } from '@teambit/legacy/dist/consumer/exceptions';
 import yesno from 'yesno';
 import { defaults, flatMap, isFunction, pick, uniq } from 'lodash';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
@@ -117,6 +118,9 @@ export class WorkspaceConfigFilesMain {
    * - cleanResults: array of deleted paths
    */
   async writeConfigFiles(options: WriteConfigFilesOptions = {}): Promise<WriteConfigFilesResult> {
+    if (!this.workspace) {
+      throw new ConsumerNotFound();
+    }
     const defaultOpts: WriteConfigFilesOptions = {
       clean: false,
       dedupe: false,
@@ -164,6 +168,9 @@ export class WorkspaceConfigFilesMain {
    */
   async cleanConfigFiles(options: CleanConfigFilesOptions = {}): Promise<string[]> {
     // const execContext = await this.getExecContext();
+    if (!this.workspace) {
+      throw new ConsumerNotFound();
+    }
     const cleanResults = await this.clean(options);
     return cleanResults;
   }
@@ -182,6 +189,9 @@ export class WorkspaceConfigFilesMain {
    * @returns An array of objects with aspectId and configWriter properties.
    */
   async listConfigWriters(): Promise<EnvConfigWritersList> {
+    if (!this.workspace) {
+      throw new ConsumerNotFound();
+    }
     const execContexts = await this.getExecContext();
 
     const result: EnvConfigWritersList = execContexts.map((executionContext) => {

--- a/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
+++ b/scopes/workspace/workspace-config-files/workspace-config-files.main.runtime.ts
@@ -137,7 +137,7 @@ export class WorkspaceConfigFilesMain {
     }
 
     let writeErr;
-    let writeResults: WriteResults;
+    let writeResults;
     try {
       writeResults = await this.write(execContext, optionsWithDefaults);
       const allWrittenFiles = writeResults.writersResult.flatMap((writerResult) => {


### PR DESCRIPTION
## Proposed Changes

- Before this change when running `bit ws-config write` with `--clean` (for example via the `bit create` command). we first cleaned all the config files, then write again new config files.
Many times, the new config files are exactly the same as the ones before (especially on bit create).
Deleting and re-creating the files, lead to issues with the IDE ts-server which sometimes needs to be restarted as a result of this.
Now, we write all the files first (and override existing files), and then only delete files that were not written during the write action. 
This minimizes the cases of deleting and re-creating the same files, which makes it play better with IDEs.