### PR TITLE
feat, update dependencies policy in workspace.jsonc during import

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -330,4 +330,51 @@ describe('import functionality on Harmony', function () {
       expect(path.join(helper.scopes.localPath, `${helper.scopes.remote}/comp1/file`)).to.be.a.file();
     });
   });
+  describe('import with deps having different versions than workspace.jsonc', () => {
+    const initWsWithVer = (ver: string) => {
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.workspaceJsonc.addPolicyToDependencyResolver({
+        dependencies: {
+          'lodash.get': ver,
+        },
+      });
+      helper.npm.addFakeNpmPackage('lodash.get', ver.replace('^', '').replace('~', ''));
+      helper.command.importComponent('comp1', '-x');
+    };
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/foo.js', `const get = require('lodash.get'); console.log(get);`);
+      helper.workspaceJsonc.addPolicyToDependencyResolver({
+        dependencies: {
+          'lodash.get': '^4.4.2',
+        },
+      });
+      helper.npm.addFakeNpmPackage('lodash.get', '4.4.2');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+    });
+
+    it('if the ws has a lower range, it should update workspace.jsonc with the new range', () => {
+      initWsWithVer('^4.4.1');
+      const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+      expect(policy.dependencies['lodash.get']).to.equal('^4.4.2');
+    });
+
+    it('if the ws has a higher range, it should not update', () => {
+      initWsWithVer('^4.4.3');
+      const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+      expect(policy.dependencies['lodash.get']).to.equal('^4.4.3');
+    });
+
+    it('if the ws has a lower exact version, it should write a conflict', () => {
+      initWsWithVer('4.4.1');
+      const policy = helper.workspaceJsonc.readRaw();
+      expect(policy).to.have.string('<<<<<<< ours');
+      expect(policy).to.have.string('"lodash.get": "4.4.1"');
+      expect(policy).to.have.string('"lodash.get": "^4.4.2"');
+      expect(policy).to.have.string('>>>>>>> theirs');
+    });
+  });
 });

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -15,6 +15,7 @@ import { isDir, isDirEmptySync } from '@teambit/legacy/dist/utils';
 import { PathLinuxRelative, pathNormalizeToLinux, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
+import ConfigMergerAspect, { ConfigMergerMain } from '@teambit/config-merger';
 import Consumer from '@teambit/legacy/dist/consumer/consumer';
 import ComponentWriter, { ComponentWriterProps } from './component-writer';
 import { ComponentWriterAspect } from './component-writer.aspect';
@@ -31,6 +32,7 @@ export interface ManyComponentsWriterParams {
   skipUpdatingBitMap?: boolean;
   skipWriteConfigFiles?: boolean;
   reasonForBitmapChange?: string; // optional. will be written in the bitmap-history-metadata
+  shouldUpdateWorkspaceConfig?: boolean; // whether it should update dependencies policy (or leave conflicts) in workspace.jsonc
 }
 
 export type ComponentWriterResults = { installationError?: Error; compilationError?: Error };
@@ -41,7 +43,8 @@ export class ComponentWriterMain {
     private compiler: CompilerMain,
     private workspace: Workspace,
     private logger: Logger,
-    private mover: MoverMain
+    private mover: MoverMain,
+    private configMerge: ConfigMergerMain
   ) {}
 
   get consumer(): Consumer {
@@ -57,6 +60,9 @@ export class ComponentWriterMain {
     if (!opts.skipUpdatingBitMap) await this.consumer.writeBitMap(opts.reasonForBitmapChange);
     let installationError: Error | undefined;
     let compilationError: Error | undefined;
+    if (opts.shouldUpdateWorkspaceConfig) {
+      await this.configMerge.updateDepsInWorkspaceConfig(opts.components);
+    }
     if (!opts.skipDependencyInstallation) {
       installationError = await this.installPackagesGracefully(opts.skipWriteConfigFiles);
       // no point to compile if the installation is not running. the environment is not ready.
@@ -286,17 +292,18 @@ to move all component files to a different directory, run bit remove and then bi
   }
 
   static slots = [];
-  static dependencies = [InstallAspect, CompilerAspect, LoggerAspect, WorkspaceAspect, MoverAspect];
+  static dependencies = [InstallAspect, CompilerAspect, LoggerAspect, WorkspaceAspect, MoverAspect, ConfigMergerAspect];
   static runtime = MainRuntime;
-  static async provider([install, compiler, loggerMain, workspace, mover]: [
+  static async provider([install, compiler, loggerMain, workspace, mover, configMerger]: [
     InstallMain,
     CompilerMain,
     LoggerMain,
     Workspace,
-    MoverMain
+    MoverMain,
+    ConfigMergerMain
   ]) {
     const logger = loggerMain.createLogger(ComponentWriterAspect.id);
-    return new ComponentWriterMain(install, compiler, workspace, logger, mover);
+    return new ComponentWriterMain(install, compiler, workspace, logger, mover, configMerger);
   }
 }
 

--- a/scopes/dependencies/dependency-resolver/dependencies/base-dependency.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/base-dependency.ts
@@ -57,6 +57,10 @@ export abstract class BaseDependency implements Dependency {
     return this._optional;
   }
 
+  get idWithoutVersion() {
+    return this._id;
+  }
+
   serialize<SerializedDependency>(): SerializedDependency {
     return {
       id: this.id,

--- a/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/component-dependency/component-dependency.ts
@@ -46,6 +46,10 @@ export class ComponentDependency extends BaseDependency {
     return this.packageName;
   }
 
+  get idWithoutVersion() {
+    return this.componentId.toStringWithoutVersion();
+  }
+
   setVersion(newVersion: string) {
     super.setVersion(newVersion);
     const newComponentId = this.componentId.changeVersion(newVersion);

--- a/scopes/dependencies/dependency-resolver/dependencies/dependency.ts
+++ b/scopes/dependencies/dependency-resolver/dependencies/dependency.ts
@@ -30,6 +30,7 @@ export interface Dependency {
   id: string;
   version: string;
   type: string;
+  idWithoutVersion: string;
   lifecycle: DependencyLifecycleType;
   source?: DependencySource;
   hidden?: boolean;

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -763,6 +763,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       verbose: this.options.verbose,
       throwForExistingDir: !this.options.override,
       skipWritingToFs: this.options.trackOnly,
+      shouldUpdateWorkspaceConfig: true,
       reasonForBitmapChange: 'import',
     };
     return this.componentWriter.writeMany(manyComponentsWriterOpts);

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -292,8 +292,8 @@ export class ImporterMain {
 
   private async removeFromWorkspaceConfig(component: ConsumerComponent[]) {
     const importedPackageNames = this.getImportedPackagesNames(component);
-    this.depResolver.removeFromRootPolicy(importedPackageNames);
-    await this.depResolver.persistConfig('import (remove package)');
+    const isRemoved = this.depResolver.removeFromRootPolicy(importedPackageNames);
+    if (isRemoved) await this.depResolver.persistConfig('import (remove package)');
   }
 
   private getImportedPackagesNames(components: ConsumerComponent[]): string[] {

--- a/scopes/workspace/config-merger/config-merger.main.runtime.ts
+++ b/scopes/workspace/config-merger/config-merger.main.runtime.ts
@@ -1,11 +1,18 @@
 import semver from 'semver';
 import { isEmpty } from 'lodash';
-import { DependencyResolverAspect, WorkspacePolicyConfigKeysNames } from '@teambit/dependency-resolver';
+import {
+  DependencyResolverAspect,
+  DependencyResolverMain,
+  WorkspacePolicy,
+  WorkspacePolicyConfigKeysNames,
+  WorkspacePolicyEntry,
+} from '@teambit/dependency-resolver';
 import tempy from 'tempy';
 import fs from 'fs-extra';
 import { MainRuntime } from '@teambit/cli';
 import { WorkspaceAspect, Workspace } from '@teambit/workspace';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
+import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { DEPENDENCIES_FIELDS } from '@teambit/legacy/dist/constants';
 import { BitError } from '@teambit/bit-error';
 import mergeFiles, { MergeFileParams } from '@teambit/legacy/dist/utils/merge-files';
@@ -21,7 +28,12 @@ export type WorkspaceDepsUpdates = { [pkgName: string]: [string, string] }; // f
 export type WorkspaceDepsConflicts = Record<WorkspacePolicyConfigKeysNames, Array<{ name: string; version: string }>>; // the pkg value is in a format of CONFLICT::OURS::THEIRS
 
 export class ConfigMergerMain {
-  constructor(private workspace: Workspace, private logger: Logger, private config: ConfigMain) {}
+  constructor(
+    private workspace: Workspace,
+    private logger: Logger,
+    private config: ConfigMain,
+    private depsResolver: DependencyResolverMain
+  ) {}
 
   async generateConfigMergeConflictFileForAll(allConfigMerge: ConfigMergeResult[]) {
     const configMergeFile = this.workspace.getConflictMergeFile();
@@ -101,6 +113,7 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
       throw new Error('unable to generate conflict from the workspace.jsonc file. see debug.log for the file content');
     }
     await wsConfig.backupConfigFile('before writing conflicts');
+    this.logger.debug('writing workspace.jsonc with conflicts');
     await fs.writeFile(wsJsoncPath, conflictFile);
   }
 
@@ -252,12 +265,222 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
     };
   }
 
+  async updateDepsInWorkspaceConfig(components: ConsumerComponent[]) {
+    const workspacePolicy = this.depsResolver.getWorkspacePolicyFromConfig();
+    const workspacePolicyObj = workspacePolicy.entries.reduce((acc, current) => {
+      acc[current.dependencyId] = current.value.version;
+      return acc;
+    }, {});
+    const componentDepsWithMultipleVer: Record<string, string[]> = {};
+    components.forEach((component) => {
+      const deps = this.depsResolver.getDependenciesFromLegacyComponent(component);
+      deps.forEach((dep) => {
+        if (dep.source !== 'auto') return;
+        const depId = dep.idWithoutVersion;
+        if (!workspacePolicyObj[depId]) return;
+        if (workspacePolicyObj[depId] === dep.version) return;
+        if (componentDepsWithMultipleVer[depId]?.includes(dep.version)) return;
+
+        (componentDepsWithMultipleVer[depId] ||= []).push(dep.version);
+      });
+    });
+
+    const compToLog = Object.keys(componentDepsWithMultipleVer)
+      .map(
+        (depId) =>
+          `${depId} => workspace: ${workspacePolicyObj[depId]}, components: ${componentDepsWithMultipleVer[depId].join(
+            ', '
+          )}`
+      )
+      .join('\n');
+    this.logger.info(`found the following deps to update/conflict:\n${compToLog}`);
+
+    const componentDeps = Object.keys(componentDepsWithMultipleVer).reduce((acc, depId) => {
+      // if there are different versions of this dep between the components, forget about it.
+      if (componentDepsWithMultipleVer[depId].length > 1) return acc;
+      acc[depId] = componentDepsWithMultipleVer[depId][0];
+      return acc;
+    }, {});
+
+    if (isEmpty(componentDeps)) {
+      return;
+    }
+
+    const workspaceDepsUpdates: WorkspaceDepsUpdates = {};
+    const workspaceDepsConflicts: WorkspaceDepsConflicts = { dependencies: [], peerDependencies: [] };
+
+    const logs: string[] = [];
+
+    Object.keys(componentDeps).forEach((depId) => {
+      const depInCompVer: string = componentDeps[depId];
+      const depInWsVer: string = workspacePolicyObj[depId];
+      const isDepInCompVersion = Boolean(semver.valid(depInCompVer));
+      const isDepInCompRange = !isDepInCompVersion && Boolean(semver.validRange(depInCompVer));
+
+      const addNotUpdateToLogs = (reason: string) => {
+        logs.push(`${depId} - not updating. ${reason}`);
+      };
+
+      if (!isDepInCompVersion && !isDepInCompRange) {
+        addNotUpdateToLogs(`probably a snap-hash`);
+        return; // probably a snap-hash.
+      }
+      const isDepInWsVersion = Boolean(semver.valid(depInWsVer));
+      const isDepInWsRange = !isDepInWsVersion && Boolean(semver.validRange(depInWsVer));
+      if (!isDepInWsVersion && !isDepInWsRange) {
+        addNotUpdateToLogs(`probably a snap-hash`);
+        return; // probably a snap-hash.
+      }
+
+      // both are either versions or ranges
+      const lifeCycle =
+        workspacePolicy.entries.find((d) => d.dependencyId === depId)?.lifecycleType === 'peer'
+          ? 'peerDependencies'
+          : 'dependencies';
+
+      const addToUpdate = (addRangeFrom?: string) => {
+        if (addRangeFrom) {
+          // depInCompVer is a version, depInWsVer is a range
+          const potentialRangeChar = depInWsVer[0];
+          const newRange = potentialRangeChar + depInCompVer;
+          if (!semver.validRange(newRange)) {
+            const warnMsg = `failed to add the range "${potentialRangeChar}" to ${depInCompVer}, the result is not a valid range`;
+            this.logger.warn(warnMsg);
+            addNotUpdateToLogs(warnMsg);
+            return;
+          }
+          logs.push(`${depId} - updating from ${depInWsVer} to ${newRange} (new range based on ${depInCompVer})`);
+          workspaceDepsUpdates[depId] = [depInWsVer, newRange];
+        } else {
+          logs.push(`${depId} - updating from ${depInWsVer} to ${depInCompVer}`);
+          workspaceDepsUpdates[depId] = [depInWsVer, depInCompVer];
+        }
+      };
+      const addToConflict = () => {
+        workspaceDepsConflicts[lifeCycle].push({ name: depId, version: `CONFLICT::${depInWsVer}::${depInCompVer}` });
+        logs.push(`${depId} - conflict. ours: ${depInWsVer}, theirs: ${depInCompVer}`);
+      };
+
+      // both are versions
+      if (isDepInCompVersion && isDepInWsVersion) {
+        if (semver.gt(depInCompVer, depInWsVer)) {
+          addToConflict();
+          return;
+        }
+        addNotUpdateToLogs(`the version from ws ${depInWsVer} is greater than ${depInCompVer} from comp`);
+        return;
+      }
+
+      // both are ranges
+      if (isDepInCompRange && isDepInWsRange) {
+        if (this.isRange1GreaterThanRange2Naively(depInCompVer, depInWsVer)) {
+          addToUpdate();
+          return;
+        }
+        addNotUpdateToLogs(`the range from ws ${depInWsVer} is greater than ${depInCompVer} from comp`);
+        return;
+      }
+
+      if (isDepInCompVersion && isDepInWsRange) {
+        const wsMinVer = semver.minVersion(depInWsVer);
+        if (!wsMinVer) {
+          this.logger.warn(`unable to calculate the min version of ${depInWsVer}`);
+          addNotUpdateToLogs(`unable to calculate the min version of ${depInWsVer} from ws`);
+          return;
+        }
+        if (semver.gt(wsMinVer, depInCompVer)) {
+          addNotUpdateToLogs(`the min version from ws ${depInWsVer} is greater than ${depInCompVer} from comp`);
+          return;
+        }
+        if (semver.satisfies(depInCompVer, depInWsVer)) {
+          addToUpdate(depInWsVer);
+          return;
+        }
+        addToConflict();
+        return;
+      }
+
+      if (isDepInCompRange && isDepInWsVersion) {
+        if (semver.satisfies(depInWsVer, depInCompVer)) {
+          addToUpdate();
+          return;
+        }
+        const compMinVer = semver.minVersion(depInCompVer);
+        if (!compMinVer) {
+          this.logger.warn(`unable to calculate the min version of ${compMinVer}`);
+          addNotUpdateToLogs(`unable to calculate the min version of ${compMinVer} from comp`);
+          return;
+        }
+        if (semver.gt(compMinVer, depInWsVer)) {
+          addToConflict();
+          return;
+        }
+        addNotUpdateToLogs(`the min version from comp ${compMinVer} is less than ${depInWsVer} from ws`);
+      }
+      throw new Error(`unhandled case: comp: ${depInCompVer}, ws: ${depInWsVer}`);
+    });
+
+    WS_DEPS_FIELDS.forEach((depField) => {
+      if (isEmpty(workspaceDepsConflicts[depField])) delete workspaceDepsConflicts[depField];
+    });
+
+    this.logger.debug(`workspace config-merge all components logs\n${logs.join('\n')}`);
+    this.logger.debug('final workspace.jsonc updates [from, to]', workspaceDepsUpdates);
+    this.logger.debug(`final workspace.jsonc conflicts ${JSON.stringify(workspaceDepsConflicts, undefined, 2)}`);
+
+    await this.updateWsConfigWithGivenChanges(workspaceDepsUpdates, workspacePolicy);
+    if (!isEmpty(workspaceDepsConflicts)) {
+      await this.writeWorkspaceJsoncWithConflictsGracefully(workspaceDepsConflicts);
+    }
+  }
+
+  private async updateWsConfigWithGivenChanges(workspaceDepsUpdates: WorkspaceDepsUpdates, wsPolicy: WorkspacePolicy) {
+    if (isEmpty(workspaceDepsUpdates)) return;
+    const getLifeCycle = (depId: string) => {
+      const lifeCycle = wsPolicy.entries.find((d) => d.dependencyId === depId)?.lifecycleType;
+      if (!lifeCycle) throw new Error(`unable to find the lifecycle of ${depId}`);
+      return lifeCycle;
+    };
+
+    const newWorkspacePolicyEntries: WorkspacePolicyEntry[] = Object.keys(workspaceDepsUpdates).map((pkgName) => {
+      return {
+        dependencyId: pkgName,
+        lifecycleType: getLifeCycle(pkgName),
+        value: {
+          version: workspaceDepsUpdates[pkgName][1],
+        },
+      };
+    });
+    this.depsResolver.addToRootPolicy(newWorkspacePolicyEntries, {
+      updateExisting: true,
+    });
+    await this.depsResolver.persistConfig('config-merger (update root policy)');
+  }
+
+  /**
+   * if both versions are ranges, it's hard to check which one is bigger. sometimes it's even impossible.
+   * remember that a range can be something like `1.2 <1.2.9 || >2.0.0`.
+   * this check is naive in a way that it assumes the range is simple, such as "^1.2.3" or "~1.2.3.
+   * in this case, it's possible to check for the minimum version and compare it.
+   */
+  private isRange1GreaterThanRange2Naively(range1: string, range2: string) {
+    const minVersion1 = semver.minVersion(range1);
+    const minVersion2 = semver.minVersion(range2);
+    if (!minVersion1 || !minVersion2) return false;
+    return semver.gt(minVersion1, minVersion2);
+  }
+
   static slots = [];
-  static dependencies = [WorkspaceAspect, ConfigAspect, LoggerAspect];
+  static dependencies = [WorkspaceAspect, ConfigAspect, LoggerAspect, DependencyResolverAspect];
   static runtime = MainRuntime;
-  static async provider([workspace, config, loggerMain]: [Workspace, ConfigMain, LoggerMain]) {
+  static async provider([workspace, config, loggerMain, depsResolver]: [
+    Workspace,
+    ConfigMain,
+    LoggerMain,
+    DependencyResolverMain
+  ]) {
     const logger = loggerMain.createLogger(ConfigMergerAspect.id);
-    return new ConfigMergerMain(workspace, logger, config);
+    return new ConfigMergerMain(workspace, logger, config, depsResolver);
   }
 }
 


### PR DESCRIPTION
For example, a workspace.jsonc has `lodash@^4.4.1` and a user is running `bit import` of a component that uses `lodash@^4.4.2`.
Until now, after the import, the component is modified and the diff shows the change from 4.4.2 to 4.4.1.
With this PR, the workspace.jsonc will be updated during the import to `lodash@^4.4.2`.

In case the Semver is not satisfies, it writes a conflict inside the workspace.jsonc file.
In case the component has an older version, it doesn't do anything.