### PR TITLE
do not show missing-files in bit-status when the file exists in the same comp with a different extension

### DIFF
--- a/e2e/harmony/dependencies.e2e.ts
+++ b/e2e/harmony/dependencies.e2e.ts
@@ -108,4 +108,15 @@ const isPositive = require('is-positive');
       helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingPackagesDependenciesOnFs.name);
     });
   });
+  describe('a file-dependency exists with a different extension', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fs.outputFile('comp1/index.ts', `export const foo = 'foo';`);
+      helper.fs.outputFile('comp1/bar.cjs', `import { foo } from './index.js';`);
+      helper.command.addComponent('comp1');
+    });
+    it('should not show an issue of missing-files because the file could exist later in the dist', () => {
+      helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingDependenciesOnFs.name);
+    });
+  });
 });

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -13,7 +13,7 @@ import Consumer from '../../../../consumer/consumer';
 import GeneralError from '../../../../error/general-error';
 import logger from '../../../../logger/logger';
 import { getExt, pathNormalizeToLinux, pathRelativeLinux } from '../../../../utils';
-import { PathLinux, PathLinuxRelative, PathOsBased } from '../../../../utils/path';
+import { PathLinux, PathLinuxRelative, PathOsBased, removeFileExtension } from '../../../../utils/path';
 import ComponentMap from '../../../bit-map/component-map';
 import Component from '../../../component/consumer-component';
 import { RelativePath } from '../dependency';
@@ -152,8 +152,8 @@ export default class DependencyResolver {
     this.component = component;
     this.consumer = consumer;
     this.componentId = component.componentId;
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    this.componentMap = this.component.componentMap;
+    // the consumerComponent is coming from the workspace, so it must have the componentMap prop
+    this.componentMap = this.component.componentMap as ComponentMap;
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.componentFromModel = this.component.componentFromModel;
     this.consumerPath = this.consumer.getPath();
@@ -201,9 +201,7 @@ export default class DependencyResolver {
     cacheResolvedDependencies: Record<string, any>,
     cacheProjectAst: Record<string, any> | undefined
   ): Promise<DependenciesData> {
-    const componentDir = this.componentMap?.rootDir
-      ? path.join(this.consumerPath, this.componentMap?.rootDir)
-      : this.consumerPath;
+    const componentDir = path.join(this.consumerPath, this.componentMap.rootDir);
     const { nonTestsFiles, testsFiles } = this.componentMap.getFilesGroupedByBeingTests();
     const allFiles = [...nonTestsFiles, ...testsFiles];
     const envDetectors = await this.getEnvDetectors();
@@ -420,14 +418,12 @@ export default class DependencyResolver {
     let depFileRelative: PathLinux = depFile; // dependency file path relative to consumer root
     let destination: string | null | undefined;
     const rootDir = this.componentMap.rootDir;
-    if (rootDir) {
-      // The depFileRelative is relative to rootDir, change it to be relative to current consumer.
-      // We can't use path.resolve(rootDir, fileDep) because this might not work when running
-      // bit commands not from root, because resolve take by default the process.cwd
-      const rootDirFullPath = path.join(this.consumerPath, rootDir);
-      const fullDepFile = path.resolve(rootDirFullPath, depFile);
-      depFileRelative = pathNormalizeToLinux(path.relative(this.consumerPath, fullDepFile));
-    }
+    // The depFileRelative is relative to rootDir, change it to be relative to current consumer.
+    // We can't use path.resolve(rootDir, fileDep) because this might not work when running
+    // bit commands not from root, because resolve take by default the process.cwd
+    const rootDirFullPath = path.join(this.consumerPath, rootDir);
+    const fullDepFile = path.resolve(rootDirFullPath, depFile);
+    depFileRelative = pathNormalizeToLinux(path.relative(this.consumerPath, fullDepFile));
 
     const componentId = this.consumer.bitMap.getComponentIdByPath(depFileRelative);
 
@@ -863,15 +859,19 @@ either, use the ignore file syntax or change the require statement to have a mod
     const missing = this.tree[originFile].missing;
     if (!missing) return;
     const processMissingFiles = () => {
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       if (isEmpty(missing.files)) return;
-      const absOriginFile = this.consumer.toAbsolutePath(originFile);
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      const missingFiles = missing.files.filter((missingFile) => {
-        // convert from importSource (the string inside the require/import call) to the path relative to consumer
-        const resolvedPath = path.resolve(path.dirname(absOriginFile), missingFile);
-        const relativeToConsumer = this.consumer.getPathRelativeToConsumer(resolvedPath);
-        return !this.overridesDependencies.shouldIgnoreFile(relativeToConsumer, fileType);
+      const missingFiles = missing.files.filter((file) => {
+        const hasExtension = Boolean(path.extname(file));
+        if (!hasExtension) return true;
+        // the missing file has extension, e.g. "index.js". It's possible that this file doesn't exist in the source
+        // but will be available in the dists. so if found same filename without the extension, we assume it's fine.
+        const rootDirAbs = this.consumer.toAbsolutePath(this.componentMap.rootDir);
+        const filePathAbs = path.resolve(rootDirAbs, file);
+        const relativeToCompDir = path.relative(rootDirAbs, filePathAbs);
+        const relativeToCompDirWithoutExt = removeFileExtension(relativeToCompDir);
+        const compFilesWithoutExt = this.componentMap.getAllFilesPaths().map((f) => removeFileExtension(f));
+        const existWithDifferentExt = compFilesWithoutExt.some((f) => f === relativeToCompDirWithoutExt);
+        return !existWithDifferentExt;
       });
       if (R.isEmpty(missingFiles)) return;
       this._pushToMissingDependenciesOnFs(originFile, missingFiles);

--- a/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
@@ -36,6 +36,7 @@ export default class OverridesDependencies {
     this.missingPackageDependencies = [];
   }
 
+  // @todo: remove. it's not supported anymore
   shouldIgnoreFile(file: string, fileType: FileType): boolean {
     const shouldIgnoreByGlobMatch = (patterns: string[]) => {
       return patterns.some((pattern) => minimatch(file, pattern));

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -35,3 +35,11 @@ export function getPathRelativeRegardlessCWD(from: PathOsBasedRelative, to: Path
   // change them to absolute so path.relative won't consider the cwd
   return pathRelativeLinux(`/${fromLinux}`, `/${toLinux}`);
 }
+
+/**
+ * e.g. given `a/b/index.js` return `a/b/index`.
+ */
+export function removeFileExtension(filePath: string): string {
+  const parsedPath = path.parse(filePath);
+  return path.join(parsedPath.dir, parsedPath.name);
+}


### PR DESCRIPTION
Because it's possible that the file doesn't exist in the source, but will be available later on in the dists.