### PR TITLE
fix(checkout-reset), reset component.json if exists locally

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -6,7 +6,7 @@ import * as path from 'path';
 import { MissingBitMapComponent } from '../../src/consumer/bit-map/exceptions';
 import { NewerVersionFound } from '../../src/consumer/exceptions';
 import Helper, { FileStatusWithoutChalk } from '../../src/e2e-helper/e2e-helper';
-import { FILE_CHANGES_CHECKOUT_MSG } from '../../src/constants';
+import { Extensions, FILE_CHANGES_CHECKOUT_MSG } from '../../src/constants';
 
 chai.use(require('chai-fs'));
 
@@ -627,6 +627,25 @@ describe('bit checkout command', function () {
       expect(policy).to.have.string('"lodash.get": "4.4.1"');
       expect(policy).to.have.string('"lodash.get": "^4.4.2"');
       expect(policy).to.have.string('>>>>>>> theirs');
+    });
+  });
+  describe('checkout reset with changes in component.json', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.ejectConf('comp1');
+      helper.componentJson.setExtension(Extensions.pkg, { name: 'new-name' }, 'comp1');
+      // an intermediate step make sure the component is modified
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(1);
+
+      helper.command.checkoutReset('-a -x');
+    });
+    it('status should not show the component as modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
     });
   });
 });

--- a/e2e/harmony/component-config.e2e.ts
+++ b/e2e/harmony/component-config.e2e.ts
@@ -79,7 +79,7 @@ describe('component config', function () {
           output = helper.command.ejectConf('bar/foo');
         });
         it('should throw error if override not used', () => {
-          componentJsonPath = helper.componentJson.composePath('bar');
+          componentJsonPath = helper.componentJson.composePath('bar', false);
           const ejectCmd = () => helper.command.ejectConf('bar/foo');
           const error = new AlreadyExistsError(componentJsonPath);
           helper.general.expectToThrow(ejectCmd, error);

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -13,6 +13,7 @@ import ConsumerComponent from '@teambit/legacy/dist/consumer/component';
 import { isDir, isDirEmptySync } from '@teambit/legacy/dist/utils';
 import { PathLinuxRelative, pathNormalizeToLinux, PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
 import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
+import { COMPONENT_CONFIG_FILE_NAME } from '@teambit/legacy/dist/constants';
 import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
 import { ConfigMergerAspect, ConfigMergerMain, WorkspaceConfigUpdateResult } from '@teambit/config-merger';
 import Consumer from '@teambit/legacy/dist/consumer/consumer';
@@ -125,6 +126,13 @@ export class ComponentWriterMain {
         componentWriter.existingComponentMap =
           componentWriter.existingComponentMap ||
           (await componentWriter.addComponentToBitMap(componentWriter.writeToPath));
+        const componentConfigPath = path.join(
+          this.workspace.path,
+          componentWriter.existingComponentMap.rootDir,
+          COMPONENT_CONFIG_FILE_NAME
+        );
+        const componentConfigExist = await fs.pathExists(componentConfigPath);
+        componentWriter.writeConfig = componentWriter.writeConfig || componentConfigExist;
       })
     );
     if (opts.resetConfig) {

--- a/scopes/workspace/workspace/component-config-file/component-config-file.ts
+++ b/scopes/workspace/workspace/component-config-file/component-config-file.ts
@@ -2,17 +2,17 @@ import { ComponentID, AspectList, AspectEntry, ResolveComponentIdFunc } from '@t
 import { COMPONENT_CONFIG_FILE_NAME } from '@teambit/legacy/dist/constants';
 import { ExtensionDataList, configEntryToDataEntry } from '@teambit/legacy/dist/consumer/config/extension-data';
 import { PathOsBasedAbsolute } from '@teambit/legacy/dist/utils/path';
+import { JsonVinyl } from '@teambit/legacy/dist/consumer/component/json-vinyl';
 import detectIndent from 'detect-indent';
 import detectNewline from 'detect-newline';
 import fs from 'fs-extra';
 import path from 'path';
-import stringifyPackage from 'stringify-package';
 import { REMOVE_EXTENSION_SPECIAL_SIGN } from '@teambit/legacy/dist/consumer/config';
 import { merge } from 'lodash';
 import { AlreadyExistsError } from './exceptions';
 
 interface ComponentConfigFileOptions {
-  indent: number;
+  indent: string;
   newLine: '\r\n' | '\n' | undefined;
 }
 
@@ -28,7 +28,7 @@ interface ComponentConfigFileJson {
   defaultScope?: string;
 }
 
-const DEFAULT_INDENT = 2;
+const DEFAULT_INDENT = '  ';
 const DEFAULT_NEWLINE = '\n';
 
 export class ComponentConfigFile {
@@ -53,7 +53,7 @@ export class ComponentConfigFile {
     }
     const content = await fs.readFile(filePath, 'utf-8');
     const parsed: ComponentConfigFileJson = parseComponentJsonContent(content, componentDir);
-    const indent = detectIndent(content).amount;
+    const indent = detectIndent(content).indent;
     const newLine = detectNewline(content);
     const componentId = ComponentID.fromObject(parsed.componentId, parsed.defaultScope || outsideDefaultScope);
     const aspects = await aspectListFactory(ExtensionDataList.fromConfigObject(parsed.extensions));
@@ -72,14 +72,27 @@ export class ComponentConfigFile {
     return path.join(componentRootFolder, COMPONENT_CONFIG_FILE_NAME);
   }
 
-  async write(options: WriteConfigFileOptions = {}): Promise<void> {
+  async toVinylFile(options: WriteConfigFileOptions = {}): Promise<JsonVinyl> {
     const json = this.toJson();
     const filePath = ComponentConfigFile.composePath(this.componentDir);
     const isExist = await fs.pathExists(filePath);
     if (isExist && !options.override) {
       throw new AlreadyExistsError(filePath);
     }
-    return fs.writeJsonSync(filePath, json, { spaces: this.options.indent, EOL: this.options.newLine });
+
+    return JsonVinyl.load({
+      base: path.dirname(filePath),
+      path: filePath,
+      content: json,
+      override: true,
+      indent: this.options.indent,
+      newline: this.options.newLine,
+    });
+  }
+
+  async write(options: WriteConfigFileOptions = {}): Promise<void> {
+    const vinyl = await this.toVinylFile(options);
+    await vinyl.write();
   }
 
   async addAspect(
@@ -129,11 +142,6 @@ export class ComponentConfigFile {
       defaultScope: this.defaultScope,
       extensions: this.aspects.toConfigObject(),
     };
-  }
-
-  toString(): string {
-    const json = this.toJson();
-    return stringifyPackage(json, this.options.indent, this.options.newLine);
   }
 }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -69,6 +69,8 @@ import { ScopeNotFoundOrDenied } from '@teambit/legacy/dist/remotes/exceptions/s
 import { isHash } from '@teambit/component-version';
 import { GlobalConfigMain } from '@teambit/global-config';
 import { getAuthHeader, fetchWithAgent as fetch } from '@teambit/legacy/dist/scope/network/http/http';
+import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
+import { JsonVinyl } from '@teambit/legacy/dist/consumer/component/json-vinyl';
 import { ComponentConfigFile } from './component-config-file';
 import {
   OnComponentAdd,
@@ -917,28 +919,38 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
     return ExtensionDataList.fromConfigObject(this.config.extensions);
   }
 
-  async ejectMultipleConfigs(ids: ComponentID[], options: EjectConfOptions): Promise<EjectConfResult[]> {
-    return Promise.all(ids.map((id) => this.ejectConfig(id, options)));
-  }
-
-  async ejectConfig(id: ComponentID, options: EjectConfOptions): Promise<EjectConfResult> {
+  async getComponentConfigVinylFile(
+    id: ComponentID,
+    options: EjectConfOptions,
+    excludeLocalChanges = false
+  ): Promise<JsonVinyl> {
     const componentId = await this.resolveComponentId(id);
-    const extensions = await this.getExtensionsFromScopeAndSpecific(id);
+    const extensions = await this.getExtensionsFromScopeAndSpecific(id, excludeLocalChanges);
     const aspects = await this.createAspectList(extensions);
-    const componentDir = this.componentDir(id, { ignoreVersion: true });
-    const componentConfigFile = new ComponentConfigFile(componentId, aspects, componentDir, options.propagate);
-    await componentConfigFile.write({ override: options.override });
-    // remove config from the .bitmap as it's not needed anymore. it is replaced by the component.json
-    this.bitMap.removeEntireConfig(id);
-    await this.bitMap.write(`eject-conf (${id.toString()})`);
-    return {
-      configPath: ComponentConfigFile.composePath(componentDir),
-    };
+    const componentDir = this.componentDir(id, { ignoreVersion: true }, { relative: true });
+    const configFile = new ComponentConfigFile(componentId, aspects, componentDir, options.propagate);
+    return configFile.toVinylFile(options);
   }
 
-  async getExtensionsFromScopeAndSpecific(id: ComponentID): Promise<ExtensionDataList> {
+  async ejectMultipleConfigs(ids: ComponentID[], options: EjectConfOptions): Promise<EjectConfResult[]> {
+    const vinylFiles = await Promise.all(ids.map((id) => this.getComponentConfigVinylFile(id, options)));
+    const EjectConfResult = vinylFiles.map((file) => ({ configPath: file.path }));
+    const dataToPersist = new DataToPersist();
+    dataToPersist.addManyFiles(vinylFiles);
+    dataToPersist.addBasePath(this.path);
+    await dataToPersist.persistAllToFS();
+
+    ids.map((id) => this.bitMap.removeEntireConfig(id));
+    await this.bitMap.write(`eject-conf (${ids.length} component(s))`);
+
+    return EjectConfResult;
+  }
+
+  async getExtensionsFromScopeAndSpecific(id: ComponentID, excludeComponentJson = false): Promise<ExtensionDataList> {
     const componentFromScope = await this.scope.get(id);
-    const { extensions } = await this.componentExtensions(id, componentFromScope, ['WorkspaceVariants']);
+    const exclude: ExtensionsOrigin[] = ['WorkspaceVariants'];
+    if (excludeComponentJson) exclude.push('ComponentJsonFile');
+    const { extensions } = await this.componentExtensions(id, componentFromScope, exclude);
 
     return extensions;
   }

--- a/src/consumer/component/json-vinyl.ts
+++ b/src/consumer/component/json-vinyl.ts
@@ -1,4 +1,4 @@
-import { dirname } from 'path';
+import { dirname, basename } from 'path';
 import fs from 'fs-extra';
 import stringifyPackage from 'stringify-package';
 import writeFileAtomic from 'write-file-atomic';
@@ -13,28 +13,25 @@ import AbstractVinyl from './sources/abstract-vinyl';
  * package.json is exactly the same used by NPM. The indentation and newline are detected when the
  * file is loaded. (@see package-json-file.js)
  */
-export default class PackageJsonVinyl extends AbstractVinyl {
+export class JsonVinyl extends AbstractVinyl {
   override = true;
 
   async write(): Promise<string> {
     const stat = await this._getStatIfFileExists();
     if (stat) {
       if (stat.isSymbolicLink()) {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        throw new ValidationError(`fatal: trying to write a package.json file into a symlink file at "${this.path}"`);
+        throw new ValidationError(
+          `fatal: trying to write a ${basename(this.path)} file into a symlink file at "${this.path}"`
+        );
       }
       if (!this.override) {
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        logger.debug(`package-json-vinyl.write, ignore existing file ${this.path}`);
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+        logger.debug(`json-vinyl.write, ignore existing file ${this.path}`);
         return this.path;
       }
     }
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    logger.debug(`package-json-vinyl.write, path ${this.path}`);
+    logger.debug(`json-vinyl.write, path ${this.path}`);
     await fs.mkdirp(dirname(this.path));
     await writeFileAtomic(this.path, this.contents);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     return this.path;
   }
 
@@ -52,10 +49,9 @@ export default class PackageJsonVinyl extends AbstractVinyl {
     indent?: string | null | undefined;
     newline?: string | null | undefined;
     override?: boolean;
-  }): PackageJsonVinyl {
+  }): JsonVinyl {
     const jsonStr = stringifyPackage(content, indent, newline);
-    // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-    const jsonFile = new PackageJsonVinyl({ base, path, contents: Buffer.from(jsonStr) });
+    const jsonFile = new JsonVinyl({ base, path, contents: Buffer.from(jsonStr) });
     jsonFile.override = override;
     return jsonFile;
   }

--- a/src/consumer/component/package-json-file.ts
+++ b/src/consumer/component/package-json-file.ts
@@ -11,7 +11,7 @@ import logger from '../../logger/logger';
 import componentIdToPackageName from '../../utils/bit/component-id-to-package-name';
 import { PathOsBased, PathOsBasedAbsolute, PathOsBasedRelative, PathRelative } from '../../utils/path';
 import Component from './consumer-component';
-import PackageJsonVinyl from './package-json-vinyl';
+import { JsonVinyl } from './json-vinyl';
 
 /**
  * when a package.json file is loaded, we save the indentation and the type of newline it uses, so
@@ -170,8 +170,8 @@ export default class PackageJsonFile {
     return new PackageJsonFile({ filePath, packageJsonObject, fileExist: false });
   }
 
-  toVinylFile(): PackageJsonVinyl {
-    return PackageJsonVinyl.load({
+  toVinylFile(): JsonVinyl {
+    return JsonVinyl.load({
       base: path.dirname(this.filePath),
       path: this.filePath,
       content: this.packageJsonObject,


### PR DESCRIPTION
currently, if there are local changes in the component.json (generated by `bit config eject-conf`), then `bit checkout reset` doesn't reset them. It leaves the file as is.
This PR refactors the way how this component.json file is saved to reuse the infrastructure we had for package.json (with indent and EOL taken into account). With this, it was easier to change the component-written command to make sure this file is written if it was there before.