### PR TITLE
feat(Schema): disable config - allow disabling schema task

### DIFF
--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -186,6 +186,10 @@ export class SchemaMain {
     };
   }
 
+  isSchemaTaskDisabled(component: Component) {
+    return component.state.aspects.get(SchemaAspect.id)?.data?.disabled;
+  }
+
   static runtime = MainRuntime;
   static dependencies = [
     EnvsAspect,

--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -180,7 +180,7 @@ export class SchemaMain {
     return this;
   }
 
-  async calcSchemaData(): Promise<{ disabled?: boolean }> {
+  async getSchemaData(): Promise<{ disabled?: boolean }> {
     return {
       disabled: this.config.disabled,
     };
@@ -230,10 +230,10 @@ export class SchemaMain {
     graphql.register(schemaSchema(schema));
     envs.registerService(new SchemaService());
     if (workspace) {
-      workspace.registerOnComponentLoad(async () => schema.calcSchemaData());
+      workspace.registerOnComponentLoad(async () => schema.getSchemaData());
     }
     if (scope) {
-      scope.registerOnCompAspectReCalc(async () => schema.calcSchemaData());
+      scope.registerOnCompAspectReCalc(async () => schema.getSchemaData());
     }
     // register all default schema classes
     Object.values(Schemas).forEach((Schema) => {

--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -14,6 +14,7 @@ import {
 } from '@teambit/semantics.entities.semantic-schema';
 import { BuilderMain, BuilderAspect } from '@teambit/builder';
 import { Workspace, WorkspaceAspect } from '@teambit/workspace';
+import ScopeAspect, { ScopeMain } from '@teambit/scope';
 import { Formatter } from '@teambit/formatter';
 import { Parser } from './parser';
 import { SchemaAspect } from './schema.aspect';
@@ -30,6 +31,10 @@ export type SchemaConfig = {
    * default parser
    */
   defaultParser: string;
+  /**
+   * disable extracting schema
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -107,6 +112,10 @@ export class SchemaMain {
     contextPath?: string,
     skipInternals?: boolean
   ): Promise<APISchema> {
+    if (this.config.disabled) {
+      return APISchema.empty(component.id as any);
+    }
+
     if (alwaysRunExtractor || this.workspace) {
       const env = this.envs.getEnv(component).env;
       // types need to be fixed
@@ -171,6 +180,12 @@ export class SchemaMain {
     return this;
   }
 
+  async calcSchemaData(): Promise<{ disabled?: boolean }> {
+    return {
+      disabled: this.config.disabled,
+    };
+  }
+
   static runtime = MainRuntime;
   static dependencies = [
     EnvsAspect,
@@ -180,22 +195,25 @@ export class SchemaMain {
     LoggerAspect,
     BuilderAspect,
     WorkspaceAspect,
+    ScopeAspect,
   ];
   static slots = [Slot.withType<Parser>()];
 
   static defaultConfig = {
     defaultParser: 'teambit.typescript/typescript',
+    disabled: false,
   };
 
   static async provider(
-    [envs, cli, component, graphql, loggerMain, builder, workspace]: [
+    [envs, cli, component, graphql, loggerMain, builder, workspace, scope]: [
       EnvsMain,
       CLIMain,
       ComponentMain,
       GraphqlMain,
       LoggerMain,
       BuilderMain,
-      Workspace
+      Workspace,
+      ScopeMain
     ],
     config: SchemaConfig,
     [parserSlot]: [ParserSlot]
@@ -207,7 +225,12 @@ export class SchemaMain {
     cli.register(new SchemaCommand(schema, component, logger));
     graphql.register(schemaSchema(schema));
     envs.registerService(new SchemaService());
-
+    if (workspace) {
+      workspace.registerOnComponentLoad(async () => schema.calcSchemaData());
+    }
+    if (scope) {
+      scope.registerOnCompAspectReCalc(async () => schema.calcSchemaData());
+    }
     // register all default schema classes
     Object.values(Schemas).forEach((Schema) => {
       schema.registerSchemaClass(Schema);

--- a/scopes/semantics/schema/schema.main.runtime.ts
+++ b/scopes/semantics/schema/schema.main.runtime.ts
@@ -180,14 +180,18 @@ export class SchemaMain {
     return this;
   }
 
-  async getSchemaData(): Promise<{ disabled?: boolean }> {
+  async calcSchemaData(): Promise<{ disabled?: boolean }> {
     return {
       disabled: this.config.disabled,
     };
   }
 
+  getSchemaData(component: Component) {
+    return component.state.aspects.get(SchemaAspect.id)?.data;
+  }
+
   isSchemaTaskDisabled(component: Component) {
-    return component.state.aspects.get(SchemaAspect.id)?.data?.disabled;
+    return this.getSchemaData(component)?.disabled;
   }
 
   static runtime = MainRuntime;
@@ -230,10 +234,10 @@ export class SchemaMain {
     graphql.register(schemaSchema(schema));
     envs.registerService(new SchemaService());
     if (workspace) {
-      workspace.registerOnComponentLoad(async () => schema.getSchemaData());
+      workspace.registerOnComponentLoad(async () => schema.calcSchemaData());
     }
     if (scope) {
-      scope.registerOnCompAspectReCalc(async () => schema.getSchemaData());
+      scope.registerOnCompAspectReCalc(async () => schema.calcSchemaData());
     }
     // register all default schema classes
     Object.values(Schemas).forEach((Schema) => {

--- a/scopes/semantics/schema/schema.task.ts
+++ b/scopes/semantics/schema/schema.task.ts
@@ -33,8 +33,8 @@ export class SchemaTask implements BuildTask {
     const rootDir = context.capsuleNetwork.capsulesRootDir;
     await pMapSeries(capsules, async (capsule) => {
       const component = capsule.component;
-      const isSchemaTaskDisabled = component.state.aspects.get(this.aspectId)?.data?.disabled;
-      if (isSchemaTaskDisabled) return;
+      const isTaskDisabled = this.schema.isSchemaTaskDisabled(component);
+      if (isTaskDisabled) return;
       try {
         const schema = await this.schema.getSchema(component, false, true, rootDir, capsule.path);
         const schemaObj = schema.toObject();

--- a/scopes/semantics/schema/schema.task.ts
+++ b/scopes/semantics/schema/schema.task.ts
@@ -33,6 +33,8 @@ export class SchemaTask implements BuildTask {
     const rootDir = context.capsuleNetwork.capsulesRootDir;
     await pMapSeries(capsules, async (capsule) => {
       const component = capsule.component;
+      const isSchemaTaskDisabled = component.state.aspects.get(this.aspectId)?.data?.disabled;
+      if (isSchemaTaskDisabled) return;
       try {
         const schema = await this.schema.getSchema(component, false, true, rootDir, capsule.path);
         const schemaObj = schema.toObject();


### PR DESCRIPTION
This PR adds a new config for `teambit.semantics/schema` aspect called `disabled` - which disables the extraction of schema during the build task and also disables extracting the schema ad hoc when queried from the workspace. 