### PR TITLE
fix(import), write refs of remote lanes during import even when no comp was imported

### DIFF
--- a/e2e/commands/untag.e2e.2.ts
+++ b/e2e/commands/untag.e2e.2.ts
@@ -24,7 +24,7 @@ describe('bit reset command', function () {
     });
     describe('with one version', () => {
       before(() => {
-        helper.command.untag('bar/foo', true);
+        helper.command.reset('bar/foo', true);
       });
       it('should delete the entire component from the model', () => {
         const output = helper.command.listLocalScope();
@@ -39,7 +39,7 @@ describe('bit reset command', function () {
         // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
         expect(catComponent.versions).to.have.property('0.0.2');
 
-        helper.command.untag('bar/foo', true);
+        helper.command.reset('bar/foo', true);
       });
       it('should delete only the specified tag', () => {
         const catComponent = helper.command.catComponent('bar/foo');
@@ -73,7 +73,7 @@ describe('bit reset command', function () {
           // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
           expect(catComponent.versions).to.have.property('0.0.2');
 
-          helper.command.untag('bar/foo');
+          helper.command.reset('bar/foo');
         });
         it('should delete the entire component from the model', () => {
           const output = helper.command.listLocalScope();
@@ -94,7 +94,7 @@ describe('bit reset command', function () {
       });
       describe('untagging without version', () => {
         before(() => {
-          helper.command.untag('bar/foo');
+          helper.command.reset('bar/foo');
         });
         it('should delete only the local tag and leave the exported tag', () => {
           const catComponent = helper.command.catComponent('bar/foo');
@@ -107,7 +107,7 @@ describe('bit reset command', function () {
     });
     describe('when tagging non-existing component', () => {
       it('should show an descriptive error', () => {
-        const resetFunc = () => helper.command.untag('non-exist-scope/non-exist-comp');
+        const resetFunc = () => helper.command.reset('non-exist-scope/non-exist-comp');
         const error = new MissingBitMapComponent('non-exist-scope/non-exist-comp');
         helper.general.expectToThrow(resetFunc, error);
       });
@@ -132,7 +132,7 @@ describe('bit reset command', function () {
     describe('without specifying a version', () => {
       let untagOutput;
       before(() => {
-        untagOutput = helper.command.untagAll();
+        untagOutput = helper.command.resetAll();
       });
       it('should display a descriptive successful message', () => {
         expect(untagOutput).to.have.string('2 component(s) were untagged');
@@ -148,7 +148,7 @@ describe('bit reset command', function () {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
         helper.command.tagIncludeUnmodified('0.0.5');
-        untagOutput = helper.command.untagAll('--head');
+        untagOutput = helper.command.resetAll('--head');
       });
       it('should display a descriptive successful message', () => {
         expect(untagOutput).to.have.string('3 component(s) were untagged');
@@ -178,7 +178,7 @@ describe('bit reset command', function () {
         let untagOutput;
         before(() => {
           try {
-            helper.command.untag('utils/is-type');
+            helper.command.reset('utils/is-type');
           } catch (err: any) {
             untagOutput = err.message;
           }
@@ -192,7 +192,7 @@ describe('bit reset command', function () {
       describe('with force flag', () => {
         let untagOutput;
         before(() => {
-          untagOutput = helper.command.untag('utils/is-type', undefined, '--force');
+          untagOutput = helper.command.reset('utils/is-type', undefined, '--force');
         });
         it('should untag successfully', () => {
           expect(untagOutput).to.have.string('1 component(s) were untagged');
@@ -207,7 +207,7 @@ describe('bit reset command', function () {
           helper.command.export();
           helper.command.tagIncludeUnmodified('1.0.5');
           try {
-            output = helper.command.untag('utils/is-type');
+            output = helper.command.reset('utils/is-type');
           } catch (err: any) {
             output = err.message;
           }
@@ -221,7 +221,7 @@ describe('bit reset command', function () {
       describe('when all components have only local versions', () => {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScope);
-          helper.command.untagAll();
+          helper.command.resetAll();
         });
         it('should remove all the components because it does not leave a damaged component without dependency', () => {
           const output = helper.command.listLocalScope();
@@ -233,7 +233,7 @@ describe('bit reset command', function () {
       let untagOutput;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
-        untagOutput = helper.command.untag('utils/is-string');
+        untagOutput = helper.command.reset('utils/is-string');
       });
       it('should untag successfully the dependent', () => {
         expect(untagOutput).to.have.string('1 component(s) were untagged');
@@ -260,7 +260,7 @@ describe('bit reset command', function () {
       describe('untag using the id without scope-name', () => {
         let output;
         before(() => {
-          output = helper.command.untag('utils/is-string');
+          output = helper.command.reset('utils/is-string');
         });
         it('should untag successfully', () => {
           expect(output).to.have.string('1 component(s) were untagged');
@@ -272,7 +272,7 @@ describe('bit reset command', function () {
           helper.scopeHelper.getClonedLocalScope(scopeAfterImport);
           helper.fs.modifyFile('components/utils/is-string/is-string.js');
           helper.command.tagAllWithoutBuild('--ignore-issues "*"');
-          helper.command.untagAll();
+          helper.command.resetAll();
         });
         it('should show the component as modified', () => {
           const output = helper.command.runCmd('bit status');
@@ -292,7 +292,7 @@ describe('bit reset command', function () {
       helper.command.tagWithoutBuild();
       const isDeprecated = helper.command.isDeprecated('comp1');
       expect(isDeprecated).to.be.true; // intermediate step.
-      helper.command.untagAll();
+      helper.command.resetAll();
     });
     it('bit reset should leave the config as they were before the tag', () => {
       const isDeprecated = helper.command.isDeprecated('comp1');

--- a/e2e/flows/id-with-wildcard.e2e.2.ts
+++ b/e2e/flows/id-with-wildcard.e2e.2.ts
@@ -200,7 +200,7 @@ describe('component id with wildcard', function () {
       describe('when wildcard match some of the components', () => {
         let output;
         before(() => {
-          output = helper.command.untag('"*/is/*"');
+          output = helper.command.reset('"*/is/*"');
         });
         it('should indicate the untagged components', () => {
           expect(output).to.have.string('2 component(s) were untagged');

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -220,7 +220,7 @@ describe('components that are not synced between the scope and the consumer', fu
       helper.fixtures.tagComponentBarFoo();
       helper.command.tagIncludeUnmodified('2.0.0');
       const bitMap = helper.bitMap.read();
-      helper.command.untag('bar/foo', true);
+      helper.command.reset('bar/foo', true);
       helper.bitMap.write(bitMap);
       scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
     });

--- a/e2e/functionalities/components-index.e2e.2.ts
+++ b/e2e/functionalities/components-index.e2e.2.ts
@@ -130,7 +130,7 @@ describe('scope components index mechanism', function () {
         helper.fixtures.addComponentBarFooAsDir();
         helper.command.tagAllWithoutBuild();
         const indexJsonWithBarFoo = helper.general.getComponentsFromIndexJson();
-        helper.command.untag('bar/foo');
+        helper.command.reset('bar/foo');
         helper.general.writeIndexJson(indexJsonWithBarFoo);
         // now, index.json has barFoo, however the scope doesn't have it
       });

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -101,7 +101,7 @@ describe('custom env', function () {
       });
       // previously it used to throw "error: component "node-env@0.0.1" was not found."
       it('should untag successfully', () => {
-        expect(() => helper.command.untag('--all')).to.not.throw();
+        expect(() => helper.command.reset('--all')).to.not.throw();
       });
     });
     describe('out-of-sync scenario where the id is changed during the process', () => {

--- a/e2e/harmony/export-harmony.e2e.ts
+++ b/e2e/harmony/export-harmony.e2e.ts
@@ -58,7 +58,7 @@ describe('export functionality on Harmony', function () {
       // before it used to throw VersionNotFound
       helper.fixtures.populateComponents(1, undefined, '-v3');
       helper.command.tagAllWithoutBuild();
-      expect(() => helper.command.untag('comp1')).not.to.throw();
+      expect(() => helper.command.reset('comp1')).not.to.throw();
     });
   });
   describe.skip('export to multiple scope with circular between the scopes', () => {

--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -27,7 +27,7 @@ describe('bit reset when on lane', function () {
       headOnLane = helper.command.getHeadOfLane('dev', 'comp1');
       helper.command.switchLocalLane('main');
       helper.command.mergeLane('dev');
-      helper.command.untagAll();
+      helper.command.resetAll();
     });
     it('should not delete the head of the lane', () => {
       expect(() => helper.command.catObject(headOnLane)).to.not.throw();
@@ -47,7 +47,7 @@ describe('bit reset when on lane', function () {
       helper.command.snapAllComponentsWithoutBuild('--unmodified');
     });
     it('bit reset should not throw', () => {
-      expect(() => helper.command.untagAll()).to.not.throw();
+      expect(() => helper.command.resetAll()).to.not.throw();
     });
   });
   // this state is now impossible because we blocked the option to create a lane when there are
@@ -66,7 +66,7 @@ describe('bit reset when on lane', function () {
       expect(status.stagedComponents[0].versions).to.have.lengthOf(2);
     });
     it('bit reset should reset the component to new', () => {
-      expect(() => helper.command.untagAll()).to.not.throw();
+      expect(() => helper.command.resetAll()).to.not.throw();
       const status = helper.command.statusJson();
       expect(status.newComponents).to.have.lengthOf(1);
     });
@@ -86,7 +86,7 @@ describe('bit reset when on lane', function () {
       expect(status.stagedComponents[0].versions).to.have.lengthOf(1);
     });
     it('bit reset should not throw', () => {
-      expect(() => helper.command.untagAll()).to.not.throw();
+      expect(() => helper.command.resetAll()).to.not.throw();
     });
   });
   describe('reset on a new lane after merging from another lane', () => {
@@ -110,7 +110,7 @@ describe('bit reset when on lane', function () {
     // it is similar to running git-reset without specifying any origin and expecting all the local commits to be removed.
     // there is no way to know what should be the new head)
     it('bit reset should throw a descriptive error suggesting either removing the component or the lane', () => {
-      expect(() => helper.command.untagAll()).to.throw();
+      expect(() => helper.command.resetAll()).to.throw();
     });
   });
   describe('reset after merge where it snapped multiple snaps on the other lane', () => {
@@ -136,7 +136,7 @@ describe('bit reset when on lane', function () {
     });
     // previously, it was throwing VersionNotFound error as it doesn't have the version objects snapped on the other lane
     it('bit reset should not throw', () => {
-      expect(() => helper.command.untagAll()).not.to.throw();
+      expect(() => helper.command.resetAll()).not.to.throw();
     });
   });
 });

--- a/e2e/harmony/lanes/diverged-from-remote-lane.e2e.ts
+++ b/e2e/harmony/lanes/diverged-from-remote-lane.e2e.ts
@@ -32,7 +32,7 @@ describe('local is diverged from the remote', function () {
       expect(status.mergePendingComponents).to.have.lengthOf(1);
     });
     it('bit reset should not throw', () => {
-      expect(() => helper.command.untagAll()).to.not.throw();
+      expect(() => helper.command.resetAll()).to.not.throw();
     });
   });
   describe('import first then snap', () => {

--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -429,7 +429,7 @@ describe('merge lanes', function () {
         // previously it was throwing:
         // removeComponentVersions found multiple parents for a local (un-exported) version 368fb583865af40a8823d2ac1d556f4b65582ba2 of iw4j2eko-remote/comp1
         it('bit reset should not throw', () => {
-          expect(() => helper.command.untagAll()).to.not.throw();
+          expect(() => helper.command.resetAll()).to.not.throw();
         });
       });
       describe('switching to main and merging the lane to main (with squash)', () => {

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -119,7 +119,7 @@ describe('bit snap command', function () {
     });
     describe('untag the head snap', () => {
       before(() => {
-        helper.command.untag(`bar/foo`, true);
+        helper.command.reset(`bar/foo`, true);
       });
       it('should change the head to the first snap', () => {
         const compAfterUntag = helper.command.catComponent('bar/foo');
@@ -465,7 +465,7 @@ describe('bit snap command', function () {
             helper.scopeHelper.getClonedLocalScope(scopeWithConflicts);
             // change it so the file would be valid without conflicts marks
             helper.fixtures.createComponentBarFoo('');
-            helper.command.untag('bar/foo');
+            helper.command.reset('bar/foo');
           });
           it('bit status should not show the component as a component with conflicts but as modified', () => {
             const status = helper.command.statusJson();
@@ -717,7 +717,7 @@ describe('bit snap command', function () {
       });
       describe('reset all local versions', () => {
         before(() => {
-          helper.command.untagAll();
+          helper.command.resetAll();
         });
         it('should change the head to point to the parent of the untagged version not to the remote head', () => {
           const head = helper.command.getHead('comp1');
@@ -735,7 +735,7 @@ describe('bit snap command', function () {
       describe('reset only head', () => {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(beforeUntag);
-          helper.command.untagAll('--head');
+          helper.command.resetAll('--head');
         });
         it('should change the head to point to the parent of the head and not to the remote head', () => {
           const head = helper.command.getHead('comp1');

--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -177,7 +177,7 @@ describe('tag components on Harmony', function () {
     describe('untag', () => {
       before(() => {
         helper.command.softTag('-a -s 3.0.0');
-        helper.command.untagSoft('--all');
+        helper.command.resetSoft('--all');
       });
       it('should remove the nextVersion from the .bitmap file', () => {
         const bitMap = helper.bitMap.readComponentsMapOnly();

--- a/e2e/harmony/untag-harmony.e2e.ts
+++ b/e2e/harmony/untag-harmony.e2e.ts
@@ -29,7 +29,7 @@ describe('untag components on Harmony', function () {
     });
     // before, it was throwing: "error: version "0.0.1" of component scope/comp1 was not found"
     it('should untag successfully with no errors', () => {
-      expect(() => helper.command.untagAll()).not.to.throw();
+      expect(() => helper.command.resetAll()).not.to.throw();
     });
   });
   describe('untagging multiple versions', () => {
@@ -38,7 +38,7 @@ describe('untag components on Harmony', function () {
       helper.fixtures.populateComponents(1);
       helper.command.tagIncludeUnmodifiedWithoutBuild(); // 0.0.1
       helper.command.tagIncludeUnmodifiedWithoutBuild(); // 0.0.2
-      helper.command.untagAll();
+      helper.command.resetAll();
     });
     // a previous bug saved the hash of 0.0.1 as the head, which made the component both: staged and snapped.
     it('should show the component as new only, not as staged nor snapped', () => {
@@ -53,7 +53,7 @@ describe('untag components on Harmony', function () {
       helper.command.export();
       helper.command.tagIncludeUnmodifiedWithoutBuild(); // 0.0.2
       helper.command.tagIncludeUnmodifiedWithoutBuild(); // 0.0.3
-      helper.command.untagAll();
+      helper.command.resetAll();
     });
     // a previous bug saved the hash of 0.0.2 as the head.
     it('bit status should be clean', () => {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -419,13 +419,13 @@ export default class CommandHelper {
     if (!artifacts) throw new Error(`unable to find artifacts data for ${id}`);
     return artifacts;
   }
-  untag(id: string, head = false, flag = '') {
+  reset(id: string, head = false, flag = '') {
     return this.runCmd(`bit reset ${id} ${head ? '--head' : ''} ${flag}`);
   }
-  untagAll(options = '') {
+  resetAll(options = '') {
     return this.runCmd(`bit reset ${options} --all`);
   }
-  untagSoft(id: string) {
+  resetSoft(id: string) {
     return this.runCmd(`bit reset ${id} --soft`);
   }
   exportIds(ids: string, flags = '', assert = true) {

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -99,6 +99,8 @@ ${failedScopesErr.join('\n')}`);
     if (totalComponents) {
       await this.mergeAndPersistComponents(multipleComponentsMerger);
     }
+    // even when no component has updated, we need to write the refs we got from the remote lanes
+    await this.repo.writeRemoteLanes();
     logger.debug(`[-] fetchFromRemoteAndWrite, completed writing ${totalComponents} components`);
 
     return objectsQueue.addedHashes;
@@ -128,7 +130,6 @@ ${failedScopesErr.join('\n')}`);
         );
       })
     );
-    await this.repo.writeRemoteLanes();
   }
 
   private async fetchFromSingleRemote(scopeName: string, ids: string[]): Promise<ObjectItemsStream | null> {


### PR DESCRIPTION
The issue this PR fixes is when export fails, user resets and re-snap, then `bit import` doesn't write the "ref" file of that lane, which result in `bit status` doesn't show the components as merge-pending.