### PR TITLE
fix(switch), fix an installation error due to outdated versions from workspace.listIds

### DIFF
--- a/scopes/lanes/lanes/switch-lanes.ts
+++ b/scopes/lanes/lanes/switch-lanes.ts
@@ -30,7 +30,7 @@ export class LaneSwitcher {
     private logger: Logger,
     private switchProps: SwitchProps,
     private checkoutProps: CheckoutProps,
-    private Lanes: LanesMain
+    private lanes: LanesMain
   ) {
     this.consumer = this.workspace.consumer;
   }
@@ -56,7 +56,7 @@ export class LaneSwitcher {
       lane: this.laneToSwitchTo,
     };
 
-    const results = await this.Lanes.checkout.checkout(checkoutProps);
+    const results = await this.lanes.checkout.checkout(checkoutProps);
 
     await this.saveLanesData();
     await this.consumer.onDestroy('lane-switch');
@@ -99,7 +99,7 @@ export class LaneSwitcher {
     this.laneIdToSwitchTo = remoteLaneId;
     this.logger.debug(`populatePropsAccordingToRemoteLane, remoteLaneId: ${remoteLaneId.toString()}`);
     this.throwForSwitchingToCurrentLane();
-    const remoteLane = await this.Lanes.fetchLaneWithItsComponents(remoteLaneId);
+    const remoteLane = await this.lanes.fetchLaneWithItsComponents(remoteLaneId);
     this.switchProps.laneName = remoteLaneId.name;
     this.switchProps.localTrackedLane = this.consumer.scope.lanes.getAliasByLaneId(remoteLaneId) || undefined;
     this.switchProps.remoteLane = remoteLane;

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -157,7 +157,6 @@ export class Workspace implements ComponentFactory {
    * This is important to know to ignore missing modules across different places
    */
   inInstallContext = false;
-  private _cachedListIds?: ComponentIdList;
   private componentLoadedSelfAsAspects: InMemoryCache<boolean>; // cache loaded components
   private aspectsMerger: AspectsMerger;
   private componentDefaultScopeFromComponentDirAndNameWithoutConfigFileMemoized;
@@ -397,13 +396,7 @@ export class Workspace implements ComponentFactory {
    * get ids of all workspace components.
    */
   listIds(): ComponentIdList {
-    if (this._cachedListIds && this.bitMap.hasChanged()) {
-      delete this._cachedListIds;
-    }
-    if (!this._cachedListIds) {
-      this._cachedListIds = this.consumer.bitmapIdsFromCurrentLane;
-    }
-    return this._cachedListIds;
+    return this.consumer.bitmapIdsFromCurrentLane;
   }
 
   listIdsIncludeRemoved(): ComponentIdList {
@@ -737,7 +730,6 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
     this.aspectLoader.resetFailedLoadAspects();
     if (!options.skipClearFailedToLoadEnvs) this.envs.resetFailedToLoadEnvs();
     this.logger.debug('clearing the workspace and scope caches');
-    delete this._cachedListIds;
     this.componentLoader.clearCache();
     this.componentStatusLoader.clearCache();
     await this.scope.clearCache();


### PR DESCRIPTION
This `workspace.listIds` in the past was converting legacy ids to ComponentIDs so it needed a cache. Now that legacy also using ComponentIDs, no need for this cache. It got removed in this PR.