### PR TITLE
improvement(insights), make the circular dependencies output clearer

### DIFF
--- a/scopes/component/graph/component-id-graph.ts
+++ b/scopes/component/graph/component-id-graph.ts
@@ -152,6 +152,8 @@ export class ComponentIdGraph extends Graph<ComponentID, DepEdgeType> {
    */
   findCycles(graph?: this, includeDeps = false): string[][] {
     const cycles = super.findCycles(graph);
+    // reverse the order to show a more intuitive cycle order. from the dependent to the dependency.
+    cycles.forEach((cycle) => cycle.reverse());
     if (!this.shouldLimitToSeedersOnly() || includeDeps) {
       return cycles;
     }

--- a/scopes/explorer/insights/all-insights/find-circulars.ts
+++ b/scopes/explorer/insights/all-insights/find-circulars.ts
@@ -23,6 +23,8 @@ export default class FindCycles implements Insight {
       };
     }
     const cycles = graph.findCycles(undefined, opts?.includeDeps);
+    // add the first component to the end to make the circular visible in the output
+    cycles.forEach((cycle) => cycle.push(cycle[0]));
     if (cycles.length === 1) {
       return {
         message: `Found ${cycles.length} cycle.`,


### PR DESCRIPTION
By doing the following two:

- reverse the order of the components to start from the dependents to the dependencies
- add the first item to the last to help understanding the circular.

For example, imagine the following circular: A1 -> B1 -> B2 -> A1 (read as A1 uses B1).

Before
```
Cyclic dependency
-----------------
- f46b89d0-remote/comp/b2@0.0.1
- f46b89d0-remote/comp/b1@0.0.1
- f46b89d0-remote/comp/a1@0.0.1
```

Now
```
Cyclic dependency
-----------------
- f46b89d0-remote/comp/a1@0.0.1
- f46b89d0-remote/comp/b1@0.0.1
- f46b89d0-remote/comp/b2@0.0.1
- f46b89d0-remote/comp/a1@0.0.1
```