### PR TITLE
feat(Cloud): handle npmrc conflicts

### DIFF
--- a/scopes/cloud/cloud/login.cmd.ts
+++ b/scopes/cloud/cloud/login.cmd.ts
@@ -1,4 +1,5 @@
 import chalk from 'chalk';
+import yesno from 'yesno';
 import { Command, CommandOptions } from '@teambit/cli';
 import { CloudMain } from './cloud.main.runtime';
 
@@ -44,19 +45,23 @@ export class LoginCmd implements Command {
       machineName?: string;
     }
   ): Promise<string> {
-    if (suppressBrowserLaunch) {
-      noBrowser = true;
-    }
+    noBrowser = noBrowser || suppressBrowserLaunch;
+
     const result = await this.cloud.login(port || this.port, noBrowser, machineName, cloudDomain, undefined);
+    let message = chalk.green(`Logged in as ${result?.username}`);
+
     if (result?.isAlreadyLoggedIn) {
-      return chalk.yellow(`already logged in as ${result?.username}`);
+      return message;
     }
-    const npmrcUpdateResultMsg = result?.npmrcUpdateResult?.success
-      ? ' and .npmrc updated'
-      : chalk.red(
-          ` but failed to update .npmrc. Visit https://bit.dev/reference/packages/npmrc for instructions on how to update it manually`
-        );
-    return chalk.green(`success! logged in as ${result?.username}${npmrcUpdateResultMsg}`);
+
+    const conflicts = result?.npmrcUpdateResult?.conflicts;
+    if (conflicts && conflicts.length > 0) {
+      message += await this.handleNpmrcConflicts(conflicts);
+    } else {
+      message += this.getNpmrcUpdateMessage(result?.npmrcUpdateResult?.error);
+    }
+
+    return message;
   }
 
   async json(
@@ -82,7 +87,50 @@ export class LoginCmd implements Command {
     return {
       username: result?.username,
       token: result?.token,
-      successfullyUpdatedNpmrc: result?.npmrcUpdateResult?.success,
+      successfullyUpdatedNpmrc: !!result?.npmrcUpdateResult?.configUpdates,
     };
+  }
+
+  async handleNpmrcConflicts(conflicts): Promise<string> {
+    this.cloud.logger.clearStatusLine();
+    const conflictDetails = conflicts
+      .map(
+        (conflict, index) =>
+          `${chalk.yellow(`Conflict #${index + 1}:`)}
+Original: ${chalk.red(conflict.original)}
+Modification: ${chalk.green(conflict.modifications)}`
+      )
+      .join('\n\n');
+
+    const question = `\n${chalk.yellow(
+      'Conflict detected in .npmrc file with the following configurations:'
+    )}\n${conflictDetails}\n${chalk.yellow(
+      'Do you want to override these configurations and continue? [yes(y)/no(n)]'
+    )}`;
+
+    const ok = await yesno({ question });
+    if (!ok) {
+      return chalk.red(' but updating .npmrc was aborted due to conflicts.');
+    }
+
+    try {
+      await this.cloud.generateNpmrc({ force: true });
+      return chalk.green(' and .npmrc updated successfully after resolving conflicts.');
+    } catch (e) {
+      return `${chalk.red(' but failed to update .npmrc after resolving conflicts.')} Visit ${chalk.bold(
+        'https://bit.dev/reference/packages/npmrc'
+      )} for instructions on how to update it manually.`;
+    }
+  }
+
+  getNpmrcUpdateMessage(error): string {
+    if (!error) {
+      return chalk.green(' and .npmrc updated.');
+    }
+    return chalk.red(
+      ` but failed to update .npmrc. Visit ${chalk.bold(
+        'https://bit.dev/reference/packages/npmrc'
+      )} for instructions on how to update it manually.`
+    );
   }
 }


### PR DESCRIPTION
This PR adds the ability to detect conflicts in the npmrc while updating it during bit login and bit npm generate command. It allows the user to by pass the conflicts by using the `--force` flag. If the `--force` flag is not used, it prompts the user to confirm before overriding the npm config to allow them to either continue or abort the process. 

<img width="651" alt="Screenshot 2024-02-13 at 2 30 14 PM" src="https://github.com/teambit/bit/assets/8999604/95d39493-54b6-4ef6-9b5d-77e23a65f612">

<img width="657" alt="Screenshot 2024-02-13 at 2 31 09 PM" src="https://github.com/teambit/bit/assets/8999604/559f4f0a-cbf6-49cf-8576-668ce0fabd31">

<img width="661" alt="Screenshot 2024-02-13 at 2 31 36 PM" src="https://github.com/teambit/bit/assets/8999604/6487b26e-7a58-4e80-a367-df6d6146e2b5">
