### PR TITLE
fix, avoid using instanceof to find a component-issue

### DIFF
--- a/components/component-issues/issues-list.ts
+++ b/components/component-issues/issues-list.ts
@@ -90,13 +90,11 @@ export class IssuesList {
     this._issues = this._issues.filter((issue) => issue.constructor.name !== IssueClass.name);
   }
 
-  /**
-   * Use getIssueByName to prevent issues when getting different instances while using both bit from bvm and from the repo
-   * @param IssueClass
-   * @returns
-   */
   getIssue<T extends ComponentIssue>(IssueClass: { new (): T }): T | undefined {
-    return this._issues.find((issue) => issue instanceof IssueClass) as T | undefined;
+    // don't use instanceof, e.g. `this._issues.find((issue) => issue instanceof IssueClass)`
+    // the "component-issues" package can come from different sources, so the "instanceof" won't work.
+    // use only getIssueByName for this.
+    return this.getIssueByName(IssueClass.name as IssuesNames);
   }
 
   getIssueByName<T extends ComponentIssue>(issueType: IssuesNames): T | undefined {


### PR DESCRIPTION
In many cases, the component-issue is installed as a package in different places, causing the `instanceof` to always return `false`. Instead, change the implementation of `getIssue` to use the `getIssueByName`.