### PR TITLE
add a graphql query to get bit version of the remote scope

### DIFF
--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -2,6 +2,7 @@ import { ComponentID } from '@teambit/component';
 import { gql } from 'graphql-tag';
 import { latestVersions } from '@teambit/legacy/dist/api/scope';
 import { LegacyComponentLog as ComponentLog } from '@teambit/legacy-component-log';
+import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import { ScopeMain } from './scope.main.runtime';
 
 export function scopeSchema(scopeMain: ScopeMain) {
@@ -40,6 +41,9 @@ export function scopeSchema(scopeMain: ScopeMain) {
 
         # filter existing objects in the scope.
         hasObjects(hashes: [String]!): [String]
+
+        # get bit version
+        getBitVersion: String
 
         # get serialized legacy component ids with versions. deprecated. PLEASE DO NOT USE THIS API.
         _legacyLatestVersions(ids: [String]!): [String]
@@ -110,6 +114,10 @@ export function scopeSchema(scopeMain: ScopeMain) {
 
         hasObjects: async (scope: ScopeMain, { hashes }: { hashes: string[] }) => {
           return scope.hasObjects(hashes);
+        },
+
+        getBitVersion: () => {
+          return getHarmonyVersion(true);
         },
         // delete: async (scope: ScopeMain, props: {  }) => {
 


### PR DESCRIPTION
Once deployed on the remote scopes, it can help a client in negotiating with the server and adjusting API compatibility.

Example:
```
query BitVer {
  scope {
    getBitVersion
  }
}
```
Response
```
{
  "data": {
    "scope": {
      "getBitVersion": "1.6.150"
    }
  }
}
```
