### PR TITLE
temporarily ignore ts errors for Link and Handle

### DIFF
--- a/components/renderers/react/react.renderer.tsx
+++ b/components/renderers/react/react.renderer.tsx
@@ -5,7 +5,9 @@ import { APINodeDetails } from '@teambit/api-reference.renderers.api-node-detail
 import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
 import classnames from 'classnames';
 import { TagName } from '@teambit/semantics.entities.semantic-schema';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 import styles from './react.renderer.module.scss';
 
@@ -161,6 +163,7 @@ function ReactOverviewComponent(props: APINodeRenderProps) {
   const description =
     api.doc?.comment ??
     api?.doc?.tags?.filter((tag) => tag.comment).reduce((acc, tag) => acc.concat(`${tag.comment}\n` ?? ''), '');
+
   return (
     <div className={styles.reactOverview}>
       <div className={styles.reactOverviewHeader}>

--- a/components/renderers/schema-nodes-index/schema-nodes-index.tsx
+++ b/components/renderers/schema-nodes-index/schema-nodes-index.tsx
@@ -4,9 +4,12 @@ import classnames from 'classnames';
 import { classes } from '@teambit/design.ui.surfaces.menu.item';
 import flatten from 'lodash.flatten';
 import { trackedElementClassName } from '@teambit/api-reference.renderers.schema-node-member-summary';
-import { useLocation, Link } from '@teambit/base-react.navigation.link';
+import { useLocation, Link as BaseLink } from '@teambit/base-react.navigation.link';
 
 import styles from './schema-nodes-index.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type SchemaNodesIndexProps = {
   title?: string;

--- a/components/ui/component-filters/env-filter/envs-filter.tsx
+++ b/components/ui/component-filters/env-filter/envs-filter.tsx
@@ -5,7 +5,7 @@ import { ComponentUrl } from '@teambit/component.modules.component-url';
 import classNames from 'classnames';
 import { Ellipsis } from '@teambit/design.ui.styles.ellipsis';
 import { Tooltip } from '@teambit/design.ui.tooltip';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import {
   ComponentFilterCriteria,
   ComponentFilterRenderProps,
@@ -15,6 +15,9 @@ import {
 } from '@teambit/component.ui.component-filters.component-filter-context';
 
 import styles from './envs-filter.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 type EnvFilterEnvState = {
   active: boolean;

--- a/components/ui/menus/use-lanes-menu/use-lanes-menu.tsx
+++ b/components/ui/menus/use-lanes-menu/use-lanes-menu.tsx
@@ -5,9 +5,12 @@ import { Ellipsis } from '@teambit/design.ui.styles.ellipsis';
 import { linkStyles } from '@teambit/ui-foundation.ui.use-box.bottom-link';
 import { LanesHost } from '@teambit/lanes.ui.models.lanes-model';
 import { UseBoxDropdown } from '@teambit/ui-foundation.ui.use-box.dropdown';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import { LaneId } from '@teambit/lane-id';
 import styles from './use-lanes-menu.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type LaneImportContentProps = {
   currentLaneId: LaneId;

--- a/components/ui/version-block/version-block.tsx
+++ b/components/ui/version-block/version-block.tsx
@@ -1,6 +1,6 @@
 import { H3 } from '@teambit/documenter.ui.heading';
 import { Contributors } from '@teambit/design.ui.contributors';
-import { Link, useLocation } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink, useLocation } from '@teambit/base-react.navigation.link';
 import { Labels } from '@teambit/component.ui.version-label';
 import classNames from 'classnames';
 import React, { HTMLAttributes, useMemo } from 'react';
@@ -10,6 +10,9 @@ import { useLanes } from '@teambit/lanes.hooks.use-lanes';
 import { LanesModel } from '@teambit/lanes.ui.models.lanes-model';
 
 import styles from './version-block.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type VersionBlockProps = {
   componentId: string;

--- a/scopes/api-reference/overview/api-reference-table-of-contents/api-reference.table-of-contents.tsx
+++ b/scopes/api-reference/overview/api-reference-table-of-contents/api-reference.table-of-contents.tsx
@@ -3,9 +3,12 @@ import classNames from 'classnames';
 import { SchemaNode } from '@teambit/semantics.entities.semantic-schema';
 import { APINode, APIReferenceModel } from '@teambit/api-reference.models.api-reference-model';
 import { sortAPINodes } from '@teambit/api-reference.utils.sort-api-nodes';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 
 import styles from './api-reference.table-of-contents.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type APIReferenceTableOfContentsProps = {
   apiModel: APIReferenceModel;

--- a/scopes/api-reference/renderers/grouped-schema-nodes-overview-summary/grouped-schema-nodes-overview-summary.tsx
+++ b/scopes/api-reference/renderers/grouped-schema-nodes-overview-summary/grouped-schema-nodes-overview-summary.tsx
@@ -11,11 +11,14 @@ import { VariableNodeSummary, EnumMemberSummary } from '@teambit/api-reference.r
 import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import defaultTheme from '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import pluralize from 'pluralize';
 import classnames from 'classnames';
 
 import styles from './grouped-schema-nodes-overview-summary.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type SchemaNodesSummaryProps = {
   name: string;

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
@@ -7,9 +7,12 @@ import classnames from 'classnames';
 import { useUpdatedUrlFromQuery } from '@teambit/api-reference.hooks.use-api-ref-url';
 import { ComponentID } from '@teambit/component-id';
 import { ComponentUrl } from '@teambit/component.modules.component-url';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 
 import styles from './type-ref.renderer.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export const typeRefRenderer: APINodeRenderer = {
   predicate: (node) => node.__schema === TypeRefSchema.name,

--- a/scopes/api-reference/sections/api-reference-page/api-reference-page.tsx
+++ b/scopes/api-reference/sections/api-reference-page/api-reference-page.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames';
 import { ComponentContext } from '@teambit/component';
 import { H1 } from '@teambit/documenter.ui.heading';
 import { useIsMobile } from '@teambit/ui-foundation.ui.hooks.use-is-mobile';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import { useQuery } from '@teambit/ui-foundation.ui.react-router.use-query';
 import { Collapser } from '@teambit/ui-foundation.ui.buttons.collapser';
 import { HoverSplitter } from '@teambit/base-ui.surfaces.split-pane.hover-splitter';
@@ -20,6 +20,9 @@ import { EmptyBox } from '@teambit/design.ui.empty-box';
 import { ComponentUrl } from '@teambit/component.modules.component-url';
 
 import styles from './api-reference-page.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type APIRefPageProps = {
   host: string;

--- a/scopes/cloud/ui/login/login.tsx
+++ b/scopes/cloud/ui/login/login.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
-import { Link } from '@teambit/design.ui.navigation.link';
+import { Link as BaseLink } from '@teambit/design.ui.navigation.link';
 import styles from './login.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link for @teambit/design.ui.navigation.link
+const Link = BaseLink as any;
 
 export type LoginProps = {
   loginText?: string;

--- a/scopes/component/component/ui/top-bar-nav/top-bar-nav.tsx
+++ b/scopes/component/component/ui/top-bar-nav/top-bar-nav.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import classnames from 'classnames';
 import { useLocation } from 'react-router-dom';
-import { Link } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink } from '@teambit/base-react.navigation.link';
 import { NavPluginProps } from '../menu/nav-plugin';
 
 import styles from './top-bar-nav.module.scss';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export function TopBarNav({
   href,

--- a/scopes/component/graph/ui/dependencies-compare/dependencies-compare.tsx
+++ b/scopes/component/graph/ui/dependencies-compare/dependencies-compare.tsx
@@ -23,11 +23,12 @@ import { diffGraph } from './diff-graph';
 
 function ComponentNodeContainer(props: NodeProps) {
   const { sourcePosition = Position.Top, targetPosition = Position.Bottom, data, id } = props;
-
+  // @todo - this will be fixed as part of the react-flow-renderer v10 upgrade
+  const ReactFlowHandle = Handle as any;
   return (
     <div key={id}>
-      <Handle type="target" position={targetPosition} isConnectable={false} />
-      <Handle type="source" position={sourcePosition} isConnectable={false} />
+      <ReactFlowHandle type="target" position={targetPosition} isConnectable={false} />
+      <ReactFlowHandle type="source" position={sourcePosition} isConnectable={false} />
       <DependencyCompareNode node={data.node} type={data.type} />
     </div>
   );

--- a/scopes/component/graph/ui/dependencies-graph/dependencies-graph.tsx
+++ b/scopes/component/graph/ui/dependencies-graph/dependencies-graph.tsx
@@ -25,11 +25,12 @@ import styles from './dependencies-graph.module.scss';
 
 function ComponentNodeContainer(props: NodeProps) {
   const { sourcePosition = Position.Top, targetPosition = Position.Bottom, data, id } = props;
-
+  // @todo - this will be fixed as part of the react-flow-renderer v10 upgrade
+  const ReactFlowHandle = Handle as any;
   return (
     <div key={id}>
-      <Handle type="target" position={targetPosition} isConnectable={false} />
-      <Handle type="source" position={sourcePosition} isConnectable={false} />
+      <ReactFlowHandle type="target" position={targetPosition} isConnectable={false} />
+      <ReactFlowHandle type="source" position={sourcePosition} isConnectable={false} />
       <ComponentNode node={data.node} type={data.type} />
     </div>
   );

--- a/scopes/compositions/compositions/compositions.tsx
+++ b/scopes/compositions/compositions/compositions.tsx
@@ -19,7 +19,7 @@ import { MDXLayout } from '@teambit/mdx.ui.mdx-layout';
 import { Separator } from '@teambit/design.ui.separator';
 import { H1 } from '@teambit/documenter.ui.heading';
 import { AlertCard } from '@teambit/design.ui.alert-card';
-import { Link, useNavigate, useLocation } from '@teambit/base-react.navigation.link';
+import { Link as BaseLink, useNavigate, useLocation } from '@teambit/base-react.navigation.link';
 import { OptionButton } from '@teambit/design.ui.input.option-button';
 import { StatusMessageCard } from '@teambit/design.ui.surfaces.status-message-card';
 import { EmptyStateSlot } from './compositions.ui.runtime';
@@ -29,6 +29,9 @@ import { ComponentComposition } from './ui';
 import { CompositionsPanel } from './ui/compositions-panel/compositions-panel';
 import type { CompositionsMenuSlot } from './compositions.ui.runtime';
 import { ComponentCompositionProps } from './ui/composition-preview';
+
+// @todo - this will be fixed as part of the @teambit/base-react.navigation.link upgrade to latest
+const Link = BaseLink as any;
 
 export type MenuBarWidget = {
   location: 'start' | 'end';


### PR DESCRIPTION
This PR silences the type errors when rendering the Link component from `teambit.base-react/navigation/link` or `@teambit/design.ui.navigation.link` along with errors from react-flow-renderer when using the Handle component

These issues will be fixed as part of the upcoming PR which updates these deps to the latest