### PR TITLE
fix(bit start) - restore elementsUrl field in component gql to have backward compatibility

### DIFF
--- a/scopes/component/component/component.graphql.ts
+++ b/scopes/component/component/component.graphql.ts
@@ -120,6 +120,12 @@ export function componentSchema(componentExtension: ComponentMain) {
         ): [LogEntry]!
 
         aspects(include: [String]): [Aspect]
+
+        """
+        element url of the component - this is deprecated, and will return empty string now.
+        it's here to not break old queries
+        """
+        elementsUrl: String @deprecated(reason: "Not in use anymore")
       }
 
       type Aspect {
@@ -194,6 +200,8 @@ export function componentSchema(componentExtension: ComponentMain) {
         aspects: (component: Component, { include }: { include?: string[] }) => {
           return component.state.aspects.filter(include).serialize();
         },
+        // Here only to not break old queries
+        elementsUrl: () => undefined,
         logs: async (
           component: Component,
           filter?: {

--- a/scopes/component/component/ui/component-model/component-model.ts
+++ b/scopes/component/component/ui/component-model/component-model.ts
@@ -19,7 +19,6 @@ export type ComponentModelProps = {
   server?: ComponentServer;
   displayName: string;
   packageName: string; // pkg aspect
-  elementsUrl?: string; // pkg aspect
   compositions?: CompositionProps[];
   tags?: TagProps[];
   issuesCount?: number; // component/issues aspect
@@ -101,10 +100,6 @@ export class ComponentModel {
      */
     readonly issuesCount?: number,
     /**
-     * elements url
-     */
-    readonly elementsUrl?: string,
-    /**
      * status of component.
      */
     readonly status?: any,
@@ -162,7 +157,6 @@ export class ComponentModel {
     displayName,
     compositions = [],
     packageName,
-    elementsUrl,
     tags = [],
     deprecation,
     buildStatus,
@@ -186,7 +180,6 @@ export class ComponentModel {
       TagMap.fromArray(tags.map((tag) => Tag.fromObject(tag))),
       buildStatus,
       issuesCount,
-      elementsUrl,
       status,
       deprecation,
       env,

--- a/scopes/component/component/ui/use-component.fragments.ts
+++ b/scopes/component/component/ui/use-component.fragments.ts
@@ -20,7 +20,6 @@ export const componentOverviewFields = gql`
       id
       data
     }
-    elementsUrl
     description
     deprecation {
       isDeprecate


### PR DESCRIPTION
## Proposed Changes

- fix(bit start) - restore elementsUrl field in component gql to have backward compatibility
- stop querying the deprecated elementsUrl in gql requests
