### PR TITLE
fix(remove), block removal of new aspects that are used by other components

### DIFF
--- a/scopes/component/remove/remove-components.ts
+++ b/scopes/component/remove/remove-components.ts
@@ -131,19 +131,21 @@ async function removeLocal(
           throw err;
         }
       }
+    });
+    if (newIds.length) {
       const list = await workspace.listWithInvalid();
       list.components.forEach((c) => {
         if (bitIds.hasWithoutVersion(c.id)) return; // it gets deleted anyway
         const aspectIds = c.state.aspects.ids;
         const used = newIds.find((newId) => aspectIds.includes(newId));
         if (used)
-          throw new BitError(`Unable to remove ${id.toStringWithoutVersion()}.
+          throw new BitError(`Unable to remove ${c.id.toStringWithoutVersion()}.
 This component is 1) an aspect 2) is used by other components, such as "${c.id.toStringWithoutVersion()}" 3) it's a new component so it can't be installed as a package.
 Removing this component from the workspace will disrupt the functionality of other components that depend on it, and resolving these issues may not be straightforward.
 If you understand the risks and wish to proceed with the removal, please use the --force flag.
 `);
       });
-    });
+    }
   }
   const idsToRemove = force ? bitIds : nonModifiedComponents;
   const componentsList = new ComponentsList(consumer);


### PR DESCRIPTION
Otherwise, the components that depend on these removed aspects are trying to load them, find out they don't exists, then trying to import them and throw an error "unable to import".
Because these removed aspects are new, there is no easy way to fix this. It's impossible to install them as packages.
This PR blocks it unless `--force` flag was used. 