### PR TITLE
default to not re-fetch missing version history

### DIFF
--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -141,8 +141,13 @@ export default class ScopeComponentsImporter {
       return false;
     });
 
-    const incompleteVersionHistory = await this.getIncompleteVersionHistory(checkForIncompleteHistory);
-    externalsToFetch.push(...incompleteVersionHistory);
+    const shouldRefetchIncompleteHistory = process.env.BIT_FETCH_INCOMPLETE_VERSION_HISTORY;
+
+    let incompleteVersionHistory: ComponentID[] = [];
+    if (shouldRefetchIncompleteHistory) {
+      incompleteVersionHistory = await this.getIncompleteVersionHistory(checkForIncompleteHistory);
+      externalsToFetch.push(...incompleteVersionHistory);
+    }
 
     await this.findMissingExternalsRecursively(
       existingDefs,
@@ -166,7 +171,9 @@ export default class ScopeComponentsImporter {
       reason
     );
 
-    await this.warnForIncompleteVersionHistory(incompleteVersionHistory);
+    if (shouldRefetchIncompleteHistory) {
+      await this.warnForIncompleteVersionHistory(incompleteVersionHistory);
+    }
 
     const versionDeps = await this.bitIdsToVersionDeps(idsToImport, throwForSeederNotFound, preferDependencyGraph);
     logger.debug('importMany, completed!');


### PR DESCRIPTION
Currently, when import is running and a component is found to have an incomplete version-history object, it refetches it. 
This was originally done due to the new importer brings incomplete version history objects. It should be fine now.
If for some reason it's needed, run `BIT_FETCH_INCOMPLETE_VERSION_HISTORY=1 bit import`.

Keep in mind that in some cases, enabling it can cause an issue. e.g. when there is a version conflict and the import process is unable to merge between the `ModelComponent` object of the remote and the local. It also shows the VersionHistory as incomplete inaccurately, the VersionHistory doesn't have the local version. 