### PR TITLE
fix(get-diverge-data), avoid traversing unrelated and squashed in case the common-snap has found

### DIFF
--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -143,6 +143,12 @@ export async function getDivergeData({
         error = err;
       }
     });
+    if (commonSnapBeforeDiverge) {
+      // only reason to traverse the "unrelated" and the "squashed" is to find the common snap and avoid the "NoCommonSnap" error.
+      // once the common snap is found, no need to deal with the unrelated and squashed, only traverse the parents to
+      // find maybe another common snap with lower depth.
+      return;
+    }
     if (version.unrelated) {
       const unrelatedData = getVersionData(version.unrelated);
       if (unrelatedData) {


### PR DESCRIPTION
Only reason to traverse the "unrelated" and the "squashed" is to find the common snap and avoid the `NoCommonSnap` error. Once the common snap is found, no need to deal with the unrelated and squashed, only traverse the parents to find maybe another common snap with lower depth.