### PR TITLE
use aspect manifest to determine which dependencies are aspects instead importing and loading them

### DIFF
--- a/scopes/workspace/workspace/build-graph-from-fs.ts
+++ b/scopes/workspace/workspace/build-graph-from-fs.ts
@@ -13,7 +13,7 @@ import { Logger } from '@teambit/logger';
 import { BitError } from '@teambit/bit-error';
 import { Workspace } from './workspace';
 
-export type ShouldLoadFunc = (id: ComponentID) => Promise<boolean>;
+export type ShouldLoadFunc = (component: Component, deps: ComponentID[]) => Promise<ComponentID[]>;
 
 export class GraphFromFsBuilder {
   private graph = new Graph<Component, string>();
@@ -75,23 +75,24 @@ export class GraphFromFsBuilder {
     return this.graph;
   }
 
-  private async getAllDepsUnfiltered(component: Component): Promise<ComponentID[]> {
-    const deps = await this.dependencyResolver.getComponentDependencies(component);
+  private getAllDepsUnfiltered(component: Component): ComponentID[] {
+    const deps = this.dependencyResolver.getComponentDependencies(component);
     const depsIds = deps.map((dep) => dep.componentId);
 
     return depsIds.filter((depId) => !this.ignoreIds.includes(depId.toString()));
   }
 
   private async getAllDepsFiltered(component: Component): Promise<ComponentID[]> {
-    const depsWithoutIgnore = await this.getAllDepsUnfiltered(component);
+    const depsWithoutIgnore = this.getAllDepsUnfiltered(component);
     const shouldLoadFunc = this.shouldLoadItsDeps;
     if (!shouldLoadFunc) return depsWithoutIgnore;
-    const deps = await mapSeries(depsWithoutIgnore, async (depId) => {
-      const shouldLoad = await shouldLoadFunc(depId);
-      if (!shouldLoad) this.ignoreIds.push(depId.toString());
-      return shouldLoad ? depId : null;
+    const depsToLoad = await shouldLoadFunc(component, depsWithoutIgnore);
+    const depsToLoadStr = depsToLoad.map((d) => d.toString());
+    depsWithoutIgnore.forEach((dep) => {
+      const depStr = dep.toString();
+      if (!depsToLoadStr.includes(depStr)) this.ignoreIds.push(depStr);
     });
-    return compact(deps);
+    return compact(depsToLoad);
   }
 
   private async processManyComponents(components: Component[]) {
@@ -134,7 +135,7 @@ export class GraphFromFsBuilder {
     const allIds = await this.getAllDepsFiltered(component);
 
     const allDependenciesComps = await this.loadManyComponents(allIds, idStr);
-    const deps = await this.dependencyResolver.getComponentDependencies(component);
+    const deps = this.dependencyResolver.getComponentDependencies(component);
     deps.forEach((dep) => {
       const depId = dep.componentId;
       if (this.ignoreIds.includes(depId.toString())) return;

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -303,7 +303,10 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     const groupedByIsPlugin = groupBy(components, (component) => {
       return this.aspectLoader.hasPluginFiles(component);
     });
-    const graph = await this.getAspectsGraphWithoutCore(groupedByIsPlugin.false, this.isAspect.bind(this));
+    const graph = await this.getAspectsGraphWithoutCore(
+      groupedByIsPlugin.false,
+      this.filterOutNonAspectDeps.bind(this)
+    );
     const aspectsComponents = graph.nodes.map((node) => node.attr).concat(groupedByIsPlugin.true || []);
     this.logger.debug(`${loggerPrefix} found ${aspectsComponents.length} aspects in the aspects-graph`);
     const { workspaceComps, nonWorkspaceComps } = await this.groupComponentsByWorkspaceExistence(
@@ -391,6 +394,18 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     const idsToFilter = idsToResolve.map((idStr) => ComponentID.fromString(idStr));
     const filteredDefs = this.aspectLoader.filterAspectDefs(allDefs, idsToFilter, runtimeName, mergedOpts);
     return filteredDefs;
+  }
+
+  async filterOutNonAspectDeps(component: Component, deps: ComponentID[]): Promise<ComponentID[]> {
+    const aspectsDefs = await this.aspectLoader.resolveAspects([component], this.getWorkspaceAspectResolver([]));
+
+    const { manifests } = await this.loadAspectDefsByOrder(aspectsDefs, [component.id.toString()], true, true);
+    const manifest = manifests[0];
+    const runtimeDeps = manifest.getRuntime(MainRuntime)?.dependencies?.map((dep) => dep.id);
+    const aspectDeps = manifest.dependencies?.map((d) => d.id) || [];
+    const allDeps = [...runtimeDeps, ...aspectDeps];
+
+    return deps.filter((dep) => allDeps.includes(dep.toString()));
   }
 
   shouldUseHashForCapsules(): boolean {
@@ -668,12 +683,12 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
   /**
    * Create a graph of aspects without the core aspects.
    * @param components
-   * @param isAspect
+   * @param shouldLoadFunc
    * @returns
    */
   private async getAspectsGraphWithoutCore(
     components: Component[] = [],
-    isAspect?: ShouldLoadFunc
+    shouldLoadFunc?: ShouldLoadFunc
   ): Promise<Graph<Component, string>> {
     const ids = components.map((component) => component.id);
     const coreAspectsStringIds = this.aspectLoader.getCoreAspectIds();
@@ -695,7 +710,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
     // const depsWhichAreNotAspectsBitIds = depsWhichAreNotAspects.map((strId) => otherDependenciesMap[strId]);
     // We only want to load into the graph components which are aspects and not regular dependencies
     // This come to solve a circular loop when an env aspect use an aspect (as regular dep) and the aspect use the env aspect as its env
-    return this.workspace.buildOneGraphForComponents(ids, coreAspectsStringIds, isAspect);
+    return this.workspace.buildOneGraphForComponents(ids, coreAspectsStringIds, shouldLoadFunc);
   }
 
   /**


### PR DESCRIPTION
Currently, we load (and import if not exist) each one of the aspect dependencies in order to check if it's an aspect. 
To improve the performance and to not bring unnecessary components, this PR finds and reads the manifest to see which dependencies were injected.