### PR TITLE
feat(cli), introduce "wait" handler for commands that never exit

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -85,14 +85,13 @@ export class ApiServerMain {
     const port = options.port || 3000;
     const server = await this.express.listen(port);
 
-    // never ending promise to not exit the process (is there a better way?)
     return new Promise((resolve, reject) => {
       server.on('error', (err) => {
         reject(err);
       });
       server.on('listening', () => {
         this.logger.consoleSuccess(`Bit Server is listening on port ${port}`);
-        resolve('success');
+        resolve(true);
       });
     });
   }

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -92,6 +92,7 @@ export class ApiServerMain {
       });
       server.on('listening', () => {
         this.logger.consoleSuccess(`Bit Server is listening on port ${port}`);
+        resolve('success');
       });
     });
   }

--- a/scopes/harmony/api-server/server.cmd.ts
+++ b/scopes/harmony/api-server/server.cmd.ts
@@ -15,8 +15,7 @@ export class ServerCmd implements Command {
 
   constructor(private apiServer: ApiServerMain) {}
 
-  async report(args, options: { port: number; compile: boolean }): Promise<string> {
+  async wait(args, options: { port: number; compile: boolean }) {
     await this.apiServer.runApiServer(options);
-    return 'server is running successfully'; // should never get here, the previous line is blocking
   }
 }

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -30,6 +30,9 @@ export class CommandRunner {
       if (this.command.report) {
         return await this.runReportHandler();
       }
+      if (this.command.wait) {
+        return await this.runWaitHandler();
+      }
     } catch (err: any) {
       return handleErrorAndExit(err, this.commandName);
     }
@@ -93,6 +96,11 @@ export class CommandRunner {
     const data = typeof result === 'string' ? result : result.data;
     const exitCode = typeof result === 'string' ? 0 : result.code;
     return this.writeAndExit(`${data}\n`, exitCode);
+  }
+
+  private async runWaitHandler() {
+    if (!this.command.wait) throw new Error('runReportHandler expects command.wait to be implemented');
+    await this.command.wait(this.args, this.flags);
   }
 
   /**

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -112,6 +112,13 @@ export interface Command {
   report?(args: CLIArgs, flags: Flags): Promise<string | Report>;
 
   /**
+   * Command handler which never exits the process
+   * @param args  - arguments object as defined in name.
+   * @param flags - command flags as described in options.
+   */
+  wait?(args: CLIArgs, flags: Flags): Promise<void>;
+
+  /**
    * Optional handler to provide a raw result of the command.
    * Will be go called if '-j'/'--json' option is provided by user.
    * @param args  - arguments object as defined in name.

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -104,7 +104,8 @@ export interface Command {
   render?(args: CLIArgs, flags: Flags): Promise<RenderResult | React.ReactElement>;
 
   /**
-   * Command handler which is called for legacy commands or when process.isTTY is false
+   * Command handler which prints the return value to the console and exits.
+   * If the command has both, `render` and `report`, this one will be called when process.isTTY is false.
    * @param args  - arguments object as defined in name.
    * @param flags - command flags as described in options.
    * @return - Report object. The Report.data is printed to the stdout as is.


### PR DESCRIPTION
Some commands should never exit. Such as `bit watch` or `bit server` that helps IDE to communicate with bit.
Instead of hacking the `report` handler by waiting for the promise forever, this PR adds a new handler `wait`, which never exits the process. 