### PR TITLE
fix(link): it should be possible to link a subset of components from the workspace

### DIFF
--- a/e2e/harmony/link.e2e.ts
+++ b/e2e/harmony/link.e2e.ts
@@ -21,6 +21,25 @@ describe('linking to a target', function () {
   });
 });
 
+describe('linking a subset of components to a target', function () {
+  this.timeout(0);
+  let helper: Helper;
+  let targetDir: string;
+  before(() => {
+    helper = new Helper();
+    helper.scopeHelper.setWorkspaceWithRemoteScope();
+    helper.fixtures.populateComponents(2);
+    targetDir = globalBitTempDir();
+    helper.command.link(`comp1 --target=${targetDir}`);
+  });
+  it('should link the scecified component to the target directory', () => {
+    expect(path.join(targetDir, `node_modules/@${helper.scopes.remote}/comp1`)).to.be.a.path();
+  });
+  it('should not link the not specified component to the target directory', () => {
+    expect(path.join(targetDir, `node_modules/@${helper.scopes.remote}/comp2`)).not.to.be.a.path();
+  });
+});
+
 describe('linking to a target including peers', function () {
   this.timeout(0);
   let helper: Helper;

--- a/scopes/component/testing/mock-components/mock-components.ts
+++ b/scopes/component/testing/mock-components/mock-components.ts
@@ -38,7 +38,7 @@ export async function mockComponents(
   });
   await workspace.bitMap.write();
   const install = harmony.get<InstallMain>(InstallAspect.id);
-  await install.link({ rewire: true });
+  await install.link([], { rewire: true });
 
   const compiler = harmony.get<CompilerMain>(CompilerAspect.id);
   await compiler.compileOnWorkspace();

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1565,7 +1565,7 @@ export class InstallMain {
       return;
     }
     if (needLink) {
-      await this.link();
+      await this.link([]);
     }
   }
 

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -403,7 +403,7 @@ export class InstallMain {
       linkNestedDepsInNM: !this.workspace.isLegacy && !hasRootComponents,
     };
     const { linkedRootDeps } = await this.logger.profileAsync('install.calculateLinks', () =>
-      this.calculateLinks(linkOpts)
+      this.calculateLinks([], linkOpts)
     );
     // eslint-disable-next-line prefer-const
     let { mergedRootPolicy, componentsAndManifests: current } = await this.logger.profileAsync(
@@ -1411,10 +1411,11 @@ export class InstallMain {
    * This information may then be passed to the package manager, which will create the links on its own.
    */
   async calculateLinks(
+    ids: ComponentID[],
     options: WorkspaceLinkOptions = {}
   ): Promise<{ linkResults: WorkspaceLinkResults; linkedRootDeps: Record<string, string> }> {
     await pMapSeries(this.preLinkSlot.values(), (fn) => fn(options)); // import objects if not disabled in options
-    const compDirMap = await this.getComponentsDirectory([]);
+    const compDirMap = await this.getComponentsDirectory(ids);
     const linker = this.dependencyResolver.getLinker({
       rootDir: this.workspace.path,
       linkingOptions: options,
@@ -1458,8 +1459,9 @@ export class InstallMain {
     return linkToNodeModulesWithCodemod(this.workspace, bitIds, options?.rewire ?? false);
   }
 
-  async link(options: WorkspaceLinkOptions = {}): Promise<WorkspaceLinkResults> {
-    const { linkResults, linkedRootDeps } = await this.calculateLinks(options);
+  async link(ids: string[], options: WorkspaceLinkOptions = {}): Promise<WorkspaceLinkResults> {
+    const componentIds = await Promise.all(ids.map((id) => this.workspace.resolveComponentId(id)));
+    const { linkResults, linkedRootDeps } = await this.calculateLinks(componentIds, options);
     await createLinks(options.linkToDir ?? this.workspace.path, linkedRootDeps, {
       avoidHardLink: true,
       skipIfSymlinkValid: true,

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1529,9 +1529,10 @@ export class InstallMain {
     // loading seeders during installation causes regressions where lane imports fail with errors like:
     // "Cannot find module '/private/tmp/a27cc147/node_modules/@teambit/node.envs.node-babel-mocha/dist/node-babel-mocha.bit-env.js'"
     // The env aspect files are not yet available during the initial installation phase.
+    const loadOpts = { loadSeedersAsAspects: false };
     const components = ids.length
-      ? await this.workspace.getMany(ids)
-      : await this.workspace.list(undefined, { loadSeedersAsAspects: false });
+      ? await this.workspace.getMany(ids, loadOpts)
+      : await this.workspace.list(undefined, loadOpts);
     return ComponentMap.as<string>(components, (component) => this.workspace.componentDir(component.id));
   }
 

--- a/scopes/workspace/install/link/link.cmd.ts
+++ b/scopes/workspace/install/link/link.cmd.ts
@@ -117,7 +117,7 @@ useful for development when components need to reference each other or when debu
       fetchObject: !opts.skipFetchingObjects,
       includePeers: opts.peers,
     };
-    const linkResults = await this.install.link(linkOpts);
+    const linkResults = await this.install.link(ids ?? [], linkOpts);
     return linkResults;
   }
 }


### PR DESCRIPTION
## Problem

When linking to a target directory, `bit link <component> --target=<dir>` ignores the selected component IDs and links every component in the workspace.

## Proposed Changes

- pass component IDs from the link command into the install/link flow
- resolve the requested IDs and calculate links only for their component directories
- preserve the existing link-all behavior for internal callers by passing an empty component list
- update link call sites to use the new method signature

## Test Coverage

Add an end-to-end regression test that links only `comp1` to a target directory and verifies that:

- `comp1` is linked
- an unselected `comp2` is not linked
