### PR TITLE
change Version hash to be auto-generated and not based on content

### DIFF
--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -3,6 +3,7 @@ import { pickBy } from 'lodash';
 import { isSnap } from '@teambit/component-version';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { LaneId } from '@teambit/lane-id';
+import { v4 } from 'uuid';
 import { BuildStatus, DEFAULT_BUNDLE_FILENAME, Extensions } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { isSchemaSupport, SchemaFeature, SchemaName } from '../../consumer/component/component-schema';
@@ -13,7 +14,7 @@ import { ComponentOverridesData } from '../../consumer/config/component-override
 import { ExtensionDataEntry, ExtensionDataList } from '../../consumer/config/extension-data';
 import { Doclet } from '../../jsdoc/types';
 import logger from '../../logger/logger';
-import { getStringifyArgs } from '../../utils';
+import { getStringifyArgs, sha1 } from '../../utils';
 import { PathLinux, pathNormalizeToLinux } from '../../utils/path';
 import VersionInvalid from '../exceptions/version-invalid';
 import { BitObject, Ref } from '../objects';
@@ -680,8 +681,7 @@ export default class Version extends BitObject {
   }
 
   setNewHash() {
-    // @todo: after v15 is deployed, this can be changed to generate a random uuid
-    this._hash = this.calculateHash().toString();
+    this._hash = sha1(v4());
   }
 
   get ignoreSharedDir(): boolean {


### PR DESCRIPTION
In the legacy it was completely based on hashing part of the content. Since Harmony, only tag (not snap) used this calculation and only for the first time. Once generated, the hash was saved as part of the object and was used purely by the hash prop and not by the calculation.

This PR completes the transition by aligning tag and snap and always auto-generating the hash by a random UUID. 

(the reason this was done now is because I have noticed a very rare occurrence when an e2e-test was creating two components with the exact same files and their tag hashes were identical. It's rare because part of the hash calculation based on the "log.date" which changes every second).