### PR TITLE
refactor, move codemod-components from legacy to node-modules-linker component

### DIFF
--- a/scopes/preview/preview/pre-bundle-utils.ts
+++ b/scopes/preview/preview/pre-bundle-utils.ts
@@ -29,10 +29,8 @@ export function readBundleHash(bundleId: string, bundleDir: string, aspectDir: s
 export async function createBundleHash(uiRoot: UIRoot, runtime: string): Promise<string> {
   const aspects = await uiRoot.resolveAspects(runtime);
   aspects.sort((a, b) => ((a.getId || a.aspectPath) > (b.getId || b.aspectPath) ? 1 : -1));
-  const aspectPathStrings = aspects.map((aspect) => {
-    return [aspect.aspectPath, aspect.runtimePath].join('');
-  });
-  return sha1(aspectPathStrings.join(''));
+  const aspectIds = aspects.map((aspect) => aspect.getId || aspect.aspectPath);
+  return sha1(aspectIds.join(''));
 }
 
 export async function generateBundleHash(uiRoot: UIRoot, runtime: string, outputPath: string): Promise<void> {

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -15,7 +15,11 @@ import { Component, ComponentID, ComponentMap } from '@teambit/component';
 import { createLinks } from '@teambit/dependencies.fs.linked-dependencies';
 import pMapSeries from 'p-map-series';
 import { Slot, SlotRegistry } from '@teambit/harmony';
-import { linkToNodeModulesWithCodemod, NodeModulesLinksResult } from '@teambit/workspace.modules.node-modules-linker';
+import {
+  CodemodResult,
+  linkToNodeModulesWithCodemod,
+  NodeModulesLinksResult,
+} from '@teambit/workspace.modules.node-modules-linker';
 import { EnvsMain, EnvsAspect } from '@teambit/envs';
 import IpcEventsAspect, { IpcEventsMain } from '@teambit/ipc-events';
 import { IssuesClasses } from '@teambit/component-issues';
@@ -39,7 +43,6 @@ import {
 import WorkspaceConfigFilesAspect, { WorkspaceConfigFilesMain } from '@teambit/workspace-config-files';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { IssuesAspect, IssuesMain } from '@teambit/issues';
-import { CodemodResult } from '@teambit/legacy/dist/consumer/component-ops/codemod-components';
 import { snapToSemver } from '@teambit/component-package-version';
 import hash from 'object-hash';
 import { DependencyTypeNotSupportedInPolicy } from './exceptions';

--- a/scopes/workspace/install/link/rewire-row.ts
+++ b/scopes/workspace/install/link/rewire-row.ts
@@ -1,4 +1,4 @@
-import { CodemodResult } from '@teambit/legacy/dist/consumer/component-ops/codemod-components';
+import { CodemodResult } from '@teambit/workspace.modules.node-modules-linker';
 import chalk from 'chalk';
 
 type RewireRowProps = {

--- a/scopes/workspace/modules/node-modules-linker/codemod-components.ts
+++ b/scopes/workspace/modules/node-modules-linker/codemod-components.ts
@@ -39,10 +39,10 @@ export async function changeCodeFromRelativeToModulePaths(
   return codemodResults.filter((c) => c.changedFiles.length || c.warnings);
 }
 
-async function reloadComponents(workspace: Workspace, bitIds: ComponentID[]) {
-  await workspace.clearCache();
-  if (!bitIds.length) return;
-  const components = await loadComponents(workspace, bitIds);
+async function reloadComponents(workspace: Workspace, compIds: ComponentID[]) {
+  workspace.clearAllComponentsCache();
+  if (!compIds.length) return;
+  const components = await loadComponents(workspace, compIds);
   const componentsWithRelativeIssues = components.filter(
     (c) => c.state.issues && c.state.issues.getIssue(IssuesClasses.RelativeComponentsAuthored)
   );

--- a/scopes/workspace/modules/node-modules-linker/index.ts
+++ b/scopes/workspace/modules/node-modules-linker/index.ts
@@ -7,3 +7,5 @@ export {
 } from './node-modules-linker';
 
 export { PackageJsonTransformer } from './package-json-transformer';
+
+export type { CodemodResult } from './codemod-components';

--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -13,13 +13,13 @@ import Consumer from '@teambit/legacy/dist/consumer/consumer';
 import logger from '@teambit/legacy/dist/logger/logger';
 import getNodeModulesPathOfComponent from '@teambit/legacy/dist/utils/bit/component-node-modules-path';
 import { PathOsBasedAbsolute, PathOsBasedRelative } from '@teambit/legacy/dist/utils/path';
-import { changeCodeFromRelativeToModulePaths } from '@teambit/legacy/dist/consumer/component-ops/codemod-components';
 import Symlink from '@teambit/legacy/dist/links/symlink';
 import componentIdToPackageName from '@teambit/legacy/dist/utils/bit/component-id-to-package-name';
 import { Workspace } from '@teambit/workspace';
 import { snapToSemver } from '@teambit/component-package-version';
 import { Component } from '@teambit/component';
 import { PackageJsonTransformer } from './package-json-transformer';
+import { changeCodeFromRelativeToModulePaths } from './codemod-components';
 
 type LinkDetail = { from: string; to: string };
 export type NodeModulesLinksResult = {
@@ -234,7 +234,7 @@ export async function linkToNodeModulesWithCodemod(
 ) {
   let codemodResults;
   if (changeRelativeToModulePaths) {
-    codemodResults = await changeCodeFromRelativeToModulePaths(workspace.consumer, bitIds);
+    codemodResults = await changeCodeFromRelativeToModulePaths(workspace, bitIds);
   }
   const linksResults = await linkToNodeModulesByIds(workspace, bitIds);
   return { linksResults, codemodResults };


### PR DESCRIPTION
This is a start of a broader task to move away from the legacy `loadComponents`.