### PR TITLE
refactor(core-aspects) - update core aspect env to use mocha by default

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -16,7 +16,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/api-reference",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "api-server": {
@@ -26,7 +26,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/api-server",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "application": {
@@ -36,7 +36,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/application",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "aspect": {
@@ -46,7 +46,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "aspect-docs/babel": {
@@ -203,7 +203,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/aspect-loader",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "babel": {
@@ -213,7 +213,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/babel",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "babel/bit-react-transformer": {
@@ -230,7 +230,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "builder": {
@@ -240,7 +240,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/pipelines/builder",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "builder-data": {
@@ -257,7 +257,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/bundler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "cache": {
@@ -267,7 +267,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cache",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "changelog": {
@@ -277,7 +277,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/changelog",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "checkout": {
@@ -287,7 +287,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/checkout",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "clear-cache": {
@@ -297,7 +297,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/clear-cache",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "cli": {
@@ -307,7 +307,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/cli",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "cli-table": {
@@ -359,7 +359,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/cloud/cloud",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "code": {
@@ -369,7 +369,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/code",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "command-bar": {
@@ -379,7 +379,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/command-bar",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "community": {
@@ -389,7 +389,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/community/community",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "compiler": {
@@ -399,7 +399,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/compiler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component": {
@@ -409,7 +409,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-compare": {
@@ -419,7 +419,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-compare",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-descriptor": {
@@ -429,7 +429,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-descriptor",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-issues": {
@@ -446,7 +446,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-log",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-package-version": {
@@ -463,7 +463,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-sizer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-tree": {
@@ -473,7 +473,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-tree",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "component-writer": {
@@ -483,7 +483,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/component-writer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "composition-card": {
@@ -500,7 +500,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compositions/compositions",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "config": {
@@ -510,7 +510,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/config",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "config-merger": {
@@ -520,7 +520,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/config-merger",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "content/cli-reference": {
@@ -537,7 +537,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependencies",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "dependency-resolver": {
@@ -547,7 +547,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "deprecation": {
@@ -557,7 +557,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/deprecation",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "dev-files": {
@@ -567,7 +567,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/dev-files",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "diagnostic": {
@@ -577,7 +577,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/diagnostic",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "docs": {
@@ -587,7 +587,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/docs/docs",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "eject": {
@@ -597,7 +597,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/eject",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "entities/lane-diff": {
@@ -621,7 +621,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/env",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "envs": {
@@ -631,7 +631,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/envs/envs",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "eslint": {
@@ -669,7 +669,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/export",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "express": {
@@ -679,7 +679,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/express",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "forking": {
@@ -689,7 +689,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/forking",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "formatter": {
@@ -699,7 +699,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/formatter",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "fs/hard-link-directory": {
@@ -723,7 +723,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/generator/generator",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "git": {
@@ -733,7 +733,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/git/git",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "global-config": {
@@ -743,7 +743,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/global-config",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "graph": {
@@ -753,7 +753,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/graph",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "graphql": {
@@ -763,7 +763,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/graphql",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "harmony-ui-app": {
@@ -773,7 +773,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "hooks/use-api": {
@@ -860,7 +860,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/importer",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "insights": {
@@ -870,7 +870,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/explorer/insights",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "install": {
@@ -880,7 +880,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/install",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "ipc-events": {
@@ -890,7 +890,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/ipc-events",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "isolator": {
@@ -900,7 +900,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/isolator",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "issues": {
@@ -910,7 +910,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/issues",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "jest": {
@@ -920,7 +920,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/jest",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "lanes": {
@@ -930,7 +930,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/lanes",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "linter": {
@@ -940,7 +940,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/linter",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "lister": {
@@ -950,7 +950,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/lister",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "logger": {
@@ -960,7 +960,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/logger",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "mdx": {
@@ -977,7 +977,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/lanes/merge-lanes",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "merging": {
@@ -987,7 +987,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/merging",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "mocha": {
@@ -997,7 +997,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/mocha",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "model/composition-id": {
@@ -1196,7 +1196,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/mover",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "multi-compiler": {
@@ -1206,7 +1206,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/compilation/multi-compiler",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "multi-tester": {
@@ -1216,7 +1216,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/multi-tester",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "network/get-port": {
@@ -1233,7 +1233,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/new-component-helper",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "node": {
@@ -1250,7 +1250,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/notifications/aspect",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "overview/api-reference-table-of-contents": {
@@ -1274,7 +1274,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/panels",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "panels/composition-gallery": {
@@ -1319,7 +1319,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/pkg/pkg",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "plugins/inject-head-webpack-plugin": {
@@ -1336,7 +1336,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/pnpm",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "prettier": {
@@ -1346,7 +1346,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/prettier",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "prettier/config-mutator": {
@@ -1363,7 +1363,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/preview/preview",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "pubsub": {
@@ -1373,7 +1373,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/pubsub",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "react": {
@@ -1397,7 +1397,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/react-router/react-router",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "readme": {
@@ -1414,7 +1414,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/refactoring",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "remove": {
@@ -1424,7 +1424,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/remove",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "renaming": {
@@ -1434,7 +1434,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/renaming",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "renderers/api-node-details": {
@@ -1584,7 +1584,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/semantics/schema",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "scope": {
@@ -1594,7 +1594,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/scope",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "sections/api-reference-page": {
@@ -1618,7 +1618,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/sidebar",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "sign": {
@@ -1628,7 +1628,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/sign",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "snapping": {
@@ -1638,7 +1638,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/snapping",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "stash": {
@@ -1648,7 +1648,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/stash",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "status": {
@@ -1658,7 +1658,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/status",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "string/capitalize": {
@@ -1703,7 +1703,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/defender/tester",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "testing/load-aspect": {
@@ -1741,7 +1741,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/component/tracker",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "ts-server": {
@@ -1765,7 +1765,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/typescript/typescript",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "ui": {
@@ -2125,7 +2125,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/scope/update-dependencies",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "url/add-avatar-query-params": {
@@ -2149,7 +2149,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/ui-foundation/user-agent",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "utils/code-editor-options": {
@@ -2201,7 +2201,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/variants",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "watcher": {
@@ -2211,7 +2211,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/watcher",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "webpack": {
@@ -2221,7 +2221,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/webpack/webpack",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "worker": {
@@ -2231,7 +2231,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/worker",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "workspace": {
@@ -2241,7 +2241,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "workspace-config-files": {
@@ -2251,7 +2251,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/workspace/workspace-config-files",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "yarn": {
@@ -2261,7 +2261,7 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/yarn",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
         }
     },
     "$schema-version": "17.0.0"

--- a/.bitmap
+++ b/.bitmap
@@ -14,28 +14,40 @@
         "scope": "teambit.api-reference",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/api-reference"
+        "rootDir": "scopes/api-reference/api-reference",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "api-server": {
         "name": "api-server",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/api-server"
+        "rootDir": "scopes/harmony/api-server",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "application": {
         "name": "application",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/application"
+        "rootDir": "scopes/harmony/application",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "aspect": {
         "name": "aspect",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect"
+        "rootDir": "scopes/harmony/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "aspect-docs/babel": {
         "name": "aspect-docs/babel",
@@ -189,14 +201,20 @@
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/aspect-loader"
+        "rootDir": "scopes/harmony/aspect-loader",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "babel": {
         "name": "babel",
         "scope": "teambit.compilation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/babel"
+        "rootDir": "scopes/compilation/babel",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "babel/bit-react-transformer": {
         "name": "babel/bit-react-transformer",
@@ -210,14 +228,20 @@
         "scope": "teambit.harmony",
         "version": "1.6.35",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/bit"
+        "rootDir": "scopes/harmony/bit",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "builder": {
         "name": "builder",
         "scope": "teambit.pipelines",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/builder"
+        "rootDir": "scopes/pipelines/builder",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "builder-data": {
         "name": "builder-data",
@@ -231,42 +255,60 @@
         "scope": "teambit.compilation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/bundler"
+        "rootDir": "scopes/compilation/bundler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "cache": {
         "name": "cache",
         "scope": "teambit.harmony",
         "version": "0.0.941",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cache"
+        "rootDir": "scopes/harmony/cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "changelog": {
         "name": "changelog",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/changelog"
+        "rootDir": "scopes/component/changelog",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "checkout": {
         "name": "checkout",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/checkout"
+        "rootDir": "scopes/component/checkout",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "clear-cache": {
         "name": "clear-cache",
         "scope": "teambit.workspace",
         "version": "0.0.401",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/clear-cache"
+        "rootDir": "scopes/workspace/clear-cache",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "cli": {
         "name": "cli",
         "scope": "teambit.harmony",
         "version": "0.0.848",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/cli"
+        "rootDir": "scopes/harmony/cli",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "cli-table": {
         "name": "cli-table",
@@ -315,56 +357,80 @@
         "scope": "teambit.cloud",
         "version": "0.0.418",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/cloud"
+        "rootDir": "scopes/cloud/cloud",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "code": {
         "name": "code",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/code"
+        "rootDir": "scopes/component/code",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "command-bar": {
         "name": "command-bar",
         "scope": "teambit.explorer",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/command-bar"
+        "rootDir": "scopes/explorer/command-bar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "community": {
         "name": "community",
         "scope": "teambit.community",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/community/community"
+        "rootDir": "scopes/community/community",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "compiler": {
         "name": "compiler",
         "scope": "teambit.compilation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/compiler"
+        "rootDir": "scopes/compilation/compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component": {
         "name": "component",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component"
+        "rootDir": "scopes/component/component",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-compare": {
         "name": "component-compare",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-compare"
+        "rootDir": "scopes/component/component-compare",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-descriptor": {
         "name": "component-descriptor",
         "scope": "teambit.component",
         "version": "0.0.413",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-descriptor"
+        "rootDir": "scopes/component/component-descriptor",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
@@ -378,7 +444,10 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-log"
+        "rootDir": "scopes/component/component-log",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-package-version": {
         "name": "component-package-version",
@@ -392,21 +461,30 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-sizer"
+        "rootDir": "scopes/component/component-sizer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-tree": {
         "name": "component-tree",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-tree"
+        "rootDir": "scopes/component/component-tree",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "component-writer": {
         "name": "component-writer",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-writer"
+        "rootDir": "scopes/component/component-writer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "composition-card": {
         "name": "composition-card",
@@ -420,21 +498,30 @@
         "scope": "teambit.compositions",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/compositions"
+        "rootDir": "scopes/compositions/compositions",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "config": {
         "name": "config",
         "scope": "teambit.harmony",
         "version": "0.0.893",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/config"
+        "rootDir": "scopes/harmony/config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "config-merger": {
         "name": "config-merger",
         "scope": "teambit.workspace",
         "version": "0.0.9",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/config-merger"
+        "rootDir": "scopes/workspace/config-merger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
@@ -448,49 +535,70 @@
         "scope": "teambit.dependencies",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependencies"
+        "rootDir": "scopes/dependencies/dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
         "scope": "teambit.dependencies",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/dependency-resolver"
+        "rootDir": "scopes/dependencies/dependency-resolver",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "deprecation": {
         "name": "deprecation",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/deprecation"
+        "rootDir": "scopes/component/deprecation",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "dev-files": {
         "name": "dev-files",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/dev-files"
+        "rootDir": "scopes/component/dev-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "diagnostic": {
         "name": "diagnostic",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/diagnostic"
+        "rootDir": "scopes/harmony/diagnostic",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "docs": {
         "name": "docs",
         "scope": "teambit.docs",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/docs/docs"
+        "rootDir": "scopes/docs/docs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "eject": {
         "name": "eject",
         "scope": "teambit.workspace",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/eject"
+        "rootDir": "scopes/workspace/eject",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "entities/lane-diff": {
         "name": "entities/lane-diff",
@@ -511,14 +619,20 @@
         "scope": "teambit.envs",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/env"
+        "rootDir": "scopes/envs/env",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "envs": {
         "name": "envs",
         "scope": "teambit.envs",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/envs/envs"
+        "rootDir": "scopes/envs/envs",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "eslint": {
         "name": "eslint",
@@ -553,28 +667,40 @@
         "scope": "teambit.scope",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/export"
+        "rootDir": "scopes/scope/export",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "express": {
         "name": "express",
         "scope": "teambit.harmony",
         "version": "0.0.947",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/express"
+        "rootDir": "scopes/harmony/express",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "forking": {
         "name": "forking",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/forking"
+        "rootDir": "scopes/component/forking",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "formatter": {
         "name": "formatter",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/formatter"
+        "rootDir": "scopes/defender/formatter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "fs/hard-link-directory": {
         "name": "fs/hard-link-directory",
@@ -595,42 +721,60 @@
         "scope": "teambit.generator",
         "version": "1.0.143",
         "mainFile": "index.ts",
-        "rootDir": "scopes/generator/generator"
+        "rootDir": "scopes/generator/generator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "git": {
         "name": "git",
         "scope": "teambit.git",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/git"
+        "rootDir": "scopes/git/git",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "global-config": {
         "name": "global-config",
         "scope": "teambit.harmony",
         "version": "0.0.851",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/global-config"
+        "rootDir": "scopes/harmony/global-config",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "graph": {
         "name": "graph",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/graph"
+        "rootDir": "scopes/component/graph",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "graphql": {
         "name": "graphql",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/graphql"
+        "rootDir": "scopes/harmony/graphql",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "harmony-ui-app": {
         "name": "harmony-ui-app",
         "scope": "teambit.ui-foundation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app"
+        "rootDir": "scopes/ui-foundation/harmony-ui-app/harmony-ui-app",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "hooks/use-api": {
         "name": "hooks/use-api",
@@ -714,77 +858,110 @@
         "scope": "teambit.scope",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/importer"
+        "rootDir": "scopes/scope/importer",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "insights": {
         "name": "insights",
         "scope": "teambit.explorer",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/explorer/insights"
+        "rootDir": "scopes/explorer/insights",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "install": {
         "name": "install",
         "scope": "teambit.workspace",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/install"
+        "rootDir": "scopes/workspace/install",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "ipc-events": {
         "name": "ipc-events",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/ipc-events"
+        "rootDir": "scopes/harmony/ipc-events",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "isolator": {
         "name": "isolator",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/isolator"
+        "rootDir": "scopes/component/isolator",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "issues": {
         "name": "issues",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/issues"
+        "rootDir": "scopes/component/issues",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "jest": {
         "name": "jest",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/jest"
+        "rootDir": "scopes/defender/jest",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "lanes": {
         "name": "lanes",
         "scope": "teambit.lanes",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/lanes"
+        "rootDir": "scopes/lanes/lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "linter": {
         "name": "linter",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/linter"
+        "rootDir": "scopes/defender/linter",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "lister": {
         "name": "lister",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/lister"
+        "rootDir": "scopes/component/lister",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "logger": {
         "name": "logger",
         "scope": "teambit.harmony",
         "version": "0.0.941",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/logger"
+        "rootDir": "scopes/harmony/logger",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -798,21 +975,30 @@
         "scope": "teambit.lanes",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/merge-lanes"
+        "rootDir": "scopes/lanes/merge-lanes",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "merging": {
         "name": "merging",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/merging"
+        "rootDir": "scopes/component/merging",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "mocha": {
         "name": "mocha",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/mocha"
+        "rootDir": "scopes/defender/mocha",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "model/composition-id": {
         "name": "model/composition-id",
@@ -1008,21 +1194,30 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/mover"
+        "rootDir": "scopes/component/mover",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "multi-compiler": {
         "name": "multi-compiler",
         "scope": "teambit.compilation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compilation/multi-compiler"
+        "rootDir": "scopes/compilation/multi-compiler",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "multi-tester": {
         "name": "multi-tester",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/multi-tester"
+        "rootDir": "scopes/defender/multi-tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
@@ -1036,7 +1231,10 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/new-component-helper"
+        "rootDir": "scopes/component/new-component-helper",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "node": {
         "name": "node",
@@ -1050,7 +1248,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/notifications/aspect"
+        "rootDir": "scopes/ui-foundation/notifications/aspect",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "overview/api-reference-table-of-contents": {
         "name": "overview/api-reference-table-of-contents",
@@ -1071,7 +1272,10 @@
         "scope": "teambit.ui-foundation",
         "version": "0.0.850",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/panels"
+        "rootDir": "scopes/ui-foundation/panels",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "panels/composition-gallery": {
         "name": "panels/composition-gallery",
@@ -1113,7 +1317,10 @@
         "scope": "teambit.pkg",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/pkg"
+        "rootDir": "scopes/pkg/pkg",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "plugins/inject-head-webpack-plugin": {
         "name": "plugins/inject-head-webpack-plugin",
@@ -1127,14 +1334,20 @@
         "scope": "teambit.dependencies",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/pnpm"
+        "rootDir": "scopes/dependencies/pnpm",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "prettier": {
         "name": "prettier",
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier"
+        "rootDir": "scopes/defender/prettier",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "prettier/config-mutator": {
         "name": "prettier/config-mutator",
@@ -1148,14 +1361,20 @@
         "scope": "teambit.preview",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/preview/preview"
+        "rootDir": "scopes/preview/preview",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "pubsub": {
         "name": "pubsub",
         "scope": "teambit.harmony",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/pubsub"
+        "rootDir": "scopes/harmony/pubsub",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "react": {
         "name": "react",
@@ -1176,7 +1395,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/react-router/react-router"
+        "rootDir": "scopes/ui-foundation/react-router/react-router",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "readme": {
         "name": "readme",
@@ -1190,21 +1412,30 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/refactoring"
+        "rootDir": "scopes/component/refactoring",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "remove": {
         "name": "remove",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/remove"
+        "rootDir": "scopes/component/remove",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "renaming": {
         "name": "renaming",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/renaming"
+        "rootDir": "scopes/component/renaming",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "renderers/api-node-details": {
         "name": "renderers/api-node-details",
@@ -1351,14 +1582,20 @@
         "scope": "teambit.semantics",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/semantics/schema"
+        "rootDir": "scopes/semantics/schema",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "scope": {
         "name": "scope",
         "scope": "teambit.scope",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/scope"
+        "rootDir": "scopes/scope/scope",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "sections/api-reference-page": {
         "name": "sections/api-reference-page",
@@ -1379,35 +1616,50 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/sidebar"
+        "rootDir": "scopes/ui-foundation/sidebar",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "sign": {
         "name": "sign",
         "scope": "teambit.scope",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/sign"
+        "rootDir": "scopes/scope/sign",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "snapping": {
         "name": "snapping",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snapping"
+        "rootDir": "scopes/component/snapping",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "stash": {
         "name": "stash",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/stash"
+        "rootDir": "scopes/component/stash",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "status": {
         "name": "status",
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/status"
+        "rootDir": "scopes/component/status",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "string/capitalize": {
         "name": "string/capitalize",
@@ -1449,7 +1701,10 @@
         "scope": "teambit.defender",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/tester"
+        "rootDir": "scopes/defender/tester",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "testing/load-aspect": {
         "name": "testing/load-aspect",
@@ -1484,7 +1739,10 @@
         "scope": "teambit.component",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/tracker"
+        "rootDir": "scopes/component/tracker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "ts-server": {
         "name": "ts-server",
@@ -1505,7 +1763,10 @@
         "scope": "teambit.typescript",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/typescript"
+        "rootDir": "scopes/typescript/typescript",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "ui": {
         "name": "ui",
@@ -1862,7 +2123,10 @@
         "scope": "teambit.scope",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/update-dependencies"
+        "rootDir": "scopes/scope/update-dependencies",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "url/add-avatar-query-params": {
         "name": "url/add-avatar-query-params",
@@ -1883,7 +2147,10 @@
         "scope": "teambit.ui-foundation",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/ui-foundation/user-agent"
+        "rootDir": "scopes/ui-foundation/user-agent",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "utils/code-editor-options": {
         "name": "utils/code-editor-options",
@@ -1932,49 +2199,70 @@
         "scope": "teambit.workspace",
         "version": "0.0.986",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/variants"
+        "rootDir": "scopes/workspace/variants",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "watcher": {
         "name": "watcher",
         "scope": "teambit.workspace",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/watcher"
+        "rootDir": "scopes/workspace/watcher",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "webpack": {
         "name": "webpack",
         "scope": "teambit.webpack",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/webpack"
+        "rootDir": "scopes/webpack/webpack",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "worker": {
         "name": "worker",
         "scope": "teambit.harmony",
         "version": "0.0.1152",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/worker"
+        "rootDir": "scopes/harmony/worker",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "workspace": {
         "name": "workspace",
         "scope": "teambit.workspace",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace"
+        "rootDir": "scopes/workspace/workspace",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "workspace-config-files": {
         "name": "workspace-config-files",
         "scope": "teambit.workspace",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/workspace-config-files"
+        "rootDir": "scopes/workspace/workspace-config-files",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "yarn": {
         "name": "yarn",
         "scope": "teambit.dependencies",
         "version": "1.0.142",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/yarn"
+        "rootDir": "scopes/dependencies/yarn",
+        "config": {
+            "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+        }
     },
     "$schema-version": "17.0.0"
 }

--- a/.bitmap
+++ b/.bitmap
@@ -547,7 +547,11 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.21": {}
+            "teambit.harmony/envs/core-aspect-env@0.0.21": {},
+            "teambit.harmony/envs/core-aspect-env-jest@0.0.2": {},
+            "teambit.envs/envs": {
+                "env": "teambit.harmony/envs/core-aspect-env-jest"
+            }
         }
     },
     "deprecation": {

--- a/.bitmap
+++ b/.bitmap
@@ -547,7 +547,6 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/dependencies/dependency-resolver",
         "config": {
-            "teambit.harmony/envs/core-aspect-env@0.0.21": {},
             "teambit.harmony/envs/core-aspect-env-jest@0.0.2": {},
             "teambit.envs/envs": {
                 "env": "teambit.harmony/envs/core-aspect-env-jest"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v0.0.21-v1
+          key: core-aspect-env-v0.0.21-v2
       - run: echo $BIT_FEATURES
       - run: node -v
       - run: npm -v
@@ -502,7 +502,7 @@ jobs:
           name: bbit install
           command: cd bit && bbit install
       - save_cache:
-          key: core-aspect-env-v0.0.21-v1
+          key: core-aspect-env-v0.0.21-v2
           paths:
             - /home/circleci/Library/Caches/Bit/capsules/caec9a1075d4addee151dbe7e351b809aaa4b088
       - run: cd bit && npm run link-bit-legacy
@@ -547,7 +547,7 @@ jobs:
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
       - restore_cache:
-          key: core-aspect-env-v0.0.21-v1
+          key: core-aspect-env-v0.0.21-v2
       # - update_ssh_agent
       # temporary, check if we can remove it
       - run: cd bit && bit cc
@@ -583,7 +583,7 @@ jobs:
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
       - restore_cache:
-          key: core-aspect-env-v0.0.21-v1
+          key: core-aspect-env-v0.0.21-v2
       - bit_config:
           env: "hub"
       - restore_cache:
@@ -894,7 +894,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v0.0.21-v1
+          key: core-aspect-env-v0.0.21-v2
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -472,7 +472,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v0.0.19-v10
+          key: core-aspect-env-v0.0.21-v1
       - run: echo $BIT_FEATURES
       - run: node -v
       - run: npm -v
@@ -502,7 +502,7 @@ jobs:
           name: bbit install
           command: cd bit && bbit install
       - save_cache:
-          key: core-aspect-env-v0.0.19-v10
+          key: core-aspect-env-v0.0.21-v1
           paths:
             - /home/circleci/Library/Caches/Bit/capsules/caec9a1075d4addee151dbe7e351b809aaa4b088
       - run: cd bit && npm run link-bit-legacy
@@ -547,7 +547,7 @@ jobs:
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
       - restore_cache:
-          key: core-aspect-env-v0.0.19-v10
+          key: core-aspect-env-v0.0.21-v1
       # - update_ssh_agent
       # temporary, check if we can remove it
       - run: cd bit && bit cc
@@ -583,7 +583,7 @@ jobs:
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}
       - restore_cache:
-          key: core-aspect-env-v0.0.19-v10
+          key: core-aspect-env-v0.0.21-v1
       - bit_config:
           env: "hub"
       - restore_cache:
@@ -894,7 +894,7 @@ jobs:
       - restore_cache:
           key: bitsrc-registry10
       - restore_cache:
-          key: core-aspect-env-v0.0.19-v10
+          key: core-aspect-env-v0.0.21-v1
       - run: npm view @teambit/bit version > ./version.txt
       - restore_cache:
           key: v3-linux-bvm-folder-{{ checksum "version.txt" }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2026,8 +2026,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/mdx.ui.mdx-layout':
         specifier: ^1.0.6
         version: 1.0.6(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
@@ -2178,6 +2178,9 @@ importers:
       chai:
         specifier: 4.3.0
         version: 4.3.0
+      chai-subset:
+        specifier: ^1.6.0
+        version: 1.6.0
       json-formatter-js:
         specifier: 2.3.4
         version: 2.3.4
@@ -6367,7 +6370,7 @@ importers:
       '@teambit/yarn':
         injected: true
 
-  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@0.0.19:
+  node_modules/.bit_roots/teambit.harmony_envs_core-aspect-env@0.0.21:
     dependencies:
       '@mdx-js/react':
         specifier: 1.6.22
@@ -6790,8 +6793,8 @@ importers:
         specifier: workspace:*
         version: file:scopes/harmony/cli-reference(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/harmony.modules.harmony-root-generator':
         specifier: workspace:*
         version: file:components/modules/harmony-root-generator
@@ -12082,20 +12085,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/api-reference/explorer/api-reference-explorer:
     dependencies:
@@ -12855,26 +12855,23 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/express':
         specifier: 4.17.13
         version: 4.17.13
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/uuid':
         specifier: 8.3.4
         version: 8.3.4
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/cloud/hooks/use-cloud-scopes:
     dependencies:
@@ -13130,17 +13127,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compilation/aspect-docs/babel:
     dependencies:
@@ -13329,23 +13323,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compilation/bundler:
     dependencies:
@@ -13396,20 +13387,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compilation/cli/webpack/error:
     dependencies:
@@ -13503,23 +13491,20 @@ importers:
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compilation/modules/babel-compiler:
     dependencies:
@@ -13583,17 +13568,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/aspect-docs/component:
     dependencies:
@@ -13696,20 +13678,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/checkout:
     dependencies:
@@ -13760,20 +13739,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/code:
     dependencies:
@@ -13824,17 +13800,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component:
     dependencies:
@@ -13978,14 +13951,11 @@ importers:
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14001,9 +13971,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-compare:
     dependencies:
@@ -14066,20 +14036,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash.flatten':
         specifier: 4.4.6
         version: 4.4.6
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-descriptor:
     dependencies:
@@ -14118,17 +14085,14 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-log:
     dependencies:
@@ -14191,23 +14155,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-package-version:
     dependencies:
@@ -14265,17 +14226,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-tree:
     dependencies:
@@ -14311,17 +14269,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/component-url:
     dependencies:
@@ -14412,23 +14367,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/deprecation:
     dependencies:
@@ -14476,17 +14428,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/dev-files:
     dependencies:
@@ -14534,23 +14483,17 @@ importers:
         specifier: 1.95.9
         version: 1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -14607,20 +14550,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/graph:
     dependencies:
@@ -14737,8 +14677,8 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
@@ -14748,9 +14688,6 @@ importers:
       '@types/graphlib':
         specifier: 2.1.7
         version: 2.1.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14760,9 +14697,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/isolator:
     dependencies:
@@ -14846,14 +14783,11 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14866,12 +14800,12 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/uuid':
         specifier: 8.3.4
         version: 8.3.4
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/issues:
     dependencies:
@@ -14916,17 +14850,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/lister:
     dependencies:
@@ -14977,14 +14908,11 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/cli-table':
         specifier: ^0.3.0
         version: 0.3.4
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -14994,9 +14922,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/merging:
     dependencies:
@@ -15050,20 +14978,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/mover:
     dependencies:
@@ -15111,23 +15036,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/new-component-helper:
     dependencies:
@@ -15175,20 +15097,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/refactoring:
     dependencies:
@@ -15239,20 +15158,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/remove:
     dependencies:
@@ -15312,20 +15228,17 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/renaming:
     dependencies:
@@ -15376,20 +15289,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/snapping:
     dependencies:
@@ -15458,14 +15368,11 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15475,12 +15382,12 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/uuid':
         specifier: 8.3.4
         version: 8.3.4
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
       fs-extra:
         specifier: 10.0.0
         version: 10.0.0
@@ -15537,23 +15444,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/status:
     dependencies:
@@ -15607,20 +15511,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/component/testing/mock-components:
     dependencies:
@@ -15708,23 +15609,20 @@ importers:
         version: 0.5.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compositions/aspect-docs/compositions:
     dependencies:
@@ -15933,14 +15831,11 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -15950,9 +15845,9 @@ importers:
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/compositions/model/composition-id:
     dependencies:
@@ -16093,26 +15988,26 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/eslint':
         specifier: 7.28.0
         version: 7.28.0
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/eslint-config-mutator:
     dependencies:
@@ -16194,20 +16089,17 @@ importers:
         specifier: 1.96.1
         version: 1.96.1(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/jest:
     dependencies:
@@ -16273,8 +16165,8 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
@@ -16287,9 +16179,12 @@ importers:
       '@types/minimatch':
         specifier: 3.0.4
         version: 3.0.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/linter:
     dependencies:
@@ -16343,20 +16238,17 @@ importers:
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/mocha:
     dependencies:
@@ -16407,20 +16299,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/multi-tester:
     dependencies:
@@ -16468,20 +16357,17 @@ importers:
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/prettier:
     dependencies:
@@ -16523,20 +16409,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
       '@types/prettier':
         specifier: 2.3.2
         version: 2.3.2
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/defender/prettier-config-mutator:
     dependencies:
@@ -16645,14 +16528,11 @@ importers:
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16662,9 +16542,9 @@ importers:
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/dependencies/aspect-docs/dependency-resolver:
     dependencies:
@@ -16868,8 +16748,8 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
@@ -16879,9 +16759,6 @@ importers:
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -16891,9 +16768,6 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -17001,17 +16875,14 @@ importers:
         version: 0.3.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17021,9 +16892,6 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -17158,14 +17026,11 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17175,9 +17040,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/dependencies/yarn:
     dependencies:
@@ -17258,23 +17123,20 @@ importers:
         version: 1.10.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/docs/docs:
     dependencies:
@@ -17343,23 +17205,20 @@ importers:
         specifier: 1.95.9
         version: 1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/docs/ui/queries/get-docs:
     dependencies:
@@ -17478,17 +17337,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/envs/envs:
     dependencies:
@@ -17551,20 +17407,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/envs/ui/env-icon:
     dependencies:
@@ -17664,14 +17517,11 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash.flatten':
         specifier: 4.4.6
         version: 4.4.6
@@ -17681,9 +17531,9 @@ importers:
       '@types/mousetrap':
         specifier: 1.6.5
         version: 1.6.5
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/explorer/insights:
     dependencies:
@@ -17737,11 +17587,8 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -17751,9 +17598,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/generator/aspect-docs/generator:
     dependencies:
@@ -17868,23 +17715,20 @@ importers:
         version: 2.2.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/git/git:
     dependencies:
@@ -17932,20 +17776,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/api-server:
     dependencies:
@@ -17993,23 +17834,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/application:
     dependencies:
@@ -18066,11 +17904,8 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -18080,9 +17915,9 @@ importers:
       '@types/pluralize':
         specifier: 0.0.29
         version: 0.0.29
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/aspect:
     dependencies:
@@ -18175,20 +18010,20 @@ importers:
         version: 4.7.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/aspect-docs/logger:
     dependencies:
@@ -18349,26 +18184,23 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/bit:
     dependencies:
@@ -18473,20 +18305,20 @@ importers:
         specifier: 1.96.2
         version: 1.96.2(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/cache:
     dependencies:
@@ -18525,23 +18357,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/cacache':
         specifier: 12.0.1
         version: 12.0.1
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/uuid':
         specifier: 8.3.4
         version: 8.3.4
@@ -18610,26 +18436,23 @@ importers:
         version: 17.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/didyoumean':
         specifier: 1.2.0
         version: 1.2.0
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/yargs':
         specifier: 17.0.0
         version: 17.0.0
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/cli-reference:
     dependencies:
@@ -18720,23 +18543,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/diagnostic:
     dependencies:
@@ -18775,17 +18595,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/express:
     dependencies:
@@ -18830,23 +18647,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/express':
         specifier: 4.17.13
         version: 4.17.13
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/global-config:
     dependencies:
@@ -18891,20 +18705,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/graphql:
     dependencies:
@@ -19009,17 +18820,14 @@ importers:
         version: 7.4.2(bufferutil@4.0.3)(utf-8-validate@5.0.5)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/cors':
         specifier: 2.8.10
         version: 2.8.10
       '@types/express':
         specifier: 4.17.13
         version: 4.17.13
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash.pick':
         specifier: 4.4.6
         version: 4.4.6
@@ -19029,9 +18837,9 @@ importers:
       '@types/node-fetch':
         specifier: 2.5.12
         version: 2.5.12
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/ipc-events:
     dependencies:
@@ -19073,20 +18881,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/logger:
     dependencies:
@@ -19128,17 +18933,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/modules/requireable-component:
     devDependencies:
@@ -19265,20 +19067,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/ui-foundation.ui.is-browser':
         specifier: ^0.0.500
         version: 0.0.500(react-dom@17.0.2)(react@17.0.2)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/harmony/testing/load-aspect:
     dependencies:
@@ -19394,17 +19193,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/html/aspect-docs/html:
     dependencies:
@@ -19675,20 +19471,17 @@ importers:
         version: 2.0.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/lanes/merge-lanes:
     dependencies:
@@ -19751,23 +19544,20 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/mdx/aspect-docs/mdx:
     dependencies:
@@ -20129,17 +19919,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/archiver':
         specifier: 5.3.1
         version: 5.3.1
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20152,9 +19939,9 @@ importers:
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/pipelines/modules/builder-data:
     devDependencies:
@@ -20330,17 +20117,14 @@ importers:
         version: 10.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/pkg.content.packages-overview':
         specifier: 1.95.9
         version: 1.95.9(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20350,9 +20134,9 @@ importers:
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/preview/aspect-docs/preview:
     dependencies:
@@ -20537,14 +20321,11 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -20563,12 +20344,12 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/webpack':
         specifier: 5.28.1
         version: 5.28.1(esbuild@0.14.29)
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
       cross-fetch:
         specifier: 3.1.5
         version: 3.1.5
@@ -21276,17 +21057,17 @@ importers:
         version: 4.7.4
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/react/ui/compositions-app:
     dependencies:
@@ -21745,23 +21526,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/scope/importer:
     dependencies:
@@ -21824,20 +21602,17 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/scope/models/scope-model:
     dependencies:
@@ -22006,8 +21781,8 @@ importers:
         version: 7.5.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/scope.content.scope-overview':
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -22017,9 +21792,6 @@ importers:
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -22029,9 +21801,9 @@ importers:
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/scope/sign:
     dependencies:
@@ -22082,17 +21854,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/scope/update-dependencies:
     dependencies:
@@ -22143,20 +21912,17 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/semantics/schema:
     dependencies:
@@ -22210,20 +21976,23 @@ importers:
         specifier: ^1.2.0
         version: 1.2.0
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@types/chai':
+        specifier: 4.2.15
+        version: 4.2.15
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
+      chai-subset:
+        specifier: ^1.6.0
+        version: 1.6.0
 
   scopes/toolbox/fs/hard-link-directory:
     dependencies:
@@ -22684,26 +22453,20 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/chai':
         specifier: 4.2.15
         version: 4.2.15
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       chai:
         specifier: 4.3.0
         version: 4.3.0
@@ -22795,17 +22558,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/notifications/aspect:
     dependencies:
@@ -22853,20 +22613,17 @@ importers:
         version: 8.3.2
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/uuid':
         specifier: 8.3.4
         version: 8.3.4
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/panels:
     dependencies:
@@ -22908,23 +22665,20 @@ importers:
         version: 3.2.0(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
       '@types/react-tabs':
         specifier: 2.3.2
         version: 2.3.2
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/react-router/react-router:
     dependencies:
@@ -22969,17 +22723,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/sidebar:
     dependencies:
@@ -23024,23 +22775,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/classnames':
         specifier: 2.2.11
         version: 2.2.11
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/ui:
     dependencies:
@@ -23220,17 +22968,14 @@ importers:
         version: 6.2.4(@types/babel__core@7.20.0)(webpack@5.84.1)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/express':
         specifier: 4.17.13
         version: 4.17.13
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23249,12 +22994,12 @@ importers:
       '@types/react-dev-utils':
         specifier: 9.0.10
         version: 9.0.10(debug@4.3.4)
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/webpack':
         specifier: 5.28.1
         version: 5.28.1(esbuild@0.14.29)
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/ui-foundation/user-agent:
     dependencies:
@@ -23296,20 +23041,17 @@ importers:
         version: 0.7.24
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/ua-parser-js':
         specifier: 0.7.35
         version: 0.7.35
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/webpack/config-mutator:
     dependencies:
@@ -23466,9 +23208,15 @@ importers:
       '@types/react-dom':
         specifier: ^17.0.21
         version: 17.0.25
+      assert:
+        specifier: ^2.1.0
+        version: 2.1.0
       browserify-zlib:
         specifier: 0.2.0
         version: 0.2.0
+      buffer:
+        specifier: 6.0.3
+        version: 6.0.3
       camelcase:
         specifier: 6.2.0
         version: 6.2.0
@@ -23523,6 +23271,9 @@ importers:
       process:
         specifier: 0.11.10
         version: 0.11.10
+      punycode:
+        specifier: ^2.3.1
+        version: 2.3.1
       querystring-es3:
         specifier: 0.2.1
         version: 0.2.1
@@ -23544,12 +23295,21 @@ importers:
       stream-http:
         specifier: 3.2.0
         version: 3.2.0
+      string_decoder:
+        specifier: ^1.3.0
+        version: 1.3.0
       timers-browserify:
         specifier: 2.0.12
         version: 2.0.12
       tty-browserify:
         specifier: 0.0.1
         version: 0.0.1
+      url:
+        specifier: ^0.11.3
+        version: 0.11.3
+      util:
+        specifier: ^0.12.5
+        version: 0.12.5
       vm-browserify:
         specifier: 1.1.2
         version: 1.1.2
@@ -23567,26 +23327,26 @@ importers:
         version: 5.8.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/find-root':
         specifier: 1.1.2
         version: 1.1.2
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
       '@types/react-dev-utils':
         specifier: 9.0.10
         version: 9.0.10(debug@4.3.4)
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
       '@types/webpack':
         specifier: 5.28.1
         version: 5.28.1(esbuild@0.14.29)
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/aspect-docs/variants:
     dependencies:
@@ -23671,17 +23431,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/config-merger:
     dependencies:
@@ -23738,23 +23495,23 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
+      '@types/mocha':
+        specifier: 10.0.1
+        version: 10.0.1
       '@types/semver':
         specifier: 7.3.4
         version: 7.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/eject:
     dependencies:
@@ -23796,17 +23553,14 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/install:
     dependencies:
@@ -23878,14 +23632,11 @@ importers:
         version: 5.4.6
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -23895,9 +23646,9 @@ importers:
       '@types/object-hash':
         specifier: 1.3.4
         version: 1.3.4
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
       strip-ansi:
         specifier: 6.0.0
         version: 6.0.0
@@ -24044,23 +23795,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/workspace.content.variants':
         specifier: 1.95.9
         version: 1.95.9(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/watcher:
     dependencies:
@@ -24120,23 +23868,20 @@ importers:
         version: 6.8.1(react-dom@17.0.2)(react@17.0.2)
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
       '@types/mocha':
         specifier: 9.1.0
         version: 9.1.0
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/workspace:
     dependencies:
@@ -24304,8 +24049,8 @@ importers:
         version: 1.0.1
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/workspace.content.workspace-overview':
         specifier: 1.95.0
         version: 1.95.0(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
@@ -24318,9 +24063,6 @@ importers:
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -24339,9 +24081,9 @@ importers:
       '@types/pluralize':
         specifier: 0.0.29
         version: 0.0.29
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
   scopes/workspace/workspace-config-files:
     dependencies:
@@ -24404,14 +24146,14 @@ importers:
         version: 0.4.0
     devDependencies:
       '@teambit/harmony.envs.core-aspect-env':
-        specifier: 0.0.19
-        version: 0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+        specifier: 0.0.21
+        version: 0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
+      '@types/chai':
+        specifier: 4.2.15
+        version: 4.2.15
       '@types/fs-extra':
         specifier: 9.0.7
         version: 9.0.7
-      '@types/jest':
-        specifier: ^29.2.2
-        version: 29.5.11
       '@types/lodash':
         specifier: 4.14.165
         version: 4.14.165
@@ -24421,9 +24163,9 @@ importers:
       '@types/normalize-path':
         specifier: ^3.0.0
         version: 3.0.2
-      '@types/testing-library__jest-dom':
-        specifier: ^5.9.5
-        version: 5.9.5
+      chai:
+        specifier: 4.3.0
+        version: 4.3.0
 
 packages:
 
@@ -25295,7 +25037,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
       '@babel/plugin-syntax-object-rest-spread': 7.8.3(@babel/core@7.12.9)
       '@babel/plugin-transform-parameters': 7.23.3(@babel/core@7.12.9)
 
@@ -25678,7 +25420,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.12.9
-      '@babel/helper-plugin-utils': 7.10.4
+      '@babel/helper-plugin-utils': 7.22.5
 
   /@babel/plugin-syntax-jsx@7.23.3(@babel/core@7.19.6):
     resolution: {integrity: sha512-EB2MELswq55OHUoRZLGg/zC7QWUKfNLpE57m/S2yr1uEneIgsTgrSzXP3NXEsMkVn76OlaVVnzN+ugObuYGwhg==}
@@ -34269,24 +34011,6 @@ packages:
     dependencies:
       '@teambit/legacy-bit-id': 1.0.1
 
-  /@teambit/component-id@1.1.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-o42ZmByQf2xpkb/CHEe1Wh1LJvSeGeXTWcv73YC8/1dM+oU85kGrZcXIs2bMwkhcCsCknBioy7CKSXYPvpJwFg==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.578
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.20.0
-      '@teambit/component-version': 1.0.3
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      '@teambit/legacy-bit-id': 1.0.4(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/component-id@1.2.0:
     resolution: {integrity: sha512-rdOUec8IfdvPP1jqo/8JpCoLEp8TfTdWdkj5K0oEggSQd1kM9IY2vRoWUguqKAbVVFk7TEnOKGtESOp2mkbglw==}
     engines: {node: '>=12.22.0'}
@@ -34415,21 +34139,6 @@ packages:
       query-string: 7.0.0
       react: 17.0.2
     transitivePeerDependencies:
-      - react-dom
-    dev: false
-
-  /@teambit/component.modules.component-url@0.0.162(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-FLhpVmlH7zYC5G/L7u3BBOchjKouVxLbIymnRQ8XHXkYOjwi8CzDTzvNyMn1691Uz0AO1gFpmvbkFehs4wTv6w==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: 17.0.2
-    dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component-id': 1.1.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      query-string: 7.0.0
-      react: 17.0.2
-    transitivePeerDependencies:
-      - '@teambit/legacy'
       - react-dom
     dev: false
 
@@ -38221,18 +37930,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  /@teambit/envs.ui.env-icon@0.0.500(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-/HcLKG/XtP9e1U4UJTzn1LQwM5/YU668hYbLDsjCb68tUs24Nu6k8uJeolF15T4cH7TXzj15SipkChUKwfwGEw==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      core-js: 3.13.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
   /@teambit/evangelist.css-components.fade-in-out@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-oi5xKYxUqVUXP3Ae6eZS2LSaVe9sthO4nA3f95SnFnJ8O5HAX4O/xGi4WCYoxNPDo1muzp5/mfJkdmyRiILLRA==, tarball: https://registry.npmjs.org/@teambit/evangelist.css-components.fade-in-out/-/evangelist.css-components.fade-in-out-1.0.1.tgz}
     peerDependencies:
@@ -38845,8 +38542,8 @@ packages:
       - '@teambit/legacy'
     dev: true
 
-  /@teambit/harmony.envs.core-aspect-env@0.0.19(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0):
-    resolution: {integrity: sha512-bwDdLtrxwEgsj0iHKt6WDKcGStj9h2wF2mU1L37l4V2CoTtT2ybjr7g3XFNsfFWDexNhfleAKwlIJBqywNXiQw==}
+  /@teambit/harmony.envs.core-aspect-env@0.0.21(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(typescript@4.7.4)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0):
+    resolution: {integrity: sha512-yIHUw7rQXhIPPRffEuN76zyKsPIDkqEw/kgTpZZ1blzWwj//z0aQTIKWAUPaglRX/PVqYW0GpLCWyGxBrgm2uA==}
     dependencies:
       '@babel/plugin-proposal-decorators': 7.23.7(@babel/core@7.19.6)
       '@babel/plugin-transform-class-properties': 7.23.3(@babel/core@7.19.6)
@@ -38859,23 +38556,19 @@ packages:
       '@mdx-js/react': 1.6.22(react@17.0.2)
       '@teambit/compilation.babel-compiler': 1.1.3
       '@teambit/defender.eslint-linter': 1.0.14(@teambit/legacy@node_modules+@teambit+legacy)
-      '@teambit/defender.jest-tester': 1.0.12(@teambit/legacy@node_modules+@teambit+legacy)(@types/node@12.20.4)
       '@teambit/defender.mocha-tester': 1.0.11(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/defender.prettier-formatter': 1.0.7(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/mdx.ui.mdx-scope-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/preview.react-preview': 1.0.20(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(@types/webpack@5.28.1)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(eslint@7.32.0)(graphql@15.8.0)(less@4.2.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)(utf-8-validate@5.0.5)
-      '@teambit/react.jest.react-jest': 1.0.11(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@types/node@12.20.4)(bufferutil@4.0.3)(utf-8-validate@5.0.5)
       '@teambit/react.react-env': 1.0.28(@babel/core@7.19.6)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/express@4.17.13)(@types/node@12.20.4)(@types/webpack@5.28.1)(@typescript-eslint/parser@5.62.0)(bufferutil@4.0.3)(debug@4.3.4)(esbuild@0.14.29)(html-webpack-plugin@5.3.2)(less@4.2.0)(puppeteer@13.7.0)(utf-8-validate@5.0.5)(webpack-dev-server@4.15.0)
       '@teambit/react.v17.docs-template': 1.0.0(@testing-library/react@12.1.5)(@types/react@17.0.74)(graphql@15.8.0)(react-dom@17.0.2)(react@17.0.2)(typescript@4.7.4)
       '@teambit/react.v17.mounter': 1.0.1(react-dom@17.0.2)(react@17.0.2)
       '@teambit/typescript.typescript-compiler': 2.0.12(@teambit/legacy@node_modules+@teambit+legacy)
       '@types/react': 17.0.74
       '@types/react-dom': 17.0.25
-      babel-plugin-ramda: 2.1.1
       babel-plugin-transform-typescript-metadata: 0.3.2(@babel/core@7.19.6)
       core-js: 3.13.0
       graphql: 15.8.0
-      jest-environment-node: 29.3.1
       mocha: 10.2.0
       ramda: 0.29.1
       react: 17.0.2
@@ -38993,30 +38686,6 @@ packages:
       '@teambit/legacy': link:node_modules/@teambit/legacy
     dev: false
 
-  /@teambit/lanes.hooks.use-lanes@0.0.255(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-/FZtxHJhloHDZN5xjQhL92T8yufEZR+W0yhSr1cRL8H8XKJBexh7TuDdGDjifuDSN5cmmxdoR+I+IUhtHYCB3Q==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      '@apollo/client': ^3.6.0
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@apollo/client': 3.6.9(graphql@15.8.0)(react@17.0.2)(subscriptions-transport-ws@0.9.18)
-      '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lane-id': 0.0.305(@teambit/legacy@node_modules+@teambit+legacy)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.209(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/ui-foundation.ui.hooks.use-data-query': 0.0.505(@apollo/client@3.6.9)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/ui-foundation.ui.react-router.use-query': 0.0.501(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      core-js: 3.13.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-      - '@testing-library/react'
-      - '@types/react'
-    dev: false
-
   /@teambit/lanes.ui.icons.lane-icon@0.0.9(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-i/ZDfBZfxmCdpa8wuvTTlKaJzXc47D3vzo4W4YNQTqrjIovhartAqhUAtO1oh6TRALaLh04kFH05wSqfIvjXww==}
     engines: {node: '>=12.22.0'}
@@ -39071,44 +38740,6 @@ packages:
     transitivePeerDependencies:
       - '@testing-library/react'
       - '@types/react'
-    dev: false
-
-  /@teambit/lanes.ui.models.lanes-model@0.0.209(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-McJE7/rdyxSzVCvbKOxlurzPB8gwHfeLlv/9R9I9a+qgZoASKCR8M+suvF3rFCaYxDlOoOWSdRE/F62U2b51fQ==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component-id': 1.1.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lane-id': 0.0.305(@teambit/legacy@node_modules+@teambit+legacy)
-      core-js: 3.13.0
-      lodash: 4.17.21
-      path-to-regexp: 6.2.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
-    dev: false
-
-  /@teambit/lanes.ui.models.lanes-model@0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-h9X8psNad//rvZaiHYtceCP5qYZNbhLfi7HsgtypbMyZz5QBJ730+4kbbmJ8/1h8bE5XYUx2rvROqeWmz4XfDQ==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-ui.utils.string.affix': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component-id': 1.2.0
-      '@teambit/lane-id': 0.0.305(@teambit/legacy@node_modules+@teambit+legacy)
-      core-js: 3.13.0
-      lodash: 4.17.21
-      path-to-regexp: 6.2.0
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@teambit/legacy'
     dev: false
 
   /@teambit/legacy-bit-id@0.0.368(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
@@ -39168,26 +38799,6 @@ packages:
       decamelize: 1.2.0
       lodash: 4.17.21
       semver: 7.3.4
-
-  /@teambit/legacy-bit-id@1.0.4(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-1u5QN1AOvu+e9FgiizdoL0JwRzffQCxiuEiZBL9HcRzE5GAP4K58EwEcSfbEsCmmNrB6MLVXvEXdv34R+rY9pQ==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      '@teambit/legacy': 1.0.584
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@babel/runtime': 7.20.0
-      '@teambit/bit-error': 0.0.404
-      '@teambit/component-version': 1.0.3
-      '@teambit/legacy': link:node_modules/@teambit/legacy
-      core-js: 3.13.0
-      decamelize: 1.2.0
-      lodash: 4.17.21
-      react: 17.0.2
-      react-dom: 17.0.2(react@17.0.2)
-      semver: 7.5.2
-    dev: false
 
   /@teambit/legacy-bit-id@1.1.0:
     resolution: {integrity: sha512-svFHTgVXh24nK3o1JauMs/z5JFmvduqjEYgX7KupBU7hR5+pbTL9ZYq+tZqUPRoueMaPEsPdjAwmhVYHwZ2nZA==}
@@ -40414,8 +40025,8 @@ packages:
   /@teambit/react.v17.mounter@1.0.1(react-dom@17.0.2)(react@17.0.2):
     resolution: {integrity: sha512-5e1LiJC29/Ix2k+JpKDjFBq6BzsKtQ4PToLYt+uiJh3x2kVHRLB7Qz2KE3tHMgO+kNP0oG8AEIuaty/eE2y44Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
+      react: '*'
+      react-dom: '*'
     dependencies:
       core-js: 3.13.0
       react: 17.0.2
@@ -40938,7 +40549,7 @@ packages:
     engines: {node: '>=12.22.0'}
 
   /@teambit/toolbox.string.ellipsis@0.0.173:
-    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=}
+    resolution: {integrity: sha1-CY+uj2sRmPejtTCee4HDvLFeeI8=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/string/ellipsis@0.0.173.tgz}
     engines: {node: '>=12.22.0'}
     dev: true
 
@@ -40970,7 +40581,7 @@ packages:
     dev: false
 
   /@teambit/toolbox.types.serializable@0.0.483:
-    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=}
+    resolution: {integrity: sha1-bUTnjhsNOvMScS8+fSEk80Bvq3E=, tarball: https://node-registry.bit.cloud/tarballs/teambit.toolbox/types/serializable@0.0.483.tgz}
     engines: {node: '>=12.22.0'}
 
   /@teambit/toolbox.types.serializable@0.0.491:
@@ -41678,40 +41289,6 @@ packages:
       core-js: 3.13.0
       react: 17.0.2
       react-dom: 17.0.2(react@17.0.2)
-    dev: false
-
-  /@teambit/ui-foundation.ui.side-bar@0.0.872(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2):
-    resolution: {integrity: sha512-VUwRI+qTTCkNttXLpw86w6dqLtW4z3NLWBubIERqi29nkL0w69PFzirpSZM2FIgg1Iap3Bz4QrjnjEv4jnCrgA==}
-    engines: {node: '>=12.22.0'}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0
-      react-dom: ^16.8.0 || ^17.0.0
-    dependencies:
-      '@teambit/base-react.navigation.link': 2.0.27(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.indent': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.inflate-paths': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.recursive-tree': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.graph.tree.tree-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/base-ui.theme.colors': 1.0.0(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component-id': 1.1.1(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.modules.component-url': 0.0.162(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/component.ui.deprecation-icon': 0.0.509(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.tooltip': 0.0.361(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/envs.ui.env-icon': 0.0.500(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/evangelist.elements.icon': 1.0.2(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.hooks.use-lanes': 0.0.255(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.209(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
-      classnames: 2.2.6
-      core-js: 3.13.0
-      react: 17.0.2
-      react-animate-height: 2.0.23(react-dom@17.0.2)(react@17.0.2)
-      react-dom: 17.0.2(react@17.0.2)
-    transitivePeerDependencies:
-      - '@apollo/client'
-      - '@teambit/legacy'
-      - '@testing-library/react'
-      - '@types/react'
     dev: false
 
   /@teambit/ui-foundation.ui.top-bar@0.0.514(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2):
@@ -42744,6 +42321,10 @@ packages:
 
   /@types/minimatch@5.1.2:
     resolution: {integrity: sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==}
+    dev: true
+
+  /@types/mocha@10.0.1:
+    resolution: {integrity: sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==}
     dev: true
 
   /@types/mocha@9.1.0:
@@ -45992,6 +45573,7 @@ packages:
     resolution: {integrity: sha512-J/+7vUTTmwF47QFsLx7A1YjAg0ZS3kx5NtajMGuYEntwD+4jg8vFEos4sNsiEBj4LsXZNqpkQEa7/bbJ3IvEEg==}
     dependencies:
       '@babel/helper-module-imports': 7.22.15
+    dev: false
 
   /babel-plugin-syntax-trailing-function-commas@7.0.0-beta.0:
     resolution: {integrity: sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==}
@@ -46856,6 +46438,11 @@ packages:
     dependencies:
       chai: 4.3.0
     dev: false
+
+  /chai-subset@1.6.0:
+    resolution: {integrity: sha512-K3d+KmqdS5XKW5DWPd5sgNffL3uxdDe+6GdnJh3AYPhwnBGRY5urfvfcbRtWIvvpz+KxkL9FeBB6MZewLUNwug==}
+    engines: {node: '>=4'}
+    dev: true
 
   /chai@4.3.0:
     resolution: {integrity: sha512-/BFd2J30EcOwmdOgXvVsmM48l0Br0nmZPlO0uOW4XKh6kpsUumRXBgPV+IlaqFaqr9cYbeoZAM1Npx0i4A+aiA==}
@@ -53820,17 +53407,6 @@ packages:
       jest-util: 27.5.1
     dev: false
 
-  /jest-environment-node@29.3.1:
-    resolution: {integrity: sha512-xm2THL18Xf5sIHoU7OThBPtuH6Lerd+Y1NLYiZJlkE3hbE+7N7r8uvHIl/FkZ5ymKXJe/11SQuf3fv4v6rUMag==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-    dependencies:
-      '@jest/environment': 29.7.0
-      '@jest/fake-timers': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 12.20.4
-      jest-mock: 29.7.0
-      jest-util: 29.7.0
-
   /jest-environment-node@29.7.0:
     resolution: {integrity: sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -60629,7 +60205,6 @@ packages:
     dependencies:
       envify: 3.4.1
       fbjs: 0.6.1
-    bundledDependencies: false
 
   /react@17.0.2:
     resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
@@ -66785,9 +66360,9 @@ packages:
       '@teambit/design.ui.tree': 0.0.15(react-dom@17.0.2)(react@17.0.2)
       '@teambit/harmony': 0.4.6
       '@teambit/lanes.hooks.use-lanes': file:components/hooks/use-lanes(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scope.models.scope-model': file:scopes/scope/models/scope-model
-      '@teambit/ui-foundation.ui.side-bar': 0.0.872(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/ui-foundation.ui.side-bar': file:components/ui/side-bar(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.tree.drawer': file:components/ui/tree/drawer(react-dom@17.0.2)(react@17.0.2)
       classnames: 2.2.6
       core-js: 3.13.0
@@ -66946,7 +66521,7 @@ packages:
       '@teambit/lanes.hooks.use-lane-components': file:components/hooks/use-lane-components(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.hooks.use-lanes': file:components/hooks/use-lanes(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.lane-details': 0.0.204(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/preview.ui.preview-placeholder': file:scopes/preview/ui/preview-placeholder(react-dom@17.0.2)(react@17.0.2)
       '@teambit/scopes.scope-id': 0.0.7
       '@teambit/ui-foundation.ui.empty-component-gallery': 0.0.508(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
@@ -68151,7 +67726,7 @@ packages:
       '@teambit/harmony': 0.4.6
       '@teambit/harmony.ui.aspect-box': file:scopes/harmony/ui/aspect-box(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.hooks.use-lanes': file:components/hooks/use-lanes(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/legacy-bit-id': 1.1.0
       '@teambit/legacy-component-log': 0.0.402
       '@teambit/mdx.ui.mdx-scope-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -70406,7 +69981,7 @@ packages:
       '@teambit/lanes.ui.lane-overview': file:components/ui/lane-overview(@apollo/client@3.6.9)(@teambit/base-react.navigation.link@2.0.27)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
       '@teambit/lanes.ui.menus.lanes-overview-menu': 0.0.10(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
       '@teambit/lanes.ui.menus.use-lanes-menu': file:components/ui/menus/use-lanes-menu(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.ui.navigation.lane-switcher': file:components/ui/navigation/lane-switcher(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
       '@teambit/legacy-bit-id': 1.1.0
       '@teambit/mdx.ui.mdx-scope-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -71382,7 +70957,7 @@ packages:
       '@teambit/lane-id': 0.0.311(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/lanes.hooks.use-lane-components': file:components/hooks/use-lane-components(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.hooks.use-lanes': file:components/hooks/use-lanes(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/legacy-bit-id': 1.1.0
       '@teambit/legacy-component-log': 0.0.402
       '@teambit/mdx.ui.mdx-scope-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
@@ -71401,7 +70976,7 @@ packages:
       '@teambit/ui-foundation.ui.main-dropdown': 0.0.502(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.menu': 0.0.502(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.react-router.slot-router': 0.0.506(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
-      '@teambit/ui-foundation.ui.side-bar': 0.0.872(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/ui-foundation.ui.side-bar': file:components/ui/side-bar(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.top-bar': 0.0.514(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
       '@teambit/ui-foundation.ui.tree.drawer': file:components/ui/tree/drawer(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.use-box.dropdown': 0.0.141(react-dom@17.0.2)(react@17.0.2)
@@ -72326,7 +71901,7 @@ packages:
       '@teambit/lane-id': 0.0.311(@teambit/legacy@node_modules+@teambit+legacy)
       '@teambit/lanes.hooks.use-lane-components': file:components/hooks/use-lane-components(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/lanes.hooks.use-lanes': file:components/hooks/use-lanes(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
-      '@teambit/lanes.ui.models.lanes-model': 0.0.210(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/lanes.ui.models.lanes-model': file:components/ui/models/lanes-model(@teambit/legacy@node_modules+@teambit+legacy)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/legacy-bit-id': 1.1.0
       '@teambit/mdx.ui.mdx-scope-context': 1.0.0(react-dom@17.0.2)(react@17.0.2)
       '@teambit/preview.ui.preview-placeholder': file:scopes/preview/ui/preview-placeholder(react-dom@17.0.2)(react@17.0.2)
@@ -72340,7 +71915,7 @@ packages:
       '@teambit/ui-foundation.ui.menu': 0.0.502(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.notifications.notification-context': 0.0.501(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.react-router.slot-router': 0.0.506(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
-      '@teambit/ui-foundation.ui.side-bar': 0.0.872(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
+      '@teambit/ui-foundation.ui.side-bar': file:components/ui/side-bar(@apollo/client@3.6.9)(@teambit/legacy@node_modules+@teambit+legacy)(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react@17.0.2)
       '@teambit/ui-foundation.ui.top-bar': 0.0.514(@testing-library/react@12.1.5)(@types/react@17.0.74)(react-dom@17.0.2)(react-router-dom@6.8.1)(react@17.0.2)
       '@teambit/ui-foundation.ui.tree.drawer': file:components/ui/tree/drawer(react-dom@17.0.2)(react@17.0.2)
       '@teambit/workspace.modules.match-pattern': file:scopes/workspace/modules/match-pattern

--- a/scopes/component/component-descriptor/component-descriptor.spec.ts
+++ b/scopes/component/component-descriptor/component-descriptor.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { ComponentID } from '@teambit/component';
 import { ComponentDescriptor } from './component-descriptor';
 import { AspectList } from './aspect-list';
@@ -24,11 +25,11 @@ const MOCK_ASPECT_MAP_JSON = AspectList.fromJson({
 describe('ComponentDescriptor', () => {
   it('should contain a component id', () => {
     const descriptor = new ComponentDescriptor(ComponentID.fromString(MOCK_ID), MOCK_ASPECT_MAP);
-    expect(descriptor.id.scope).toEqual('teambit.components');
+    expect(descriptor.id.scope).to.equal('teambit.components');
   });
 
   it('should contain a component id', () => {
     const descriptor = new ComponentDescriptor(ComponentID.fromString(MOCK_ID), MOCK_ASPECT_MAP_JSON);
-    expect(descriptor.id.scope).toEqual('teambit.components');
+    expect(descriptor.id.scope).to.equal('teambit.components');
   });
 });

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -15,7 +15,9 @@ import { SnappingMain } from './snapping.main.runtime';
 import { SnappingAspect } from './snapping.aspect';
 import { ComponentsHaveIssues } from './components-have-issues';
 
-describe('Snapping aspect', () => {
+describe('Snapping aspect', function () {
+  this.timeout(0);
+
   let workspaceData: WorkspaceData;
   let snapping: SnappingMain;
   describe('components with issues', () => {

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import fs from 'fs-extra';
 import path from 'path';
 import { loadAspect } from '@teambit/harmony.testing.load-aspect';
@@ -18,7 +19,7 @@ describe('Snapping aspect', () => {
   let workspaceData: WorkspaceData;
   let snapping: SnappingMain;
   describe('components with issues', () => {
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       // eslint-disable-next-line no-console
@@ -28,12 +29,12 @@ describe('Snapping aspect', () => {
       const compiler: CompilerMain = await loadAspect(CompilerAspect, workspacePath);
       await compiler.compileOnWorkspace();
       snapping = await loadAspect(SnappingAspect, workspacePath);
-    }, 30000);
+    });
     it('tag should throw an ComponentsHaveIssues error', async () => {
       try {
         await snapping.tag({ ids: ['comp1'] });
       } catch (err: any) {
-        expect(err.constructor.name).toEqual(ComponentsHaveIssues.name);
+        expect(err.constructor.name).to.equal(ComponentsHaveIssues.name);
       }
     });
     // @todo: this test fails during "bit build" for some reason. It passes on "bit test";
@@ -43,9 +44,9 @@ describe('Snapping aspect', () => {
       });
       snapping = await loadAspect(SnappingAspect, workspaceData.workspacePath);
       const results = await snapping.tag({ ids: ['comp1'] });
-      expect(results?.taggedComponents.length).toEqual(1);
+      expect(results?.taggedComponents.length).to.equal(1);
     });
-    afterAll(async () => {
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
   });

--- a/scopes/defender/eslint/component.json
+++ b/scopes/defender/eslint/component.json
@@ -18,6 +18,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.21": {}
   }
 }

--- a/scopes/defender/eslint/component.json
+++ b/scopes/defender/eslint/component.json
@@ -18,6 +18,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.19": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
   }
 }

--- a/scopes/dependencies/dependency-resolver/apply-updates.spec.ts
+++ b/scopes/dependencies/dependency-resolver/apply-updates.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { ComponentID } from '@teambit/component';
 import { applyUpdates } from './apply-updates';
 
@@ -23,7 +24,7 @@ describe('applyUpdates()', () => {
       }
     );
     // @ts-ignore
-    expect(updatedWorkspacePolicyEntries).toStrictEqual(
+    expect(updatedWorkspacePolicyEntries).to.deep.equal(
       [
         {
           dependencyId: 'lodash',
@@ -118,7 +119,7 @@ describe('applyUpdates()', () => {
       }
     );
     // @ts-ignore
-    expect(variantPoliciesByPatterns.variant1).toStrictEqual({
+    expect(variantPoliciesByPatterns.variant1).to.deep.equal({
       dependencies: {
         'variant1-runtime-dep1': { version: '2.0.0', resolveFromEnv: true },
         'variant1-runtime-dep2': '1.0.0',
@@ -133,7 +134,7 @@ describe('applyUpdates()', () => {
       },
     });
     // @ts-ignore
-    expect(variantPoliciesByPatterns.variant2).toStrictEqual({
+    expect(variantPoliciesByPatterns.variant2).to.deep.equal({
       dependencies: {
         'variant2-runtime-dep1': '1.0.0',
         'variant2-runtime-dep2': '1.0.0',
@@ -148,7 +149,7 @@ describe('applyUpdates()', () => {
       },
     });
     // @ts-ignore
-    expect(variantPoliciesByPatterns.variant3).toStrictEqual({
+    expect(variantPoliciesByPatterns.variant3).to.deep.equal({
       dependencies: {
         'variant3-runtime-dep1': '1.0.0',
         'variant3-runtime-dep2': '1.0.0',
@@ -193,7 +194,7 @@ describe('applyUpdates()', () => {
       }
     );
     // @ts-ignore
-    expect(updatedComponents).toStrictEqual([
+    expect(updatedComponents).to.deep.equal([
       {
         componentId: ComponentID.fromString('scope/component1'),
         config: {

--- a/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.spec.ts
+++ b/scopes/dependencies/dependency-resolver/get-all-policy-pkgs.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { ComponentID } from '@teambit/component';
 import { getAllPolicyPkgs } from './get-all-policy-pkgs';
 import { WorkspacePolicy } from './policy';
@@ -21,8 +22,7 @@ describe('getAllPolicyPkgs()', () => {
       componentPolicies: [],
       componentModelVersions: [],
     });
-    // @ts-ignore
-    expect(outdatedPkgs).toStrictEqual([
+    expect(outdatedPkgs).to.deep.equal([
       {
         currentRange: '1',
         name: 'foo',
@@ -61,7 +61,7 @@ describe('getAllPolicyPkgs()', () => {
       ],
     });
     // @ts-ignore
-    expect(outdatedPkgs).toStrictEqual([
+    expect(outdatedPkgs).to.deep.equal([
       {
         currentRange: '1',
         name: 'foo',

--- a/scopes/dependencies/dependency-resolver/policy/env-policy/validate-env-policy.spec.ts
+++ b/scopes/dependencies/dependency-resolver/policy/env-policy/validate-env-policy.spec.ts
@@ -1,24 +1,25 @@
+import { expect } from 'chai';
 import { validateEnvPolicyConfigObject } from './validate-env-policy';
 
 describe('validateEnvPolicyConfigObject', () => {
   it('should throw an exception if peer supportedRange is empty', () => {
-    expect(() => validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: '' }] } as any)).toThrowError(
+    expect(() => validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: '' }] } as any)).to.throw(
       'Peer "peer" has an empty supportedRange'
     );
   });
   it('should throw an exception if peer supportedRange is null', () => {
-    expect(() =>
-      validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: null }] } as any)
-    ).toThrowError('Peer "peer" has no supportedRange set');
+    expect(() => validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: null }] } as any)).to.throw(
+      'Peer "peer" has no supportedRange set'
+    );
   });
   it('should throw an exception if peer version is empty', () => {
     expect(() =>
       validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: '1', version: '' }] } as any)
-    ).toThrowError('Peer "peer" has an empty version');
+    ).to.throw('Peer "peer" has an empty version');
   });
   it('should throw an exception if peer version is null', () => {
     expect(() =>
       validateEnvPolicyConfigObject({ peers: [{ name: 'peer', supportedRange: '1', version: null }] } as any)
-    ).toThrowError('Peer "peer" has no version set');
+    ).to.throw('Peer "peer" has no version set');
   });
 });

--- a/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
+++ b/scopes/dependencies/pnpm/pnpm-error-to-bit-error.spec.ts
@@ -1,7 +1,8 @@
 import { PnpmError } from '@pnpm/error';
+import { expect } from 'chai';
 import { pnpmErrorToBitError } from './pnpm-error-to-bit-error';
 
-test('the hint from the fetch error is used', () => {
+it('the hint from the fetch error is used', () => {
   const bitError = pnpmErrorToBitError(
     new PnpmError('FETCH_404', 'GET https://node-registry.bit.cloud/dsffsdf: Not Found - 404', {
       hint: `dsffsdf is not in the npm registry, or you have no permission to fetch it.
@@ -9,14 +10,14 @@ test('the hint from the fetch error is used', () => {
 An authorization header was used: Bearer df96[hidden]`,
     })
   );
-  expect(bitError.report()).toEqual(`GET https://node-registry.bit.cloud/dsffsdf: Not Found - 404
+  expect(bitError.report()).to.equal(`GET https://node-registry.bit.cloud/dsffsdf: Not Found - 404
 
 dsffsdf is not in the npm registry, or you have no permission to fetch it.
 
 An authorization header was used: Bearer df96[hidden]`);
 });
 
-test('a regular error object is reported', () => {
+it('a regular error object is reported', () => {
   const bitError = pnpmErrorToBitError(new Error('some error') as any);
-  expect(bitError.report()).toEqual('some error');
+  expect(bitError.report()).to.equal('some error');
 });

--- a/scopes/harmony/aspect-loader/core-aspects.spec.ts
+++ b/scopes/harmony/aspect-loader/core-aspects.spec.ts
@@ -1,10 +1,11 @@
+import { expect } from 'chai';
 import { getCoreAspectName } from './core-aspects';
 
 describe('core-aspects', () => {
   describe('getCoreAspectName', () => {
     it('should include the namespace in the aspect name', () => {
       const aspectName = getCoreAspectName('teambit.workspace/e2e/workspace');
-      expect(aspectName).toEqual('e2e.workspace');
+      expect(aspectName).to.equal('e2e.workspace');
     });
   });
 });

--- a/scopes/harmony/cache/cache.spec.ts
+++ b/scopes/harmony/cache/cache.spec.ts
@@ -26,7 +26,7 @@ describe('Cache Aspect', () => {
     expect(data).to.equal('bar');
   });
 
-  afterAll(() => {
+  after(() => {
     rmdirSync(cacheDirectory, { recursive: true });
   });
 });

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { loadAspect } from '@teambit/harmony.testing.load-aspect';
 import SnappingAspect, { SnappingMain } from '@teambit/snapping';
 import { ExportAspect, ExportMain } from '@teambit/export';
@@ -10,23 +11,25 @@ import { LanesAspect } from './lanes.aspect';
 import { LanesMain } from './lanes.main.runtime';
 
 describe('LanesAspect', function () {
+  this.timeout(0);
+
   describe('getLanes()', () => {
     let lanes: LanesMain;
     let workspaceData: WorkspaceData;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
       lanes = await loadAspect(LanesAspect, workspacePath);
       await lanes.createLane('stage');
-    }, 30000);
-    afterAll(async () => {
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should list all lanes', async () => {
       const currentLanes = await lanes.getLanes({});
-      expect(currentLanes.length).toEqual(1);
-      expect(currentLanes[0].id.name).toEqual('stage');
+      expect(currentLanes).to.have.lengthOf(1);
+      expect(currentLanes[0].name).to.equal('stage');
     });
   });
 
@@ -34,7 +37,7 @@ describe('LanesAspect', function () {
     let lanes: LanesMain;
     let snapping: SnappingMain;
     let workspaceData: WorkspaceData;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
@@ -51,9 +54,9 @@ describe('LanesAspect', function () {
         ignoreIssues: 'MissingManuallyConfiguredPackages',
       });
       // intermediate step, make sure it is snapped
-      expect(result?.snappedComponents.length).toEqual(1);
-    }, 30000);
-    afterAll(async () => {
+      expect(result?.snappedComponents.length).to.equal(1);
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should return that the lane is up to date when the lane is ahead of main', async () => {
@@ -63,7 +66,7 @@ describe('LanesAspect', function () {
         await lanes.diffStatus(currentLane.toLaneId(), undefined, { skipChanges: true })
       ).componentsStatus.every((c) => c.upToDate);
 
-      expect(isUpToDate).toEqual(true);
+      expect(isUpToDate).to.be.true;
     });
     it('should return that the lane is not up to date when main is ahead', async () => {
       const currentLane = await lanes.getCurrentLane();
@@ -79,7 +82,7 @@ describe('LanesAspect', function () {
         await lanes.diffStatus(currentLane.toLaneId(), undefined, { skipChanges: true })
       ).componentsStatus.every((c) => c.upToDate);
 
-      expect(isUpToDate).toEqual(false);
+      expect(isUpToDate).to.be.false;
     });
   });
 
@@ -87,7 +90,7 @@ describe('LanesAspect', function () {
     let lanes: LanesMain;
     let snapping: SnappingMain;
     let workspaceData: WorkspaceData;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
@@ -99,17 +102,17 @@ describe('LanesAspect', function () {
       await lanes.createLane('stage');
       const result = await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
       // intermediate step, make sure it is snapped
-      expect(result?.snappedComponents.length).toEqual(1);
-    }, 30000);
-    afterAll(async () => {
+      expect(result?.snappedComponents.length).to.equal(1);
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should return that the lane is up to date when the lane is ahead of main', async () => {
       const currentLane = await lanes.getCurrentLane();
       if (!currentLane) throw new Error('unable to get the current lane');
       const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
-      expect(laneDiffResults.componentsStatus[0].upToDate).toEqual;
-      expect(laneDiffResults.componentsStatus[0].changeType).toEqual(ChangeType.NONE);
+      expect(laneDiffResults.componentsStatus[0].upToDate).to.be.true;
+      expect(laneDiffResults.componentsStatus[0].changeType).to.equal(ChangeType.NONE);
     });
     it('should return that the lane is not up to date when main is ahead', async () => {
       const currentLane = await lanes.getCurrentLane();
@@ -118,15 +121,15 @@ describe('LanesAspect', function () {
       await snapping.snap({ pattern: 'comp1', build: false, unmodified: true });
 
       const laneDiffResults = await lanes.diffStatus(currentLane.toLaneId());
-      expect(laneDiffResults.componentsStatus[0].upToDate).toEqual(false);
-      expect(laneDiffResults.componentsStatus[0].changeType).toEqual(ChangeType.NONE);
+      expect(laneDiffResults.componentsStatus[0].upToDate).to.be.false;
+      expect(laneDiffResults.componentsStatus[0].changeType).to.equal(ChangeType.NONE);
     });
   });
 
   describe('restoreLane()', () => {
     let lanes: LanesMain;
     let workspaceData: WorkspaceData;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
@@ -135,32 +138,32 @@ describe('LanesAspect', function () {
 
       // as an intermediate step, make sure the lane was created
       const currentLanes = await lanes.getLanes({});
-      expect(currentLanes.length).toEqual(1);
+      expect(currentLanes).to.have.lengthOf(1);
 
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
       await lanes.removeLanes(['stage']);
 
       // as an intermediate step, make sure the lane was removed
       const lanesAfterDelete = await lanes.getLanes({});
-      expect(lanesAfterDelete.length).toEqual(0);
+      expect(lanesAfterDelete).to.have.lengthOf(0);
 
       await lanes.restoreLane(currentLanes[0].hash);
-    }, 30000);
-    afterAll(async () => {
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should restore the deleted lane', async () => {
       const currentLanes = await lanes.getLanes({});
-      expect(currentLanes.length).toEqual(1);
-      expect(currentLanes[0].id.name).toEqual('stage');
+      expect(currentLanes).to.have.lengthOf(1);
+      expect(currentLanes[0].id.name).to.equal('stage');
     });
     describe('delete restored lane', () => {
       let output: string[];
-      beforeAll(async () => {
+      before(async () => {
         output = await lanes.removeLanes(['stage']);
       });
       it('should not throw', () => {
-        expect(output.length).toEqual(1);
+        expect(output).to.have.lengthOf(1);
       });
     });
   });
@@ -169,7 +172,7 @@ describe('LanesAspect', function () {
     let lanes: LanesMain;
     let workspaceData: WorkspaceData;
     let laneHash: string;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
@@ -178,15 +181,15 @@ describe('LanesAspect', function () {
 
       // as an intermediate step, make sure the lane was created
       const currentLanes = await lanes.getLanes({});
-      expect(currentLanes.length).toEqual(1);
+      expect(currentLanes).to.have.lengthOf(1);
 
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
       await lanes.removeLanes(['stage']);
 
       await lanes.createLane('stage');
       laneHash = currentLanes[0].hash;
-    }, 30000);
-    afterAll(async () => {
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should throw when restoring the lane', async () => {
@@ -196,8 +199,8 @@ describe('LanesAspect', function () {
       } catch (err: any) {
         error = err;
       }
-      expect(error).toBeInstanceOf(Error);
-      expect(error?.message).toMatch(/unable to restore lane/);
+      expect(error).to.be.instanceOf(Error);
+      expect(error?.message).to.include('unable to restore lane');
     });
   });
 
@@ -206,7 +209,7 @@ describe('LanesAspect', function () {
     let workspaceData: WorkspaceData;
     let snapping: SnappingMain;
     let laneId: LaneId;
-    beforeAll(async () => {
+    before(async () => {
       addFeature(SUPPORT_LANE_HISTORY);
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
@@ -217,53 +220,53 @@ describe('LanesAspect', function () {
       const currentLaneId = lanes.getCurrentLaneId();
       if (!currentLaneId) throw new Error('unable to get the current lane-id');
       laneId = currentLaneId;
-    }, 30000);
-    afterAll(async () => {
+    });
+    after(async () => {
       removeFeature(SUPPORT_LANE_HISTORY);
       await destroyWorkspace(workspaceData);
     });
     it('should create lane history object when creating a new lane', async () => {
       const laneHistory = await lanes.getLaneHistory(laneId);
       const history = laneHistory.getHistory();
-      expect(Object.keys(history).length).toEqual(1);
+      expect(Object.keys(history).length).to.equal(1);
     });
     it('should add a record to LaneHistory when snapping', async () => {
       const results = await snapping.snap({ pattern: 'comp1', build: false, message: 'first snap' });
       const laneHistory = await lanes.getLaneHistory(laneId);
       const history = laneHistory.getHistory();
-      expect(Object.keys(history).length).toEqual(2);
+      expect(Object.keys(history).length).to.equal(2);
       const snapHistory = history[Object.keys(history)[1]];
-      expect(snapHistory.log.message).toEqual('snap (first snap)');
-      expect(snapHistory.components.length).toEqual(1);
-      expect(snapHistory.components[0]).toEqual(results?.snappedComponents[0].id.toString() as string);
+      expect(snapHistory.log.message).to.equal('snap (first snap)');
+      expect(snapHistory.components.length).to.equal(1);
+      expect(snapHistory.components[0]).to.equal(results?.snappedComponents[0].id.toString() as string);
     });
     describe('import to another workspace', () => {
       let newWorkspace: WorkspaceData;
-      beforeAll(async () => {
+      before(async () => {
         // make another snap to check to test the checkout later.
         await snapping.snap({ pattern: 'comp1', build: false, message: 'second snap' });
         const laneHistory = await lanes.getLaneHistory(laneId);
         const history = laneHistory.getHistory();
-        expect(Object.keys(history).length).toEqual(3);
+        expect(Object.keys(history).length).to.equal(3);
 
         const exporter: ExportMain = await loadAspect(ExportAspect, workspaceData.workspacePath);
         const exportResults = await exporter.export();
-        expect(exportResults.componentsIds.length).toEqual(1);
-        expect(exportResults.exportedLanes.length).toEqual(1);
+        expect(exportResults.componentsIds.length).to.equal(1);
+        expect(exportResults.exportedLanes.length).to.equal(1);
 
         newWorkspace = mockWorkspace({ bareScopeName: workspaceData.remoteScopeName });
 
         lanes = await loadAspect(LanesAspect, newWorkspace.workspacePath);
         await lanes.switchLanes(laneId.toString(), { skipDependencyInstallation: true, getAll: true });
         await lanes.importLaneObject(laneId, true, true);
-      }, 30000);
-      afterAll(async () => {
+      });
+      after(async () => {
         await destroyWorkspace(newWorkspace);
       });
       it('should not add a record to the lane-history', async () => {
         const laneHistory = await lanes.getLaneHistory(laneId);
         const history = laneHistory.getHistory();
-        expect(Object.keys(history).length).toEqual(3);
+        expect(Object.keys(history).length).to.equal(3);
       });
       it('should be able to checkout to a previous state of the lane', async () => {
         const laneHistory = await lanes.getLaneHistory(laneId);
@@ -271,8 +274,8 @@ describe('LanesAspect', function () {
         const snapHistoryId = Object.keys(history).find((key) => history[key].log.message?.includes('first snap'));
         if (!snapHistoryId) throw new Error('unable to find snap history of the first snap');
         const results = await lanes.checkoutHistory(snapHistoryId, { skipDependencyInstallation: true });
-        expect(results.components?.length).toEqual(1);
-        expect(results.failedComponents?.length).toEqual(0);
+        expect(results.components?.length).to.equal(1);
+        expect(results.failedComponents?.length).to.equal(0);
       });
     });
   });
@@ -280,23 +283,23 @@ describe('LanesAspect', function () {
   describe('create lanes with the same name different scope', () => {
     let lanes: LanesMain;
     let workspaceData: WorkspaceData;
-    beforeAll(async () => {
+    before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
       lanes = await loadAspect(LanesAspect, workspacePath);
       await lanes.createLane('stage');
       await lanes.switchLanes('main', { skipDependencyInstallation: true });
-    }, 30000);
-    afterAll(async () => {
+    });
+    after(async () => {
       await destroyWorkspace(workspaceData);
     });
     it('should not throw when creating the second lane', async () => {
       await lanes.createLane('stage', { scope: 'new-scope' });
       const currentLanes = await lanes.getLanes({});
-      expect(currentLanes.length).toEqual(2);
-      expect(currentLanes[0].id.name).toEqual('stage');
-      expect(currentLanes[1].id.name).toEqual('stage');
+      expect(currentLanes.length).to.equal(2);
+      expect(currentLanes[0].id.name).to.equal('stage');
+      expect(currentLanes[1].id.name).to.equal('stage');
     });
   });
 });

--- a/scopes/preview/preview/bundler/create-peer-link.spec.ts
+++ b/scopes/preview/preview/bundler/create-peer-link.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { generatePeerLink } from './create-peers-link';
 
 const guardSnapshot = `function guard(property, expected) {
@@ -28,6 +29,6 @@ describe('peers link', () => {
   it('should output snapshot', () => {
     const result = generatePeerLink(['foo-bar', '@buz/qux']);
 
-    expect(result).toEqual(snapshot);
+    expect(result).to.equal(snapshot);
   });
 });

--- a/scopes/react/react-native/component.json
+++ b/scopes/react/react-native/component.json
@@ -27,6 +27,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.21": {}
   }
 }

--- a/scopes/react/react-native/component.json
+++ b/scopes/react/react-native/component.json
@@ -27,6 +27,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.19": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
   }
 }

--- a/scopes/semantics/schema/schema.spec.ts
+++ b/scopes/semantics/schema/schema.spec.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import fs from 'fs-extra';
+import chai, { expect } from 'chai';
 import { APISchema, UnknownSchema } from '@teambit/semantics.entities.semantic-schema';
+import chaiSubset from 'chai-subset';
 import TrackerAspect, { TrackerMain } from '@teambit/tracker';
 import { loadAspect, loadManyAspects } from '@teambit/harmony.testing.load-aspect';
 import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
@@ -9,23 +11,26 @@ import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { SchemaMain } from './schema.main.runtime';
 import { SchemaAspect } from '.';
 
+chai.use(chaiSubset);
+
 describe('SchemaAspect', function () {
+  this.timeout(0);
   let schema: SchemaMain;
   let workspace: Workspace;
   let workspaceData: WorkspaceData;
-  beforeAll(async () => {
+  before(async () => {
     workspaceData = mockWorkspace();
     const { workspacePath } = workspaceData;
     // eslint-disable-next-line no-console
     console.log('workspace created at ', workspacePath);
     schema = await loadAspect(SchemaAspect, workspacePath);
-  }, 30000);
-  afterAll(async () => {
+  });
+  after(async () => {
     await destroyWorkspace(workspaceData);
   });
   describe('getSchema()', () => {
     let apiSchema: APISchema;
-    beforeAll(async () => {
+    before(async () => {
       const { workspacePath } = workspaceData;
       const compDir = path.join(workspacePath, 'button');
       const src = path.join(getMockDir(), 'button');
@@ -39,7 +44,7 @@ describe('SchemaAspect', function () {
       const compId = await workspace.resolveComponentId('button');
       const comp = await workspace.get(compId);
       apiSchema = await schema.getSchema(comp, true);
-    }, 30000);
+    });
     it('should be able to generate JSON object with all schemas', async () => {
       const results = apiSchema.toObject();
       const expectedJsonPath = path.join(getMockDir(), 'button-schemas.json');
@@ -47,7 +52,7 @@ describe('SchemaAspect', function () {
       // fs.outputFileSync(expectedJsonPath, JSON.stringify(results, undefined, 2));
       const expectedJson = fs.readJsonSync(expectedJsonPath);
       // @ts-ignore it exists on Jest. for some reason ts assumes this is Jasmine.
-      expect(results).toMatchObject(expectedJson);
+      expect(results).to.to.containSubset(expectedJson);
     });
   });
   describe('getSchemaFromObject', () => {
@@ -55,19 +60,19 @@ describe('SchemaAspect', function () {
       const jsonPath = path.join(getMockDir(), 'button-schemas.json');
       const json = fs.readJsonSync(jsonPath);
       const apiSchema = schema.getSchemaFromObject(json);
-      expect(apiSchema instanceof APISchema).toEqual(true);
-      expect(apiSchema.componentId.constructor.name).toEqual(ComponentID.name);
+      expect(apiSchema instanceof APISchema).to.be.true;
+      expect(apiSchema.componentId.constructor.name).to.equal(ComponentID.name);
       // @ts-ignore it exists on Jest. for some reason ts assumes this is Jasmine.
-      expect(apiSchema.toObject()).toMatchObject(json);
+      expect(apiSchema.toObject()).to.containSubset(json);
     });
     it('should not throw when it does not recognize the schema', () => {
       const jsonPath = path.join(getMockDir(), 'button-old-schema.json');
       const json = fs.readJsonSync(jsonPath);
       const apiSchema = schema.getSchemaFromObject(json);
-      expect(apiSchema instanceof APISchema).toEqual(true);
-      expect(apiSchema.module.exports[0] instanceof UnknownSchema).toEqual(true);
+      expect(apiSchema instanceof APISchema).to.be.true;
+      expect(apiSchema.module.exports[0] instanceof UnknownSchema).to.be.true;
       // @ts-ignore
-      expect(apiSchema.module.exports[0].location).toMatchObject({ file: 'index.ts', line: 21, character: 14 });
+      expect(apiSchema.module.exports[0].location).to.deep.equal({ file: 'index.ts', line: 21, character: 14 });
     });
   });
 });

--- a/scopes/typescript/typescript/dedupe-path.spec.ts
+++ b/scopes/typescript/typescript/dedupe-path.spec.ts
@@ -1,10 +1,11 @@
+import { expect } from 'chai';
 import { dedupePaths } from './tsconfig-writer';
 
 describe('dedupePath', () => {
   it('should return the root-dir if there is only one env involved', () => {
     const input = [{ ids: ['env1'], paths: ['p1/e1, p2'] }];
     const output = dedupePaths(input);
-    expect(output).toEqual([{ ids: ['env1'], paths: ['.'] }]);
+    expect(output).to.deep.equal([{ ids: ['env1'], paths: ['.'] }]);
   });
   it('should set the env with the most components', () => {
     const input = [
@@ -13,13 +14,10 @@ describe('dedupePath', () => {
     ];
     const output = dedupePaths(input);
     // @ts-ignore
-    expect(output).toEqual(
-      // @ts-ignore
-      expect.arrayContaining([
-        { ids: ['env1'], paths: ['.'] },
-        { ids: ['env2'], paths: ['p1/e3'] },
-      ])
-    );
+    expect(output).to.deep.equal([
+      { ids: ['env2'], paths: ['p1/e3'] },
+      { ids: ['env1'], paths: ['.'] },
+    ]);
   });
   it('should not set any env to a shared dir if it no env has max components', () => {
     const input = [
@@ -27,8 +25,8 @@ describe('dedupePath', () => {
       { ids: ['env2'], paths: ['p1/e2'] },
     ];
     const output = dedupePaths(input);
-    expect(output.length).toEqual(2);
+    expect(output.length).to.equal(2);
     // @ts-ignore
-    expect(output).toEqual(expect.arrayContaining(input));
+    expect(output).to.deep.equal(input);
   });
 });

--- a/scopes/typescript/typescript/transform-source-file.spec.ts
+++ b/scopes/typescript/typescript/transform-source-file.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import ts from 'typescript';
 import {
   transformSourceFile,
@@ -32,7 +33,7 @@ describe('transformSourceFile', () => {
       const normalizedResult = normalizeFormatting(result);
       const normalizedExpectedCode = normalizeFormatting(expectedCode);
 
-      expect(normalizedResult).toBe(normalizedExpectedCode);
+      expect(normalizedResult).to.equal(normalizedExpectedCode);
     });
   };
 
@@ -138,7 +139,7 @@ describe('transformSourceFile', () => {
     const result = await transformSourceFile('test.ts', sourceCode, []);
     const normalizedResult = normalizeFormatting(result);
     const normalizedSourceCode = normalizeFormatting(sourceCode);
-    expect(normalizedResult).toBe(normalizedSourceCode);
+    expect(normalizedResult).to.equal(normalizedSourceCode);
   });
 
   it('should handle multiple transformers', async () => {
@@ -150,6 +151,6 @@ describe('transformSourceFile', () => {
     ]);
     const normalizedResult = normalizeFormatting(result);
     const normalizedExpectedCode = normalizeFormatting(expectedCode);
-    expect(normalizedResult).toBe(normalizedExpectedCode);
+    expect(normalizedResult).to.equal(normalizedExpectedCode);
   });
 });

--- a/scopes/ui-foundation/ui/component.json
+++ b/scopes/ui-foundation/ui/component.json
@@ -31,6 +31,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.19": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
   }
 }

--- a/scopes/ui-foundation/ui/component.json
+++ b/scopes/ui-foundation/ui/component.json
@@ -31,6 +31,6 @@
     "teambit.envs/envs": {
       "env": "teambit.harmony/envs/core-aspect-env"
     },
-    "teambit.harmony/envs/core-aspect-env@0.0.20": {}
+    "teambit.harmony/envs/core-aspect-env@0.0.21": {}
   }
 }

--- a/scopes/workspace/install/pick-outdated-pkgs.spec.ts
+++ b/scopes/workspace/install/pick-outdated-pkgs.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import stripAnsi from 'strip-ansi';
 import { ComponentID } from '@teambit/component';
 import { makeOutdatedPkgChoices } from './pick-outdated-pkgs';
@@ -38,7 +39,7 @@ describe('makeOutdatedPkgChoices', () => {
     const stripped = stripAnsiFromChoices(choices);
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    expect(stripped).toMatchObject(orderedChoices);
+    expect(stripped).to.deep.equal(orderedChoices);
   });
   it('should render choices with context information', () => {
     const choices = makeOutdatedPkgChoices([
@@ -63,7 +64,7 @@ describe('makeOutdatedPkgChoices', () => {
     const stripped = stripAnsiFromChoices(choices);
     // @ts-ignore
     // eslint-disable-next-line @typescript-eslint/no-use-before-define
-    expect(stripped).toMatchObject(contextOrders);
+    expect(stripped).to.deep.equal(contextOrders);
   });
 });
 

--- a/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
+++ b/scopes/workspace/workspace-config-files/dedup-paths.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { DedupedPaths, dedupePaths } from './dedup-paths';
 import { ExtendingConfigFilesMap } from './writers';
 
@@ -294,55 +295,54 @@ const prettierExpectedDedupedPaths: DedupedPaths = [
 ];
 
 describe('Workspace Config files - dedupe paths', function () {
+  this.timeout(0);
+
   describe('dedupePaths', () => {
     describe('ts example', () => {
       let result: DedupedPaths;
-      beforeAll(async () => {
+      before(async () => {
         // @ts-ignore (we don't really care about the env itself here)
         result = dedupePaths(tsExtendingConfigFilesMap, envCompsDirsMap);
       });
 
       it('should reduce files to minimum necessary', async () => {
-        expect(result.length).toEqual(tsExpectedDedupedPaths.length);
+        expect(result).to.have.lengthOf(tsExpectedDedupedPaths.length);
       });
 
       it('should place files in correct folders', async () => {
-        // @ts-ignore
-        expect(result).toMatchObject(tsExpectedDedupedPaths);
+        expect(result).to.deep.equal(tsExpectedDedupedPaths);
       });
     });
 
     describe('eslint example', () => {
       let result: DedupedPaths;
-      beforeAll(async () => {
+      before(async () => {
         // @ts-ignore (we don't really care about the env itself here)
         result = dedupePaths(eslintExtendingConfigFilesMap, envCompsDirsMap);
       });
 
       it('should reduce files to minimum necessary', async () => {
-        expect(result.length).toEqual(eslintExpectedDedupedPaths.length);
+        expect(result).to.have.lengthOf(eslintExpectedDedupedPaths.length);
       });
 
       it('should place files in correct folders', async () => {
-        // @ts-ignore
-        expect(result).toMatchObject(eslintExpectedDedupedPaths);
+        expect(result).to.deep.equal(eslintExpectedDedupedPaths);
       });
     });
 
     describe('prettier example', () => {
       let result: DedupedPaths;
-      beforeAll(async () => {
+      before(async () => {
         // @ts-ignore (we don't really care about the env itself here)
         result = dedupePaths(prettierExtendingConfigFilesMap, envCompsDirsMap);
       });
 
       it('should reduce files to minimum necessary', async () => {
-        expect(result.length).toEqual(prettierExpectedDedupedPaths.length);
+        expect(result).to.have.lengthOf(prettierExpectedDedupedPaths.length);
       });
 
       it('should place files in correct folders', async () => {
-        // @ts-ignore
-        expect(result).toMatchObject(prettierExpectedDedupedPaths);
+        expect(result).to.deep.equal(prettierExpectedDedupedPaths);
       });
     });
   });

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -366,6 +366,7 @@
         "body-parser": "1.19.0",
         "buffer": "6.0.3",
         "camelcase": "6.2.0",
+        "chai-subset": "^1.6.0",
         "classnames": "2.2.6",
         "cli-highlight": "2.1.9",
         "comlink": "4.3.0",


### PR DESCRIPTION
## Proposed Changes

- refactor(core-aspects) - update core aspect env to use mocha by default
- bump core aspect env version
- refresh circle cache for core aspect env
- migrate all core aspects (except deps-resolver) to use Mocha
- install chai-subset