### PR TITLE
fix(snap), keep the dependency version of a deleted component as the user intended

### DIFF
--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -48,8 +48,12 @@ describe('bit delete command', function () {
       it('bit status should not show RemovedDependencies issues', () => {
         helper.command.expectStatusToNotHaveIssue(IssuesClasses.RemovedDependencies.name);
       });
-      it('bit snap should not fail due to removedDependencies error', () => {
+      it('bit snap should not fail due to removedDependencies error, also it should save the correct dep version', () => {
         expect(() => helper.command.snapAllComponentsWithoutBuild()).not.to.throw();
+
+        const catComp1 = helper.command.catComponent('comp1@latest');
+        expect(catComp1.dependencies[0].id.name).to.equal('comp2');
+        expect(catComp1.dependencies[0].id.version).to.equal('0.0.1');
       });
       it('bit snap output should be relevant for lanes when --lane command used', () => {
         expect(output).to.not.have.string('will mark the component as deleted');

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -53,9 +53,14 @@ export type BasicTagParams = BasicTagSnapParams & {
 };
 
 function updateDependenciesVersions(
-  componentsToTag: ConsumerComponent[],
+  allComponentsToTag: ConsumerComponent[],
   dependencyResolver: DependencyResolverMain
-): void {
+) {
+  // filter out removed components.
+  // if a component has a deleted-component as a dependency, it was probably running "bit install <dep>" with a version
+  // from main. we want to keep it as the user requested. Otherwise, this changes the dependency version to the newly
+  // snapped one unintentionally.
+  const componentsToTag = allComponentsToTag.filter((c) => !c.isRemoved());
   const getNewDependencyVersion = (id: ComponentID): ComponentID | null => {
     const foundDependency = componentsToTag.find((component) => component.id.isEqualWithoutVersion(id));
     return foundDependency ? id.changeVersion(foundDependency.version) : null;


### PR DESCRIPTION
In case compA is using compB on a lane and compB got deleted and installed as a package from main, `bit snap` was changing back the version of compB to the deleted one instead of the version from main.
This PR fixes it to keep the version from main.