### PR TITLE
make watch output more compact, refactor formatCompileResults to use toString()

### DIFF
--- a/scopes/compilation/compiler/workspace-compiler.ts
+++ b/scopes/compilation/compiler/workspace-compiler.ts
@@ -6,6 +6,7 @@ import type { PubsubMain } from '@teambit/pubsub';
 import { SerializableResults, Workspace, OutsideWorkspaceError } from '@teambit/workspace';
 import { WatcherMain, WatchOptions } from '@teambit/watcher';
 import path from 'path';
+import chalk from 'chalk';
 import { ComponentID } from '@teambit/component-id';
 import { Logger } from '@teambit/logger';
 import loader from '@teambit/legacy/dist/cli/loader';
@@ -291,11 +292,10 @@ export class WorkspaceCompiler {
       { initiator: watchOpts.initiator || CompilationInitiator.ComponentChanged, deleteDistDir },
       true
     );
-    // await linkToNodeModulesByComponents([component], this.workspace);
     return {
       results: buildResults,
       toString() {
-        return `${buildResults[0]?.buildResults?.join('\n\t')}`;
+        return formatCompileResults(buildResults, watchOpts.verbose);
       },
     };
   }
@@ -393,4 +393,18 @@ export class WorkspaceCompiler {
     }
     return this.workspace.listIds();
   }
+}
+
+function formatCompileResults(buildResults: BuildResult[], verbose?: boolean) {
+  if (!buildResults.length) return '';
+  // this gets called when a file is changed, so the buildResults array always has only one item
+  const buildResult = buildResults[0];
+  const title = ` ${chalk.underline('STATUS\tCOMPONENT ID')}`;
+  const verboseComponentFilesArrayToString = () => {
+    return buildResult.buildResults.map((filePath) => ` \t - ${filePath}`).join('\n');
+  };
+
+  return `${title}
+  ${Logger.successSymbol()}SUCCESS\t${buildResult.component}\n
+  ${verbose ? `${verboseComponentFilesArrayToString()}\n` : ''}`;
 }

--- a/scopes/workspace/watcher/output-formatter.ts
+++ b/scopes/workspace/watcher/output-formatter.ts
@@ -1,51 +1,25 @@
 import { Logger } from '@teambit/logger';
+import { CompilerAspect } from '@teambit/compiler';
 import { OnComponentEventResult } from '@teambit/workspace';
 import chalk from 'chalk';
+import { RootDirs } from './watcher';
+import { compact } from 'lodash';
 
-const verboseComponentFilesArrayToString = (componentFiles = []) => {
-  return componentFiles.reduce((outputString, filePath) => `${outputString} \t - ${filePath}\n`, ``);
-};
+export function formatWatchPathsSortByComponent(trackDirs: RootDirs) {
+  const title = ` ${chalk.underline('STATUS\tCOMPONENT ID')}\n`;
+  return Object.keys(trackDirs).reduce((outputString, watchPath) => {
+    const componentId = trackDirs[watchPath];
+    const formattedWatchPath = `\t\t - ${watchPath}\n`;
+    return `${outputString}${Logger.successSymbol()} SUCCESS\t${componentId}\n${formattedWatchPath}`;
+  }, title);
+}
 
-const resultsForExtensionArrayToString = (resultsForExtension, verbose) => {
-  return resultsForExtension.reduce(
-    (outputString, resultForExtension) =>
-      `${outputString}${Logger.successSymbol()}SUCCESS\t${resultForExtension.component}\n
-     ${verbose ? resultForExtension.componentFilesAsString : ''}\n`,
-    ''
-  );
-};
-
-export const formatWatchPathsSortByComponent = (trackDirs) => {
-  return Object.keys(trackDirs).reduce(
-    (outputString, watchPath) =>
-      `${outputString}
-    ${Logger.successSymbol()} SUCCESS\t${trackDirs[watchPath]}\n
-    \t - ${watchPath}\n\n`,
-    ` ${chalk.underline('STATUS\t\tCOMPONENT ID')}\n`
-  );
-};
-
-/**
- * todo: this was implemented incorrectly.
- * the original idea of `SerializableResults` was to have each one of the aspects registered to the slot, the
- * ability to have their own formatting to their results, and then `toString()` method to print them.
- * Here, the printing is specifically to the Compiler aspect. It should move to where it belongs.
- */
-export function formatCompileResults(compileResults: OnComponentEventResult[], verbose: boolean) {
-  if (!compileResults.length || !Array.isArray(compileResults)) return '';
-  return compileResults
-    .filter((compileResult) => compileResult.results?.results && Array.isArray(compileResult.results?.results))
-    .map((compileResult) => ({
-      extensionId: compileResult.extensionId,
-      resultsForExtension: compileResult.results?.results?.map((resultForExtension) => ({
-        component: resultForExtension.component,
-        componentFilesAsString: verboseComponentFilesArrayToString(resultForExtension.buildResults),
-      })),
-    }))
-    .reduce(
-      (outputString, compileResult) =>
-        `${outputString}
-  ${resultsForExtensionArrayToString(compileResult.resultsForExtension, verbose)}`,
-      ` ${chalk.underline('STATUS\tCOMPONENT ID')}`
-    );
+export function formatCompileResults(compileResults: OnComponentEventResult[]) {
+  if (!compileResults.length) return '';
+  return compact(
+    compileResults
+      // currently, we are interested only in the compiler results
+      .filter((compileResult) => compileResult.extensionId === CompilerAspect.id)
+      .map((compileResult) => compileResult.results.toString())
+  ).join('\n');
 }

--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -3,12 +3,12 @@ import moment from 'moment';
 import { Command, CommandOptions } from '@teambit/cli';
 import type { Logger } from '@teambit/logger';
 import type { BitBaseEvent, PubsubMain } from '@teambit/pubsub';
-import { OnComponentEventResult } from '@teambit/workspace';
+import { OnComponentEventResult, Workspace } from '@teambit/workspace';
 
 // import IDs and events
 import { CompilerAspect, CompilerErrorEvent } from '@teambit/compiler';
 
-import { EventMessages, WatchOptions } from './watcher';
+import { EventMessages, RootDirs, WatchOptions } from './watcher';
 import { formatCompileResults, formatWatchPathsSortByComponent } from './output-formatter';
 import { CheckTypes } from './check-types';
 import { WatcherMain } from './watcher.main.runtime';
@@ -102,14 +102,14 @@ function getMessages(logger: Logger): EventMessages {
   return {
     onAll: (event: string, path: string) => logger.console(`Event: "${event}". Path: ${path}`),
     onStart: () => {},
-    onReady: (workspace, watchPathsSortByComponent, verbose?: boolean) => {
+    onReady: (workspace: Workspace, watchPathsSortByComponent: RootDirs, verbose?: boolean) => {
       clearOutdatedData();
       if (verbose) {
         logger.console(formatWatchPathsSortByComponent(watchPathsSortByComponent));
       }
       logger.console(
         chalk.yellow(
-          `Watching for component changes in workspace ${workspace.config.name} (${moment().format('HH:mm:ss')})...\n`
+          `Watching for component changes in workspace ${workspace.name} (${moment().format('HH:mm:ss')})...\n`
         )
       );
     },
@@ -146,9 +146,9 @@ function printOnFileEvent(
     logger.console(`${failureMsg}\n\n`);
     return;
   }
-  logger.console(`The file(s) ${files} have been ${eventMsgPlaceholder}.\n\n`);
-  logger.console(formatCompileResults(buildResults, verbose));
-  logger.console(`Finished. (${duration}ms)`);
+  logger.console(`The file(s) ${files} have been ${eventMsgPlaceholder}.\n`);
+  logger.console(formatCompileResults(buildResults));
+  logger.console(`Finished (${duration}ms).`);
   logger.console(chalk.yellow(`Watching for component changes (${moment().format('HH:mm:ss')})...`));
 }
 


### PR DESCRIPTION
This `formatCompileResults` was implemented incorrectly. The watcher was building the output of the compiler based on unknown data. 
In this PR, the compiler formats its own data and returns the formatted data to the `toString()` method in `OnComponentEventResult` type as intended originally. This way, each aspect can have its own formatting and as long as it implements `toString()`, it can be shown in the output. 