### PR TITLE
perf, avoid deleting all components cache when one component is linked/compiled

### DIFF
--- a/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
+++ b/scopes/workspace/modules/node-modules-linker/node-modules-linker.ts
@@ -52,7 +52,11 @@ export default class NodeModuleLinker {
     const workspacePath = this.workspace.path;
     links.addBasePath(workspacePath);
     await links.persistAllToFS();
-    await this.consumer?.componentFsCache.deleteAllDependenciesDataCache();
+    await Promise.all(
+      this.components.map((component) =>
+        this.consumer?.componentFsCache.deleteDependenciesDataCache(component.id.toString())
+      )
+    );
     // if this cache is not cleared, then when asking workspace.get again to the same component, it returns it with
     // component-issues like "MissingLinksFromNodeModulesToSrc" incorrectly.
     this.workspace.clearAllComponentsCache();

--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -68,6 +68,10 @@ export class ComponentFsCache {
     await cacache.rm.all(this.getCachePath(DEPS));
   }
 
+  async deleteDependenciesDataCache(idStr: string) {
+    await cacache.rm.entry(this.getCachePath(DEPS), idStr);
+  }
+
   async listDependenciesDataCache() {
     return cacache.ls(this.getCachePath(DEPS));
   }


### PR DESCRIPTION
currently when compiling even one component, the link process deletes all FS cache (dependencies cache) of all components. It seems to be unnecessary. This PR deletes the caches of the linked components only.