### PR TITLE
reintroduce --manual flag to manually resolve conflicts

### DIFF
--- a/e2e/harmony/binary-files.e2e.ts
+++ b/e2e/harmony/binary-files.e2e.ts
@@ -30,7 +30,7 @@ describe('handling binary files in Bit', function () {
         helper.scopeHelper.getClonedLocalScope(afterFirstTag);
         helper.fixtures.copyFixtureFile('png/png-fixture3.png', 'comp1/icon.png');
         helper.command.import();
-        checkoutOutput = helper.command.checkoutHead('--all --auto-merge-resolve manual');
+        checkoutOutput = helper.command.checkoutHead('--all --manual');
       });
       it('should checkout with no errors and leave the file as is indicating there was a conflict', () => {
         expect(checkoutOutput).to.include(FileStatusWithoutChalk.binaryConflict);

--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -283,7 +283,7 @@ describe('bit checkout command', function () {
     describe('using manual strategy', () => {
       let output;
       before(() => {
-        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve manual');
+        output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--manual');
       });
       it('should indicate that the file has conflicts', () => {
         expect(output).to.have.string(successOutput);
@@ -389,7 +389,7 @@ describe('bit checkout command', function () {
       describe('using manual strategy', () => {
         let output;
         before(() => {
-          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--auto-merge-resolve manual');
+          output = helper.command.checkoutVersion('0.0.1', 'bar/foo', '--manual');
         });
         it('should indicate that a new file was added', () => {
           expect(output).to.have.string(FileStatusWithoutChalk.added);

--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -1226,7 +1226,7 @@ describe('bit lane command', function () {
         expect(status.mergePendingComponents).to.have.lengthOf(1);
       });
       it('bit merge with no args should merge them', () => {
-        const output = helper.command.merge(`--auto-merge-resolve manual`);
+        const output = helper.command.merge(`--manual`);
         expect(output).to.have.string('successfully merged');
         expect(output).to.have.string('CONFLICT');
       });

--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -52,7 +52,7 @@ describe('merge config scenarios', function () {
     });
     describe('merging the lane to main', () => {
       before(() => {
-        helper.command.mergeLane(`${helper.scopes.remote}/dev`, '--auto-merge-resolve manual --no-squash');
+        helper.command.mergeLane(`${helper.scopes.remote}/dev`, '--manual --no-squash');
         // fixes the conflicts
         helper.fs.outputFile(`${helper.scopes.remoteWithoutOwner}/comp1/index.js`);
         helper.fs.outputFile(`${helper.scopes.remoteWithoutOwner}/comp2/index.js`);
@@ -94,7 +94,7 @@ describe('merge config scenarios', function () {
       });
       describe('merge from main to the lane', () => {
         before(() => {
-          helper.command.mergeLane('main', '--auto-merge-resolve manual');
+          helper.command.mergeLane('main', '--manual');
         });
         // previous bug, showed only comp1 as componentsDuringMergeState, but the rest, because they're not in the
         // workspace, it didn't merge them correctly.

--- a/e2e/harmony/snap.e2e.2.ts
+++ b/e2e/harmony/snap.e2e.2.ts
@@ -383,7 +383,7 @@ describe('bit snap command', function () {
         before(() => {
           helper.scopeHelper.getClonedLocalScope(localScope);
           helper.command.importComponent('bar/foo --objects');
-          mergeOutput = helper.command.merge('bar/foo --auto-merge-resolve manual');
+          mergeOutput = helper.command.merge('bar/foo --manual');
           scopeWithConflicts = helper.scopeHelper.cloneLocalScope();
         });
         it('should succeed and indicate that the files were left in a conflict state', () => {
@@ -412,7 +412,7 @@ describe('bit snap command', function () {
           expect(status.mergePendingComponents).to.have.lengthOf(0);
         });
         it('should block checking out the component', () => {
-          expect(() => helper.command.checkoutVersion(firstSnap, 'bar/foo', '--auto-merge-resolve manual')).to.throw(
+          expect(() => helper.command.checkoutVersion(firstSnap, 'bar/foo', '--manual')).to.throw(
             'is in during-merge state'
           );
         });

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -49,6 +49,11 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       'auto-merge-resolve <merge-strategy>',
       'in case of merge conflict, resolve according to the provided strategy: [ours, theirs, manual]',
     ],
+    [
+      '',
+      'manual',
+      'same as "--auto-merge-resolve manual". in case of merge conflict, write the files with the conflict markers',
+    ],
     ['a', 'all', 'all components'],
     [
       'e',
@@ -71,6 +76,7 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       forceOurs,
       forceTheirs,
       autoMergeResolve,
+      manual,
       all = false,
       workspaceOnly = false,
       verbose = false,
@@ -81,6 +87,7 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
       forceOurs?: boolean;
       forceTheirs?: boolean;
       autoMergeResolve?: MergeStrategy;
+      manual?: boolean;
       all?: boolean;
       workspaceOnly?: boolean;
       verbose?: boolean;
@@ -99,6 +106,7 @@ when on a lane, "checkout head" only checks out components on this lane. to upda
     ) {
       throw new BitError('--auto-merge-resolve must be one of the following: [ours, theirs, manual]');
     }
+    if (manual) autoMergeResolve = 'manual';
     if (workspaceOnly && to !== HEAD) {
       throw new BitError('--workspace-only is only relevant when running "bit checkout head" on a lane');
     }

--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -33,7 +33,11 @@ ${WILDCARD_HELP('merge')}`;
       'theirs',
       'DEPRECATED. use --auto-merge-resolve. in case of a conflict, override the local modification with the specified version',
     ],
-    ['', 'manual', 'DEPRECATED. use --auto-merge-resolve'],
+    [
+      '',
+      'manual',
+      'same as "--auto-merge-resolve manual". in case of merge conflict, write the files with the conflict markers',
+    ],
     [
       '',
       'auto-merge-resolve <merge-strategy>',
@@ -80,10 +84,8 @@ ${WILDCARD_HELP('merge')}`;
     }
   ) {
     build = (await this.globalConfig.getBool(CFG_FORCE_LOCAL_BUILD)) || Boolean(build);
-    if (ours || theirs || manual) {
-      throw new BitError(
-        'the "--ours", "--theirs" and "--manual" flags are deprecated. use "--auto-merge-resolve" instead'
-      );
+    if (ours || theirs) {
+      throw new BitError('the "--ours" and "--theirs" flags are deprecated. use "--auto-merge-resolve" instead');
     }
     if (
       autoMergeResolve &&
@@ -93,6 +95,7 @@ ${WILDCARD_HELP('merge')}`;
     ) {
       throw new BitError('--auto-merge-resolve must be one of the following: [ours, theirs, manual]');
     }
+    if (manual) autoMergeResolve = 'manual';
     if (abort && resolve) throw new BitError('unable to use "abort" and "resolve" flags together');
     if (noSnap && message) throw new BitError('unable to use "noSnap" and "message" flags together');
     const {

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -39,14 +39,18 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
   ];
   alias = '';
   options = [
-    ['', 'ours', 'DEPRECATED. use --auto-merge-resolve. in case of a conflict, keep local modifications'],
-    ['', 'theirs', 'DEPRECATED. use --auto-merge-resolve. in case of a conflict, override local with incoming changes'],
-    ['', 'manual', 'DEPRECATED. use --auto-merge-resolve'],
+    [
+      '',
+      'manual',
+      'same as "--auto-merge-resolve manual". in case of merge conflict, write the files with the conflict markers',
+    ],
     [
       '',
       'auto-merge-resolve <merge-strategy>',
       'in case of a merge conflict, resolve according to the provided strategy: [ours, theirs, manual]',
     ],
+    ['', 'ours', 'DEPRECATED. use --auto-merge-resolve. in case of a conflict, keep local modifications'],
+    ['', 'theirs', 'DEPRECATED. use --auto-merge-resolve. in case of a conflict, override local with incoming changes'],
     ['', 'workspace', 'merge only lane components that are in the current workspace'],
     ['', 'no-snap', 'do not auto snap after merge completed without conflicts'],
     ['', 'tag', 'auto-tag all lane components after merging into main (or tag-merge in case of snap-merge)'],
@@ -139,9 +143,9 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     }
   ): Promise<string> {
     build = (await this.globalConfig.getBool(CFG_FORCE_LOCAL_BUILD)) || Boolean(build);
-    if (ours || theirs || manual) {
+    if (ours || theirs) {
       throw new BitError(
-        'the "--ours", "--theirs" and "--manual" flags are deprecated. use "--auto-merge-resolve" instead. see "bit lane merge --help" for more information'
+        'the "--ours" and "--theirs" flags are deprecated. use "--auto-merge-resolve" instead. see "bit lane merge --help" for more information'
       );
     }
     if (
@@ -152,6 +156,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     ) {
       throw new BitError('--auto-merge-resolve must be one of the following: [ours, theirs, manual]');
     }
+    if (manual) autoMergeResolve = 'manual';
     const mergeStrategy = autoMergeResolve;
     if (noSnap && snapMessage) throw new BitError('unable to use "no-snap" and "message" flags together');
     if (includeDeps && !pattern && !existingOnWorkspaceOnly) {


### PR DESCRIPTION
It had been deprecated a few months ago along with `--ours` and `--theirs`. However, there is no need to deprecate the manual flag only the others which are going to get different functionality (see https://github.com/teambit/bit/pull/8397). 