### PR TITLE
add an API to calculate artifacts rootDir

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-list.ts
+++ b/scopes/pipelines/builder/artifact/artifact-list.ts
@@ -44,6 +44,20 @@ export class ArtifactList<T extends Artifact> extends Array<T> {
     return ArtifactList.fromArray(filtered);
   }
 
+  /**
+   * find by the artifact name. it's possible to have multiple artifacts with the same name, in which case it returns the first.
+   */
+  findByName(name: string): Artifact | undefined {
+    return this.find((artifact) => artifact.name === name);
+  }
+
+  /**
+   * find by the task name. it's possible to have multiple tasks with the same name (different aspects), in which case it returns the first.
+   */
+  findByTaskName(name: string): Artifact | undefined {
+    return this.find((artifact) => artifact.task.name === name);
+  }
+
   isEmpty(): boolean {
     return this.every((artifact) => artifact.files.isEmpty());
   }

--- a/scopes/pipelines/builder/artifact/artifact.ts
+++ b/scopes/pipelines/builder/artifact/artifact.ts
@@ -50,6 +50,27 @@ export class Artifact {
     return this.def.generatedBy || this.task.aspectId;
   }
 
+  /**
+   * calculate what could possibly be the root directory of the artifact.
+   * in case the deprecated rootDir is set, use it.
+   * otherwise, get the common first directory of all files.
+   * if there is no common directory, or there are multiple directories return undefined.
+   */
+  get artifactDir(): string | undefined {
+    if (this.def.rootDir) return this.def.rootDir;
+
+    // not sure if needed, it's unclear whether the paths are OS specific or not. (coming from globby).
+    const pathsLinux = this.files.paths.map((p) => p.replace(/\\/g, '/'));
+    // get the common dir of all paths.
+    const firstPath = pathsLinux[0];
+    // it's a file in the root, so there is no shared root directory.
+    if (!firstPath.includes('/')) return undefined;
+    const [potentialSharedDir] = firstPath.split('/');
+    const isSharedDir = pathsLinux.every((p) => p.startsWith(`${potentialSharedDir}/`));
+    if (!isSharedDir) return undefined;
+    return potentialSharedDir;
+  }
+
   isEmpty(): boolean {
     return this.files.isEmpty();
   }


### PR DESCRIPTION
## Proposed Changes

- add `Artifact.artifactDir` API. (a calculation of what is probably the root dir of the artifact).
- add `ArtifactList.findByName` and `ArtifactList.findByTaskName` APIs.

