### PR TITLE
allow disabling console and spinner in the CLI output

### DIFF
--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -1,4 +1,4 @@
-import logger from '@teambit/legacy/dist/logger/logger';
+import logger, { shouldDisableLoader } from '@teambit/legacy/dist/logger/logger';
 import { CLIArgs, Command, Flags } from '@teambit/legacy/dist/cli/command';
 import { parseCommandName } from '@teambit/legacy/dist/cli/command-registry';
 import loader from '@teambit/legacy/dist/cli/loader';
@@ -93,7 +93,7 @@ export class CommandRunner {
    * for internals commands, such as, _put, _fetch, the command.loader = false.
    */
   private determineConsoleWritingDuringCommand() {
-    if (this.command.loader && !this.flags.json && !this.flags['get-yargs-completions']) {
+    if (this.command.loader && !this.flags.json && !this.flags['get-yargs-completions'] && !shouldDisableLoader) {
       loader.on();
       loader.start(`running command "${this.commandName}"...`);
       logger.shouldWriteToConsole = true;

--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -8,7 +8,7 @@ import { Analytics } from './analytics/analytics';
 import { handleUnhandledRejection } from './cli/handle-errors';
 import { BIT_VERSION, GLOBAL_CONFIG, GLOBAL_LOGS } from './constants';
 import HooksManager from './hooks';
-import { printWarning } from './logger/logger';
+import { printWarning, shouldDisableConsole, shouldDisableLoader } from './logger/logger';
 import loader from './cli/loader';
 
 const RECOMMENDED_NODE_VERSIONS = '>=18.12.0 <21.0.0';
@@ -121,11 +121,7 @@ function enableLoaderIfPossible() {
     'env',
     'envs',
   ];
-  if (
-    safeCommandsForLoader.includes(process.argv[2]) &&
-    !process.argv.includes('--json') &&
-    !process.argv.includes('-j')
-  ) {
+  if (safeCommandsForLoader.includes(process.argv[2]) && !shouldDisableConsole && !shouldDisableLoader) {
     loader.on();
     // loader.start('loading bit...');
   }

--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -26,6 +26,10 @@ export { Level as LoggerLevel };
 const jsonFormat =
   yn(getSync(CFG_LOG_JSON_FORMAT), { default: false }) || yn(process.env.JSON_LOGS, { default: false });
 
+export const shouldDisableLoader = yn(process.env.BIT_DISABLE_SPINNER);
+export const shouldDisableConsole =
+  yn(process.env.BIT_DISABLE_CONSOLE) || process.argv.includes('--json') || process.argv.includes('-j');
+
 const LEVELS = ['fatal', 'error', 'warn', 'info', 'debug', 'trace'];
 
 const logLevel = getLogLevel();
@@ -75,7 +79,7 @@ class BitLogger implements IBitLogger {
    * it set before the command-registrar is loaded. at this stage we don't know for sure the "-j"
    * is actually "json". that's why this variable is overridden once the command-registrar is up.
    */
-  shouldWriteToConsole = !process.argv.includes('--json') && !process.argv.includes('-j');
+  shouldWriteToConsole = !shouldDisableConsole;
   /**
    * helpful to get a list in the .bit/command-history of all commands that were running on this workspace.
    * it's written only if the consumer is loaded. otherwise, the commandHistory.fileBasePath is undefined


### PR DESCRIPTION
It's useful for CIs.
To disable console printing during command execution: `BIT_DISABLE_CONSOLE=true`.
To disable the spinner/loader: `BIT_DISABLE_SPINNER=true`.