### PR TITLE
refactor, remove the old unused code related to overrides of files

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -545,8 +545,6 @@ export const MANUALLY_REMOVE_ENVIRONMENT = '-';
 
 export const MANUALLY_ADD_DEPENDENCY = '+';
 
-export const OVERRIDE_FILE_PREFIX = 'file://';
-
 export const OVERRIDE_COMPONENT_PREFIX = '@bit/';
 
 export const ACCEPTABLE_NPM_VERSIONS = '>=5.0.0';

--- a/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/dependencies-resolver.ts
@@ -258,9 +258,6 @@ export default class DependencyResolver {
         isTestFile: testsFiles.includes(file),
       };
       this.throwForNonExistFile(file);
-      if (this.overridesDependencies.shouldIgnoreFile(file, fileType)) {
-        return;
-      }
       this.processCoreAspects(file);
       this.processMissing(file, fileType);
       this.processErrors(file);
@@ -468,7 +465,6 @@ export default class DependencyResolver {
     const allDepsFiles = this.tree[originFile].files;
     if (!allDepsFiles || R.isEmpty(allDepsFiles)) return;
     allDepsFiles.forEach((depFile: FileObject) => {
-      if (!nested && this.overridesDependencies.shouldIgnoreFile(depFile.file, fileType)) return;
       if (depFile.isLink) this.processLinkFile(originFile, depFile, fileType);
       else {
         const isDepFileUntracked = this.processOneDepFile(

--- a/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
+++ b/src/consumer/component/dependencies/dependency-resolver/overrides-dependencies.ts
@@ -1,4 +1,3 @@
-import minimatch from 'minimatch';
 import path from 'path';
 import _ from 'lodash';
 import { ComponentID } from '@teambit/component-id';
@@ -34,20 +33,6 @@ export default class OverridesDependencies {
     this.manuallyRemovedDependencies = {};
     this.manuallyAddedDependencies = {};
     this.missingPackageDependencies = [];
-  }
-
-  // @todo: remove. it's not supported anymore
-  shouldIgnoreFile(file: string, fileType: FileType): boolean {
-    const shouldIgnoreByGlobMatch = (patterns: string[]) => {
-      return patterns.some((pattern) => minimatch(file, pattern));
-    };
-    const field = fileType.isTestFile ? 'devDependencies' : 'dependencies';
-    const ignoreField = this.component.overrides.getIgnoredFiles(field);
-    const ignore = shouldIgnoreByGlobMatch(ignoreField);
-    if (ignore) {
-      this._addManuallyRemovedDep(field, file);
-    }
-    return ignore;
   }
 
   shouldIgnorePackage(packageName: string, fileType: FileType): boolean {

--- a/src/consumer/config/component-overrides.ts
+++ b/src/consumer/config/component-overrides.ts
@@ -1,12 +1,7 @@
 import R from 'ramda';
 import { pickBy } from 'lodash';
 import { ComponentID } from '@teambit/component-id';
-import {
-  MANUALLY_ADD_DEPENDENCY,
-  MANUALLY_REMOVE_DEPENDENCY,
-  OVERRIDE_COMPONENT_PREFIX,
-  OVERRIDE_FILE_PREFIX,
-} from '../../constants';
+import { MANUALLY_ADD_DEPENDENCY, MANUALLY_REMOVE_DEPENDENCY, OVERRIDE_COMPONENT_PREFIX } from '../../constants';
 import { SourceFile } from '../component/sources';
 import ComponentConfig from './component-config';
 import {
@@ -156,23 +151,9 @@ export default class ComponentOverrides {
   getIgnored(field: string): string[] {
     return R.keys(R.filter((dep) => dep === MANUALLY_REMOVE_DEPENDENCY, this.overrides[field] || {}));
   }
-  getIgnoredFiles(field: string): string[] {
-    const ignoredRules = this.getIgnored(field);
-    return ignoredRules
-      .filter((rule) => rule.startsWith(OVERRIDE_FILE_PREFIX))
-      .map((rule) => rule.replace(OVERRIDE_FILE_PREFIX, ''));
-  }
-
   getIgnoredPackages(field: string): string[] {
     const ignoredRules = this.getIgnored(field);
-    return ignoredRules.filter((rule) => !rule.startsWith(OVERRIDE_FILE_PREFIX));
-  }
-  static getAllFilesPaths(overrides: Record<string, any>): string[] {
-    if (!overrides) return [];
-    const allDeps = Object.assign({}, overrides.dependencies, overrides.devDependencies, overrides.peerDependencies);
-    return Object.keys(allDeps)
-      .filter((rule) => rule.startsWith(OVERRIDE_FILE_PREFIX))
-      .map((rule) => rule.replace(OVERRIDE_FILE_PREFIX, ''));
+    return ignoredRules;
   }
   clone(): ComponentOverrides {
     return new ComponentOverrides(R.clone(this.overrides));

--- a/src/consumer/config/consumer-overrides.ts
+++ b/src/consumer/config/consumer-overrides.ts
@@ -1,9 +1,7 @@
-import chalk from 'chalk';
 import R from 'ramda';
 import { ComponentID } from '@teambit/component-id';
-import { DEPENDENCIES_FIELDS, OVERRIDE_FILE_PREFIX } from '../../constants';
+import { DEPENDENCIES_FIELDS } from '../../constants';
 import GeneralError from '../../error/general-error';
-import logger from '../../logger/logger';
 import isBitIdMatchByWildcards from '../../utils/bit/is-bit-id-match-by-wildcards';
 import hasWildcard from '../../utils/string/has-wildcard';
 import { validateUserInputType } from '../../utils/validate-type';
@@ -178,14 +176,6 @@ the following fields are not allowed: ${overridesForbiddenFields.join(', ')}.`);
       validateUserInputType(message, override[field], `overrides.${id}.${field}`, 'object');
       Object.keys(override[field]).forEach((rule) => {
         validateUserInputType(message, override[field][rule], `overrides.${id}.${field}.${rule}`, 'string');
-        if (rule.startsWith(OVERRIDE_FILE_PREFIX)) {
-          // @todo: once v15 is out, this warning should be replaced by an error
-          logger.console(
-            chalk.yellow(
-              `warning: file overrides (using "${OVERRIDE_FILE_PREFIX}") is deprecated and will be removed on the next major version`
-            )
-          );
-        }
       });
     }
     function validateEnv(override: Record<string, any>, id: string) {


### PR DESCRIPTION
In the past it was possible to add to the "overrides" section a file-override (with `file://` prefix). It's not supported since Harmony.