### PR TITLE
fix(status,checkout-head), fix status to show deleted when merge-pending, fix checkout-head to consider deleted

### DIFF
--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -135,9 +135,8 @@ describe('bit delete command', function () {
       expect(status.locallySoftRemoved).to.have.lengthOf(1);
     });
   });
-  describe('bit checkout head after local delete when it is diverged', () => {
+  describe('deleted component that is also diverged (merge pending)', () => {
     let beforeUpdates: string;
-    let checkoutOutput: string;
     before(() => {
       helper = new Helper();
       helper.scopeHelper.setNewLocalAndRemoteScopes();
@@ -156,16 +155,34 @@ describe('bit delete command', function () {
       const list = helper.command.listParsed();
       expect(list).to.have.lengthOf(2);
 
-      checkoutOutput = helper.general.runWithTryCatch('bit checkout head comp1');
+      helper.command.import();
     });
-    it('should block the checkout as any other diverged component', () => {
-      expect(checkoutOutput).to.have.string('comp1');
-      expect(checkoutOutput).to.have.string('component is merge-pending and cannot be checked out');
+    describe('bit checkout head', () => {
+      let checkoutOutput: string;
+      before(() => {
+        checkoutOutput = helper.general.runWithTryCatch('bit checkout head comp1');
+      });
+      it('should block the checkout as any other diverged component', () => {
+        expect(checkoutOutput).to.have.string('comp1');
+        expect(checkoutOutput).to.have.string('component is merge-pending and cannot be checked out');
+      });
     });
-    it('bit status should show the component as both, deleted and merge-pending', () => {
-      const status = helper.command.statusJson();
-      expect(status.locallySoftRemoved).to.have.lengthOf(1);
-      expect(status.mergePendingComponents).to.have.lengthOf(3);
+    describe('bit status', () => {
+      it('should show the component as both, deleted and merge-pending', () => {
+        const status = helper.command.statusJson();
+        expect(status.locallySoftRemoved).to.have.lengthOf(1);
+        expect(status.mergePendingComponents).to.have.lengthOf(3);
+      });
+    });
+    describe('bit reset', () => {
+      before(() => {
+        helper.command.reset('comp1');
+      });
+      it('should reset the component successfully', () => {
+        const status = helper.command.statusJson();
+        expect(status.mergePendingComponents).to.have.lengthOf(2);
+        expect(status.locallySoftRemoved).to.have.lengthOf(1);
+      });
     });
   });
 });

--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -1,7 +1,10 @@
+import path from 'path';
 import { IssuesClasses } from '@teambit/component-issues';
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import Helper from '../../src/e2e-helper/e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+
+chai.use(require('chai-fs'));
 
 describe('bit delete command', function () {
   let helper: Helper;
@@ -96,6 +99,73 @@ describe('bit delete command', function () {
     it('should bring the component back', () => {
       const list = helper.command.listParsed();
       expect(list).to.have.lengthOf(3);
+    });
+  });
+  describe('bit checkout head after local delete', () => {
+    let beforeUpdates: string;
+    let checkoutOutput: string;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      beforeUpdates = helper.scopeHelper.cloneLocalScope();
+
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(beforeUpdates);
+
+      helper.command.softRemoveComponent('comp1');
+      // make sure it's deleted
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(2);
+
+      checkoutOutput = helper.command.checkoutHead('-x');
+    });
+    it('should checkout also the deleted component same as it checks out any other modified component', () => {
+      expect(checkoutOutput).to.have.string('successfully switched 3 components');
+    });
+    it('should write the deleted component files to the filesystem', () => {
+      const comp1Dir = path.join(helper.scopes.localPath, 'comp1');
+      expect(comp1Dir).to.be.a.directory();
+    });
+    it('bit status should still show the component as deleted', () => {
+      const status = helper.command.statusJson();
+      expect(status.locallySoftRemoved).to.have.lengthOf(1);
+    });
+  });
+  describe('bit checkout head after local delete when it is diverged', () => {
+    let beforeUpdates: string;
+    let checkoutOutput: string;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(3);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      beforeUpdates = helper.scopeHelper.cloneLocalScope();
+
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.scopeHelper.getClonedLocalScope(beforeUpdates);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+
+      helper.command.softRemoveComponent('comp1');
+      // make sure it's deleted
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(2);
+
+      checkoutOutput = helper.general.runWithTryCatch('bit checkout head comp1');
+    });
+    it('should block the checkout as any other diverged component', () => {
+      expect(checkoutOutput).to.have.string('comp1');
+      expect(checkoutOutput).to.have.string('component is merge-pending and cannot be checked out');
+    });
+    it('bit status should show the component as both, deleted and merge-pending', () => {
+      const status = helper.command.statusJson();
+      expect(status.locallySoftRemoved).to.have.lengthOf(1);
+      expect(status.mergePendingComponents).to.have.lengthOf(3);
     });
   });
 });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -280,7 +280,7 @@ export class CheckoutMain {
     if (checkoutProps.revert) {
       checkoutProps.skipUpdatingBitmap = true;
     }
-    if (checkoutProps.reset) {
+    if (checkoutProps.reset || checkoutProps.head) {
       checkoutProps.includeLocallyDeleted = true;
     }
 

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -589,8 +589,8 @@ there are matching among unmodified components thought. consider using --unmodif
         return removeLocalVersionsForAllComponents(consumer, currentLane, head);
       }
       const candidateComponents = await getComponentsWithOptionToUntag(consumer);
-      const idsMatchingPattern = await this.workspace.idsByPattern(componentPattern);
-      const idsMatchingPatternBitIds = ComponentIdList.fromArray(idsMatchingPattern.map((id) => id));
+      const idsMatchingPattern = await this.workspace.idsByPattern(componentPattern, true, { includeDeleted: true });
+      const idsMatchingPatternBitIds = ComponentIdList.fromArray(idsMatchingPattern);
       const componentsToUntag = candidateComponents.filter((modelComponent) =>
         idsMatchingPatternBitIds.hasWithoutVersion(modelComponent.toComponentId())
       );

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -274,7 +274,7 @@ export default class ComponentsList {
   }
 
   async listExportPendingComponentsIds(lane?: Lane | null): Promise<ComponentIdList> {
-    const fromBitMap = this.bitMap.getAllBitIds();
+    const fromBitMap = this.bitMap.getAllIdsAvailableOnLaneIncludeRemoved();
     const modelComponents = await this.getModelComponents();
     const pendingExportComponents = await pFilter(modelComponents, async (component: ModelComponent) => {
       if (!fromBitMap.searchWithoutVersion(component.toComponentId())) {

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -203,18 +203,18 @@ export default class ComponentsList {
     return compact(results);
   }
 
-  async listMergePendingComponents(loadOpts?: ComponentLoadOptions): Promise<DivergedComponent[]> {
+  async listMergePendingComponents(): Promise<DivergedComponent[]> {
     if (!this._mergePendingComponents) {
-      const componentsFromFs = await this.getComponentsFromFS(loadOpts);
+      const allIds = this.bitMap.getAllIdsAvailableOnLaneIncludeRemoved();
       const componentsFromModel = await this.getModelComponents();
       const duringMergeComps = this.listDuringMergeStateComponents();
       this._mergePendingComponents = (
         await Promise.all(
-          componentsFromFs.map(async (component: Component) => {
+          allIds.map(async (componentId: ComponentID) => {
             const modelComponent = componentsFromModel.find((c) =>
-              c.toComponentId().isEqualWithoutVersion(component.componentId)
+              c.toComponentId().isEqualWithoutVersion(componentId)
             );
-            if (!modelComponent || duringMergeComps.hasWithoutVersion(component.componentId)) return null;
+            if (!modelComponent || duringMergeComps.hasWithoutVersion(componentId)) return null;
             const divergedData = await modelComponent.getDivergeDataForMergePending(this.scope.objects);
             if (!divergedData.isDiverged()) return null;
             return { id: modelComponent.toComponentId(), diverge: divergedData };


### PR DESCRIPTION
## Proposed Changes

-  in case a component is both: diverge (merge-pending) and also deleted, `bit status` shows it in both categories. (previously it was showing it only as deleted).
- running `bit checkout head` on deleted component is not ignored anymore. Instead, it is updated to the head while keeping the local change of the removal. So the end result is that the files are the same as the head and it's still locally deleted.
- allow running bit-reset on deleted components (otherwise, if the component is diverged, there is no good way out of this state).