### PR TITLE
feat, support using .gitignore file in the component root-dir

### DIFF
--- a/e2e/harmony/bit-ignore.e2e.ts
+++ b/e2e/harmony/bit-ignore.e2e.ts
@@ -51,4 +51,31 @@ describe('Bit Ignore functionality', function () {
       expect(files).to.include('hello.json');
     });
   });
+  describe('adding only .gitignore in the component dir', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/.gitignore', '*.json');
+      helper.fs.outputFile('comp1/hello.json', '{"hello": "world"}');
+    });
+    it('should consider the .gitignore, ignore the patterns in it, but track this .gitignore file', () => {
+      const files = helper.command.getComponentFiles('comp1');
+      expect(files).to.include('.gitignore');
+      expect(files).to.not.include('hello.json');
+    });
+  });
+  describe('adding .gitignore and .bitignore in the component dir', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.fs.outputFile('comp1/.bitignore', '');
+      helper.fs.outputFile('comp1/.gitignore', '*.json');
+      helper.fs.outputFile('comp1/hello.json', '{"hello": "world"}');
+    });
+    it('.bitignore should take precedence', () => {
+      const files = helper.command.getComponentFiles('comp1');
+      expect(files).to.include('.gitignore');
+      expect(files).to.include('hello.json');
+    });
+  });
 });

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -236,7 +236,6 @@ export const IGNORE_LIST = [
   '**/.env.**.local',
   '**/.bit.map.json',
   '**/.bitmap',
-  '**/.gitignore',
   '**/bit.json',
   '**/component.json',
   '**/bitBindings.js',

--- a/src/consumer/bit-map/component-map.ts
+++ b/src/consumer/bit-map/component-map.ts
@@ -13,7 +13,7 @@ import Consumer from '../consumer';
 import OutsideRootDir from './exceptions/outside-root-dir';
 import ComponentNotFoundInPath from '../component/exceptions/component-not-found-in-path';
 import { IgnoredDirectory } from '../component-ops/add-components/exceptions/ignored-directory';
-import { BIT_IGNORE, getBitIgnoreFile } from '../../utils/ignore/ignore';
+import { BIT_IGNORE, getBitIgnoreFile, getGitIgnoreFile } from '../../utils/ignore/ignore';
 
 export type Config = { [aspectId: string]: Record<string, any> | '-' };
 
@@ -382,9 +382,11 @@ export async function getFilesByDir(dir: string, consumerPath: string, gitIgnore
   // the path is relative to consumer. remove the rootDir.
   const relativePathsLinux = filteredMatches.map((match) => pathNormalizeToLinux(match).replace(`${dir}/`, ''));
   const filteredByIgnoredFromRoot = relativePathsLinux.filter((match) => !IGNORE_ROOT_ONLY_LIST.includes(match));
-  const bitIgnore = filteredByIgnoredFromRoot.includes(BIT_IGNORE) ? await getBitIgnoreFile(dir) : '';
-  const filteredByBitIgnore = bitIgnore
-    ? ignore().add(bitIgnore).filter(filteredByIgnoredFromRoot)
+  const bitOrGitIgnore = filteredByIgnoredFromRoot.includes(BIT_IGNORE)
+    ? await getBitIgnoreFile(dir)
+    : await getGitIgnoreFile(dir);
+  const filteredByBitIgnore = bitOrGitIgnore
+    ? ignore().add(bitOrGitIgnore).filter(filteredByIgnoredFromRoot)
     : filteredByIgnoredFromRoot;
   if (!filteredByBitIgnore.length) throw new IgnoredDirectory(dir);
   return filteredByBitIgnore.map((relativePath) => ({

--- a/src/utils/ignore/ignore.ts
+++ b/src/utils/ignore/ignore.ts
@@ -7,7 +7,7 @@ import { GIT_IGNORE, IGNORE_LIST } from '../../constants';
 
 export const BIT_IGNORE = '.bitignore';
 
-async function getGitIgnoreFile(dir: string): Promise<string[]> {
+export async function getGitIgnoreFile(dir: string): Promise<string[]> {
   const gitIgnoreFile = findUp.sync([GIT_IGNORE], { cwd: dir });
   return gitIgnoreFile ? gitignore(await fs.readFile(gitIgnoreFile)) : [];
 }


### PR DESCRIPTION
Until now, `.gitignore` files were always ignored by default and never tracked by Bit.

## Proposed Changes

- track `.gitignore` files. This way, when multiple users import the same component and using different git repos, they could use the same .gitignore file.
- in case `.gitignore` is found in the component root-dir, Bit reads it and uses it to untrack component files.
- in case `.bitignore` is found in the component root-dir in addition to `.gitignore`, the `.bitignore` takes precedence and is used to untrack component files. (still, `.gitignore` itself is tracked). This way, it's possible to have different patterns/rules for bit and git.
