### PR TITLE
fix(sign), do not try to update VersionHistory during bit sign

### DIFF
--- a/src/scope/component-ops/export-scope-components.ts
+++ b/src/scope/component-ops/export-scope-components.ts
@@ -66,7 +66,9 @@ export async function saveObjects(scope: Scope, objectList: ObjectList): Promise
   ];
   scope.objects.validateObjects(true, allObjects);
   await scope.objects.writeObjectsToTheFS(allObjects);
-  logger.debugAndAddBreadCrumb('exportManyBareScope', 'objects were written successfully to the filesystem');
+  logger.debug(
+    `export-scope-components.saveObjects, ${allObjects.length} objects were written successfully to the filesystem`
+  );
 
   return mergedIds;
 }
@@ -83,6 +85,15 @@ async function updateVersionHistory(
   mergedComponents: ModelComponent[],
   versionObjects: Version[]
 ): Promise<VersionHistory[]> {
+  if (!mergedComponents.length) {
+    // this is important for bit-sign to not try to update VersionHistory and then error due to missing components
+    logger.debug('updateVersionHistory, no components were merged, no need to update VersionHistory');
+    return [];
+  }
+  logger.debug(
+    `updateVersionHistory, total components: ${mergedComponents.length}, total versions: ${versionObjects.length}`
+  );
+
   const versionsWithComponentId = versionObjects.filter((obj) => obj.origin?.id);
 
   const [versionsWithOrigin, versionWithoutOrigin] = partition(versionsWithComponentId, (v) => v.origin?.id);

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -1174,6 +1174,7 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
   async updateVersionHistory(repo: Repository, versions: Version[]): Promise<VersionHistory> {
     const versionHistory = await this.getVersionHistory(repo);
     versionHistory.addFromVersionsObjects(versions);
+    logger.debug(`updating version history of ${this.id()} with ${versions.length} versions`);
     return versionHistory;
   }
 
@@ -1215,6 +1216,9 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
         return { err, added };
       }
       versionHistory.addFromVersionsObjects(versionsToAdd);
+      logger.debug(
+        `populateVersionHistoryIfMissingGracefully, updating ${this.id()} with ${versionsToAdd.length} versions`
+      );
       await repo.writeObjectsToTheFS([versionHistory]);
       return { added };
     });

--- a/src/scope/repositories/sources.ts
+++ b/src/scope/repositories/sources.ts
@@ -79,7 +79,7 @@ export default class SourceRepository {
     if (!ids.length) return [];
     const concurrency = concurrentComponentsLimit();
     logger.trace(`sources.getMany, Ids: ${ids.join(', ')}`);
-    logger.debug(`sources.getMany, ${ids.length} Ids`);
+    logger.trace(`sources.getMany, ${ids.length} Ids`);
     return pMapPool(
       ids,
       async (id) => {


### PR DESCRIPTION
Otherwise, it'll log confusing errors about missing Component objects.
Also, add some logs around the update of VersionHistory to debug issues with the remotes when some data is missing.