### PR TITLE
refactor, remove resolveMultipleComponentIds when not needed

### DIFF
--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -382,10 +382,7 @@ export class WorkspaceCompiler {
     return grouped as { envs: Component[]; other: Component[] };
   }
 
-  private async getIdsToCompile(
-    componentsIds: Array<string | ComponentID | ComponentID>,
-    changed = false
-  ): Promise<ComponentID[]> {
+  private async getIdsToCompile(componentsIds: Array<string | ComponentID>, changed = false): Promise<ComponentID[]> {
     if (componentsIds.length) {
       const componentIds = await this.workspace.resolveMultipleComponentIds(componentsIds);
       return this.workspace.filterIds(componentIds);

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -300,7 +300,7 @@ export class CheckoutMain {
     const idsOnWorkspace = await getIds();
 
     const currentLane = await this.workspace.consumer.getCurrentLaneObject();
-    const currentLaneIds = currentLane?.toBitIds();
+    const currentLaneIds = currentLane?.toComponentIds();
     const ids = currentLaneIds ? idsOnWorkspace.filter((id) => currentLaneIds.hasWithoutVersion(id)) : idsOnWorkspace;
     checkoutProps.ids = ids.map((id) => (checkoutProps.head || checkoutProps.latest ? id.changeVersion(LATEST) : id));
   }
@@ -311,9 +311,8 @@ export class CheckoutMain {
     if (!lane) {
       return [];
     }
-    const laneBitIds = lane.toBitIds();
-    const newIds = laneBitIds.filter((bitId) => !ids.find((id) => id.isEqualWithoutVersion(bitId)));
-    const newComponentIds = await this.workspace.resolveMultipleComponentIds(newIds);
+    const laneBitIds = lane.toComponentIds();
+    const newComponentIds = laneBitIds.filter((bitId) => !ids.find((id) => id.isEqualWithoutVersion(bitId)));
     const nonRemovedNewIds: ComponentID[] = [];
     await Promise.all(
       newComponentIds.map(async (id) => {

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -295,11 +295,12 @@ ${mainComps.map((c) => c.id.toString()).join('\n')}`);
   private async getRemovedStagedFromLane(): Promise<ComponentID[]> {
     const currentLane = await this.workspace.getCurrentLaneObject();
     if (!currentLane) return [];
-    const laneIds = currentLane.toBitIds();
+    const laneIds = currentLane.toComponentIds();
     const workspaceIds = await this.workspace.listIds();
-    const laneIdsNotInWorkspace = laneIds.filter((id) => !workspaceIds.find((wId) => wId.isEqualWithoutVersion(id)));
-    if (!laneIdsNotInWorkspace.length) return [];
-    const laneCompIdsNotInWorkspace = await this.workspace.scope.resolveMultipleComponentIds(laneIdsNotInWorkspace);
+    const laneCompIdsNotInWorkspace = laneIds.filter(
+      (id) => !workspaceIds.find((wId) => wId.isEqualWithoutVersion(id))
+    );
+    if (!laneCompIdsNotInWorkspace.length) return [];
     const comps = await this.workspace.scope.getMany(laneCompIdsNotInWorkspace);
     const removed = comps.filter((c) => this.isRemoved(c));
     const staged = await Promise.all(

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -198,10 +198,10 @@ export class SnappingMain {
     );
     if (!bitIds.length) return null;
 
-    const legacyBitIds = ComponentIdList.fromArray(bitIds);
+    const compIds = ComponentIdList.fromArray(bitIds);
 
-    this.logger.debug(`tagging the following components: ${legacyBitIds.toString()}`);
-    const components = await this.loadComponentsForTagOrSnap(legacyBitIds, !soft);
+    this.logger.debug(`tagging the following components: ${compIds.toString()}`);
+    const components = await this.loadComponentsForTagOrSnap(compIds, !soft);
     const consumerComponents = components.map((c) => c.state._consumer) as ConsumerComponent[];
     await this.throwForVariousIssues(components, ignoreIssues);
 
@@ -212,7 +212,7 @@ export class SnappingMain {
         snapping: this,
         builder: this.builder,
         consumerComponents,
-        ids: legacyBitIds,
+        ids: compIds,
         message,
         editor,
         exactVersion: validExactVersion,
@@ -992,14 +992,13 @@ another option, in case this dependency is not in main yet is to remove all refe
   }
 
   private async loadComponentsForTagOrSnap(ids: ComponentIdList, shouldClearCacheFirst = true): Promise<Component[]> {
-    const compIds = await this.workspace.resolveMultipleComponentIds(ids);
     if (shouldClearCacheFirst) {
       await this.workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
       // don't clear only the cache of these ids. we need also the auto-tag. so it's safer to just clear all.
       this.workspace.clearAllComponentsCache();
     }
 
-    return this.workspace.getMany(compIds.map((id) => id.changeVersion(undefined)));
+    return this.workspace.getMany(ids.map((id) => id.changeVersion(undefined)));
   }
 
   private async throwForComponentIssues(components: Component[], ignoreIssues?: string) {

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -560,8 +560,6 @@ export class AspectLoaderMain {
     const globalScopeHarmony = await loadBit(globalScope.path);
     const scope = globalScopeHarmony.get<ScopeMain>(ScopeAspect.id);
     const aspectLoader = globalScopeHarmony.get<AspectLoaderMain>(AspectLoaderAspect.id);
-    // @todo: Gilad make this work
-    // const ids = await scope.resolveMultipleComponentIds(aspectIds);
     const ids = aspectIds.map((id) => ComponentID.fromString(id));
     const hasVersions = ids.every((id) => id.hasVersion());
     const useCache = hasVersions; // if all components has versions, try to use the cached aspects

--- a/scopes/lanes/diff/lane-diff-generator.ts
+++ b/scopes/lanes/diff/lane-diff-generator.ts
@@ -86,8 +86,7 @@ export class LaneDiffGenerator {
 
     let idsToCheckDiff: ComponentIdList | undefined;
     if (pattern) {
-      const allIds = this.toLaneData.components.map((c) => c.id);
-      const compIds = await (this.workspace || this.scope).resolveMultipleComponentIds(allIds);
+      const compIds = this.toLaneData.components.map((c) => c.id);
       idsToCheckDiff = ComponentIdList.fromArray(await this.scope.filterIdsFromPoolIdsByPattern(pattern, compIds));
     }
 

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -43,11 +43,10 @@ export class LaneSwitcher {
     await this.populateSwitchProps();
     const bitMapIds = this.workspace.consumer.bitmapIdsFromCurrentLaneIncludeRemoved;
     const idsToSwitch = this.switchProps.ids || [];
-    const idsWithVersion = idsToSwitch.map((id) => {
+    const ids = idsToSwitch.map((id) => {
       const bitMapId = bitMapIds.searchWithoutVersion(id);
       return bitMapId || id;
     });
-    const ids = await this.workspace.resolveMultipleComponentIds(idsWithVersion);
 
     const checkoutProps: CheckoutProps = {
       ...this.checkoutProps,

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -571,8 +571,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     const consumer: Consumer = this.workspace.consumer;
     let ejectResults: EjectResults;
     try {
-      const componentIds = await this.workspace.resolveMultipleComponentIds(componentsIds);
-      ejectResults = await this.eject.eject(componentIds, { force: true });
+      ejectResults = await this.eject.eject(componentsIds, { force: true });
     } catch (err: any) {
       const ejectErr = `The components ${componentsIds.map((c) => c.toString()).join(', ')} were exported successfully.
       However, the eject operation has failed due to an error: ${err.msg || err}`;
@@ -752,9 +751,8 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
 
   private async removeFromStagedConfig(ids: ComponentID[]) {
     this.logger.debug(`removeFromStagedConfig, ${ids.length} ids`);
-    const componentIds = await this.workspace.resolveMultipleComponentIds(ids);
     const stagedConfig = await this.workspace.scope.getStagedConfig();
-    componentIds.map((compId) => stagedConfig.removeComponentConfig(compId));
+    ids.map((compId) => stagedConfig.removeComponentConfig(compId));
     await stagedConfig.write();
   }
 

--- a/scopes/scope/importer/dependents-getter.ts
+++ b/scopes/scope/importer/dependents-getter.ts
@@ -21,11 +21,10 @@ export class DependentsGetter {
     private options: ImportOptions
   ) {}
 
-  async getDependents(compIds: ComponentID[]): Promise<ComponentID[]> {
+  async getDependents(targetCompIds: ComponentID[]): Promise<ComponentID[]> {
     this.logger.setStatusLine('finding dependents');
     const { silent } = this.options;
     const graph = await this.graph.getGraphIds();
-    const targetCompIds = await this.workspace.resolveMultipleComponentIds(compIds);
     const sourceIds = await this.workspace.listIds();
     const getIdsForThrough = () => {
       if (!this.options.dependentsVia) return undefined;

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -510,8 +510,7 @@ export class ScopeMain implements ComponentFactory {
       cache: true,
       reason: `which are unique flattened dependencies to get the graph of ${ids.length} ids`,
     });
-    const allFlattenedCompIds = await this.resolveMultipleComponentIds(allFlattenedUniq);
-    const dependencies = await this.getMany(allFlattenedCompIds);
+    const dependencies = await this.getMany(allFlattenedUniq);
     const allComponents: Component[] = [...components, ...dependencies];
 
     // build the graph
@@ -1221,10 +1220,9 @@ export class ScopeMain implements ComponentFactory {
 
     const onPostExportHook = async (ids: ComponentID[], lanes: Lane[]): Promise<void> => {
       logger.debug(`onPostExportHook, started. (${ids.length} components)`);
-      const componentIds = await scope.resolveMultipleComponentIds(ids);
       const fns = postExportSlot.values();
       const data = {
-        ids: componentIds,
+        ids,
         lanes,
       };
       const metadata = { auth: getAuthData() };

--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -242,16 +242,15 @@ export async function linkToNodeModulesWithCodemod(
 
 export async function linkToNodeModulesByIds(
   workspace: Workspace,
-  bitIds: ComponentID[],
+  componentsIds: ComponentID[],
   loadFromScope = false
 ): Promise<NodeModulesLinksResult[]> {
-  const componentsIds = await workspace.resolveMultipleComponentIds(bitIds);
   if (!componentsIds.length) return [];
   const getComponents = async () => {
     if (loadFromScope) {
       return workspace.scope.getMany(componentsIds);
     }
-    return workspace.getMany(componentsIds, { idsToNotLoadAsAspects: bitIds.map((id) => id.toString()) });
+    return workspace.getMany(componentsIds, { idsToNotLoadAsAspects: componentsIds.map((id) => id.toString()) });
   };
   const components = await getComponents();
   const nodeModuleLinker = new NodeModuleLinker(components, workspace);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -374,8 +374,7 @@ export class Workspace implements ComponentFactory {
    */
   async list(filter?: { offset: number; limit: number }, loadOpts?: ComponentLoadOptions): Promise<Component[]> {
     const loadOptsWithDefaults: ComponentLoadOptions = Object.assign(loadOpts || {});
-    const legacyIds = this.consumer.bitMap.getAllIdsAvailableOnLane();
-    const ids = await this.resolveMultipleComponentIds(legacyIds);
+    const ids = this.consumer.bitMap.getAllIdsAvailableOnLane();
     const idsToGet = filter && filter.limit ? slice(ids, filter.offset, filter.offset + filter.limit) : ids;
     return this.getMany(idsToGet, loadOptsWithDefaults);
   }
@@ -390,8 +389,7 @@ export class Workspace implements ComponentFactory {
    * (see the invalid criteria in ConsumerComponent.isComponentInvalidByErrorType())
    */
   async listInvalid(): Promise<InvalidComponent[]> {
-    const legacyIds = this.consumer.bitMap.getAllIdsAvailableOnLane();
-    const ids = await this.resolveMultipleComponentIds(legacyIds);
+    const ids = this.consumer.bitMap.getAllIdsAvailableOnLane();
     return this.componentLoader.getInvalid(ids);
   }
 
@@ -477,8 +475,7 @@ export class Workspace implements ComponentFactory {
   }
 
   async locallyDeletedIds(): Promise<ComponentID[]> {
-    const locallyDeleted = await this.componentList.listLocallySoftRemoved();
-    return this.resolveMultipleComponentIds(locallyDeleted);
+    return this.componentList.listLocallySoftRemoved();
   }
 
   async duringMergeIds(): Promise<ComponentID[]> {
@@ -491,8 +488,7 @@ export class Workspace implements ComponentFactory {
    * get all workspace component-ids
    */
   getAllComponentIds(): Promise<ComponentID[]> {
-    const bitIds = this.consumer.bitMap.getAllBitIds();
-    return this.resolveMultipleComponentIds(bitIds);
+    return this.listIds();
   }
 
   async listTagPendingIds(): Promise<ComponentID[]> {
@@ -564,7 +560,7 @@ export class Workspace implements ComponentFactory {
         if (modelComp && modelComp.head) compsWithHead.push(id);
       })
     );
-    return this.resolveMultipleComponentIds(compsWithHead);
+    return compsWithHead;
   }
 
   async getSavedGraphOfComponentIfExist(component: Component) {


### PR DESCRIPTION
This was needed in the past mostly to convert `BitId` to `ComponentID`. Currently it's needed only to convert strings to `ComponentID`.