### PR TITLE
fix(tag-from-scope), avoid overriding artifacts with the same task-id and task-name if their artifacts name is different

### DIFF
--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -256,7 +256,10 @@ export class BuilderMain {
         const artifactObj = artifact.toObject();
         if (!builderData.artifacts) builderData.artifacts = [];
         if (
-          builderData.artifacts.find((a) => a.task.id === artifactObj.task.id && a.task.name === artifactObj.task.name)
+          builderData.artifacts.find(
+            (a) =>
+              a.task.id === artifactObj.task.id && a.task.name === artifactObj.task.name && a.name === artifactObj.name
+          )
         ) {
           return;
         }


### PR DESCRIPTION
For example, it's possible for `teambit.harmony/application` aspect to use the `build_application` task for both: build pipeline and tag pipeline. The artifacts it is generating are different and have a different name. This PR fixes the `_tag` command to keep both artifacts. 