### PR TITLE
fix(scope-fork), enable forking a scope with conflicting paths

### DIFF
--- a/e2e/harmony/scope-cmd.e2e.ts
+++ b/e2e/harmony/scope-cmd.e2e.ts
@@ -148,4 +148,25 @@ describe('bit scope command', function () {
       expect(linkPath).to.be.a.directory();
     });
   });
+  describe('bit scope fork when the paths of two components conflicting', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.fs.outputFile('comp1/ui/index.js');
+      helper.command.addComponent('comp1/ui', '--id comp1/ui');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('should not throw an error about a component is nested in another component dir', () => {
+      const cmd = () => helper.command.forkScope(helper.scopes.remote, 'org.scope', '-x');
+      expect(cmd).to.not.throw();
+    });
+  });
 });

--- a/scopes/component/component-writer/index.ts
+++ b/scopes/component/component-writer/index.ts
@@ -5,5 +5,6 @@ export type {
   ComponentWriterResults,
   ManyComponentsWriterParams,
 } from './component-writer.main.runtime';
+export { incrementPathRecursively } from './component-writer.main.runtime';
 export default ComponentWriterAspect;
 export { ComponentWriterAspect };

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -29,6 +29,10 @@ export class BitMap {
     return this.legacyBitMap.mapPath;
   }
 
+  getAllRootDirs(): string[] {
+    return Object.keys(this.legacyBitMap.getAllTrackDirs());
+  }
+
   /**
    * adds component config to the .bitmap file.
    * later, upon `bit tag`, the data is saved in the scope.

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -315,8 +315,8 @@ export default class CommandHelper {
   fork(sourceId: string, values = '') {
     return this.runCmd(`bit fork ${sourceId} ${values}`);
   }
-  forkScope(originalScope: string, newScope: string) {
-    return this.runCmd(`bit scope fork ${originalScope} ${newScope}`);
+  forkScope(originalScope: string, newScope: string, flags = '') {
+    return this.runCmd(`bit scope fork ${originalScope} ${newScope} ${flags}`);
   }
   rename(sourceId: string, targetId: string, flags = '') {
     return this.runCmd(`bit rename ${sourceId} ${targetId} ${flags}`);


### PR DESCRIPTION
For example, a scope has two components: `bar/foo` and `bar`. Until now when running `bit scope fork` it'd complain about the fact that "bar/foo" can't be written in an existing "bar" directory. 
With this fix, it increments the path to "bar_1" and allows the fork. 