### PR TITLE
fix(testing/load-aspect), avoid clearing the core names cache

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -295,7 +295,7 @@ function clearGlobalsIfNeeded() {
   globalsState.loadDeps = ComponentLoader.loadDeps;
   // @ts-ignore
   ComponentLoader.loadDeps = undefined;
-  ExtensionDataList.coreExtensionsNames = new Map();
+  // ExtensionDataList.coreExtensionsNames = new Map();
   ExtensionDataList.toModelObjectsHook = [];
   // @ts-ignore
   WorkspaceConfig.workspaceConfigEnsuringRegistry = undefined;

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -12,7 +12,6 @@ import ComponentLoader from '@teambit/legacy/dist/consumer/component/component-l
 import ComponentConfig from '@teambit/legacy/dist/consumer/config/component-config';
 import ComponentOverrides from '@teambit/legacy/dist/consumer/config/component-overrides';
 import { PackageJsonTransformer } from '@teambit/workspace.modules.node-modules-linker';
-import { ExtensionDataList } from '@teambit/legacy/dist/consumer/config';
 import WorkspaceConfig from '@teambit/legacy/dist/consumer/config/workspace-config';
 import DependenciesAspect from '@teambit/dependencies';
 
@@ -125,7 +124,9 @@ function clearGlobalsIfNeeded() {
   PackageJsonTransformer.packageJsonTransformersRegistry = [];
   // @ts-ignore
   ComponentLoader.loadDeps = undefined;
-  ExtensionDataList.coreExtensionsNames = new Map();
+  // don't clear this one. it's a static list of core-ids. if you delete it, you'll have to call
+  // registerCoreExtensions() from @teambit/bit, which as far as I remember should not be a dependency of this aspect.
+  // ExtensionDataList.coreExtensionsNames = new Map();
   // @ts-ignore
   WorkspaceConfig.workspaceConfigEnsuringRegistry = undefined;
   // @ts-ignore

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -355,10 +355,7 @@ describe('LanesAspect', function () {
     });
   });
 
-  // @todo: the last `await snapping.snap({ build: false });` fails with the following error. try to fix it.
-  // EnvNotConfiguredForComponent: environment with ID: "teambit.envs/env" is not configured as extension for the component teambit.harmony/envs/core-aspect-env@0.0.24.
-  // you probably need to set this environment to your component(s). for example, "bit env set <component-pattern> teambit.envs/env"
-  describe.skip('delete component on a lane after export', () => {
+  describe('delete component on a lane after export', () => {
     let lanes: LanesMain;
     let workspaceData: WorkspaceData;
     let snapping: SnappingMain;
@@ -374,7 +371,7 @@ describe('LanesAspect', function () {
       );
       lanes = harmony.get(LanesAspect.id);
       await lanes.createLane('stage');
-      // snapping = await loadAspect(SnappingAspect, workspacePath);
+
       const currentLaneId = lanes.getCurrentLaneId();
       if (!currentLaneId) throw new Error('unable to get the current lane-id');
       laneId = currentLaneId;
@@ -400,8 +397,8 @@ describe('LanesAspect', function () {
     it('should save the deleted data into lane history', async () => {
       const laneHistory = await lanes.getLaneHistory(laneId);
       const history = laneHistory.getHistory();
-      expect(Object.keys(history).length).to.equal(2);
-      const snapHistory = history[Object.keys(history)[1]];
+      expect(Object.keys(history).length).to.equal(3);
+      const snapHistory = history[Object.keys(history)[2]];
       expect(snapHistory.deleted?.length).to.equal(1);
     });
   });


### PR DESCRIPTION
Otherwise, it needs to re-register them when `loadAspect` is called due to the clear-global-cache, and then it'll need teambit/harmony.bit as a dependency which is not ideal.
There is no reason to clear this cache, it's not gonna change during the life of the process. 