### PR TITLE
improvement(import), introduce a new flag --dependents-dry-run

### DIFF
--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -30,6 +30,7 @@ type ImportFlags = {
   saveInLane?: boolean;
   dependencies?: boolean;
   dependents?: boolean;
+  dependentsDryRun?: boolean;
   allHistory?: boolean;
   fetchDeps?: boolean;
   trackOnly?: boolean;
@@ -77,6 +78,11 @@ export class ImportCmd implements Command {
       '',
       'dependents',
       'import components found while traversing from the imported components upwards to the workspace components',
+    ],
+    [
+      '',
+      'dependents-dry-run',
+      'same as --dependents, except it prints the found dependents and wait for confirmation before importing them',
     ],
     [
       '',
@@ -198,6 +204,7 @@ export class ImportCmd implements Command {
       saveInLane = false,
       dependencies = false,
       dependents = false,
+      dependentsDryRun = false,
       allHistory = false,
       fetchDeps = false,
       trackOnly = false,
@@ -215,6 +222,9 @@ export class ImportCmd implements Command {
     }
     if (!ids.length && dependents) {
       throw new GeneralError('you have to specify ids to use "--dependents" flag');
+    }
+    if (!ids.length && dependentsDryRun) {
+      throw new GeneralError('you have to specify ids to use "--dependents-dry-run" flag');
     }
     if (!ids.length && trackOnly) {
       throw new GeneralError('you have to specify ids to use "--track-only" flag');
@@ -245,6 +255,7 @@ export class ImportCmd implements Command {
       saveInLane,
       importDependenciesDirectly: dependencies,
       importDependents: dependents,
+      dependentsDryRun,
       allHistory,
       fetchDeps,
       trackOnly,

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -56,13 +56,7 @@ export class ImporterMain {
         importOptions.lanes = { laneId: currentLaneId };
       }
     }
-    const importComponents = new ImportComponents(
-      this.workspace,
-      this.graph,
-      this.componentWriter,
-      this.envs,
-      importOptions
-    );
+    const importComponents = this.createImportComponents(importOptions);
     const results = await importComponents.importComponents();
     Analytics.setExtraData('num_components', results.importedIds.length);
     if (results.writtenComponents && results.writtenComponents.length) {
@@ -84,13 +78,7 @@ export class ImporterMain {
       installNpmPackages: false,
       writeConfigFiles: false,
     };
-    const importComponents = new ImportComponents(
-      this.workspace,
-      this.graph,
-      this.componentWriter,
-      this.envs,
-      importOptions
-    );
+    const importComponents = this.createImportComponents(importOptions);
     return importComponents.importComponents();
   }
 
@@ -123,13 +111,7 @@ export class ImporterMain {
     if (currentRemoteLane) {
       importOptions.lanes = { laneId: currentRemoteLane.toLaneId(), remoteLane: currentRemoteLane };
     }
-    const importComponents = new ImportComponents(
-      this.workspace,
-      this.graph,
-      this.componentWriter,
-      this.envs,
-      importOptions
-    );
+    const importComponents = this.createImportComponents(importOptions);
     return importComponents.importComponents();
   }
 
@@ -188,13 +170,7 @@ export class ImporterMain {
       fromOriginalScope,
     };
 
-    const importComponents = new ImportComponents(
-      this.workspace,
-      this.graph,
-      this.componentWriter,
-      this.envs,
-      importOptions
-    );
+    const importComponents = this.createImportComponents(importOptions);
     const { importedIds, importDetails } = await importComponents.importComponents();
     Analytics.setExtraData('num_components', importedIds.length);
     await consumer.onDestroy('import');
@@ -233,6 +209,17 @@ export class ImporterMain {
 
       return [];
     }
+  }
+
+  private createImportComponents(importOptions: ImportOptions) {
+    return new ImportComponents(
+      this.workspace,
+      this.graph,
+      this.componentWriter,
+      this.envs,
+      this.logger,
+      importOptions
+    );
   }
 
   async fetchLanes(


### PR DESCRIPTION
With this flag it'll show the list of the found dependents before importing them and will ask the user whether or not to continue with the import.