### PR TITLE
fix: make hoisting deterministic

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -381,7 +381,7 @@ function findMostCommonVersion(versions: SemverVersion[]): MostCommonVersion {
     count: 0,
   };
   forEach(counts, (count, version) => {
-    if (count > result.count) {
+    if (count > result.count || (count === result.count && semver.gt(version, result.version))) {
       result.version = version;
       result.count = count;
     }


### PR DESCRIPTION
When the same package is in dependencies twice with different versions, always hoist the one with the biggest version.

## Proposed Changes

-
-
-
