### PR TITLE
feat(cloud): npmrc generate cmd

### DIFF
--- a/scopes/cloud/cloud/login.cmd.ts
+++ b/scopes/cloud/cloud/login.cmd.ts
@@ -22,13 +22,17 @@ export class LoginCmd implements Command {
   remoteOp = true;
   skipWorkspace = true;
 
-  constructor(private cloud: CloudMain) {}
+  private port?: string;
+
+  constructor(private cloud: CloudMain, _port?: number) {
+    this.port = _port?.toString();
+  }
 
   async report(
     [], // eslint-disable-line no-empty-pattern
     {
       cloudDomain,
-      port = '8889',
+      port,
       suppressBrowserLaunch,
       noBrowser,
       machineName,
@@ -43,7 +47,7 @@ export class LoginCmd implements Command {
     if (suppressBrowserLaunch) {
       noBrowser = true;
     }
-    const result = await this.cloud.login(port, noBrowser, machineName, cloudDomain, undefined);
+    const result = await this.cloud.login(port || this.port, noBrowser, machineName, cloudDomain, undefined);
     if (result?.isAlreadyLoggedIn) {
       return chalk.yellow(`already logged in as ${result?.username}`);
     }

--- a/scopes/cloud/cloud/npmrc.cmd.ts
+++ b/scopes/cloud/cloud/npmrc.cmd.ts
@@ -1,0 +1,61 @@
+/* eslint-disable max-classes-per-file */
+import chalk from 'chalk';
+import yesno from 'yesno';
+import { Command, CommandOptions, Flags } from '@teambit/cli';
+import { CloudMain } from './cloud.main.runtime';
+
+export class NpmrcGenerateCmd implements Command {
+  name = 'generate';
+  description = 'update npmrc file with scope, registry, and token information from bit.cloud';
+  group = 'cloud';
+  alias = '';
+  options = [['', 'dry-run', 'show the .npmrc file content that will be written']] as CommandOptions;
+  skipWorkspace = false;
+
+  private port?: string;
+
+  constructor(private cloud: CloudMain, _port?: number) {
+    this.port = _port?.toString();
+  }
+
+  async report(_, flags: Flags): Promise<string> {
+    this.cloud.logger.clearStatusLine();
+    const isLoggedIn = await this.cloud.isLoggedIn();
+    if (!isLoggedIn) {
+      const loginOk = await yesno({
+        question: `You are not logged in.\n\n${chalk.bold('Would you like to login? [yes(y)/no(n)]')}`,
+      });
+      if (!loginOk) {
+        throw new Error('the operation has been canceled');
+      }
+      await this.cloud.login(this.port);
+    }
+    const config = await this.cloud.generateNpmrc({ dryRun: flags.dryRun });
+    if (flags.dryRun) {
+      return chalk.green(`.npmrc file content that will be written:\n${config}`);
+    }
+    return chalk.green(`.npmrc file has been updated successfully`);
+  }
+
+  async json() {
+    const config = await this.cloud.generateNpmrc();
+    return { config };
+  }
+}
+
+export class NpmrcCmd implements Command {
+  name = 'npmrc [sub-command]';
+  description = 'manage npmrc file with scope, registry, and token information from bit.cloud';
+  group = 'cloud';
+  alias = '';
+  options = [];
+  loader = true;
+  skipWorkspace = true;
+  commands: Command[] = [];
+
+  async report([unrecognizedSubcommand]: [string]) {
+    return chalk.red(
+      `"${unrecognizedSubcommand}" is not a subcommand of "npmrc", please run "bit npmrc --help" to list the subcommands`
+    );
+  }
+}


### PR DESCRIPTION
This PR adds a new command `bit npmrc generate` - that allows users to update the npmrc scope, registry and token configuration from bit cloud. It also allows passing a `--dry-run` flag to output the configuration that will be updated. 
If the user is not logged in, it prompts the user to login and then updates the config. 
