### PR TITLE
fix(UI): add polyfills for @pnpm/node-fetch 

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -114,6 +114,12 @@ export default function createWebpackConfig(
         tls: false,
         child_process: false,
         process: fallbacks.process,
+        http: fallbacks.http,
+        https: fallbacks.https,
+        zlib: fallbacks.zlib,
+        crypto: fallbacks.crypto,
+        vm: fallbacks.vm,
+        buffer: fallbacks.buffer,
       },
     },
     module: {

--- a/scopes/ui-foundation/ui/webpack/webpack.browser.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.browser.config.ts
@@ -122,7 +122,7 @@ function createBrowserConfig(outputDir: string, title: string, publicDir: string
         },
       }),
 
-      new ProvidePlugin({ process: fallbacksProvidePluginConfig.process }),
+      new ProvidePlugin({ process: fallbacksProvidePluginConfig.process, Buffer: fallbacksProvidePluginConfig.Buffer }),
     ],
   };
 

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -185,6 +185,12 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
         path: fallbacks.path,
         stream: false,
         process: fallbacks.process,
+        http: fallbacks.http,
+        https: fallbacks.https,
+        zlib: fallbacks.zlib,
+        crypto: fallbacks.crypto,
+        vm: fallbacks.vm,
+        buffer: fallbacks.buffer,
       },
     },
 
@@ -357,7 +363,7 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
         chunks: ['main'],
         filename: 'index.html',
       }),
-      new ProvidePlugin({ process: fallbacksProvidePluginConfig.process }),
+      new ProvidePlugin({ process: fallbacksProvidePluginConfig.process, Buffer: fallbacksProvidePluginConfig.Buffer }),
     ],
   };
 }


### PR DESCRIPTION
This PR adds the polyfills required for @pnpm/node-fetch which replaced cross-fetch in graphql.ui.runtime. With this bit start now runs without any errors. 