### PR TITLE
fix(status), do not show RemovedDependencies issue when main version is used

### DIFF
--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -941,7 +941,15 @@ consider using --ignore-missing-artifacts flag if you're sure the artifacts are 
   }
 
   async isRemoved(repo: Repository, specificVersion?: string): Promise<boolean | null> {
-    const head = this.getHeadRegardlessOfLane();
+    const getHead = () => {
+      if (!this.laneHeadLocal) return this.getHead();
+      // you're checked out to a lane.
+      if (!specificVersion) return this.laneHeadLocal;
+      // it's possible that this specificVersion is from main.
+      if (specificVersion === this.laneHeadLocal.toString()) return this.laneHeadLocal;
+      return this.getHead();
+    };
+    const head = getHead();
     if (!head) {
       // it's new or only on lane
       return false;


### PR DESCRIPTION
Fixes an issue when on a lane and a dependency from within the lane is deleted. In case the user installed the main version, `bit status` should not warn about using removed dependencies.