### PR TITLE
refactor, extract createSymlinkOrCopy to a new component teambit.toolbox/fs/link-or-symlink

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -591,6 +591,14 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/toolbox/fs/hard-link-directory"
     },
+    "fs/link-or-symlink": {
+        "name": "fs/link-or-symlink",
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.toolbox",
+        "mainFile": "index.ts",
+        "rootDir": "scopes/toolbox/fs/link-or-symlink"
+    },
     "fs/linked-dependencies": {
         "name": "fs/linked-dependencies",
         "scope": "teambit.dependencies",

--- a/scopes/dependencies/dependency-resolver/package-manager-legacy.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager-legacy.ts
@@ -4,7 +4,7 @@
 import { Capsule } from '@teambit/isolator';
 import { Logger } from '@teambit/logger';
 import { pipeOutput } from '@teambit/legacy/dist/utils/child_process';
-import createSymlinkOrCopy from '@teambit/legacy/dist/utils/fs/create-symlink-or-copy';
+import { createLinkOrSymlink } from '@teambit/toolbox.fs.link-or-symlink';
 import { EventEmitter } from 'events';
 import execa from 'execa';
 import fs from 'fs-extra';
@@ -133,5 +133,5 @@ function linkBitLegacyInCapsule(capsule) {
   // that the capusle fs does not deal with well (eg. identifying and deleting
   // a symlink rather than the what the symlink links to)
   fs.removeSync(bitLegacyPath);
-  createSymlinkOrCopy(localBitLegacyPath, bitLegacyPath);
+  createLinkOrSymlink(localBitLegacyPath, bitLegacyPath);
 }

--- a/scopes/dependencies/fs/linked-dependencies/linked-dependencies.ts
+++ b/scopes/dependencies/fs/linked-dependencies/linked-dependencies.ts
@@ -1,8 +1,8 @@
 import path from 'path';
-import { createSymlinkOrCopy } from '@teambit/legacy/dist/utils';
+import { createLinkOrSymlink } from '@teambit/toolbox.fs.link-or-symlink';
 
 type CreateLinksOpts = {
-  componentId?: string | null | undefined;
+  componentId?: string;
   avoidHardLink?: boolean;
   skipIfSymlinkValid?: boolean;
 };
@@ -11,7 +11,7 @@ export async function createLinks(rootDir: string, linkedDeps: Record<string, st
   const modulesDir = path.join(rootDir, 'node_modules');
   await Promise.all(
     Object.entries(linkedDeps).map(([packageName, linkPath]) =>
-      createSymlinkOrCopy(
+      createLinkOrSymlink(
         linkPath.substring(5),
         path.join(modulesDir, packageName),
         opts.componentId,

--- a/scopes/toolbox/fs/link-or-symlink/index.ts
+++ b/scopes/toolbox/fs/link-or-symlink/index.ts
@@ -1,0 +1,1 @@
+export { createLinkOrSymlink } from './create-link-or-symlink';

--- a/src/e2e-helper/e2e-scope-helper.ts
+++ b/src/e2e-helper/e2e-scope-helper.ts
@@ -4,10 +4,10 @@ import fs from 'fs-extra';
 import * as path from 'path';
 import * as yaml from 'yaml';
 import * as ini from 'ini';
+import { createLinkOrSymlink } from '@teambit/toolbox.fs.link-or-symlink';
 import { IS_WINDOWS } from '../constants';
 import { InteractiveInputs } from '../interactive/utils/run-interactive-cmd';
 import { generateRandomStr } from '../utils';
-import createSymlinkOrCopy from '../utils/fs/create-symlink-or-copy';
 import CommandHelper from './e2e-command-helper';
 import FsHelper from './e2e-fs-helper';
 import NpmHelper from './e2e-npm-helper';
@@ -285,6 +285,6 @@ export default class ScopeHelper {
     console.log('aspectsRoot', aspectsRoot);
     console.log('localAspectsRoot', localAspectsRoot);
     fs.removeSync(aspectsRoot);
-    createSymlinkOrCopy(localAspectsRoot, aspectsRoot);
+    createLinkOrSymlink(localAspectsRoot, aspectsRoot);
   }
 }

--- a/src/links/symlink.ts
+++ b/src/links/symlink.ts
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import * as path from 'path';
 import { ComponentID } from '@teambit/component-id';
-import createSymlinkOrCopy from '../utils/fs/create-symlink-or-copy';
+import { createLinkOrSymlink } from '@teambit/toolbox.fs.link-or-symlink';
 
 export default class Symlink {
   src: string; // current existing path
@@ -13,12 +13,7 @@ export default class Symlink {
     this.componentId = componentId;
   }
   write() {
-    return createSymlinkOrCopy(
-      this.src,
-      this.dest,
-      this.componentId ? this.componentId.toString() : null,
-      this.avoidHardLink
-    );
+    return createLinkOrSymlink(this.src, this.dest, this.componentId?.toString(), this.avoidHardLink);
   }
 
   /**

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -3,7 +3,6 @@ import sha1 from './encryption/sha1';
 import * as eol from './eol';
 import writeFile from './fs-write-file';
 import { checksum, checksumFile } from './checksum';
-import createSymlinkOrCopy from './fs/create-symlink-or-copy';
 import calculateFileInfo from './fs/file-info';
 import getWithoutExt from './fs/fs-no-ext';
 import getExt from './fs/get-ext';
@@ -64,7 +63,6 @@ export {
   cleanObject,
   readDirIgnoreDsStore,
   readDirSyncIgnoreDsStore,
-  createSymlinkOrCopy,
   cleanBang,
   prependBang,
   isBitUrl,


### PR DESCRIPTION
The name is changed as well because it doesn't do copy anymore. It only links (hard) or symlink. 