### PR TITLE
feat(watch), introduce --import to fetch objects on .bitmap change

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -846,7 +846,7 @@ export class ScopeMain implements ComponentFactory {
   }
 
   /**
-   * wether a component is soft-removed.
+   * whether a component is soft-removed.
    * the version is required as it can be removed on a lane. in which case, the version is the head in the lane.
    */
   async isComponentRemoved(id: ComponentID): Promise<Boolean> {
@@ -855,6 +855,13 @@ export class ScopeMain implements ComponentFactory {
     const modelComponent = await this.legacyScope.getModelComponent(id);
     const versionObj = await modelComponent.loadVersion(version, this.legacyScope.objects);
     return versionObj.isRemoved();
+  }
+
+  /**
+   * whether the id with the specified version exits in the local scope.
+   */
+  async isComponentInScope(id: ComponentID): Promise<boolean> {
+    return this.legacyScope.isComponentInScope(id);
   }
 
   /**

--- a/scopes/workspace/watcher/watch.cmd.ts
+++ b/scopes/workspace/watcher/watch.cmd.ts
@@ -17,6 +17,7 @@ export type WatchCmdOpts = {
   verbose?: boolean;
   skipPreCompilation?: boolean;
   checkTypes?: string | boolean;
+  import?: boolean;
 };
 
 export class WatchCommand implements Command {
@@ -35,6 +36,7 @@ if this doesn't work well for you, run "bit config set watch_use_polling true" t
       'check-types [string]',
       'EXPERIMENTAL. show errors/warnings for types. options are [file, project] to investigate only changed file or entire project. defaults to project',
     ],
+    ['i', 'import', 'helpful when using git. import component objects if .bitmap changed not by bit'],
   ] as CommandOptions;
 
   constructor(
@@ -70,7 +72,7 @@ if this doesn't work well for you, run "bit config set watch_use_polling true" t
   };
 
   async report(cliArgs: [], watchCmdOpts: WatchCmdOpts) {
-    const { verbose, checkTypes } = watchCmdOpts;
+    const { verbose, checkTypes, import: importIfNeeded } = watchCmdOpts;
     const getCheckTypesEnum = () => {
       switch (checkTypes) {
         case undefined:
@@ -92,6 +94,7 @@ if this doesn't work well for you, run "bit config set watch_use_polling true" t
       preCompile: !watchCmdOpts.skipPreCompilation,
       spawnTSServer: Boolean(checkTypes), // if check-types is enabled, it must spawn the tsserver.
       checkTypes: getCheckTypesEnum(),
+      import: importIfNeeded,
     };
     await this.watcher.watch(watchOpts);
     return 'watcher terminated';

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -2,7 +2,7 @@ import { PubsubMain } from '@teambit/pubsub';
 import fs from 'fs-extra';
 import { dirname, basename } from 'path';
 import { compact, difference, partition } from 'lodash';
-import { ComponentID } from '@teambit/component-id';
+import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import loader from '@teambit/legacy/dist/cli/loader';
 import { BIT_MAP, CFG_WATCH_USE_POLLING, WORKSPACE_JSONC } from '@teambit/legacy/dist/constants';
 import { Consumer } from '@teambit/legacy/dist/consumer';
@@ -56,6 +56,7 @@ export type WatchOptions = {
   checkTypes?: CheckTypes; // if enabled, the spawnTSServer becomes true.
   preCompile?: boolean; // whether compile all components before start watching
   compile?: boolean; // whether compile modified/added components during watch process
+  import?: boolean; // whether import objects when .bitmap got version changes
 };
 
 export type RootDirs = { [dir: PathLinux]: ComponentID };
@@ -290,8 +291,10 @@ export class Watcher {
    */
   private async handleBitmapChanges(): Promise<OnComponentEventResult[]> {
     const previewsRootDirs = { ...this.rootDirs };
+    const previewsIds = this.consumer.bitMap.getAllBitIds();
     await this.workspace._reloadConsumer();
     await this.setRootDirs();
+    await this.importObjectsIfNeeded(previewsIds);
     await this.workspace.triggerOnBitmapChange();
     const newDirs: string[] = difference(Object.keys(this.rootDirs), Object.keys(previewsRootDirs));
     const removedDirs: string[] = difference(Object.keys(previewsRootDirs), Object.keys(this.rootDirs));
@@ -307,6 +310,44 @@ export class Watcher {
     }
 
     return results;
+  }
+
+  /**
+   * needed when using git.
+   * it resolves the following issue - a user is running `git pull` which updates the components and the .bitmap file.
+   * because the objects locally are not updated, the .bitmap has new versions that don't exist in the local scope.
+   * as soon as the watcher gets an event about a file change, it loads the component which throws
+   * ComponentsPendingImport error.
+   * to resolve this, we import the new objects as soon as the .bitmap file changes.
+   * for performance reasons, we import only when: 1) the .bitmap file has version changes and 2) this new version is
+   * not already in the scope.
+   */
+  private async importObjectsIfNeeded(previewsIds: ComponentIdList) {
+    if (!this.options.import) {
+      return;
+    }
+    const currentIds = this.consumer.bitMap.getAllBitIds();
+    const hasVersionChanges = currentIds.find((id) => {
+      const prevId = previewsIds.searchWithoutVersion(id);
+      return prevId && prevId.version !== id.version;
+    });
+    if (!hasVersionChanges) {
+      return;
+    }
+    const existsInScope = await this.workspace.scope.isComponentInScope(hasVersionChanges);
+    if (existsInScope) {
+      // the .bitmap change was probably a result of tag/snap/merge, no need to import.
+      return;
+    }
+    if (this.options.verbose) {
+      logger.console(
+        `Watcher: .bitmap has changed with new versions which do not exist locally, importing the objects...`
+      );
+    }
+    await this.workspace.scope.import(currentIds, {
+      useCache: true,
+      lane: (await this.workspace.getCurrentLaneObject()) || undefined,
+    });
   }
 
   private async executeWatchOperationsOnRemove(componentId: ComponentID) {


### PR DESCRIPTION
Helpful when using git.
It resolves the following issue - a user is running `git pull` which updates the components and the .bitmap file. Because the objects locally are not updated, the .bitmap has new versions that don't exist in the local scope. As soon as the watcher gets an event about a file change, it loads the component which throws `ComponentsPendingImport` error.

To resolve this, the new `--import` flag imports the new objects as soon as the .bitmap file changes. For performance reasons, we import only when: 1) the .bitmap file has version changes and 2) this new version is not already in the scope.