### PR TITLE
fix(move), enable running "bit move" after manually moving a component on the fs

### DIFF
--- a/e2e/commands/move.e2e.1.ts
+++ b/e2e/commands/move.e2e.1.ts
@@ -77,4 +77,18 @@ describe('bit move command', function () {
       expect(output.includes('modified components')).to.be.false;
     });
   });
+  describe('move directory manually then run bit move', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFooAsDir();
+      helper.fixtures.tagComponentBarFoo();
+      helper.fs.moveSync('bar', 'baz');
+    });
+    it('should be able to run bit move with no error', () => {
+      expect(() => helper.command.move('bar', 'baz')).to.not.throw();
+      const bitmap = helper.bitMap.read();
+      expect(bitmap['bar/foo'].rootDir).to.equal('baz');
+    });
+  });
 });

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -200,26 +200,6 @@ export default class ComponentMap {
     this.validate();
   }
 
-  updateFileLocation(fileFrom: PathOsBased, fileTo: PathOsBased): PathChange[] {
-    fileFrom = pathNormalizeToLinux(fileFrom);
-    fileTo = pathNormalizeToLinux(fileTo);
-    const currentFile = this._findFile(fileFrom);
-    const changes = [];
-    if (currentFile) {
-      const rootDir = this.rootDir;
-      const newLocation = rootDir ? ComponentMap.getPathWithoutRootDir(rootDir, fileTo) : fileTo;
-      logger.debug(`updating file location from ${currentFile.relativePath} to ${newLocation}`);
-      if (this.mainFile === currentFile.relativePath) this.mainFile = newLocation;
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-      changes.push({ from: currentFile.relativePath, to: newLocation });
-      currentFile.relativePath = newLocation;
-      currentFile.name = path.basename(newLocation);
-    }
-    this.validate();
-    return changes;
-  }
-
   updateDirLocation(dirFrom: PathOsBasedRelative, dirTo: PathOsBasedRelative): PathChange[] {
     dirFrom = pathNormalizeToLinux(dirFrom);
     dirTo = pathNormalizeToLinux(dirTo);

--- a/src/consumer/component/exceptions/component-not-found-in-path.ts
+++ b/src/consumer/component/exceptions/component-not-found-in-path.ts
@@ -10,8 +10,8 @@ export default class ComponentNotFoundInPath extends BitError {
       path
     )}" was not found, the following options are available depending on the situation:
 1. if the component directory was deleted by mistake, you can restore it by running "bit checkout reset <component-id>".
-2. if the component-dir was renamed, you can use "bit move" to move it to the new location.
-3. if the component directory was deleted deliberately, you can remove it from the workspace by running "bit remove <component-id>".`);
+2. if the component-dir was renamed, you can use "bit move <old-dir> <new-dir>" to move it to the new location.
+3. if the component directory was deleted deliberately, you can remove the component from the workspace by running "bit remove <component-id>".`);
     this.code = 127;
     this.path = path;
     if (cause) this.cause = cause;


### PR DESCRIPTION
Currently, in this case it throws `ComponentNotFoundInPath` error. This PR let bit change the rootDir of the component in the `.bitmap` file.