### PR TITLE
improvement(cli), introduce onCommandStartSlot

### DIFF
--- a/scopes/harmony/cli/cli-parser.ts
+++ b/scopes/harmony/cli/cli-parser.ts
@@ -11,10 +11,15 @@ import { getCommandId } from './get-command-id';
 import { formatHelp } from './help';
 import { GLOBAL_GROUP, STANDARD_GROUP, YargsAdapter } from './yargs-adapter';
 import { CommandNotFound } from './exceptions/command-not-found';
+import { OnCommandStartSlot } from './cli.main.runtime';
 
 export class CLIParser {
   public parser = yargs;
-  constructor(private commands: Command[], private groups: GroupsType) {}
+  constructor(
+    private commands: Command[],
+    private groups: GroupsType,
+    private onCommandStartSlot: OnCommandStartSlot
+  ) {}
 
   async parse(args = process.argv.slice(2)) {
     this.throwForNonExistsCommand(args[0]);
@@ -138,7 +143,7 @@ export class CLIParser {
   }
 
   private getYargsCommand(command: Command): YargsAdapter {
-    const yarnCommand = new YargsAdapter(command);
+    const yarnCommand = new YargsAdapter(command, this.onCommandStartSlot);
     yarnCommand.builder = yarnCommand.builder.bind(yarnCommand);
     yarnCommand.handler = yarnCommand.handler.bind(yarnCommand);
 

--- a/scopes/harmony/cli/cli.cmd.ts
+++ b/scopes/harmony/cli/cli.cmd.ts
@@ -64,7 +64,7 @@ export class CliCmd implements Command {
       completer: (line, cb) => completer(line, cb, this.cliMain),
     });
 
-    const cliParser = new CLIParser(this.cliMain.commands, this.cliMain.groups);
+    const cliParser = new CLIParser(this.cliMain.commands, this.cliMain.groups, this.cliMain.onCommandStartSlot);
 
     rl.prompt();
 

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -31,7 +31,7 @@ export class CLIMain {
   constructor(
     private commandsSlot: CommandsSlot,
     private onStartSlot: OnStartSlot,
-    private onCommandStartSlot: OnCommandStartSlot,
+    readonly onCommandStartSlot: OnCommandStartSlot,
     private onBeforeExitSlot: OnBeforeExitSlot,
     private logger: Logger
   ) {}

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -1,7 +1,7 @@
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import { buildRegistry } from '@teambit/legacy/dist/cli';
 import legacyLogger from '@teambit/legacy/dist/logger/logger';
-import { Command } from '@teambit/legacy/dist/cli/command';
+import { CLIArgs, Flags, Command } from '@teambit/legacy/dist/cli/command';
 import pMapSeries from 'p-map-series';
 import { groups, GroupsType } from '@teambit/legacy/dist/cli/command-groups';
 import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
@@ -18,9 +18,11 @@ import { VersionCmd } from './version.cmd';
 
 export type CommandList = Array<Command>;
 export type OnStart = (hasWorkspace: boolean, currentCommand: string) => Promise<void>;
+export type OnCommandStart = (commandName: string, args: CLIArgs, flags: Flags) => Promise<void>;
 export type OnBeforeExitFn = () => Promise<void>;
 
 export type OnStartSlot = SlotRegistry<OnStart>;
+export type OnCommandStartSlot = SlotRegistry<OnCommandStart>;
 export type CommandsSlot = SlotRegistry<CommandList>;
 export type OnBeforeExitSlot = SlotRegistry<OnBeforeExitFn>;
 
@@ -29,6 +31,7 @@ export class CLIMain {
   constructor(
     private commandsSlot: CommandsSlot,
     private onStartSlot: OnStartSlot,
+    private onCommandStartSlot: OnCommandStartSlot,
     private onBeforeExitSlot: OnBeforeExitSlot,
     private logger: Logger
   ) {}
@@ -86,8 +89,20 @@ export class CLIMain {
     }
   }
 
+  /**
+   * onStart is when bootstrapping the CLI. (it happens before onCommandStart)
+   */
   registerOnStart(onStartFn: OnStart) {
     this.onStartSlot.register(onStartFn);
+    return this;
+  }
+
+  /**
+   * onCommandStart is when a command is about to start and we have the command object and the parsed args and flags
+   * already. (it happens after onStart)
+   */
+  registerOnCommandStart(onCommandStartFn: OnCommandStart) {
+    this.onCommandStartSlot.register(onCommandStartFn);
     return this;
   }
 
@@ -117,7 +132,7 @@ export class CLIMain {
    */
   async run(hasWorkspace: boolean) {
     await this.invokeOnStart(hasWorkspace);
-    const CliParser = new CLIParser(this.commands, this.groups);
+    const CliParser = new CLIParser(this.commands, this.groups, this.onCommandStartSlot);
     await CliParser.parse();
   }
 
@@ -146,15 +161,25 @@ export class CLIMain {
 
   static dependencies = [LoggerAspect];
   static runtime = MainRuntime;
-  static slots = [Slot.withType<CommandList>(), Slot.withType<OnStart>(), Slot.withType<OnBeforeExitFn>()];
+  static slots = [
+    Slot.withType<CommandList>(),
+    Slot.withType<OnStart>(),
+    Slot.withType<OnCommandStart>(),
+    Slot.withType<OnBeforeExitFn>(),
+  ];
 
   static async provider(
     [loggerMain]: [LoggerMain],
     config,
-    [commandsSlot, onStartSlot, onBeforeExitSlot]: [CommandsSlot, OnStartSlot, OnBeforeExitSlot]
+    [commandsSlot, onStartSlot, onCommandStartSlot, onBeforeExitSlot]: [
+      CommandsSlot,
+      OnStartSlot,
+      OnCommandStartSlot,
+      OnBeforeExitSlot
+    ]
   ) {
     const logger = loggerMain.createLogger(CLIAspect.id);
-    const cliMain = new CLIMain(commandsSlot, onStartSlot, onBeforeExitSlot, logger);
+    const cliMain = new CLIMain(commandsSlot, onStartSlot, onCommandStartSlot, onBeforeExitSlot, logger);
     const legacyRegistry = buildRegistry();
     await ensureWorkspaceAndScope();
     const legacyCommands = legacyRegistry.commands;

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -6,10 +6,17 @@ import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
 import { TOKEN_FLAG_NAME } from '@teambit/legacy/dist/constants';
 import globalFlags from '@teambit/legacy/dist/cli/global-flags';
 import { Analytics } from '@teambit/legacy/dist/analytics/analytics';
+import { OnCommandStartSlot } from './cli.main.runtime';
+import pMapSeries from 'p-map-series';
 
 export class CommandRunner {
   private commandName: string;
-  constructor(private command: Command, private args: CLIArgs, private flags: Flags) {
+  constructor(
+    private command: Command,
+    private args: CLIArgs,
+    private flags: Flags,
+    private onCommandStartSlot: OnCommandStartSlot
+  ) {
     this.commandName = parseCommandName(this.command.name);
   }
 
@@ -19,6 +26,7 @@ export class CommandRunner {
   async runCommand() {
     try {
       this.bootstrapCommand();
+      await this.invokeOnCommandStart();
       this.determineConsoleWritingDuringCommand();
       if (this.flags.json) {
         return await this.runJsonHandler();
@@ -46,6 +54,11 @@ export class CommandRunner {
     if (token) {
       globalFlags.token = token.toString();
     }
+  }
+
+  private async invokeOnCommandStart() {
+    const funcs = this.onCommandStartSlot.values();
+    await pMapSeries(funcs, (onCommandStart) => onCommandStart(this.commandName, this.args, this.flags));
   }
 
   /**

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -3,6 +3,7 @@ import { Arguments, CommandModule, Argv, Options } from 'yargs';
 import { TOKEN_FLAG } from '@teambit/legacy/dist/constants';
 import { camelCase } from 'lodash';
 import { CommandRunner } from './command-runner';
+import { OnCommandStartSlot } from './cli.main.runtime';
 
 export const GLOBAL_GROUP = 'Global';
 export const STANDARD_GROUP = 'Options';
@@ -11,7 +12,7 @@ export class YargsAdapter implements CommandModule {
   command: string;
   describe?: string;
   aliases?: string;
-  constructor(private commanderCommand: Command) {
+  constructor(private commanderCommand: Command, private onCommandStartSlot: OnCommandStartSlot) {
     this.command = commanderCommand.name;
     this.describe = commanderCommand.description;
     this.aliases = commanderCommand.alias;
@@ -43,7 +44,7 @@ export class YargsAdapter implements CommandModule {
     }, {});
     this.commanderCommand._packageManagerArgs = (argv['--'] || []) as string[];
 
-    const commandRunner = new CommandRunner(this.commanderCommand, argsValues, flags);
+    const commandRunner = new CommandRunner(this.commanderCommand, argsValues, flags, this.onCommandStartSlot);
     return commandRunner.runCommand();
   }
 


### PR DESCRIPTION
Helps to interact with a command before it starts. One example (asked in community slack channel) is to manipulate the snap/tag message. The following is an example how it can be done with this slot:

1. create a new bit-aspect: `bit create bit-aspect my-aspect`.
2. replace the content of the my-aspect.main.runtime.ts with the following.

```
import { MainRuntime, CLIAspect, CLIMain } from '@teambit/cli';
import { MyAspectAspect } from './my-aspect.aspect';

export class MyAspectMain {
  static slots = [];
  static dependencies = [CLIAspect];
  static runtime = MainRuntime;
  static async provider([cli]: [CLIMain]) {
    cli.registerOnCommandStart(async (commandName, args, flags) => {
      if (commandName === 'snap' && flags.message) {
        flags.message = `${flags.message} world!`;
      }
    });
    return new MyAspectMain();
  }
}

MyAspectAspect.addRuntime(MyAspectMain);

export default MyAspectMain;
```

3. make sure that your aspect is loaded (`bit use my-scope/my-aspect`).
4. now if you run `bit snap -m 'hello'` , the message will be saved as `hello world!`.



<img width="771" alt="Screenshot 2024-03-20 at 1 43 09 PM" src="https://github.com/teambit/bit/assets/1963573/b7f0074e-760f-48f9-855f-8c4faf7600a1">
