### PR TITLE
fix(deps-set), add snap prefix (0.0.0-) to the version in .bitmap if needed

### DIFF
--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -14,6 +14,7 @@ import ComponentLoader, { DependencyLoaderOpts } from '@teambit/legacy/dist/cons
 import DependencyGraph from '@teambit/legacy/dist/scope/graph/scope-graph';
 import DevFilesAspect, { DevFilesMain } from '@teambit/dev-files';
 import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
+import { snapToSemver } from '@teambit/component-package-version';
 import { DependenciesLoader } from './dependencies-loader/dependencies-loader';
 import { DependenciesData, OverridesDependenciesData } from './dependencies-loader/dependencies-data';
 import {
@@ -35,7 +36,7 @@ import { DependenciesAspect } from './dependencies.aspect';
 import { DebugDependencies } from './dependencies-loader/auto-detect-deps';
 
 export type RemoveDependencyResult = { id: ComponentID; removedPackages: string[] };
-
+export type SetDependenciesResult = { changedComps: string[]; addedPackages: Record<string, string> };
 export type DependenciesResultsDebug = DebugDependencies &
   OverridesDependenciesData & { coreAspects: string[]; sources: { id: string; source: string }[] };
 
@@ -65,8 +66,8 @@ export class DependenciesMain {
   async setDependency(
     componentPattern: string,
     packages: string[],
-    options: SetDependenciesFlags
-  ): Promise<{ changedComps: string[]; addedPackages: Record<string, string> }> {
+    options: SetDependenciesFlags = {}
+  ): Promise<SetDependenciesResult> {
     const compIds = await this.workspace.idsByPattern(componentPattern);
     const getDepField = () => {
       if (options.dev) return 'devDependencies';
@@ -330,7 +331,7 @@ export class DependenciesMain {
     };
     const [name, version] = this.splitPkgToNameAndVer(pkg);
     const versionResolved = !version || version === 'latest' ? await resolveLatest(name) : version;
-    return [name, versionResolved];
+    return [name, snapToSemver(versionResolved)];
   }
 
   private splitPkgToNameAndVer(pkg: string): [string, string | undefined] {

--- a/scopes/dependencies/dependencies/dependencies.spec.ts
+++ b/scopes/dependencies/dependencies/dependencies.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from 'chai';
+import { loadAspect } from '@teambit/harmony.testing.load-aspect';
+import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
+import { mockComponents } from '@teambit/component.testing.mock-components';
+import { DependenciesMain, SetDependenciesResult } from './dependencies.main.runtime';
+import { DependenciesAspect } from './dependencies.aspect';
+
+describe('Dependencies Aspect', function () {
+  this.timeout(0);
+
+  describe('setDependency() with a snap', () => {
+    let workspaceData: WorkspaceData;
+    let setDepsResult: SetDependenciesResult;
+    before(async () => {
+      workspaceData = mockWorkspace();
+      const { workspacePath } = workspaceData;
+      await mockComponents(workspacePath);
+      const dependencies: DependenciesMain = await loadAspect(DependenciesAspect, workspacePath);
+      setDepsResult = await dependencies.setDependency('comp1', [
+        '@org/scope.some-comp@ccb187997f01c2d8ec180fd321c7cd04034cd2d9',
+      ]);
+    });
+    after(async () => {
+      await destroyWorkspace(workspaceData);
+    });
+    it('should add the snap prefix', () => {
+      expect(setDepsResult.addedPackages).to.deep.eq({
+        '@org/scope.some-comp': '0.0.0-ccb187997f01c2d8ec180fd321c7cd04034cd2d9',
+      });
+    });
+  });
+});


### PR DESCRIPTION
`bit deps set` saves the data into the `policy` of the dependencies resolver config, which accepts package name and a valid Semver. Users are not aware of the prefix added to the package version of snaps, so running `bit deps set pkg-name@snap-hash` result in saving the version as the snap-hash in the objects, which later fails the installation.
This PR adds the `0.0.0-` prefix to the snap hash to make it a valid Semver.