### PR TITLE
fix(component compare): import missing objects from main 

### DIFF
--- a/scopes/component/component-compare/component-compare.main.runtime.ts
+++ b/scopes/component/component-compare/component-compare.main.runtime.ts
@@ -27,6 +27,7 @@ import { ComponentAspect, Component, ComponentMain } from '@teambit/component';
 import { componentCompareSchema } from './component-compare.graphql';
 import { ComponentCompareAspect } from './component-compare.aspect';
 import { DiffCmd } from './diff-cmd';
+import { ImporterAspect, ImporterMain } from '@teambit/importer';
 
 export type ComponentCompareResult = {
   id: string;
@@ -48,6 +49,7 @@ export class ComponentCompareMain {
     private logger: Logger,
     private tester: TesterMain,
     private depResolver: DependencyResolverMain,
+    private importer: ImporterMain,
     private workspace?: Workspace
   ) {}
 
@@ -59,6 +61,11 @@ export class ComponentCompareMain {
     if (!modelComponent) {
       throw new BitError(`component ${compareCompId.toString()} doesn't have any version yet`);
     }
+
+    // import missing components that might be on main
+    await this.importer.importObjectsFromMainIfExist([baseCompId, compareCompId], {
+      cache: true,
+    });
 
     const baseVersion = baseCompId.version as string;
     const compareVersion = compareCompId.version as string;
@@ -292,9 +299,10 @@ export class ComponentCompareMain {
     WorkspaceAspect,
     TesterAspect,
     DependencyResolverAspect,
+    ImporterAspect,
   ];
   static runtime = MainRuntime;
-  static async provider([graphql, component, scope, loggerMain, cli, workspace, tester, depResolver]: [
+  static async provider([graphql, component, scope, loggerMain, cli, workspace, tester, depResolver, importer]: [
     GraphqlMain,
     ComponentMain,
     ScopeMain,
@@ -302,10 +310,19 @@ export class ComponentCompareMain {
     CLIMain,
     Workspace,
     TesterMain,
-    DependencyResolverMain
+    DependencyResolverMain,
+    ImporterMain
   ]) {
     const logger = loggerMain.createLogger(ComponentCompareAspect.id);
-    const componentCompareMain = new ComponentCompareMain(component, scope, logger, tester, depResolver, workspace);
+    const componentCompareMain = new ComponentCompareMain(
+      component,
+      scope,
+      logger,
+      tester,
+      depResolver,
+      importer,
+      workspace
+    );
     cli.register(new DiffCmd(componentCompareMain));
     graphql.register(componentCompareSchema(componentCompareMain));
     return componentCompareMain;

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -716,7 +716,7 @@ please create a new lane instead, which will include all components of this lane
           )
         : [];
 
-    await this.importer.importObjectsFromMainIfExist(targetMainHeads);
+    await this.importer.importObjectsFromMainIfExist(targetMainHeads, { cache: true });
 
     const diffProps = compact(
       await Promise.all(

--- a/scopes/scope/importer/importer.main.runtime.ts
+++ b/scopes/scope/importer/importer.main.runtime.ts
@@ -115,9 +115,9 @@ export class ImporterMain {
     return importComponents.importComponents();
   }
 
-  async importObjectsFromMainIfExist(ids: ComponentID[]) {
+  async importObjectsFromMainIfExist(ids: ComponentID[], { cache } = { cache: false }) {
     await this.scope.legacyScope.scopeImporter.importWithoutDeps(ComponentIdList.fromArray(ids), {
-      cache: false,
+      cache,
       includeVersionHistory: true,
       ignoreMissingHead: true,
     });


### PR DESCRIPTION
This PR fixes the issue of missing component objects of versions that might be from main when comparing two component versions. With the fix, it now first tries to fetch the missing components objects for both base and compare component ids before diffing. 