### PR TITLE
feat(Preview): fullscreen - allow rendering preview in full viewport height of the iframe

### DIFF
--- a/scopes/compositions/compositions/compositions.tsx
+++ b/scopes/compositions/compositions/compositions.tsx
@@ -79,7 +79,10 @@ export function Compositions({ menuBarWidgets, emptyState }: CompositionsProp) {
 
   const currentCompositionFullUrl = toPreviewUrl(component, 'compositions', compositionIdentifierParam);
 
-  const [compositionParams, setCompositionParams] = useState<Record<string, any>>({});
+  const [compositionParams, setCompositionParams] = useState<Record<string, any>>({
+    fullscreen: true,
+  });
+
   const queryParams = useMemo(() => queryString.stringify(compositionParams), [compositionParams]);
 
   // collapse sidebar when empty, reopen when not

--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -141,7 +141,6 @@ export class PreviewPreview {
   setViewport() {
     const query = this.getQuery();
     const viewPort = this.getParam(query, 'viewport');
-    window.document.body.style.height = '100vh';
 
     if (!viewPort) {
       window.document.body.style.width = '100%';

--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -121,12 +121,28 @@ export class PreviewPreview {
 
     this.reportSize();
     this.setViewport();
+    this.setFullScreen();
     return render;
   };
+
+  setFullScreen() {
+    const query = this.getQuery();
+    const fullScreen = this.getParam(query, 'fullscreen');
+
+    if (!fullScreen) return;
+
+    const root = window.document.getElementById('root');
+
+    if (root) {
+      root.style.height = '100vh';
+    }
+  }
 
   setViewport() {
     const query = this.getQuery();
     const viewPort = this.getParam(query, 'viewport');
+    window.document.body.style.height = '100vh';
+
     if (!viewPort) {
       window.document.body.style.width = '100%';
       return;

--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -141,7 +141,6 @@ export class PreviewPreview {
   setViewport() {
     const query = this.getQuery();
     const viewPort = this.getParam(query, 'viewport');
-
     if (!viewPort) {
       window.document.body.style.width = '100%';
       return;


### PR DESCRIPTION
This PR adds the ability to render the Component Preview in the full viewport height of the iframe. It adds a new query param; `fullscreen` which adds a height of`100vh` to the root div. It also sets the fullscreen query param in the Compositions page for a given Component.