### PR TITLE
fix(Cloud UI): duplicate render keys

### DIFF
--- a/scopes/cloud/cloud/cloud.ui.runtime.tsx
+++ b/scopes/cloud/cloud/cloud.ui.runtime.tsx
@@ -156,7 +156,7 @@ export class CloudUI {
     workspace.registerMenuWidget([CloudUserBar]);
     if (workspace) {
       lanes.registerMenuWidget(CloudUserBar);
-      component.registerRightSideMenuItem({ item: <CloudUserBar />, order: 100 });
+      component.registerRightSideMenuItem({ item: <CloudUserBar key={'cloud-user-bar-comp-menu'} />, order: 100 });
     }
     return cloudUI;
   }

--- a/scopes/cloud/ui/user-bar/user-bar.tsx
+++ b/scopes/cloud/ui/user-bar/user-bar.tsx
@@ -44,7 +44,7 @@ export function UserBar({ sections = [], items = [] }: UserBarProps) {
       return {
         ...rest,
         link: href,
-        component: Component ? <Component key={index} user={currentUser} /> : undefined,
+        component: Component ? <Component key={`user-bar-item-${index}`} user={currentUser} /> : undefined,
       };
     });
 


### PR DESCRIPTION
This PR fixes the warning thrown by react at runtime about duplicate keys for the Current User menu item registered by the Cloud UI Runtime in the User Bar and in the Component Menu. 