### PR TITLE
fix(deps-resolver), resolve snap versions coming from overrides without the snap-prefix (0.0.0-)

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
@@ -12,6 +12,7 @@ import logger from '@teambit/legacy/dist/logger/logger';
 import { getExt, pathNormalizeToLinux, pathRelativeLinux } from '@teambit/legacy/dist/utils';
 import { PathLinux, PathLinuxRelative, PathOsBased, removeFileExtension } from '@teambit/legacy/dist/utils/path';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
+import { SNAP_VERSION_PREFIX } from '@teambit/component-package-version';
 import Component from '@teambit/legacy/dist/consumer/component/consumer-component';
 import { DependencyResolverMain } from '@teambit/dependency-resolver';
 import { RelativePath } from '@teambit/legacy/dist/consumer/component/dependencies/dependency';
@@ -740,6 +741,12 @@ export class AutoDetectDeps {
 export function getValidVersion(version: string | undefined) {
   if (!version) {
     return null;
+  }
+  if (version.startsWith(SNAP_VERSION_PREFIX)) {
+    const versionWithoutSnapPrefix = version.replace(SNAP_VERSION_PREFIX, '');
+    if (isSnap(versionWithoutSnapPrefix)) {
+      return versionWithoutSnapPrefix;
+    }
   }
   if (semver.valid(version)) {
     // this takes care of pre-releases as well, as they're considered valid semver.

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -152,7 +152,7 @@ export function updateDependenciesVersions(
     return depsResolver.getWorkspacePolicyManifest().dependencies?.[pkgName];
   }
 
-  function resolveFromMergeConfig(id: ComponentID, pkgName: string) {
+  function resolveFromMergeConfig(id: ComponentID, pkgName: string): ComponentID | undefined {
     let foundVersion: string | undefined | null;
     DEPENDENCIES_FIELDS.forEach((field) => {
       if (autoDetectConfigMerge[field]?.[pkgName]) {


### PR DESCRIPTION
Currently, it is saved with the snap-prefix inside the component `dependencies` array incorrectly. 