### PR TITLE
feat(cli), autocomplete component ids, commands, sub-commands and flags

### DIFF
--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -13,6 +13,7 @@ import { autocomplete } from './autocomplete';
 
 if (process.argv.includes('--get-yargs-completions')) {
   autocomplete();
+  process.exit(0);
 }
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -9,6 +9,11 @@ import './hook-require';
 import { bootstrap } from '@teambit/legacy/dist/bootstrap';
 import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
 import { runCLI } from './load-bit';
+import { autocomplete } from './autocomplete';
+
+if (process.argv.includes('--get-yargs-completions')) {
+  autocomplete();
+}
 
 // eslint-disable-next-line @typescript-eslint/no-floating-promises
 initApp();

--- a/scopes/harmony/bit/autocomplete.ts
+++ b/scopes/harmony/bit/autocomplete.ts
@@ -29,6 +29,7 @@ export function autocomplete() {
   if (!matchedCommand) {
     return;
   }
+  log(`matchedCommand: ${matchedCommand.name}`);
   const currentArg = argv.length ? argv[argv.length - 1] : '';
   if (currentArg.startsWith('-')) {
     printCommandFlags(matchedCommand);
@@ -38,9 +39,11 @@ export function autocomplete() {
   const firstCmdArg = commandArgs[0];
   const commandNamePrefixes = ['<component-name', '<component-pattern', '[component-name', '[component-pattern'];
   if (firstCmdArg && commandNamePrefixes.some((prefix) => firstCmdArg.startsWith(prefix))) {
+    log(`completing component name`);
     const compIds = getCompsFromBitmap();
     process.stdout.write(compIds.join('\n'));
   }
+  process.exit(0);
 }
 
 function printCommandFlags(cmd: Cmd): void {

--- a/scopes/harmony/bit/autocomplete.ts
+++ b/scopes/harmony/bit/autocomplete.ts
@@ -1,0 +1,29 @@
+import fs from 'fs-extra';
+import json from 'comment-json';
+
+// const log = (msg) => fs.writeFileSync('compilation.log', `${msg}\n`);
+
+const supportedCommands = ['show'];
+
+export function autocomplete() {
+  if (supportedCommands.every((command) => !process.argv.includes(command))) {
+    return;
+  }
+  const compIds = getCompsFromBitmap();
+  process.stdout.write(compIds.join('\n'));
+  process.exit(0);
+}
+
+function getCompsFromBitmap() {
+  const bitMap = fs.readFileSync('.bitmap');
+  const componentsJson = json.parse(bitMap.toString('utf8'), undefined, true);
+  const compIds: string[] = [];
+  Object.keys(componentsJson).forEach((componentId) => {
+    if (componentId === '$schema-version') return;
+    const value = componentsJson[componentId];
+    const scope = value.scope || value.defaultScope;
+    const name = value.name;
+    compIds.push(`${scope}/${name}`);
+  });
+  return compIds;
+}

--- a/scopes/harmony/bit/autocomplete.ts
+++ b/scopes/harmony/bit/autocomplete.ts
@@ -3,13 +3,31 @@ import json from 'comment-json';
 
 const COMPLETION_FLAG = '--get-yargs-completions';
 
-const log = (msg) => fs.writeFileSync('compilation.log', `${msg}\n`);
+// to get the log working, add `export BIT_DEBUG_AUTOCOMPLETE=true` to your bash profile
+// prefixing the command with this won't work for some reason.
+const shouldLog = process.env.BIT_DEBUG_AUTOCOMPLETE === 'true';
+const logFile = 'compilation.log';
+if (shouldLog) fs.ensureFileSync(logFile);
+const log = (msg: string) => (shouldLog ? fs.appendFileSync(logFile, `${msg}\n`) : null);
 
-type Cmd = { name: string; options: string[]; description?: string };
+type Cmd = { name: string; options: string[]; description?: string; commands?: Cmd[] };
 
 export function autocomplete() {
+  log('[*] autocomplete started');
+  const results = getAutocompleteResults();
+  if (!results.length) {
+    log(`[*] autocomplete completed, no results found`);
+    return;
+  }
+  log(`[*] autocomplete completed with ${results.length} results`);
+  process.stdout.write(results.join('\n'), () => {
+    process.exit(0);
+  });
+}
+
+function getAutocompleteResults(): string[] {
   const argv = process.argv.slice(2).filter((arg) => arg !== COMPLETION_FLAG);
-  // remove the first element, it is always the command itself "bit"
+  // remove the first element, it is always the executable "bit"
   argv.shift();
   log(`argv: ${argv.join(' ')}, length: ${argv.length}`);
   if (argv.length === 0) {
@@ -18,8 +36,7 @@ export function autocomplete() {
   if (argv.length === 1) {
     // either "bit " or "bit x" where x can be any string without a space
     // in both cases, we should return all commands
-    printCommandNames();
-    process.exit(0);
+    return getAllCommandNames();
   }
 
   // argv has at least 2 elements, the first one is the command name.
@@ -27,38 +44,44 @@ export function autocomplete() {
   const allCommands = getAllCommands();
   const matchedCommand = allCommands.find((cmd) => cmd.name === command || cmd.name.startsWith(`${command} `));
   if (!matchedCommand) {
-    return;
+    return [];
   }
   log(`matchedCommand: ${matchedCommand.name}`);
   const currentArg = argv.length ? argv[argv.length - 1] : '';
   if (currentArg.startsWith('-')) {
-    printCommandFlags(matchedCommand);
-    process.exit(0);
+    return getCommandFlags(matchedCommand);
   }
   const commandArgs = matchedCommand.name.split(' ').slice(1);
   const firstCmdArg = commandArgs[0];
   const commandNamePrefixes = ['<component-name', '<component-pattern', '[component-name', '[component-pattern'];
   if (firstCmdArg && commandNamePrefixes.some((prefix) => firstCmdArg.startsWith(prefix))) {
     log(`completing component name`);
-    const compIds = getCompsFromBitmap();
-    process.stdout.write(compIds.join('\n'));
+    return getCompsFromBitmap();
   }
-  process.exit(0);
+  const subCommands = matchedCommand.commands || [];
+  if (subCommands.length && argv.length === 2) {
+    return getCommandNames(subCommands);
+  }
+  return [];
 }
 
-function printCommandFlags(cmd: Cmd): void {
-  cmd.options.map((opt) => {
+function getCommandFlags(cmd: Cmd): string[] {
+  return cmd.options.map((opt) => {
     const [, name, description] = opt;
-    process.stdout.write(`--${name}:${description}\n`);
+    return `--${name}:${description}`;
   });
 }
 
-function printCommandNames() {
+function getAllCommandNames(): string[] {
   const allCommands = getAllCommands();
-  allCommands.forEach((cmd) => {
+  return getCommandNames(allCommands);
+}
+
+function getCommandNames(commands: Cmd[]): string[] {
+  return commands.map((cmd) => {
     const name = cmd.name.split(' ')[0];
     const desc = cmd.description || '';
-    process.stdout.write(`${name}:${desc}\n`);
+    return `${name}:${desc}`;
   });
 }
 

--- a/scopes/harmony/bit/autocomplete.ts
+++ b/scopes/harmony/bit/autocomplete.ts
@@ -3,26 +3,13 @@ import json from 'comment-json';
 
 const COMPLETION_FLAG = '--get-yargs-completions';
 
-// to get the log working, add `export BIT_DEBUG_AUTOCOMPLETE=true` to your bash profile
-// prefixing the command with this won't work for some reason.
-const shouldLog = process.env.BIT_DEBUG_AUTOCOMPLETE === 'true';
-const logFile = 'compilation.log';
-if (shouldLog) fs.ensureFileSync(logFile);
-const log = (msg: string) => (shouldLog ? fs.appendFileSync(logFile, `${msg}\n`) : null);
-
 type Cmd = { name: string; options: string[]; description?: string; commands?: Cmd[] };
 
 export function autocomplete() {
   log('[*] autocomplete started');
   const results = getAutocompleteResults();
-  if (!results.length) {
-    log(`[*] autocomplete completed, no results found`);
-    return;
-  }
   log(`[*] autocomplete completed with ${results.length} results`);
-  process.stdout.write(results.join('\n'), () => {
-    process.exit(0);
-  });
+  if (results.length) process.stdout.write(results.join('\n'));
 }
 
 function getAutocompleteResults(): string[] {
@@ -46,6 +33,7 @@ function getAutocompleteResults(): string[] {
   if (!matchedCommand) {
     return [];
   }
+  // the second element can be a sub-command or an arg or a flag
   const possiblySubCommandName = argv[1];
   const matchedSubCommand = possiblySubCommandName
     ? findCommandByName(possiblySubCommandName, matchedCommand.commands || [])
@@ -127,4 +115,13 @@ function getCompsFromBitmap(): string[] {
     compIds.push(`${scope}/${name}`);
   });
   return compIds;
+}
+
+// to get the log working, add `export BIT_DEBUG_AUTOCOMPLETE=true` to your bash profile
+// prefixing the command with this won't work for some reason.
+const shouldLog = process.env.BIT_DEBUG_AUTOCOMPLETE === 'true';
+const logFile = 'compilation.log';
+if (shouldLog) fs.ensureFileSync(logFile);
+function log(msg: string) {
+  if (shouldLog) fs.appendFileSync(logFile, `${msg}\n`);
 }

--- a/scopes/harmony/bit/autocomplete.ts
+++ b/scopes/harmony/bit/autocomplete.ts
@@ -1,20 +1,70 @@
 import fs from 'fs-extra';
 import json from 'comment-json';
 
-// const log = (msg) => fs.writeFileSync('compilation.log', `${msg}\n`);
+const COMPLETION_FLAG = '--get-yargs-completions';
 
-const supportedCommands = ['show'];
+const log = (msg) => fs.writeFileSync('compilation.log', `${msg}\n`);
+
+type Cmd = { name: string; options: string[]; description?: string };
 
 export function autocomplete() {
-  if (supportedCommands.every((command) => !process.argv.includes(command))) {
+  const argv = process.argv.slice(2).filter((arg) => arg !== COMPLETION_FLAG);
+  // remove the first element, it is always the command itself "bit"
+  argv.shift();
+  log(`argv: ${argv.join(' ')}, length: ${argv.length}`);
+  if (argv.length === 0) {
+    throw new Error(`argv is empty, it must have at least one element. argv: ${process.argv.join(' ')}`);
+  }
+  if (argv.length === 1) {
+    // either "bit " or "bit x" where x can be any string without a space
+    // in both cases, we should return all commands
+    printCommandNames();
+    process.exit(0);
+  }
+
+  // argv has at least 2 elements, the first one is the command name.
+  const command = argv[0];
+  const allCommands = getAllCommands();
+  const matchedCommand = allCommands.find((cmd) => cmd.name === command || cmd.name.startsWith(`${command} `));
+  if (!matchedCommand) {
     return;
   }
-  const compIds = getCompsFromBitmap();
-  process.stdout.write(compIds.join('\n'));
-  process.exit(0);
+  const currentArg = argv.length ? argv[argv.length - 1] : '';
+  if (currentArg.startsWith('-')) {
+    printCommandFlags(matchedCommand);
+    process.exit(0);
+  }
+  const commandArgs = matchedCommand.name.split(' ').slice(1);
+  const firstCmdArg = commandArgs[0];
+  const commandNamePrefixes = ['<component-name', '<component-pattern', '[component-name', '[component-pattern'];
+  if (firstCmdArg && commandNamePrefixes.some((prefix) => firstCmdArg.startsWith(prefix))) {
+    const compIds = getCompsFromBitmap();
+    process.stdout.write(compIds.join('\n'));
+  }
 }
 
-function getCompsFromBitmap() {
+function printCommandFlags(cmd: Cmd): void {
+  cmd.options.map((opt) => {
+    const [, name, description] = opt;
+    process.stdout.write(`--${name}:${description}\n`);
+  });
+}
+
+function printCommandNames() {
+  const allCommands = getAllCommands();
+  allCommands.forEach((cmd) => {
+    const name = cmd.name.split(' ')[0];
+    const desc = cmd.description || '';
+    process.stdout.write(`${name}:${desc}\n`);
+  });
+}
+
+function getAllCommands(): Cmd[] {
+  const cliReferences = require('@teambit/harmony.content.cli-reference/cli-reference.json');
+  return cliReferences;
+}
+
+function getCompsFromBitmap(): string[] {
   const bitMap = fs.readFileSync('.bitmap');
   const componentsJson = json.parse(bitMap.toString('utf8'), undefined, true);
   const compIds: string[] = [];

--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -3,6 +3,7 @@ import { pickBy } from 'lodash';
 import { isSnap } from '@teambit/component-version';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { LaneId } from '@teambit/lane-id';
+import { v4 } from 'uuid';
 import { BuildStatus, DEFAULT_BUNDLE_FILENAME, Extensions } from '../../constants';
 import ConsumerComponent from '../../consumer/component';
 import { isSchemaSupport, SchemaFeature, SchemaName } from '../../consumer/component/component-schema';
@@ -13,7 +14,7 @@ import { ComponentOverridesData } from '../../consumer/config/component-override
 import { ExtensionDataEntry, ExtensionDataList } from '../../consumer/config/extension-data';
 import { Doclet } from '../../jsdoc/types';
 import logger from '../../logger/logger';
-import { getStringifyArgs } from '../../utils';
+import { getStringifyArgs, sha1 } from '../../utils';
 import { PathLinux, pathNormalizeToLinux } from '../../utils/path';
 import VersionInvalid from '../exceptions/version-invalid';
 import { BitObject, Ref } from '../objects';
@@ -680,8 +681,7 @@ export default class Version extends BitObject {
   }
 
   setNewHash() {
-    // @todo: after v15 is deployed, this can be changed to generate a random uuid
-    this._hash = this.calculateHash().toString();
+    this._hash = sha1(v4());
   }
 
   get ignoreSharedDir(): boolean {

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -626,6 +626,7 @@
         "policy": {
           "dependencies": {
             "@teambit/base-react.navigation.link": "2.0.27",
+            "@teambit/harmony.content.cli-reference": "^2.0.279",
             "@teambit/ui-foundation.ui.navigation.react-router-adapter": "6.1.1",
             "@apollo/client": "3.6.9",
             "@teambit/legacy": "1.0.701",


### PR DESCRIPTION
The response feels almost instantaneous (0.07 seconds). 
It doesn't load any of the bit-core files. As soon as it detects autocomplete, it executes a separate file that doesn't import any bit-core internal files or packages.

Component IDs
<img width="947" alt="Screenshot 2024-05-14 at 4 42 55 PM" src="https://github.com/teambit/bit/assets/1963573/7c947d43-7bda-48c6-9055-3614ccb98293">

Commands:
<img width="822" alt="Screenshot 2024-05-15 at 7 40 12 PM" src="https://github.com/teambit/bit/assets/1963573/2daf524f-7cb0-4865-baf6-28c05d95d6a4">

Flags:
<img width="1086" alt="Screenshot 2024-05-15 at 7 40 50 PM" src="https://github.com/teambit/bit/assets/1963573/da73428f-20e3-4c28-9d57-79e0b939e247">

