### PR TITLE
chore: change back chokidar from "@teambit/chokidar" to chokidar

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,7 +141,7 @@
     "cacache": "15.0.5",
     "chalk": "2.4.2",
     "checksum": "0.1.1",
-    "@teambit/chokidar": "3.5.6",
+    "chokidar": "3.6.0",
     "cli-spinners": "1.3.1",
     "comment-json": "3.0.3",
     "core-js": "3.9.0",


### PR DESCRIPTION
We had to fork chokidar in the [past](https://github.com/teambit/bit/pull/7915) because no release was in the horizon. Now that a new version was released we can change it back to the original package.