### PR TITLE
fix(init), rewrite workspace.jsonc if missing

### DIFF
--- a/e2e/harmony/init-harmony.e2e.ts
+++ b/e2e/harmony/init-harmony.e2e.ts
@@ -64,4 +64,13 @@ describe('init command on Harmony', function () {
       expect(() => helper.command.install()).to.throw(`fatal: unable to load the workspace`);
     });
   });
+  describe('workspace.jsonc is missing', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScope();
+      helper.fs.deletePath('workspace.jsonc');
+    });
+    it('bit init should fix it', () => {
+      expect(() => helper.command.init()).to.not.throw();
+    });
+  });
 });

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -107,7 +107,7 @@ async function getWsConfig(consumerPath: string, configOpts: ConfigOptions) {
  * @param config
  */
 function attachVersionsFromBitmap(config: Config, consumerInfo: ConsumerInfo): Config {
-  if (!consumerInfo || !consumerInfo.hasBitMap) {
+  if (!consumerInfo || !consumerInfo.hasBitMap || !consumerInfo.hasConsumerConfig) {
     return config;
   }
   const rawConfig = config.toObject();

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -345,12 +345,6 @@ export function takeLegacyGlobalsSnapshot(): LegacyGlobal[] {
     },
     {
       classInstance: WorkspaceConfig,
-      methodName: 'workspaceConfigIsExistRegistry',
-      value: WorkspaceConfig.workspaceConfigIsExistRegistry,
-      empty: undefined,
-    },
-    {
-      classInstance: WorkspaceConfig,
       methodName: 'workspaceConfigLoadingRegistry',
       value: WorkspaceConfig.workspaceConfigLoadingRegistry,
       empty: undefined,

--- a/scopes/harmony/config/config.main.runtime.ts
+++ b/scopes/harmony/config/config.main.runtime.ts
@@ -7,7 +7,6 @@ import {
 } from '@teambit/legacy/dist/consumer/config';
 import LegacyWorkspaceConfig, {
   WorkspaceConfigEnsureFunction,
-  WorkspaceConfigIsExistFunction,
   WorkspaceConfigLoadFunction,
 } from '@teambit/legacy/dist/consumer/config/workspace-config';
 import { PathOsBased, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
@@ -100,7 +99,6 @@ export class ConfigMain {
   static dependencies = [];
   static config = {};
   static async provider(_deps, _config, _slots, harmony: Harmony) {
-    LegacyWorkspaceConfig.registerOnWorkspaceConfigIsExist(onLegacyWorkspaceConfigIsExist());
     LegacyWorkspaceConfig.registerOnWorkspaceConfigEnsuring(onLegacyWorkspaceEnsure());
 
     let configMain: ConfigMain | any;
@@ -128,12 +126,6 @@ async function loadWorkspaceConfigIfExist(cwd = process.cwd()): Promise<Workspac
   const scopePath = findScopePath(configDirPath);
   const workspaceConfig = await WorkspaceConfig.loadIfExist(configDirPath, scopePath);
   return workspaceConfig;
-}
-
-function onLegacyWorkspaceConfigIsExist(): WorkspaceConfigIsExistFunction {
-  return async (dirPath: PathOsBased): Promise<boolean | undefined> => {
-    return WorkspaceConfig.isExist(dirPath);
-  };
 }
 
 function onLegacyWorkspaceLoad(config?: ConfigMain): WorkspaceConfigLoadFunction {

--- a/scopes/harmony/testing/load-aspect/load-aspect.ts
+++ b/scopes/harmony/testing/load-aspect/load-aspect.ts
@@ -130,7 +130,5 @@ function clearGlobalsIfNeeded() {
   // @ts-ignore
   WorkspaceConfig.workspaceConfigEnsuringRegistry = undefined;
   // @ts-ignore
-  WorkspaceConfig.workspaceConfigIsExistRegistry = undefined;
-  // @ts-ignore
   WorkspaceConfig.workspaceConfigLoadingRegistry = undefined;
 }

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -266,7 +266,7 @@ export class Workspace implements ComponentFactory {
     if (this.consumer.isLegacy) return;
     if (isEmpty(this.config))
       throw new BitError(
-        `fatal: workspace config is empty. probably one of bit files is missing. consider running "bit init"`
+        `fatal: workspace config is empty. probably one of bit files is missing. please run "bit init" to rewrite them`
       );
     const defaultScope = this.config.defaultScope;
     if (!defaultScope) throw new BitError('defaultScope is missing');

--- a/src/consumer/config/workspace-config.ts
+++ b/src/consumer/config/workspace-config.ts
@@ -49,11 +49,6 @@ export default class WorkspaceConfig extends AbstractConfig {
   packageJsonObject: Record<string, any> | null | undefined; // workspace package.json if exists (parsed)
   defaultScope: string | undefined; // default remote scope to export to
 
-  static workspaceConfigIsExistRegistry: WorkspaceConfigIsExistFunction;
-  static registerOnWorkspaceConfigIsExist(func: WorkspaceConfigIsExistFunction) {
-    this.workspaceConfigIsExistRegistry = func;
-  }
-
   static workspaceConfigLoadingRegistry: WorkspaceConfigLoadFunction;
   static registerOnWorkspaceConfigLoading(func: WorkspaceConfigLoadFunction) {
     this.workspaceConfigLoadingRegistry = func;
@@ -150,14 +145,6 @@ export default class WorkspaceConfig extends AbstractConfig {
     const loadFunc = this.workspaceConfigLoadingRegistry;
     if (loadFunc && typeof loadFunc === 'function') {
       return loadFunc(dirPath, scopePath);
-    }
-    return undefined;
-  }
-
-  static async isExist(dirPath: string): Promise<boolean | undefined> {
-    const isExistFunc = this.workspaceConfigIsExistRegistry;
-    if (isExistFunc && typeof isExistFunc === 'function') {
-      return isExistFunc(dirPath);
     }
     return undefined;
   }

--- a/src/consumer/consumer-locator.ts
+++ b/src/consumer/consumer-locator.ts
@@ -6,8 +6,7 @@
 import fs from 'fs-extra';
 import * as pathlib from 'path';
 
-import { BIT_GIT_DIR, BIT_HIDDEN_DIR, BIT_MAP, DOT_GIT_DIR, OLD_BIT_MAP } from '../constants';
-import { LegacyWorkspaceConfig } from './config';
+import { BIT_GIT_DIR, BIT_HIDDEN_DIR, BIT_MAP, DOT_GIT_DIR, OLD_BIT_MAP, WORKSPACE_JSONC } from '../constants';
 
 export type ConsumerInfo = {
   path: string;
@@ -76,7 +75,7 @@ export async function getConsumerInfo(absPath: string): Promise<ConsumerInfo | u
   }
 
   async function pathHasConsumerConfig(path: string): Promise<boolean> {
-    const isExist = await LegacyWorkspaceConfig.isExist(path);
-    return !!isExist;
+    const wsPath = pathlib.join(path, WORKSPACE_JSONC);
+    return fs.pathExists(wsPath);
   }
 }


### PR DESCRIPTION
Currently, if the worksapce.jsonc is missing, it throws an unclear error:

> workspace.jsonc is missing the "teambit.workspace/workspace" property

And `bit init` doesn't fix it.

Now, the error is clearer:

> fatal: workspace config is empty. probably one of bit files is missing. consider running "bit init"

And running `bit init` rewrite the file.