### PR TITLE
improvement(version-history), enable generating graph as SVG without installing graphviz

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,7 @@
     "@teambit/toolbox.fs.readdir-skip-system-files": "~0.0.2",
     "@teambit/scope.modules.find-scope-path": "~0.0.1",
     "@teambit/toolbox.object.sorter": "~0.0.2",
+    "@viz-js/viz": "^3.4.0",
     "@types/normalize-path": "^3.0.0",
     "array-difference": "0.0.2",
     "async-mutex": "0.3.1",

--- a/scopes/scope/version-history/version-history-cmd.ts
+++ b/scopes/scope/version-history/version-history-cmd.ts
@@ -78,20 +78,16 @@ const colorPerEdgeType = {
 export class VersionHistoryGraphCmd implements Command {
   name = 'graph <component-id>';
   alias = '';
-  description = 'generate a graph of the version history of a component. GraphVis must be installed';
+  description = 'generate a graph of the version history of a component and save as an SVG file';
   options = [
-    [
-      'p',
-      'graph-path <image>',
-      'image path and format. use one of the following extensions: [gif, png, svg]. default to png in the os tmp dir',
-    ],
+    ['s', 'short-hash', 'show only 9 chars of the hash'],
+    ['m', 'mark <string>', 'paint the given node-ids in the graph in red color, for multiple, separate by commas'],
+    ['', 'png', 'save the graph as a png file instead of svg. requires "graphviz" to be installed'],
     [
       'l',
       'layout <name>',
       'GraphVis layout. default to "dot". options are [circo, dot, fdp, neato, osage, patchwork, sfdp, twopi]',
     ],
-    ['s', 'short-hash', 'show only 9 chars of the hash'],
-    ['m', 'mark <string>', 'paint the given node-ids in the graph in red color, for multiple, separate by commas'],
   ] as CommandOptions;
   group = 'info';
   commands: Command[] = [];
@@ -101,15 +97,15 @@ export class VersionHistoryGraphCmd implements Command {
   async report(
     [id]: [string],
     {
-      mark,
-      graphPath,
-      layout,
       shortHash,
+      mark,
+      png,
+      layout,
     }: {
-      mark?: string;
-      graphPath?: string;
-      layout?: string;
       shortHash?: boolean;
+      mark?: string;
+      png?: boolean;
+      layout?: string;
     }
   ) {
     const graphHistory = await this.versionHistoryMain.generateGraph(id, shortHash);
@@ -117,8 +113,7 @@ export class VersionHistoryGraphCmd implements Command {
     const config: GraphConfig = { colorPerEdgeType };
     if (layout) config.layout = layout;
     const visualDependencyGraph = await VisualDependencyGraph.loadFromClearGraph(graphHistory, config, markIds);
-    const result = await visualDependencyGraph.image(graphPath);
-    return `image created at ${result}`;
+    return png ? visualDependencyGraph.image() : visualDependencyGraph.renderUsingViz();
   }
 }
 

--- a/src/scope/graph/vizgraph.ts
+++ b/src/scope/graph/vizgraph.ts
@@ -1,8 +1,10 @@
 import execa from 'execa';
+import tempy from 'tempy';
 import os from 'os';
 import fs from 'fs-extra';
 import { Graph } from 'graphlib';
 import graphviz, { Digraph } from 'graphviz';
+import { instance } from '@viz-js/viz';
 import { Graph as ClearGraph } from '@teambit/graph.cleargraph';
 import { generateRandomStr } from '@teambit/toolbox.string.random';
 import * as path from 'path';
@@ -30,7 +32,6 @@ export default class VisualDependencyGraph {
 
   static async loadFromGraphlib(graphlib: Graph, config: GraphConfig = {}): Promise<VisualDependencyGraph> {
     const mergedConfig = Object.assign({}, defaultConfig, config);
-    await checkGraphvizInstalled(config.graphVizPath);
     const graph: Digraph = VisualDependencyGraph.buildDependenciesGraph(graphlib, mergedConfig);
     return new VisualDependencyGraph(graphlib, graph, mergedConfig);
   }
@@ -41,7 +42,6 @@ export default class VisualDependencyGraph {
     markIds?: string[]
   ): Promise<VisualDependencyGraph> {
     const mergedConfig = { ...defaultConfig, ...config };
-    await checkGraphvizInstalled(config.graphVizPath);
     const graph: Digraph = VisualDependencyGraph.buildDependenciesGraphFromClearGraph(
       clearGraph,
       mergedConfig,
@@ -131,11 +131,32 @@ export default class VisualDependencyGraph {
   }
 
   /**
+   * with this library no need to install Graphviz in the OS.
+   * it supports SVG and other formats (run vs.format to see all formats), but not "png" nor "gif".
+   *
+   * returns the path to the rendered file.
+   */
+  async renderUsingViz(format: string = 'svg'): Promise<string> {
+    const dot = this.dot();
+    const viz = await instance();
+    const result = viz.render(dot, { format });
+    if (result.errors.length) {
+      throw new Error(
+        `failed to render the graph, errors:\n${result.errors.map((e) => `${e.level}: ${e.message}`).join('\n')}`
+      );
+    }
+    const file = tempy.file({ extension: 'svg' });
+    await fs.writeFile(file, result.output);
+    return file;
+  }
+
+  /**
    * Creates an image from the module dependency graph.
    * @param  {String} imagePath
    * @return {Promise}
    */
   async image(imagePath: string = this.getTmpFilename()): Promise<string> {
+    await checkGraphvizInstalled();
     const options: Record<string, any> = createGraphvizOptions(this.config);
     const type: string = path.extname(imagePath).replace('.', '') || 'png';
     options.type = type;
@@ -158,6 +179,11 @@ export default class VisualDependencyGraph {
    * @return {dot}
    */
   dot() {
+    const { G, E, N } = createGraphvizOptions(this.config);
+    Object.keys(G).forEach((key) => this.graph.set(key, G[key]));
+    Object.keys(E).forEach((key) => this.graph.setEdgeAttribut(key, E[key]));
+    Object.keys(N).forEach((key) => this.graph.setNodeAttribut(key, N[key]));
+
     return this.graph.to_dot();
   }
 }
@@ -212,7 +238,7 @@ function createGraphvizOptions(config: GraphConfig) {
       fontname: 'Arial',
       color: '#c6c5fe',
       fontcolor: '#c6c5fe',
-      fontsize: '14px',
+      fontsize: '14',
     }),
   };
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -348,7 +348,6 @@
         "@types/url-join": "4.0.0",
         "@types/url-parse": "1.4.3",
         "@types/webpack": "5.28.1",
-        "@viz-js/viz": "^3.4.0",
         "@yarnpkg/cli": "3.6.1",
         "@yarnpkg/core": "3.5.2",
         "@yarnpkg/fslib": "2.10.3",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -348,6 +348,7 @@
         "@types/url-join": "4.0.0",
         "@types/url-parse": "1.4.3",
         "@types/webpack": "5.28.1",
+        "@viz-js/viz": "^3.4.0",
         "@yarnpkg/cli": "3.6.1",
         "@yarnpkg/core": "3.5.2",
         "@yarnpkg/fslib": "2.10.3",


### PR DESCRIPTION
Until now to generate a graph (either for Version History or for dependencies), the GraphViz library had to be installed in the OS, which made it cumbersome especially for Windows. 
This PR uses [viz-js](https://github.com/mdaines/viz-js) package which is basically an implementation of Graphviz in javascript. It doesn't support png/gif formats, but it does support "svg" which is superior for such graphs that can be huge. (with png trying to zoom in result in a blurry image). 
In this PR, the `bit version-history graph` command defaults to this new alternative and a new flag `--png` falls back to GraphViz.
Later, the dependency graph will be updated as well.