### PR TITLE
fix(update-dependencies), add flattened-dependencies when --simulation is used

### DIFF
--- a/e2e/harmony/update-dependencies.e2e.ts
+++ b/e2e/harmony/update-dependencies.e2e.ts
@@ -128,7 +128,7 @@ describe('update-dependencies command', function () {
         expect(compB.dependencies[0].id.version).to.equal('1.1.0');
       });
     });
-    describe('running from a new bare scope using --simulate and --tag flags', () => {
+    describe('running from a new bare scope using --simulation and --tag flags', () => {
       let updateDepsOutput: string;
       let updateRemote;
       before(() => {

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -686,6 +686,7 @@ there are matching among unmodified components thought. consider using --unmodif
 
   async _addFlattenedDependenciesToComponents(components: ConsumerComponent[], rebuildDepsGraph = false) {
     loader.start('importing missing dependencies...');
+    this.logger.profile('snap._addFlattenedDependenciesToComponents');
     const getLane = async () => {
       const lane = await this.scope.legacyScope.getCurrentLaneObject();
       if (!lane) return undefined;
@@ -714,6 +715,7 @@ there are matching among unmodified components thought. consider using --unmodif
     components.forEach((component) => {
       flattenedEdgesGetter.populateFlattenedAndEdgesForComp(component);
     });
+    this.logger.profile('snap._addFlattenedDependenciesToComponents');
   }
 
   async throwForDepsFromAnotherLane(components: ConsumerComponent[]) {

--- a/scopes/scope/update-dependencies/update-dependencies.cmd.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.cmd.ts
@@ -26,7 +26,7 @@ an example of the final data: '[{"componentId":"ci.remote2/comp-b","dependencies
   group = 'development';
   options = [
     ['', 'tag', 'tag once the build is completed (by default it snaps)'],
-    ['', 'simulation', 'simulation purpose. should never be pushed (otherwise, flattened-deps are invalid)'],
+    ['', 'simulation', 'simulation purpose. should never be pushed'],
     ['', 'push', 'export the updated objects to the original scopes once tagged/snapped'],
     ['', 'message <string>', 'message to be saved as part of the version log'],
     ['', 'username <string>', 'username to be saved as part of the version log'],

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -86,9 +86,13 @@ export class UpdateDependenciesMain {
     await this.updateFutureVersion();
     await this.updateAllDeps();
     this.addLogToComponents();
-    if (!updateDepsOptions.simulation) {
-      await this.snapping._addFlattenedDependenciesToComponents(this.legacyComponents);
-    }
+    // note - in the past it was skipping the flattened for performance issues. Now that flattened are calculated
+    // using the flattened-edges, it's ok to add them.
+    // the issue with not adding them is that in case of updating envs/aspects, the version-validator throws
+    // an error saying "the extension ${extensionId.toString()} is missing from the flattenedDependencies"
+    // if (!updateDepsOptions.simulation) {
+    await this.snapping._addFlattenedDependenciesToComponents(this.legacyComponents);
+    // }
     this.addBuildStatus();
     await this.addComponentsToScope();
     await this.updateComponents();


### PR DESCRIPTION
Otherwise, in case of updating envs/aspects, the version-validator throws an error saying "the extension ${extensionId.toString()} is missing from the flattenedDependencies".

We didn't add flattened-deps in the past because it was very slow, it used to import all flattened dependencies. This is not the case anymore. A recent change (a month ago) calculates the flattened using the "flattened-edges" saved in the Version object.
