### PR TITLE
fix(testing-load-aspects), avoid loading the config from process.cwd

### DIFF
--- a/scopes/component/renaming/renaming.spec.ts
+++ b/scopes/component/renaming/renaming.spec.ts
@@ -1,8 +1,4 @@
 import chai, { expect } from 'chai';
-import {
-  ConfigAspect,
-  // ConfigMain
-} from '@teambit/config';
 import { loadManyAspects } from '@teambit/harmony.testing.load-aspect';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
 import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
@@ -15,10 +11,7 @@ chai.use(require('chai-fs'));
 describe('Renaming Aspect', function () {
   this.timeout(0);
 
-  // @todo: when running this, it changes the workspace.jsonc of this bit repo itself.
-  // see the commented line, it shows why. the config aspect is the config-aspect of bit repo instead of the
-  // same Harmony instance for some reason.
-  describe.skip('rename scope when a component id has a namespace', () => {
+  describe('rename scope when a component id has a namespace', () => {
     let renaming: RenamingMain;
     let workspace: Workspace;
     let workspaceData: WorkspaceData;
@@ -27,13 +20,9 @@ describe('Renaming Aspect', function () {
       const { workspacePath } = workspaceData;
       await mockComponents(workspacePath);
 
-      const harmony = await loadManyAspects([WorkspaceAspect, RenamingAspect, ConfigAspect], workspacePath);
+      const harmony = await loadManyAspects([WorkspaceAspect, RenamingAspect], workspacePath);
       renaming = harmony.get<RenamingMain>(RenamingAspect.id);
       workspace = harmony.get<Workspace>(WorkspaceAspect.id);
-
-      // console.log('\nworkspace', workspace.path);
-      // const config = harmony.get<ConfigMain>('teambit.harmony/config');
-      // console.log('\nconfig path ', config.path);
 
       await renaming.rename('comp1', 'ui/comp1');
       await renaming.renameScope(workspaceData.remoteScopeName, 'another-scope-name');

--- a/scopes/harmony/config/config.main.runtime.ts
+++ b/scopes/harmony/config/config.main.runtime.ts
@@ -13,7 +13,7 @@ import LegacyWorkspaceConfig, {
 import { PathOsBased, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import { findScopePath } from '@teambit/legacy/dist/utils';
 import { MainRuntime } from '@teambit/cli';
-import { GlobalConfig } from '@teambit/harmony';
+import { GlobalConfig, Harmony } from '@teambit/harmony';
 import path from 'path';
 import { transformLegacyPropsToExtensions, WorkspaceConfig, WorkspaceConfigFileProps } from './workspace-config';
 import { ConfigType, HostConfig } from './types';
@@ -50,8 +50,8 @@ export class ConfigMain {
     return this.scopeConfig;
   }
 
-  async reloadWorkspaceConfig() {
-    const workspaceConfig = await loadWorkspaceConfigIfExist();
+  async reloadWorkspaceConfig(cwd: string) {
+    const workspaceConfig = await loadWorkspaceConfigIfExist(cwd);
     if (workspaceConfig) this.workspaceConfig = workspaceConfig;
   }
 
@@ -99,12 +99,13 @@ export class ConfigMain {
   static slots = [];
   static dependencies = [];
   static config = {};
-  static async provider() {
+  static async provider(_deps, _config, _slots, harmony: Harmony) {
     LegacyWorkspaceConfig.registerOnWorkspaceConfigIsExist(onLegacyWorkspaceConfigIsExist());
     LegacyWorkspaceConfig.registerOnWorkspaceConfigEnsuring(onLegacyWorkspaceEnsure());
 
     let configMain: ConfigMain | any;
-    const workspaceConfig = await loadWorkspaceConfigIfExist();
+    const bitConfig = harmony.config.raw.get('teambit.harmony/bit') as any;
+    const workspaceConfig = await loadWorkspaceConfigIfExist(bitConfig?.cwd);
     if (workspaceConfig) {
       configMain = new ConfigMain(workspaceConfig, undefined);
     } else {
@@ -121,9 +122,9 @@ export class ConfigMain {
 
 ConfigAspect.addRuntime(ConfigMain);
 
-async function loadWorkspaceConfigIfExist(): Promise<WorkspaceConfig | undefined> {
-  const consumerInfo = await getConsumerInfo(process.cwd());
-  const configDirPath = consumerInfo?.path || process.cwd();
+async function loadWorkspaceConfigIfExist(cwd = process.cwd()): Promise<WorkspaceConfig | undefined> {
+  const consumerInfo = await getConsumerInfo(cwd);
+  const configDirPath = consumerInfo?.path || cwd;
   const scopePath = findScopePath(configDirPath);
   const workspaceConfig = await WorkspaceConfig.loadIfExist(configDirPath, scopePath);
   return workspaceConfig;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -836,7 +836,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
   async triggerOnWorkspaceConfigChange(): Promise<void> {
     this.logger.debug('triggerOnWorkspaceConfigChange, reloading workspace config');
     const config = this.harmony.get<ConfigMain>('teambit.harmony/config');
-    await config.reloadWorkspaceConfig();
+    await config.reloadWorkspaceConfig(this.path);
     const workspaceConfig = config.workspaceConfig;
     if (!workspaceConfig) throw new Error('workspace config is missing from Config aspect');
     const configOfWorkspaceAspect = workspaceConfig.extensions.findExtension(WorkspaceAspect.id);


### PR DESCRIPTION
Instead, use the `cwd` from the config of `teambit.harmony/bit`.
Otherwise, when running tests on a different workspace, it loads the `Config` aspect with the workspace.jsonc of the bit repo. (to reproduce, run `bit test renaming` and notice how the workspace.jsonc of bit-repo is changed)