### PR TITLE
fix(init), keep workspace-aspect-config values when running with --default-scope

### DIFF
--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -11,7 +11,7 @@ import { assign, parse, stringify, CommentJSONValue } from 'comment-json';
 import * as fs from 'fs-extra';
 import * as path from 'path';
 import { isEmpty, omit } from 'lodash';
-
+import WorkspaceAspect from '@teambit/workspace';
 import { SetExtensionOptions } from './config.main.runtime';
 import { ExtensionAlreadyConfigured } from './exceptions';
 import { ConfigDirNotDefined } from './exceptions/config-dir-not-defined';
@@ -146,9 +146,10 @@ export class WorkspaceConfig implements HostConfig {
    */
   static async create(props: WorkspaceConfigFileProps, dirPath?: PathOsBasedAbsolute) {
     const template = await getWorkspaceConfigTemplateParsed();
-    // TODO: replace this assign with some kind of deepAssign that keeps the comments
-    // right now the comments above the internal props are overrides after the assign
-    const merged = assign(template, props);
+    // previously, we just did `assign(template, props)`, but it was replacing the entire workspace config with the "props".
+    // so for example, if the props only had defaultScope, it was removing the defaultDirectory.
+    const workspaceAspectConf = assign(template[WorkspaceAspect.id], props[WorkspaceAspect.id]);
+    const merged = assign(template, { [WorkspaceAspect.id]: workspaceAspectConf });
     const instance = new WorkspaceConfig(merged);
     if (dirPath) {
       instance.path = WorkspaceConfig.composeWorkspaceJsoncPath(dirPath);

--- a/src/cli/commands/public-cmds/init-cmd.ts
+++ b/src/cli/commands/public-cmds/init-cmd.ts
@@ -95,8 +95,9 @@ export default class Init implements LegacyCommand {
         };
       });
     }
-    if (reset && resetHard)
+    if (reset && resetHard) {
       throw new GeneralError('cannot use both --reset and --reset-hard, please use only one of them');
+    }
     const workspaceConfigFileProps: WorkspaceConfigProps = {
       componentsDefaultDirectory: defaultDirectory ?? getSync(CFG_INIT_DEFAULT_DIRECTORY),
       defaultScope: defaultScope ?? getSync(CFG_INIT_DEFAULT_SCOPE),


### PR DESCRIPTION
currently, when running `bit init --default-scope <some-scope>`, it removes all other workspace config values, such as `defaultDirectory`. 