### PR TITLE
improvement(cat-version-history-graph), show tags, lane heads and squashed/unrelated text

### DIFF
--- a/scopes/component/graph/graph-cmd.ts
+++ b/scopes/component/graph/graph-cmd.ts
@@ -23,6 +23,7 @@ type GraphOpt = {
 export class GraphCmd implements Command {
   name = 'graph [id]';
   description = "generate an image file with the workspace components' dependencies graph";
+  extendedDescription: 'black arrow is a runtime dependency. red arrow is either dev or peer';
   group = 'discover';
   alias = '';
   options = [

--- a/src/api/scope/lib/cat-version-history.ts
+++ b/src/api/scope/lib/cat-version-history.ts
@@ -9,13 +9,29 @@ export async function catVersionHistory(id: string) {
 }
 
 export async function generateVersionHistoryGraph(id: string) {
-  const versionHistory = await getVersionHistory(id);
-  return versionHistory.getGraph();
+  const scope: Scope = await loadScope();
+  const compId = await scope.getParsedId(id);
+  const component = await scope.getModelComponent(compId);
+  const versionHistory = await component.getVersionHistory(scope.objects);
+  const lanePerRef = await scope.objects.remoteLanes.getRefsPerLaneId(compId);
+  if (component.head) {
+    lanePerRef.main = component.head;
+  }
+  // convert to hash per lane
+  const laneHeads: { [hash: string]: string[] } = {};
+  Object.keys(lanePerRef).forEach((lane) => {
+    const hash = lanePerRef[lane].toString();
+    if (!laneHeads[hash]) laneHeads[hash] = [];
+    laneHeads[hash].push(lane);
+  });
+
+  return versionHistory.getGraph(component, laneHeads);
 }
 
 async function getVersionHistory(id: string): Promise<VersionHistory> {
   const scope: Scope = await loadScope();
   const bitId = await scope.getParsedId(id);
   const component = await scope.getModelComponent(bitId);
-  return component.getVersionHistory(scope.objects);
+  const versionHistory = await component.getVersionHistory(scope.objects);
+  return versionHistory;
 }

--- a/src/api/scope/lib/cat-version-history.ts
+++ b/src/api/scope/lib/cat-version-history.ts
@@ -8,7 +8,7 @@ export async function catVersionHistory(id: string) {
   return versionHistoryObj;
 }
 
-export async function generateVersionHistoryGraph(id: string) {
+export async function generateVersionHistoryGraph(id: string, shortHash?: boolean) {
   const scope: Scope = await loadScope();
   const compId = await scope.getParsedId(id);
   const component = await scope.getModelComponent(compId);
@@ -25,7 +25,7 @@ export async function generateVersionHistoryGraph(id: string) {
     laneHeads[hash].push(lane);
   });
 
-  return versionHistory.getGraph(component, laneHeads);
+  return versionHistory.getGraph(component, laneHeads, shortHash);
 }
 
 async function getVersionHistory(id: string): Promise<VersionHistory> {

--- a/src/cli/commands/private-cmds/cat-version-history-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-version-history-cmd.ts
@@ -52,7 +52,7 @@ export class CatVersionHistoryCmd implements LegacyCommand {
       const markIds = mark ? mark.split(',').map((node) => node.trim()) : undefined;
       const config: GraphConfig = { colorPerEdgeType };
       if (layout) config.layout = layout;
-      const visualDependencyGraph = await VisualDependencyGraph.loadFromClearGraph(graphHistory, config, markIds, true);
+      const visualDependencyGraph = await VisualDependencyGraph.loadFromClearGraph(graphHistory, config, markIds);
       const result = await visualDependencyGraph.image(graphPath);
       return `image created at ${result}`;
     }

--- a/src/cli/commands/private-cmds/cat-version-history-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-version-history-cmd.ts
@@ -26,6 +26,7 @@ export class CatVersionHistoryCmd implements LegacyCommand {
       'layout <name>',
       'GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
     ],
+    ['', 'short-hash', 'relevant for --graph only. show only 9 chars of the hash'],
     [
       '',
       'mark <string>',
@@ -40,15 +41,17 @@ export class CatVersionHistoryCmd implements LegacyCommand {
       mark,
       graphPath,
       layout,
+      shortHash,
     }: {
       graph: boolean;
       mark?: string;
       graphPath?: string;
       layout?: string;
+      shortHash?: boolean;
     }
   ): Promise<any> {
     if (graph) {
-      const graphHistory = await generateVersionHistoryGraph(id);
+      const graphHistory = await generateVersionHistoryGraph(id, shortHash);
       const markIds = mark ? mark.split(',').map((node) => node.trim()) : undefined;
       const config: GraphConfig = { colorPerEdgeType };
       if (layout) config.layout = layout;

--- a/src/cli/commands/private-cmds/cat-version-history-cmd.ts
+++ b/src/cli/commands/private-cmds/cat-version-history-cmd.ts
@@ -1,9 +1,8 @@
 import { catVersionHistory, generateVersionHistoryGraph } from '../../../api/scope/lib/cat-version-history';
-import VisualDependencyGraph from '../../../scope/graph/vizgraph';
+import VisualDependencyGraph, { GraphConfig } from '../../../scope/graph/vizgraph';
 import { CommandOptions, LegacyCommand } from '../../legacy-command';
 
 const colorPerEdgeType = {
-  parent: 'green',
   unrelated: 'red',
   squashed: 'blue',
 };
@@ -16,7 +15,17 @@ export class CatVersionHistoryCmd implements LegacyCommand {
   opts = [
     // json is also the default for this command. it's only needed to suppress the logger.console
     ['j', 'json', 'json format'],
-    ['g', 'graph', `generate graph image (arrows color: ${JSON.stringify(colorPerEdgeType)})`],
+    ['g', 'graph', `generate graph image`],
+    [
+      'p',
+      'graph-path <image>',
+      'relevant for --graph only. image path and format. use one of the following extensions: [gif, png, svg]',
+    ],
+    [
+      '',
+      'layout <name>',
+      'GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
+    ],
     [
       '',
       'mark <string>',
@@ -24,18 +33,27 @@ export class CatVersionHistoryCmd implements LegacyCommand {
     ],
   ] as CommandOptions;
 
-  async action([id]: [string], { graph, mark }: { graph: boolean; mark?: string }): Promise<any> {
+  async action(
+    [id]: [string],
+    {
+      graph,
+      mark,
+      graphPath,
+      layout,
+    }: {
+      graph: boolean;
+      mark?: string;
+      graphPath?: string;
+      layout?: string;
+    }
+  ): Promise<any> {
     if (graph) {
       const graphHistory = await generateVersionHistoryGraph(id);
       const markIds = mark ? mark.split(',').map((node) => node.trim()) : undefined;
-      const visualDependencyGraph = await VisualDependencyGraph.loadFromClearGraph(
-        graphHistory,
-        {
-          colorPerEdgeType,
-        },
-        markIds
-      );
-      const result = await visualDependencyGraph.image();
+      const config: GraphConfig = { colorPerEdgeType };
+      if (layout) config.layout = layout;
+      const visualDependencyGraph = await VisualDependencyGraph.loadFromClearGraph(graphHistory, config, markIds, true);
+      const result = await visualDependencyGraph.image(graphPath);
       return `image created at ${result}`;
     }
     return catVersionHistory(id);

--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -103,10 +103,11 @@ export default class VisualDependencyGraph {
         props.style = 'filled';
       }
       if (typeof attr === 'object' && (attr.tag || attr.pointers)) {
-        const tag = attr.tag ? `\nTag: ${attr.tag}` : '';
-        const pointers = attr.pointers ? `\n[*] ${attr.pointers.join(', ')} [*]` : '';
-        props.label = `${node.id}${tag}${pointers}`;
-        // if (attr.pointers) props.shape = 'doubleoctagon';
+        const tag = attr.tag ? ` (${attr.tag})` : '';
+        const pointers = attr.pointers ? `<BR/><B>${attr.pointers.join(', ')}</B>` : '';
+        // the "!" prefix enables the "html-like" syntax
+        props.label = `!${node.id}${tag}${pointers}`;
+        if (attr.pointers) props.style = 'bold';
       }
 
       graph.addNode(node.id, props);

--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -106,7 +106,7 @@ export default class VisualDependencyGraph {
         const tag = attr.tag ? `\nTag: ${attr.tag}` : '';
         const pointers = attr.pointers ? `\n[*] ${attr.pointers.join(', ')} [*]` : '';
         props.label = `${node.id}${tag}${pointers}`;
-        if (attr.pointers) props.shape = 'doubleoctagon';
+        // if (attr.pointers) props.shape = 'doubleoctagon';
       }
 
       graph.addNode(node.id, props);
@@ -201,12 +201,18 @@ function createGraphvizOptions(config: GraphConfig) {
   return {
     G: Object.assign({
       layout: config.layout,
+      bgcolor: 'black',
     }),
     E: Object.assign({
-      // color: config.edgeColor,
+      color: 'green',
+      fontcolor: 'white',
+      labelfontcolor: 'white',
     }),
     N: Object.assign({
-      shape: 'box',
+      fontname: 'Arial',
+      color: '#c6c5fe',
+      fontcolor: '#c6c5fe',
+      fontsize: '14px',
     }),
   };
 }

--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -107,7 +107,6 @@ export default class VisualDependencyGraph {
         const pointers = attr.pointers ? `<BR/><B>${attr.pointers.join(', ')}</B>` : '';
         // the "!" prefix enables the "html-like" syntax
         props.label = `!${node.id}${tag}${pointers}`;
-        if (attr.pointers) props.style = 'bold';
       }
 
       graph.addNode(node.id, props);

--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -38,16 +38,14 @@ export default class VisualDependencyGraph {
   static async loadFromClearGraph(
     clearGraph: ClearGraph<any, any>,
     config: GraphConfig = {},
-    markIds?: string[],
-    printNodeAttr?: boolean
+    markIds?: string[]
   ): Promise<VisualDependencyGraph> {
     const mergedConfig = { ...defaultConfig, ...config };
     await checkGraphvizInstalled(config.graphVizPath);
     const graph: Digraph = VisualDependencyGraph.buildDependenciesGraphFromClearGraph(
       clearGraph,
       mergedConfig,
-      markIds,
-      printNodeAttr
+      markIds
     );
     // @ts-ignore
     return new VisualDependencyGraph(clearGraph, graph, mergedConfig);
@@ -83,8 +81,7 @@ export default class VisualDependencyGraph {
   static buildDependenciesGraphFromClearGraph(
     clearGraph: ClearGraph<any, any>,
     config: GraphConfig,
-    markIds?: string[],
-    printNodeAttr?: boolean
+    markIds?: string[]
   ): Digraph {
     const graph = graphviz.digraph('G');
 

--- a/src/scope/lanes/remote-lanes.ts
+++ b/src/scope/lanes/remote-lanes.ts
@@ -87,6 +87,18 @@ export default class RemoteLanes {
     return compact(results);
   }
 
+  async getRefsPerLaneId(compId: ComponentID): Promise<{ [laneIdStr: string]: Ref }> {
+    const allLaneIds = await this.getAllRemoteLaneIds();
+    const results = {};
+    await pMapSeries(allLaneIds, async (laneId) => {
+      const ref = await this.getRef(laneId, compId);
+      if (ref) {
+        results[laneId.toString()] = ref;
+      }
+    });
+    return results;
+  }
+
   async getRemoteBitIds(remoteLaneId: LaneId): Promise<ComponentID[]> {
     const remoteLane = await this.getRemoteLane(remoteLaneId);
     return remoteLane.map((item) => item.id.changeVersion(item.head.toString()));

--- a/src/scope/models/version-history.ts
+++ b/src/scope/models/version-history.ts
@@ -149,7 +149,8 @@ export default class VersionHistory extends BitObject {
     this.versions = newVersions;
   }
 
-  getGraph(modelComponent?: ModelComponent, laneHeads?: { [hash: string]: string[] }) {
+  getGraph(modelComponent?: ModelComponent, laneHeads?: { [hash: string]: string[] }, shortHash = false) {
+    const refToStr = (ref: Ref) => (shortHash ? ref.toShortString() : ref.toString());
     const graph = new Graph<string | HashMetadata, string>();
     const allHashes = uniqBy(
       this.versions
@@ -165,14 +166,14 @@ export default class VersionHistory extends BitObject {
       const pointers = laneHeads[ref.toString()];
       return { tag, pointers };
     };
-    const nodes = allHashes.map((v) => new Node(v.toString(), getMetadata(v) || v.toString()));
+    const nodes = allHashes.map((v) => new Node(refToStr(v), getMetadata(v) || refToStr(v)));
     const edges = this.versions
       .map((v) => {
-        const verEdges = v.parents.map((p) => new Edge(v.hash.toString(), p.toString(), 'parent'));
-        if (v.unrelated) verEdges.push(new Edge(v.hash.toString(), v.unrelated.toString(), 'unrelated'));
+        const verEdges = v.parents.map((p) => new Edge(refToStr(v.hash), refToStr(p), 'parent'));
+        if (v.unrelated) verEdges.push(new Edge(refToStr(v.hash), refToStr(v.unrelated), 'unrelated'));
         if (v.squashed) {
           const squashed = v.squashed.filter((s) => !v.parents.find((p) => p.isEqual(s)));
-          squashed.map((p) => verEdges.push(new Edge(v.hash.toString(), p.toString(), 'squashed')));
+          squashed.map((p) => verEdges.push(new Edge(refToStr(v.hash), refToStr(p), 'squashed')));
         }
         return verEdges;
       })


### PR DESCRIPTION
- show tags when applicable. 
- in case a lane has a component with head pointing to one of the hashes, show it.
- introduce `--graph-path` flag to support saving the graph as other formats, e.g. `svg`. 
- introduce `--short-hash` flag to show the hash as 9 digits instead of 40.


Before:

<img width="544" alt="Screenshot 2023-11-21 at 12 09 50 PM" src="https://github.com/teambit/bit/assets/1963573/45c3d78f-4066-4dfe-8973-0307c46f9938">



After:

<img width="645" alt="Screenshot 2023-11-21 at 5 56 13 PM" src="https://github.com/teambit/bit/assets/1963573/5f977763-ab25-4185-9937-b213777a58cb">


And with `--short-hash`:

<img width="418" alt="Screenshot 2023-11-21 at 6 15 41 PM" src="https://github.com/teambit/bit/assets/1963573/2484a350-b014-4e36-af6f-965dd1163d34">

