### PR TITLE
add a GraphQL query to remove updateDependents from the lane object

### DIFF
--- a/scopes/lanes/lanes/lanes.graphql.ts
+++ b/scopes/lanes/lanes/lanes.graphql.ts
@@ -1,5 +1,6 @@
 import { Schema } from '@teambit/graphql';
 import { LaneId } from '@teambit/lane-id';
+import { ComponentID } from '@teambit/component-id';
 import Fuse from 'fuse.js';
 import { LaneData } from '@teambit/legacy/dist/scope/lanes/lanes';
 import gql from 'graphql-tag';
@@ -113,6 +114,7 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
         default: Lane
         diff(from: String!, to: String!, options: DiffOptions): GetDiffResult
         diffStatus(source: String!, target: String, options: DiffStatusOptions): LaneDiffStatus!
+        removeUpdateDependents(laneId: String!, ids: [String!]): Boolean
         current: Lane
       }
 
@@ -243,6 +245,11 @@ export function lanesSchema(lanesMainRuntime: LanesMain): Schema {
           const sourceLaneId = LaneId.parse(source);
           const targetLaneId = target ? LaneId.parse(target) : undefined;
           return lanesMain.diffStatus(sourceLaneId, targetLaneId, options);
+        },
+        removeUpdateDependents: async (lanesMain: LanesMain, { laneId, ids }: { laneId: string; ids?: string[] }) => {
+          const laneIdParsed = LaneId.parse(laneId);
+          const compIds = ids?.map((id) => ComponentID.fromString(id));
+          return lanesMain.removeUpdateDependents(laneIdParsed, compIds);
         },
       },
       LaneDiffStatus: {

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -1068,6 +1068,25 @@ please create a new lane instead, which will include all components of this lane
     return compact(results);
   }
 
+  /**
+   * default to remove all of them.
+   * returns true if the lane has changed
+   */
+  async removeUpdateDependents(laneId: LaneId, ids?: ComponentID[]): Promise<Boolean> {
+    const lane = await this.loadLane(laneId);
+    if (!lane) throw new BitError(`unable to find a lane ${laneId.toString()}`);
+    if (ids?.length) {
+      ids.forEach((id) => lane.removeComponentFromUpdateDependents(id));
+    } else {
+      lane.removeAllUpdateDependents();
+    }
+    if (lane.hasChanged) {
+      await this.scope.legacyScope.lanes.saveLane(lane, { laneHistoryMsg: 'remove update-dependents' });
+      return true;
+    }
+    return false;
+  }
+
   private async getLaneDataOfDefaultLane(): Promise<LaneData | null> {
     const consumer = this.workspace?.consumer;
     let bitIds: ComponentID[] = [];

--- a/src/scope/models/lane.ts
+++ b/src/scope/models/lane.ts
@@ -54,7 +54,7 @@ export default class Lane extends BitObject {
    * otherwise, the user is not aware of it. it's not imported to the workspace and the objects are not fetched.
    */
   updateDependents?: ComponentID[];
-  overrideUpdateDependents?: boolean;
+  private overrideUpdateDependents?: boolean;
   constructor(props: LaneProps) {
     super();
     if (!props.name) throw new TypeError('Lane constructor expects to get a name parameter');
@@ -189,15 +189,34 @@ export default class Lane extends BitObject {
   }
   removeComponentFromUpdateDependents(componentId: ComponentID) {
     const updateDependentsList = ComponentIdList.fromArray(this.updateDependents || []);
-    this.updateDependents = updateDependentsList.filterWithoutVersion(componentId);
-    this.hasChanged = updateDependentsList.length !== this.updateDependents.length;
-    this.overrideUpdateDependents = true;
+    const exist = updateDependentsList.searchWithoutVersion(componentId);
+    if (!exist) return;
+    this.updateDependents = updateDependentsList.removeIfExist(exist);
+    this.hasChanged = true;
   }
   addComponentToUpdateDependents(componentId: ComponentID) {
     this.removeComponentFromUpdateDependents(componentId);
     (this.updateDependents ||= []).push(componentId);
     this.hasChanged = true;
-    this.overrideUpdateDependents = true;
+  }
+  removeAllUpdateDependents() {
+    if (this.updateDependents?.length) return;
+    this.updateDependents = undefined;
+    this.hasChanged = true;
+  }
+  shouldOverrideUpdateDependents() {
+    return this.overrideUpdateDependents;
+  }
+  /**
+   * !!! important !!!
+   * this should get called only on a "temp lane", such as running "bit _snap", which the scope gets destroys after the
+   * command is done. when _scope exports the lane, this "overrideUpdateDependents" is not saved to the remote-scope.
+   *
+   * on a user local lane object, this prop should never be true. otherwise, it'll override the remote-scope data.
+   */
+  setOverrideUpdateDependents(overrideUpdateDependents: boolean) {
+    this.overrideUpdateDependents = overrideUpdateDependents;
+    this.hasChanged = true;
   }
 
   removeComponent(id: ComponentID): boolean {
@@ -347,6 +366,7 @@ export default class Lane extends BitObject {
     return new Lane({
       ...this,
       hash: this._hash,
+      overrideUpdateDependents: this.overrideUpdateDependents,
       components: cloneDeep(this.components),
     });
   }

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -647,9 +647,12 @@ export default class Component extends BitObject {
       if (parent && !parent.isEqual(versionToAddRef)) {
         version.addAsOnlyParent(parent);
       }
-      addToUpdateDependentsInLane
-        ? lane.addComponentToUpdateDependents(currentBitId.changeVersion(versionToAddRef.toString()))
-        : lane.addComponent({ id: currentBitId, head: versionToAddRef, isDeleted: version.isRemoved() });
+      if (addToUpdateDependentsInLane) {
+        lane.addComponentToUpdateDependents(currentBitId.changeVersion(versionToAddRef.toString()));
+        lane.setOverrideUpdateDependents(true);
+      } else {
+        lane.addComponent({ id: currentBitId, head: versionToAddRef, isDeleted: version.isRemoved() });
+      }
 
       if (lane.readmeComponent && lane.readmeComponent.id.fullName === currentBitId.fullName) {
         lane.setReadmeComponent(currentBitId);

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -706,7 +706,7 @@ otherwise, to collaborate on the same lane as the remote, you'll need to remove 
     if (isImport && existingLane) {
       existingLane.updateDependents = lane.updateDependents;
     }
-    if (isExport && existingLane && lane.overrideUpdateDependents) {
+    if (isExport && existingLane && lane.shouldOverrideUpdateDependents()) {
       existingLane.updateDependents = lane.updateDependents;
     }
 


### PR DESCRIPTION
See https://github.com/teambit/bit/pull/8534 for more info about update-dependents.
This PR adds a new GraphQL query to allow removal of some or all components from the `updateDependents` prop.

An example to remove all:
```
query Lanes {
  lanes {
    removeUpdateDependents(laneId: "gfruwtu9-remote/dev")
  }
}
```

An example to remove one id:
```
query Lanes {
  lanes {
    removeUpdateDependents(laneId: "gfruwtu9-remote/dev", ids: ["gfruwtu9-remote/comp2"])
  }
}
```