### PR TITLE
perf, upgrade cleargraph to fix build-graph-ids performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "@teambit/component-version": "^1.0.3",
     "@teambit/toolbox.network.agent": "^0.0.554",
     "@teambit/legacy-component-log": "^0.0.402",
-    "@teambit/graph.cleargraph": "0.0.1",
+    "@teambit/graph.cleargraph": "0.0.8",
     "@babel/core": "7.19.6",
     "@babel/runtime": "7.23.2",
     "@teambit/legacy-bit-id": "^1.1.0",


### PR DESCRIPTION
In some scenarios this makes `bit status` 130% faster