### PR TITLE
feat, introduce a new command "bit lane eject" to delete from lane and install as package

### DIFF
--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -79,7 +79,8 @@ this command marks the components as deleted, and after snap/tag and export they
       return `${localMessage}${this.paintArray(remoteResult)}`;
     }
 
-    const removedCompIds = await this.remove.deleteComps(componentsPattern, { updateMain });
+    const removedComps = await this.remove.deleteComps(componentsPattern, { updateMain });
+    const removedCompIds = removedComps.map((comp) => comp.id.toString());
     return `${chalk.green('successfully deleted the following components:')}
 ${removedCompIds.join('\n')}
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -93,7 +93,7 @@ export class RemoveMain {
     return results;
   }
 
-  async markRemoveComps(componentIds: ComponentID[], shouldUpdateMain = false) {
+  private async markRemoveComps(componentIds: ComponentID[], shouldUpdateMain = false): Promise<Component[]> {
     const components = await this.workspace.getMany(componentIds);
     await removeComponentsFromNodeModules(
       this.workspace.consumer,
@@ -105,13 +105,13 @@ export class RemoveMain {
     if (shouldUpdateMain) config.removeOnMain = true;
     componentIds.map((compId) => this.workspace.bitMap.addComponentConfig(compId, RemoveAspect.id, config));
     await this.workspace.bitMap.write('delete');
-    const bitIds = ComponentIdList.fromArray(componentIds.map((id) => id));
+    const bitIds = ComponentIdList.fromArray(componentIds);
     await deleteComponentsFiles(this.workspace.consumer, bitIds);
 
-    return componentIds;
+    return components;
   }
 
-  async deleteComps(componentsPattern: string, opts: { updateMain?: boolean } = {}): Promise<ComponentID[]> {
+  async deleteComps(componentsPattern: string, opts: { updateMain?: boolean } = {}): Promise<Component[]> {
     if (!this.workspace) throw new ConsumerNotFound();
     const componentIds = await this.workspace.idsByPattern(componentsPattern);
     const newComps = componentIds.filter((id) => !id.hasVersion());

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -351,6 +351,31 @@ export class LaneHistoryCmd implements Command {
   }
 }
 
+export class LaneEjectCmd implements Command {
+  name = 'eject <component-pattern>';
+  description = `delete a component from the lane and install it as a package from main`;
+  extendedDescription = `NOTE: unlike "bit eject" on main, this command doesn't only remove the component from the
+workspace, but also mark it as deleted from the lane, so it won't be merged later on.`;
+  alias = '';
+  arguments = [
+    {
+      name: 'component-pattern',
+      description: COMPONENT_PATTERN_HELP,
+    },
+  ];
+  options = [] as CommandOptions;
+  loader = true;
+
+  constructor(private lanes: LanesMain) {}
+
+  async report([pattern]: [string]) {
+    const results = await this.lanes.eject(pattern);
+    const title = chalk.green('successfully ejected the following components');
+    const body = results.map((r) => r.toString()).join('\n');
+    return `${title}\n${body}`;
+  }
+}
+
 export class LaneChangeScopeCmd implements Command {
   name = 'change-scope <remote-scope-name>';
   description = `changes the remote scope of a lane`;

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -530,6 +530,9 @@ export default class CommandHelper {
   fetchLane(id: string) {
     return this.runCmd(`bit fetch ${id} --lanes`);
   }
+  ejectFromLane(id: string) {
+    return this.runCmd(`bit lane eject ${id}`);
+  }
   fetchRemoteLane(id: string) {
     return this.runCmd(`bit fetch ${this.scopes.remote}${LANE_REMOTE_DELIMITER}${id} --lanes`);
   }


### PR DESCRIPTION
In many cases, the reason to remove a component from a lane is by realizing that there is no need to change the component, and it's perfectly fine to use it from main. 
Until now, it required two commands: 1) `bit delete comp-x --lane` and 2) `bit install comp-x-pkg`. 
Without the installation of the package, `bit status` was complaining (rightfully so) about using deleted components. 
This new command `bit lane eject` is practically a sugar of executing the two commands above. 