### PR TITLE
fix, fix warning when exporting non-workspace components

### DIFF
--- a/e2e/commands/add.e2e.1.ts
+++ b/e2e/commands/add.e2e.1.ts
@@ -60,12 +60,13 @@ describe('bit add command', function () {
       output = helper.fixtures.addComponentBarFooAsDir();
       expect(output).to.contain('bar/foo');
     });
-    // @TODO: FIX ON HARMONY!
-    it.skip('Should print warning when trying to add file that is already tracked with different id and not add it as a new one', () => {
+    it('Should print warning when trying to add file that is already tracked with different id and not add it as a new one', () => {
       helper.fixtures.createComponentBarFoo();
       helper.fixtures.addComponentBarFooAsDir();
       output = helper.command.addComponent('bar -i bar/new');
-      expect(output).to.have.string('warning: files bar/foo.js already used by component: bar/foo');
+      expect(output).to.have.string(
+        `warning: files bar/foo.js already used by component: ${helper.scopes.remote}/bar/foo`
+      );
       const bitMap = helper.bitMap.read();
       expect(bitMap).to.not.have.property('bar/new');
     });
@@ -207,25 +208,6 @@ describe('bit add command', function () {
       const mainPath = path.join(helper.scopes.localPath, 'mainDir');
       const error = new MainFileIsDir(mainPath);
       helper.general.expectToThrow(addFunc, error);
-    });
-  });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('add file as lowercase and then re-add it as CamelCase', () => {
-    before(() => {
-      helper.scopeHelper.reInitLocalScope();
-      helper.fixtures.createComponentBarFoo();
-      helper.command.addComponent('bar', { i: 'bar/foo' });
-      fs.removeSync(path.join(helper.scopes.localPath, 'bar'));
-      helper.fs.createFile('Bar', 'foo.js');
-      helper.command.addComponent('Bar', { i: 'bar/foo' });
-    });
-    it('should update the files and the mainFile with the new case', () => {
-      const bitMap = helper.bitMap.read();
-      const componentMap = bitMap['bar/foo'];
-      expect(componentMap.files).to.have.lengthOf(1);
-      expect(componentMap.files[0].relativePath).to.equal('Bar/foo.js');
-      expect(componentMap.files[0].relativePath).to.not.equal('bar/foo.js');
-      expect(componentMap.mainFile).to.equal('Bar/foo.js');
     });
   });
   describe('add the main file when it was removed before', () => {

--- a/e2e/commands/import-all.e2e.1.ts
+++ b/e2e/commands/import-all.e2e.1.ts
@@ -11,8 +11,7 @@ describe('bit import command with no ids', function () {
   after(() => {
     helper.scopeHelper.destroy();
   });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('with a component in bit.map', () => {
+  describe('with a component in bit.map and --merge flag', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.createComponentBarFoo();
@@ -24,13 +23,11 @@ describe('bit import command with no ids', function () {
       helper.scopeHelper.addRemoteScope();
       helper.bitMap.write(bitMap);
     });
-    it('should display a successful message with the list of installed components', () => {
-      const output = helper.command.importAllComponents(true);
-      expect(output.includes('successfully imported one component')).to.be.true;
+    it('should throw an error and suggest using bit checkout reset', () => {
+      expect(() => helper.command.importAllComponents(true)).to.throw('checkout reset');
     });
   });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('with components in bit.map when they are modified locally', () => {
+  describe('with components in bit.map when they are modified locally', () => {
     let localScope;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
@@ -42,7 +39,7 @@ describe('bit import command with no ids', function () {
       helper.scopeHelper.reInitLocalScope();
       helper.scopeHelper.addRemoteScope();
       helper.bitMap.write(bitMap);
-      helper.command.importAllComponents(true);
+      helper.command.checkoutReset('--all');
       const barFooFixtureV2 = "module.exports = function foo() { return 'got foo v2'; };";
       helper.fs.createFile('bar', 'foo.js', barFooFixtureV2);
       localScope = helper.scopeHelper.cloneLocalScope();
@@ -58,34 +55,24 @@ describe('bit import command with no ids', function () {
       });
       it('should display a successful message', () => {
         expect(output).to.have.string('successfully imported');
-        expect(output).to.have.string('bar/foo');
       });
     });
     describe('with --override flag', () => {
-      let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
-        output = helper.command.runCmd('bit import --override');
       });
-      it('should display a successful message', () => {
-        expect(output).to.have.string('successfully imported');
-        expect(output).to.have.string('bar/foo');
-      });
-      it('should override them all', () => {
-        const statusOutput = helper.command.runCmd('bit status');
-        expect(statusOutput).to.not.have.string('modified components');
-        expect(statusOutput).to.not.have.string('bar/foo');
+      it('should throw an error and suggest using bit checkout reset', () => {
+        expect(() => helper.command.import('--override')).to.throw('checkout reset');
       });
     });
     describe('with --merge=manual flag', () => {
       let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
-        output = helper.command.runCmd('bit import --merge=manual');
+        output = helper.command.runCmd(`bit import ${helper.scopes.remote}/bar/foo --merge=manual`);
       });
       it('should display a successful message', () => {
         expect(output).to.have.string('successfully imported');
-        expect(output).to.have.string('bar/foo');
       });
       it('should show them as modified', () => {
         const statusOutput = helper.command.runCmd('bit status');
@@ -97,12 +84,11 @@ describe('bit import command with no ids', function () {
       before(() => {
         helper.scopeHelper.getClonedLocalScope(localScope);
         helper.command.tagAllComponents();
-        output = helper.command.runCmd('bit import --merge=manual');
+        output = helper.command.runCmd(`bit import ${helper.scopes.remote}/bar/foo --merge=manual`);
       });
       it('should display a successful message', () => {
         // before, it'd throw an error component-not-found as the tag exists only locally
         expect(output).to.have.string('successfully imported');
-        expect(output).to.have.string('bar/foo');
       });
     });
   });

--- a/e2e/commands/import.e2e.1.ts
+++ b/e2e/commands/import.e2e.1.ts
@@ -111,8 +111,7 @@ describe('bit import', function () {
         it('should throw an error', () => {
           expect(output).to.have.string('unable to import');
         });
-        // @TODO: FIX ON HARMONY!
-        it.skip('should import successfully if the --override flag is used', () => {
+        it('should import successfully if the --override flag is used', () => {
           output = helper.command.importComponent('global/simple --override');
           expect(componentFileLocation).to.be.a.file();
         });
@@ -134,8 +133,7 @@ describe('bit import', function () {
         it('should throw an error', () => {
           expect(output).to.have.string('unable to import');
         });
-        // @TODO: FIX ON HARMONY!
-        it.skip('should throw an error also when the --override flag is used', () => {
+        it('should throw an error also when the --override flag is used', () => {
           output = helper.general.runWithTryCatch(`bit import ${helper.scopes.remote}/global/simple --override`);
           expect(output).to.have.string('unable to import');
         });
@@ -191,8 +189,7 @@ describe('bit import', function () {
           it('should throw an error', () => {
             expect(output).to.have.string('unable to import');
           });
-          // @TODO: FIX ON HARMONY!
-          it.skip('should import successfully if the --override flag is used', () => {
+          it('should import successfully if the --override flag is used', () => {
             helper.command.runCmd(`bit import ${helper.scopes.remote}/global/simple -p my-custom-location --override`);
             expect(componentFileLocation).to.be.a.file();
           });
@@ -280,8 +277,7 @@ describe('bit import', function () {
       });
     });
   });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('with an existing component in bit.map (as author)', () => {
+  describe('with an existing component in bit.map (as author)', () => {
     let localConsumerFiles;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();

--- a/e2e/flows/cyclic-dependencies.e2e.2.ts
+++ b/e2e/flows/cyclic-dependencies.e2e.2.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import { IssuesClasses } from '@teambit/component-issues';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import * as fixtures from '../../src/fixtures/fixtures';
 
 const fixtureA = `const b = require('../b/b');
 console.log('got ' + b() + ' and got A')`;
@@ -86,31 +85,32 @@ describe('cyclic dependencies', function () {
       });
     });
   });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('a complex case with a long chain of dependencies', () => {
+  describe('a complex case with a long chain of dependencies', () => {
     let output;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       // isString => isType
-      helper.fs.createFile('utils', 'is-type.js', fixtures.isType);
-      helper.fs.createFile('utils', 'is-string.js', fixtures.isString);
-      helper.fixtures.addComponentUtilsIsType();
-      helper.fixtures.addComponentUtilsIsString();
+      helper.fixtures.createComponentIsType();
+      helper.fixtures.createComponentIsString();
+      helper.fixtures.addComponentUtilsIsTypeAsDir();
+      helper.fixtures.addComponentUtilsIsStringAsDir();
+      helper.command.linkAndRewire();
       helper.command.tagAllWithoutBuild();
 
       // A1 => A2 => A3 (leaf)
       // B1 => B2 => B3 => B4
       // A1 => B1, B2 => A1
       // B4 => is-string => is-type (leaf)
-      helper.fs.createFile('comp', 'A1.js', "const A2 = require('./A2'); const B1 = require ('./B1');");
-      helper.fs.createFile('comp', 'A2.js', "const A3 = require('./A3')");
-      helper.fs.createFile('comp', 'A3.js', "console.log('Im a leaf')");
-      helper.fs.createFile('comp', 'B1.js', "const B2 = require('./B2');");
-      helper.fs.createFile('comp', 'B2.js', "const B3 = require('./B3'); const A1 = require ('./A1');");
-      helper.fs.createFile('comp', 'B3.js', "const B4 = require('./B4')");
-      helper.fs.createFile('comp', 'B4.js', "const isString = require('../utils/is-string')");
-      helper.command.addComponent('comp/*.js', { n: 'comp' });
-      output = helper.command.tagAllWithoutBuild();
+      helper.fs.outputFile('comp/A1/index.js', "const A2 = require('../A2'); const B1 = require ('../B1');");
+      helper.fs.outputFile('comp/A2/index.js', "const A3 = require('../A3')");
+      helper.fs.outputFile('comp/A3/index.js', "console.log('Im a leaf')");
+      helper.fs.outputFile('comp/B1/index.js', "const B2 = require('../B2');");
+      helper.fs.outputFile('comp/B2/index.js', "const B3 = require('../B3'); const A1 = require ('../A1');");
+      helper.fs.outputFile('comp/B3/index.js', "const B4 = require('../B4')");
+      helper.fs.outputFile('comp/B4/index.js', "const isString = require('../../is-string/is-string')");
+      helper.command.addComponent('comp/**', { n: 'comp' });
+      helper.command.linkAndRewire();
+      output = helper.command.tagAllWithoutBuild('--ignore-issues="CircularDependencies"');
     });
     it('should be able to tag with no errors', () => {
       expect(output).to.have.string('7 component(s) tagged');
@@ -399,14 +399,15 @@ describe('cyclic dependencies', function () {
           const list = helper.command.listLocalScope();
           expect(list).to.have.string('comp/a1');
         });
-        it('should not show a clean workspace', () => {
-          helper.command.expectStatusToBeClean();
+        it('bit status should the circular dependency issue', () => {
+          const status = helper.command.status();
+          expect(status).to.have.string('issues found');
+          expect(status).to.have.string('circular dependencies');
         });
       });
     });
   });
-  // @TODO: FIX ON HARMONY!
-  describe.skip('same component require itself using module path (@bit/component-name)', () => {
+  describe('same component require itself using module path', () => {
     let tagOutput;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
@@ -415,7 +416,7 @@ describe('cyclic dependencies', function () {
       helper.command.tagAllWithoutBuild();
       helper.command.export();
       // after export, the author now has a link from node_modules.
-      helper.fixtures.createComponentBarFoo(`require('${helper.general.getRequireBitPath('bar', 'foo')}');`);
+      helper.fixtures.createComponentBarFoo(`require('@${helper.scopes.remote}/bar.foo');`);
       tagOutput = helper.command.tagAllWithoutBuild();
     });
     it('should tag successfully with no error', () => {

--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -110,8 +110,9 @@ describe('components that are not synced between the scope and the consumer', fu
       helper.command.init('--force');
       scopeOutOfSync = helper.scopeHelper.cloneLocalScope();
     });
-    // @TODO: FIX ON HARMONY!
-    // it should not show the component as staged because it is not in the bitmap.
+    // @todo: decide what needs to be done. currently, bit-status shows it as staged.
+    // the reason we don't blindly filter out components that are not in the bitmap is because the "delete"
+    // (soft-remove) feature, which snaps/tags after the component is deleted from the file-system.
     describe.skip('bit status', () => {
       let output;
       before(() => {
@@ -129,10 +130,7 @@ describe('components that are not synced between the scope and the consumer', fu
         expect(showFunc).to.not.throw();
       });
     });
-    // @TODO: FIX ON HARMONY!
-    // currently it throws MissingBitMapComponent because the component is not in the bitmap and is staged.
-    // it should probably show "nothing to export"
-    describe.skip('bit export all', () => {
+    describe('bit export all', () => {
       let output;
       before(() => {
         helper.scopeHelper.getClonedLocalScope(scopeOutOfSync);

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -499,7 +499,9 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
       return emptyResult;
     }
     if (!this.options.objectsOnly) {
-      throw new Error(`bit import with no ids and --merge flag was not implemented yet`);
+      const flagUsed = this.options.merge ? '--merge' : '--override';
+      throw new Error(`bit import with no ids and ${flagUsed} flag is not supported.
+to write the components from .bitmap file according to the their remote, please use "bit checkout reset --all"`);
     }
     const versionDependenciesArr = await this._importComponentsObjects(componentsIdsToImport, {
       fromOriginalScope: this.options.fromOriginalScope,

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -758,9 +758,7 @@ export default class BitMap {
 
   /**
    * needed after exporting or tagging a component.
-   * We don't support export/tag of nested components, only authored or imported. For authored/imported components, could be
-   * in the file-system only one instance with the same component-name. As a result, we can strip the
-   * scope-name and the version, find the older version in bit.map and update the id with the new one.
+   * find the older version in bit.map and update the id with the new one.
    */
   updateComponentId(
     id: ComponentID,


### PR DESCRIPTION
Also, suggest `bit checkout reset --all` when running `bit import --merge` or `bit import --override`.