### PR TITLE
fix, show RemovedDependencies issue more consistently

### DIFF
--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -305,7 +305,7 @@ ${mainComps.map((c) => c.id.toString()).join('\n')}`);
     const bitmapEntry = this.workspace.bitMap.getBitmapEntryIfExist(componentId);
     if (bitmapEntry && bitmapEntry.isRemoved()) return true;
     if (bitmapEntry && bitmapEntry.isRecovered()) return false;
-    const modelComp = await this.workspace.scope.getBitObjectModelComponent(componentId);
+    const modelComp = await this.workspace.scope.getBitObjectModelComponent(componentId.changeVersion(undefined));
     if (!modelComp) return false;
     const isRemoved = await modelComp.isRemoved(
       this.workspace.scope.legacyScope.objects,


### PR DESCRIPTION
Currently, in case the exact dependency version is not in the objects, it doesn't get the removed data. With this change, it's enough to have the ModelComponent there.