### PR TITLE
fix(Overview): handle legacy comps and errors in docs app

### DIFF
--- a/scopes/docs/docs/overview/overview.tsx
+++ b/scopes/docs/docs/overview/overview.tsx
@@ -47,8 +47,12 @@ export function Overview({ titleBadges, overviewOptions, previewProps, getEmptyS
   const EmptyState = getEmptyState && getEmptyState();
   const buildFailed = component.buildStatus?.toLowerCase() !== 'succeed' && component?.host === 'teambit.scope/scope';
   const isScaling = Boolean(component.preview?.isScaling);
+  const includesEnvTemplate = Boolean(component.preview?.includesEnvTemplate);
+  const calcDefaultLoadingState = React.useCallback(() => {
+    return isScaling && !includesEnvTemplate;
+  }, [isScaling, includesEnvTemplate]);
 
-  const [isLoading, setLoading] = useState(() => isScaling);
+  const [isLoading, setLoading] = useState(calcDefaultLoadingState);
 
   const iframeQueryParams = `skipIncludes=${component.preview?.skipIncludes || 'false'}`;
 
@@ -65,10 +69,10 @@ export function Overview({ titleBadges, overviewOptions, previewProps, getEmptyS
     [onLoad]
   );
 
-  // reset the loading flag when components are swiched or turn it off if the component is not scaling
   React.useEffect(() => {
-    if (!isLoading && isScaling) setLoading(true);
-    if (isLoading && !isScaling) setLoading(false);
+    const defaultLoadingState = calcDefaultLoadingState();
+    if (!isLoading && defaultLoadingState) setLoading(true);
+    if (isLoading && !defaultLoadingState) setLoading(false);
   }, [component.id.toString(), isScaling]);
 
   return (

--- a/scopes/docs/docs/overview/overview.tsx
+++ b/scopes/docs/docs/overview/overview.tsx
@@ -48,11 +48,11 @@ export function Overview({ titleBadges, overviewOptions, previewProps, getEmptyS
   const buildFailed = component.buildStatus?.toLowerCase() !== 'succeed' && component?.host === 'teambit.scope/scope';
   const isScaling = Boolean(component.preview?.isScaling);
   const includesEnvTemplate = Boolean(component.preview?.includesEnvTemplate);
-  const calcDefaultLoadingState = React.useCallback(() => {
+  const defaultLoadingState = React.useMemo(() => {
     return isScaling && !includesEnvTemplate;
   }, [isScaling, includesEnvTemplate]);
 
-  const [isLoading, setLoading] = useState(calcDefaultLoadingState);
+  const [isLoading, setLoading] = useState(defaultLoadingState);
 
   const iframeQueryParams = `skipIncludes=${component.preview?.skipIncludes || 'false'}`;
 
@@ -70,10 +70,9 @@ export function Overview({ titleBadges, overviewOptions, previewProps, getEmptyS
   );
 
   React.useEffect(() => {
-    const defaultLoadingState = calcDefaultLoadingState();
     if (!isLoading && defaultLoadingState) setLoading(true);
     if (isLoading && !defaultLoadingState) setLoading(false);
-  }, [component.id.toString(), isScaling, includesEnvTemplate]);
+  }, [component.id.toString(), defaultLoadingState]);
 
   return (
     <div className={styles.overviewWrapper} key={`${component.id.toString()}`}>

--- a/scopes/docs/docs/overview/overview.tsx
+++ b/scopes/docs/docs/overview/overview.tsx
@@ -73,7 +73,7 @@ export function Overview({ titleBadges, overviewOptions, previewProps, getEmptyS
     const defaultLoadingState = calcDefaultLoadingState();
     if (!isLoading && defaultLoadingState) setLoading(true);
     if (isLoading && !defaultLoadingState) setLoading(false);
-  }, [component.id.toString(), isScaling]);
+  }, [component.id.toString(), isScaling, includesEnvTemplate]);
 
   return (
     <div className={styles.overviewWrapper} key={`${component.id.toString()}`}>

--- a/scopes/react/ui/docs/properties-table/properties-table.tsx
+++ b/scopes/react/ui/docs/properties-table/properties-table.tsx
@@ -12,7 +12,11 @@ export function PropertiesTable({ componentId, ...rest }: PropertiesTableProps) 
   const { loading, error, data } = useFetchDocs(componentId);
 
   if (!data || loading) return null;
-  if (error) throw error;
+  if (error) {
+    // eslint-disable-next-line no-console
+    console.error(`failed to fetch docs for ${componentId} in PropertiesTable`, error);
+    return null;
+  }
 
   const { properties } = data.docs;
 


### PR DESCRIPTION
This PR fixes the following issues

1. The iframe not handling errors correctly. Previously, it would throw an error which makes it impossible to detect in the host app, resulting in an infinite loader. This PR updates the PropertiesTable to just log the error and render nothing instead. 
2. Hiding the loader if includesEnvTemplate is true. This handles corrupted preview data for legacy components, where isScaling gets incorrectly calculated as true but the preview was bundled with env