### PR TITLE
deprecate ExtensionDataEntry.newExtensionId

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -97,8 +97,8 @@ export function updateDependenciesVersions(
   }
 
   function updateExtension(extension: ExtensionDataEntry) {
-    if (extension.newExtensionId && extension.extensionId) {
-      const resolvedVersion = resolveVersion(extension.newExtensionId);
+    if (extension.extensionId) {
+      const resolvedVersion = resolveVersion(extension.extensionId);
       if (resolvedVersion) {
         extension.extensionId = extension.extensionId.changeVersion(resolvedVersion);
       }

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -678,10 +678,10 @@ export class EnvsMain {
     // we search in the component aspect list a matching aspect which is match the id from the teambit.envs/envs
     if (envIdFromEnvsConfigWithoutVersion) {
       const matchedEntry = extensions.find((extension) => {
-        if (extension.newExtensionId) {
+        if (extension.extensionId) {
           return (
-            envIdFromEnvsConfigWithoutVersion === extension.newExtensionId.toString() ||
-            envIdFromEnvsConfigWithoutVersion === extension.newExtensionId.toString({ ignoreVersion: true })
+            envIdFromEnvsConfigWithoutVersion === extension.extensionId.toString() ||
+            envIdFromEnvsConfigWithoutVersion === extension.extensionId.toString({ ignoreVersion: true })
           );
         }
         return envIdFromEnvsConfigWithoutVersion === extension.stringId;
@@ -692,9 +692,8 @@ export class EnvsMain {
     // in case there is no config in teambit.envs/envs search the aspects for the first env that registered as env
     const ids: string[] = [];
     extensions.forEach((extension) => {
-      if (extension.newExtensionId) {
-        ids.push(extension.newExtensionId.toString());
-        // ids.push(extension.newExtensionId.toString({ ignoreVersion: true }));
+      if (extension.extensionId) {
+        ids.push(extension.extensionId.toString());
       } else {
         ids.push(extension.stringId);
       }
@@ -727,10 +726,10 @@ export class EnvsMain {
     // we search in the component aspect list a matching aspect which is match the id from the teambit.envs/envs
     if (envIdFromEnvsConfigWithoutVersion) {
       const matchedEntry = extensions.find((extension) => {
-        if (extension.newExtensionId) {
+        if (extension.extensionId) {
           return (
-            envIdFromEnvsConfigWithoutVersion === extension.newExtensionId.toString() ||
-            envIdFromEnvsConfigWithoutVersion === extension.newExtensionId.toString({ ignoreVersion: true })
+            envIdFromEnvsConfigWithoutVersion === extension.extensionId.toString() ||
+            envIdFromEnvsConfigWithoutVersion === extension.extensionId.toString({ ignoreVersion: true })
           );
         }
         return envIdFromEnvsConfigWithoutVersion === extension.stringId;
@@ -757,9 +756,8 @@ export class EnvsMain {
     // in case there is no config in teambit.envs/envs search the aspects for the first env that registered as env
     const ids: string[] = [];
     extensions.forEach((extension) => {
-      if (extension.newExtensionId) {
-        ids.push(extension.newExtensionId.toString());
-        // ids.push(extension.newExtensionId.toString({ ignoreVersion: true }));
+      if (extension.extensionId) {
+        ids.push(extension.extensionId.toString());
       } else {
         ids.push(extension.stringId);
       }
@@ -808,8 +806,8 @@ export class EnvsMain {
   }
 
   private getEnvDefinitionByLegacyExtension(extension: ExtensionDataEntry): EnvDefinition | undefined {
-    const envDef = extension.newExtensionId
-      ? this.getEnvDefinitionById(extension.newExtensionId)
+    const envDef = extension.extensionId
+      ? this.getEnvDefinitionById(extension.extensionId)
       : this.getEnvDefinitionByStringId(extension.stringId);
     return envDef;
   }

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -297,7 +297,6 @@ export class AspectsMerger {
         if (
           (envFromEnvsAspect && e.stringId === envFromEnvsAspect) ||
           (envFromEnvsAspect && e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect) ||
-          (envFromEnvsAspect && e.newExtensionId?.toStringWithoutVersion() === envFromEnvsAspect) ||
           aspectsRegisteredAsEnvs.includes(e.stringId)
         ) {
           return false;

--- a/src/consumer/config/extension-data.ts
+++ b/src/consumer/config/extension-data.ts
@@ -29,6 +29,9 @@ export class ExtensionDataEntry {
     public name?: string,
     public rawConfig: ExtensionConfig = {},
     public data: { [key: string]: any } = {},
+    /**
+     * @deprecated use extensionId instead (it's the same)
+     */
     public newExtensionId?: ComponentID
   ) {}
 


### PR DESCRIPTION
It was needed in the past when `extensionId` was `BitId`. Currently, it's `ComponentID`, so it's the same as `newExtensionId`.