### PR TITLE
default to calculate deps-graph from the saved flattened-edges unless --rebuild-deps-graph was used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -529,7 +529,6 @@ jobs:
     <<: *defaults
     environment:
       BIT_FEATURES: cloud-importer-v2
-      BIT_BUILD_GRAPH_FROM_HISTORIC_FLATTENED_EDGES: true
     steps:
       - attach_workspace:
           at: ./
@@ -863,7 +862,6 @@ jobs:
     environment:
       BITSRC_ENV: stg
       BIT_FEATURES: cloud-importer-v2
-      BIT_BUILD_GRAPH_FROM_HISTORIC_FLATTENED_EDGES: true
     parallelism: 25
     steps:
       - attach_workspace:

--- a/scopes/component/snapping/snap-cmd.ts
+++ b/scopes/component/snapping/snap-cmd.ts
@@ -47,6 +47,7 @@ export class SnapCmd implements Command {
     ],
     ['', 'force-deploy', 'DEPRECATED. use --ignore-build-error instead'],
     ['', 'ignore-build-errors', 'proceed to snap pipeline even when build pipeline fails'],
+    ['', 'rebuild-deps-graph', 'do not reuse the saved dependencies graph, instead build it from scratch'],
     [
       'i',
       'ignore-issues [issues]',
@@ -86,6 +87,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       disableSnapPipeline = false,
       forceDeploy = false,
       ignoreBuildErrors = false,
+      rebuildDepsGraph,
       unmodified = false,
       failFast = false,
     }: {
@@ -135,6 +137,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       skipAutoSnap,
       disableTagAndSnapPipelines,
       ignoreBuildErrors,
+      rebuildDepsGraph,
       unmodified,
       exitOnFirstFailedTask: failFast,
     });

--- a/scopes/component/snapping/snap-from-scope.cmd.ts
+++ b/scopes/component/snapping/snap-from-scope.cmd.ts
@@ -48,6 +48,7 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","message": "f
     ['', 'disable-snap-pipeline', 'skip the snap pipeline'],
     ['', 'force-deploy', 'DEPRECATED. use --ignore-build-error instead'],
     ['', 'ignore-build-errors', 'run the snap pipeline although the build pipeline failed'],
+    ['', 'rebuild-deps-graph', 'do not reuse the saved dependencies graph, instead build it from scratch'],
     [
       'i',
       'ignore-issues [issues]',
@@ -85,6 +86,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       skipTests = false,
       disableSnapPipeline = false,
       ignoreBuildErrors = false,
+      rebuildDepsGraph,
       forceDeploy = false,
     }: SnapFromScopeOptions
   ) {
@@ -107,6 +109,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       skipTests,
       disableTagAndSnapPipelines,
       ignoreBuildErrors,
+      rebuildDepsGraph,
     });
 
     return results;

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -61,6 +61,7 @@ if patterns are entered, you can specify a version per pattern using "@" sign, e
     ['', 'disable-tag-pipeline', 'skip the tag pipeline to avoid publishing the components'],
     ['', 'force-deploy', 'DEPRECATED. use --ignore-build-error instead'],
     ['', 'ignore-build-errors', 'proceed to tag pipeline even when build pipeline fails'],
+    ['', 'rebuild-deps-graph', 'do not reuse the saved dependencies graph, instead build it from scratch'],
     [
       '',
       'increment-by <number>',
@@ -134,6 +135,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       disableTagPipeline = false,
       forceDeploy = false,
       ignoreBuildErrors = false,
+      rebuildDepsGraph,
       failFast = false,
       incrementBy = 1,
     }: {
@@ -268,6 +270,7 @@ To undo local tag use the "bit reset" command.`
       unmodified,
       disableTagAndSnapPipelines,
       ignoreBuildErrors,
+      rebuildDepsGraph,
       incrementBy,
       version: ver,
       failFast,

--- a/scopes/component/snapping/tag-from-scope.cmd.ts
+++ b/scopes/component/snapping/tag-from-scope.cmd.ts
@@ -53,6 +53,7 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","dependencies
     ['', 'disable-tag-pipeline', 'skip the tag pipeline to avoid publishing the components'],
     ['', 'force-deploy', 'DEPRECATED. use --ignore-build-error instead'],
     ['', 'ignore-build-errors', 'run the tag pipeline although the build pipeline failed'],
+    ['', 'rebuild-deps-graph', 'do not reuse the saved dependencies graph, instead build it from scratch'],
     [
       '',
       'increment-by <number>',
@@ -90,6 +91,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       disableTagPipeline = false,
       forceDeploy = false,
       ignoreBuildErrors = false,
+      rebuildDepsGraph,
       incrementBy = 1,
     }: {
       push?: boolean;
@@ -160,6 +162,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       persist: true,
       disableTagAndSnapPipelines: disableTagPipeline,
       ignoreBuildErrors,
+      rebuildDepsGraph,
       forceDeploy,
       incrementBy,
       version: ver,

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -46,6 +46,7 @@ export type BasicTagSnapParams = {
   skipTests?: boolean;
   build?: boolean;
   ignoreBuildErrors?: boolean;
+  rebuildDepsGraph?: boolean;
 };
 
 export type BasicTagParams = BasicTagSnapParams & {
@@ -196,6 +197,7 @@ export async function tagModelComponent({
   isSnap = false,
   disableTagAndSnapPipelines,
   ignoreBuildErrors,
+  rebuildDepsGraph,
   incrementBy,
   packageManagerConfigRootDir,
   dependencyResolver,
@@ -312,7 +314,7 @@ export async function tagModelComponent({
     if (!consumer) throw new Error(`unable to soft-tag without consumer`);
     consumer.updateNextVersionOnBitmap(allComponentsToTag, preReleaseId);
   } else {
-    await snapping._addFlattenedDependenciesToComponents(allComponentsToTag);
+    await snapping._addFlattenedDependenciesToComponents(allComponentsToTag, rebuildDepsGraph);
     await snapping.throwForDepsFromAnotherLane(allComponentsToTag);
     if (!build) emptyBuilderData(allComponentsToTag);
     addBuildStatus(allComponentsToTag, BuildStatus.Pending);


### PR DESCRIPTION
This is a continuation of https://github.com/teambit/bit/pull/8281.
In that PR this calculation was done only when an env variable was used. This PR takes it to the next step, which enables it by default. In case an error was thrown due to discrepancies between the methods of calculating the graph, it suggests adding `--rebuild-deps-graph` flag to not get blocked. 