### PR TITLE
fix(merge-from-scope), merge components that were deleted with --update-main

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -470,6 +470,9 @@ describe('bit lane command', function () {
     });
   });
   describe('remove on lane with --update-main then merge to main', () => {
+    let localWs: string;
+    let remoteScope: string;
+    let headOnLane: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(1, false);
@@ -478,31 +481,65 @@ describe('bit lane command', function () {
       helper.command.createLane();
       helper.command.softRemoveOnLane('comp1', '--update-main');
       helper.command.snapAllComponentsWithoutBuild();
+      headOnLane = helper.command.getHeadOfLane('dev', 'comp1');
       helper.command.export();
-      helper.command.switchLocalLane('main', '-x');
-      helper.command.mergeLane('dev', '-x');
+      localWs = helper.scopeHelper.cloneLocalScope();
+      remoteScope = helper.scopeHelper.cloneRemoteScope();
     });
-    it('should be marked as removed on main', () => {
-      const removeData = helper.command.showAspectConfig('comp1', Extensions.remove);
-      expect(removeData.config.removed).to.be.true;
-    });
-    it('bit status should show the component as staged', () => {
-      const status = helper.command.statusJson();
-      expect(status.stagedComponents).to.have.lengthOf(1);
-    });
-    it('bitmap should not have the component', () => {
-      const bitMap = helper.bitMap.read();
-      expect(bitMap).to.not.have.property('comp1');
-    });
-    describe('export and import the component to a new workspace', () => {
+    describe('merge from the workspace', () => {
       before(() => {
-        helper.command.export();
-        helper.scopeHelper.reInitLocalScope();
-        helper.scopeHelper.addRemoteScope();
-        helper.command.importComponent('comp1', '-x');
+        helper.command.switchLocalLane('main', '-x');
+        helper.command.mergeLane('dev', '-x');
       });
-      it('should show the component as removed', () => {
+      it('should be marked as removed on main', () => {
         const removeData = helper.command.showAspectConfig('comp1', Extensions.remove);
+        expect(removeData.config.removed).to.be.true;
+      });
+      it('bit status should show the component as staged', () => {
+        const status = helper.command.statusJson();
+        expect(status.stagedComponents).to.have.lengthOf(1);
+      });
+      it('bitmap should not have the component', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap).to.not.have.property('comp1');
+      });
+      describe('export and import the component to a new workspace', () => {
+        before(() => {
+          helper.command.export();
+          helper.scopeHelper.reInitLocalScope();
+          helper.scopeHelper.addRemoteScope();
+          helper.command.importComponent('comp1', '-x');
+        });
+        it('should show the component as removed', () => {
+          const removeData = helper.command.showAspectConfig('comp1', Extensions.remove);
+          expect(removeData.config.removed).to.be.true;
+        });
+      });
+    });
+    describe('merge from scope', () => {
+      let bareMerge;
+      let mergeOutput: string;
+      before(() => {
+        helper.scopeHelper.getClonedLocalScope(localWs);
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        bareMerge = helper.scopeHelper.getNewBareScope('-bare-merge');
+        helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareMerge.scopePath);
+        mergeOutput = helper.command.mergeLaneFromScope(bareMerge.scopePath, `${helper.scopes.remote}/dev`);
+      });
+      it('should indicate in the output the new head, not the only one', () => {
+        expect(mergeOutput).to.have.string(headOnLane);
+        expect(mergeOutput).to.not.have.string('0.0.1');
+      });
+      it('should merge successfully to main', () => {
+        const headOnMain = helper.command.getHead('comp1', bareMerge.scopePath);
+        expect(headOnMain).to.equal(headOnLane);
+      });
+      it('should be marked as removed on main', () => {
+        const removeData = helper.command.showAspectConfig(
+          `${helper.scopes.remote}/comp1`,
+          Extensions.remove,
+          bareMerge.scopePath
+        );
         expect(removeData.config.removed).to.be.true;
       });
     });

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -294,7 +294,9 @@ export class MergingMain {
         });
       } catch (err: any) {
         this.logger.error(`failed installing packages`, err);
-        this.logger.consoleError(`failed installing packages, see the log for full stacktrace. error: ${err.message}`);
+        this.logger.consoleFailure(
+          `failed installing packages, see the log for full stacktrace. error: ${err.message}`
+        );
       }
     }
 
@@ -432,7 +434,6 @@ export class MergingMain {
       laneId: otherLaneId,
     };
     id = currentComponent ? currentComponent.id : id;
-
     const modelComponent = await legacyScope.getModelComponent(id);
 
     const addToCurrentLane = (head: Ref) => {
@@ -527,7 +528,7 @@ export class MergingMain {
     }
 
     return {
-      applyVersionResult: { id, filesStatus },
+      applyVersionResult: { id: idToLoad, filesStatus },
       component: currentComponent || undefined,
       legacyCompToWrite: legacyComponent,
     };

--- a/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
@@ -154,6 +154,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
         },
       };
     } catch (err: any) {
+      this.mergeLanes.logger.error('merge-lane-from-scope.json, error: ', err);
       return {
         code: 1,
         error: err.message,

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -701,13 +701,13 @@ export default class CommandHelper {
     return JSON.parse(output);
   }
 
-  showComponentParsedHarmony(id = 'bar/foo') {
-    const output = this.runCmd(`bit show ${id} --json`);
+  showComponentParsedHarmony(id = 'bar/foo', cwd?: string) {
+    const output = this.runCmd(`bit show ${id} --json`, cwd);
     return JSON.parse(output);
   }
 
-  showAspectConfig(compId: string, aspectId: string) {
-    const show = this.showComponentParsedHarmony(compId);
+  showAspectConfig(compId: string, aspectId: string, cwd?: string) {
+    const show = this.showComponentParsedHarmony(compId, cwd);
     return show.find((_) => _.title === 'configuration').json.find((_) => _.id === aspectId);
   }
 


### PR DESCRIPTION
Currently the code that merges from scope is different than the one on the workspace (except when merging main to a lane).
As a result, the change done in the last few months of allowing `--update-main` flag during bit-delete was supported only in the workspace. On the scope, it was just ignoring the component, assuming it was deleted and should not be merged.
This PR reuses the merge on the workspace instead of having different code on the scope, which as a result, merges those deleted components with "update-main" prop.