### PR TITLE
do not delete ModelComponent objects during export

### DIFF
--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -492,15 +492,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       return mapSeries(manyObjectsPerRemote, async (objectsPerRemote: ObjectsPerRemoteExtended) => {
         const { remote, idsToChangeLocally, componentsAndObjects, exportedIds } = objectsPerRemote;
         const remoteNameStr = remote.name;
-        // on Harmony, version hashes don't change, the new versions will replace the old ones.
-        const removeComponentVersions = false;
-        const refsToRemove = await Promise.all(
-          idsToChangeLocally.map((id) => scope.sources.getRefsForComponentRemoval(id, removeComponentVersions))
-        );
-        scope.objects.removeManyObjects(refsToRemove.flat());
-        // idsToChangeLocally.forEach((id) => {
-        //   scope.createSymlink(id, idsWithFutureScope.searchWithoutScopeAndVersion(id)?.scope || remoteNameStr);
-        // });
+
         componentsAndObjects.forEach((componentObject) => scope.sources.put(componentObject));
 
         // update lanes


### PR DESCRIPTION
This was needed in the past when the original ModelComponent consisted of the name only and a symlink object was created with the same hash. Currently that ModelComponent always has the scope-name it's not needed anymore.
(the trigger of this change was an unclear scenario where the model-component wasn't there after hitting Ctrl+C during export).