### PR TITLE
fix(recover), fix recovevering a local deleted component when it is also diverged

### DIFF
--- a/e2e/harmony/recover.e2e.ts
+++ b/e2e/harmony/recover.e2e.ts
@@ -2,7 +2,6 @@ import { IssuesClasses } from '@teambit/component-issues';
 import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import { Extensions } from '../../src/constants';
-import { help } from 'yargs';
 
 chai.use(require('chai-fs'));
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -134,6 +134,8 @@ export class RemoveMain {
    * recover a soft-removed component.
    * there are 4 different scenarios.
    * 1. a component was just soft-removed, it wasn't snapped yet.  so it's now in .bitmap with the "removed" aspect entry.
+   * 1.a. the component still exists in the local scope. no need to import. write it from there.
+   * 1.b. the component doesn't exist in the local scope. import it.
    * 2. soft-removed and then snapped. It's not in .bitmap now.
    * 3. soft-removed, snapped, exported. it's not in .bitmap now.
    * 4. a soft-removed components was imported, so it's now in .bitmap without the "removed" aspect entry.
@@ -160,8 +162,17 @@ export class RemoveMain {
     if (bitMapEntry) {
       if (bitMapEntry.config?.[RemoveAspect.id]) {
         // case #1
-        delete bitMapEntry.config?.[RemoveAspect.id];
-        await importComp(bitMapEntry.id.toString());
+        const compFromScope = await this.workspace.scope.get(bitMapEntry.id);
+        if (compFromScope) {
+          // in the case the component is in the scope, we prefer to write it from the scope rather than import it.
+          // because in some cases the "import" throws an error, e.g. when the component is diverged.
+          await this.workspace.write(compFromScope, bitMapEntry.rootDir);
+          this.workspace.bitMap.removeComponentConfig(bitMapEntry.id, RemoveAspect.id, false);
+          await this.workspace.bitMap.write('recover');
+        } else {
+          delete bitMapEntry.config?.[RemoveAspect.id];
+          await importComp(bitMapEntry.id.toString());
+        }
         return true;
       }
       // case #4


### PR DESCRIPTION
Currently, it tries to import it and then throw an error about the component being diverged. 
In this PR, instead of importing it, it tries to get it from the local scope first.