### PR TITLE
show a descriptive error when target snap does not exist in the local VersionHistory

### DIFF
--- a/src/scope/component-ops/get-diverge-data.ts
+++ b/src/scope/component-ops/get-diverge-data.ts
@@ -86,6 +86,10 @@ export async function getDivergeData({
     versionParentsFromObjects,
   });
   const unmergedData = repo.unmergedComponents.getEntry(modelComponent.toComponentId());
+  if (!versionParents.find((p) => p.hash.isEqual(targetHead))) {
+    throw new Error(`error: a remote of "${modelComponent.id()}" points to ${targetHead}, which is missing from the VersionHistory object for some reason.
+running "bit import" should fix the issue.`);
+  }
 
   return getDivergeDataBetweenTwoSnaps(
     modelComponent.id(),


### PR DESCRIPTION
Old error:

> Node 9752cabd9efd7ead337429f75a1fa680dda10f97 does not exist on graph

Now

> error: a remote of "org.scope/ui/button" points to 9752cabd9efd7ead337429f75a1fa680dda10f97, which is missing from the VersionHistory object for some reason.
> running "bit import" should fix the issue.