### PR TITLE
save metadata when backing up .bitmap files

### DIFF
--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -227,7 +227,7 @@ export class CheckoutMain {
     if (head) await this.makeLaneComponentsAvailableOnMain();
     await this.parseValues(componentPattern, checkoutProps);
     const checkoutResults = await this.checkout(checkoutProps);
-    await consumer.onDestroy();
+    await consumer.onDestroy(`checkout (${componentPattern})`);
     return checkoutResults;
   }
 

--- a/scopes/component/component-compare/component-compare.main.runtime.ts
+++ b/scopes/component/component-compare/component-compare.main.runtime.ts
@@ -110,7 +110,7 @@ export class ComponentCompareMain {
       verbose,
       formatDepsAsTable: table,
     });
-    await consumer.onDestroy();
+    await consumer.onDestroy('diff');
     return diffResults;
   }
 

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -51,7 +51,7 @@ export class DeprecationMain {
       deprecate: true,
       newId: newId?.toObject(),
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`deprecate ${componentId.toString()}`);
 
     return results;
   }
@@ -61,7 +61,7 @@ export class DeprecationMain {
       deprecate: false,
       newId: '',
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`undeprecate ${componentId.toString()}`);
 
     return results;
   }

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -146,7 +146,7 @@ export class MergingMain {
         skipDependencyInstallation
       );
     }
-    await consumer.onDestroy();
+    await consumer.onDestroy('merge');
     return mergeResults;
   }
 

--- a/scopes/component/mover/mover.main.runtime.ts
+++ b/scopes/component/mover/mover.main.runtime.ts
@@ -44,7 +44,7 @@ export class MoverMain {
       const componentsIds = changes.map((c) => c.id);
       await linkToNodeModulesByIds(this.workspace, componentsIds);
     }
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('move');
     return changes;
   }
 

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -88,7 +88,7 @@ export class NewComponentHelperMain {
       throw err;
     }
 
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`adding ${targetId.toString()}`);
     await this.workspace.clearCache();
     // this takes care of compiling the component as well
     await this.workspace.triggerOnComponentAdd(targetId, { compile: true });

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -68,7 +68,7 @@ export class RemoveMain {
       track,
       deleteFiles,
     });
-    if (consumer) await consumer.onDestroy();
+    if (consumer) await consumer.onDestroy('remove');
     return removeResults;
   }
 
@@ -85,7 +85,7 @@ export class RemoveMain {
       track: false,
       deleteFiles: true,
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('remove');
 
     return results;
   }
@@ -101,7 +101,7 @@ export class RemoveMain {
     const config: RemoveInfo = { removed: true };
     if (shouldUpdateMain) config.removeOnMain = true;
     componentIds.map((compId) => this.workspace.bitMap.addComponentConfig(compId, RemoveAspect.id, config));
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('delete');
     const bitIds = ComponentIdList.fromArray(componentIds.map((id) => id));
     await deleteComponentsFiles(this.workspace.consumer, bitIds);
 
@@ -155,7 +155,7 @@ export class RemoveMain {
     };
     const setAsRemovedFalse = async (compId: ComponentID) => {
       await this.workspace.addSpecificComponentConfig(compId, RemoveAspect.id, { removed: false });
-      await this.workspace.bitMap.write();
+      await this.workspace.bitMap.write('recover');
     };
     if (bitMapEntry) {
       if (bitMapEntry.config?.[RemoveAspect.id]) {

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -64,7 +64,7 @@ make sure this argument is the name only, without the scope-name. to change the 
       await this.deprecation.deprecate(sourceId, targetId);
     } else {
       this.workspace.bitMap.renameNewComponent(sourceId, targetId);
-      await this.workspace.bitMap.write();
+      await this.workspace.bitMap.write(`rename (${sourceIdStr} to ${targetName})`);
       await this.deleteLinkFromNodeModules(sourcePackageName);
     }
     await this.renameAspectIdInWorkspaceConfig(sourceId, targetId);
@@ -93,7 +93,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     }
 
     this.workspace.bitMap.renameAspectInConfig(sourceId, targetId);
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`rename (${sourceIdStr} to ${targetName})`);
 
     await linkToNodeModulesByComponents([targetComp], this.workspace); // link the new-name to node-modules
     await this.compileGracefully([targetComp.id]);
@@ -150,7 +150,7 @@ make sure this argument is the name only, without the scope-name. to change the 
       await this.workspace.setDefaultScope(newScope);
     }
     componentsUsingOldScope.forEach((comp) => this.workspace.bitMap.setDefaultScope(comp.id, newScope));
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`rename-scope (${oldScope} to ${newScope})`);
     await this.workspace.clearCache();
 
     await Promise.all(
@@ -256,7 +256,7 @@ make sure this argument is the name only, without the scope-name. to change the 
       this.workspace.bitMap.setDefaultScope(comp.id, newCompScope);
       return new ComponentID(comp.id._legacy, newCompScope);
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`rename-owner (${oldOwner} to ${newOwner})`);
     const refactoredIds: ComponentID[] = [];
     if (options.refactor) {
       const legacyComps = componentsUsingOldScope.map((c) => c.state._consumer);

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -229,7 +229,7 @@ export class SnappingMain {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       R.concat(tagResults.taggedComponents, tagResults.autoTaggedResults, tagResults.newComponents).length
     );
-    await consumer.onDestroy();
+    await consumer.onDestroy(`tag (message: ${message || 'N/A'})`);
     await stagedConfig?.write();
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return tagResults;
@@ -533,7 +533,7 @@ if you're willing to lose the history from the head to the specified version, us
 
     const currentLane = consumer.getCurrentLaneId();
     snapResults.laneName = currentLane.isDefault() ? null : currentLane.toString();
-    await consumer.onDestroy();
+    await consumer.onDestroy(`snap (message: ${message || 'N/A'})`);
     await stagedConfig?.write();
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return snapResults;
@@ -629,7 +629,7 @@ there are matching among unmodified components thought. consider using --unmodif
       consumer.bitMap.markAsChanged();
     }
 
-    await consumer.onDestroy();
+    await consumer.onDestroy('reset');
     return { results, isSoftUntag: !isRealUntag };
   }
 
@@ -638,7 +638,7 @@ there are matching among unmodified components thought. consider using --unmodif
     const hashes = notExported.map((id) => BitObject.makeHash(id.fullName));
     await this.scope.legacyScope.objects.deleteObjectsFromFS(hashes.map((h) => Ref.from(h)));
     notExported.map((id) => this.workspace.consumer.bitMap.updateComponentId(id.changeVersion(undefined)));
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`reset (never-exported)`);
     return notExported;
   }
 

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -152,7 +152,7 @@ export class StatusMain {
       return objectsWithId.sort((a, b) => a.id.toString().localeCompare(b.id.toString()));
     };
 
-    await consumer.onDestroy();
+    await consumer.onDestroy('status');
     return {
       newComponents: await convertBitIdToComponentIdsAndSort(newComponents.map((c) => c.id)),
       modifiedComponents: await convertBitIdToComponentIdsAndSort(modifiedComponents.map((c) => c.id)),

--- a/scopes/component/tracker/tracker.main.runtime.ts
+++ b/scopes/component/tracker/tracker.main.runtime.ts
@@ -56,7 +56,7 @@ export class TrackerMain {
     }
     const addComponents = new AddComponents(addContext, addProps);
     const addResults = await addComponents.add();
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('add');
 
     return addResults;
   }

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -89,7 +89,7 @@ export class DependenciesMain {
       })
     );
 
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`deps-set (${componentPattern})`);
 
     return {
       changedComps: compIds.map((compId) => compId.toStringWithoutVersion()),
@@ -144,7 +144,7 @@ export class DependenciesMain {
       await this.workspace.addSpecificComponentConfig(compId, DependencyResolverAspect.id, newDepResolverConfig);
       return { id: compId, removedPackages };
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`deps-remove (${componentPattern})`);
 
     return compact(results);
   }
@@ -154,7 +154,7 @@ export class DependenciesMain {
     await pMapSeries(compIds, async (compId) => {
       await this.workspace.addSpecificComponentConfig(compId, DependencyResolverAspect.id, { policy: {} });
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`deps-reset (${componentPattern})`);
 
     return compIds;
   }
@@ -172,7 +172,7 @@ export class DependenciesMain {
         }
       );
     });
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`deps-eject (${componentPattern})`);
 
     return compIds;
   }

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -77,7 +77,7 @@ export class ComponentGenerator {
       }
     });
 
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`create (${this.componentIds.length} components)`);
 
     const ids = generateResults.map((r) => r.id);
     await this.tryLinkToNodeModules(ids);

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -193,7 +193,7 @@ export class WorkspaceGenerator {
       );
     });
 
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('new');
   }
 
   private async compileComponents(clearCache = true) {

--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -103,7 +103,7 @@ export class AspectMain {
         });
       })
     );
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`aspect-set (${aspectId})`);
 
     return componentIds;
   }
@@ -121,7 +121,7 @@ export class AspectMain {
         updatedCompIds.push(component.id);
       })
     );
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`aspect-unset (${aspectId})`);
     return updatedCompIds;
   }
 
@@ -187,7 +187,7 @@ export class AspectMain {
         return comp.id;
       })
     );
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`aspect-update (${aspectCompId})`);
     return { updated: compact(updatedComponentIds), alreadyUpToDate };
   }
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -286,7 +286,7 @@ if you wish to keep ${scope} scope, please re-run the command with "--fork-lane-
     };
     this.scope.legacyScope.lanes.trackLane(trackLaneData);
     this.scope.legacyScope.scopeJson.setLaneAsNew(name);
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('lane-create');
 
     const results = {
       alias,
@@ -321,7 +321,7 @@ if you wish to keep ${scope} scope, please re-run the command with "--fork-lane-
       remoteScope,
     };
     this.scope.legacyScope.lanes.trackLane(afterTrackData);
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('lane-track');
 
     return { beforeTrackData: beforeTrackDataCloned, afterTrackData };
   }
@@ -351,7 +351,7 @@ if you wish to keep ${scope} scope, please re-run the command with "--fork-lane-
       : laneName;
     this.scope.legacyScope.lanes.removeTrackLane(laneNameWithoutScope);
     this.scope.legacyScope.lanes.trackLane(trackData);
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('lane-alias');
 
     return { laneId };
   }
@@ -393,7 +393,7 @@ please create a new lane instead, which will include all components of this lane
     this.scope.legacyScope.lanes.trackLane(trackData);
     await this.scope.legacyScope.lanes.saveLane(lane);
     this.workspace.consumer.bitMap.setCurrentLane(newLaneId, false);
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('lane-scope-change');
 
     return { remoteScopeBefore, localName: laneNameWithoutScope };
   }
@@ -445,7 +445,7 @@ please create a new lane instead, which will include all components of this lane
       this.setCurrentLane(newLaneId, undefined, isExported);
     }
 
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy('lane-rename');
 
     return { currentName };
   }
@@ -521,7 +521,7 @@ please create a new lane instead, which will include all components of this lane
       return laneNames;
     }
     const results = await removeLanes(this.workspace?.consumer, laneNames, !!opts?.remote, !!opts?.force);
-    if (this.workspace) await this.workspace.consumer.onDestroy();
+    if (this.workspace) await this.workspace.consumer.onDestroy('lane-remove');
 
     return results.laneResults;
   }
@@ -684,7 +684,7 @@ please create a new lane instead, which will include all components of this lane
 
     lane.setReadmeComponent(undefined);
     await scope.lanes.saveLane(lane);
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write(`lane-remove-readme`);
 
     return { result: true };
   }
@@ -886,7 +886,7 @@ please create a new lane instead, which will include all components of this lane
         },
       });
     }
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('lane-add-readme');
     return { result: true };
   }
 

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -60,7 +60,7 @@ export class LaneSwitcher {
     const results = await this.Lanes.checkout.checkout(checkoutProps);
 
     await this.saveLanesData();
-    await this.consumer.onDestroy();
+    await this.consumer.onDestroy('lane-switch');
 
     return results;
   }

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -257,7 +257,7 @@ export class MergeLanesMain {
     }
     const configMergeResults = allComponentsStatus.map((c) => c.configMergeResult);
 
-    await this.workspace.consumer.onDestroy();
+    await this.workspace.consumer.onDestroy(`lane-merge (${otherLaneId.name})`);
 
     return { mergeResults, deleteResults, configMergeResults: compact(configMergeResults) };
   }

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -201,7 +201,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     // it is important to have consumer.onDestroy() before running the eject operation, we want the
     // export and eject operations to function independently. we don't want to lose the changes to
     // .bitmap file done by the export action in case the eject action has failed.
-    await consumer.onDestroy();
+    await consumer.onDestroy('export');
     return {
       updatedIds,
       nonExistOnBitMap: nonExistOnBitMap.filter((id) => !removedIds.hasWithoutVersion(id)),
@@ -572,7 +572,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       throw new Error(ejectErr);
     }
     // run the consumer.onDestroy() again, to write the changes done by the eject action to .bitmap
-    await consumer.onDestroy();
+    await consumer.onDestroy('export (eject)');
     return ejectResults;
   }
 

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -68,7 +68,7 @@ export class ImporterMain {
     if (results.writtenComponents && results.writtenComponents.length) {
       await this.removeFromWorkspaceConfig(results.writtenComponents);
     }
-    await consumer.onDestroy();
+    await consumer.onDestroy('import');
     return results;
   }
 
@@ -193,7 +193,7 @@ export class ImporterMain {
     );
     const { importedIds, importDetails } = await importComponents.importComponents();
     Analytics.setExtraData('num_components', importedIds.length);
-    await consumer.onDestroy();
+    await consumer.onDestroy('import');
     return { importedIds, importDetails };
 
     async function getLanes(logger: Logger): Promise<Lane[]> {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -822,7 +822,7 @@ export class InstallMain {
         });
       })
     );
-    await this.workspace.bitMap.write();
+    await this.workspace.bitMap.write('update (dependencies)');
   }
 
   private _updateVariantsPolicies(variantPatterns: Record<string, any>, updateVariantPolicies: string[]) {

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -129,15 +129,16 @@ export class BitMap {
 
   /**
    * write .bitmap object to the filesystem
+   * optionally pass a reason for the change to be saved in the local scope `bitmap-history-metadata.txt` file.
    */
-  async write() {
-    await this.consumer.writeBitMap();
+  async write(reasonForChange?: string) {
+    await this.consumer.writeBitMap(reasonForChange);
   }
 
   /**
    * get the data saved in the .bitmap file for this component-id.
    * throws if not found
-   * @see getBitmapEntryIfExist
+   * @see this.getBitmapEntryIfExist
    */
   getBitmapEntry(id: ComponentID, { ignoreVersion }: GetBitMapComponentOptions = {}): ComponentMap {
     return this.legacyBitMap.getComponent(id, { ignoreVersion });

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -885,7 +885,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
     await componentConfigFile.write({ override: options.override });
     // remove config from the .bitmap as it's not needed anymore. it is replaced by the component.json
     this.bitMap.removeEntireConfig(id);
-    await this.bitMap.write();
+    await this.bitMap.write(`eject-conf (${id.toString()})`);
     return {
       configPath: ComponentConfigFile.composePath(componentDir),
     };
@@ -1296,7 +1296,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       );
     }
     newComponentIds.map((comp) => this.bitMap.setDefaultScope(comp, scopeName));
-    await this.bitMap.write();
+    await this.bitMap.write('scope-set');
     return newComponentIds;
   }
 
@@ -1318,7 +1318,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
 
     this.config.defaultScope = scopeName;
     await config.workspaceConfig?.write({ dir: path.dirname(config.workspaceConfig.path) });
-    await this.bitMap.write();
+    await this.bitMap.write('scope-set');
   }
 
   async addSpecificComponentConfig(
@@ -1743,7 +1743,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
         await this.addSpecificComponentConfig(componentId, EnvsAspect.id, { env: envIdStrNoVersion });
       })
     );
-    await this.bitMap.write();
+    await this.bitMap.write(`env-set (${envId.toString()})`);
   }
 
   /**
@@ -1799,7 +1799,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
         changed.push(id);
       })
     );
-    await this.bitMap.write();
+    await this.bitMap.write(`env-unset`);
     return { changed, unchanged };
   }
 
@@ -1872,7 +1872,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
         (updated[envToUpdate.toString()] ||= []).push(comp.id);
       })
     );
-    await this.bitMap.write();
+    await this.bitMap.write('env-update');
     return { updated, alreadyUpToDate };
   }
 

--- a/src/api/consumer/lib/get-consumer-component.ts
+++ b/src/api/consumer/lib/get-consumer-component.ts
@@ -44,6 +44,6 @@ export default (async function getConsumerBit({
     if (!component.componentFromModel) throw new NothingToCompareTo(id);
     return { component, componentModel: component.componentFromModel };
   }
-  await consumer.onDestroy();
+  await consumer.onDestroy('get-component');
   return { component, dependentsInfo, dependenciesInfo };
 });

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -658,8 +658,8 @@ export default class Consumer {
     return ComponentIdList.fromArray(compact(componentIds));
   }
 
-  async writeBitMap() {
-    await this.backupBitMap();
+  async writeBitMap(reasonForChange?: string) {
+    await this.backupBitMap(reasonForChange);
     await this.bitMap.write();
   }
 
@@ -667,13 +667,16 @@ export default class Consumer {
     return path.join(this.scope.path, BITMAP_HISTORY_DIR_NAME);
   }
 
-  private async backupBitMap() {
+  private async backupBitMap(reasonForBitmapChange?: string) {
     if (!this.bitMap.hasChanged) return;
     try {
       const baseDir = this.getBitmapHistoryDir();
       await fs.ensureDir(baseDir);
-      const backupPath = path.join(baseDir, `.bitmap-${this.currentDateAndTimeToFileName()}`);
+      const fileId = this.currentDateAndTimeToFileName();
+      const backupPath = path.join(baseDir, `.bitmap-${fileId}`);
       await fs.copyFile(this.bitMap.mapPath, backupPath);
+      const metadataFile = path.join(this.scope.path, 'bitmap-history-metadata.txt');
+      await fs.appendFile(metadataFile, `${fileId} ${reasonForBitmapChange || ''}\n`);
     } catch (err: any) {
       if (err.code === 'ENOENT') return; // no such file or directory, meaning the .bitmap file doesn't exist (yet)
       // it's a nice to have feature. don't kill the process if something goes wrong.
@@ -692,9 +695,9 @@ export default class Consumer {
     return `${year}-${month}-${day}-${hours}-${minutes}-${seconds}`;
   }
 
-  async onDestroy() {
+  async onDestroy(reasonForBitmapChange?: string) {
     await this.cleanTmpFolder();
     await this.scope.scopeJson.writeIfChanged(this.scope.path);
-    await this.writeBitMap();
+    await this.writeBitMap(reasonForBitmapChange);
   }
 }


### PR DESCRIPTION
It provides some context to help understanding the diff between historic .bitmap file. (a future feature for vscode-ext).
For example, when a .bitmap is change due to a tag, it saves the info that it's coming from "bit tag" and the tag-message.