### PR TITLE
feat(snap-from-scope), support removing existing dependencies

### DIFF
--- a/scopes/component/snapping/snap-from-scope.cmd.ts
+++ b/scopes/component/snapping/snap-from-scope.cmd.ts
@@ -22,6 +22,7 @@ export type SnapDataPerCompRaw = {
     isComponent?: boolean; // default true. if false, it's a package dependency
     type?: 'runtime' | 'dev' | 'peer'; // default "runtime".
   }>;
+  removeDependencies?: string[];
 };
 
 type SnapFromScopeOptions = {
@@ -40,7 +41,7 @@ export class SnapFromScopeCmd implements Command {
 the input data is a stringified JSON of an array of the following object.
 {
   componentId: string;     // ids always have scope, so it's safe to parse them from string
-  dependencies?: string[]; // dependencies to update their versions, e.g. [teambit/compiler@1.0.0, teambit/tester@1.0.0]
+  dependencies?: string[]; // dependencies component-ids to update their versions, e.g. [teambit.compilation/compiler@1.0.0, teambit.defender/tester@1.0.0]
   aspects?: Record<string,any> // e.g. { "teambit.react/react": {}, "teambit.envs/envs": { "env": "teambit.react/react" } }
   message?: string;       // tag-message.
   files?: Array<{path: string, content: string}>; // replace content of specified source-files. the content is base64 encoded.
@@ -52,6 +53,7 @@ the input data is a stringified JSON of an array of the following object.
     isComponent?: boolean;   // default true. if false, it's a package dependency
     type?: 'runtime' | 'dev' | 'peer'; // default "runtime".
   }>;
+  removeDependencies?: string[]; // component-id (for components) or package-name (for packages) to remove from the dependencies.
 }
 an example of the final data: '[{"componentId":"ci.remote2/comp-b","message": "first snap"}]'
 `;

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -86,6 +86,7 @@ export type SnapDataParsed = {
     isComponent: boolean;
     type: 'runtime' | 'dev' | 'peer';
   }[];
+  removeDependencies?: string[];
 };
 
 export type SnapResults = BasicTagResults & {
@@ -415,6 +416,7 @@ if you're willing to lose the history from the head to the specified version, us
           isComponent: dep.isComponent ?? true,
           type: dep.type ?? 'runtime',
         })),
+        removeDependencies: snapData.removeDependencies,
       };
     });
 

--- a/scopes/component/testing/mock-components/mock-components.ts
+++ b/scopes/component/testing/mock-components/mock-components.ts
@@ -29,10 +29,9 @@ export async function mockComponents(
   const harmony = await loadManyAspects([WorkspaceAspect, TrackerAspect, InstallAspect, CompilerAspect], workspacePath);
   const workspace = harmony.get<Workspace>(WorkspaceAspect.id);
   const tracker = harmony.get<TrackerMain>(TrackerAspect.id);
-  const results: CompDirs[] = [];
-  await pMapSeries(compsDirs, async (compDir) => {
+  const results: CompDirs[] = await pMapSeries(compsDirs, async (compDir) => {
     const { componentId } = await tracker.track({ rootDir: compDir });
-    results.push({ id: componentId, dir: compDir });
+    return { id: componentId, dir: compDir };
   });
   await workspace.bitMap.write();
   const install = harmony.get<InstallMain>(InstallAspect.id);

--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -44,6 +44,11 @@ export default class NodeModuleLinker {
     this.components = this.components.filter((component) => this.bitMap.getComponentIfExist(component.id));
     const links = await this.getLinks();
     const linksResults = this.getLinksResults();
+    if (!linksResults.length) {
+      // avoid clearing the cache if it ends up with no links. (e.g. happens when mistakenly generating links for a
+      // component not in the workspace)
+      return [];
+    }
     const workspacePath = this.workspace.path;
     links.addBasePath(workspacePath);
     await links.persistAllToFS();

--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -48,6 +48,9 @@ export default class NodeModuleLinker {
     links.addBasePath(workspacePath);
     await links.persistAllToFS();
     await this.consumer?.componentFsCache.deleteAllDependenciesDataCache();
+    // if this cache is not cleared, then when asking workspace.get again to the same component, it returns it with
+    // component-issues like "MissingLinksFromNodeModulesToSrc" incorrectly.
+    this.workspace.clearAllComponentsCache();
     await linkPkgsToBitRoots(
       workspacePath,
       this.components.map((comp) => componentIdToPackageName(comp.state._consumer))

--- a/scopes/workspace/testing/mock-workspace/mock-workspace.ts
+++ b/scopes/workspace/testing/mock-workspace/mock-workspace.ts
@@ -5,10 +5,14 @@ import { assign, parse, stringify } from 'comment-json';
 
 export type WorkspaceData = { workspacePath: string; remoteScopePath: string; remoteScopeName: string };
 
+const isDebugMode = () => process.argv.includes('--debug');
+
 /**
  * setup a new workspace on a temp directory and setup a bare-scope locally to simulate a remote scope for commands
  * such as `bit export`.
  * call `destroyWorkspace()` once the tests completed to keep the filesystem clean.
+ *
+ * to print the path of the workspace, run the tests with `--debug` flag.
  */
 export function mockWorkspace(opts: { bareScopeName?: string } = {}): WorkspaceData {
   const legacyHelper = new LegacyHelper();
@@ -20,6 +24,10 @@ export function mockWorkspace(opts: { bareScopeName?: string } = {}): WorkspaceD
     legacyHelper.scopeHelper.setNewLocalAndRemoteScopes();
   }
   legacyHelper.workspaceJsonc.setupDefault();
+  if (isDebugMode()) {
+    // eslint-disable-next-line no-console
+    console.log('workspace created at ', legacyHelper.scopes.localPath);
+  }
 
   return {
     workspacePath: legacyHelper.scopes.localPath,
@@ -31,13 +39,21 @@ export function mockWorkspace(opts: { bareScopeName?: string } = {}): WorkspaceD
 export function mockBareScope(remoteToAdd: string, scopeNameSuffix?: string) {
   const legacyHelper = new LegacyHelper();
   const { scopeName, scopePath } = legacyHelper.scopeHelper.getNewBareScope(scopeNameSuffix, undefined, remoteToAdd);
+  if (isDebugMode()) {
+    // eslint-disable-next-line no-console
+    console.log('base-scope created at ', scopePath);
+  }
+
   return { scopeName, scopePath };
 }
 
 /**
  * deletes the paths created by mockWorkspace. pass the results you got from `mockWorkspace()`
+ *
+ * to keep the workspace and the remote scope, run the tests with `--debug` flag.
  */
 export async function destroyWorkspace(workspaceData: WorkspaceData) {
+  if (isDebugMode()) return;
   const { workspacePath, remoteScopePath } = workspaceData;
   await Promise.all([workspacePath, remoteScopePath].map((_) => fs.remove(_)));
 }

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -321,7 +321,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
       this.getWorkspaceAspectResolver(stringIds, runtimeName)
     );
 
-    await this.linkIfMissingWorkspaceAspects(wsAspectDefs, workspaceCompsIds);
+    await this.linkIfMissingWorkspaceAspects(wsAspectDefs);
 
     // TODO: hard coded use the old approach and loading from the scope capsules
     // This is because right now loading from the ws node_modules causes issues in some cases
@@ -505,21 +505,21 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     return compact(requireableComponents);
   }
 
-  private async linkIfMissingWorkspaceAspects(aspects: AspectDefinition[], ids: ComponentID[]) {
-    let missingPaths = false;
-    const existsP = aspects.map(async (aspect) => {
-      const exist = await fs.pathExists(aspect.aspectPath);
-      if (!exist) {
-        missingPaths = true;
-      }
-    });
-    await Promise.all(existsP);
-    // TODO: this should be done properly by the install aspect by slot
-    if (missingPaths) {
-      const bitIds: ComponentID[] = ids.map((id) => id);
-      return linkToNodeModulesByIds(this.workspace, bitIds);
-    }
-    return Promise.resolve();
+  private async linkIfMissingWorkspaceAspects(aspects: AspectDefinition[]) {
+    const idsToLink = await Promise.all(
+      aspects.map(async (aspect) => {
+        if (!aspect.component)
+          throw new Error(`linkIfMissingWorkspaceAspects, aspect.component is missing for ${aspect.aspectPath}`);
+        const isInWs = await this.workspace.hasId(aspect.component.id);
+        if (!isInWs) return null;
+        const exist = await fs.pathExists(aspect.aspectPath);
+        if (!exist) return aspect.component.id;
+        return null;
+      })
+    );
+    const idsToLinkWithoutNull = compact(idsToLink);
+    if (!idsToLinkWithoutNull.length) return;
+    await linkToNodeModulesByIds(this.workspace, idsToLinkWithoutNull);
   }
 
   /**

--- a/scopes/workspace/workspace/workspace-component/component-status-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/component-status-loader.ts
@@ -54,7 +54,11 @@ export class ComponentStatusLoader {
    */
   async getComponentStatusById(id: ComponentID): Promise<ComponentStatusLegacy> {
     if (!this._componentsStatusCache[id.toString()]) {
-      this._componentsStatusCache[id.toString()] = await this.getStatus(id);
+      // don't do this: `this._componentsStatusCache[id.toString()] = await this.getStatus(id);`
+      // yes, it doesn't make sense right? turns out that "getStatus" can call `linkIfMissingWorkspaceAspects` which
+      // calls `linkToNodeModulesByIds` which deletes this cache. and makes this: `this._componentsStatusCache[id.toString()]` undefined.
+      const result = await this.getStatus(id);
+      this._componentsStatusCache[id.toString()] = result;
     }
     return this._componentsStatusCache[id.toString()];
   }


### PR DESCRIPTION
## Proposed Changes

- until now snap-from-scope supported only updating comp deps or adding new deps. this PR supports removing components/packages dependencies.
- clear components cache after linking. otherwise, mockComponents with more than one component fails to codemod (link-rewire).
- print the mocked workspace paths when `bit test` is running with `--debug` flag.
- don't try to "link" aspects that don't exist in the current workspace.
- don't clear the cache during link if no link was created.

