### PR TITLE
fix workspace.getFilesModification to compare against the current, not the head

### DIFF
--- a/scopes/workspace/workspace/workspace-component/comp-files.ts
+++ b/scopes/workspace/workspace/workspace-component/comp-files.ts
@@ -13,14 +13,14 @@ export class CompFiles {
     private repository: Repository,
     private currentFiles: SourceFile[],
     readonly compDir: PathLinux,
-    private headFiles: SourceFileModel[] = []
+    private modelFiles: SourceFileModel[] = []
   ) {}
 
   isModified(): boolean {
-    if (!this.headFiles.length) return false;
-    if (this.currentFiles.length !== this.headFiles.length) return true;
+    if (!this.modelFiles.length) return false;
+    if (this.currentFiles.length !== this.modelFiles.length) return true;
     return this.currentFiles.some((file) => {
-      const headFile = this.headFiles.find((h) => h.relativePath === file.relative);
+      const headFile = this.modelFiles.find((h) => h.relativePath === file.relative);
       if (!headFile) return true;
       return !headFile.file.isEqual(file.toSourceAsLinuxEOL().hash());
     });
@@ -31,12 +31,12 @@ export class CompFiles {
   }
 
   async getHeadFiles(): Promise<SourceFile[]> {
-    return Promise.all(this.headFiles.map((file) => SourceFile.loadFromSourceFileModel(file, this.repository)));
+    return Promise.all(this.modelFiles.map((file) => SourceFile.loadFromSourceFileModel(file, this.repository)));
   }
 
   getFilesStatus(): FilesStatus {
     const result = this.currentFiles.reduce((acc, file) => {
-      const headFile = this.headFiles.find((h) => h.relativePath === file.relative);
+      const headFile = this.modelFiles.find((h) => h.relativePath === file.relative);
       const getType = (): FILE_STATUS => {
         if (!headFile) return 'new';
         if (headFile.file.isEqual(file.toSourceAsLinuxEOL().hash())) return 'unchanged';
@@ -45,7 +45,7 @@ export class CompFiles {
       acc[file.relative] = getType();
       return acc;
     }, {});
-    this.headFiles.forEach((headFile) => {
+    this.modelFiles.forEach((headFile) => {
       const currentFile = this.currentFiles.find((c) => c.relative === headFile.relativePath);
       if (!currentFile) {
         result[headFile.relativePath] = 'deleted';

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -665,17 +665,16 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
       return SourceFile.load(filePath, compDirAbs, this.path, {});
     });
     const repo = this.scope.legacyScope.objects;
-    const getHeadFiles = async () => {
+    const getModelFiles = async () => {
       const modelComp = await this.scope.legacyScope.getModelComponentIfExist(id);
       if (!modelComp) return [];
-      const head = modelComp.getHeadRegardlessOfLane();
-      if (!head) return [];
+      if (!bitMapEntry.id.hasVersion()) return [];
 
-      const verObj = await modelComp.loadVersion(head.toString(), repo);
+      const verObj = await modelComp.loadVersion(bitMapEntry.id.version, repo);
       return verObj.files;
     };
 
-    return new CompFiles(id, repo, sourceFilesVinyls, compDir, await getHeadFiles());
+    return new CompFiles(id, repo, sourceFilesVinyls, compDir, await getModelFiles());
   }
 
   /**


### PR DESCRIPTION
It fixes an issue of showing an incorrect "modify" status in two places: `bit mini-status` and in the vscode extension.