### PR TITLE
fix(UI/CurrentUser): handle null values for current user response

### DIFF
--- a/scopes/cloud/cloud/cloud.main.runtime.ts
+++ b/scopes/cloud/cloud/cloud.main.runtime.ts
@@ -261,7 +261,12 @@ export class CloudMain {
           return null;
         }
         const response: CloudUserAPIResponse = await res.json();
-        return { ...(response.payload || {}) };
+        return {
+          isLoggedIn,
+          displayName: response.payload?.displayName ?? undefined,
+          username: response.payload?.username ?? undefined,
+          profileImage: response.payload?.profileImage ?? undefined,
+        };
       })
       .catch((err) => {
         this.logger.error(`failed to get current user, err: ${err}`);

--- a/scopes/cloud/models/cloud-user/cloud-user.model.ts
+++ b/scopes/cloud/models/cloud-user/cloud-user.model.ts
@@ -1,7 +1,7 @@
 export type CloudUser = {
-  displayName?: string | null;
-  username?: string | null;
-  profileImage?: string | null;
+  displayName?: string;
+  username?: string;
+  profileImage?: string;
   isLoggedIn?: boolean;
 };
 

--- a/scopes/cloud/models/cloud-user/cloud-user.model.ts
+++ b/scopes/cloud/models/cloud-user/cloud-user.model.ts
@@ -1,14 +1,14 @@
 export type CloudUser = {
-  displayName?: string;
-  username?: string;
-  profileImage?: string;
+  displayName?: string | null;
+  username?: string | null;
+  profileImage?: string | null;
   isLoggedIn?: boolean;
 };
 
 export type CloudUserAPIResponse = {
   payload?: {
-    displayName?: string;
-    username?: string;
-    profileImage?: string;
+    displayName?: string | null;
+    username?: string | null;
+    profileImage?: string | null;
   };
 };

--- a/scopes/cloud/ui/current-user/current-user.tsx
+++ b/scopes/cloud/ui/current-user/current-user.tsx
@@ -8,11 +8,17 @@ export type CurrentUserProps = {
   currentUser: CloudUser;
 } & React.HTMLAttributes<HTMLDivElement>;
 
-export function CurrentUser({ currentUser, onClick, className, ...rest }: CurrentUserProps) {
+export function CurrentUser({ currentUser: currentUserFromProps, onClick, className, ...rest }: CurrentUserProps) {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       onClick?.(event as unknown as React.MouseEvent<HTMLDivElement, MouseEvent>);
     }
+  };
+  const currentUser = {
+    ...currentUserFromProps,
+    displayName: currentUserFromProps.displayName ?? undefined,
+    username: currentUserFromProps.username ?? undefined,
+    profileImage: currentUserFromProps.profileImage ?? undefined,
   };
   return (
     <div

--- a/scopes/cloud/ui/current-user/current-user.tsx
+++ b/scopes/cloud/ui/current-user/current-user.tsx
@@ -6,13 +6,17 @@ import styles from './current-user.module.scss';
 
 export type CurrentUserProps = {
   currentUser: CloudUser;
-} & React.HTMLAttributes<HTMLDivElement>;
+  handleClick: (event: React.SyntheticEvent) => void;
+} & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>;
 
-export function CurrentUser({ currentUser: currentUserFromProps, onClick, className, ...rest }: CurrentUserProps) {
+export function CurrentUser({ currentUser: currentUserFromProps, handleClick, className, ...rest }: CurrentUserProps) {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
-      onClick?.(event as unknown as React.MouseEvent<HTMLDivElement, MouseEvent>);
+      handleClick?.(event);
     }
+  };
+  const handleOnClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
+    handleClick?.(event);
   };
   const currentUser = {
     ...currentUserFromProps,
@@ -23,7 +27,7 @@ export function CurrentUser({ currentUser: currentUserFromProps, onClick, classN
   return (
     <div
       tabIndex={0}
-      onClick={onClick}
+      onClick={handleOnClick}
       onKeyDown={handleKeyDown}
       role="button"
       className={classNames(styles.user, className)}

--- a/scopes/cloud/ui/current-user/current-user.tsx
+++ b/scopes/cloud/ui/current-user/current-user.tsx
@@ -9,7 +9,7 @@ export type CurrentUserProps = {
   handleClick: (event: React.SyntheticEvent) => void;
 } & Omit<React.HTMLAttributes<HTMLDivElement>, 'onClick'>;
 
-export function CurrentUser({ currentUser: currentUserFromProps, handleClick, className, ...rest }: CurrentUserProps) {
+export function CurrentUser({ currentUser, handleClick, className, ...rest }: CurrentUserProps) {
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       handleClick?.(event);
@@ -17,12 +17,6 @@ export function CurrentUser({ currentUser: currentUserFromProps, handleClick, cl
   };
   const handleOnClick = (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => {
     handleClick?.(event);
-  };
-  const currentUser = {
-    ...currentUserFromProps,
-    displayName: currentUserFromProps.displayName ?? undefined,
-    username: currentUserFromProps.username ?? undefined,
-    profileImage: currentUserFromProps.profileImage ?? undefined,
   };
   return (
     <div

--- a/scopes/cloud/ui/user-bar/user-bar.tsx
+++ b/scopes/cloud/ui/user-bar/user-bar.tsx
@@ -25,7 +25,7 @@ export type UserBarProps = {
 };
 
 export function UserBar({ sections = [], items = [] }: UserBarProps) {
-  const { currentUser: currentUserFromAPI, loginUrl, loading, isLoggedIn } = useCurrentUser();
+  const { currentUser, loginUrl, loading, isLoggedIn } = useCurrentUser();
   const { logout, loading: loadingLoggingOut, loggedOut } = useLogout();
 
   const navigate = useNavigate();
@@ -34,16 +34,9 @@ export function UserBar({ sections = [], items = [] }: UserBarProps) {
     return <CircleSkeleton className={styles.loader} />;
   }
 
-  if (!currentUserFromAPI || !isLoggedIn || loggedOut) {
+  if (!currentUser || !isLoggedIn || loggedOut) {
     return <Login loginUrl={loginUrl} />;
   }
-
-  const currentUser = {
-    ...currentUserFromAPI,
-    displayName: currentUserFromAPI?.displayName ?? undefined,
-    username: currentUserFromAPI?.username ?? undefined,
-    profileImage: currentUserFromAPI?.profileImage ?? undefined,
-  };
 
   const itemList: MenuItemType[] = items
     .filter((item) => !item.category)

--- a/scopes/cloud/ui/user-bar/user-bar.tsx
+++ b/scopes/cloud/ui/user-bar/user-bar.tsx
@@ -25,7 +25,7 @@ export type UserBarProps = {
 };
 
 export function UserBar({ sections = [], items = [] }: UserBarProps) {
-  const { currentUser, loginUrl, loading, isLoggedIn } = useCurrentUser();
+  const { currentUser: currentUserFromAPI, loginUrl, loading, isLoggedIn } = useCurrentUser();
   const { logout, loading: loadingLoggingOut, loggedOut } = useLogout();
 
   const navigate = useNavigate();
@@ -34,9 +34,16 @@ export function UserBar({ sections = [], items = [] }: UserBarProps) {
     return <CircleSkeleton className={styles.loader} />;
   }
 
-  if (!currentUser || !isLoggedIn || loggedOut) {
+  if (!currentUserFromAPI || !isLoggedIn || loggedOut) {
     return <Login loginUrl={loginUrl} />;
   }
+
+  const currentUser = {
+    ...currentUserFromAPI,
+    displayName: currentUserFromAPI?.displayName ?? undefined,
+    username: currentUserFromAPI?.username ?? undefined,
+    profileImage: currentUserFromAPI?.profileImage ?? undefined,
+  };
 
   const itemList: MenuItemType[] = items
     .filter((item) => !item.category)

--- a/scopes/cloud/ui/user-bar/user-bar.tsx
+++ b/scopes/cloud/ui/user-bar/user-bar.tsx
@@ -98,7 +98,7 @@ export function UserBar({ sections = [], items = [] }: UserBarProps) {
       <CurrentUser
         className={styles.currentUser}
         currentUser={currentUser}
-        onClick={() => {
+        handleClick={() => {
           window.open(`https://bit.cloud/${currentUser.username}`, '_blank');
         }}
       />


### PR DESCRIPTION
This PR handles the case where the properties of the CurrentUser response from the API are null, so that it matches the signature of what UserAvatar component expects. Previously, it would throw the error, `cannot read properties of null reading '0' `