### PR TITLE
fix(snap), fix ComponentNotFound error thrown during isPartOfMainHistory check

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -47,7 +47,7 @@ import {
   ArtifactSource,
   getArtifactsFiles,
 } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
-import { VersionNotFound } from '@teambit/legacy/dist/scope/exceptions';
+import { VersionNotFound, ComponentNotFound } from '@teambit/legacy/dist/scope/exceptions';
 import { AutoTagResult } from '@teambit/legacy/dist/scope/component-ops/auto-tag';
 import DependenciesAspect, { DependenciesMain } from '@teambit/dependencies';
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
@@ -776,7 +776,7 @@ there are matching among unmodified components thought. consider using --unmodif
             : await this.scope.legacyScope.isPartOfMainHistory(dep.id);
         } catch (err) {
           if (throwForMissingObjects) throw err;
-          if (err instanceof VersionNotFound) {
+          if (err instanceof VersionNotFound || err instanceof ComponentNotFound) {
             missingDeps.push(dep.id);
             return;
           }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -371,7 +371,7 @@ once done, to continue working, please run "bit cc"`
 
     // component is in the lane object but with a different version.
     // we have to figure out whether this version is part of the lane history
-    const component = await this.getModelComponent(id);
+    const component = await this.getModelComponent(id.changeVersion(undefined));
     const laneVersionRef = Ref.from(laneIdWithDifferentVersion.version as string);
     const verHistory = await component.getAndPopulateVersionHistory(this.objects, laneVersionRef);
     const verRef = component.getRef(id.version);
@@ -382,7 +382,7 @@ once done, to continue working, please run "bit cc"`
   async isPartOfMainHistory(id: ComponentID) {
     if (!id.version) throw new Error(`isIdOnMain expects id with version, got ${id.toString()}`);
     if (isTag(id.version)) return true; // tags can be on main only
-    const component = await this.getModelComponent(id);
+    const component = await this.getModelComponent(id.changeVersion(undefined));
     if (!component.head) return false; // it's not on main. must be on a lane. (even if it was forked from another lane, current lane must have all objects)
     if (component.head.toString() === id.version) return true; // it's on main
 


### PR DESCRIPTION
This is a regression caused by a recent optimization of not importing flattened-deps during snap.
One of the validations occurring during snap/tag on lane is that all direct dependencies are either part of the same lane or main. To check this we need the `ModelComponent` object, which was missing due to the optimization above.
This PR fixes it by adding the missing one to the "missingDeps" array which later gets imported. 