### PR TITLE
avoid throwing errors when calling toBitObjects() and the object type is unidentified

### DIFF
--- a/src/scope/README.md
+++ b/src/scope/README.md
@@ -10,8 +10,10 @@ When importing components to a scope, normally, Bit brings all its flattened-dep
 
 - `Component` - has the main data about the component, such as, name, scope-name, head-hash and a list of tags:hashes.
 - `Version` - represents a snap. has the source file hashes, dependencies data, build data, etc.
-- `Source` - source-file/dist-file
-- `Lane` - component ids and their heads of the lane
+- `Source` - source-file/dist-file.
+- `Lane` - component ids and their heads of the lane.
+- `LaneHistory` - aggregation of all changes done to a lane.
+- `ExportMetadata` - deprecated since 0.0.928. (see #6758).
 
 ### Export Process
 

--- a/src/scope/models/export-metadata.ts
+++ b/src/scope/models/export-metadata.ts
@@ -9,6 +9,10 @@ type ExportMetadataProps = {
 
 export type ExportVersions = { id: ComponentID; versions: string[]; head: Ref };
 
+/**
+ * @deprecated since 0.0.928 (see #6758). this object is not sent to the remote anymore.
+ * introduced in 0.0.782 (see #5935)
+ */
 export default class ExportMetadata extends BitObject {
   exportVersions: ExportVersions[];
   constructor(props: ExportMetadataProps) {

--- a/src/scope/objects/bit-object-list.ts
+++ b/src/scope/objects/bit-object-list.ts
@@ -28,6 +28,10 @@ export class BitObjectList {
     return this.objects;
   }
 
+  excludeTypes(types: string[]): BitObject[] {
+    return this.objects.filter((object) => !types.includes(object.getType()));
+  }
+
   getExportMetadata(): ExportMetadata | undefined {
     return this.objects.find((object) => object instanceof ExportMetadata) as ExportMetadata | undefined;
   }
@@ -50,6 +54,6 @@ export class BitObjectList {
   }
 
   private objectTypesRequireMerge() {
-    return [ModelComponent, Lane, VersionHistory];
+    return [ModelComponent, Lane, VersionHistory, LaneHistory];
   }
 }

--- a/src/scope/objects/object.ts
+++ b/src/scope/objects/object.ts
@@ -6,10 +6,11 @@ import { typesObj as types } from '../object-registrar';
 import { ObjectItem } from './object-list';
 import Ref from './ref';
 import Repository from './repository';
+import { UnknownObjectType } from '../exceptions/unknown-object-type';
 
 function parse(buffer: Buffer): BitObject {
   const { type, hash, contents } = extractHeaderAndContent(buffer);
-  if (!types[type]) throw new Error(`BitObject: unable to find subclass "${type}"`);
+  if (!types[type]) throw new UnknownObjectType(type);
   return types[type].parse(contents, hash);
 }
 


### PR DESCRIPTION
Currently, if the client supports a new `BitObject` type and the remote is not up to date with this type, it throws an error when trying to parse it. This PR, instead, filters these objects out. 