### PR TITLE
improvement(lane-merge), clarify reasons for not updating dependencies in workspace.jsonc

### DIFF
--- a/e2e/harmony/merge-config.e2e.ts
+++ b/e2e/harmony/merge-config.e2e.ts
@@ -621,6 +621,84 @@ describe('merge config scenarios', function () {
       });
     }
   );
+  (supportNpmCiRegistryTesting ? describe : describe.skip)(
+    'diverge with multiple components, each has a different dependency version',
+    () => {
+      let npmCiRegistry: NpmCiRegistry;
+      let beforeDiverge: string;
+      let barPkgName: string;
+      // let barCompName: string;
+      let pkgHelper: Helper;
+      let laneWs: string;
+      before(async () => {
+        pkgHelper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+        pkgHelper.scopeHelper.setNewLocalAndRemoteScopes();
+        pkgHelper.fixtures.createComponentBarFoo();
+        pkgHelper.fixtures.addComponentBarFoo();
+        npmCiRegistry = new NpmCiRegistry(pkgHelper);
+        npmCiRegistry.configureCiInPackageJsonHarmony();
+        await npmCiRegistry.init();
+        pkgHelper.command.tagAllComponents();
+        barPkgName = pkgHelper.general.getPackageNameByCompName('bar/foo');
+        // barCompName = `${pkgHelper.scopes.remote}/bar/foo`;
+        pkgHelper.command.export();
+
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.scopeHelper.addRemoteScope(pkgHelper.scopes.remotePath);
+        helper.fixtures.populateComponents(2);
+        helper.fs.outputFile('comp1/index.js', `require("${barPkgName}");`);
+        helper.fs.outputFile('comp2/index.js', `require("${barPkgName}");`);
+        helper.command.install(barPkgName);
+        helper.command.tagAllWithoutBuild();
+        helper.command.export();
+        beforeDiverge = helper.scopeHelper.cloneLocalScope();
+
+        helper.command.createLane();
+        helper.command.snapAllComponentsWithoutBuild('--unmodified'); // add another snap to make it diverged from main.
+        helper.command.export();
+        laneWs = helper.scopeHelper.cloneLocalScope();
+
+        pkgHelper.command.tagAllComponents('--unmodified'); // 0.0.2
+        pkgHelper.command.export();
+
+        helper.scopeHelper.getClonedLocalScope(beforeDiverge);
+        helper.command.install(`${barPkgName}@0.0.2`);
+        helper.command.tagAllWithoutBuild();
+        helper.command.export();
+
+        pkgHelper.command.tagAllComponents('--unmodified'); // 0.0.3
+        pkgHelper.command.export();
+
+        helper.command.install(`${barPkgName}@0.0.3`);
+        helper.command.tagComponent('comp1');
+        helper.command.export();
+      });
+      after(() => {
+        npmCiRegistry.destroy();
+      });
+      describe('when the dep was updated on the lane only, not on main', () => {
+        describe('when the dep is in workspace.jsonc', () => {
+          let mergeOutput: string;
+          before(() => {
+            helper.scopeHelper.getClonedLocalScope(laneWs);
+            mergeOutput = helper.command.mergeLane(`main --no-snap -x`);
+          });
+          it('should not update workspace.jsonc', () => {
+            const policy = helper.workspaceJsonc.getPolicyFromDependencyResolver();
+            expect(policy.dependencies[barPkgName]).to.equal('^0.0.1');
+          });
+          it('should tell why workspace.jsonc was not updated', () => {
+            expect(mergeOutput).to.have.string('workspace.jsonc was unable to update the following dependencies');
+            expect(mergeOutput).to.have.string(
+              `multiple versions found. 0.0.3 (by ${helper.scopes.remote}/comp1), 0.0.2 (by ${helper.scopes.remote}/comp2)`
+            );
+            expect(mergeOutput).to.have.string(`0.0.3 (by ${helper.scopes.remote}/comp1)`);
+            expect(mergeOutput).to.have.string(`0.0.2 (by ${helper.scopes.remote}/comp2)`);
+          });
+        });
+      });
+    }
+  );
   describe('diverge with merge-able auto-detected dependencies config and pre-config explicitly set', () => {
     let mainBeforeDiverge: string;
     before(() => {

--- a/scopes/component/merging/merge-cmd.ts
+++ b/scopes/component/merging/merge-cmd.ts
@@ -263,7 +263,7 @@ ${mergeSnapError.message}
 
 export function getWorkspaceConfigUpdateOutput(workspaceConfigUpdateResult?: WorkspaceConfigUpdateResult): string {
   if (!workspaceConfigUpdateResult) return '';
-  const { workspaceConfigConflictWriteError, workspaceDepsConflicts, workspaceDepsUpdates } =
+  const { workspaceConfigConflictWriteError, workspaceDepsConflicts, workspaceDepsUpdates, workspaceDepsUnchanged } =
     workspaceConfigUpdateResult;
 
   const getWorkspaceConflictsOutput = () => {
@@ -274,7 +274,23 @@ export function getWorkspaceConfigUpdateOutput(workspaceConfigUpdateResult?: Wor
     return chalk.yellow('workspace.jsonc has conflicts, please edit the file and fix them');
   };
 
-  return compact([getWorkspaceDepsOutput(workspaceDepsUpdates), getWorkspaceConflictsOutput()]).join('\n\n');
+  const getWorkspaceUnchangedDepsOutput = () => {
+    if (!workspaceDepsUnchanged) return '';
+    const title = '\nworkspace.jsonc was unable to update the following dependencies';
+    const body = Object.keys(workspaceDepsUnchanged)
+      .map((pkgName) => {
+        return `  ${pkgName}: ${workspaceDepsUnchanged[pkgName]}`;
+      })
+      .join('\n');
+
+    return `${chalk.underline(title)}\n${body}`;
+  };
+
+  return compact([
+    getWorkspaceUnchangedDepsOutput(),
+    getWorkspaceDepsOutput(workspaceDepsUpdates),
+    getWorkspaceConflictsOutput(),
+  ]).join('\n\n');
 }
 
 function getWorkspaceDepsOutput(workspaceDepsUpdates?: WorkspaceDepsUpdates): string {

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -262,9 +262,9 @@ export class MergingMain {
 
     const allConfigMerge = compact(succeededComponents.map((c) => c.configMergeResult));
 
-    const { workspaceDepsUpdates, workspaceDepsConflicts } = this.workspace
+    const { workspaceDepsUpdates, workspaceDepsConflicts, workspaceDepsUnchanged } = this.workspace
       ? await this.configMerger.updateWorkspaceJsoncWithDepsIfNeeded(allConfigMerge)
-      : { workspaceDepsUpdates: undefined, workspaceDepsConflicts: undefined };
+      : { workspaceDepsUpdates: undefined, workspaceDepsConflicts: undefined, workspaceDepsUnchanged: undefined };
 
     let workspaceConfigConflictWriteError: Error | undefined;
     if (workspaceDepsConflicts) {
@@ -343,6 +343,7 @@ export class MergingMain {
       workspaceConfigUpdateResult: {
         workspaceDepsUpdates,
         workspaceDepsConflicts,
+        workspaceDepsUnchanged,
         workspaceConfigConflictWriteError,
       },
       leftUnresolvedConflicts,

--- a/scopes/workspace/config-merger/aggregated-deps.ts
+++ b/scopes/workspace/config-merger/aggregated-deps.ts
@@ -37,7 +37,7 @@ export class AggregatedDeps {
       .map((version) => {
         const compIds = compIdsPerVersion[version];
         const compIdsStr = compIds.length > 1 ? `${compIds[0]} and ${compIds.length - 1} more` : compIds[0];
-        return `${version} (by ${compIdsStr})`;
+        return `${this.getVersionStr(version)} (by ${compIdsStr})`;
       })
       .join(', ');
     return `multiple versions found. ${multipleVerStr}`;
@@ -45,6 +45,15 @@ export class AggregatedDeps {
 
   toString(): string {
     return JSON.stringify(this.deps, null, 2);
+  }
+
+  private getVersionStr(version: string): string {
+    if (version.includes('::')) {
+      // in case of a conflict, the version is in a format of CONFLICT::OURS::THEIRS
+      const [, , otherVal] = version.split('::');
+      return otherVal;
+    }
+    return version;
   }
 
   private getCompIdsPerVersion(pkgName: string): { [version: string]: string[] } {

--- a/scopes/workspace/config-merger/aggregated-deps.ts
+++ b/scopes/workspace/config-merger/aggregated-deps.ts
@@ -1,0 +1,58 @@
+import { PkgEntry } from './config-merger.main.runtime';
+
+type UsedBy = { compIdStr: string; version: string };
+
+type Deps = { [depId: string]: UsedBy[] };
+
+export class AggregatedDeps {
+  private deps: Deps = {};
+
+  push(pkg: PkgEntry, compIdStr: string) {
+    if (pkg.force) return; // we only care about auto-detected dependencies
+    if (!this.deps[pkg.name]) this.deps[pkg.name] = [];
+    this.deps[pkg.name].push({ compIdStr: compIdStr, version: pkg.version });
+  }
+
+  get depsNames(): string[] {
+    return Object.keys(this.deps);
+  }
+
+  getCompIdsBy(pkgName: string): string[] {
+    return this.deps[pkgName].map((dep) => dep.compIdStr);
+  }
+
+  hasSameVersions(pkgName: string): boolean {
+    const versions = this.deps[pkgName].map((dep) => dep.version);
+    return versions.every((v) => v === versions[0]);
+  }
+
+  getFirstVersion(pkgName: string): string {
+    return this.deps[pkgName][0].version;
+  }
+
+  reportMultipleVersions(pkgName: string): string {
+    const compIdsPerVersion = this.getCompIdsPerVersion(pkgName);
+    const versions = Object.keys(compIdsPerVersion);
+    const multipleVerStr = versions
+      .map((version) => {
+        const compIds = compIdsPerVersion[version];
+        const compIdsStr = compIds.length > 1 ? `${compIds[0]} and ${compIds.length - 1} more` : compIds[0];
+        return `${version} (by ${compIdsStr})`;
+      })
+      .join(', ');
+    return `multiple versions found. ${multipleVerStr}`;
+  }
+
+  toString(): string {
+    return JSON.stringify(this.deps, null, 2);
+  }
+
+  private getCompIdsPerVersion(pkgName: string): { [version: string]: string[] } {
+    const compIdsPerVersion: { [version: string]: string[] } = {};
+    this.deps[pkgName].forEach((dep) => {
+      if (!compIdsPerVersion[dep.version]) compIdsPerVersion[dep.version] = [];
+      compIdsPerVersion[dep.version].push(dep.compIdStr);
+    });
+    return compIdsPerVersion;
+  }
+}

--- a/scopes/workspace/config-merger/config-merger.main.runtime.ts
+++ b/scopes/workspace/config-merger/config-merger.main.runtime.ts
@@ -198,7 +198,7 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
     const workspaceJsonConflicts = { dependencies: [], peerDependencies: [] };
     const conflictPackagesToRemoveFromConfigMerge: string[] = [];
     conflictedPackages.forEach((pkgName) => {
-      if (conflictDeps.hasSameVersions(pkgName)) {
+      if (!conflictDeps.hasSameVersions(pkgName)) {
         // we only want the deps that the other lane has them in the workspace.json and that all comps use the same dep.
         workspaceDepsUnchanged[pkgName] = conflictDeps.reportMultipleVersions(pkgName);
         return;

--- a/scopes/workspace/config-merger/config-merger.main.runtime.ts
+++ b/scopes/workspace/config-merger/config-merger.main.runtime.ts
@@ -20,17 +20,20 @@ import mergeFiles, { MergeFileParams } from '@teambit/legacy/dist/utils/merge-fi
 import { ConfigAspect, ConfigMain } from '@teambit/config';
 import { ConfigMergeResult, parseVersionLineWithConflict } from './config-merge-result';
 import { ConfigMergerAspect } from './config-merger.aspect';
+import { AggregatedDeps } from './aggregated-deps';
 
-type PkgEntry = { name: string; version: string; force: boolean };
+export type PkgEntry = { name: string; version: string; force: boolean };
 
 const WS_DEPS_FIELDS = ['dependencies', 'peerDependencies'];
 
 export type WorkspaceDepsUpdates = { [pkgName: string]: [string, string] }; // from => to
 export type WorkspaceDepsConflicts = Record<WorkspacePolicyConfigKeysNames, Array<{ name: string; version: string }>>; // the pkg value is in a format of CONFLICT::OURS::THEIRS
+export type WorkspaceDepsUnchanged = { [pkgName: string]: string }; // the pkg value is the message why it wasn't updated
 
 export type WorkspaceConfigUpdateResult = {
   workspaceDepsUpdates?: WorkspaceDepsUpdates; // in case workspace.jsonc has been updated with dependencies versions
   workspaceDepsConflicts?: WorkspaceDepsConflicts; // in case workspace.jsonc has conflicts
+  workspaceDepsUnchanged?: WorkspaceDepsUnchanged; // in case the deps in workspace.jsonc couldn't be updated
   workspaceConfigConflictWriteError?: Error; // in case workspace.jsonc has conflicts and we failed to write the conflicts to the file
   logs?: string[]; // verbose details about the updates/conflicts for each one of the deps
 };
@@ -124,56 +127,39 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
     await fs.writeFile(wsJsoncPath, conflictFile);
   }
 
-  async updateWorkspaceJsoncWithDepsIfNeeded(
-    allConfigMerge: ConfigMergeResult[]
-  ): Promise<{ workspaceDepsUpdates?: WorkspaceDepsUpdates; workspaceDepsConflicts?: WorkspaceDepsConflicts }> {
+  async updateWorkspaceJsoncWithDepsIfNeeded(allConfigMerge: ConfigMergeResult[]): Promise<{
+    workspaceDepsUpdates?: WorkspaceDepsUpdates;
+    workspaceDepsConflicts?: WorkspaceDepsConflicts;
+    workspaceDepsUnchanged?: WorkspaceDepsUnchanged;
+  }> {
     const allResults = allConfigMerge.map((c) => c.getDepsResolverResult());
 
     // aggregate all dependencies that can be updated (not conflicting)
-    const nonConflictDeps: { [pkgName: string]: string[] } = {};
-    const nonConflictSources: { [pkgName: string]: string[] } = {}; // for logging/debugging purposes
+    const nonConflictDeps = new AggregatedDeps();
     allConfigMerge.forEach((configMerge) => {
       const mergedConfig = configMerge.getDepsResolverResult()?.mergedConfig;
       if (!mergedConfig || mergedConfig === '-') return;
       const mergedConfigPolicy = mergedConfig.policy || {};
       DEPENDENCIES_FIELDS.forEach((depField) => {
-        if (!mergedConfigPolicy[depField]) return;
-        mergedConfigPolicy[depField].forEach((pkg: PkgEntry) => {
-          if (pkg.force) return; // we only care about auto-detected dependencies
-          if (nonConflictDeps[pkg.name]) {
-            if (!nonConflictDeps[pkg.name].includes(pkg.version)) nonConflictDeps[pkg.name].push(pkg.version);
-            nonConflictSources[pkg.name].push(configMerge.compIdStr);
-            return;
-          }
-          nonConflictDeps[pkg.name] = [pkg.version];
-          nonConflictSources[pkg.name] = [configMerge.compIdStr];
-        });
+        mergedConfigPolicy[depField]?.forEach((pkg: PkgEntry) => nonConflictDeps.push(pkg, configMerge.compIdStr));
       });
     });
 
     // aggregate all dependencies that have conflicts
-    const conflictDeps: { [pkgName: string]: string[] } = {};
-    const conflictDepsSources: { [pkgName: string]: string[] } = {}; // for logging/debugging purposes
+    const conflictDeps = new AggregatedDeps();
     allConfigMerge.forEach((configMerge) => {
       const mergedConfigConflict = configMerge.getDepsResolverResult()?.conflict;
       if (!mergedConfigConflict) return;
       DEPENDENCIES_FIELDS.forEach((depField) => {
-        if (!mergedConfigConflict[depField]) return;
-        mergedConfigConflict[depField].forEach((pkg: PkgEntry) => {
-          if (pkg.force) return; // we only care about auto-detected dependencies
-          if (conflictDeps[pkg.name]) {
-            if (!conflictDeps[pkg.name].includes(pkg.version)) conflictDeps[pkg.name].push(pkg.version);
-            conflictDepsSources[pkg.name].push(configMerge.compIdStr);
-            return;
-          }
-          conflictDeps[pkg.name] = [pkg.version];
-          conflictDepsSources[pkg.name] = [configMerge.compIdStr];
-        });
+        mergedConfigConflict[depField]?.forEach((pkg: PkgEntry) => conflictDeps.push(pkg, configMerge.compIdStr));
       });
     });
 
-    const notConflictedPackages = Object.keys(nonConflictDeps);
-    const conflictedPackages = Object.keys(conflictDeps);
+    // uncomment to get the aggregated deps of both the conflicted and non-conflicted
+    // console.log('nonConflictDeps', nonConflictDeps.toString(), 'conflictDeps', conflictDeps.toString());
+
+    const notConflictedPackages = nonConflictDeps.depsNames;
+    const conflictedPackages = conflictDeps.depsNames;
     if (!notConflictedPackages.length && !conflictedPackages.length) return {};
 
     const workspaceConfig = this.config.workspaceConfig;
@@ -184,24 +170,26 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
       return {};
     }
 
+    const workspaceDepsUnchanged: { [pkgName: string]: string } = {};
+
     // calculate the workspace.json updates
-    const workspaceJsonUpdates = {};
+    const workspaceJsonUpdates: WorkspaceDepsUpdates = {};
     notConflictedPackages.forEach((pkgName) => {
-      if (nonConflictDeps[pkgName].length > 1) {
-        // we only want the deps that the other lane has them in the workspace.json and that all comps use the same dep.
-        return;
-      }
       DEPENDENCIES_FIELDS.forEach((depField) => {
         if (!policy[depField]?.[pkgName]) return; // doesn't exists in the workspace.json
         const currentVer = policy[depField][pkgName];
-        const newVer = nonConflictDeps[pkgName][0];
+        if (!nonConflictDeps.hasSameVersions(pkgName)) {
+          // we only want the deps that the other lane has them in the workspace.json and that all comps use the same dep.
+          workspaceDepsUnchanged[pkgName] = nonConflictDeps.reportMultipleVersions(pkgName);
+          return;
+        }
+        const newVer = nonConflictDeps.getFirstVersion(pkgName);
         if (currentVer === newVer) return;
         workspaceJsonUpdates[pkgName] = [currentVer, newVer];
         policy[depField][pkgName] = newVer;
+        const compIds = nonConflictDeps.getCompIdsBy(pkgName).join(', ');
         this.logger.debug(
-          `update workspace.jsonc: ${pkgName} from ${currentVer} to ${newVer}. Triggered by: ${nonConflictSources[
-            pkgName
-          ].join(', ')}`
+          `update workspace.jsonc: ${pkgName} from ${currentVer} to ${newVer}. Triggered by: ${compIds}`
         );
       });
     });
@@ -210,11 +198,12 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
     const workspaceJsonConflicts = { dependencies: [], peerDependencies: [] };
     const conflictPackagesToRemoveFromConfigMerge: string[] = [];
     conflictedPackages.forEach((pkgName) => {
-      if (conflictDeps[pkgName].length > 1) {
+      if (conflictDeps.hasSameVersions(pkgName)) {
         // we only want the deps that the other lane has them in the workspace.json and that all comps use the same dep.
+        workspaceDepsUnchanged[pkgName] = conflictDeps.reportMultipleVersions(pkgName);
         return;
       }
-      const conflictRaw = conflictDeps[pkgName][0];
+      const conflictRaw = conflictDeps.getFirstVersion(pkgName);
       const [, currentVal, otherVal] = conflictRaw.split('::');
       // in case of a snap, the otherVal is the snap-hash, we need to convert it to semver
       const otherValValid = snapToSemver(otherVal);
@@ -234,10 +223,9 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
           force: false,
         });
         conflictPackagesToRemoveFromConfigMerge.push(pkgName);
+        const compIds = conflictDeps.getCompIdsBy(pkgName).join(', ');
         this.logger.debug(
-          `conflict workspace.jsonc: ${pkgName} current: ${currentVerInWsJson}, other: ${otherValValid}. Triggered by: ${conflictDepsSources[
-            pkgName
-          ].join(', ')}`
+          `conflict workspace.jsonc: ${pkgName} current: ${currentVerInWsJson}, other: ${otherValValid}. Triggered by: ${compIds}`
         );
       });
     });
@@ -270,6 +258,7 @@ see the conflicts below and edit your workspace.jsonc as you see fit.`;
     return {
       workspaceDepsUpdates: Object.keys(workspaceJsonUpdates).length ? workspaceJsonUpdates : undefined,
       workspaceDepsConflicts: Object.keys(workspaceJsonConflicts).length ? workspaceJsonConflicts : undefined,
+      workspaceDepsUnchanged: Object.keys(workspaceDepsUnchanged).length ? workspaceDepsUnchanged : undefined,
     };
   }
 

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -3,6 +3,7 @@ import { pickBy } from 'lodash';
 import { isSnap } from '@teambit/component-version';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { LaneId } from '@teambit/lane-id';
+import { v4 } from 'uuid';
 import { BuildStatus, DEFAULT_BUNDLE_FILENAME, Extensions } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { isSchemaSupport, SchemaFeature, SchemaName } from '../../consumer/component/component-schema';
@@ -13,7 +14,7 @@ import { ComponentOverridesData } from '../../consumer/config/component-override
 import { ExtensionDataEntry, ExtensionDataList } from '../../consumer/config/extension-data';
 import { Doclet } from '../../jsdoc/types';
 import logger from '../../logger/logger';
-import { getStringifyArgs } from '../../utils';
+import { getStringifyArgs, sha1 } from '../../utils';
 import { PathLinux, pathNormalizeToLinux } from '../../utils/path';
 import VersionInvalid from '../exceptions/version-invalid';
 import { BitObject, Ref } from '../objects';
@@ -680,8 +681,7 @@ export default class Version extends BitObject {
   }
 
   setNewHash() {
-    // @todo: after v15 is deployed, this can be changed to generate a random uuid
-    this._hash = this.calculateHash().toString();
+    this._hash = sha1(v4());
   }
 
   get ignoreSharedDir(): boolean {

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -3,7 +3,6 @@ import { pickBy } from 'lodash';
 import { isSnap } from '@teambit/component-version';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { LaneId } from '@teambit/lane-id';
-import { v4 } from 'uuid';
 import { BuildStatus, DEFAULT_BUNDLE_FILENAME, Extensions } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { isSchemaSupport, SchemaFeature, SchemaName } from '../../consumer/component/component-schema';
@@ -14,7 +13,7 @@ import { ComponentOverridesData } from '../../consumer/config/component-override
 import { ExtensionDataEntry, ExtensionDataList } from '../../consumer/config/extension-data';
 import { Doclet } from '../../jsdoc/types';
 import logger from '../../logger/logger';
-import { getStringifyArgs, sha1 } from '../../utils';
+import { getStringifyArgs } from '../../utils';
 import { PathLinux, pathNormalizeToLinux } from '../../utils/path';
 import VersionInvalid from '../exceptions/version-invalid';
 import { BitObject, Ref } from '../objects';
@@ -681,7 +680,8 @@ export default class Version extends BitObject {
   }
 
   setNewHash() {
-    this._hash = sha1(v4());
+    // @todo: after v15 is deployed, this can be changed to generate a random uuid
+    this._hash = this.calculateHash().toString();
   }
 
   get ignoreSharedDir(): boolean {


### PR DESCRIPTION
When merging a lane and components of that lane has different dependencies versions of workpsace.jsonc, we update workspace.json accordingly.
An exception occurs when different lane components use different versions of the same dependency. 
This PR addresses these cases by detailing in the output which component uses which version.