### PR TITLE
fix(import-dependents), fix algorithm to get some missing paths

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -382,19 +382,26 @@ describe('import functionality on Harmony', function () {
     // create the following graph:
     // comp1 -> comp2 -> comp3 -> comp4
     // comp1 -> comp-a -> comp4
+    // comp1 -> comp-a2 -> comp3 -> comp4
     // comp1 -> comp-b
     before(() => {
       helper = new Helper();
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(4);
       helper.fs.outputFile('comp-a/index.js', `require('${helper.general.getPackageNameByCompName('comp4', false)}');`);
+      helper.fs.outputFile(
+        'comp-a2/index.js',
+        `require('${helper.general.getPackageNameByCompName('comp3', false)}');`
+      );
       helper.fs.outputFile('comp-b/index.js');
       helper.command.addComponent('comp-a');
       helper.command.addComponent('comp-b');
+      helper.command.addComponent('comp-a2');
       helper.command.compile();
       helper.fs.appendFile(
         'comp1/index.js',
-        `\nrequire('${helper.general.getPackageNameByCompName('comp-a', false)}');`
+        `\nrequire('${helper.general.getPackageNameByCompName('comp-a', false)}');
+        require('${helper.general.getPackageNameByCompName('comp-a2', false)}')`
       );
       helper.fs.appendFile(
         'comp1/index.js',
@@ -415,6 +422,7 @@ describe('import functionality on Harmony', function () {
       expect(bitMap).to.have.property('comp3');
       expect(bitMap).to.have.property('comp4');
       expect(bitMap).to.have.property('comp-a');
+      expect(bitMap).to.have.property('comp-a2');
       expect(bitMap).to.not.have.property('comp-b');
     });
     it('with --dependents-via should limit to graph traversing through the given id', () => {

--- a/scopes/component/graph/component-id-graph.ts
+++ b/scopes/component/graph/component-id-graph.ts
@@ -94,32 +94,33 @@ export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
     through?: ComponentID[]
   ): string[][] {
     const removeVerFromIdStr = (idStr: string) => idStr.split('@')[0];
-    const targetsStr = targets.map((t) => t.toStringWithoutVersion());
 
-    const traverseDFS = (
-      node: string,
-      visitedInPath: string[],
-      visitedInGraph: string[] = [],
-      allPaths: string[][]
-    ) => {
-      if (visitedInPath.includes(node)) return;
-      visitedInPath.push(node);
-      if (targetsStr.includes(removeVerFromIdStr(node))) {
-        allPaths.push(visitedInPath);
-        return;
+    const findAllPathsBFS = (start: string[], end: string[]): string[][] => {
+      const paths: string[][] = [];
+      const visited = new Set<string>();
+      const queue: { node: string; path: string[] }[] = [];
+      start.forEach((s) => queue.push({ node: s, path: [s] }));
+      while (queue.length) {
+        const { node, path } = queue.shift()!;
+        visited.add(node);
+        if (end.includes(removeVerFromIdStr(node))) {
+          paths.push([...path]);
+        } else {
+          const successors = this.outEdges(node).map((e) => e.targetId);
+          for (const successor of successors) {
+            if (!visited.has(successor)) {
+              queue.push({ node: successor, path: [...path, successor] });
+            }
+          }
+        }
       }
-      if (visitedInGraph.includes(node)) return;
-      visitedInGraph.push(node);
-      const successors = Array.from(this.successorMap(node).values());
-      successors.forEach((s) => {
-        traverseDFS(s.id, [...visitedInPath], visitedInGraph, allPaths);
-      });
+      return paths;
     };
 
-    let allPaths: string[][] = [];
-    sources.forEach((source) => {
-      traverseDFS(source.toString(), [], [], allPaths);
-    });
+    const targetsStr = targets.map((t) => t.toStringWithoutVersion());
+    const sourcesStr = sources.map((s) => s.toString());
+
+    let allPaths = findAllPathsBFS(sourcesStr, targetsStr);
 
     if (through?.length) {
       allPaths = allPaths.filter((pathWithVer) => {
@@ -128,7 +129,6 @@ export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
       });
     }
 
-    const sourcesStr = sources.map((s) => s.toString());
     const filtered = allPaths.filter((path) => {
       if (path.length < 3) {
         // if length is 1, the source and target are the same.

--- a/scopes/component/graph/component-id-graph.ts
+++ b/scopes/component/graph/component-id-graph.ts
@@ -102,10 +102,10 @@ export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
       start.forEach((s) => queue.push({ node: s, path: [s] }));
       while (queue.length) {
         const { node, path } = queue.shift()!;
-        visited.add(node);
         if (end.includes(removeVerFromIdStr(node))) {
           paths.push([...path]);
         } else {
+          visited.add(node);
           const successors = this.outEdges(node).map((e) => e.targetId);
           for (const successor of successors) {
             if (!visited.has(successor)) {

--- a/scopes/scope/importer/dependents-getter.ts
+++ b/scopes/scope/importer/dependents-getter.ts
@@ -23,7 +23,7 @@ export class DependentsGetter {
 
   async getDependents(targetCompIds: ComponentID[]): Promise<ComponentID[]> {
     this.logger.setStatusLine('finding dependents');
-    const { silent } = this.options;
+    const { silent, dependentsAll } = this.options;
     const graph = await this.graph.getGraphIds();
     const sourceIds = this.workspace.listIds();
     const getIdsForThrough = () => {
@@ -34,7 +34,7 @@ export class DependentsGetter {
         .map((id) => ComponentID.fromString(id));
     };
     const allPaths = graph.findAllPathsFromSourcesToTargets(sourceIds, targetCompIds, getIdsForThrough());
-    const selectedPaths = silent ? allPaths : await this.promptDependents(allPaths);
+    const selectedPaths = silent || dependentsAll ? allPaths : await this.promptDependents(allPaths);
     const uniqAsStrings = uniq(selectedPaths.flat());
 
     const ids: ComponentID[] = [];

--- a/scopes/scope/importer/dependents-getter.ts
+++ b/scopes/scope/importer/dependents-getter.ts
@@ -72,7 +72,7 @@ export class DependentsGetter {
     this.logger.clearStatusLine();
 
     const totalToShow = SHOW_ALL_PATHS_LIMIT;
-    if (allPaths.length >= totalToShow) {
+    if (allPaths.length > totalToShow) {
       return this.promptLevelByLevel(allPaths);
     }
     const firstItems = allPaths.slice(0, totalToShow);

--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -51,6 +51,7 @@ export type ImportOptions = {
   importDependenciesDirectly?: boolean; // default: false, normally it imports them as packages, not as imported
   importDependents?: boolean;
   dependentsVia?: string;
+  dependentsAll?: boolean;
   silent?: boolean; // don't show prompt for --dependents flag
   fromOriginalScope?: boolean; // default: false, otherwise, it fetches flattened dependencies from their dependents
   saveInLane?: boolean; // save the imported component on the current lane (won't be available on main)
@@ -442,7 +443,8 @@ bit import ${idsFromRemote.map((id) => id.toStringWithoutVersion()).join(' ')}`)
     const bitIds: ComponentID[] = this.options.lanes
       ? await this.getBitIdsForLanes()
       : await this.getBitIdsForNonLanes();
-    const shouldImportDependents = this.options.importDependents || this.options.dependentsVia;
+    const shouldImportDependents =
+      this.options.importDependents || this.options.dependentsVia || this.options.dependentsAll;
     if (this.options.importDependenciesDirectly || shouldImportDependents) {
       if (this.options.importDependenciesDirectly) {
         const dependenciesIds = await this.getFlattenedDepsUnique(bitIds);

--- a/scopes/scope/importer/import.cmd.ts
+++ b/scopes/scope/importer/import.cmd.ts
@@ -31,6 +31,7 @@ type ImportFlags = {
   dependents?: boolean;
   dependentsDryRun?: boolean;
   dependentsVia?: string;
+  dependentsAll?: boolean;
   silent?: boolean;
   allHistory?: boolean;
   fetchDeps?: boolean;
@@ -84,6 +85,11 @@ export class ImportCmd implements Command {
       '',
       'dependents-via <string>',
       'same as --dependents except the traversal must go through the specified component. to specify multiple components, wrap with quotes and separate by a comma',
+    ],
+    [
+      '',
+      'dependents-all',
+      'same as --dependents except not prompting for selecting paths but rather selecting all paths and showing final confirmation before importing',
     ],
     [
       '',
@@ -214,6 +220,7 @@ export class ImportCmd implements Command {
       dependentsDryRun = false,
       silent,
       dependentsVia,
+      dependentsAll,
       allHistory = false,
       fetchDeps = false,
       trackOnly = false,
@@ -268,6 +275,7 @@ export class ImportCmd implements Command {
       importDependenciesDirectly: dependencies,
       importDependents: dependents,
       dependentsVia,
+      dependentsAll,
       silent,
       allHistory,
       fetchDeps,


### PR DESCRIPTION
Still, this is not a complete list of all paths, which can be huge and take very long to calculate (it's an NP-Hard problem).
To be able to run it in a reasonable amount of time, it's using "visitor" which helps to run each node only once. 
However, this visitor caused a bug in the following scenario: 
A -> B1 -> D -> E
A -> B2 -> D -> E
The traversal was done using DFS, so it started with A -> B1 all the way to E. Then, because D is already visited, it was skipping the other path [A, B2, D, E]. 

This PR uses BFS instead and the check for visited is done before adding to the queue. 
The end result is not only more paths, but also shorter and more relevant paths due to the BFS nature.  