### PR TITLE
feat(deprecate), support deprecating a range of versions

### DIFF
--- a/e2e/harmony/deprecate.e2e.1.ts
+++ b/e2e/harmony/deprecate.e2e.1.ts
@@ -132,4 +132,70 @@ describe('bit deprecate and undeprecate commands', function () {
       expect(deprecationData).to.be.undefined;
     });
   });
+  describe('deprecate previous versions', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.fixtures.populateComponents(2, undefined, 'version2');
+      helper.command.deprecateComponent('comp2', '--range 0.0.1');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+    });
+    it('should not show the current version as deprecated', () => {
+      const deprecationData = helper.command.showComponentParsedHarmonyByTitle('comp2', 'deprecated');
+      expect(deprecationData.isDeprecate).to.be.false;
+      expect(deprecationData.range).to.equal('0.0.1');
+    });
+    it('should show the previous version as deprecated', () => {
+      const deprecationData = helper.command.showComponentParsedHarmonyByTitle('comp2@0.0.1', 'deprecated');
+      expect(deprecationData.isDeprecate).to.be.true;
+      expect(deprecationData.range).to.equal('0.0.1');
+    });
+    it('bit list should not show the component as deprecated', () => {
+      const list = helper.command.listParsed();
+      const comp2 = list.find((c) => c.id === `${helper.scopes.remote}/comp2`);
+      expect(comp2?.deprecated).to.be.false;
+    });
+    it('un-deprecating the component should remove the range data', () => {
+      helper.command.undeprecateComponent('comp2');
+
+      const deprecationData = helper.command.showComponentParsedHarmonyByTitle('comp2@0.0.1', 'deprecated');
+      expect(deprecationData.isDeprecate).to.be.false;
+      expect(deprecationData).to.not.have.property('range');
+    });
+    describe('importing the component', () => {
+      before(() => {
+        helper.scopeHelper.reInitLocalScope();
+        helper.scopeHelper.addRemoteScope();
+      });
+      it('import the latest version should not show the deprecated message', () => {
+        const output = helper.command.importComponent('comp2', '-x');
+        expect(output).to.not.have.string('deprecated');
+      });
+      it('import the previous version should show the deprecated message', () => {
+        const output = helper.command.importComponent('comp2@0.0.1', '-x --override');
+        expect(output).to.have.string('deprecated');
+      });
+    });
+  });
+  describe('deprecating with --range when it overlaps the current version', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.deprecateComponent('comp1', '--range "<1.0.0"');
+      helper.command.tagAllWithoutBuild();
+    });
+    it('should show the component as deprecated', () => {
+      const deprecationData = helper.command.showComponentParsedHarmonyByTitle('comp1', 'deprecated');
+      expect(deprecationData.isDeprecate).to.be.true;
+      expect(deprecationData.range).to.equal('<1.0.0');
+    });
+    it('when the range is outside the current version it should not show as deprecated', () => {
+      helper.command.tagAllWithoutBuild('--ver 2.0.0 --unmodified');
+      const deprecationData = helper.command.showComponentParsedHarmonyByTitle('comp1', 'deprecated');
+      expect(deprecationData.isDeprecate).to.be.false;
+    });
+  });
 });

--- a/scopes/component/deprecation/deprecate-cmd.ts
+++ b/scopes/component/deprecation/deprecate-cmd.ts
@@ -14,7 +14,12 @@ export class DeprecateCmd implements Command {
     [
       '',
       'new-id <string>',
-      'if replaced by another component, enter the new component id. alternatively use "bit rename" to do this automatically',
+      'if replaced by another component, enter the new component id. alternatively use "bit rename --deprecate" to do this automatically',
+    ],
+    [
+      '',
+      'range <string>',
+      'enter a Semver range to deprecate specific versions. see https://www.npmjs.com/package/semver#ranges for the range syntax',
     ],
   ] as CommandOptions;
   loader = true;
@@ -23,17 +28,17 @@ export class DeprecateCmd implements Command {
 
   constructor(private deprecation: DeprecationMain, private workspace: Workspace) {}
 
-  async report([id]: [string], { newId }: { newId?: string }): Promise<string> {
-    const result = await this.deprecate(id, newId);
+  async report([id]: [string], { newId, range }: { newId?: string; range?: string }): Promise<string> {
+    const result = await this.deprecate(id, newId, range);
     if (result) {
       return chalk.green(`the component "${id}" has been deprecated successfully`);
     }
     return chalk.bold(`the component "${id}" is already deprecated. no changes have been made`);
   }
 
-  private async deprecate(id: string, newId?: string): Promise<boolean> {
+  private async deprecate(id: string, newId?: string, range?: string): Promise<boolean> {
     const componentId = await this.workspace.resolveComponentId(id);
     const newComponentId = newId ? await this.workspace.resolveComponentId(newId) : undefined;
-    return this.deprecation.deprecate(componentId, newComponentId);
+    return this.deprecation.deprecate(componentId, newComponentId, range);
   }
 }

--- a/scopes/component/deprecation/deprecation.fragment.ts
+++ b/scopes/component/deprecation/deprecation.fragment.ts
@@ -10,9 +10,10 @@ export class DeprecationFragment implements ShowFragment {
     const deprecationInfo = await this.deprecation.getDeprecationInfo(component);
     const isDeprecate = deprecationInfo.isDeprecate.toString();
     const newId = deprecationInfo.newId ? ` (new-id: ${deprecationInfo.newId})` : '';
+    const range = deprecationInfo.range ? ` (range: ${deprecationInfo.range})` : '';
     return {
       title: this.title,
-      content: isDeprecate + newId,
+      content: isDeprecate + newId + range,
     };
   }
 

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -1,4 +1,5 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
+import semver from 'semver';
 import { ComponentMain, ComponentAspect, Component, ComponentID } from '@teambit/component';
 import { ScopeMain, ScopeAspect } from '@teambit/scope';
 import WorkspaceAspect, { Workspace } from '@teambit/workspace';
@@ -13,11 +14,22 @@ import { UndeprecateCmd } from './undeprecate-cmd';
 export type DeprecationInfo = {
   isDeprecate: boolean;
   newId?: string;
+  range?: string;
 };
 
 export type DeprecationMetadata = {
+  /**
+   * whether the head is deprecated
+   */
   deprecate?: boolean;
+  /**
+   * the new id to use instead of the current one
+   */
   newId?: ComponentIdObj;
+  /**
+   * Semver range to deprecate previous versions
+   */
+  range?: string;
 };
 
 export class DeprecationMain {
@@ -26,16 +38,37 @@ export class DeprecationMain {
   static dependencies = [GraphqlAspect, ScopeAspect, ComponentAspect, WorkspaceAspect, CLIAspect];
 
   async getDeprecationInfo(component: Component): Promise<DeprecationInfo> {
-    const data = component.config.extensions.findExtension(DeprecationAspect.id)?.config as
+    const headComponent = await this.getHeadComponent(component);
+
+    const data = headComponent.config.extensions.findExtension(DeprecationAspect.id)?.config as
       | DeprecationMetadata
       | undefined;
     const deprecatedBackwardCompatibility = component.state._consumer.deprecated;
     const isDeprecate = Boolean(data?.deprecate || deprecatedBackwardCompatibility);
+    const currentTag = component.getTag();
+    const isDeprecateByRange = Boolean(data?.range && currentTag && semver.satisfies(currentTag.version, data.range));
     const newId = data?.newId ? ComponentID.fromObject(data?.newId).toString() : undefined;
     return {
-      isDeprecate,
+      isDeprecate: isDeprecate || isDeprecateByRange,
       newId,
+      range: data?.range,
     };
+  }
+
+  private async getHeadComponent(component: Component): Promise<Component> {
+    if (
+      component.id.version &&
+      component.head &&
+      component.id.version !== component.head?.hash &&
+      component.id.version !== component.headTag?.version.version
+    ) {
+      const headComp = this.workspace // if workspace exits, prefer using the workspace as it may be modified
+        ? await this.workspace.get(component.id.changeVersion(undefined))
+        : await this.scope.get(component.id.changeVersion(component.head.hash));
+      if (!headComp) throw new Error(`unable to get the head of ${component.id.toString()}`);
+      return headComp;
+    }
+    return component;
   }
 
   /**
@@ -46,10 +79,11 @@ export class DeprecationMain {
    * @param newId
    * @returns boolean whether or not the component has been deprecated
    */
-  async deprecate(componentId: ComponentID, newId?: ComponentID): Promise<boolean> {
+  async deprecate(componentId: ComponentID, newId?: ComponentID, range?: string): Promise<boolean> {
     const results = this.workspace.bitMap.addComponentConfig(componentId, DeprecationAspect.id, {
-      deprecate: true,
+      deprecate: !range,
       newId: newId?.toObject(),
+      range,
     });
     await this.workspace.bitMap.write(`deprecate ${componentId.toString()}`);
 

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -564,7 +564,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
         return 'updated';
       };
       const filesStatus = this.mergeStatus && this.mergeStatus[idStr] ? this.mergeStatus[idStr] : null;
-      const deprecated = await modelComponent.isDeprecated(this.scope.objects, id.version);
+      const deprecated = Boolean(await modelComponent.isDeprecated(this.scope.objects, id.version));
       const removed = await component.component.component.isRemoved(this.scope.objects);
       const latestVersion = modelComponent.getHeadRegardlessOfLaneAsTagOrHash(true);
       return {

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -564,7 +564,7 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
         return 'updated';
       };
       const filesStatus = this.mergeStatus && this.mergeStatus[idStr] ? this.mergeStatus[idStr] : null;
-      const deprecated = await modelComponent.isDeprecated(this.scope.objects);
+      const deprecated = await modelComponent.isDeprecated(this.scope.objects, id.version);
       const removed = await component.component.component.isRemoved(this.scope.objects);
       const latestVersion = modelComponent.getHeadRegardlessOfLaneAsTagOrHash(true);
       return {

--- a/src/consumer/component/components-list.ts
+++ b/src/consumer/component/components-list.ts
@@ -392,7 +392,7 @@ export default class ComponentsList {
         const deprecated = await component?.isDeprecated(this.scope.objects);
         return {
           id: component ? component.toComponentIdWithLatestVersion() : id,
-          deprecated,
+          deprecated: Boolean(deprecated),
           laneReadmeOf,
         };
       })
@@ -454,7 +454,7 @@ export default class ComponentsList {
       componentsSorted.map(async (component: ModelComponent) => {
         return {
           id: component.toComponentIdWithLatestVersion(),
-          deprecated: await component.isDeprecated(scope.objects),
+          deprecated: Boolean(await component.isDeprecated(scope.objects)),
           removed: await component.isRemoved(scope.objects),
           laneReadmeOf: await component.isLaneReadmeOf(scope.objects),
         };


### PR DESCRIPTION
Currently, `bit deprecate` marks the entire component as deprecated.
This PR introduces a new flag `--range` to specify which versions to deprecate. It accepts the same syntax of [Semver range](https://www.npmjs.com/package/semver#ranges). 