### PR TITLE
feat, support .bitignore in workspace-root

### DIFF
--- a/e2e/harmony/bit-ignore.e2e.ts
+++ b/e2e/harmony/bit-ignore.e2e.ts
@@ -25,4 +25,30 @@ describe('Bit Ignore functionality', function () {
       expect(files).to.include('index.js');
     });
   });
+  describe('adding .bitignore in the root dir', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('.bitignore', '*.json');
+      helper.fs.outputFile('comp1/hello.json', '{"hello": "world"}');
+    });
+    it('should respect the .bitignore file and ignore according to the pattern', () => {
+      const files = helper.command.getComponentFiles('comp1');
+      expect(files).to.not.include('hello.json');
+      expect(files).to.include('index.js');
+    });
+  });
+  describe('adding .gitignore and an empty .bitignore in the root dir', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('.gitignore', '*.json');
+      helper.fs.outputFile('.bitignore', '');
+      helper.fs.outputFile('comp1/hello.json', '{"hello": "world"}');
+    });
+    it('should only consider the .bitignore and ignore the .gitignore file', () => {
+      const files = helper.command.getComponentFiles('comp1');
+      expect(files).to.include('hello.json');
+    });
+  });
 });

--- a/scopes/component/tracker/add-components.ts
+++ b/scopes/component/tracker/add-components.ts
@@ -506,13 +506,13 @@ you can add the directory these files are located at and it'll change the root d
     return addedComp;
   }
 
-  getIgnoreList(): string[] {
+  async getIgnoreList(): Promise<string[]> {
     const consumerPath = this.consumer.getPath();
     return getIgnoreListHarmony(consumerPath);
   }
 
   async add(): Promise<AddActionResults> {
-    this.ignoreList = this.getIgnoreList();
+    this.ignoreList = await this.getIgnoreList();
     this.gitIgnore = ignore().add(this.ignoreList); // add ignore list
 
     let componentPathsStats: PathsStats = {};

--- a/src/consumer/bit-map/bit-map.ts
+++ b/src/consumer/bit-map/bit-map.ts
@@ -210,7 +210,7 @@ export default class BitMap {
   }
 
   async loadFiles() {
-    const gitIgnore = getGitIgnoreHarmony(this.projectRoot);
+    const gitIgnore = await getGitIgnoreHarmony(this.projectRoot);
     await Promise.all(
       this.components.map(async (componentMap) => {
         const rootDir = componentMap.rootDir;

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -285,7 +285,7 @@ export default class ComponentMap {
     if (!trackDir) {
       return;
     }
-    const gitIgnore = getGitIgnoreHarmony(consumer.getPath());
+    const gitIgnore = await getGitIgnoreHarmony(consumer.getPath());
     this.files = await getFilesByDir(trackDir, consumer.getPath(), gitIgnore);
   }
 
@@ -394,13 +394,13 @@ export async function getFilesByDir(dir: string, consumerPath: string, gitIgnore
   }));
 }
 
-export function getGitIgnoreHarmony(consumerPath: string): any {
-  const ignoreList = getIgnoreListHarmony(consumerPath);
+export async function getGitIgnoreHarmony(consumerPath: string): Promise<any> {
+  const ignoreList = await getIgnoreListHarmony(consumerPath);
   return ignore().add(ignoreList);
 }
 
-export function getIgnoreListHarmony(consumerPath: string): string[] {
-  const ignoreList = retrieveIgnoreList(consumerPath);
+export async function getIgnoreListHarmony(consumerPath: string): Promise<string[]> {
+  const ignoreList = await retrieveIgnoreList(consumerPath);
   // the ability to track package.json is deprecated since Harmony
   ignoreList.push(PACKAGE_JSON);
   return ignoreList;

--- a/src/utils/ignore/ignore.ts
+++ b/src/utils/ignore/ignore.ts
@@ -7,9 +7,13 @@ import { GIT_IGNORE, IGNORE_LIST } from '../../constants';
 
 export const BIT_IGNORE = '.bitignore';
 
-function getGitIgnoreFile(dir: string): string[] {
+async function getGitIgnoreFile(dir: string): Promise<string[]> {
   const gitIgnoreFile = findUp.sync([GIT_IGNORE], { cwd: dir });
-  return gitIgnoreFile ? gitignore(fs.readFileSync(gitIgnoreFile)) : [];
+  return gitIgnoreFile ? gitignore(await fs.readFile(gitIgnoreFile)) : [];
+}
+
+async function isBitIgnoreFileExistsInDir(dir: string): Promise<boolean> {
+  return fs.pathExists(path.join(dir, BIT_IGNORE));
 }
 
 export async function getBitIgnoreFile(dir: string): Promise<string[]> {
@@ -17,7 +21,9 @@ export async function getBitIgnoreFile(dir: string): Promise<string[]> {
   return gitignore(fileContent);
 }
 
-export default function retrieveIgnoreList(cwd: string) {
-  const ignoreList = getGitIgnoreFile(cwd).concat(IGNORE_LIST);
-  return ignoreList;
+export async function retrieveIgnoreList(consumerRoot: string): Promise<string[]> {
+  const userIgnoreList = (await isBitIgnoreFileExistsInDir(consumerRoot))
+    ? await getBitIgnoreFile(consumerRoot)
+    : await getGitIgnoreFile(consumerRoot);
+  return [...userIgnoreList, ...IGNORE_LIST];
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -7,7 +7,7 @@ import getWithoutExt from './fs/fs-no-ext';
 import getExt from './fs/get-ext';
 import isDirEmpty from './fs/is-dir-empty';
 import glob from './glob';
-import retrieveIgnoreList from './ignore/ignore';
+import { retrieveIgnoreList } from './ignore/ignore';
 import immutableUnshift from './immutable-unshift';
 import isBitUrl from './is-bit-url';
 import isDir from './is-dir';


### PR DESCRIPTION
Until now the `.gitignore` file in the root was always respected and there was no way to override/skip/ignore it. 
With this PR, if a file `.bitignore` found in the workspace root dir, then `.gitignore` is skipped. 

As a side note, the `.bitignore` we supported already was in the component level, this one is on the workspace level.