### PR TITLE
change x-request-id to x-bit-request-id

### DIFF
--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -354,7 +354,7 @@ export class Http implements Network {
     const headers = this.getHeaders({
       'Content-Type': 'application/json',
       'x-verb': Verb.READ,
-      'x-request-id': requestId.toString(),
+      'x-bit-request-id': requestId.toString(),
     });
     const opts = this.addAgentIfExist({
       method: 'post',


### PR DESCRIPTION
because `x-request-id` is already used by CloudFlare.