### PR TITLE
fix(NewComponentHelper): Sync default component dir creation with import

### DIFF
--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -54,7 +54,7 @@ export class NewComponentHelperMain {
       return pathFromUser;
     }
 
-    return composeComponentPath(componentId.changeScope(componentId.scope), this.workspace.defaultDirectory);
+    return this.workspace.consumer.composeRelativeComponentPath(componentId.changeScope(componentId.scope));
   }
   async writeAndAddNewComp(
     comp: Component,

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -3,7 +3,6 @@ import path from 'path';
 import { BitError } from '@teambit/bit-error';
 import { InvalidScopeName, isValidScopeName } from '@teambit/legacy-bit-id';
 import { MainRuntime } from '@teambit/cli';
-import { composeComponentPath } from '@teambit/legacy/dist/utils/bit/compose-component-path';
 import { Component } from '@teambit/component';
 import TrackerAspect, { TrackerMain } from '@teambit/tracker';
 import { isDirEmpty } from '@teambit/legacy/dist/utils';

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -4,7 +4,7 @@
     "name": "bit",
     "icon": "https://static.bit.dev/bit-logo.svg",
     "defaultScope": "teambit.bit",
-    "defaultDirectory": "components"
+    "defaultDirectory": "{scope}/{name}"
   },
   "teambit.dependencies/dependency-resolver": {
     "packageManager": "teambit.dependencies/pnpm",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -4,7 +4,7 @@
     "name": "bit",
     "icon": "https://static.bit.dev/bit-logo.svg",
     "defaultScope": "teambit.bit",
-    "defaultDirectory": "{scope}/{name}"
+    "defaultDirectory": "components"
   },
   "teambit.dependencies/dependency-resolver": {
     "packageManager": "teambit.dependencies/pnpm",


### PR DESCRIPTION
This PR fixes the `NewComponentHelper` aspect by using the consumer's `composeRelativeComponentPath` method instead of `composeComponentPath` directly from legacy - which results in the default behaviour of newly created components to belong to a sub directory with their `{name}`, syncing it with how the import works. 

Previously, if you tried to create a component in a defaultDirectory without specifying an explicit pattern (e.g. `{scope}/{name}`), it will throw an error about the path existing after the first component creation since it never appended the `{name}` pattern to the defaultDir string, where else if you imported a component with the same defaultDirectory it would be imported to the `/{name}` directory instead - resulting in different behaviour for the both commands with the same defaults. 