### PR TITLE
add a new API "getDependencies()" to Component

### DIFF
--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -5,6 +5,7 @@ import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { CompIdGraph } from '@teambit/graph';
 import type { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
 import type { AspectDefinition } from '@teambit/aspect-loader';
+import type { DependencyList } from '@teambit/dependency-resolver';
 import { Component, InvalidComponent } from './component';
 import { State } from './state';
 import { Snap } from './snap';
@@ -118,6 +119,8 @@ export interface ComponentFactory {
   getGraphIds(ids?: ComponentID[], shouldThrowOnMissingDep?: boolean): Promise<CompIdGraph>;
 
   getLogs(id: ComponentID, shortHash?: boolean, startsFrom?: string): Promise<ComponentLog[]>;
+
+  getDependencies(component: Component): DependencyList;
 
   /**
    * returns a specific state of a component by hash or semver.

--- a/scopes/component/component/component.ts
+++ b/scopes/component/component/component.ts
@@ -5,7 +5,7 @@ import { ComponentID } from '@teambit/component-id';
 import { BitError } from '@teambit/bit-error';
 import { BuildStatus } from '@teambit/legacy/dist/constants';
 import { ComponentLog } from '@teambit/legacy/dist/scope/models/model-component';
-
+import type { DependencyList } from '@teambit/dependency-resolver';
 import { slice } from 'lodash';
 import { ComponentFactory } from './component-factory';
 import ComponentFS from './component-fs';
@@ -144,6 +144,10 @@ export class Component implements IComponent {
     }
 
     return filteredLogs;
+  }
+
+  getDependencies(): DependencyList {
+    return this.factory.getDependencies(this);
   }
 
   stringify(): string {

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -309,6 +309,10 @@ export class ScopeMain implements ComponentFactory {
     return component;
   }
 
+  getDependencies(component: Component) {
+    return this.dependencyResolver.getDependencies(component);
+  }
+
   private async upsertExtensionData(component: Component, extension: string, data: any) {
     if (!data) return;
     const existingExtension = component.state._consumer.extensions.findExtension(extension);

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -18,7 +18,12 @@ import {
 import { BitError } from '@teambit/bit-error';
 import { REMOVE_EXTENSION_SPECIAL_SIGN } from '@teambit/legacy/dist/consumer/config';
 import { ComponentScopeDirMap, ConfigMain } from '@teambit/config';
-import { DependencyResolverMain, DependencyResolverAspect, VariantPolicy } from '@teambit/dependency-resolver';
+import {
+  DependencyResolverMain,
+  DependencyResolverAspect,
+  VariantPolicy,
+  DependencyList,
+} from '@teambit/dependency-resolver';
 import { EnvsMain, EnvsAspect } from '@teambit/envs';
 import { GraphqlMain } from '@teambit/graphql';
 import { Harmony } from '@teambit/harmony';
@@ -558,6 +563,10 @@ export class Workspace implements ComponentFactory {
       })
     );
     return compsWithHead;
+  }
+
+  getDependencies(component: Component): DependencyList {
+    return this.dependencyResolver.getDependencies(component);
   }
 
   async getSavedGraphOfComponentIfExist(component: Component) {


### PR DESCRIPTION
It helps to get the dependencies without having to inject the `DependencyResolver` aspect, which in many cases it's not trivial. 