### PR TITLE
feat(Preview): onlyOverview global feature flag

### DIFF
--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -493,7 +493,6 @@ export class PreviewMain {
 
   async isSupportSkipIncludes(component: Component) {
     if (!this.config.onlyOverview && !isFeatureEnabled(ONLY_OVERVIEW)) return false;
-    console.log('\n\nisSupportSkipIncludes');
     const isCore = this.envs.isUsingCoreEnv(component);
     if (isCore) return false;
 
@@ -507,7 +506,6 @@ export class PreviewMain {
    */
   async getOnlyOverview(component: Component): Promise<boolean> {
     if (!this.config.onlyOverview && !isFeatureEnabled(ONLY_OVERVIEW)) return false;
-    console.log('\n\ngetOnlyOverview');
     const previewData = this.getPreviewData(component);
     return previewData?.onlyOverview ?? false;
   }

--- a/scopes/preview/preview/preview.main.runtime.ts
+++ b/scopes/preview/preview/preview.main.runtime.ts
@@ -33,6 +33,7 @@ import { ArtifactFiles } from '@teambit/legacy/dist/consumer/component/sources/a
 import WatcherAspect, { WatcherMain } from '@teambit/watcher';
 import GraphqlAspect, { GraphqlMain } from '@teambit/graphql';
 import ScopeAspect, { ScopeMain } from '@teambit/scope';
+import { ONLY_OVERVIEW, isFeatureEnabled } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
 import { BundlingStrategyNotFound } from './exceptions';
 import { generateLink, MainModulesMap } from './generate-link';
 import { PreviewArtifact } from './preview-artifact';
@@ -491,8 +492,8 @@ export class PreviewMain {
   }
 
   async isSupportSkipIncludes(component: Component) {
-    if (!this.config.onlyOverview) return false;
-
+    if (!this.config.onlyOverview && !isFeatureEnabled(ONLY_OVERVIEW)) return false;
+    console.log('\n\nisSupportSkipIncludes');
     const isCore = this.envs.isUsingCoreEnv(component);
     if (isCore) return false;
 
@@ -505,7 +506,8 @@ export class PreviewMain {
    * check if the component preview should only include the overview (skipping rendering of the compostions and properties table)
    */
   async getOnlyOverview(component: Component): Promise<boolean> {
-    if (!this.config.onlyOverview) return false;
+    if (!this.config.onlyOverview && !isFeatureEnabled(ONLY_OVERVIEW)) return false;
+    console.log('\n\ngetOnlyOverview');
     const previewData = this.getPreviewData(component);
     return previewData?.onlyOverview ?? false;
   }

--- a/src/api/consumer/lib/feature-toggle.ts
+++ b/src/api/consumer/lib/feature-toggle.ts
@@ -60,6 +60,8 @@ export const LEGACY_SHARED_DIR_FEATURE = 'legacy-shared-dir';
 
 export const NO_FS_CACHE_FEATURE = 'no-fs-cache';
 
+export const ONLY_OVERVIEW = 'only-overview';
+
 export const CLOUD_IMPORTER = 'cloud-importer';
 export const CLOUD_IMPORTER_V2 = 'cloud-importer-v2';
 


### PR DESCRIPTION
This PR adds a global feature flag `only-overview` to enable the new Overview section which only renders the docs and mounts the Compositions and API Reference outside of the iframe. 