### PR TITLE
feature(starters) - add new create API for starters API

### DIFF
--- a/scopes/generator/generator/index.ts
+++ b/scopes/generator/generator/index.ts
@@ -14,6 +14,7 @@ export type {
   WorkspaceFile,
   ForkComponentInfo,
   ImportComponentInfo,
+  CreateComponentInfo,
 } from './workspace-template';
 export type { GeneratorEnv } from './generator-env-type';
 export { GeneratorAspect } from './generator.aspect';

--- a/scopes/generator/generator/workspace-template.ts
+++ b/scopes/generator/generator/workspace-template.ts
@@ -62,6 +62,33 @@ export interface WorkspaceFile {
   content: string;
 }
 
+export interface CreateComponentInfo {
+  /**
+   * the template for generating the component
+   */
+  templateName: string;
+  /**
+   * component name to generate
+   */
+  componentName: string;
+  /**
+   * sets the component's scope-name. if not entered, the default-scope will be used
+   */
+  scope?: string;
+  /**
+   * relative path in the workspace. by default the path is `<scope>/<namespace>/<name>`
+   */
+  path?: string;
+  /**
+   * set the component's environment. (overrides the env from variants and the template)
+   */
+  env?: string;
+  /**
+   * aspect-id of the template.
+   */
+  aspect?: string;
+}
+
 export interface ForkComponentInfo extends ImportComponentInfo {
   /**
    * a new component name. if not specified, use the original id (without the scope)
@@ -148,4 +175,9 @@ export interface WorkspaceTemplate {
    * change their source code and update the dependency names according to the new component names.
    */
   fork?: (context: WorkspaceContext) => ForkComponentInfo[];
+
+  /**
+   * populate new components into the new workspace and add them as new components.
+   */
+  create?: (context: WorkspaceContext) => CreateComponentInfo[];
 }


### PR DESCRIPTION
## Proposed Changes

Added a new `create` API for starters.
Example:
```
// my.starter.ts
create(){
    return [
      {
        templateName: 'ng-app',
        componentName: 'my-ng-app',
        aspect: 'bitdev.angular/angular-env'
      }
    ]
  }
```
Each entry should satisfy the following:
```
export interface CreateComponentInfo {
  /**
   * the template for generating the component
   */
  templateName: string;
  /**
   * component name to generate
   */
  componentName: string;
  /**
   * sets the component's scope-name. if not entered, the default-scope will be used
   */
  scope?: string;
  /**
   * relative path in the workspace. by default the path is `<scope>/<namespace>/<name>`
   */
  path?: string;
  /**
   * set the component's environment. (overrides the env from variants and the template)
   */
  env?: string;
  /**
   * aspect-id of the template.
   */
  aspect?: string;
}
```
