### PR TITLE
improvement(checkout), introduce --force-ours and --force-theirs flags

### DIFF
--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -44,19 +44,11 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       'interactive-merge',
       'when a component is modified and the merge process found conflicts, display options to resolve them',
     ],
-    ['', 'ours', 'DEPRECATED. use --auto-merge-resolve. In the future, this flag will leave the current code intact'],
-    [
-      '',
-      'theirs',
-      'DEPRECATED. use --auto-merge-resolve. In the future, this flag will override the current code with the incoming code',
-    ],
-    ['', 'manual', 'DEPRECATED. use --auto-merge-resolve'],
     [
       '',
       'auto-merge-resolve <merge-strategy>',
       'in case of merge conflict, resolve according to the provided strategy: [ours, theirs, manual]',
     ],
-    ['r', 'reset', 'revert changes that were not snapped/tagged'],
     ['a', 'all', 'all components'],
     [
       'e',
@@ -65,6 +57,8 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
     ],
     ['v', 'verbose', 'showing verbose output for inspection'],
     ['x', 'skip-dependency-installation', 'do not auto-install dependencies of the imported components'],
+    ['', 'force-ours', 'regardless of conflicts, ignore theirs changes and keep our local files intact'],
+    ['', 'force-theirs', 'regardless of conflicts, ignore our local changes and use theirs files'],
   ] as CommandOptions;
   loader = true;
 
@@ -74,9 +68,8 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
     [to, componentPattern]: [string, string],
     {
       interactiveMerge = false,
-      ours = false,
-      theirs = false,
-      manual = false,
+      forceOurs,
+      forceTheirs,
       autoMergeResolve,
       all = false,
       workspaceOnly = false,
@@ -85,9 +78,8 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       revert = false,
     }: {
       interactiveMerge?: boolean;
-      ours?: boolean;
-      theirs?: boolean;
-      manual?: boolean;
+      forceOurs?: boolean;
+      forceTheirs?: boolean;
       autoMergeResolve?: MergeStrategy;
       all?: boolean;
       workspaceOnly?: boolean;
@@ -96,10 +88,8 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       revert?: boolean;
     }
   ) {
-    if (ours || theirs || manual) {
-      throw new BitError(
-        'the "--ours", "--theirs" and "--manual" flags are deprecated. use "--auto-merge-resolve" instead.'
-      );
+    if (forceOurs && forceTheirs) {
+      throw new BitError('please use either --force-ours or --force-theirs, not both');
     }
     if (
       autoMergeResolve &&
@@ -121,6 +111,8 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       skipNpmInstall: skipDependencyInstallation,
       workspaceOnly,
       revert,
+      forceOurs,
+      forceTheirs,
     };
     if (to === HEAD) checkoutProps.head = true;
     else if (to === LATEST) checkoutProps.latest = true;

--- a/scopes/component/checkout/checkout-version.ts
+++ b/scopes/component/checkout/checkout-version.ts
@@ -36,17 +36,21 @@ export type ApplyVersionWithComps = {
 };
 
 /**
- * 1) when the files are modified with conflicts and the strategy is "ours", leave the FS as is
- * and update only bitmap id version. (not the componentMap object).
+ * This function optionally returns "component" object. If it returns, it means it needs to be written to the filesystem.
+ * Otherwise, it means the component is already up to date and no need to write it.
  *
- * 2) when the files are modified with conflicts and the strategy is "theirs", write the component
- * according to id.version.
+ * If no need to change anything (ours), then don't return the component object.
+ * Otherwise, either return the component object as is (if no conflicts or "theirs"), or change the files in this
+ * component object. Later, this component object is written to the filesystem.
+ *
+ * 1) when the files are modified with conflicts and the strategy is "ours", or forceOurs was used, leave the FS as is.
+ *
+ * 2) when the files are modified with conflicts and the strategy is "theirs", or forceTheirs was used, write the
+ * component according to "component" object
  *
  * 3) when files are modified with no conflict or files are modified with conflicts and the
  * strategy is manual, load the component according to id.version and update component.files.
  * applyModifiedVersion() docs explains what files are updated/added.
- *
- * 4) when --reset flag is used, write the component according to the bitmap version
  *
  * Side note:
  * Deleted file => if files are in used version but not in the modified one, no need to delete it. (similar to git).
@@ -61,9 +65,9 @@ export async function applyVersion(
 ): Promise<ApplyVersionWithComps> {
   if (!checkoutProps.isLane && !componentFromFS)
     throw new Error(`applyVersion expect to get componentFromFS for ${id.toString()}`);
-  const { mergeStrategy } = checkoutProps;
+  const { mergeStrategy, forceOurs } = checkoutProps;
   let filesStatus = {};
-  if (mergeResults && mergeResults.hasConflicts && mergeStrategy === MergeOptions.ours) {
+  if ((mergeResults?.hasConflicts && mergeStrategy === MergeOptions.ours) || forceOurs) {
     // even when isLane is true, the mergeResults is possible only when the component is on the filesystem
     // otherwise it's impossible to have conflicts
     if (!componentFromFS) throw new Error(`applyVersion expect to get componentFromFS for ${id.toString()}`);
@@ -88,6 +92,9 @@ export async function applyVersion(
     filesStatus = { ...filesStatus, ...modifiedStatus };
     component.files = modifiedFiles;
   }
+
+  // in case of forceTheirs, the mergeResults is undefined, the "component" object is according to "theirs", so it'll work
+  // expected. (later, it writes the component object).
 
   return {
     applyVersionResult: { id, filesStatus },

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -32,7 +32,9 @@ export type CheckoutProps = {
   latest?: boolean;
   main?: boolean; // relevant for "revert" only
   promptMergeOptions?: boolean;
-  mergeStrategy?: MergeStrategy | null;
+  mergeStrategy?: MergeStrategy | null; // strategy to use in case of conflicts
+  forceOurs?: boolean; // regardless of conflicts, use ours
+  forceTheirs?: boolean; // regardless of conflicts, use theirs
   verbose?: boolean;
   skipNpmInstall?: boolean;
   reset?: boolean; // remove local changes. if set, the version is undefined.
@@ -326,7 +328,17 @@ export class CheckoutMain {
     checkoutProps: CheckoutProps
   ): Promise<ComponentStatusBeforeMergeAttempt> {
     const consumer = this.workspace.consumer;
-    const { version, head: headVersion, reset, revert, main, latest: latestVersion, versionPerId } = checkoutProps;
+    const {
+      version,
+      head: headVersion,
+      reset,
+      revert,
+      main,
+      latest: latestVersion,
+      versionPerId,
+      forceOurs,
+      forceTheirs,
+    } = checkoutProps;
     const repo = consumer.scope.objects;
 
     let existingBitMapId = consumer.bitMap.getComponentIdIfExist(id, { ignoreVersion: true });
@@ -434,7 +446,7 @@ export class CheckoutMain {
 
     const newId = id.changeVersion(newVersion);
 
-    if (reset || !isModified || revert || !currentlyUsedVersion) {
+    if (reset || !isModified || revert || !currentlyUsedVersion || forceTheirs || forceOurs) {
       // if the component is not modified, no need to try merge the files, they will be written later on according to the
       // checked out version. same thing when no version is specified, it'll be reset to the model-version later.
 


### PR DESCRIPTION
The `--auto-merge-resolve [ours, theirs, manual]` flag of `bit checkout` handles cases when conflicts were found during the merge. 
In some cases, a component needs to be written according to "theirs" or "ours" regardless of the conflict state. These new two flags take care of this.