### PR TITLE
fix(preview): revert back to cross-fetch in preview runtime

### DIFF
--- a/e2e/harmony/lanes/lane-eject.e2e.ts
+++ b/e2e/harmony/lanes/lane-eject.e2e.ts
@@ -1,0 +1,75 @@
+import chai, { expect } from 'chai';
+import path from 'path';
+import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../../npm-ci-registry';
+import Helper from '../../../src/e2e-helper/e2e-helper';
+import { DEFAULT_OWNER } from '../../../src/e2e-helper/e2e-scopes';
+
+chai.use(require('chai-fs'));
+
+describe('bit lane command', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  (supportNpmCiRegistryTesting ? describe : describe.skip)('eject components with dependencies after export', () => {
+    let npmCiRegistry: NpmCiRegistry;
+    let scopeWithoutOwner: string;
+    before(async () => {
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      scopeWithoutOwner = helper.scopes.remoteWithoutOwner;
+      helper.fixtures.populateComponents(3);
+      npmCiRegistry = new NpmCiRegistry(helper);
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+      await npmCiRegistry.init();
+      helper.command.tagAllComponents();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.scopeHelper.removeRemoteScope();
+      npmCiRegistry.setResolver();
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+    });
+    describe('eject with the default options', () => {
+      let ejectOutput: string;
+      before(() => {
+        ejectOutput = helper.command.ejectFromLane('comp1');
+      });
+      it('should indicate that the eject was successful', () => {
+        expect(ejectOutput).to.have.string('successfully ejected');
+      });
+      it('should save the component in workspace.jsonc', () => {
+        const workspaceJson = helper.workspaceJsonc.read();
+        expect(workspaceJson['teambit.dependencies/dependency-resolver'].policy.dependencies).to.have.property(
+          `@${DEFAULT_OWNER}/${scopeWithoutOwner}.comp1`
+        );
+      });
+      it('should mark the component as deleted on the lane', () => {
+        const status = helper.command.statusJson();
+        expect(status.locallySoftRemoved).to.have.lengthOf(1);
+      });
+      it('should have the component files as a package (in node_modules)', () => {
+        const fileInPackage = path.join(`node_modules/@${DEFAULT_OWNER}`, `${scopeWithoutOwner}.comp1`, 'index.js');
+        expect(path.join(helper.scopes.localPath, fileInPackage)).to.be.a.path();
+      });
+      it('should delete the original component files from the file-system', () => {
+        expect(path.join(helper.scopes.localPath, 'comp1')).not.to.be.a.path();
+      });
+      it('bit status should show no issues', () => {
+        helper.command.expectStatusToNotHaveIssues();
+      });
+      it('should not delete the objects from the scope', () => {
+        const listScope = helper.command.listLocalScopeParsed('--scope');
+        const ids = listScope.map((l) => l.id);
+        expect(ids).to.include(`${helper.scopes.remote}/comp1`);
+      });
+    });
+  });
+});

--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -79,7 +79,8 @@ this command marks the components as deleted, and after snap/tag and export they
       return `${localMessage}${this.paintArray(remoteResult)}`;
     }
 
-    const removedCompIds = await this.remove.deleteComps(componentsPattern, { updateMain });
+    const removedComps = await this.remove.deleteComps(componentsPattern, { updateMain });
+    const removedCompIds = removedComps.map((comp) => comp.id.toString());
     return `${chalk.green('successfully deleted the following components:')}
 ${removedCompIds.join('\n')}
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -93,7 +93,7 @@ export class RemoveMain {
     return results;
   }
 
-  async markRemoveComps(componentIds: ComponentID[], shouldUpdateMain = false) {
+  private async markRemoveComps(componentIds: ComponentID[], shouldUpdateMain = false): Promise<Component[]> {
     const components = await this.workspace.getMany(componentIds);
     await removeComponentsFromNodeModules(
       this.workspace.consumer,
@@ -105,13 +105,13 @@ export class RemoveMain {
     if (shouldUpdateMain) config.removeOnMain = true;
     componentIds.map((compId) => this.workspace.bitMap.addComponentConfig(compId, RemoveAspect.id, config));
     await this.workspace.bitMap.write('delete');
-    const bitIds = ComponentIdList.fromArray(componentIds.map((id) => id));
+    const bitIds = ComponentIdList.fromArray(componentIds);
     await deleteComponentsFiles(this.workspace.consumer, bitIds);
 
-    return componentIds;
+    return components;
   }
 
-  async deleteComps(componentsPattern: string, opts: { updateMain?: boolean } = {}): Promise<ComponentID[]> {
+  async deleteComps(componentsPattern: string, opts: { updateMain?: boolean } = {}): Promise<Component[]> {
     if (!this.workspace) throw new ConsumerNotFound();
     const componentIds = await this.workspace.idsByPattern(componentsPattern);
     const newComps = componentIds.filter((id) => !id.hasVersion());

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -351,6 +351,31 @@ export class LaneHistoryCmd implements Command {
   }
 }
 
+export class LaneEjectCmd implements Command {
+  name = 'eject <component-pattern>';
+  description = `delete a component from the lane and install it as a package from main`;
+  extendedDescription = `NOTE: unlike "bit eject" on main, this command doesn't only remove the component from the
+workspace, but also mark it as deleted from the lane, so it won't be merged later on.`;
+  alias = '';
+  arguments = [
+    {
+      name: 'component-pattern',
+      description: COMPONENT_PATTERN_HELP,
+    },
+  ];
+  options = [] as CommandOptions;
+  loader = true;
+
+  constructor(private lanes: LanesMain) {}
+
+  async report([pattern]: [string]) {
+    const results = await this.lanes.eject(pattern);
+    const title = chalk.green('successfully ejected the following components');
+    const body = results.map((r) => r.toString()).join('\n');
+    return `${title}\n${body}`;
+  }
+}
+
 export class LaneChangeScopeCmd implements Command {
   name = 'change-scope <remote-scope-name>';
   description = `changes the remote scope of a lane`;

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -530,6 +530,9 @@ export default class CommandHelper {
   fetchLane(id: string) {
     return this.runCmd(`bit fetch ${id} --lanes`);
   }
+  ejectFromLane(id: string) {
+    return this.runCmd(`bit lane eject ${id}`);
+  }
   fetchRemoteLane(id: string) {
     return this.runCmd(`bit fetch ${this.scopes.remote}${LANE_REMOTE_DELIMITER}${id} --lanes`);
   }


### PR DESCRIPTION
This PR fixes the issue of preview not rendering when tagged with the last stable bit version (1.6.140). This was because of our custom cross fetch library (`@pnpm/node-fetch`) which replaced the cross-fetch lib in preview runtime to provide better support for proxy and ca cert support, but didn't handle relative routes correctly like the old cross-fetch lib did.
Since preview makes a request from the frontend - we don't need support for proxy and ca cert handling - so we revert back to the old cross-fetch lib in preview runtime which fixes the issue of preview not rendering by handling relative urls correctly. 