### PR TITLE
feat(stash), make bit-stash work, add basic merge flags

### DIFF
--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -291,13 +291,24 @@ export class Component implements IComponent {
   }
 
   /**
-   * id.version can be either a version or a hash.
+   * id.version can be either a tag or a hash.
    * if it's a hash, it may have a tag point to it. if it does, return the tag.
    */
   getTag(): Tag | undefined {
     const currentVersion = this.id.version;
     if (!currentVersion) return undefined;
     return this.tags.byVersion(currentVersion) || this.tags.byHash(currentVersion);
+  }
+
+  /**
+   * id.version can be either a tag or a hash.
+   * if it's a tag, find the hash it points to.
+   */
+  getSnapHash(): string | undefined {
+    if (!this.id.hasVersion()) return undefined;
+    const tag = this.tags.byVersion(this.id.version);
+    if (tag) return tag.hash;
+    return this.id.version;
   }
 
   /**

--- a/scopes/component/stash/stash-data.ts
+++ b/scopes/component/stash/stash-data.ts
@@ -1,7 +1,6 @@
 import { ComponentID, ComponentIdObj } from '@teambit/component-id';
-import { Ref } from '@teambit/legacy/dist/scope/objects';
 
-export type StashCompData = { id: ComponentID; hash: Ref };
+export type StashCompData = { id: ComponentID; hash: string };
 export type StashCompDataWithIdObj = { id: ComponentIdObj; hash: string };
 export type StashMetadata = { message?: string };
 export type StashDataObj = {
@@ -16,9 +15,8 @@ export class StashData {
     return {
       metadata: this.metadata,
       stashCompsData: this.stashCompsData.map(({ id, hash }) => ({
-        // id: { scope: id.scope, name: id.fullName },
         id: id.changeVersion(undefined).toObject(),
-        hash: hash.toString(),
+        hash,
       })),
     };
   }
@@ -29,7 +27,7 @@ export class StashData {
         const id = ComponentID.fromObject(compData.id);
         return {
           id,
-          hash: Ref.from(compData.hash),
+          hash: compData.hash,
         };
       })
     );

--- a/scopes/component/stash/stash.cmd.ts
+++ b/scopes/component/stash/stash.cmd.ts
@@ -1,7 +1,10 @@
 // eslint-disable-next-line max-classes-per-file
 import chalk from 'chalk';
+import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
 import { Command, CommandOptions } from '@teambit/cli';
+import { CheckoutProps } from '@teambit/checkout';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
+import { BitError } from '@teambit/bit-error';
 import { StashMain } from './stash.main.runtime';
 
 export class StashSaveCmd implements Command {
@@ -31,17 +34,55 @@ export class StashSaveCmd implements Command {
   }
 }
 
+type StashLoadOpts = {
+  autoMergeResolve?: MergeStrategy;
+  manual?: boolean;
+  forceOurs?: boolean;
+  forceTheirs?: boolean;
+};
+
 export class StashLoadCmd implements Command {
   name = 'load';
   description = 'load latest stash, checkout components and delete stash';
   group = 'development';
-  options = [] as CommandOptions;
+  options = [
+    [
+      '',
+      'auto-merge-resolve <merge-strategy>',
+      'in case of merge conflict, resolve according to the provided strategy: [ours, theirs, manual]',
+    ],
+    [
+      '',
+      'manual',
+      'same as "--auto-merge-resolve manual". in case of merge conflict, write the files with the conflict markers',
+    ],
+    ['', 'force-ours', 'do not merge, preserve local files as is'],
+    ['', 'force-theirs', 'do not merge, just overwrite with incoming files'],
+  ] as CommandOptions;
   loader = true;
 
   constructor(private stash: StashMain) {}
 
-  async report() {
-    const compIds = await this.stash.loadLatest();
+  async report(_arg, { autoMergeResolve, forceOurs, forceTheirs, manual }: StashLoadOpts) {
+    if (forceOurs && forceTheirs) {
+      throw new BitError('please use either --force-ours or --force-theirs, not both');
+    }
+    if (
+      autoMergeResolve &&
+      autoMergeResolve !== 'ours' &&
+      autoMergeResolve !== 'theirs' &&
+      autoMergeResolve !== 'manual'
+    ) {
+      throw new BitError('--auto-merge-resolve must be one of the following: [ours, theirs, manual]');
+    }
+    if (manual) autoMergeResolve = 'manual';
+
+    const checkoutProps: CheckoutProps = {
+      mergeStrategy: autoMergeResolve,
+      forceOurs,
+      forceTheirs,
+    };
+    const compIds = await this.stash.loadLatest(checkoutProps);
     return chalk.green(`checked out ${compIds.length} components according to the latest stash`);
   }
 }
@@ -50,7 +91,6 @@ export class StashCmd implements Command {
   name = 'stash [sub-command]';
   description = 'EXPERIMENTAL (more like a POC). stash modified components';
   group = 'development';
-  private = true; // too early to make it public. it's still in a POC mode.
   options = [
     ['p', 'pattern', COMPONENT_PATTERN_HELP],
     ['m', 'message <string>', 'message to be attached to the stashed components'],

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -564,8 +564,8 @@ export default class CommandHelper {
     return this.runCmd('bit stash');
   }
 
-  stashLoad() {
-    return this.runCmd('bit stash load');
+  stashLoad(flags = '') {
+    return this.runCmd(`bit stash load ${flags}`);
   }
 
   isDeprecated(compName: string): boolean {


### PR DESCRIPTION
Until now, `bit stash` was a private-command and worked naively on a very basic use-case.
This PR makes this command usable and change it to be public.