### PR TITLE
chore(outputs) - ignore @teambit/legacy and typescript warnings on bit install

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -541,7 +541,9 @@
       "allowAny": [
         "react",
         "react-dom",
-        "@testing-library/react"
+        "@testing-library/react",
+        "@teambit/legacy",
+        "typescript"
       ],
       "ignoreMissing": []
     },


### PR DESCRIPTION
This is only relevant for the warnings on this repo specifically, and not affecting bit's users