### PR TITLE
fix(compare): make component compare context single instance at runtime

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.base.config.ts
@@ -101,6 +101,9 @@ export default function createWebpackConfig(
           'react-dom$': 'react-dom/profiling',
           'scheduler/tracing': 'scheduler/tracing-profiling',
         }),
+        '@teambit/component.ui.component-compare.context': require.resolve(
+          '@teambit/component.ui.component-compare.context'
+        ),
       },
       fallback: {
         module: false,

--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -178,6 +178,9 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
         react: require.resolve('react'),
         'react-dom/server': require.resolve('react-dom/server'),
         'react-dom': require.resolve('react-dom'),
+        '@teambit/component.ui.component-compare.context': require.resolve(
+          '@teambit/component.ui.component-compare.context'
+        ),
         // 'react-refresh/runtime': require.resolve('react-refresh/runtime'),
       },
       fallback: {


### PR DESCRIPTION
This PR fixes the issue with component compare not rendering configuration diffs. The issue was because of multiple versions of `@teambit/component.ui.component-compare.context` at runtime. This fix adds a webpack alias for `@teambit/component.ui.component-compare.context` ensuring there is only one instance of the context at runtime. 

<img width="1405" alt="Screenshot 2024-04-22 at 1 09 54 PM" src="https://github.com/teambit/bit/assets/8999604/0c74d844-391d-488a-b2a9-f6820a822503">
