### PR TITLE
feature(starters) - add option to specify targetScope in fork entry from starters

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -32,6 +32,7 @@ type MultipleForkInfo = {
 type MultipleComponentsToFork = Array<{
   sourceId: string;
   targetId?: string; // if not specified, it'll be the same as the source
+  targetScope?: string; // if not specified, it'll be taken from the options or from the default scope
   path?: string; // if not specified, use the default component path
   env?: string; // if not specified, use the default env
   config?: ComponentConfig; // if specified, adds to/overrides the existing config
@@ -88,17 +89,20 @@ export class ForkingMain {
   async forkMultipleFromRemote(componentsToFork: MultipleComponentsToFork, options: MultipleForkOptions = {}) {
     const componentsToForkSorted = this.sortComponentsToFork(componentsToFork);
     const { scope } = options;
-    const results = await pMapSeries(componentsToForkSorted, async ({ sourceId, targetId, path, env, config }) => {
-      const sourceCompId = await this.workspace.resolveComponentId(sourceId);
-      const sourceIdWithScope = sourceCompId._legacy.scope ? sourceCompId : ComponentID.fromString(sourceId);
-      const { targetCompId, component } = await this.forkRemoteComponent(sourceIdWithScope, targetId, {
-        scope,
-        path,
-        env,
-        config,
-      });
-      return { targetCompId, sourceId, component };
-    });
+    const results = await pMapSeries(
+      componentsToForkSorted,
+      async ({ sourceId, targetId, path, env, config, targetScope }) => {
+        const sourceCompId = await this.workspace.resolveComponentId(sourceId);
+        const sourceIdWithScope = sourceCompId._legacy.scope ? sourceCompId : ComponentID.fromString(sourceId);
+        const { targetCompId, component } = await this.forkRemoteComponent(sourceIdWithScope, targetId, {
+          scope: targetScope || scope,
+          path,
+          env,
+          config,
+        });
+        return { targetCompId, sourceId, component };
+      }
+    );
     await this.refactorMultipleAndInstall(results, options);
   }
 

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -160,9 +160,10 @@ export class WorkspaceGenerator {
     const componentsToFork =
       this.template?.importComponents?.(workspaceContext) || this.template?.fork?.(workspaceContext) || [];
     if (!componentsToFork.length) return;
-    const componentsToForkRestructured = componentsToFork.map(({ id, targetName, path, env, config }) => ({
+    const componentsToForkRestructured = componentsToFork.map(({ id, targetName, path, env, config, targetScope }) => ({
       sourceId: id,
       targetId: targetName,
+      targetScope,
       path,
       env,
       config,

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -67,6 +67,12 @@ export interface ForkComponentInfo extends ImportComponentInfo {
    * a new component name. if not specified, use the original id (without the scope)
    */
   targetName?: string;
+
+  /**
+   * a new scope for the component. if not specified, use the original scope
+   */
+  targetScope?: string;
+
   /**
    * env to use for the component.
    */


### PR DESCRIPTION
## Proposed Changes

With this PR you can specify targetScope in any fork entry in the fork function of your starter.
for example:
```
// my.starter.ts
fork() {
    return [
      {
        id: 'teambit.base-ui/text/heading',
        targetName: 'design/heading',
        targetScope: 'my-org.scope'
      },
    ];
  }
```
