### PR TITLE
fix(tag), save app artifacts into the objects on Windows

### DIFF
--- a/scopes/component/component-compare/component-compare.ui.runtime.tsx
+++ b/scopes/component/component-compare/component-compare.ui.runtime.tsx
@@ -38,7 +38,7 @@ export class ComponentCompareUI {
     return (
       <ComponentCompare
         {...(props || {})}
-        tabs={tabs}
+        tabs={tabs} // @ts-ignore
         routes={routes}
         host={host}
         isFullScreen={props?.isFullScreen ?? true}

--- a/scopes/pipelines/builder/artifact/artifact-factory.ts
+++ b/scopes/pipelines/builder/artifact/artifact-factory.ts
@@ -3,6 +3,7 @@ import globby from 'globby';
 import { flatten } from 'lodash';
 import { ArtifactFiles } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
 import { Component, ComponentMap } from '@teambit/component';
+import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 import { ArtifactDefinition } from './artifact-definition';
 import { DefaultResolver } from '../storage';
 import { ArtifactList } from './artifact-list';
@@ -17,7 +18,8 @@ export type ArtifactMap = ComponentMap<ArtifactList<FsArtifact>>;
 export class ArtifactFactory {
   resolvePaths(root: string, def: ArtifactDefinition): string[] {
     const patternsFlattened = flatten(def.globPatterns);
-    const paths = globby.sync(patternsFlattened, { cwd: root });
+    const patternsFlattenedLinux = patternsFlattened.map(pathNormalizeToLinux);
+    const paths = globby.sync(patternsFlattenedLinux, { cwd: root });
     return paths;
   }
 


### PR DESCRIPTION
We use `globby` package to resolve paths from the artifacts definition.
The `app-bundle` artifact has `'artifacts/app-bundle'` pattern on linux/mac but `artifacts//app-bundle` on Windows.
Turns out that globby [doesn't support Windows paths](https://github.com/sindresorhus/globby/issues/179). This PR changes the paths to Linux before sending to globby.