### PR TITLE
fix(preview): revert to cross-fetch lib in preview preview runtime

### DIFF
--- a/scopes/preview/preview/preview.preview.runtime.tsx
+++ b/scopes/preview/preview/preview.preview.runtime.tsx
@@ -1,7 +1,7 @@
 import { PubsubAspect, PubsubPreview } from '@teambit/pubsub';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import { ComponentID } from '@teambit/component-id';
-import _crossFetch from '@pnpm/node-fetch';
+import crossFetch from 'cross-fetch';
 import memoize from 'memoizee';
 import { debounce, intersection, isObject } from 'lodash';
 
@@ -15,8 +15,6 @@ import { fetchComponentAspects } from './gql/fetch-component-aspects';
 import { PREVIEW_MODULES } from './preview-modules';
 import { loadScript, loadLink } from './html-utils';
 import { SizeEvent } from './size-event';
-
-const crossFetch: typeof fetch = _crossFetch as unknown as typeof fetch;
 
 // forward linkModules() for generate-link.ts
 export { linkModules } from './preview-modules';


### PR DESCRIPTION
This PR fixes the issue of preview not rendering when tagged with the last stable bit version (1.6.140). This was because of our custom cross fetch library (`@pnpm/node-fetch`) which replaced the cross-fetch lib in preview runtime to provide better support for proxy and ca cert support, but didn't handle relative routes correctly like the old cross-fetch lib did.
Since preview makes a request from the frontend - we don't need support for proxy and ca cert handling - so we revert back to the old cross-fetch lib in preview runtime which fixes the issue of preview not rendering by handling relative urls correctly. 