### PR TITLE
resolve dependencies versions from updateDependents prop if exists

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
@@ -39,7 +39,7 @@ export class DependenciesLoader {
     applyOverrides.issues = dependenciesData.issues;
     const results = await applyOverrides.getDependenciesData();
     this.setDependenciesDataOnComponent(results.dependenciesData, results.overridesDependencies);
-    updateDependenciesVersions(
+    await updateDependenciesVersions(
       this.depsResolver,
       workspace,
       this.component,


### PR DESCRIPTION
In case the current lane has `updateDependents` prop (see https://github.com/teambit/bit/pull/8534 for more info) , the dependencies versions are resolved from there.