### PR TITLE
improve the error when running bit-show when no host is available

### DIFF
--- a/e2e/flows/remote-commands-outside-workspace.e2e.2.ts
+++ b/e2e/flows/remote-commands-outside-workspace.e2e.2.ts
@@ -42,11 +42,13 @@ describe('bit remote command', function () {
       const output = helper.command.listRemoteScope(false);
       expect(output).to.have.string('found 1 components');
     });
-    // @TODO: FIX ON HARMONY!
-    // it was showing the old show.
-    it.skip('bit show should show the component and not throw an error about missing workspace', () => {
-      const output = helper.command.showComponent(`${helper.scopes.remote}/bar/foo --remote`);
+    it('bit show --legacy should show the component and not throw an error about missing workspace', () => {
+      const output = helper.command.showComponent(`${helper.scopes.remote}/bar/foo --legacy --remote`);
       expect(output).to.have.string('bar/foo');
+    });
+    it('bit show without --legacy should throw a descriptive error', () => {
+      const cmd = () => helper.command.showComponent(`${helper.scopes.remote}/bar/foo --remote`);
+      expect(cmd).to.throw('error: the current directory is not a workspace nor a scope');
     });
     describe('bit remove with --remote flag', () => {
       let output;

--- a/scopes/component/component/component.main.runtime.ts
+++ b/scopes/component/component/component.main.runtime.ts
@@ -106,6 +106,15 @@ export class ComponentMain {
     return this.getPriorHost();
   }
 
+  getHostIfExist(id?: string): ComponentFactory | undefined {
+    try {
+      return this.getHost(id);
+    } catch (err) {
+      if (err instanceof HostNotFound) return undefined;
+      throw err;
+    }
+  }
+
   getRoute(id: ComponentID, routeName: string) {
     return `/api/${id.toString()}/~aspect/${routeName}`;
   }

--- a/scopes/component/component/show/show.cmd.ts
+++ b/scopes/component/component/show/show.cmd.ts
@@ -30,7 +30,10 @@ export class ShowCmd implements Command {
   private async getComponent(idStr: string, remote: boolean) {
     if (remote) {
       const id = ComponentID.fromString(idStr); // user used --remote so we know it has a scope
-      const host = this.component.getHost('teambit.scope/scope');
+      const host = this.component.getHostIfExist('teambit.scope/scope');
+      if (!host)
+        throw new Error(`error: the current directory is not a workspace nor a scope. the full "bit show" is not supported.
+to see the legacy bit show, please use "--legacy" flag`);
       if (!host.getRemoteComponent) {
         throw new Error('Component Host does not implement getRemoteComponent()');
       }


### PR DESCRIPTION
until now it was throwing `[component] error: host 'teambit.scope/scope' was not found` which is very confusing. 
