### PR TITLE
fix(format), avoid replacing end-of-line character on Windows, keep them as you got them from Prettier.

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -148,7 +148,7 @@
         "@teambit/defender.content.linter-overview": "1.95.0",
         "@teambit/defender.content.tester-overview": "1.95.0",
         "@teambit/defender.eslint-linter": "1.0.22",
-        "@teambit/defender.prettier-formatter": "1.0.11",
+        "@teambit/defender.prettier-formatter": "1.0.12",
         "@teambit/defender.ui.test-compare-section": "^0.0.100",
         "@teambit/defender.ui.test-loader": "^0.0.504",
         "@teambit/defender.ui.test-row": "^0.0.503",


### PR DESCRIPTION
Fixes #7477 

The change was done in this PR: https://bit.cloud/teambit/defender/~change-requests/fix-eol-win.