### PR TITLE
chore: remove 3rd party `package-json-validator` package

### DIFF
--- a/package.json
+++ b/package.json
@@ -208,7 +208,6 @@
     "p-queue": "6.6.2",
     "p-series": "2.1.0",
     "pretty-time": "1.1.0",
-    "package-json-validator": "0.6.3",
     "pad-right": "0.2.2",
     "parse-gitignore": "1.0.1",
     "pino": "8.7.0",


### PR DESCRIPTION
This PR removes the `package-json-validator` package from package.json