### PR TITLE
fix(version-resolver), prefer version from deps-set over .bitmap

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -12,6 +12,8 @@ import Dependency from '@teambit/legacy/dist/consumer/component/dependencies/dep
 import OverridesDependencies from './overrides-dependencies';
 import { DebugComponentsDependency, getValidVersion } from './auto-detect-deps';
 
+type DepType = 'dependencies' | 'devDependencies';
+
 export function updateDependenciesVersions(
   depsResolver: DependencyResolverMain,
   workspace: Workspace,
@@ -23,8 +25,8 @@ export function updateDependenciesVersions(
   const consumer: Consumer = workspace.consumer;
   const autoDetectConfigMerge = workspace.getAutoDetectConfigMerge(component.id) || {};
 
-  updateDependencies(component.dependencies);
-  updateDependencies(component.devDependencies);
+  updateDependencies(component.dependencies, 'dependencies');
+  updateDependencies(component.devDependencies, 'devDependencies');
   updateExtensions(component.extensions);
 
   /**
@@ -33,13 +35,13 @@ export function updateDependenciesVersions(
    * running bit link --rewire).
    * 2: this gets called for extension-id.
    */
-  function resolveVersion(id: ComponentID, pkg?: string): string | undefined {
+  function resolveVersion(id: ComponentID, depType: DepType, pkg?: string): string | undefined {
     const idFromBitMap = getIdFromBitMap(id);
     const idFromComponentConfig = getIdFromComponentConfig(id);
     const getFromComponentConfig = () => idFromComponentConfig;
     const getFromBitMap = () => idFromBitMap || null;
     // later, change this to return the version from the overrides.
-    const getFromOverrides = () => (pkg && isPkgInOverrides(pkg) ? id : null);
+    const getFromOverrides = () => resolveFromOverrides(id, depType, pkg);
     const debugDep = debugDependencies?.find((dep) => dep.id.isEqualWithoutVersion(id));
     // the id we get from the auto-detect is coming from the package.json of the dependency.
     const getFromDepPackageJson = () => (id.hasVersion() ? id : null);
@@ -85,20 +87,20 @@ export function updateDependenciesVersions(
     return undefined;
   }
 
-  function updateDependency(dependency: Dependency) {
+  function updateDependency(dependency: Dependency, depType: DepType) {
     const { id, packageName } = dependency;
-    const resolvedVersion = resolveVersion(id, packageName);
+    const resolvedVersion = resolveVersion(id, depType, packageName);
     if (resolvedVersion) {
       dependency.id = dependency.id.changeVersion(resolvedVersion);
     }
   }
-  function updateDependencies(dependencies: Dependencies) {
-    dependencies.get().forEach(updateDependency);
+  function updateDependencies(dependencies: Dependencies, depType: DepType) {
+    dependencies.get().forEach((dep) => updateDependency(dep, depType));
   }
 
   function updateExtension(extension: ExtensionDataEntry) {
     if (extension.extensionId) {
-      const resolvedVersion = resolveVersion(extension.extensionId);
+      const resolvedVersion = resolveVersion(extension.extensionId, 'devDependencies');
       if (resolvedVersion) {
         extension.extensionId = extension.extensionId.changeVersion(resolvedVersion);
       }
@@ -128,13 +130,13 @@ export function updateDependenciesVersions(
     return componentId.changeVersion(dependencies[dependency]);
   }
 
-  function isPkgInOverrides(pkgName: string): boolean {
+  function resolveFromOverrides(id: ComponentID, depType: DepType, pkgName?: string): ComponentID | undefined {
+    if (!pkgName) return undefined;
     const dependencies = overridesDependencies.getDependenciesToAddManually();
-    if (!dependencies) return false;
-    const allDeps = Object.values(dependencies)
-      .map((obj) => Object.keys(obj))
-      .flat();
-    return allDeps.includes(pkgName);
+    const found = dependencies?.[depType]?.[pkgName];
+    if (!found) return undefined;
+    const validVersion = getValidVersion(found);
+    return validVersion ? id.changeVersion(validVersion) : undefined;
   }
 
   function isPkgInAutoDetectOverrides(pkgName: string): boolean {

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -649,6 +649,11 @@ export default class CommandHelper {
     return show.find((_) => _.title === 'configuration').json.find((_) => _.id === aspectId);
   }
 
+  showDependenciesData(compId: string): Array<{ id: string; version: string; packageName: string }> {
+    const showConfig = this.showAspectConfig(compId, Extensions.dependencyResolver);
+    return showConfig.data.dependencies;
+  }
+
   getCompDepsIdsFromData(compId: string): string[] {
     const aspectConf = this.showAspectConfig(compId, Extensions.dependencyResolver);
     return aspectConf.data.dependencies.map((dep) => dep.id);


### PR DESCRIPTION
It was fixed here: https://github.com/teambit/bit/pull/8206
But in some cases it wasn't working. Fixed and added an e2e-test.