### PR TITLE
fix(build), provide artifacts from previous build tasks to app-deploy

### DIFF
--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -94,7 +94,7 @@ export class BuilderMain {
     await Promise.all(storeP);
   }
 
-  private pipelineResultsToBuilderData(
+  pipelineResultsToBuilderData(
     components: Component[],
     buildPipelineResults: TaskResults[]
   ): ComponentMap<RawBuilderData> {


### PR DESCRIPTION
The issue happened when running `bit build --include-tag`, the deploy method was trying to get the artifacts from the builderData, which weren't populated yet. 
This PR provides the artifacts directly from the previous tasks. 