### PR TITLE
fix(merge-from-scope), avoid using shouldOnlyFetchFromCurrentLane

### DIFF
--- a/e2e/harmony/lanes/merge-lanes-from-scope.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes-from-scope.e2e.ts
@@ -424,6 +424,41 @@ describe('merge lanes from scope', function () {
       expect(() => helper.command.import(`${scope2Name}/comp1`)).to.not.throw();
     });
   });
+  describe('main to lane and multiple scopes when a main-version is missing from lane-scope', () => {
+    let bareMerge;
+    let scope2Name;
+    let scope2Path;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      const mainScope = helper.scopeHelper.cloneLocalScope();
+
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      scope2Name = scopeName;
+      scope2Path = scopePath;
+      helper.scopeHelper.addRemoteScope(scope2Path);
+      helper.command.createLane();
+      helper.command.changeLaneScope(scope2Name);
+
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.getClonedLocalScope(mainScope);
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+
+      bareMerge = helper.scopeHelper.getNewBareScope('-bare-merge');
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareMerge.scopePath);
+      helper.scopeHelper.addRemoteScope(scope2Path, bareMerge.scopePath);
+    });
+    it('should be able to merge with --push with no errors', () => {
+      const cmd = () => helper.command.mergeLaneFromScope(bareMerge.scopePath, 'main', `${scope2Name}/dev --push`);
+      expect(cmd).to.not.throw();
+    });
+  });
   describe('merge from scope lane to main when it is not up to date', () => {
     let bareMerge;
     before(() => {

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -407,7 +407,7 @@ export class MergeLanesMain {
       options.excludeNonLaneComps = true;
       options.skipDependencyInstallation = true;
       this.scope.legacyScope.setCurrentLaneId(toLaneId);
-      this.scope.legacyScope.scopeImporter.shouldOnlyFetchFromCurrentLane = true;
+      // this.scope.legacyScope.scopeImporter.shouldOnlyFetchFromCurrentLane = true;
 
       const result = await this.mergeLane(fromLaneId, toLaneId, options as MergeLaneOptions);
       const { mergeSnapResults, leftUnresolvedConflicts, failedComponents, components, mergeSnapError } =

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -390,6 +390,9 @@ export class MergeLanesMain {
         allVersions: false,
         // no need to export anything else other than the head. the normal calculation of what to export won't apply here
         // as it is done from the scope.
+        // @todo: if we merge main to a lane, then no need to export all main history, it'll be fetched later by fetchMissingHistory.
+        // once a change is done in the exporter about this, uncomment the next line.
+        // exportHeadsOnly: shouldSquash || fromLaneId.isDefault(),
         exportHeadsOnly: shouldSquash,
         // all artifacts must be pushed. otherwise, they'll be missing from the component-scopes.
         // unless this is a merge from main to a lane, in which case it's not necessary to export the artifacts as
@@ -407,6 +410,8 @@ export class MergeLanesMain {
       options.excludeNonLaneComps = true;
       options.skipDependencyInstallation = true;
       this.scope.legacyScope.setCurrentLaneId(toLaneId);
+      // this causes issues when merging main to a lane as it fetches from the lane instead of from main.
+      // see the e2e-test: "main to lane and multiple scopes when a main-version is missing from lane-scope"
       // this.scope.legacyScope.scopeImporter.shouldOnlyFetchFromCurrentLane = true;
 
       const result = await this.mergeLane(fromLaneId, toLaneId, options as MergeLaneOptions);

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -54,6 +54,13 @@ export default class ScopeComponentsImporter {
     TIMEOUT_FOR_MUTEX,
     new BitError(`error: fetch-multiple-objects timeout exceeded (${TIMEOUT_FOR_MUTEX} minutes)`)
   );
+  /**
+   * important!
+   * refrain from using this. it's a workaround for bare-scopes to import from the lane when the call is
+   * very deep in the stack and is hard to pass the lane object.
+   * this can be an issue in case we deliberately want to fetch from main.
+   * (especially when "importer" is not used, because the importer has a fallback to go to the main scope).
+   */
   shouldOnlyFetchFromCurrentLane = false;
   private constructor(private scope: Scope) {
     if (!scope) throw new Error('unable to instantiate ScopeComponentsImporter without Scope');


### PR DESCRIPTION
otherwise, when merging from main and objects are missing from the lane-scope for some reason, it fails to find them. 