### PR TITLE
feat(merge-from-scope), support merging main into lane

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -8,7 +8,7 @@ import {
   getMergeStrategyInteractive,
   MergeOptions,
 } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
-import SnappingAspect, { SnapResults, SnappingMain, TagResults } from '@teambit/snapping';
+import SnappingAspect, { SnappingMain, TagResults } from '@teambit/snapping';
 import hasWildcard from '@teambit/legacy/dist/utils/string/has-wildcard';
 import mapSeries from 'p-map-series';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
@@ -47,6 +47,7 @@ import {
 } from '@teambit/config-merger';
 import { SnapsDistance } from '@teambit/legacy/dist/scope/component-ops/snaps-distance';
 import { InstallMain, InstallAspect } from '@teambit/install';
+import ScopeAspect, { ScopeMain } from '@teambit/scope';
 import { MergeCmd } from './merge-cmd';
 import { MergingAspect } from './merging.aspect';
 import { MergeStatusProvider, MergeStatusProviderOptions } from './merge-status-provider';
@@ -80,6 +81,13 @@ export type FailedComponents = { id: ComponentID; unchangedMessage: string; unch
 // fileName is PathLinux. TS doesn't let anything else in the keys other than string and number
 export type FilesStatus = { [fileName: string]: keyof typeof FileStatus };
 
+export type MergeSnapResults = {
+  snappedComponents: ConsumerComponent[];
+  autoSnappedResults: AutoTagResult[];
+  removedComponents?: ComponentIdList;
+  exportedIds?: ComponentID[];
+} | null;
+
 export type ApplyVersionResult = { id: ComponentID; filesStatus: FilesStatus };
 
 export type ApplyVersionResults = {
@@ -90,11 +98,7 @@ export type ApplyVersionResults = {
   addedComponents?: ComponentID[]; // relevant when restoreMissingComponents is true (e.g. bit lane merge-abort)
   resolvedComponents?: ConsumerComponent[]; // relevant for bit merge --resolve
   abortedComponents?: ApplyVersionResult[]; // relevant for bit merge --abort
-  mergeSnapResults?: {
-    snappedComponents: ConsumerComponent[];
-    autoSnappedResults: AutoTagResult[];
-    removedComponents?: ComponentIdList;
-  } | null;
+  mergeSnapResults?: MergeSnapResults;
   mergeSnapError?: Error;
   leftUnresolvedConflicts?: boolean;
   verbose?: boolean;
@@ -108,6 +112,7 @@ export type ApplyVersionResults = {
 export class MergingMain {
   constructor(
     private workspace: Workspace,
+    private scope: ScopeMain,
     private install: InstallMain,
     private snapping: SnappingMain,
     private checkout: CheckoutMain,
@@ -209,6 +214,7 @@ export class MergingMain {
     snapMessage,
     build,
     skipDependencyInstallation,
+    shouldExport,
   }: {
     mergeStrategy: MergeStrategy;
     allComponentsStatus: ComponentMergeStatus[];
@@ -219,8 +225,10 @@ export class MergingMain {
     snapMessage: string;
     build: boolean;
     skipDependencyInstallation?: boolean;
+    shouldExport?: boolean; // relevant only when executed from scope
   }): Promise<ApplyVersionResults> {
-    const consumer = this.workspace.consumer;
+    const consumer = this.workspace?.consumer;
+    const legacyScope = this.scope.legacyScope;
     const componentWithConflict = allComponentsStatus.find(
       (component) => component.mergeResults && component.mergeResults.hasConflicts
     );
@@ -251,8 +259,9 @@ export class MergingMain {
 
     const allConfigMerge = compact(succeededComponents.map((c) => c.configMergeResult));
 
-    const { workspaceDepsUpdates, workspaceDepsConflicts } =
-      await this.configMerger.updateWorkspaceJsoncWithDepsIfNeeded(allConfigMerge);
+    const { workspaceDepsUpdates, workspaceDepsConflicts } = this.workspace
+      ? await this.configMerger.updateWorkspaceJsoncWithDepsIfNeeded(allConfigMerge)
+      : { workspaceDepsUpdates: undefined, workspaceDepsConflicts: undefined };
 
     let workspaceConfigConflictWriteError: Error | undefined;
     if (workspaceDepsConflicts) {
@@ -260,17 +269,17 @@ export class MergingMain {
         workspaceDepsConflicts
       );
     }
-    await this.configMerger.generateConfigMergeConflictFileForAll(allConfigMerge);
+    if (this.workspace) await this.configMerger.generateConfigMergeConflictFileForAll(allConfigMerge);
 
-    if (currentLane) consumer.scope.objects.add(currentLane);
+    if (currentLane) legacyScope.objects.add(currentLane);
 
-    await consumer.scope.objects.persist(); // persist anyway, if currentLane is null it should save all main heads
+    await legacyScope.objects.persist(); // persist anyway, if currentLane is null it should save all main heads
 
-    await consumer.scope.objects.unmergedComponents.write();
+    await legacyScope.objects.unmergedComponents.write();
 
-    await consumer.writeBitMap(`merge ${otherLaneId.toString()}`);
+    if (this.workspace) await consumer.writeBitMap(`merge ${otherLaneId.toString()}`);
 
-    if (componentIdsToRemove.length) {
+    if (componentIdsToRemove.length && this.workspace) {
       const compBitIdsToRemove = ComponentIdList.fromArray(componentIdsToRemove);
       await deleteComponentsFiles(consumer, compBitIdsToRemove);
       await consumer.cleanFromBitMap(compBitIdsToRemove);
@@ -291,7 +300,7 @@ export class MergingMain {
       }
     }
 
-    const getSnapOrTagResults = async () => {
+    const getSnapOrTagResults = async (): Promise<MergeSnapResults> => {
       // if one of the component has conflict, don't snap-merge. otherwise, some of the components would be snap-merged
       // and some not. besides the fact that it could by mistake tag dependent, it's a confusing state. better not snap.
       if (noSnap || leftUnresolvedConflicts || componentsHasConfigMergeConflicts) {
@@ -304,16 +313,16 @@ export class MergingMain {
         const { taggedComponents, autoTaggedResults, removedComponents } = results;
         return { snappedComponents: taggedComponents, autoSnappedResults: autoTaggedResults, removedComponents };
       }
-      return this.snapResolvedComponents(consumer, snapMessage, build);
+      return this.snapResolvedComponents(snapMessage, build, currentLane?.toLaneId(), shouldExport);
     };
-    let mergeSnapResults: ApplyVersionResults['mergeSnapResults'] = null;
+    let mergeSnapResults: MergeSnapResults = null;
     let mergeSnapError: Error | undefined;
-    const bitMapSnapshot = this.workspace.bitMap.takeSnapshot();
+    const bitMapSnapshot = this.workspace ? this.workspace.bitMap.takeSnapshot() : null;
     try {
       mergeSnapResults = await getSnapOrTagResults();
     } catch (err: any) {
       mergeSnapError = err;
-      this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
+      if (bitMapSnapshot) this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
     }
 
     return {
@@ -344,10 +353,11 @@ export class MergingMain {
     otherLane?: Lane | null // the lane we want to merged to our lane. (null if it's "main").
   ): Promise<ComponentMergeStatus[]> {
     const mergeStatusProvider = new MergeStatusProvider(
-      this.workspace,
+      this.scope,
       this.logger,
       this.importer,
       options,
+      this.workspace,
       currentLane || undefined,
       otherLane || undefined
     );
@@ -363,7 +373,7 @@ export class MergingMain {
     const componentsResults = await mapSeries(
       succeededComponents,
       async ({ currentComponent, id, mergeResults, resolvedUnrelated, configMergeResult }) => {
-        const modelComponent = await this.workspace.consumer.scope.getModelComponent(id);
+        const modelComponent = await this.scope.legacyScope.getModelComponent(id);
         const updatedLaneId = otherLaneId.isDefault() ? LaneId.from(otherLaneId.name, id.scope as string) : otherLaneId;
         return this.applyVersion({
           currentComponent,
@@ -379,16 +389,17 @@ export class MergingMain {
       }
     );
 
-    const compsToWrite = compact(componentsResults.map((c) => c.legacyCompToWrite));
-
-    const manyComponentsWriterOpts = {
-      consumer: this.workspace.consumer,
-      components: compsToWrite,
-      skipDependencyInstallation: true,
-      writeConfig: false, // @todo: should write if config exists before, needs to figure out how to do it.
-      reasonForBitmapChange: 'merge',
-    };
-    await this.componentWriter.writeMany(manyComponentsWriterOpts);
+    if (this.workspace) {
+      const compsToWrite = compact(componentsResults.map((c) => c.legacyCompToWrite));
+      const manyComponentsWriterOpts = {
+        consumer: this.workspace.consumer,
+        components: compsToWrite,
+        skipDependencyInstallation: true,
+        writeConfig: false, // @todo: should write if config exists before, needs to figure out how to do it.
+        reasonForBitmapChange: 'merge',
+      };
+      await this.componentWriter.writeMany(manyComponentsWriterOpts);
+    }
 
     return componentsResults;
   }
@@ -414,7 +425,7 @@ export class MergingMain {
     resolvedUnrelated?: ResolveUnrelatedData;
     configMergeResult?: ConfigMergeResult;
   }): Promise<ApplyVersionWithComps> {
-    const consumer = this.workspace.consumer;
+    const legacyScope = this.scope.legacyScope;
     let filesStatus = {};
     const unmergedComponent: UnmergedComponent = {
       id: { name: id.fullName, scope: id.scope },
@@ -423,7 +434,7 @@ export class MergingMain {
     };
     id = currentComponent ? currentComponent.id : id;
 
-    const modelComponent = await consumer.scope.getModelComponent(id);
+    const modelComponent = await legacyScope.getModelComponent(id);
 
     const addToCurrentLane = (head: Ref) => {
       if (!currentLane) throw new Error('currentLane must be defined when adding to the lane');
@@ -446,7 +457,7 @@ export class MergingMain {
         headOnCurrentLane: resolvedUnrelated.headOnCurrentLane,
         unrelatedLaneId: resolvedUnrelated.unrelatedLaneId,
       };
-      consumer.scope.objects.unmergedComponents.addEntry(unmergedComponent);
+      legacyScope.objects.unmergedComponents.addEntry(unmergedComponent);
       return { applyVersionResult: { id, filesStatus }, component: currentComponent, legacyCompToWrite };
     };
 
@@ -458,7 +469,7 @@ export class MergingMain {
     };
     if (mergeResults && mergeResults.hasConflicts && mergeStrategy === MergeOptions.ours) {
       markAllFilesAsUnchanged();
-      consumer.scope.objects.unmergedComponents.addEntry(unmergedComponent);
+      legacyScope.objects.unmergedComponents.addEntry(unmergedComponent);
       return { applyVersionResult: { id, filesStatus }, component: currentComponent || undefined };
     }
     if (resolvedUnrelated?.strategy === 'ours') {
@@ -467,7 +478,9 @@ export class MergingMain {
     }
     const remoteId = id.changeVersion(remoteHead.toString());
     const idToLoad = !mergeResults || mergeStrategy === MergeOptions.theirs ? remoteId : id;
-    const legacyComponent = await consumer.loadComponentFromModelImportIfNeeded(idToLoad);
+    const legacyComponent = this.workspace
+      ? await this.workspace.consumer.loadComponentFromModelImportIfNeeded(idToLoad)
+      : await legacyScope.getConsumerComponent(idToLoad); // when loading from the scope, we import all needed components first, so it should be fine. otherwise, change the code to import it here
     if (mergeResults && mergeStrategy === MergeOptions.theirs) {
       // in this case, we don't want to update .bitmap with the version of the remote. we want to keep the same version
       legacyComponent.version = id.version;
@@ -482,7 +495,7 @@ export class MergingMain {
       filesStatus = { ...filesStatus, ...modifiedStatus };
     }
 
-    await removeFilesIfNeeded(filesStatus, consumer, currentComponent || undefined);
+    if (this.workspace) await removeFilesIfNeeded(filesStatus, this.workspace.consumer, currentComponent || undefined);
 
     if (configMergeResult) {
       const successfullyMergedConfig = configMergeResult.getSuccessfullyMergedConfig();
@@ -499,7 +512,7 @@ export class MergingMain {
       if (mergeResults.hasConflicts && mergeStrategy === MergeOptions.manual) {
         unmergedComponent.unmergedPaths = mergeResults.modifiedFiles.filter((f) => f.conflict).map((f) => f.filePath);
       }
-      consumer.scope.objects.unmergedComponents.addEntry(unmergedComponent);
+      legacyScope.objects.unmergedComponents.addEntry(unmergedComponent);
     } else if (currentLane) {
       if (resolvedUnrelated) {
         // must be "theirs"
@@ -511,7 +524,7 @@ export class MergingMain {
       modelComponent.setHead(remoteHead);
       // mark it as local, otherwise, when importing this component from a remote, it'll override it.
       modelComponent.markVersionAsLocal(remoteHead.toString());
-      consumer.scope.objects.add(modelComponent);
+      legacyScope.objects.add(modelComponent);
     }
 
     return {
@@ -564,14 +577,27 @@ export class MergingMain {
   }
 
   private async snapResolvedComponents(
-    consumer: Consumer,
     snapMessage: string,
-    build: boolean
-  ): Promise<SnapResults | null> {
-    const unmergedComponents = consumer.scope.objects.unmergedComponents.getComponents();
+    build: boolean,
+    laneId?: LaneId,
+    shouldExport?: boolean
+  ): Promise<MergeSnapResults> {
+    const unmergedComponents = this.scope.legacyScope.objects.unmergedComponents.getComponents();
     this.logger.debug(`merge-snaps, snapResolvedComponents, total ${unmergedComponents.length.toString()} components`);
     if (!unmergedComponents.length) return null;
     const ids = ComponentIdList.fromArray(unmergedComponents.map((r) => ComponentID.fromObject(r.id)));
+    if (!this.workspace) {
+      const results = await this.snapping.snapFromScope(
+        ids.map((id) => ({ componentId: id.toString() })),
+        {
+          message: snapMessage,
+          build,
+          push: shouldExport,
+          lane: laneId?.toString(),
+        }
+      );
+      return { ...results, autoSnappedResults: [] };
+    }
     return this.snapping.snap({
       legacyBitIds: ids,
       build,
@@ -628,6 +654,7 @@ export class MergingMain {
   static dependencies = [
     CLIAspect,
     WorkspaceAspect,
+    ScopeAspect,
     SnappingAspect,
     CheckoutAspect,
     InstallAspect,
@@ -643,6 +670,7 @@ export class MergingMain {
   static async provider([
     cli,
     workspace,
+    scope,
     snapping,
     checkout,
     install,
@@ -656,6 +684,7 @@ export class MergingMain {
   ]: [
     CLIMain,
     Workspace,
+    ScopeMain,
     SnappingMain,
     CheckoutMain,
     InstallMain,
@@ -670,6 +699,7 @@ export class MergingMain {
     const logger = loggerMain.createLogger(MergingAspect.id);
     const merging = new MergingMain(
       workspace,
+      scope,
       install,
       snapping,
       checkout,

--- a/scopes/component/snapping/snap-from-scope.cmd.ts
+++ b/scopes/component/snapping/snap-from-scope.cmd.ts
@@ -127,7 +127,11 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       rebuildDepsGraph,
     });
 
-    return results;
+    return {
+      ...results,
+      exportedIds: results.exportedIds?.map((id) => id.toString()),
+      snappedIds: results.snappedIds.map((id) => id.toString()),
+    };
   }
   private parseData(data: string): SnapDataPerCompRaw[] {
     let dataParsed: unknown;

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -95,8 +95,9 @@ export type SnapResults = BasicTagResults & {
 };
 
 export type SnapFromScopeResults = {
-  snappedIds: string[];
-  exportedIds?: string[];
+  snappedIds: ComponentID[];
+  exportedIds?: ComponentID[];
+  snappedComponents: ConsumerComponent[];
 };
 
 export type TagResults = BasicTagResults & {
@@ -477,7 +478,7 @@ if you're willing to lose the history from the head to the specified version, us
     });
 
     const { taggedComponents } = results;
-    let exportedIds: string[] | undefined;
+    let exportedIds: ComponentIdList | undefined;
     if (params.push) {
       const updatedLane = lane ? await this.scope.legacyScope.loadLane(lane.toLaneId()) : undefined;
       const { exported } = await this.exporter.exportMany({
@@ -491,11 +492,12 @@ if you're willing to lose the history from the head to the specified version, us
         // (see the e2e - "snap on a lane when the component is new to the lane and the scope")
         exportHeadsOnly: true,
       });
-      exportedIds = exported.map((e) => e.toString());
+      exportedIds = exported;
     }
 
     return {
-      snappedIds: taggedComponents.map((comp) => comp.id.toString()),
+      snappedComponents: taggedComponents,
+      snappedIds: taggedComponents.map((comp) => comp.id),
       exportedIds,
     };
   }
@@ -884,17 +886,18 @@ another option, in case this dependency is not in main yet is to remove all refe
 
   async _addCompToObjects({
     source,
-    consumer,
     lane,
     shouldValidateVersion = false,
   }: {
     source: ConsumerComponent;
-    consumer: Consumer;
     lane: Lane | null;
     shouldValidateVersion?: boolean;
-  }): Promise<ModelComponent> {
+  }): Promise<{
+    component: ModelComponent;
+    version: Version;
+  }> {
     const { component, version } = await this._addCompFromScopeToObjects(source, lane);
-    const unmergedComponent = consumer.scope.objects.unmergedComponents.getEntry(component.toComponentId());
+    const unmergedComponent = this.scope.legacyScope.objects.unmergedComponents.getEntry(component.toComponentId());
     if (unmergedComponent) {
       if (unmergedComponent.unrelated) {
         this.logger.debug(
@@ -923,10 +926,10 @@ another option, in case this dependency is not in main yet is to remove all refe
         );
         version.log.message = version.log.message || UnmergedComponents.buildSnapMessage(unmergedComponent);
       }
-      consumer.scope.objects.unmergedComponents.removeComponent(component.toComponentId());
+      this.scope.legacyScope.objects.unmergedComponents.removeComponent(component.toComponentId());
     }
     if (shouldValidateVersion) version.validate();
-    return component;
+    return { component, version };
   }
 
   async _addCompFromScopeToObjects(

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -430,25 +430,17 @@ async function addComponentsToScope(
   consumer?: Consumer,
   tagDataPerComp?: TagDataPerComp[]
 ) {
-  if (consumer) {
-    await mapSeries(components, async (component) => {
-      await snapping._addCompToObjects({
-        source: component,
-        consumer,
-        lane,
-        shouldValidateVersion,
-      });
+  await mapSeries(components, async (component) => {
+    const results = await snapping._addCompToObjects({
+      source: component,
+      lane,
+      shouldValidateVersion,
     });
-  } else {
-    await mapSeries(components, async (component) => {
-      const results = await snapping._addCompFromScopeToObjects(component, lane);
-
-      // in case "tagData.isNew", the version object has "parents" that should not be there.
-      // they got created as a workaround to generate a new component from the scope without having a workspace.
+    if (!consumer) {
       const tagData = tagDataPerComp?.find((t) => t.componentId.isEqualWithoutVersion(component.id));
       if (tagData?.isNew) results.version.removeAllParents();
-    });
-  }
+    }
+  });
 }
 
 /**

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -499,9 +499,6 @@ please create a new lane instead, which will include all components of this lane
    */
   async fetchLaneWithItsComponents(laneId: LaneId): Promise<Lane> {
     this.logger.debug(`fetching lane ${laneId.toString()}`);
-    if (!this.workspace) {
-      throw new BitError('unable to fetch lanes outside of Bit workspace');
-    }
     const lane = await this.importer.importLaneObject(laneId);
     if (!lane) throw new Error(`unable to import lane ${laneId.toString()} from the remote`);
 

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -173,7 +173,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     if (resolveUnrelated && typeof resolveUnrelated === 'boolean') {
       resolveUnrelated = 'ours';
     }
-    const { mergeResults, deleteResults, configMergeResults } = await this.mergeLanes.mergeLane(name, {
+    const { mergeResults, deleteResults, configMergeResults } = await this.mergeLanes.mergeLaneByCLI(name, {
       build,
       // @ts-ignore
       mergeStrategy,

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -718,8 +718,8 @@ export default class CommandHelper {
   mergeAbortLane(options = '') {
     return this.runCmd(`bit lane merge-abort ${options} --silent`);
   }
-  mergeLaneFromScope(cwd: string, laneName: string, options = '') {
-    return this.runCmd(`bit _merge-lane ${laneName} ${options}`, cwd);
+  mergeLaneFromScope(cwd: string, fromLane: string, options = '') {
+    return this.runCmd(`bit _merge-lane ${fromLane} ${options}`, cwd);
   }
   tagFromScope(cwd: string, data: Record<string, any>, options = '') {
     return this.runCmd(`bit _tag '${JSON.stringify(data)}' ${options}`, cwd);


### PR DESCRIPTION
Until now, merge-from-scope was able to do a simple merge, e.g. lane to main when the lane is up do date, so all it did was changing the head and its parents. 
Merging main into a lane is more complex because normally the main and the lane are diverged. The classic use-case is creating a CR, planning to merge to main but then main progressed with more snaps so the lane became out of date. In this use case, main and lane are diverged, so it needs a "snap-merge" to point to both main and lane, and it needs files-merge to check whether there are conflicts, in which case we stop the merge and notify the user.