### PR TITLE
preparation for performance improvement by asking server for existence of objects rather than trying to fetch them

### DIFF
--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -38,6 +38,9 @@ export function scopeSchema(scopeMain: ScopeMain) {
         # get many components by ID.
         getMany(ids: [String]!): [Component]
 
+        # filter existing objects in the scope.
+        hasObjects(hashes: [String]!): [String]
+
         # get serialized legacy component ids with versions. deprecated. PLEASE DO NOT USE THIS API.
         _legacyLatestVersions(ids: [String]!): [String]
       }
@@ -103,6 +106,10 @@ export function scopeSchema(scopeMain: ScopeMain) {
 
         getMany: async (scope: ScopeMain, { ids }: { ids: string[] }) => {
           return scope.getMany(ids.map((str) => ComponentID.fromString(str)));
+        },
+
+        hasObjects: async (scope: ScopeMain, { hashes }: { hashes: string[] }) => {
+          return scope.hasObjects(hashes);
         },
         // delete: async (scope: ScopeMain, props: {  }) => {
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1153,6 +1153,12 @@ export class ScopeMain implements ComponentFactory {
     // no-op (it's relevant for the workspace only)
   }
 
+  async hasObjects(hashes: string[]): Promise<string[]> {
+    const refs = hashes.map((h) => Ref.from(h));
+    const results = await this.legacyScope.objects.hasMultiple(refs);
+    return results.map((r) => r.hash);
+  }
+
   /**
    * declare the slots of scope extension.
    */

--- a/src/remotes/remote.ts
+++ b/src/remotes/remote.ts
@@ -104,6 +104,9 @@ export default class Remote {
   listLanes(name?: string, mergeData?: boolean): Promise<LaneData[]> {
     return this.connect().then((network) => network.listLanes(name, mergeData));
   }
+  async hasObjects(hashes: string[]): Promise<string[]> {
+    return this.connect().then((network) => network.hasObjects(hashes));
+  }
   async action<Options extends Record<string, any>, Result>(name: string, options: Options): Promise<Result> {
     const network = await this.connect();
     logger.debug(`[-] Running action ${name} on a remote ${this.name}, options: ${JSON.stringify(options)}`);

--- a/src/scope/component-ops/scope-components-importer.ts
+++ b/src/scope/component-ops/scope-components-importer.ts
@@ -30,7 +30,6 @@ import { getAllVersionHashes } from './traverse-versions';
 import { FETCH_OPTIONS } from '../../api/scope/lib/fetch';
 import { pMapPool } from '../../utils/promise-with-concurrent';
 import { CLOUD_IMPORTER, CLOUD_IMPORTER_V2, isFeatureEnabled } from '../../api/consumer/lib/feature-toggle';
-import getRemoteByName from '../../remotes/get-remote-by-name';
 
 type HashesPerRemote = { [remoteName: string]: string[] };
 

--- a/src/scope/network/fs/fs.ts
+++ b/src/scope/network/fs/fs.ts
@@ -14,6 +14,7 @@ import Scope, { ScopeDescriptor } from '../../scope';
 import loadScope from '../../scope-loader';
 import { FsScopeNotLoaded } from '../exceptions';
 import { Network } from '../network';
+import { Ref } from '../../objects';
 
 export default class Fs implements Network {
   scopePath: string;
@@ -102,5 +103,10 @@ export default class Fs implements Network {
       this.scope = scope;
       return this;
     });
+  }
+
+  async hasObjects(hashes: string[]): Promise<string[]> {
+    const results = await this.getScope().objects.hasMultiple(hashes.map((h) => Ref.from(h)));
+    return results.map((result) => result.toString());
   }
 }

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -619,6 +619,19 @@ export class Http implements Network {
     }));
   }
 
+  async hasObjects(hashes: string[]): Promise<string[]> {
+    const HAS_OBJECTS = gql`
+      query hasObjects($hashes: [String!]) {
+        scope {
+          hasObjects(hashes: $hashes)
+        }
+      }
+    `;
+    const res = await this.graphClientRequest(HAS_OBJECTS, Verb.READ, { hashes });
+
+    return res;
+  }
+
   private getHeaders(headers: { [key: string]: string } = {}) {
     const authHeader = this.token ? getAuthHeader(this.token) : {};
     const localScope = this.localScopeName ? { 'x-request-scope': this.localScopeName } : {};

--- a/src/scope/network/network.ts
+++ b/src/scope/network/network.ts
@@ -30,4 +30,5 @@ export interface Network {
   latestVersions(bitIds: ComponentIdList): Promise<string[]>;
   graph(bitId?: ComponentID): Promise<DependencyGraph>;
   listLanes(name?: string, mergeData?: boolean): Promise<LaneData[]>;
+  hasObjects(hashes: string[]): Promise<string[]>;
 }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -154,6 +154,19 @@ export default class Repository {
     return fs.pathExists(objectPath);
   }
 
+  async hasMultiple(refs: Ref[]): Promise<Ref[]> {
+    const concurrency = concurrentIOLimit();
+    const existingRefs = await pMap(
+      refs,
+      async (ref) => {
+        const pathExists = await this.has(ref);
+        return pathExists ? ref : null;
+      },
+      { concurrency }
+    );
+    return compact(existingRefs);
+  }
+
   async load(ref: Ref, throws = false, preferInMemoryObjects = false): Promise<BitObject> {
     if (preferInMemoryObjects) {
       // during tag, the updated objects are in `this.objects`.


### PR DESCRIPTION
This will be actually used once remotes are updated and support the new GraphQL query.
An example of this query:
```
query HasObjects {
  scope {
    hasObjects(hashes: ["075b5e1d5ab0c81e6a17648cbe966091c8d9bfb1", "075b5e1d5ab0c81e6a17648cbe966091c8d9bfb2"])
  }
}
```
and a result could be:
```
{
  "data": {
    "scope": {
      "hasObjects": [
        "075b5e1d5ab0c81e6a17648cbe966091c8d9bfb1"
      ]
    }
  }
}
```