### PR TITLE
improvement(doctor) - remove some folders from bit doctor --archive

### DIFF
--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -191,8 +191,10 @@ async function _generateExamineResultsTarFile(
       (fileName.startsWith(`public${path.sep}`) || fileName.includes(`${path.sep}public${path.sep}`))
     )
       return true;
+    const isGit = fileName.startsWith(`.git${path.sep}`);
     const isLocalScope = fileName.startsWith(`.bit${path.sep}`) || fileName.startsWith(`.git${path.sep}bit${path.sep}`);
     if (excludeLocalScope && isLocalScope) return true;
+    if (isGit && !isLocalScope) return true;
     return false;
   };
 

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -185,7 +185,11 @@ async function _generateExamineResultsTarFile(
 
   const ignore = (fileName: string) => {
     if (fileName === tarFilePath) return true;
-    if (!includeNodeModules && fileName.startsWith(`node_modules${path.sep}`)) return true;
+    if (
+      !includeNodeModules &&
+      (fileName.startsWith(`node_modules${path.sep}`) || fileName.includes(`${path.sep}node_modules${path.sep}`))
+    )
+      return true;
     if (
       !includePublic &&
       (fileName.startsWith(`public${path.sep}`) || fileName.includes(`${path.sep}public${path.sep}`))

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -51,6 +51,7 @@ export type DoctorOptions = {
   filePath?: string;
   archiveWorkspace?: boolean;
   includeNodeModules?: boolean;
+  includePublic?: boolean;
   excludeLocalScope?: boolean;
 };
 
@@ -145,7 +146,7 @@ async function _generateExamineResultsTarFile(
   tarFilePath: string,
   options: DoctorOptions
 ): Promise<Stream.Readable> {
-  const { archiveWorkspace, includeNodeModules, excludeLocalScope } = options;
+  const { archiveWorkspace, includeNodeModules, includePublic, excludeLocalScope } = options;
   const debugLog = await _getDebugLogAsBuffer();
   const consumerInfo = await _getConsumerInfo();
   let bitmap;
@@ -185,6 +186,11 @@ async function _generateExamineResultsTarFile(
   const ignore = (fileName: string) => {
     if (fileName === tarFilePath) return true;
     if (!includeNodeModules && fileName.startsWith(`node_modules${path.sep}`)) return true;
+    if (
+      !includePublic &&
+      (fileName.startsWith(`public${path.sep}`) || fileName.includes(`${path.sep}public${path.sep}`))
+    )
+      return true;
     const isLocalScope = fileName.startsWith(`.bit${path.sep}`) || fileName.startsWith(`.git${path.sep}bit${path.sep}`);
     if (excludeLocalScope && isLocalScope) return true;
     return false;

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -185,6 +185,7 @@ async function _generateExamineResultsTarFile(
 
   const ignore = (fileName: string) => {
     if (fileName === tarFilePath) return true;
+    if (fileName === '.DS_Store') return true;
     if (
       !includeNodeModules &&
       (fileName.startsWith(`node_modules${path.sep}`) || fileName.includes(`${path.sep}node_modules${path.sep}`))

--- a/src/cli/commands/public-cmds/doctor-cmd.ts
+++ b/src/cli/commands/public-cmds/doctor-cmd.ts
@@ -26,6 +26,7 @@ export default class Doctor implements LegacyCommand {
       'archive the workspace including diagnosis info (by default exclude node-modules and include .bit)',
     ],
     ['n', 'include-node-modules', 'relevant for --archive. include node_modules in the archive file'],
+    ['p', 'include-public', 'relevant for --archive. include public folder in the archive file'],
     ['e', 'exclude-local-scope', 'relevant for --archive. exclude .bit or .git/bit from the archive file'],
   ] as CommandOptions;
 
@@ -36,12 +37,14 @@ export default class Doctor implements LegacyCommand {
       save,
       archive,
       includeNodeModules = false,
+      includePublic = false,
       excludeLocalScope = false,
     }: {
       list?: boolean;
       save?: string;
       archive?: string;
       includeNodeModules?: boolean;
+      includePublic?: boolean;
       excludeLocalScope?: boolean;
     }
   ): Promise<DoctorRunAllResults | Diagnosis[] | DoctorRunOneResult> {
@@ -65,6 +68,7 @@ export default class Doctor implements LegacyCommand {
       filePath,
       archiveWorkspace: Boolean(archive),
       includeNodeModules,
+      includePublic,
       excludeLocalScope,
     };
     return diagnosisName ? runOne(doctorOptions) : runAll(doctorOptions);


### PR DESCRIPTION
## Proposed Changes

- ignore public folder by default 
- add `--include-public` arg to the doctor command to include public folder
- ignore local `git` repo directory from `bit doctor --archive`
- ignore internal/nested `node_modules` folders in `bit doctor --archive`
- ignore `.DS_Store` file in `bit doctor --archive`
