### PR TITLE
fix(create), restore LoadDeps hook after loading bit from the global scope

### DIFF
--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -8,7 +8,7 @@ import WorkspaceConfigFilesAspect, { WorkspaceConfigFilesMain } from '@teambit/w
 import ComponentAspect, { ComponentID } from '@teambit/component';
 import type { ComponentMain, Component } from '@teambit/component';
 
-import { isCoreAspect, loadBit } from '@teambit/bit';
+import { isCoreAspect, loadBit, restoreGlobals } from '@teambit/bit';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import GitAspect, { GitMain } from '@teambit/git';
 import { BitError } from '@teambit/bit-error';
@@ -200,6 +200,8 @@ export class GeneratorMain {
     const remoteEnvsAspect = globalScopeHarmony.get<EnvsMain>(EnvsAspect.id);
     const aspect = components[0];
     const fullAspectId = aspect.id.toString();
+    restoreGlobals();
+
     return { remoteGenerator, fullAspectId, remoteEnvsAspect, aspect };
   }
 

--- a/scopes/harmony/bit/index.ts
+++ b/scopes/harmony/bit/index.ts
@@ -5,4 +5,4 @@ export { manifestsMap, isCoreAspect, getAllCoreAspectsIds } from './manifests';
 export { registerCoreExtensions } from './bit.main.runtime';
 export { BitAspect } from './bit.aspect';
 export type { BitMain } from './bit.main.runtime';
-export { loadBit } from './load-bit';
+export { loadBit, restoreGlobals } from './load-bit';

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -272,6 +272,8 @@ export async function runCLI() {
   await cli.run(hasWorkspace);
 }
 
+const globalsState: Record<string, any> = {};
+
 /**
  * loadBit may gets called multiple times (currently, it's happening during e2e-tests that call loadBit).
  * when it happens, the static methods in this function still have the callbacks that were added in
@@ -288,6 +290,7 @@ function clearGlobalsIfNeeded() {
   ComponentConfig.componentConfigLegacyLoadingRegistry = {};
   ComponentConfig.componentConfigLoadingRegistry = {};
   PackageJsonTransformer.packageJsonTransformersRegistry = [];
+  globalsState.loadDeps = ComponentLoader.loadDeps;
   // @ts-ignore
   ComponentLoader.loadDeps = undefined;
   ExtensionDataList.coreExtensionsNames = new Map();
@@ -299,4 +302,8 @@ function clearGlobalsIfNeeded() {
   // @ts-ignore
   WorkspaceConfig.workspaceConfigLoadingRegistry = undefined;
   ExternalActions.externalActions = [];
+}
+
+export function restoreGlobals() {
+  if (globalsState.loadDeps) ComponentLoader.loadDeps = globalsState.loadDeps;
 }


### PR DESCRIPTION
`loadDeps` hook is registered when Dependencies aspect is instantiated. The issue was that during `bit create`, we load another instance of bit from the global scope. When this `loadBit` is happening, it creates a new instance of Harmony and all aspects, including Dependencies aspect. In this Harmony instance, there is no Workspace because it is loaded from a global scope, hence the new registration of the `loadDeps` takes place without workspace, which fails any component load afterwards originated from the original Harmony instance. 
These ugly Globals hooks will be removed once Legacy is gone. Until then they keep bite us here and there.