### PR TITLE
fix, clear cache when unmerged.json file is changed

### DIFF
--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -262,6 +262,7 @@ export class APIForIDE {
   }
   async clearCache() {
     await this.workspace.clearCache();
+    this.workspace.clearAllComponentsCache();
   }
 
   async install(options = {}) {

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -11,6 +11,7 @@ import { pathNormalizeToLinux } from '@teambit/legacy/dist/utils';
 import mapSeries from 'p-map-series';
 import chalk from 'chalk';
 import { ChildProcess } from 'child_process';
+import { UNMERGED_FILENAME } from '@teambit/legacy/dist/scope/lanes/unmerged-components';
 import chokidar, { FSWatcher } from '@teambit/chokidar';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
@@ -185,6 +186,10 @@ export class Watcher {
       }
       if (filePath.endsWith(WORKSPACE_JSONC)) {
         await this.workspace.triggerOnWorkspaceConfigChange();
+        return { results: [], files: [filePath] };
+      }
+      if (filePath.endsWith(UNMERGED_FILENAME)) {
+        await this.workspace.clearCache();
         return { results: [], files: [filePath] };
       }
       const componentId = this.getComponentIdByPath(filePath);
@@ -385,7 +390,7 @@ export class Watcher {
     // const useFsEventsConf = await this.watcherMain.globalConfig.get(CFG_WATCH_USE_FS_EVENTS);
     // const useFsEvents = useFsEventsConf === 'true';
     const ignoreLocalScope = (pathToCheck: string) => {
-      if (pathToCheck.startsWith(this.ipcEventsDir)) return false;
+      if (pathToCheck.startsWith(this.ipcEventsDir) || pathToCheck.endsWith(UNMERGED_FILENAME)) return false;
       return (
         pathToCheck.startsWith(`${this.workspace.path}/.git/`) || pathToCheck.startsWith(`${this.workspace.path}/.bit/`)
       );

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -746,6 +746,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
   }
 
   clearAllComponentsCache() {
+    this.logger.debug('clearing all components caches');
     this.componentLoader.clearCache();
     this.consumer.componentLoader.clearComponentsCache();
     this.componentStatusLoader.clearCache();

--- a/src/scope/lanes/unmerged-components.ts
+++ b/src/scope/lanes/unmerged-components.ts
@@ -52,7 +52,7 @@ export type UnmergedComponent = {
   mergedConfig?: Record<string, any>;
 };
 
-const UNMERGED_FILENAME = 'unmerged.json';
+export const UNMERGED_FILENAME = 'unmerged.json';
 
 export default class UnmergedComponents {
   filePath: string;

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -59,11 +59,15 @@ export default class Repository {
 
   static async load({ scopePath, scopeJson }: { scopePath: string; scopeJson: ScopeJson }): Promise<Repository> {
     const repository = new Repository(scopePath, scopeJson);
-    const scopeIndex = await repository.loadOptionallyCreateScopeIndex();
-    repository.scopeIndex = scopeIndex;
-    repository.remoteLanes = new RemoteLanes(scopePath);
-    repository.unmergedComponents = await UnmergedComponents.load(scopePath);
+    await repository.init();
     return repository;
+  }
+
+  async init() {
+    const scopeIndex = await this.loadOptionallyCreateScopeIndex();
+    this.scopeIndex = scopeIndex;
+    this.remoteLanes = new RemoteLanes(this.scopePath);
+    this.unmergedComponents = await UnmergedComponents.load(this.scopePath);
   }
 
   static async create({ scopePath, scopeJson }: { scopePath: string; scopeJson: ScopeJson }): Promise<Repository> {
@@ -432,7 +436,7 @@ export default class Repository {
   async clearCache() {
     logger.debug('repository.clearCache');
     this.cache.deleteAll();
-    await this.reLoadScopeIndex();
+    await this.init();
   }
   clearObjectsFromCache() {
     logger.debug('repository.clearObjectsFromCache');


### PR DESCRIPTION
Also, when clearing the cache, reload this unmerged.json file. 
With these changes, watchers such as "bit server" are up to date with this components during-merge.