### PR TITLE
change "bit lane merge main" default to include non-lane components

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -195,11 +195,16 @@ describe('merge lanes', function () {
       helper.command.tagAllWithoutBuild();
       helper.command.export();
       helper.command.createLane('dev');
-      helper.command.mergeLane('main', '-x');
     });
-    it('should not bring non-lane components from main', () => {
+    it('when using --exclude-non-lane-comps flag, it should not bring non-lane components from main', () => {
+      helper.command.mergeLane('main', '-x --exclude-non-lane-comps');
       const lane = helper.command.showOneLaneParsed('dev');
       expect(lane.components).to.have.lengthOf(0);
+    });
+    it('by default, it should bring non-lane components from main', () => {
+      helper.command.mergeLane('main', '-x');
+      const lane = helper.command.showOneLaneParsed('dev');
+      expect(lane.components).to.have.lengthOf(1);
     });
   });
   describe('merging main lane with no snapped components', () => {

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -32,10 +32,11 @@ export class CheckoutCmd implements Command {
   helpUrl = 'reference/components/merging-changes#checkout-snaps-to-the-working-directory';
   group = 'development';
   extendedDescription = `
-  \`bit checkout <version> [component-pattern]\` => checkout the specified ids (or all components when --all is used) to the specified version
-  \`bit checkout head [component-pattern]\` => checkout to the last snap/tag (use --latest if you only want semver tags), omit [component-pattern] to checkout head for all
-  \`bit checkout latest [component-pattern]\` => checkout to the latest satisfying semver tag, omit [component-pattern] to checkout latest for all
-  \`bit checkout reset [component-pattern]\` => remove local modifications from the specified ids (or all components when --all is used)`;
+\`bit checkout <version> [component-pattern]\` => checkout the specified ids (or all components when --all is used) to the specified version
+\`bit checkout head [component-pattern]\` => checkout to the last snap/tag (use --latest if you only want semver tags), omit [component-pattern] to checkout head for all
+\`bit checkout latest [component-pattern]\` => checkout to the latest satisfying semver tag, omit [component-pattern] to checkout latest for all
+\`bit checkout reset [component-pattern]\` => remove local modifications from the specified ids (or all components when --all is used)
+when on a lane, "checkout head" only checks out components on this lane. to update main components, run "bit lane merge main"`;
   alias = 'U';
   options = [
     [

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -80,7 +80,12 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     [
       '',
       'include-non-lane-comps',
-      'when merging main, include workspace components that are not on the lane (by default only lane components are merged)',
+      'DEPRECATED (this is now the default). when merging main, include workspace components that are not on the lane (by default only lane components are merged)',
+    ],
+    [
+      '',
+      'exclude-non-lane-comps',
+      'when merging main into a lane, exclude workspace components that are not on the lane (by default all workspace components are merged)',
     ],
   ] as CommandOptions;
   loader = true;
@@ -111,7 +116,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       resolveUnrelated,
       ignoreConfigChanges,
       verbose = false,
-      includeNonLaneComps = false,
+      excludeNonLaneComps = false,
     }: {
       ours?: boolean;
       theirs?: boolean;
@@ -131,7 +136,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       resolveUnrelated?: string | boolean;
       ignoreConfigChanges?: boolean;
       verbose?: boolean;
-      includeNonLaneComps?: boolean;
+      excludeNonLaneComps?: boolean;
     }
   ): Promise<string> {
     build = (await this.globalConfig.getBool(CFG_FORCE_LOCAL_BUILD)) || Boolean(build);
@@ -183,7 +188,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       resolveUnrelated: getResolveUnrelated(),
       ignoreConfigChanges,
       includeDeps,
-      includeNonLaneComps,
+      excludeNonLaneComps,
     });
 
     const mergeResult = mergeReport({ ...mergeResults, configMergeResults, verbose });

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -55,7 +55,7 @@ export type MergeLaneOptions = {
   resolveUnrelated?: MergeStrategy;
   ignoreConfigChanges?: boolean;
   skipFetch?: boolean;
-  includeNonLaneComps?: boolean;
+  excludeNonLaneComps?: boolean;
 };
 
 export class MergeLanesMain {
@@ -97,7 +97,7 @@ export class MergeLanesMain {
       resolveUnrelated,
       ignoreConfigChanges,
       skipFetch,
-      includeNonLaneComps,
+      excludeNonLaneComps,
     } = options;
 
     const currentLaneId = consumer.getCurrentLaneId();
@@ -139,7 +139,7 @@ export class MergeLanesMain {
     const getBitIds = async () => {
       if (isDefaultLane) {
         if (!currentLane) throw new Error(`unable to merge ${DEFAULT_LANE}, the current lane was not found`);
-        return this.getMainIdsToMerge(currentLane, includeNonLaneComps);
+        return this.getMainIdsToMerge(currentLane, !excludeNonLaneComps);
       }
       if (!otherLane) throw new Error(`lane must be defined for non-default`);
       return otherLane.toBitIds();
@@ -284,7 +284,7 @@ export class MergeLanesMain {
     return { checkoutResults, restoredItems, checkoutError };
   }
 
-  private async getMainIdsToMerge(lane: Lane, includeNonLaneComps = false) {
+  private async getMainIdsToMerge(lane: Lane, includeNonLaneComps: boolean) {
     const laneIds = lane.toBitIds();
     const ids = laneIds.filter((id) => this.scope.isExported(id));
     if (includeNonLaneComps) {


### PR DESCRIPTION
The scenario is when on a lane and some of the workspace components belong to main and are not part of the lane. 
In case these main components are out of date, how to update them?
In the past, `bit checkout main` was the way to go. This had been changed to not include them, see [here](https://github.com/teambit/bit/pull/6853) the reason.
Currently, `bit lane merge main` takes care of this components. However, a change done 4 months ago, required a flag `--include-non-lane-comps` to include them.
Turns out that this is confusing, and for the most cases, it is expected to include them by default without any flag.
This PR does exactly this. In case these components are not wanted, a new flag has introduced: `--exclude-non-lane-comps` to exclude them.