### PR TITLE
fix(forking): forward ast options flag when refactoring variables and classes

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -271,7 +271,7 @@ the reason is that the refactor changes the components using ${sourceId.toString
     );
     if (!options?.preserve) {
       if (shouldRefactorVariablesAndClasses) {
-        await this.refactoring.refactorVariableAndClasses(component, sourceId, targetCompId);
+        await this.refactoring.refactorVariableAndClasses(component, sourceId, targetCompId, options);
       }
       this.refactoring.refactorFilenames(component, sourceId, targetCompId);
     }


### PR DESCRIPTION
This PR fixes the issue when forking a remote component with the `ast` flag. Previously, only the exports and imports would be refactored using the AST Transformers, leaving the variables and classes to be refactored using the default regex even with the flag. This PR fixes it by forwarding the options to the function `refactorVariableAndClasses`