### PR TITLE
improvement(snap-from-scope), support newDependencies for existing components

### DIFF
--- a/scopes/component/snapping/generate-comp-from-scope.ts
+++ b/scopes/component/snapping/generate-comp-from-scope.ts
@@ -105,19 +105,24 @@ export async function addDeps(
       return acc;
     }, {});
   };
-  const dependenciesData = {
-    allDependencies: {
-      dependencies: compDeps,
-      devDependencies: compDevDeps,
-    },
-    allPackagesDependencies: {
-      packageDependencies: toPackageObj(packageDeps.filter((dep) => dep.type === 'runtime')),
-      devPackageDependencies: toPackageObj(packageDeps.filter((dep) => dep.type === 'dev')),
-      peerPackageDependencies: toPackageObj(packageDeps.filter((dep) => dep.type === 'peer')),
-    },
+  const getPkgObj = (type: 'runtime' | 'dev' | 'peer') => {
+    return toPackageObj(packageDeps.filter((dep) => dep.type === type));
   };
 
   const consumerComponent = component.state._consumer as ConsumerComponent;
+
+  const dependenciesData = {
+    allDependencies: {
+      dependencies: [...compDeps, ...consumerComponent.dependencies.get()],
+      devDependencies: [...compDevDeps, ...consumerComponent.devDependencies.get()],
+    },
+    allPackagesDependencies: {
+      packageDependencies: { ...consumerComponent.packageDependencies, ...getPkgObj('runtime') },
+      devPackageDependencies: { ...consumerComponent.devPackageDependencies, ...getPkgObj('dev') },
+      peerPackageDependencies: { ...consumerComponent.peerPackageDependencies, ...getPkgObj('peer') },
+    },
+  };
+
   // add the dependencies to the legacy ConsumerComponent object
   // it takes care of both: given dependencies (from the cli) and the overrides, which are coming from the env.
   await deps.loadDependenciesFromScope(consumerComponent, dependenciesData);

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -458,10 +458,7 @@ if you're willing to lose the history from the head to the specified version, us
     );
     await pMapSeries(components, async (comp) => this.scope.executeOnCompAspectReCalcSlot(comp));
 
-    // run this for new components only.
-    // otherwise, running this for existing components, will override the existing dependencies unexpectedly.
-    // if this is needed for existing components, see how to merge the model data.
-    await pMapSeries(newComponents, async (component) => {
+    await pMapSeries(components, async (component) => {
       const snapData = getSnapData(component.id);
       // adds explicitly defined dependencies and dependencies from envs/aspects (overrides)
       await addDeps(component, snapData, this.scope, this.deps, this.dependencyResolver);

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -1,26 +1,34 @@
 import { expect } from 'chai';
 import fs from 'fs-extra';
 import path from 'path';
-import { loadAspect } from '@teambit/harmony.testing.load-aspect';
+import { Harmony } from '@teambit/harmony';
+import { loadAspect, loadManyAspects } from '@teambit/harmony.testing.load-aspect';
 import {
   mockWorkspace,
+  mockBareScope,
   destroyWorkspace,
   WorkspaceData,
   setWorkspaceConfig,
 } from '@teambit/workspace.testing.mock-workspace';
 import IssuesAspect from '@teambit/issues';
+import { ScopeAspect, ScopeMain } from '@teambit/scope';
+import { ExportAspect, ExportMain } from '@teambit/export';
 import { CompilerAspect, CompilerMain } from '@teambit/compiler';
+import { ComponentID } from '@teambit/component-id';
+import { Version } from '@teambit/legacy/dist/scope/models';
+import { Ref } from '@teambit/legacy/dist/scope/objects';
 import { mockComponents } from '@teambit/component.testing.mock-components';
 import { SnappingMain } from './snapping.main.runtime';
 import { SnappingAspect } from './snapping.aspect';
 import { ComponentsHaveIssues } from './components-have-issues';
+import { SnapDataPerCompRaw } from './snap-from-scope.cmd';
 
 describe('Snapping aspect', function () {
   this.timeout(0);
 
-  let workspaceData: WorkspaceData;
-  let snapping: SnappingMain;
   describe('components with issues', () => {
+    let workspaceData: WorkspaceData;
+    let snapping: SnappingMain;
     before(async () => {
       workspaceData = mockWorkspace();
       const { workspacePath } = workspaceData;
@@ -47,6 +55,55 @@ describe('Snapping aspect', function () {
       snapping = await loadAspect(SnappingAspect, workspaceData.workspacePath);
       const results = await snapping.tag({ ids: ['comp1'] });
       expect(results?.taggedComponents.length).to.equal(1);
+    });
+    after(async () => {
+      await destroyWorkspace(workspaceData);
+    });
+  });
+  describe('snap from scope an existing component with newDependencies prop populated', () => {
+    let workspaceData: WorkspaceData;
+    let snappedId: ComponentID;
+    let harmonyBareScope: Harmony;
+    before(async () => {
+      workspaceData = mockWorkspace();
+      const { workspacePath } = workspaceData;
+      await mockComponents(workspacePath);
+      const harmony = await loadManyAspects([SnappingAspect, ExportAspect], workspacePath);
+      const snapping = harmony.get<SnappingMain>(SnappingAspect.id);
+      await snapping.snap({ pattern: 'comp1', build: false, message: 'first snap' });
+      const exportMain = harmony.get<ExportMain>(ExportAspect.id);
+      await exportMain.export();
+
+      const bareScope = mockBareScope(workspaceData.remoteScopePath, 'bare-for-snap');
+      harmonyBareScope = await loadManyAspects([SnappingAspect, ScopeAspect], bareScope.scopePath);
+      const snappingScope = harmonyBareScope.get<SnappingMain>(SnappingAspect.id);
+      const snapDataPerComp: SnapDataPerCompRaw[] = [
+        {
+          componentId: `${workspaceData.remoteScopeName}/comp1`,
+          message: 'snap from scope',
+          newDependencies: [
+            {
+              id: 'lodash',
+              version: '4.1.2',
+              isComponent: false,
+              type: 'dev',
+            },
+          ],
+        },
+      ];
+      const results = await snappingScope.snapFromScope(snapDataPerComp, {});
+
+      snappedId = results.snappedIds[0];
+    });
+    it('should add the new dev dep', async () => {
+      const snapHash = snappedId.version;
+      const scope = harmonyBareScope.get<ScopeMain>(ScopeAspect.id);
+      const versionObj = (await scope.legacyScope.objects.load(Ref.from(snapHash))) as Version;
+      const devPackages = Object.keys(versionObj.devPackageDependencies);
+      expect(devPackages).to.include('lodash');
+
+      // also, it should not delete other dev-deps that were there before.
+      expect(devPackages).to.include('@types/node');
     });
     after(async () => {
       await destroyWorkspace(workspaceData);

--- a/scopes/workspace/testing/mock-workspace/index.ts
+++ b/scopes/workspace/testing/mock-workspace/index.ts
@@ -1,1 +1,1 @@
-export { mockWorkspace, destroyWorkspace, WorkspaceData, setWorkspaceConfig } from './mock-workspace';
+export { mockWorkspace, destroyWorkspace, WorkspaceData, setWorkspaceConfig, mockBareScope } from './mock-workspace';

--- a/scopes/workspace/testing/mock-workspace/mock-workspace.ts
+++ b/scopes/workspace/testing/mock-workspace/mock-workspace.ts
@@ -28,6 +28,12 @@ export function mockWorkspace(opts: { bareScopeName?: string } = {}): WorkspaceD
   };
 }
 
+export function mockBareScope(remoteToAdd: string, scopeNameSuffix?: string) {
+  const legacyHelper = new LegacyHelper();
+  const { scopeName, scopePath } = legacyHelper.scopeHelper.getNewBareScope(scopeNameSuffix, undefined, remoteToAdd);
+  return { scopeName, scopePath };
+}
+
 /**
  * deletes the paths created by mockWorkspace. pass the results you got from `mockWorkspace()`
  */

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -206,13 +206,13 @@ export default class ScopeHelper {
     return this.command.runCmd('bit init --bare', this.scopes.envPath);
   }
 
-  getNewBareScope(scopeNameSuffix = '-remote2', addOwnerPrefix = false) {
+  getNewBareScope(scopeNameSuffix = '-remote2', addOwnerPrefix = false, remoteScopeToAdd = this.scopes.remotePath) {
     const prefix = addOwnerPrefix ? `${DEFAULT_OWNER}.` : '';
     const scopeName = prefix + generateRandomStr() + scopeNameSuffix;
     const scopePath = path.join(this.scopes.e2eDir, scopeName);
     fs.emptyDirSync(scopePath);
     this.command.runCmd('bit init --bare', scopePath);
-    this.addRemoteScope(this.scopes.remotePath, scopePath);
+    this.addRemoteScope(remoteScopeToAdd, scopePath);
     const scopeWithoutOwner = scopeName.replace(prefix, '');
     return { scopeName, scopePath, scopeWithoutOwner };
   }


### PR DESCRIPTION
Until now, this prop was available only for components that were generated by this `_snap` command. This PR merges the deps with the previously existing ones so it won't override them for existing components'.