### PR TITLE
fix comment out of ws.jsonc templates

### DIFF
--- a/scopes/harmony/config/workspace-template.jsonc
+++ b/scopes/harmony/config/workspace-template.jsonc
@@ -41,14 +41,14 @@
    * comment in to include generator templates in your workspace.
    * browse more dev environments: https://bit.dev/docs/getting-started/composing/dev-environments
   **/
-  // "teambit.generator/generator": {
-  //   "envs": [
-  //     "bitdev.node/node-env",
-  //     "bitdev.react/react-env",
-  //     "bitdev.vue/vue-env",
-  //     "bitdev.angular/angular-env"
-  //   ]
-  // },
+  "teambit.generator/generator": {
+    "envs": [
+  //  "bitdev.node/node-env",
+  //  "bitdev.react/react-env",
+  //  "bitdev.vue/vue-env",
+  //  "bitdev.angular/angular-env"
+    ]
+  },
 
   /**
    * main configuration for component dependency resolution.


### PR DESCRIPTION
we should really only comment out the tempaltes and not the entire entry. this makes the DX easier for customization.

## Proposed Changes

-
-
-
