### PR TITLE
feat(why): specifying the depth until which to search for dependencies

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-cmd.ts
+++ b/scopes/dependencies/dependencies/dependencies-cmd.ts
@@ -279,6 +279,10 @@ export class DependenciesBlameCmd implements Command {
   }
 }
 
+type DependenciesUsageCmdOptions = {
+  depth?: number;
+};
+
 export class DependenciesUsageCmd implements Command {
   name = 'usage <dependency-name>';
   arguments = [
@@ -291,12 +295,12 @@ export class DependenciesUsageCmd implements Command {
   group = 'info';
   description = 'EXPERIMENTAL. find components that use the specified dependency';
   alias = '';
-  options = [] as CommandOptions;
+  options = [['', 'depth <number>', 'max display depth of the dependency graph']] as CommandOptions;
 
   constructor(private deps: DependenciesMain) {}
 
-  async report([depName]: [string]) {
-    const deepUsageResult = await this.deps.usageDeep(depName);
+  async report([depName]: [string], options: DependenciesUsageCmdOptions) {
+    const deepUsageResult = await this.deps.usageDeep(depName, options);
     if (deepUsageResult != null) return deepUsageResult;
     const results = await this.deps.usage(depName);
     if (!Object.keys(results).length) {

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -249,9 +249,12 @@ export class DependenciesMain {
     return blameResults;
   }
 
-  async usageDeep(depName: string): Promise<string | undefined> {
+  async usageDeep(depName: string, opts?: { depth?: number }): Promise<string | undefined> {
     if (!isComponentId(depName)) {
-      return this.dependencyResolver.getPackageManager()?.findUsages?.(depName, { lockfileDir: this.workspace.path });
+      return this.dependencyResolver.getPackageManager()?.findUsages?.(depName, {
+        lockfileDir: this.workspace.path,
+        depth: opts?.depth,
+      });
     }
     return undefined;
   }

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -168,5 +168,5 @@ export interface PackageManager {
    */
   getWorkspaceDepsOfBitRoots(manifests: ProjectManifest[]): Record<string, string>;
 
-  findUsages?(depName: string, opts: { lockfileDir: string }): Promise<string>;
+  findUsages?(depName: string, opts: { lockfileDir: string; depth?: number }): Promise<string>;
 }

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -239,7 +239,7 @@ export class PnpmPackageManager implements PackageManager {
     return pnpmPruneModules(rootDir);
   }
 
-  async findUsages(depName: string, opts: { lockfileDir: string }): Promise<string> {
+  async findUsages(depName: string, opts: { lockfileDir: string; depth?: number }): Promise<string> {
     const search = createPackagesSearcher([depName]);
     const lockfile = await readWantedLockfile(opts.lockfileDir, { ignoreIncompatible: false });
     const projectPaths = Object.keys(lockfile?.importers ?? {})
@@ -253,7 +253,7 @@ export class PnpmPackageManager implements PackageManager {
       : ({ path }) => path;
     const results = Object.entries(
       await buildDependenciesHierarchy(projectPaths, {
-        depth: Infinity,
+        depth: opts.depth ?? Infinity,
         include: {
           dependencies: true,
           devDependencies: true,


### PR DESCRIPTION
## Proposed Changes

- `bit why <pkg_name>` now accepts a `--depth` option for specifying how deep to search for the package in dependencies.

