### PR TITLE
disable Ctrl+C during export once started sending objects

### DIFF
--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -528,6 +528,11 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       });
     };
 
+    process.on('SIGINT', () => {
+      this.logger.consoleWarning(
+        `unable to cancel the export process at this point because the communication with the remote already started`
+      );
+    });
     let centralHubResults;
     if (resumeExportId) {
       const remotes = manyObjectsPerRemote.map((o) => o.remote);

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -528,11 +528,12 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       });
     };
 
-    process.on('SIGINT', () => {
+    const warnCancelExport = () => {
       this.logger.consoleWarning(
         `unable to cancel the export process at this point because the communication with the remote already started`
       );
-    });
+    };
+    process.on('SIGINT', warnCancelExport);
     let centralHubResults;
     if (resumeExportId) {
       const remotes = manyObjectsPerRemote.map((o) => o.remote);
@@ -547,6 +548,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
 
     loader.start('updating data locally...');
     const results = await updateLocalObjects(laneObject);
+    process.removeListener('SIGINT', warnCancelExport);
     return {
       newIdsOnRemote: R.flatten(results.map((r) => r.newIdsOnRemote)),
       exported: ComponentIdList.uniqFromArray(R.flatten(results.map((r) => r.exported))),


### PR DESCRIPTION
Otherwise, the user is under the impression that the export was cancelled while in fact the remote started processing the data. 