### PR TITLE
fix(lane-merge), handle a case when a component was locally deleted

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -172,6 +172,25 @@ describe('merge lanes', function () {
       expect(mergeOutput).to.not.have.string('unable to switch to "main", the lane was not found');
     });
   });
+  describe('merge main into a lane when it is locally deleted on the lane', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.mergeLane('dev');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('dev');
+      helper.command.softRemoveOnLane('comp1');
+    });
+    it('should show a descriptive error explaining why it cannot be merged', () => {
+      const cmd = () => helper.command.mergeLane('main', '-x');
+      expect(cmd).to.throw('component is locally deleted');
+    });
+  });
   describe('merging main into local lane when main has tagged versions', () => {
     let mergeOutput: string;
     before(() => {

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -221,6 +221,14 @@ other:   ${otherLaneHead.toString()}`);
       const divergeData = await getDivergeData({ repo, modelComponent, targetHead: otherLaneHead, throws: false });
       return { ...componentStatus, componentFromModel: componentOnOther, divergeData };
     }
+    const componentMap = consumer?.bitMap.getComponentIfExist(currentId, { ignoreVersion: true });
+    const isLocallyRemoved = componentMap?.isRemoved();
+    if (isLocallyRemoved) {
+      return this.returnUnmerged(
+        id,
+        `component is locally deleted, please snap and export first or undo by bit recover`
+      );
+    }
     const getCurrentComponent = () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       if (existingBitMapId) return consumer!.loadComponent(existingBitMapId);


### PR DESCRIPTION
Currently it shows an unhelpful error: "Cannot read properties of undefined (reading 'isRemoved')".
