### PR TITLE
fix(reset), remove from lane if was reset to main and not exist on remote-lane

### DIFF
--- a/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-reset-on-lanes.e2e.ts
@@ -139,4 +139,21 @@ describe('bit reset when on lane', function () {
       expect(() => helper.command.resetAll()).not.to.throw();
     });
   });
+  describe('reset a component that was just introduced to the lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.reset('comp1');
+    });
+    it('should remove the component from the lane', () => {
+      const lane = helper.command.showOneLaneParsed('dev');
+      expect(lane.components).to.have.lengthOf(1);
+      expect(lane.components[0].id).to.include('comp2');
+      expect(lane.components[0].id).to.not.include('comp1');
+    });
+  });
 });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -365,6 +365,14 @@ to quickly fix the issue, please delete the object at "${this.objects().objectPa
       const newHead = await getNewHead();
       if (newHead) {
         laneItem.head = newHead;
+        const divergeData = component.getDivergeData();
+        if (!component.laneHeadRemote && divergeData.commonSnapBeforeDiverge === newHead) {
+          // if the component doesn't exist on the remote lane and this reset removed all local snaps, remove the
+          // component from the lane. otherwise, the component stays on the lane but it's not staged so the export
+          // fails on the remote saying the component doesn't exist (in case the remote-lane and component-lane are
+          // not the same scope).
+          lane?.removeComponent(component.toComponentId());
+        }
       } else {
         if (lane?.isNew && this.scope.isExported(component.toComponentId()) && component.scope) {
           // the fact that the component has a scope-name means it was exported.


### PR DESCRIPTION
Here is a scenario where this was an issue: `scope-a/comp` was imported to the workspace, a new lane was created on another scope: `scope-b/dev` and this component was changed and snapped so it became part of the lane. 
Then, `bit reset` was running which changed the head on the lane to be the same as main. Now `bit export` throws an error saying `scope-a/comp` doesn't exist. This is because the lane-object included this component but this component wasn't sent to the remote as it wasn't staged. 

This PR fixes it by removing the component from the lane during the reset command. Because the component doesn't exist on the remote-lane and its head is the same as main, no reason to keep it on the lane.