### PR TITLE
change(install) - prefer root policy versions for root node_modules installation

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/deduping/index-by-dep-id.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/index-by-dep-id.ts
@@ -63,7 +63,9 @@ export function indexByDepId(
 }
 
 function addPreservedFromRoot(index: PackageNameIndex, rootPolicy: WorkspacePolicy): void {
-  const preserved = rootPolicy.filter((entry) => !!entry.value.preserve);
+  // In case the preserve is undefined we want it to be true by default
+  // to ensure workspace root policy versions are installed in the root node_modules by default
+  const preserved = rootPolicy.filter((entry) => entry.value.preserve ?? true);
   preserved.forEach((entry) => {
     const metadata: PackageNameIndexItemMetadata = {
       preservedVersion: entry.value.version,

--- a/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy-factory.ts
+++ b/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy-factory.ts
@@ -54,7 +54,7 @@ function createEntry(
   lifecycleType: WorkspaceDependencyLifecycleType
 ): WorkspacePolicyEntry {
   const version = typeof value === 'string' ? value : value.version;
-  const preserve = typeof value === 'string' ? false : value.preserve;
+  const preserve = typeof value === 'string' ? true : value.preserve;
   const entryValue: WorkspacePolicyEntryValue = {
     version,
     preserve,

--- a/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy-factory.ts
+++ b/scopes/dependencies/dependency-resolver/policy/workspace-policy/workspace-policy-factory.ts
@@ -54,7 +54,7 @@ function createEntry(
   lifecycleType: WorkspaceDependencyLifecycleType
 ): WorkspacePolicyEntry {
   const version = typeof value === 'string' ? value : value.version;
-  const preserve = typeof value === 'string' ? true : value.preserve;
+  const preserve = typeof value === 'string' ? undefined : value.preserve;
   const entryValue: WorkspacePolicyEntryValue = {
     version,
     preserve,


### PR DESCRIPTION
## Proposed Changes

- We used to have a behavior that when installing on the root node_modules we will use the deduped versions from the workspace components, over the root policy.
In case we want to "force" the root policy we used to have `preserve` as a config for root policy entries.
something like:
```
"teambit.dependencies/dependency-resolver": {
  "packageManager": "teambit.dependencies/pnpm",
  "policy": {
    "dependencies": {
      "lodash": {"version": "1.0.0", "preserve": true}
    }
  }
}
```
This behavior was changed at some point to always prefer the root policy versions on the root node_modules (making the `preserve` config redundant).
But the new behavior got broken at some point so we go back to the old one.
This PR changes the preserve default value to `true` to fix this regression in a "more" safe way.

With this PR it's still valid to configure the `preserve` value to `false` manually.

