### PR TITLE
improvement(esilnt-config) - disable react eslint rules which are not relevant for TS components

### DIFF
--- a/scopes/react/eslint-config-bit-react/bit-react-eslint.js
+++ b/scopes/react/eslint-config-bit-react/bit-react-eslint.js
@@ -44,6 +44,8 @@ module.exports = {
         'import/prefer-default-export': 'off',
         'react/jsx-props-no-spreading': 'off',
         'react/no-array-index-key': 'off',
+        'react/prop-types': 'off',
+        'react/require-default-props': 'off',
         'trailing-comma': 'off',
         '@typescript-eslint/comma-dangle': 'off',
         'object-curly-newline': 'off',


### PR DESCRIPTION
## Proposed Changes

- disable eslint react rules which are not relevant for React TS components:
  - disable `react/prop-types`
  - disable `react/require-default-props`

