### PR TITLE
Remove commented out envs from generator prop (workspace.jsonc)

### DIFF
--- a/scopes/harmony/config/workspace-template.jsonc
+++ b/scopes/harmony/config/workspace-template.jsonc
@@ -38,19 +38,6 @@
   },
 
   /**
-   * comment in to include generator templates in your workspace.
-   * browse more dev environments: https://bit.dev/docs/getting-started/composing/dev-environments
-  **/
-  // "teambit.generator/generator": {
-  //   "envs": [
-  //     "teambit.node/node",
-  //     "bitdev.react/react-env",
-  //     "bitdev.vue/vue-env",
-  //     "bitdev.angular/angular-env"
-  //   ]
-  // },
-
-  /**
    * main configuration for component dependency resolution.
    **/
   "teambit.dependencies/dependency-resolver": {


### PR DESCRIPTION
## Proposed Changes

Remove commented-out envs from the generator prop.
These are not needed as they are part of the core envs now (and can be added manually in the starters)

