### PR TITLE
fix(merge-from-scope), show merge-snap-error if thrown and fix ts parser to not access the fs

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -319,6 +319,7 @@ export class MergingMain {
     try {
       mergeSnapResults = await getSnapOrTagResults();
     } catch (err: any) {
+      this.logger.error('failed running snap. mergeSnapError:', err);
       mergeSnapError = err;
       if (bitMapSnapshot) this.workspace.bitMap.restoreFromSnapshot(bitMapSnapshot);
     }

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -64,6 +64,7 @@ export type MergeFromScopeResult = {
   conflicts?: Array<{ id: ComponentID; files: string[]; config?: boolean }>; // relevant in case of diverge (currently possible only when merging from main to a lane)
   snappedIds?: ComponentID[]; // relevant in case of diverge (currently possible only when merging from main to a lane)
   mergedPreviously: ComponentID[];
+  mergeSnapError?: Error;
 };
 
 export class MergeLanesMain {
@@ -408,7 +409,8 @@ export class MergeLanesMain {
       this.scope.legacyScope.scopeImporter.shouldOnlyFetchFromCurrentLane = true;
 
       const result = await this.mergeLane(fromLaneId, toLaneId, options as MergeLaneOptions);
-      const { mergeSnapResults, leftUnresolvedConflicts, failedComponents, components } = result.mergeResults;
+      const { mergeSnapResults, leftUnresolvedConflicts, failedComponents, components, mergeSnapError } =
+        result.mergeResults;
 
       this.logger.debug(
         `found the following config conflicts: ${result.configMergeResults
@@ -434,12 +436,13 @@ export class MergeLanesMain {
       const snappedIds = mergeSnapResults?.snappedComponents.map((c) => c.id) || [];
 
       const laneToExport = await this.lanes.loadLane(toLaneId); // needs to be loaded again after the merge as it changed
-      const exportedIds = leftUnresolvedConflicts
-        ? []
-        : await exportIfNeeded(
-            idsToMerge.map((id) => id.changeVersion(undefined)),
-            laneToExport as Lane
-          );
+      const exportedIds =
+        leftUnresolvedConflicts || mergeSnapError
+          ? []
+          : await exportIfNeeded(
+              idsToMerge.map((id) => id.changeVersion(undefined)),
+              laneToExport as Lane
+            );
 
       return {
         mergedNow: merged,
@@ -451,6 +454,7 @@ export class MergeLanesMain {
         unmerged: failedComponents?.map((c) => ({ id: c.id, reason: c.unchangedMessage })) || [],
         conflicts,
         snappedIds,
+        mergeSnapError,
       };
     }
 

--- a/scopes/typescript/typescript/typescript.parser.ts
+++ b/scopes/typescript/typescript/typescript.parser.ts
@@ -72,7 +72,7 @@ export class TypeScriptParser implements Parser {
   }
 
   parseModule(modulePath: string, content?: string) {
-    const ast = ts.createSourceFile(modulePath, content || readFileSync(modulePath, 'utf8'), ts.ScriptTarget.Latest);
+    const ast = ts.createSourceFile(modulePath, content ?? readFileSync(modulePath, 'utf8'), ts.ScriptTarget.Latest);
 
     const moduleExports = this.getExports(ast);
     return moduleExports;


### PR DESCRIPTION
in case a file is empty.