### PR TITLE
fix(code compare): correctly update modified editor height when container resizes

### DIFF
--- a/components/ui/code-compare/code-compare-view/code-compare-view.tsx
+++ b/components/ui/code-compare/code-compare-view/code-compare-view.tsx
@@ -209,8 +209,15 @@ export function CodeCompareView({
   useEffect(() => {
     if (!monacoRef.current?.editor) return;
     const modifiedEditor = monacoRef.current?.editor.getModifiedEditor();
+
+    if (!modifiedEditor) return;
+
     const modifiedDomNode = modifiedEditor.getDomNode()?.parentElement;
+
+    if (!modifiedDomNode) return;
+
     const modifiedDomNodeHeight = modifiedDomNode?.style.height;
+
     if (modifiedDomNodeHeight !== containerHeight) {
       modifiedDomNode.style.height = containerHeight;
       monacoRef.current?.editor.layout();


### PR DESCRIPTION
This PR fixes the bug in Code Compare when the container's height changes and we try to re size the modified editor's height. In some cases, the modified editor might not be still available which results in accessing the property of undefined error. 