### PR TITLE
feat(login): flag `refresh-token` to allow force refreshing token during bit login when already logged in

### DIFF
--- a/scopes/cloud/cloud/login.cmd.ts
+++ b/scopes/cloud/cloud/login.cmd.ts
@@ -10,6 +10,7 @@ export class LoginCmd implements Command {
   alias = '';
   options = [
     ['', 'skip-config-update', 'skip writing to the .npmrc file'],
+    ['', 'refresh-token', 'force refresh token even when logged in'],
     ['d', 'cloud-domain <domain>', 'login cloud domain (default bit.cloud)'],
     ['p', 'port <port>', 'port number to open for localhost server (default 8085)'],
     ['', 'no-browser', 'do not open a browser for authentication'],
@@ -39,6 +40,7 @@ export class LoginCmd implements Command {
       noBrowser,
       machineName,
       skipConfigUpdate,
+      refreshToken,
     }: {
       cloudDomain?: string;
       port: string;
@@ -46,9 +48,14 @@ export class LoginCmd implements Command {
       noBrowser?: boolean;
       machineName?: string;
       skipConfigUpdate?: boolean;
+      refreshToken?: boolean;
     }
   ): Promise<string> {
     noBrowser = noBrowser || suppressBrowserLaunch;
+
+    if (refreshToken) {
+      this.cloud.logout();
+    }
 
     const isLoggedIn = this.cloud.isLoggedIn();
 


### PR DESCRIPTION
This PR adds a new flag to the bit login cmd `--refresh-token` that re logins the user and refreshes the token even when the user is already logged in without prompting any confirmation. 