### PR TITLE
improvement(checkout), enable the workspace.jsonc update for bit checkout

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -7,6 +7,7 @@ import { MissingBitMapComponent } from '../../src/consumer/bit-map/exceptions';
 import { NewerVersionFound } from '../../src/consumer/exceptions';
 import Helper, { FileStatusWithoutChalk } from '../../src/e2e-helper/e2e-helper';
 import { FILE_CHANGES_CHECKOUT_MSG } from '../../src/constants';
+import { UPDATE_DEPS_ON_IMPORT } from '../../src/api/consumer/lib/feature-toggle';
 
 chai.use(require('chai-fs'));
 
@@ -576,6 +577,58 @@ describe('bit checkout command', function () {
       const file = helper.fs.readFile('comp1/index.js');
       expect(file).to.include(`// first line modified
 `);
+    });
+  });
+  describe('checkout head with deps having different versions than workspace.jsonc', () => {
+    let beforeCheckout: string;
+    const initWsWithVer = (ver: string) => {
+      helper.scopeHelper.getClonedLocalScope(beforeCheckout);
+      helper.workspaceJsonc.addPolicyToDependencyResolver({
+        dependencies: {
+          'lodash.get': ver,
+        },
+      });
+      helper.npm.addFakeNpmPackage('lodash.get', ver.replace('^', '').replace('~', ''));
+      helper.command.checkoutHead(undefined, '-x');
+    };
+
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.setFeatures(UPDATE_DEPS_ON_IMPORT);
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      beforeCheckout = helper.scopeHelper.cloneLocalScope();
+
+      helper.fs.outputFile('comp1/foo.js', `const get = require('lodash.get'); console.log(get);`);
+      helper.workspaceJsonc.addPolicyToDependencyResolver({
+        dependencies: {
+          'lodash.get': '^4.4.2',
+        },
+      });
+      helper.npm.addFakeNpmPackage('lodash.get', '4.4.2');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+    });
+    it('if the ws has a lower range, it should update workspace.jsonc with the new range', () => {
+      initWsWithVer('^4.4.1');
+      const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+      expect(policy.dependencies['lodash.get']).to.equal('^4.4.2');
+    });
+
+    it('if the ws has a higher range, it should not update', () => {
+      initWsWithVer('^4.4.3');
+      const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+      expect(policy.dependencies['lodash.get']).to.equal('^4.4.3');
+    });
+
+    it('if the ws has a lower exact version, it should write a conflict', () => {
+      initWsWithVer('4.4.1');
+      const policy = helper.workspaceJsonc.readRaw();
+      expect(policy).to.have.string('<<<<<<< ours');
+      expect(policy).to.have.string('"lodash.get": "4.4.1"');
+      expect(policy).to.have.string('"lodash.get": "^4.4.2"');
+      expect(policy).to.have.string('>>>>>>> theirs');
     });
   });
 });

--- a/scopes/component/checkout/checkout-cmd.ts
+++ b/scopes/component/checkout/checkout-cmd.ts
@@ -9,6 +9,7 @@ import {
   compilationErrorOutput,
   getRemovedOutput,
   getAddedOutput,
+  getWorkspaceConfigUpdateOutput,
 } from '@teambit/merging';
 import { COMPONENT_PATTERN_HELP, HEAD, LATEST } from '@teambit/legacy/dist/constants';
 import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
@@ -149,6 +150,7 @@ export function checkoutOutput(
     removedComponents,
     addedComponents,
     leftUnresolvedConflicts,
+    workspaceConfigUpdateResult,
     newFromLane,
     newFromLaneAdded,
     installationError,
@@ -179,6 +181,16 @@ export function checkoutOutput(
       .map((failedComponent) => `${failedComponent.id.toString()} - ${failedComponent.unchangedMessage}`)
       .join('\n');
     return `${chalk.underline(title)}\n${body}`;
+  };
+  const getWsConfigUpdateLogs = () => {
+    // @TODO: uncomment the line below once UPDATE_DEPS_ON_IMPORT is enabled by default
+    // if (!importFlags.verbose) return '';
+    const logs = workspaceConfigUpdateResult?.logs;
+    if (!logs || !logs.length) return '';
+    const logsStr = logs.join('\n');
+    return `${chalk.underline(
+      'verbose logs of workspace config update'
+    )}\n(this is temporarily. once this feature is enabled, use --verbose to see these logs)\n${logsStr}`;
   };
   const getConflictSummary = () => {
     if (!components || !components.length || !leftUnresolvedConflicts) return '';
@@ -246,11 +258,13 @@ once ready, snap/tag the components to persist the changes`;
   };
 
   return compact([
+    getWsConfigUpdateLogs(),
     getNotCheckedOutOutput(),
     getSuccessfulOutput(),
     getRemovedOutput(removedComponents),
     getAddedOutput(addedComponents),
     getNewOnLaneOutput(),
+    getWorkspaceConfigUpdateOutput(workspaceConfigUpdateResult),
     getConflictSummary(),
     getSummary(),
     installationErrorOutput(installationError),

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -5,6 +5,7 @@ import { BitError } from '@teambit/bit-error';
 import { compact } from 'lodash';
 import { BEFORE_CHECKOUT } from '@teambit/legacy/dist/cli/loader/loader-messages';
 import RemoveAspect, { RemoveMain } from '@teambit/remove';
+import { UPDATE_DEPS_ON_IMPORT, isFeatureEnabled } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
 import { ApplyVersionResults, FailedComponents } from '@teambit/merging';
 import ImporterAspect, { ImporterMain } from '@teambit/importer';
 import { HEAD, LATEST } from '@teambit/legacy/dist/constants';
@@ -164,6 +165,7 @@ export class CheckoutMain {
         verbose: checkoutProps.verbose,
         resetConfig: checkoutProps.reset,
         skipUpdatingBitMap: checkoutProps.skipUpdatingBitmap || checkoutProps.revert,
+        shouldUpdateWorkspaceConfig: isFeatureEnabled(UPDATE_DEPS_ON_IMPORT),
         reasonForBitmapChange: 'checkout',
       };
       componentWriterResults = await this.componentWriter.writeMany(manyComponentsWriterOpts);
@@ -188,6 +190,7 @@ export class CheckoutMain {
       leftUnresolvedConflicts,
       newFromLane: newFromLane?.map((n) => n.toString()),
       newFromLaneAdded,
+      workspaceConfigUpdateResult: componentWriterResults?.workspaceConfigUpdateResult,
       installationError: componentWriterResults?.installationError,
       compilationError: componentWriterResults?.compilationError,
     };


### PR DESCRIPTION
See #8405 for this feature description. In that PR it was enabled for `bit import`. This PR introduces the feature for `bit checkout`. The feature flag of `update-deps-on-import` is still needed.