### PR TITLE
fix(lane-rename), update records about whether a lane is exported during rename

### DIFF
--- a/e2e/harmony/lanes/rename-lane.e2e.ts
+++ b/e2e/harmony/lanes/rename-lane.e2e.ts
@@ -31,4 +31,23 @@ describe('rename lanes', function () {
       expect(bitMap[LANE_KEY].id.name).to.equal('new-dev');
     });
   });
+  // previous bug left the "lanes.new" prop in scope.json with the old name causing bit later to assume it's exported.
+  describe('rename local lane, switch to main and then switch back to the lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('dev');
+      helper.command.renameLane('new-dev');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.switchLocalLane('main');
+      helper.command.switchLocalLane('new-dev');
+    });
+    it('bit import should not throw', () => {
+      expect(() => helper.command.import()).not.to.throw();
+    });
+    it('should not show the lane as if it was exported', () => {
+      const bitmap = helper.bitMap.read();
+      expect(bitmap[LANE_KEY].exported).to.be.false;
+    });
+  });
 });

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -426,18 +426,8 @@ please create a new lane instead, which will include all components of this lane
     // rename the ref file
     await this.scope.legacyScope.objects.remoteLanes.renameRefByNewLaneName(laneNameWithoutScope, newName, lane.scope);
 
-    // change tracking data
-    const afterTrackData = {
-      localLane: newName,
-      remoteLane: newName,
-      remoteScope: lane.scope,
-    };
-    this.scope.legacyScope.lanes.trackLane(afterTrackData);
-    this.scope.legacyScope.lanes.removeTrackLane(laneNameWithoutScope);
-
-    // change the lane object
-    lane.name = newName;
-    await this.scope.legacyScope.lanes.saveLane(lane);
+    // change scope.json related data and change the lane object
+    await this.scope.legacyScope.lanes.renameLane(lane, newName);
 
     // change current-lane if needed
     const currentLaneId = this.getCurrentLaneId();
@@ -447,6 +437,7 @@ please create a new lane instead, which will include all components of this lane
       this.setCurrentLane(newLaneId, undefined, isExported);
     }
 
+    // this writes the changes done on scope.json file (along with .bitmap)
     await this.workspace.consumer.onDestroy('lane-rename');
 
     return { currentName };

--- a/src/scope/lanes/lanes.ts
+++ b/src/scope/lanes/lanes.ts
@@ -42,6 +42,27 @@ export default class Lanes {
     await this.objects.writeObjectsToTheFS([laneObject]);
   }
 
+  async renameLane(lane: Lane, newName: string) {
+    // change tracking data
+    const oldName = lane.name;
+    const afterTrackData = {
+      localLane: newName,
+      remoteLane: newName,
+      remoteScope: lane.scope,
+    };
+    this.trackLane(afterTrackData);
+    this.removeTrackLane(oldName);
+
+    // rename the lane in the "new" prop
+    if (lane.isNew) {
+      this.scopeJson.lanes.new = this.scopeJson.lanes.new.map((l) => (l === oldName ? newName : l));
+    }
+
+    // change the lane object
+    lane.name = newName;
+    await this.saveLane(lane);
+  }
+
   getAliasByLaneId(laneId: LaneId): string | null {
     return this.getLocalTrackedLaneByRemoteName(laneId.name, laneId.scope);
   }


### PR DESCRIPTION
Currently, `bit lane rename` doesn't update the scope.json "lanes.new" prop with the new name. 
As a result, switching back and forth, the .bitmap shows as if the lane is exported incorrectly.