### PR TITLE
fix(watch/ide), invalidate global-config cache upon change

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -51,6 +51,8 @@ import { ExtensionDataEntry, ExtensionDataList } from '@teambit/legacy/dist/cons
 import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { compact, slice, difference, partition } from 'lodash';
 import { DepEdge } from '@teambit/legacy/dist/scope/models/version';
+import { getGlobalConfigPath } from '@teambit/legacy/dist/global-config/config';
+import { invalidateCache } from '@teambit/legacy/dist/api/consumer/lib/global-config';
 import { ComponentNotFound } from './exceptions';
 import { ScopeAspect } from './scope.aspect';
 import { scopeSchema } from './scope.graphql';
@@ -472,13 +474,15 @@ export class ScopeMain implements ComponentFactory {
    * for long-running processes, such as `bit start` or `bit watch`, it's important to keep the following data up to date:
    * 1. scope-index (.bit/index.json file).
    * 2. remote-refs (.bit/refs/*).
+   * 3. global config. so for example if a user logs in or out it would be reflected.
    * it's possible that other commands (e.g. `bit import`) modified these files, while these processes are running.
    * Because these data are kept in memory, they're not up to date anymore.
    */
   async watchScopeInternalFiles() {
     const scopeIndexFile = this.legacyScope.objects.scopeIndex.getPath();
     const remoteLanesDir = this.legacyScope.objects.remoteLanes.basePath;
-    const pathsToWatch = [scopeIndexFile, remoteLanesDir];
+    const globalConfigFile = getGlobalConfigPath();
+    const pathsToWatch = [scopeIndexFile, remoteLanesDir, globalConfigFile];
     const watcher = chokidar.watch(pathsToWatch);
     watcher.on('ready', () => {
       this.logger.debug(`watchSystemFiles has started, watching ${pathsToWatch.join(', ')}`);
@@ -490,6 +494,9 @@ export class ScopeMain implements ComponentFactory {
         await this.legacyScope.objects.reLoadScopeIndex();
       } else if (filePath.startsWith(remoteLanesDir)) {
         this.legacyScope.objects.remoteLanes.removeFromCacheByFilePath(filePath);
+      } else if (filePath === globalConfigFile) {
+        this.logger.debug('global config file has been changed, invalidating its cache');
+        invalidateCache();
       } else {
         this.logger.error(
           'unknown file has been changed, please check why it is watched by scope.watchSystemFiles',

--- a/src/global-config/config.ts
+++ b/src/global-config/config.ts
@@ -4,7 +4,7 @@ import * as path from 'path';
 import { GLOBAL_CONFIG, GLOBAL_CONFIG_FILE } from '../constants';
 import { mapToObject } from '../utils';
 
-function getPath() {
+export function getGlobalConfigPath() {
   return path.join(GLOBAL_CONFIG, GLOBAL_CONFIG_FILE);
 }
 
@@ -18,15 +18,15 @@ export default class Config extends Map<string, string> {
   }
 
   write() {
-    return fs.outputFile(getPath(), this.toJson());
+    return fs.outputFile(getGlobalConfigPath(), this.toJson());
   }
 
   writeSync() {
-    return fs.outputFileSync(getPath(), this.toJson());
+    return fs.outputFileSync(getGlobalConfigPath(), this.toJson());
   }
 
   static loadSync(): Config {
-    const configPath = getPath();
+    const configPath = getGlobalConfigPath();
     if (!fs.existsSync(configPath)) {
       const config = new Config([]);
       config.writeSync();
@@ -37,7 +37,7 @@ export default class Config extends Map<string, string> {
   }
 
   static async load(): Promise<Config> {
-    const configPath = getPath();
+    const configPath = getGlobalConfigPath();
     const exists = await fs.pathExists(configPath);
     if (!exists) {
       const config = new Config([]);


### PR DESCRIPTION
This is especially useful when using the vscode extension to have the config up to date, so that changes like bit-login/logout are taking place.