### PR TITLE
feat(login): allow refreshing token during bit login when already logged in

### DIFF
--- a/scopes/cloud/cloud/login.cmd.ts
+++ b/scopes/cloud/cloud/login.cmd.ts
@@ -50,6 +50,20 @@ export class LoginCmd implements Command {
   ): Promise<string> {
     noBrowser = noBrowser || suppressBrowserLaunch;
 
+    const isLoggedIn = this.cloud.isLoggedIn();
+
+    if (isLoggedIn) {
+      this.cloud.logger.clearStatusLine();
+      const reLoginPrompt = chalk.yellow(
+        'You are already logged in. Do you want to re-login to refresh your access token? [yes(y)/no(n)]'
+      );
+      const ok = await yesno({ question: reLoginPrompt });
+      if (!ok) {
+        return chalk.green(`Logged in as ${this.cloud.getUsername()}`);
+      }
+      this.cloud.logout();
+    }
+
     const result = await this.cloud.login(
       port || this.port,
       noBrowser,
@@ -58,9 +72,10 @@ export class LoginCmd implements Command {
       undefined,
       skipConfigUpdate
     );
+
     let message = chalk.green(`Logged in as ${result?.username}`);
 
-    if (result?.isAlreadyLoggedIn || skipConfigUpdate) {
+    if (skipConfigUpdate) {
       return message;
     }
 


### PR DESCRIPTION
This PR allows the user to refresh their token during bit login when they have already logged in before. 
<img width="890" alt="Screenshot 2024-04-08 at 9 28 47 AM" src="https://github.com/teambit/bit/assets/8999604/eb4458fa-01d3-48cf-bed1-014430f4f930">
