### PR TITLE
fix(watch), throw a descriptive error when running outside a workspace

### DIFF
--- a/scopes/workspace/watcher/watcher.main.runtime.ts
+++ b/scopes/workspace/watcher/watcher.main.runtime.ts
@@ -6,7 +6,7 @@ import { ComponentID } from '@teambit/component-id';
 import { IpcEventsAspect, IpcEventsMain } from '@teambit/ipc-events';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { PubsubAspect, PubsubMain } from '@teambit/pubsub';
-import { WorkspaceAspect, Workspace } from '@teambit/workspace';
+import { WorkspaceAspect, Workspace, OutsideWorkspaceError } from '@teambit/workspace';
 import pMapSeries from 'p-map-series';
 import { WatchCommand } from './watch.cmd';
 import { Watcher, WatchOptions } from './watcher';
@@ -27,6 +27,7 @@ export class WatcherMain {
   ) {}
 
   async watch(opts: WatchOptions) {
+    if (!this.workspace) throw new OutsideWorkspaceError();
     const watcher = new Watcher(this.workspace, this.pubsub, this, opts);
     await watcher.watch();
   }


### PR DESCRIPTION
(currently it shows an unhelpful error "Cannot read properties of undefined (reading 'path')"). 