### PR TITLE
fix(ws-config-template): update comment to prompt user to run bit install after uncommenting generators

### DIFF
--- a/scopes/harmony/config/workspace-template.jsonc
+++ b/scopes/harmony/config/workspace-template.jsonc
@@ -38,8 +38,10 @@
   },
 
   /**
-   * comment in to include generator templates in your workspace.
-   * browse more dev environments: https://bit.dev/docs/getting-started/composing/dev-environments
+  * Enable generator templates by uncommenting the desired environments below.
+  * These generators scaffold components for Node, React, Vue, and Angular.
+  * After uncommenting, run `bit install` to make them available in your workspace.
+  * Explore more dev environments at: https://bit.dev/docs/getting-started/composing/dev-environments
   **/
   "teambit.generator/generator": {
     "envs": [


### PR DESCRIPTION
This PR updates the comment on the generators config in the workspace config template. It prompts the user to run `bit install` after uncommenting the environment in the generator config to make them available in the workspace. 