### PR TITLE
fix(merge-from-scope), do not throw an error about missing artifacts when merging main to a lane

### DIFF
--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -390,9 +390,10 @@ export class MergeLanesMain {
         // no need to export anything else other than the head. the normal calculation of what to export won't apply here
         // as it is done from the scope.
         exportHeadsOnly: shouldSquash,
-        // all artifacts must be pushed. they're all considered "external" in this case, because it's running from a
-        // bare-scope, but we don't want to ignore them, otherwise, they'll be missing from the component-scopes.
-        ignoreMissingExternalArtifacts: false,
+        // all artifacts must be pushed. otherwise, they'll be missing from the component-scopes.
+        // unless this is a merge from main to a lane, in which case it's not necessary to export the artifacts as
+        // the user importing them will get them from main.
+        ignoreMissingArtifacts: fromLaneId.isDefault(),
         exportOrigin: 'lane-merge',
       });
       return exported;

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -393,7 +393,7 @@ export class MergeLanesMain {
         // all artifacts must be pushed. otherwise, they'll be missing from the component-scopes.
         // unless this is a merge from main to a lane, in which case it's not necessary to export the artifacts as
         // the user importing them will get them from main.
-        ignoreMissingArtifacts: fromLaneId.isDefault(),
+        throwForMissingArtifacts: !fromLaneId.isDefault(),
         exportOrigin: 'lane-merge',
       });
       return exported;

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -234,7 +234,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     originDirectly,
     idsWithFutureScope,
     resumeExportId,
-    ignoreMissingArtifacts,
+    throwForMissingArtifacts,
     isOnMain = true,
     exportHeadsOnly, // relevant when exporting from bare-scope, especially when re-exporting existing versions, the normal calculation based on getDivergeData won't work
     filterOutExistingVersions, // go to the remote and check whether the version exists there. if so, don't export it
@@ -247,7 +247,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     originDirectly?: boolean;
     idsWithFutureScope: ComponentIdList;
     resumeExportId?: string | undefined;
-    ignoreMissingArtifacts?: boolean;
+    throwForMissingArtifacts?: boolean;
     isOnMain?: boolean;
     exportHeadsOnly?: boolean;
     filterOutExistingVersions?: boolean;
@@ -417,7 +417,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,
           refs.map((ref) => ref.toString()),
-          ignoreMissingArtifacts
+          throwForMissingArtifacts
         );
         const objectsList = await new ObjectList(objectItems).toBitObjects();
         const componentAndObject = { component: modelComponent, objects: objectsList.getAll() };

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -235,7 +235,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     idsWithFutureScope,
     resumeExportId,
     ignoreMissingArtifacts,
-    ignoreMissingExternalArtifacts = true,
     isOnMain = true,
     exportHeadsOnly, // relevant when exporting from bare-scope, especially when re-exporting existing versions, the normal calculation based on getDivergeData won't work
     filterOutExistingVersions, // go to the remote and check whether the version exists there. if so, don't export it
@@ -249,7 +248,6 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     idsWithFutureScope: ComponentIdList;
     resumeExportId?: string | undefined;
     ignoreMissingArtifacts?: boolean;
-    ignoreMissingExternalArtifacts?: boolean;
     isOnMain?: boolean;
     exportHeadsOnly?: boolean;
     filterOutExistingVersions?: boolean;
@@ -419,8 +417,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
         const objectItems = await modelComponent.collectVersionsObjects(
           scope.objects,
           refs.map((ref) => ref.toString()),
-          ignoreMissingArtifacts,
-          ignoreMissingExternalArtifacts
+          ignoreMissingArtifacts
         );
         const objectsList = await new ObjectList(objectItems).toBitObjects();
         const componentAndObject = { component: modelComponent, objects: objectsList.getAll() };

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -796,7 +796,7 @@ export default class Component extends BitObject {
   async collectVersionsObjects(
     repo: Repository,
     versions: string[],
-    ignoreMissingLocalArtifacts = true
+    throwForMissingLocalArtifacts = false
   ): Promise<ObjectItem[]> {
     const refsWithoutArtifacts: Ref[] = [];
     const artifactsRefs: Ref[] = [];
@@ -831,9 +831,9 @@ for a component "${this.id()}", versions: ${versions.join(', ')}`);
       throw err;
     }
     try {
-      const loaded = ignoreMissingLocalArtifacts
-        ? await repo.loadManyRawIgnoreMissing(artifactsRefs)
-        : await repo.loadManyRaw(artifactsRefs);
+      const loaded = throwForMissingLocalArtifacts
+        ? await repo.loadManyRaw(artifactsRefs)
+        : await repo.loadManyRawIgnoreMissing(artifactsRefs);
       loadedRefs.push(...loaded);
       // ignore missing artifacts when exporting old versions that were exported in the past and are now exported to a
       // different scope. this is happening for example when exporting a lane that has components from different

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -796,8 +796,7 @@ export default class Component extends BitObject {
   async collectVersionsObjects(
     repo: Repository,
     versions: string[],
-    ignoreMissingLocalArtifacts = false,
-    ignoreMissingExternalArtifacts = true
+    ignoreMissingLocalArtifacts = true
   ): Promise<ObjectItem[]> {
     const refsWithoutArtifacts: Ref[] = [];
     const artifactsRefs: Ref[] = [];
@@ -816,7 +815,7 @@ export default class Component extends BitObject {
       const refs = versionObject.refsWithOptions(false, false);
       refsWithoutArtifacts.push(...refs);
       const refsFromExtensions = getRefsFromExtensions(versionObject.extensions);
-      locallyChangedHashes.includes(versionObject.hash.toString()) || !ignoreMissingExternalArtifacts
+      locallyChangedHashes.includes(versionObject.hash().toString())
         ? artifactsRefs.push(...refsFromExtensions)
         : artifactsRefsFromExportedVersions.push(...refsFromExtensions);
     });


### PR DESCRIPTION
Previously, `collectVersionsObjects` had a bug, `ignoreMissingLocalArtifacts` didn't do anything, even when it was `false`, it was still ignoring local artifacts because `locallyChangedHashes.includes(versionObject.hash.toString())` always returned `false`. The `versionObject.hash.toString()` printed the hash method instead of the hash content. It's fixed to be `versionObject.hash().toString()` to make it work.
Because of the that bug, https://github.com/teambit/bit/pull/7119 was adding new flag `ignoreMissingExternalArtifacts` unnecessarily. It assumed that an error wasn't thrown because it was external which wasn't correct. In this PR this flag has removed.
In addition to this, when merging from scope and merging main to a lane, we can skip the import of the artifacts because once the user asks for the artifacts we retrieve it from main if not found in the lane.

One last thing, because until now `ignoreMissingLocalArtifacts` practically did nothing, I'm afraid that after this fix it'll throw errors unnecessarily, so I made the default to not throw when missing. We didn't get any complain about missing artifacts in the remote scopes, so it should be fine. 
This flag was renamed to `throwForMissingLocalArtifacts` for clarity. The only place we throw is when merging-from-scope and the source is a lane, not main.