### PR TITLE
fix(deps-get), include all flattened deps according to the get-graph-ids API

### DIFF
--- a/scopes/component/graph/component-id-graph.ts
+++ b/scopes/component/graph/component-id-graph.ts
@@ -1,6 +1,8 @@
-import { ComponentID } from '@teambit/component';
+import { ComponentID } from '@teambit/component-id';
 import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
+import GraphLib from 'graphlib';
 import { uniq } from 'lodash';
+import { DependenciesInfo } from '../../../src/scope/graph/scope-graph';
 
 export type DepEdgeType = 'prod' | 'dev' | 'ext';
 
@@ -9,9 +11,24 @@ type DependencyEdge = Edge<DepEdgeType>;
 export type CompIdGraph = Graph<ComponentID, DepEdgeType>;
 
 export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
+  private _graphLib: GraphLib.Graph;
   seederIds: ComponentID[] = []; // component IDs that started the graph. (if from workspace, the .bitmap ids normally)
   constructor(nodes: ComponentIdNode[] = [], edges: DependencyEdge[] = []) {
     super(nodes, edges);
+  }
+
+  get graphLib() {
+    if (!this._graphLib) {
+      // convert clearGraph to graphLib
+      this._graphLib = new GraphLib.Graph();
+      this.nodes.forEach((node) => {
+        this._graphLib.setNode(node.id.toString());
+      });
+      this.edges.forEach((edge) => {
+        this._graphLib.setEdge(edge.sourceId.toString(), edge.targetId.toString(), edge.attr);
+      });
+    }
+    return this._graphLib;
   }
 
   protected create(nodes: ComponentIdNode[] = [], edges: DependencyEdge[] = []): this {
@@ -153,6 +170,40 @@ export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
     return this.successorsSubgraph(componentIds, {
       edgeFilter: (edge: DependencyEdge) => edge.attr === 'prod',
     });
+  }
+
+  getDependenciesInfo(id: ComponentID): DependenciesInfo[] {
+    const dijkstraResults = GraphLib.alg.dijkstra(this.graphLib, id.toString());
+    const dependencies: DependenciesInfo[] = [];
+    Object.keys(dijkstraResults).forEach((idStr) => {
+      const distance = dijkstraResults[idStr].distance;
+      if (distance === Infinity || distance === 0) {
+        // there is no dependency or it's the same component (distance zero)
+        return;
+      }
+      const predecessor = dijkstraResults[idStr].predecessor;
+      const dependencyType = this.edge(predecessor, idStr);
+      dependencies.push({
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        id: this.node(idStr)!.attr,
+        depth: distance,
+        parent: predecessor,
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        dependencyType: dependencyType!.attr,
+      });
+    });
+    dependencies.sort((a, b) => a.depth - b.depth);
+    return dependencies;
+  }
+
+  getDependenciesAsObjectTree(id: string): Record<string, any> {
+    const label = id;
+    const children = this.outEdges(id);
+    if (!children || children.length === 0) {
+      return { label };
+    }
+    const nodes = children.map((child) => this.getDependenciesAsObjectTree(child.targetId.toString()));
+    return { label, nodes };
   }
 
   private shouldLimitToSeedersOnly() {

--- a/scopes/component/graph/component-id-graph.ts
+++ b/scopes/component/graph/component-id-graph.ts
@@ -1,8 +1,8 @@
 import { ComponentID } from '@teambit/component-id';
 import { Graph, Node, Edge } from '@teambit/graph.cleargraph';
+import type { DependenciesInfo } from '@teambit/legacy/dist/scope/graph/scope-graph';
 import GraphLib from 'graphlib';
 import { uniq } from 'lodash';
-import { DependenciesInfo } from '../../../src/scope/graph/scope-graph';
 
 export type DepEdgeType = 'prod' | 'dev' | 'ext';
 

--- a/scopes/component/graph/index.ts
+++ b/scopes/component/graph/index.ts
@@ -15,7 +15,7 @@ export { GraphFilters, styles as graphPageStyles } from './ui/graph-page';
 export { EdgeModel, GraphModel, NodeModel, useGraph, useGraphQuery } from './ui/query';
 export { styles as componentNodeStyles, root, defaultNode, external } from './ui/component-node';
 export type { RawGraph } from './ui/query';
-export type { CompIdGraph, DepEdgeType } from './component-id-graph';
+export type { CompIdGraph, DepEdgeType, ComponentIdGraph } from './component-id-graph';
 export type { ComponentGraph } from './component-graph';
 export type { ComponentWidget, ComponentWidgetProps, ComponentWidgetSlot, GraphUI } from './graph.ui.runtime';
 export { EdgeType } from './edge-type';

--- a/scopes/dependencies/dependencies/dependencies.main.runtime.ts
+++ b/scopes/dependencies/dependencies/dependencies.main.runtime.ts
@@ -11,10 +11,11 @@ import { cloneDeep, compact, set } from 'lodash';
 import pMapSeries from 'p-map-series';
 import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import ComponentLoader, { DependencyLoaderOpts } from '@teambit/legacy/dist/consumer/component/component-loader';
-import DependencyGraph from '@teambit/legacy/dist/scope/graph/scope-graph';
 import DevFilesAspect, { DevFilesMain } from '@teambit/dev-files';
+import GraphAspect, { ComponentIdGraph, GraphMain } from '@teambit/graph';
 import AspectLoaderAspect, { AspectLoaderMain } from '@teambit/aspect-loader';
 import { snapToSemver } from '@teambit/component-package-version';
+import ScopeAspect, { ScopeMain } from '@teambit/scope';
 import { DependenciesLoader } from './dependencies-loader/dependencies-loader';
 import { DependenciesData, OverridesDependenciesData } from './dependencies-loader/dependencies-data';
 import {
@@ -41,8 +42,7 @@ export type DependenciesResultsDebug = DebugDependencies &
   OverridesDependenciesData & { coreAspects: string[]; sources: { id: string; source: string }[] };
 
 export type DependenciesResults = {
-  scopeGraph: DependencyGraph;
-  workspaceGraph: DependencyGraph;
+  graph: ComponentIdGraph;
   id: ComponentID;
 };
 
@@ -58,9 +58,11 @@ export type BlameResult = {
 export class DependenciesMain {
   constructor(
     private workspace: Workspace,
+    private scope: ScopeMain,
     private dependencyResolver: DependencyResolverMain,
     private devFiles: DevFilesMain,
-    private aspectLoader: AspectLoaderMain
+    private aspectLoader: AspectLoaderMain,
+    private graph: GraphMain
   ) {}
 
   async setDependency(
@@ -187,18 +189,12 @@ export class DependenciesMain {
     return compIds;
   }
 
-  async getDependencies(id: string): Promise<DependenciesResults> {
-    // @todo: supports this on bare-scope.
-    if (!this.workspace) throw new OutsideWorkspaceError();
-    const compId = await this.workspace.resolveComponentId(id);
-    const consumer = this.workspace.consumer;
-    const scopeGraph = await DependencyGraph.buildGraphFromScope(consumer.scope);
-    const scopeDependencyGraph = new DependencyGraph(scopeGraph);
+  async getDependencies(id: string, scope?: boolean): Promise<DependenciesResults> {
+    const factory = this.workspace && !scope ? this.workspace : this.scope;
+    const compId = await (this.workspace || this.scope).resolveComponentId(id);
+    const graph = await this.graph.getGraphIds([compId], { host: factory as any });
 
-    const workspaceGraph = await DependencyGraph.buildGraphFromWorkspace(consumer, true);
-    const workspaceDependencyGraph = new DependencyGraph(workspaceGraph);
-
-    return { scopeGraph: scopeDependencyGraph, workspaceGraph: workspaceDependencyGraph, id: compId };
+    return { graph, id: graph.seederIds[0] };
   }
 
   async loadDependencies(component: ConsumerComponent, opts: DependencyLoaderOpts) {
@@ -346,18 +342,28 @@ export class DependenciesMain {
   }
 
   static slots = [];
-  static dependencies = [CLIAspect, WorkspaceAspect, DependencyResolverAspect, DevFilesAspect, AspectLoaderAspect];
+  static dependencies = [
+    CLIAspect,
+    WorkspaceAspect,
+    DependencyResolverAspect,
+    DevFilesAspect,
+    AspectLoaderAspect,
+    ScopeAspect,
+    GraphAspect,
+  ];
 
   static runtime = MainRuntime;
 
-  static async provider([cli, workspace, depsResolver, devFiles, aspectLoader]: [
+  static async provider([cli, workspace, depsResolver, devFiles, aspectLoader, scope, graph]: [
     CLIMain,
     Workspace,
     DependencyResolverMain,
     DevFilesMain,
-    AspectLoaderMain
+    AspectLoaderMain,
+    ScopeMain,
+    GraphMain
   ]) {
-    const depsMain = new DependenciesMain(workspace, depsResolver, devFiles, aspectLoader);
+    const depsMain = new DependenciesMain(workspace, scope, depsResolver, devFiles, aspectLoader, graph);
     const depsCmd = new DependenciesCmd();
     depsCmd.commands = [
       new DependenciesGetCmd(depsMain),

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -557,10 +557,10 @@ export class ScopeMain implements ComponentFactory {
       { reFetchUnBuiltVersion: false, lane, reason: `to build graph-ids from the scope` }
     );
 
-    const allFlattened = componentsWithoutSavedGraph
+    const allFlattened: ComponentID[] = componentsWithoutSavedGraph
       .map((component) => component.state._consumer.getAllFlattenedDependencies())
       .flat();
-    const allFlattenedUniq = ComponentIdList.uniqFromArray(allFlattened);
+    const allFlattenedUniq = ComponentIdList.uniqFromArray(allFlattened.concat(ids));
 
     const addEdges = (compId: ComponentID, dependencies: ConsumerComponent['dependencies'], label: DepEdgeType) => {
       dependencies.get().forEach((dep) => {


### PR DESCRIPTION
`bit deps get` was using the legacy graph and wasn't getting all the deps for some reason, also it was throwing an error when running it outside a workspace. 
This PR uses the `getGraphIds` API which is available in both Workspace and Scope. 