### PR TITLE
fix(init-reset-new), never populate "scope" field, only "defaultScope"

### DIFF
--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -273,18 +273,20 @@ export default class BitMap {
   }
 
   resetToNewComponents() {
-    this.components = this.components.map(
-      (component) =>
-        new ComponentMap({
-          id: component.id.changeVersion(undefined).changeScope(component.scope || (component.defaultScope as string)),
-          mainFile: component.mainFile,
-          rootDir: component.rootDir,
-          defaultScope: component.id.scope,
-          exported: false,
-          files: component.files,
-          onLanesOnly: false,
-        })
-    );
+    this.components = this.components.map((component) => {
+      const scope = component.id.scope;
+      const legacyId = component.id._legacy.changeVersion(undefined).changeScope(undefined);
+      const id = new ComponentID(legacyId, scope);
+      return new ComponentMap({
+        id,
+        mainFile: component.mainFile,
+        rootDir: component.rootDir,
+        defaultScope: scope,
+        exported: false,
+        files: component.files,
+        onLanesOnly: false,
+      });
+    });
   }
 
   resetLaneComponentsToNew() {


### PR DESCRIPTION
In some scenarios `bit init --reset-new` were populating the `scope` field instead of the `defaultScope`.