### PR TITLE
fix(rename), set the scope-name correctly to the targetId

### DIFF
--- a/e2e/harmony/rename.e2e.ts
+++ b/e2e/harmony/rename.e2e.ts
@@ -101,6 +101,20 @@ describe('bit rename command', function () {
       expect(list).to.have.lengthOf(1);
     });
   });
+  describe('rename a new component when the scope is different than the defaultScope', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope('different-scope', 'comp1');
+      // previously it was errored with "error: component "different-scope/comp1" was not found on your local workspace".
+      helper.command.rename('comp1', 'comp2');
+    });
+    it('should rename successfully', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap).to.not.have.property('comp1');
+      expect(bitmap).to.have.property('comp2');
+    });
+  });
   describe('rename a new component scope-name', () => {
     before(() => {
       helper.scopeHelper.reInitLocalScope();

--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -53,7 +53,7 @@ make sure this argument is the name only, without the scope-name. to change the 
     const isTagged = sourceId.hasVersion();
     const sourceComp = await this.workspace.get(sourceId);
     const sourcePackageName = this.workspace.componentPackageName(sourceComp);
-    const targetId = this.newComponentHelper.getNewComponentId(targetName, undefined, options?.scope);
+    const targetId = this.newComponentHelper.getNewComponentId(targetName, undefined, options?.scope || sourceId.scope);
     if (!options.preserve) {
       await this.refactoring.refactorVariableAndClasses(sourceComp, sourceId, targetId);
       this.refactoring.refactorFilenames(sourceComp, sourceId, targetId);


### PR DESCRIPTION
currently, if no `--scope` provided, it sets it to the defaultScope instead of the sourceId scope. 
