### PR TITLE
feature(comp-templates) - allow templates to declare they create app/env and packages to install

### DIFF
--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -28,6 +28,10 @@ export type GenerateResult = {
   envId: string;
   envSetBy: string;
   packageName: string;
+  isApp?: boolean;
+  isEnv?: boolean;
+  packages?: string[];
+  installMissingPackages?: boolean;
 };
 
 export type OnComponentCreateFn = (generateResults: GenerateResult[]) => Promise<void>;
@@ -227,6 +231,10 @@ export class ComponentGenerator {
       packageName: componentIdToPackageName(component.state._consumer),
       envId,
       envSetBy: setBy,
+      isApp: this.template.isApp,
+      isEnv: this.template.isEnv,
+      packages: this.template.packages,
+      installMissingPackages: this.template.installMissingPackages,
     };
   }
 

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -173,6 +173,9 @@ export class ComponentGenerator {
     });
     const component = await this.workspace.get(componentId);
     const hasEnvConfiguredOriginally = this.envs.hasEnvConfigured(component);
+    if (this.template.isApp) {
+      await this.workspace.use(componentId.toString());
+    }
     const envBeforeConfigChanges = this.envs.getEnv(component);
     let config = this.template.config;
     if (config && typeof config === 'function') {

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -30,8 +30,8 @@ export type GenerateResult = {
   packageName: string;
   isApp?: boolean;
   isEnv?: boolean;
-  packages?: string[];
-  installMissingPackages?: boolean;
+  dependencies?: string[];
+  installMissingDependencies?: boolean;
 };
 
 export type OnComponentCreateFn = (generateResults: GenerateResult[]) => Promise<void>;
@@ -236,8 +236,8 @@ export class ComponentGenerator {
       envSetBy: setBy,
       isApp: this.template.isApp,
       isEnv: this.template.isEnv,
-      packages: this.template.packages,
-      installMissingPackages: this.template.installMissingPackages,
+      dependencies: this.template.dependencies,
+      installMissingDependencies: this.template.installMissingDependencies,
     };
   }
 

--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -122,15 +122,15 @@ export interface ComponentTemplateOptions {
   isApp?: boolean;
 
   /**
-   * list of packages to install when the component is created.
+   * list of dependencies to install when the component is created.
    */
-  packages?: string[];
+  dependencies?: string[];
 
   /**
-   * Perform installation of missing packages after component generation.
+   * Perform installation of missing dependencies after component generation.
    * This is the same as of running `bit install --add-missing-deps` after component generation.
    */
-  installMissingPackages?: boolean;
+  installMissingDependencies?: boolean;
 }
 
 export interface ComponentTemplate extends ComponentTemplateOptions {

--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -102,9 +102,35 @@ export interface ComponentTemplateOptions {
   hidden?: boolean;
 
   /**
-   * env to use for the component.
+   * env to use for the generated component.
    */
   env?: string;
+
+  /**
+   * adds a metadata that the component that this template creates is of type env.
+   * This will be used later to do further configuration for example:
+   * - ensure to create the .bit_root for it
+   */
+  isEnv?: boolean;
+
+  /**
+   * adds a metadata that the component that this template creates is of type app.
+   * This will be used later to do further configuration for example:
+   * - add it to the workspace.jsonc as app
+   * - ensure to create the .bit_root for it
+   */
+  isApp?: boolean;
+
+  /**
+   * list of packages to install when the component is created.
+   */
+  packages?: string[];
+
+  /**
+   * Perform installation of missing packages after component generation.
+   * This is the same as of running `bit install --add-missing-deps` after component generation.
+   */
+  installMissingPackages?: boolean;
 }
 
 export interface ComponentTemplate extends ComponentTemplateOptions {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -70,6 +70,7 @@ export type WorkspaceInstallOptions = {
   copyPeerToRuntimeOnRoot?: boolean;
   copyPeerToRuntimeOnComponents?: boolean;
   updateExisting?: boolean;
+  skipIfExisting?: boolean;
   savePrefix?: string;
   compile?: boolean;
   includeOptionalDeps?: boolean;
@@ -227,7 +228,7 @@ export class InstallMain {
     // this.logger.console(
     // `the following environments are not installed yet: ${nonLoadedEnvs.join(', ')}. installing them now...`
     // );
-    await this.install(packages, { addMissingDeps: installMissing });
+    await this.install(packages, { addMissingDeps: installMissing, skipIfExisting: true });
   }
 
   private async _addPackages(packages: string[], options?: WorkspaceInstallOptions) {
@@ -261,6 +262,7 @@ export class InstallMain {
     });
     this.dependencyResolver.addToRootPolicy(newWorkspacePolicyEntries, {
       updateExisting: options?.updateExisting ?? false,
+      skipIfExisting: options?.skipIfExisting ?? false,
     });
     await this.dependencyResolver.persistConfig(this.workspace.path);
   }

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -192,11 +192,11 @@ export class InstallMain {
     let installMissing = false;
 
     const ids = generateResults.map((generateResult) => {
-      if (generateResult.packages && generateResult.packages.length) {
-        packages = packages.concat(generateResult.packages);
+      if (generateResult.dependencies && generateResult.dependencies.length) {
+        packages = packages.concat(generateResult.dependencies);
         runInstall = true;
       }
-      if (generateResult.installMissingPackages) {
+      if (generateResult.dependencies) {
         installMissing = true;
         runInstall = true;
       }


### PR DESCRIPTION
## Proposed Changes

- Add `skipIfExisting` option to `WorkspaceInstallOptions`
- New props on the ComponentTemplate interface: 
```
/**
 * adds a metadata that the component that this template creates is of type env.
 * This will be used later to do further configuration for example:
 * - ensure to create the .bit_root for it
 */
isEnv?: boolean;

/**
 * adds a metadata that the component that this template creates is of type app.
 * This will be used later to do further configuration for example:
 * - add it to the workspace.jsonc as app
 * - ensure to create the .bit_root for it
 */
isApp?: boolean;

/**
 * list of packages to install when the component is created.
 */
packages?: string[];

/**
 * Perform installation of missing packages after component generation.
 * This is the same as of running `bit install --add-missing-deps` after component generation.
 */
installMissingPackages?: boolean;
```
- If a template declares that it generates an app or env, bit will always run `install` after creation.
- if a template is an app automatically add it to workspace.jsonc
- If a template declares pacakes, bit will install these packages after creation
- If a template asks for `installMissingPackages` bit will run install with `--add-missing-deps` after creation
