### PR TITLE
deprecate --get-all of bit-switch and make it the default

### DIFF
--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -142,7 +142,6 @@ export class APIForIDE {
   ): Promise<string[]> {
     const results = await this.lanes.switchLanes(laneName, {
       skipDependencyInstallation,
-      getAll: true,
     });
     return (results.components || []).map((c) => c.id.toString());
   }

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -489,7 +489,7 @@ export class LaneImportCmd implements Command {
     [lane]: [string],
     { skipDependencyInstallation = false, pattern }: { skipDependencyInstallation: boolean; pattern?: string }
   ): Promise<string> {
-    return this.switchCmd.report([lane], { getAll: true, skipDependencyInstallation, pattern });
+    return this.switchCmd.report([lane], { skipDependencyInstallation, pattern });
   }
 }
 

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -87,7 +87,7 @@ export type CreateLaneOptions = {
 export type SwitchLaneOptions = {
   alias?: string;
   merge?: MergeStrategy;
-  getAll?: boolean;
+  workspaceOnly?: boolean;
   pattern?: string;
   skipDependencyInstallation?: boolean;
   verbose?: boolean;
@@ -548,7 +548,7 @@ please create a new lane instead, which will include all components of this lane
    */
   async switchLanes(
     laneName: string,
-    { alias, merge, pattern, getAll = false, skipDependencyInstallation = false }: SwitchLaneOptions
+    { alias, merge, pattern, workspaceOnly, skipDependencyInstallation = false }: SwitchLaneOptions
   ) {
     if (!this.workspace) {
       throw new BitError(`unable to switch lanes outside of Bit workspace`);
@@ -567,7 +567,7 @@ please create a new lane instead, which will include all components of this lane
 
     const switchProps = {
       laneName,
-      existingOnWorkspaceOnly: !getAll,
+      existingOnWorkspaceOnly: workspaceOnly,
       pattern,
       alias,
     };

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -273,7 +273,7 @@ describe('LanesAspect', function () {
             newWorkspace = mockWorkspace({ bareScopeName: workspaceData.remoteScopeName });
 
             lanes = await loadAspect(LanesAspect, newWorkspace.workspacePath);
-            await lanes.switchLanes(laneId.toString(), { skipDependencyInstallation: true, getAll: true });
+            await lanes.switchLanes(laneId.toString(), { skipDependencyInstallation: true });
             await lanes.importLaneObject(laneId, true, true);
           });
           after(async () => {
@@ -296,7 +296,7 @@ describe('LanesAspect', function () {
           it('should be able to revert to a previous history id', async () => {
             const revertWorkspace = mockWorkspace({ bareScopeName: workspaceData.remoteScopeName });
             lanes = await loadAspect(LanesAspect, revertWorkspace.workspacePath);
-            await lanes.switchLanes(laneId.toString(), { skipDependencyInstallation: true, getAll: true });
+            await lanes.switchLanes(laneId.toString(), { skipDependencyInstallation: true });
             await lanes.importLaneObject(laneId, true, true);
             const laneHistory = await lanes.getLaneHistory(laneId);
             const history = laneHistory.getHistory();

--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -15,7 +15,7 @@ export type SwitchProps = {
   ids?: ComponentID[];
   laneBitIds?: ComponentID[]; // only needed for the deprecated onLanesOnly prop. once this prop is removed, this prop can be removed as well.
   pattern?: string;
-  existingOnWorkspaceOnly: boolean;
+  existingOnWorkspaceOnly?: boolean;
   remoteLane?: Lane;
   localTrackedLane?: string;
   alias?: string;

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -29,7 +29,8 @@ export class SwitchCmd implements Command {
       'merge [strategy]',
       'merge local changes with the checked out version. strategy should be "theirs", "ours" or "manual"',
     ],
-    ['a', 'get-all', 'checkout all components in a lane, including those not currently in the workspace'],
+    ['a', 'get-all', 'DEPRECATED. this is currently the default behavior'],
+    ['a', 'workspace-only', 'checkout only the components in the workspace to the selected lane'],
     ['x', 'skip-dependency-installation', 'do not install dependencies of the imported components'],
     [
       'p',
@@ -49,6 +50,7 @@ ${COMPONENT_PATTERN_HELP}`,
       alias,
       merge,
       getAll = false,
+      workspaceOnly = false,
       skipDependencyInstallation = false,
       pattern,
       json = false,
@@ -56,6 +58,7 @@ ${COMPONENT_PATTERN_HELP}`,
       alias?: string;
       merge?: MergeStrategy;
       getAll?: boolean;
+      workspaceOnly?: boolean;
       skipDependencyInstallation?: boolean;
       override?: boolean;
       pattern?: string;
@@ -65,10 +68,13 @@ ${COMPONENT_PATTERN_HELP}`,
     const { components, failedComponents, installationError, compilationError } = await this.lanes.switchLanes(lane, {
       alias,
       merge,
-      getAll,
+      workspaceOnly,
       pattern,
       skipDependencyInstallation,
     });
+    if (getAll) {
+      this.lanes.logger.warn('the --get-all flag is deprecated and currently the default behavior');
+    }
     if (json) {
       return JSON.stringify({ components, failedComponents }, null, 4);
     }


### PR DESCRIPTION
To get the previous default, use the newly introduced `--workspace-only` flag