### PR TITLE
fix, handle the case when importing a component from updateDependents into the workspace

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -1076,7 +1076,7 @@ please create a new lane instead, which will include all components of this lane
     const lane = await this.loadLane(laneId);
     if (!lane) throw new BitError(`unable to find a lane ${laneId.toString()}`);
     if (ids?.length) {
-      ids.forEach((id) => lane.removeComponentFromUpdateDependents(id));
+      ids.forEach((id) => lane.removeComponentFromUpdateDependentsIfExist(id));
     } else {
       lane.removeAllUpdateDependents();
     }

--- a/src/api/scope/lib/fetch.ts
+++ b/src/api/scope/lib/fetch.ts
@@ -315,7 +315,7 @@ async function fetchByType(
       const scopeComponentsImporter = scope.scopeImporter;
       const laneId = fetchOptions.laneId ? LaneId.parse(fetchOptions.laneId) : null;
       const lane = laneId ? await scope.loadLane(laneId) : null;
-      const bitIdsLatest = bitIdsToLatest(bitIdsWithHashToStop, lane);
+      const bitIdsLatest = bitIdsToLatest(bitIdsWithHashToStop, fetchOptions, lane);
       const importedComponents = await scopeComponentsImporter.fetchWithoutDeps(
         bitIdsLatest,
         fetchOptions.allowExternal,
@@ -376,11 +376,13 @@ async function fetchByType(
   }
 }
 
-function bitIdsToLatest(bitIds: ComponentIdList, lane: Lane | null) {
+function bitIdsToLatest(bitIds: ComponentIdList, fetchOptions: FETCH_OPTIONS, lane: Lane | null) {
   if (!lane) {
     return bitIds.toVersionLatest();
   }
-  const laneIds = lane.toBitIds();
+  const laneIds = fetchOptions.includeUpdateDependents
+    ? lane.toComponentIdsIncludeUpdateDependents()
+    : lane.toComponentIds();
   return ComponentIdList.fromArray(
     bitIds.map((bitId) => {
       const inLane = laneIds.searchWithoutVersion(bitId);

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -1095,35 +1095,6 @@ export function groupByScopeName(ids: Array<ComponentID | LaneId>): { [scopeName
   return grouped;
 }
 
-export function groupByLanes(ids: ComponentID[], lanes: Lane[]): { [scopeName: string]: string[] } {
-  const lane = lanes[0];
-  if (!lane.scope) {
-    throw new Error(`can't group by Lane object, the scope is undefined for ${lane.id()}`);
-  }
-  const laneIds = lane.toBitIds();
-  if (lanes.length > 1) {
-    throw new Error(`groupByLanes does not support more than one lane`);
-  }
-  const grouped: { [scopeName: string]: string[] } = {};
-
-  const isLaneIncludeId = (id: ComponentID, laneBitIds: ComponentIdList) => {
-    if (laneBitIds.has(id)) return true;
-    const foundWithoutVersion = laneBitIds.searchWithoutVersion(id);
-    return foundWithoutVersion;
-  };
-
-  ids.forEach((id) => {
-    if (isLaneIncludeId(id, laneIds)) {
-      (grouped[lane.scope] ||= []).push(id.toString());
-    } else {
-      // if not found on a lane, fetch from main.
-      (grouped[id.scope] ||= []).push(id.toString());
-    }
-  });
-
-  return grouped;
-}
-
 export function errorIsTypeOfMissingObject(err: Error) {
   return err instanceof ParentNotFound || err instanceof VersionNotFound || err instanceof HeadNotFound;
 }

--- a/src/scope/models/lane.ts
+++ b/src/scope/models/lane.ts
@@ -187,15 +187,16 @@ export default class Lane extends BitObject {
       this.hasChanged = true;
     }
   }
-  removeComponentFromUpdateDependents(componentId: ComponentID) {
+  removeComponentFromUpdateDependentsIfExist(componentId: ComponentID) {
     const updateDependentsList = ComponentIdList.fromArray(this.updateDependents || []);
     const exist = updateDependentsList.searchWithoutVersion(componentId);
     if (!exist) return;
     this.updateDependents = updateDependentsList.removeIfExist(exist);
+    if (!this.updateDependents.length) this.updateDependents = undefined;
     this.hasChanged = true;
   }
   addComponentToUpdateDependents(componentId: ComponentID) {
-    this.removeComponentFromUpdateDependents(componentId);
+    this.removeComponentFromUpdateDependentsIfExist(componentId);
     (this.updateDependents ||= []).push(componentId);
     this.hasChanged = true;
   }
@@ -338,14 +339,6 @@ export default class Lane extends BitObject {
           `${message}, lane component ${component.id.toStringWithoutVersion()} head should be a hash, got ${
             component.head.hash
           }`
-        );
-      }
-    });
-    this.updateDependents?.forEach((updateDependent) => {
-      const existing = this.getComponent(updateDependent);
-      if (existing) {
-        throw new ValidationError(
-          `${message}, a component "${updateDependent.toStringWithoutVersion()}" is both in the lane and in the updateDependents list`
         );
       }
     });

--- a/src/scope/objects-fetcher/objects-fetcher.ts
+++ b/src/scope/objects-fetcher/objects-fetcher.ts
@@ -1,4 +1,4 @@
-import { ComponentID } from '@teambit/component-id';
+import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { LaneId, DEFAULT_LANE } from '@teambit/lane-id';
 import { omit, uniq } from 'lodash';
 // @ts-ignore
@@ -15,7 +15,7 @@ import { Repository } from '../objects';
 import { ObjectItemsStream } from '../objects/object-list';
 import { ObjectsWritable } from './objects-writable-stream';
 import { WriteObjectsQueue } from './write-objects-queue';
-import { groupByLanes, groupByScopeName } from '../component-ops/scope-components-importer';
+import { groupByScopeName } from '../component-ops/scope-components-importer';
 import { concurrentFetchLimit } from '../../utils/concurrency';
 import { ScopeNotFoundOrDenied } from '../../remotes/exceptions/scope-not-found-or-denied';
 import { Lane } from '../models';
@@ -56,8 +56,7 @@ export class ObjectFetcher {
       allowExternal: Boolean(this.lane),
       ...this.fetchOptions,
     };
-    const idsGrouped =
-      this.groupedHashes || (this.lane ? groupByLanes(this.ids, [this.lane]) : groupByScopeName(this.ids));
+    const idsGrouped = this.groupedHashes || (this.lane ? this.groupByLanes(this.lane) : groupByScopeName(this.ids));
     const scopes = Object.keys(idsGrouped);
     logger.debug(
       `[-] Running fetch on ${scopes.length} remote(s), to get ${this.ids.length} id(s), lane: ${
@@ -130,6 +129,30 @@ ${failedScopesErr.join('\n')}`);
         );
       })
     );
+  }
+
+  private groupByLanes(lane: Lane): { [scopeName: string]: string[] } {
+    const compIds = this.fetchOptions.includeUpdateDependents
+      ? lane.toComponentIdsIncludeUpdateDependents()
+      : lane.toComponentIds();
+    const grouped: { [scopeName: string]: string[] } = {};
+
+    const isLaneIncludeId = (id: ComponentID, laneBitIds: ComponentIdList) => {
+      if (laneBitIds.has(id)) return true;
+      const foundWithoutVersion = laneBitIds.searchWithoutVersion(id);
+      return foundWithoutVersion;
+    };
+
+    this.ids.forEach((id) => {
+      if (isLaneIncludeId(id, compIds)) {
+        (grouped[lane.scope] ||= []).push(id.toString());
+      } else {
+        // if not found on a lane, fetch from main.
+        (grouped[id.scope] ||= []).push(id.toString());
+      }
+    });
+
+    return grouped;
   }
 
   private async fetchFromSingleRemote(scopeName: string, ids: string[]): Promise<ObjectItemsStream | null> {

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -623,7 +623,10 @@ otherwise, to collaborate on the same lane as the remote, you'll need to remove 
       const existingComponent = existingLane ? existingLane.components.find((c) => c.id.isEqual(component.id)) : null;
       if (!existingComponent) {
         if (isExport) {
-          if (existingLane) existingLane.addComponent(component);
+          if (existingLane) {
+            existingLane.addComponent(component);
+            existingLane.removeComponentFromUpdateDependentsIfExist(component.id);
+          }
           if (!sentVersionHashes?.includes(component.head.toString())) {
             // during export, the remote might got a lane when some components were not sent from the client. ignore them.
             return;


### PR DESCRIPTION
When checked out to a lane and running `bit import <id>` of a component included in the `updateDependents` prop of the lane, don't bring it from there. Fetch it from main instead. Only once it's snapped, add it to the lane. It's ok that in this point, the component exists in both: `components` array and `updateDependents` array of the lane. Later, once this lane object is merged into the remote, it'll be removed from the `updateDependents` array and it'll be only in `components`. This removal needs to be done on the remote, because only the remote makes changes in this array unless it gets "overrideUpdateDependents" flag, which enabled by snap-from-scope only.

I was trying first to go with the approach of importing the component from the lane. However, it breaks in so many places. For example, the model-component has the laneHead prop which now is undefined as it doesn't recognize this component as part of the lane.