### PR TITLE
allow exiting (Ctrl+C) during typescript-compiler step in build pipeline

### DIFF
--- a/scopes/harmony/logger/logger.ts
+++ b/scopes/harmony/logger/logger.ts
@@ -6,7 +6,7 @@ import { platform } from 'os';
 import { ConsoleOnStart, LongProcessLogger } from './long-process-logger';
 
 export class Logger implements IBitLogger {
-  spinnies = new Spinnies();
+  private spinnies?: Spinnies;
   constructor(private extensionName: string) {}
 
   trace(message: string, ...meta: any[]) {
@@ -36,7 +36,8 @@ export class Logger implements IBitLogger {
     return loader.isSpinning;
   }
 
-  get multiSpinner() {
+  get multiSpinner(): Spinnies {
+    if (!this.spinnies) this.spinnies = new Spinnies();
     return this.spinnies;
   }
 

--- a/scopes/pipelines/builder/build-pipe.ts
+++ b/scopes/pipelines/builder/build-pipe.ts
@@ -76,7 +76,6 @@ export class BuildPipe {
    * execute a pipeline of build tasks.
    */
   async execute(): Promise<TaskResultsList> {
-    this.addSignalListener();
     await this.executePreBuild();
     this.longProcessLogger = this.logger.createLongProcessLogger('running tasks', this.tasksQueue.length);
     await mapSeries(this.tasksQueue, async ({ task, env }) => this.executeTask(task, env));
@@ -86,19 +85,6 @@ export class BuildPipe {
     await this.executePostBuild(tasksResultsList);
 
     return tasksResultsList;
-  }
-
-  /**
-   * for some reason, some tasks (such as typescript compilation) ignore ctrl+C. this fixes it.
-   */
-  private addSignalListener() {
-    process.on('SIGTERM', () => {
-      process.exit();
-    });
-
-    process.on('SIGINT', () => {
-      process.exit();
-    });
   }
 
   private async executePreBuild() {


### PR DESCRIPTION
When registering to process.on with exit signals, Typescript doesn’t exit the process until it executes the code that registered to this event.
Because typescript programatic API is sync and JS is single threaded, it’s blocked until TS completes the build and only then it can execute the code registered to the exit event.
In the past, Ora (the spinner) pkg caused it and it was solved by instantiating it with `hideCursor: false`. Tuned out the reason it fixed it is because this option when it’s true, it calls `cliCursor` package to hide the cursor. This package, is calling `restore-cursor` package which calls `signal-exit` package to register to exit events to make sure the cursor is restored when exiting the node process.

The reason we had the same issue now is that we had two places we registered to the exit signal.
1. when the logger starts, it calls `spinnies = new Spinnies();` which comes from `dreidels` pkg which calls to cliCursor same as Ora, but this pkg doesn’t have an option to opt-out. It's fixed to insatiate it lazily. (currently only `bit start` uses it).
2. in the `build-pipe.ts` before running the pipeline, it calls `addSignalListener` which explicitly adding the exit listeners. Absurdly, it was added to overcome this Ctrl+C issue, but it actually helped to make it non-working. This is now removed.

This fix should help for any other blocking (sync) build-tasks. Not only for typescript.