### PR TITLE
improve the error message when failed to parse workspace.jsonc due to syntax errors

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -91,6 +91,10 @@ async function getWsConfig(consumerPath: string, configOpts: ConfigOptions) {
     if (fileContent.includes('<<<<<<<') || fileContent.includes('>>>>>>>')) {
       throw new Error(`please fix the conflicts in workspace.jsonc to continue`);
     }
+    if (err.constructor.name === 'ReadConfigError' && err.err?.message) {
+      const location = err.err.line && err.err.column ? ` (${err.err.line}:${err.err.column})` : '';
+      throw new Error(`failed parsing the workspace.jsonc file at ${wsPath}. error: ${err.err.toString()}${location}`);
+    }
     throw err;
   }
 }


### PR DESCRIPTION
Before: 

> failed to read config from path: /private/tmp/cfcd0f80/workspace.jsonc

Now: 

> failed parsing the workspace.jsonc file at /private/tmp/cfcd0f80/workspace.jsonc. error: SyntaxError: Unexpected token { (9:35)