### PR TITLE
fix(checkout-reset), bring a component back if locally deleted

### DIFF
--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -78,4 +78,24 @@ describe('bit delete command', function () {
       });
     });
   });
+  describe('bit checkout reset after local delete', () => {
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.softRemoveComponent('comp1');
+
+      // make sure it's deleted
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(2);
+
+      helper.command.checkoutReset('--all');
+    });
+    it('should bring the component back', () => {
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(3);
+    });
+  });
 });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -45,6 +45,7 @@ export type CheckoutProps = {
   skipUpdatingBitmap?: boolean; // needed for stash
   restoreMissingComponents?: boolean; // in case .bitmap has a component and it's missing from the workspace, restore it (from model)
   allowAddingComponentsFromScope?: boolean; // in case the id doesn't exist in .bitmap, add it from the scope (relevant for switch)
+  includeLocallyDeleted?: boolean; // include components that were deleted locally. currently enabled for "bit checkout reset" only.
 };
 
 export type ComponentStatusBeforeMergeAttempt = ComponentStatusBase & {
@@ -279,9 +280,23 @@ export class CheckoutMain {
     if (checkoutProps.revert) {
       checkoutProps.skipUpdatingBitmap = true;
     }
-    const idsOnWorkspace = componentPattern
-      ? await this.workspace.idsByPattern(componentPattern)
-      : await this.workspace.listIds();
+    if (checkoutProps.reset) {
+      checkoutProps.includeLocallyDeleted = true;
+    }
+
+    const getIds = async () => {
+      if (componentPattern) {
+        return this.workspace.idsByPattern(componentPattern, true, {
+          includeDeleted: checkoutProps.includeLocallyDeleted,
+        });
+      }
+      return checkoutProps.includeLocallyDeleted
+        ? this.workspace.listIdsIncludeRemoved()
+        : await this.workspace.listIds();
+    };
+
+    const idsOnWorkspace = await getIds();
+
     const currentLane = await this.workspace.consumer.getCurrentLaneObject();
     const currentLaneIds = currentLane?.toBitIds();
     const ids = currentLaneIds ? idsOnWorkspace.filter((id) => currentLaneIds.hasWithoutVersion(id)) : idsOnWorkspace;
@@ -319,7 +334,11 @@ export class CheckoutMain {
     let existingBitMapId = consumer.bitMap.getComponentIdIfExist(id, { ignoreVersion: true });
     const getComponent = async () => {
       try {
-        return await consumer.loadComponent(id);
+        const results = await consumer.loadComponents(ComponentIdList.fromArray([id]));
+        if (results.components[0]) return results.components[0];
+        if (checkoutProps.includeLocallyDeleted && results.removedComponents[0]) {
+          return results.removedComponents[0];
+        }
       } catch (err) {
         if (checkoutProps.allowAddingComponentsFromScope && !existingBitMapId) return undefined;
         throw err;
@@ -400,7 +419,8 @@ export class CheckoutMain {
       const currentVersionObject: Version = await componentModel.loadVersion(currentlyUsedVersion, repo);
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       isModified = await consumer.isComponentModified(currentVersionObject, component!);
-      if (!isModified && reset) {
+      const isRemoved = component && component.isRemoved();
+      if (!isModified && !isRemoved && reset) {
         return returnFailure(`component ${id.toStringWithoutVersion()} is not modified`, true);
       }
     }


### PR DESCRIPTION
Currently, if a component was deleted (`bit delete`) before snapping/tagging, the `bit checkout reset` doesn't change it. This PR brings those components back to the workspace.