### PR TITLE
add some profiling around component-loading, enable --log=profile to see this data

### DIFF
--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -1,4 +1,4 @@
-import logger, { LoggerLevel } from '@teambit/legacy/dist/logger/logger';
+import logger from '@teambit/legacy/dist/logger/logger';
 import { CLIArgs, Command, Flags } from '@teambit/legacy/dist/cli/command';
 import { parseCommandName } from '@teambit/legacy/dist/cli/command-registry';
 import loader from '@teambit/legacy/dist/cli/loader';
@@ -100,11 +100,6 @@ export class CommandRunner {
     } else {
       loader.off();
       logger.shouldWriteToConsole = false;
-    }
-    if (this.flags.log) {
-      // probably not necessary anymore. it is handled in src/logger - determineWritingLogToScreen()
-      const logValue = typeof this.flags.log === 'string' ? this.flags.log : undefined;
-      logger.switchToConsoleLogger(logValue as LoggerLevel);
     }
   }
 

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -85,6 +85,7 @@ export class WorkspaceAspectsLoader {
     neededFor?: string,
     opts: WorkspaceLoadAspectsOptions = {}
   ): Promise<string[]> {
+    this.logger.profile('workspace.loadAspects');
     const calculatedThrowOnError: boolean = throwOnError ?? false;
     const defaultOpts: Required<WorkspaceLoadAspectsOptions> = {
       useScopeAspectsCapsule: false,
@@ -107,7 +108,10 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     this.workspace.localAspects = localAspects;
     await this.aspectLoader.loadAspectFromPath(this.workspace.localAspects);
     const notLoadedIds = nonLocalAspects.filter((id) => !this.aspectLoader.isAspectLoaded(id));
-    if (!notLoadedIds.length) return [];
+    if (!notLoadedIds.length) {
+      this.logger.profile('workspace.loadAspects');
+      return [];
+    }
     const coreAspectsStringIds = this.aspectLoader.getCoreAspectIds();
     const idsWithoutCore: string[] = difference(notLoadedIds, coreAspectsStringIds);
 
@@ -171,6 +175,7 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     await this.aspectLoader.loadExtensionsByManifests(pluginsManifests, undefined, { throwOnError });
     this.logger.debug(`${loggerPrefix} finish loading aspects`);
     const manifestIds = manifests.map((manifest) => manifest.id);
+    this.logger.profile('workspace.loadAspects');
     return compact(manifestIds.concat(scopeAspectIds));
   }
 

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -275,8 +275,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
       : difference(this.harmony.extensionsIds, coreAspectsIds);
     const rootAspectsIds: string[] = difference(configuredAspects, coreAspectsIds);
     const componentIdsToResolve = await this.workspace.resolveMultipleComponentIds(userAspectsIds);
-    const components = await this.importAndGetAspects(componentIdsToResolve);
-
+    const components = await this.importAndGetAspects(componentIdsToResolve, opts?.throwOnError);
     // Run the on load slot
     await this.runOnAspectsResolveFunctions(components);
 
@@ -753,7 +752,7 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
   /**
    * same as `this.importAndGetMany()` with a specific error handling of ComponentNotFound
    */
-  private async importAndGetAspects(componentIds: ComponentID[]): Promise<Component[]> {
+  private async importAndGetAspects(componentIds: ComponentID[], throwOnError = true): Promise<Component[]> {
     try {
       // We don't want to load the seeders as aspects as it will cause an infinite loop
       // once you try to load the seeder it will try to load the workspace component
@@ -761,7 +760,12 @@ your workspace.jsonc has this component-id set. you might want to remove/change 
       const loadOpts: ComponentLoadOptions = {
         idsToNotLoadAsAspects: componentIds.map((id) => id.toString()),
       };
-      return await this.workspace.importAndGetMany(componentIds, 'to load aspects from the workspace', loadOpts);
+      return await this.workspace.importAndGetMany(
+        componentIds,
+        'to load aspects from the workspace',
+        loadOpts,
+        throwOnError
+      );
     } catch (err: any) {
       this.throwWsJsoncAspectNotFoundError(err);
 

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -109,6 +109,8 @@ export class WorkspaceComponentLoader {
   }
 
   async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions, throwOnFailure = true): Promise<GetManyRes> {
+    const callId = Math.floor(Math.random() * 1000); // generate a random callId to be able to identify the call from the logs
+    this.logger.profile(`getMany-${callId}`);
     const idsWithoutEmpty = compact(ids);
     this.logger.setStatusLine(`loading ${ids.length} component(s)`);
     const loadOptsWithDefaults: ComponentLoadOptions = Object.assign(
@@ -134,7 +136,8 @@ export class WorkspaceComponentLoader {
 
     const { components: loadedComponents, invalidComponents } = await this.getAndLoadSlotOrdered(
       loadOrCached.idsToLoad || [],
-      loadOptsWithDefaults
+      loadOptsWithDefaults,
+      callId
     );
 
     invalidComponents.forEach(({ err }) => {
@@ -147,24 +150,35 @@ export class WorkspaceComponentLoader {
     components.forEach((comp) => {
       this.saveInCache(comp, { loadExtensions: true, executeLoadSlot: true });
     });
+    this.logger.profile(`getMany-${callId}`);
     return { components, invalidComponents };
   }
 
-  private async getAndLoadSlotOrdered(ids: ComponentID[], loadOpts: ComponentLoadOptions): Promise<GetManyRes> {
+  private async getAndLoadSlotOrdered(
+    ids: ComponentID[],
+    loadOpts: ComponentLoadOptions,
+    callId = 0
+  ): Promise<GetManyRes> {
     if (!ids?.length) return { components: [], invalidComponents: [] };
 
     const workspaceScopeIdsMap: WorkspaceScopeIdsMap = await this.groupAndUpdateIds(ids);
-
+    this.logger.profile('buildLoadGroups');
     const groupsToHandle = await this.buildLoadGroups(workspaceScopeIdsMap);
+    this.logger.profile('buildLoadGroups');
     // prefix your command with "BIT_LOG=*" to see the detailed groups
     if (process.env.BIT_LOG) {
       printGroupsToHandle(groupsToHandle, this.logger);
     }
     const groupsRes = compact(
-      await mapSeries(groupsToHandle, async (group) => {
+      await mapSeries(groupsToHandle, async (group, index) => {
         const { scopeIds, workspaceIds, aspects, core, seeders } = group;
-        if (!workspaceIds.length && !scopeIds.length) return undefined;
+        const groupDesc = `getMany-${callId} group ${index + 1}/${groupsToHandle.length} - ${loadGroupToStr(group)}`;
+        this.logger.profile(groupDesc);
+        if (!workspaceIds.length && !scopeIds.length) {
+          throw new Error('getAndLoadSlotOrdered - group has no ids to load');
+        }
         const res = await this.getAndLoadSlot(workspaceIds, scopeIds, { ...loadOpts, core, seeders, aspects });
+        this.logger.profile(groupDesc);
         // We don't want to return components that were not asked originally (we do want to load them)
         if (!group.seeders) return undefined;
         return res;
@@ -219,8 +233,8 @@ export class WorkspaceComponentLoader {
 
     await this.groupAndUpdateIds(extsNotFromTheList, workspaceScopeIdsMap);
 
-    const layerdExtFromTheList = this.regroupExtIdsFromTheList(groupedByIsExtOfAnother.true);
-    const layerdExtGroups = layerdExtFromTheList.map((ids) => {
+    const layeredExtFromTheList = this.regroupExtIdsFromTheList(groupedByIsExtOfAnother.true);
+    const layeredExtGroups = layeredExtFromTheList.map((ids) => {
       return {
         ids,
         core: false,
@@ -233,10 +247,11 @@ export class WorkspaceComponentLoader {
       // Always load first core envs
       { ids: groupedByIsCoreEnvs.true || [], core: true, aspects: true, seeders: true },
       { ids: extsNotFromTheList || [], core: false, aspects: true, seeders: false },
-      ...layerdExtGroups,
+      ...layeredExtGroups,
       { ids: groupedByIsExtOfAnother.false || [], core: false, aspects: false, seeders: true },
     ];
     const groupsByWsScope = groupsToHandle.map((group) => {
+      if (!group.ids?.length) return undefined;
       const groupedByWsScope = groupBy(group.ids, (id) => {
         return workspaceScopeIdsMap.workspaceIds.has(id.toString());
       });
@@ -248,7 +263,7 @@ export class WorkspaceComponentLoader {
         seeders: group.seeders,
       };
     });
-    return groupsByWsScope;
+    return compact(groupsByWsScope);
   }
 
   private regroupExtIdsFromTheList(ids: ComponentID[]): Array<ComponentID[]> {
@@ -281,12 +296,16 @@ export class WorkspaceComponentLoader {
     // Ensure we won't load the same extension many times
     // We don't want to ignore version here, as we do want to load different extensions with same id but different versions here
     const mergedExtensions = ExtensionDataList.mergeConfigs(allExtensions, false);
+    this.logger.profile('loadComponentsExtensions');
     await this.workspace.loadComponentsExtensions(mergedExtensions);
+    this.logger.profile('loadComponentsExtensions');
     let wsComponentsWithAspects = workspaceComponents;
     // if (loadOpts.seeders) {
+    this.logger.profile('executeLoadSlot');
     wsComponentsWithAspects = await pMapPool(workspaceComponents, (component) => this.executeLoadSlot(component), {
       concurrency: concurrentComponentsLimit(),
     });
+    this.logger.profile('executeLoadSlot');
     await this.warnAboutMisconfiguredEnvs(wsComponentsWithAspects);
     // }
 
@@ -295,6 +314,7 @@ export class WorkspaceComponentLoader {
     // It's important to load the workspace components as aspects here
     // otherwise the envs from the workspace won't be loaded at time
     // so we will get wrong dependencies from component who uses envs from the workspace
+    this.logger.profile('loadCompsAsAspects');
     if (loadOpts.loadSeedersAsAspects || (loadOpts.core && loadOpts.aspects)) {
       await this.loadCompsAsAspects(workspaceComponents.concat(scopeComponents), {
         loadApps: true,
@@ -305,6 +325,7 @@ export class WorkspaceComponentLoader {
         idsToNotLoadAsAspects: loadOpts.idsToNotLoadAsAspects,
       });
     }
+    this.logger.profile('loadCompsAsAspects');
 
     return { components: withAspects, invalidComponents };
   }
@@ -439,7 +460,7 @@ export class WorkspaceComponentLoader {
     workspaceIds.forEach((id) => {
       idsIndex[id.toString()] = id;
     });
-
+    this.logger.profile('consumer.loadComponents');
     const {
       components: legacyComponents,
       invalidComponents: legacyInvalidComponents,
@@ -449,6 +470,7 @@ export class WorkspaceComponentLoader {
       false,
       loadOptsWithDefaults
     );
+    this.logger.profile('consumer.loadComponents');
     const allLegacyComponents = legacyComponents.concat(removedComponents);
     legacyInvalidComponents.forEach((invalidComponent) => {
       const entry = { id: idsIndex[invalidComponent.id.toString()], err: invalidComponent.error };
@@ -848,4 +870,15 @@ function printGroupsToHandle(groupsToHandle: Array<LoadGroup>, logger: Logger): 
       )}`
     );
   });
+}
+
+function loadGroupToStr(loadGroup: LoadGroup): string {
+  const { scopeIds, workspaceIds, aspects, core, seeders } = loadGroup;
+
+  const attr: string[] = [];
+  if (aspects) attr.push('aspects');
+  if (core) attr.push('core');
+  if (seeders) attr.push('seeders');
+
+  return `workspaceIds: ${workspaceIds.length}, scopeIds: ${scopeIds.length}, (${attr.join('+')})`;
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -1033,8 +1033,8 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return foundEnv?.components || [];
   }
 
-  async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions): Promise<Component[]> {
-    const { components } = await this.componentLoader.getMany(ids, loadOpts);
+  async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions, throwOnFailure = true): Promise<Component[]> {
+    const { components } = await this.componentLoader.getMany(ids, loadOpts, throwOnFailure);
     return components;
   }
 
@@ -1080,7 +1080,8 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
   async importAndGetMany(
     ids: Array<ComponentID>,
     reason?: string,
-    loadOpts?: ComponentLoadOptions
+    loadOpts?: ComponentLoadOptions,
+    throwOnError = true
   ): Promise<Component[]> {
     if (!ids.length) return [];
     const lane = await this.importCurrentLaneIfMissing();
@@ -1092,7 +1093,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
       lane,
       reason,
     });
-    return this.getMany(ids, loadOpts);
+    return this.getMany(ids, loadOpts, throwOnError);
   }
 
   async importCurrentLaneIfMissing(): Promise<Lane | undefined> {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -305,7 +305,7 @@ function determineWritingLogToScreen() {
   // or it can have a level: `--log=error` or `--log error`: both syntaxes are supported
   if (process.argv.includes('--log')) {
     const level = process.argv.find((arg) => LEVELS.includes(arg)) as Level | undefined;
-    logger.switchToConsoleLogger(level || 'info');
+    logger.switchToConsoleLogger(level as Level);
     return;
   }
   LEVELS.forEach((level) => {

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -81,6 +81,7 @@ class BitLogger implements IBitLogger {
    * it's written only if the consumer is loaded. otherwise, the commandHistory.fileBasePath is undefined
    */
   commandHistoryBasePath: string | undefined;
+  shouldConsoleProfiler = false;
   constructor(logger: PinoLogger) {
     this.logger = logger;
     this.profiler = new Profiler();
@@ -169,7 +170,7 @@ class BitLogger implements IBitLogger {
     const msg = this.profiler.profile(id);
     if (!msg) return;
     const fullMsg = `${id}: ${msg}`;
-    console ? this.console(fullMsg) : this.info(fullMsg);
+    console || this.shouldConsoleProfiler ? this.console(fullMsg) : this.info(fullMsg);
   }
 
   registerOnBeforeExitFn(fn: Function) {
@@ -312,6 +313,9 @@ function determineWritingLogToScreen() {
       logger.switchToConsoleLogger(level as Level);
     }
   });
+  if (process.argv.includes(`--log=profile`)) {
+    logger.shouldConsoleProfiler = true;
+  }
 }
 
 determineWritingLogToScreen();
@@ -335,6 +339,9 @@ function isLevel(maybeLevel: Level | string): maybeLevel is Level {
 export function writeLogToScreen(levelOrPrefix = '') {
   if (isLevel(levelOrPrefix)) {
     logger.switchToConsoleLogger(levelOrPrefix);
+  }
+  if (levelOrPrefix === 'profile') {
+    logger.shouldConsoleProfiler = true;
   }
   // @todo: implement
   // const prefixes = levelOrPrefix.split(',');


### PR DESCRIPTION
With this PR, you can pass `--log=profile` to a command to print only the profile messages. 
It helps to understand what takes time during components load. 