### PR TITLE
feat, introduce a new command "bit lane checkout" to checkout to a previous lane snapshot

### DIFF
--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -136,7 +136,11 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
   }
 }
 
-export function checkoutOutput(checkoutResults: ApplyVersionResults, checkoutProps: CheckoutProps) {
+export function checkoutOutput(
+  checkoutResults: ApplyVersionResults,
+  checkoutProps: CheckoutProps,
+  alternativeTitle?: string
+) {
   const {
     components,
     version,
@@ -183,17 +187,20 @@ once ready, snap/tag the components to persist the changes`;
     return chalk.underline(title) + conflictSummaryReport(components) + chalk.yellow(suggestion);
   };
   const getSuccessfulOutput = () => {
-    const switchedOrReverted = revert ? 'reverted' : 'switched';
     if (!components || !components.length) return '';
+    const newLine = '\n';
+    const switchedOrReverted = revert ? 'reverted' : 'switched';
     if (components.length === 1) {
       const component = components[0];
       const componentName = reset ? component.id.toString() : component.id.toStringWithoutVersion();
       if (reset) return `successfully reset ${chalk.bold(componentName)}\n`;
-      const title = `successfully ${switchedOrReverted} ${chalk.bold(componentName)} to version ${chalk.bold(
-        // @ts-ignore version is defined when !reset
-        head || latest ? component.id.version : version
-      )}\n`;
-      return chalk.bold(title) + applyVersionReport(components, false);
+      const title =
+        alternativeTitle ||
+        `successfully ${switchedOrReverted} ${chalk.bold(componentName)} to version ${chalk.bold(
+          // @ts-ignore version is defined when !reset
+          head || latest ? component.id.version : version
+        )}`;
+      return chalk.bold(title) + newLine + applyVersionReport(components, false);
     }
     if (reset) {
       const title = 'successfully reset the following components\n\n';
@@ -208,9 +215,10 @@ once ready, snap/tag the components to persist the changes`;
       return `version ${chalk.bold(version)}`;
     };
     const versionOutput = getVerOutput();
-    const title = `successfully ${switchedOrReverted} ${components.length} components to ${versionOutput}\n`;
+    const title =
+      alternativeTitle || `successfully ${switchedOrReverted} ${components.length} components to ${versionOutput}`;
     const showVersion = head || reset;
-    return chalk.bold(title) + applyVersionReport(components, true, showVersion);
+    return chalk.bold(title) + newLine + applyVersionReport(components, true, showVersion);
   };
   const getNewOnLaneOutput = () => {
     if (!newFromLane?.length) return '';

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -369,6 +369,9 @@ export async function tagModelComponent({
     }
   }
 
+  // clear all objects. otherwise, ModelComponent has the wrong divergeData
+  legacyScope.objects.clearObjectsFromCache();
+
   return {
     taggedComponents: componentsToTag,
     autoTaggedResults: autoTagData,

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -3,6 +3,7 @@ import chalk from 'chalk';
 import yn from 'yn';
 import { ScopeMain } from '@teambit/scope';
 import { DEFAULT_LANE, LaneId } from '@teambit/lane-id';
+import { checkoutOutput } from '@teambit/checkout';
 import { Workspace } from '@teambit/workspace';
 import { Command, CommandOptions } from '@teambit/cli';
 import { LaneData, serializeLaneData } from '@teambit/legacy/dist/scope/lanes/lanes';
@@ -266,6 +267,28 @@ export class CatLaneHistoryCmd implements Command {
     const laneId = await this.lanes.parseLaneId(laneName);
     const laneHistory = await this.lanes.getLaneHistory(laneId);
     return JSON.stringify(laneHistory.toObject(), null, 2);
+  }
+}
+
+export type LaneCheckoutOpts = { skipDependencyInstallation?: boolean };
+
+export class LaneCheckoutCmd implements Command {
+  name = 'checkout <history-id>';
+  description = 'checkout to a previous history of the current lane';
+  arguments = [
+    { name: 'history-id', description: 'the history-id to checkout to. run "bit lane history" to list the ids' },
+  ];
+  alias = '';
+  options = [
+    ['x', 'skip-dependency-installation', 'do not install dependencies of the checked out components'],
+  ] as CommandOptions;
+  loader = true;
+
+  constructor(private lanes: LanesMain) {}
+
+  async report([historyId]: [string], opts: LaneCheckoutOpts): Promise<string> {
+    const result = await this.lanes.checkoutHistory(historyId, opts);
+    return checkoutOutput(result, {}, `successfully checked out according to history-id: ${historyId}`);
   }
 }
 


### PR DESCRIPTION
This is a continuation of the Lane History feature. See https://github.com/teambit/bit/pull/8370.
It's still hidden under a feature flag until the remotes are updated.