### PR TITLE
fix(UI/Compositions): navigating when on a specific component version

### DIFF
--- a/scopes/compositions/compositions/compositions.tsx
+++ b/scopes/compositions/compositions/compositions.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useState, useMemo, useRef, ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import head from 'lodash.head';
 import queryString from 'query-string';
 import { ThemeContext } from '@teambit/documenter.theme.theme-context';
@@ -38,30 +38,21 @@ export type CompositionsProp = { menuBarWidgets?: CompositionsMenuSlot; emptySta
 
 export function Compositions({ menuBarWidgets, emptyState }: CompositionsProp) {
   const component = useContext(ComponentContext);
-  // const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   const params = useParams();
+  const versionFromQueryParams = searchParams.get('version');
   const navigate = useNavigate();
   const location = useLocation();
   const currentCompositionName = params['*'];
-  // console.log(routes);
   const currentComposition =
     component.compositions.find((composition) => composition.identifier.toLowerCase() === currentCompositionName) ||
     head(component.compositions);
 
-  // const [selected, selectComposition] = useState(head(component.compositions));
   const selectedRef = useRef(currentComposition);
   selectedRef.current = currentComposition;
 
   const properties = useDocs(component.id);
 
-  // reset selected composition when component changes.
-  // this does trigger renderer, but perf seems to be ok
-  // useEffect(() => {
-  //   const prevId = selectedRef.current?.identifier;
-  //   const next = component.compositions.find((c) => c.identifier === prevId) || component.compositions[0];
-
-  //   navigate(next.displayName.toLowerCase().replaceAll(' ', '-'));
-  // }, [component]);
   const isMobile = useIsMobile();
   const showSidebar = !isMobile && component.compositions.length > 0;
   const [isSidebarOpen, setSidebarOpenness] = useState(showSidebar);
@@ -138,8 +129,12 @@ export function Compositions({ menuBarWidgets, emptyState }: CompositionsProp) {
                       pathSegments[pathSegments.length - 1] = composition.identifier.toLowerCase();
                     }
 
+                    const urlParams = new URLSearchParams();
+                    if (versionFromQueryParams) {
+                      urlParams.set('version', versionFromQueryParams);
+                    }
                     const newPath = pathSegments.join('/');
-                    navigate(`/${newPath}`);
+                    navigate(`/${newPath}?${urlParams.toString()}`);
                   }}
                   url={compositionUrl}
                   compositions={component.compositions}

--- a/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.tsx
+++ b/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.tsx
@@ -1,5 +1,6 @@
 import { Icon } from '@teambit/evangelist.elements.icon';
 import classNames from 'classnames';
+import { useSearchParams } from 'react-router-dom';
 import React, { useCallback } from 'react';
 import { MenuWidgetIcon } from '@teambit/ui-foundation.ui.menu-widget-icon';
 import { useNavigate, useLocation } from '@teambit/base-react.navigation.link';
@@ -54,15 +55,21 @@ export function CompositionsPanel({
   );
 
   const location = useLocation();
+  const [searchParams] = useSearchParams();
+  const versionFromQueryParams = searchParams.get('version');
   const navigate = useNavigate();
 
   const onCompositionCodeClicked = useCallback(
     (composition: Composition) => (e: React.MouseEvent<HTMLDivElement>) => {
       e.preventDefault();
+      const queryParams = new URLSearchParams();
+      if (versionFromQueryParams) {
+        queryParams.set('version', versionFromQueryParams);
+      }
       const basePath = location?.pathname.split('/~compositions')[0];
-      navigate(`${basePath}/~code/${composition.filepath}#search=${composition.identifier}`);
+      navigate(`${basePath}/~code/${composition.filepath}?${queryParams.toString()}#search=${composition.identifier}`);
     },
-    [location?.pathname]
+    [location?.pathname, versionFromQueryParams]
   );
 
   return (


### PR DESCRIPTION
This PR fixes the issue with navigating between component compositions and the code for it when on a specific version. With this fix, it takes in consideration the version from the URLParams when constructing the url to navigate to. 

https://github.com/teambit/bit/assets/8999604/fc4a7104-e23b-40c2-a045-6566696951c9

