### PR TITLE
remove v8-compile-cache usage

### DIFF
--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -1,15 +1,9 @@
-/* eslint-disable import/no-dynamic-require */
 /* eslint-disable import/first */
 process.on('uncaughtException', (err) => {
   // eslint-disable-next-line no-console
   console.error('uncaughtException', err);
   process.exit(1);
 });
-
-import { nativeCompileCache } from '@teambit/toolbox.performance.v8-cache';
-
-// Enable v8 compile cache, keep this before other imports
-nativeCompileCache?.install();
 
 import './hook-require';
 import { bootstrap } from '@teambit/legacy/dist/bootstrap';

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -6,11 +6,6 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
-import { nativeCompileCache } from '@teambit/toolbox.performance.v8-cache';
-
-// Enable v8 compile cache, keep this before other imports
-nativeCompileCache?.install();
-
 import './hook-require';
 
 import {


### PR DESCRIPTION
[v8-compile-cache](https://github.com/zertosh/v8-compile-cache) doesn't play nice with ESM, that's why 2 years ago we created a component @teambit/toolbox.performance.v8-cache to uninstall it on demand when ESM is needed.
See https://github.com/teambit/bit/pull/5071 for more info.

However, from some benchmarks I made recently, it turns out that it slows down the typescript-compilation on build (478 components, it takes 3:35 with the cache, 3:05 without the cache). 
Another benchmark I made is simply loading bit with no args. Here is the average loading time on M1 Mac:

with toolbox.performance.v8-cache: 0.995s
no cache:                                               0.84s
v8-cache-directly:                                0.75s

On Windows, without the cache and with toolbox.performance.v8-cache it took the same time.

In the near feature, all main envs will be using ESM so this v8 cache won't be relevant anyway. Also, once we are able to bundle bit to one file, this bundle won't include the v8-cache. Therefore, it makes more sense to just remove it instead of fighting it to make it somehow work for non-ESM.
