### PR TITLE
fix(forking): handle forking local components without specifying targetId

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -200,10 +200,7 @@ export class ForkingMain {
   }
 
   private async forkExistingInWorkspace(existing: Component, targetId?: string, options?: ForkOptions) {
-    if (!targetId) {
-      throw new Error(`error: unable to create "${existing.id.toStringWithoutVersion()}" component, a component with the same name already exists.
-please specify the target-id arg`);
-    }
+    targetId = targetId || existing.id.fullName;
     const targetCompId = this.newComponentHelper.getNewComponentId(targetId, undefined, options?.scope);
 
     const config = await this.getConfig(existing, options);

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -79,7 +79,7 @@ export class NewComponentHelperMain {
         rootDir: targetPath,
         componentName: targetId.fullName,
         mainFile: comp.state._consumer.mainFile,
-        defaultScope: options?.scope,
+        defaultScope: options?.scope || this.workspace.defaultScope,
         config,
       });
     } catch (err) {


### PR DESCRIPTION
This PR fixes the issue with forking local components with the same name (without specifying the targetId)
Previously, it would throw an error if you try to fork a local component without specifying the targetId. Now it derives the targetId from the existing component's fullName and forks it correctly. 