### PR TITLE
fix(snap), import VersionHistory when ParentNotFound is thrown

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -39,7 +39,12 @@ import {
   ArtifactSource,
   getArtifactsFiles,
 } from '@teambit/legacy/dist/consumer/component/sources/artifact-files';
-import { VersionNotFound, ComponentNotFound, HeadNotFound } from '@teambit/legacy/dist/scope/exceptions';
+import {
+  VersionNotFound,
+  ComponentNotFound,
+  HeadNotFound,
+  ParentNotFound,
+} from '@teambit/legacy/dist/scope/exceptions';
 import { AutoTagResult } from '@teambit/legacy/dist/scope/component-ops/auto-tag';
 import { DependenciesAspect, DependenciesMain } from '@teambit/dependencies';
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
@@ -798,7 +803,12 @@ there are matching among unmodified components thought. consider using --unmodif
             : await this.scope.legacyScope.isPartOfMainHistory(dep.id);
         } catch (err) {
           if (throwForMissingObjects) throw err;
-          if (err instanceof VersionNotFound || err instanceof ComponentNotFound || err instanceof HeadNotFound) {
+          if (
+            err instanceof VersionNotFound ||
+            err instanceof ComponentNotFound ||
+            err instanceof HeadNotFound ||
+            err instanceof ParentNotFound
+          ) {
             missingDeps.push(dep.id);
             return;
           }


### PR DESCRIPTION
In some cases, when snapping it throws "component X missing data. parent <hash> of version <hash> was not found.".
This PR fixes it by adding this type of error to the catch statement that aggregate all these components and import them with their VersionHistory.