### PR TITLE
fix(scope-rename), replace aspects properly in workspace.jsonc

### DIFF
--- a/scopes/component/renaming/renaming.main.runtime.ts
+++ b/scopes/component/renaming/renaming.main.runtime.ts
@@ -245,12 +245,13 @@ make sure this argument is the name only, without the scope-name. to change the 
   private async renameAspectIdsInWorkspaceConfig(ids: RenameId[]) {
     const config = this.config.workspaceConfig;
     if (!config) throw new Error('unable to get workspace config');
-    const hasChanged = ids.some((renameId) =>
+    const wereChangesDone = ids.map((renameId) =>
       config.renameExtensionInRaw(
         renameId.sourceId.toStringWithoutVersion(),
         renameId.targetId.toStringWithoutVersion()
       )
     );
+    const hasChanged = wereChangesDone.some((isChanged) => isChanged);
     if (hasChanged) await config.write({ reasonForChange: 'rename' });
   }
   private async changeEnvsAccordingToNewIds(renameData: RenameData[]) {

--- a/scopes/harmony/config/workspace-config.ts
+++ b/scopes/harmony/config/workspace-config.ts
@@ -108,32 +108,33 @@ export class WorkspaceConfig implements HostConfig {
   }
 
   renameExtensionInRaw(oldExtId: string, newExtId: string): boolean {
+    let isChanged = false;
     if (this.raw[oldExtId]) {
       this.raw[newExtId] = this.raw[oldExtId];
       delete this.raw[oldExtId];
-      return true;
+      isChanged = true;
     }
     const generatorEnvs = this.raw?.['teambit.generator/generator']?.envs;
     if (generatorEnvs && generatorEnvs.includes(oldExtId)) {
       generatorEnvs.splice(generatorEnvs.indexOf(oldExtId), 1, newExtId);
-      return true;
+      isChanged = true;
     }
-    return false;
+    return isChanged;
   }
 
   removeExtension(extId: string): boolean {
+    let isChanged = false;
     if (this.raw[extId]) {
       delete this.raw[extId];
-      this.loadExtensions();
-      return true;
+      isChanged = true;
     }
     const generatorEnvs = this.raw?.['teambit.generator/generator']?.envs;
     if (generatorEnvs && generatorEnvs.includes(extId)) {
       generatorEnvs.splice(generatorEnvs.indexOf(extId), 1);
-      this.loadExtensions();
-      return true;
+      isChanged = true;
     }
-    return false;
+    if (isChanged) this.loadExtensions();
+    return isChanged;
   }
 
   /**


### PR DESCRIPTION
When the `bit scope-rename` (or `bit rename`) suppose to change multiple values in the workspace.jsonc, it was changing only the first one. 
