### PR TITLE
fix(Workspace): revert navigation link to 2.0.27

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -59,7 +59,7 @@
         "@react-hook/latest": "1.0.3",
         "@teambit/any-fs": "0.0.5",
         "@teambit/base-react.layout.row": "0.0.3",
-        "@teambit/base-react.navigation.link": "2.0.31",
+        "@teambit/base-react.navigation.link": "2.0.27",
         "@teambit/base-ui.constants.storage": "1.0.0",
         "@teambit/base-ui.graph.tree.collapsable-tree-node": "0.0.4",
         "@teambit/base-ui.graph.tree.indent": "1.0.0",
@@ -521,7 +521,7 @@
       },
       "peerDependencies": {
         "@apollo/client": "^3.6.0",
-        "@teambit/base-react.navigation.link": "2.0.31",
+        "@teambit/base-react.navigation.link": "2.0.27",
         "@teambit/legacy": "1.0.636",
         "@teambit/ui-foundation.ui.navigation.react-router-adapter": "6.1.1",
         "@testing-library/react": "^12.1.5",
@@ -634,7 +634,7 @@
       "teambit.dependencies/dependency-resolver": {
         "policy": {
           "dependencies": {
-            "@teambit/base-react.navigation.link": "2.0.31",
+            "@teambit/base-react.navigation.link": "2.0.27",
             "@teambit/ui-foundation.ui.navigation.react-router-adapter": "6.1.1",
             "@apollo/client": "3.6.9",
             "@teambit/legacy": "1.0.636",


### PR DESCRIPTION
This PR reverts the peer dep `"@teambit/base-react.navigation.link"` to 2.0.27 from 2.0.31, which fixes the issue with multiple instances of it existing at runtime - resulting in ActualLinks (React Router) being rendered as Native Links. 