### PR TITLE
feature(envs) - support new "extends" field in env.jsonc

### DIFF
--- a/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
+++ b/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
@@ -1,8 +1,8 @@
-// import { resolveFrom } from '@teambit/toolbox.modules.module-resolver';
-// import { expect } from 'chai';
-// import fs from 'fs-extra';
-// import path from 'path';
-// import Helper from '../../../src/e2e-helper/e2e-helper';
+import { resolveFrom } from '@teambit/toolbox.modules.module-resolver';
+import { expect } from 'chai';
+import fs from 'fs-extra';
+import path from 'path';
+import Helper from '../../../src/e2e-helper/e2e-helper';
 
 export const ENV_POLICY = {
   peers: [
@@ -59,139 +59,343 @@ export const ENV_POLICY = {
   ],
 };
 
-// @todo: Gilad should fix.
-// describe.skip('env-jsonc-policies', function () {
-//   this.timeout(0);
-//   let helper: Helper;
-//   let componentShowParsed;
-//   let envId;
-//   before(() => {
-//     helper = new Helper();
-//     helper.scopeHelper.setNewLocalAndRemoteScopes();
-//     envId = `${helper.scopes.remote}/react-based-env`;
-//     helper.command.create('react', 'button', '-p button --env teambit.react/react');
-//     helper.fs.prependFile('button/button.tsx', 'import isPositive from "is-positive";\n');
-//     helper.env.setCustomNewEnv(undefined, undefined, { policy: ENV_POLICY });
-//     helper.command.setEnv('button', envId);
-//     helper.command.install();
-//     componentShowParsed = helper.command.showComponentParsed('button');
-//   });
-//   after(() => {
-//     helper.scopeHelper.destroy();
-//   });
+export const ENV_POLICY_LEVEL1 = {
+  peers: [
+    {
+      name: 'react',
+      version: '^18.0.0',
+      supportedRange: '^17.0.0 || ^18.0.0',
+    },
+    {
+      name: 'react-dom',
+      version: '^18.0.0',
+      supportedRange: '^17.0.0 || ^18.0.0',
+    },
+  ],
+  dev: [
+    {
+      name: 'is-positive',
+      version: '3.1.0',
+      hidden: false,
+      force: true,
+    },
+  ],
+  runtime: [
+    {
+      name: 'is-string',
+      version: '1.0.7',
+      force: true,
+    },
+  ],
+};
 
-//   describe('affect env', () => {
-//     let envShowParsed;
-//     before(() => {
-//       envShowParsed = helper.command.showComponentParsed('react-based-env');
-//     });
-//     it('should add peers as runtime deps of the env', () => {
-//       expect(envShowParsed.packageDependencies).to.include({ react: '^18.0.0' });
-//       expect(envShowParsed.packageDependencies).to.include({ 'react-dom': '^18.0.0' });
-//       expect(envShowParsed.packageDependencies).to.include({ graphql: '14.7.0' });
-//     });
-//     // TODO: implement if needed
-//     // it('should add devs as runtime / dev deps of the env', () => {
-//     // });
-//   });
-//   describe('affect component', () => {
-//     describe('peers effect', () => {
-//       it('should take supported range from env.jsonc for used peers', () => {
-//         expect(componentShowParsed.peerPackageDependencies).to.include({ react: '^17.0.0 || ^18.0.0' });
-//       });
-//       it('should not add unused peer deps from env.jsonc', () => {
-//         const keys = Object.keys(componentShowParsed.peerPackageDependencies);
-//         // Validate we use the correct array
-//         expect(keys).to.be.not.empty;
-//         expect(keys).to.not.include('graphql');
-//       });
-//     });
-//     describe('devs effect', () => {
-//       describe('used deps', () => {
-//         it('should remove hidden devs deps configured by env.jsonc', () => {
-//           const newDeps = helper.command.showComponentParsedHarmonyByTitle('button', 'dependencies');
-//           expect(newDeps).to.not.be.empty;
-//           const typesReactEntry = newDeps.find((dep) => dep.id === '@types/react');
-//           expect(typesReactEntry).to.be.undefined;
-//         });
+const ENV_JSONC_LEVEL1 = {
+  policy: ENV_POLICY_LEVEL1,
+  patterns: {
+    compositions: ['**/*.composition.*', '**/*.preview.*'],
+    docs: ['**/*.docs.*'],
+    tests: ['**/*.spec.*', '**/*.test.*'],
+  },
+};
 
-//         it('should save used dep as hidden in the deps resolver deps', () => {
-//           const depResolverAspectEntry = helper.command.showAspectConfig(
-//             'button',
-//             'teambit.dependencies/dependency-resolver'
-//           );
-//           const typesReactEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/react');
-//           expect(typesReactEntry).to.include({ version: '18.0.25' });
-//           expect(typesReactEntry).to.include({ hidden: true });
-//         });
+export const ENV_POLICY_LEVEL2 = {
+  peers: [
+    {
+      name: 'react',
+      version: '^16.0.0',
+      supportedRange: '^17.0.0 || ^16.0.0',
+    },
+  ],
+  runtime: [
+    {
+      name: 'is-odd',
+      version: '3.0.1',
+      force: true,
+    },
+    {
+      name: 'is-negative',
+      version: '2.1.0',
+      force: true,
+    },
+  ],
+};
 
-//         it('should have used dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
-//           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/react': '18.0.25' });
-//         });
+const ENV_JSONC_LEVEL2 = {
+  policy: ENV_POLICY_LEVEL2,
+  patterns: {
+    compositions: ['**/*.composition.*', '**/*.preview.*', '**/*.preview-level2.*'],
+    docs: ['**/*.docs.*', '**/*.docs-level2.*'],
+  },
+};
 
-//         it('should install used dev deps specified by the env dev deps', () => {
-//           const typesReactVersion = fs.readJsonSync(
-//             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/react/package.json'])
-//           ).version;
-//           expect(typesReactVersion).to.eq('18.0.25');
-//         });
-//       });
-//       describe('not used deps', () => {
-//         it('should save forced unused dep as hidden in the deps resolver deps', () => {
-//           const depResolverAspectEntry = helper.command.showAspectConfig(
-//             'button',
-//             'teambit.dependencies/dependency-resolver'
-//           );
-//           const typesJestEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/jest');
-//           expect(typesJestEntry).to.include({ version: '29.2.2' });
-//           expect(typesJestEntry).to.include({ hidden: true });
-//         });
+export const ENV_POLICY_LEVEL3 = {
+  dev: [
+    {
+      name: 'is-negative',
+      version: '2.1.0',
+      force: true,
+    },
+  ],
+  runtime: [
+    {
+      name: 'is-negative',
+      version: '-',
+      force: true,
+    },
+    {
+      name: 'is-string',
+      version: '1.0.6',
+      force: true,
+    },
+  ],
+};
 
-//         it('should have forced unused dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
-//           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/jest': '29.2.2' });
-//         });
+const ENV_JSONC_LEVEL3 = {
+  policy: ENV_POLICY_LEVEL3,
+  patterns: {
+    compositions: ['**/*.composition.*', '**/*.preview.*', '**/*.preview-level3.*'],
+    level3: ['**/*.level3.*'],
+  },
+};
 
-//         it('should install forced unused dev deps specified by the env dev deps', () => {
-//           const typesJestVersion = fs.readJsonSync(
-//             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/jest/package.json'])
-//           ).version;
-//           expect(typesJestVersion).to.eq('29.2.2');
-//         });
-//       });
-//     });
-//   });
-//   describe('runtime effect', () => {
-//     describe('not forced', () => {
-//       describe('detected (used) deps', () => {
-//         it('should take version from env.jsonc for used deps without force', () => {
-//           expect(componentShowParsed.packageDependencies).to.include({ 'is-positive': '2.0.0' });
-//         });
-//         it('should install is-positive specified by the env', () => {
-//           expect(
-//             fs.readJsonSync(
-//               resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-positive/package.json'])
-//             ).version
-//           ).to.eq('2.0.0');
-//         });
-//       });
-//       describe('not detected (not used) deps', () => {
-//         it('should not add the dep to the component deps', () => {
-//           const keys = Object.keys(componentShowParsed.packageDependencies);
-//           expect(keys).to.be.not.empty;
-//           expect(keys).to.not.include('is-string');
-//         });
-//       });
-//     });
-//     describe('forced', () => {
-//       it('should take version from env.jsonc for unused deps', () => {
-//         expect(componentShowParsed.packageDependencies).to.include({ 'is-odd': '3.0.1' });
-//       });
-//       it('should install is-odd specified by the env', () => {
-//         expect(
-//           fs.readJsonSync(resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-odd/package.json']))
-//             .version
-//         ).to.eq('3.0.1');
-//       });
-//     });
-//   });
-// });
+function generateEnvJsoncWithExtends(extendsName: string, envJsonc: Object) {
+  return {
+    extends: extendsName,
+    ...envJsonc,
+  };
+}
+
+describe('env-jsonc-policies', function () {
+  this.timeout(0);
+  let helper: Helper;
+  describe.skip('env-jsonc base policies', function () {
+    //   this.timeout(0);
+    //   let helper: Helper;
+    //   let componentShowParsed;
+    //   let envId;
+    //   before(() => {
+    //     helper = new Helper();
+    //     helper.scopeHelper.setNewLocalAndRemoteScopes();
+    //     envId = `${helper.scopes.remote}/react-based-env`;
+    //     helper.command.create('react', 'button', '-p button --env teambit.react/react');
+    //     helper.fs.prependFile('button/button.tsx', 'import isPositive from "is-positive";\n');
+    //     helper.env.setCustomNewEnv(undefined, undefined, { policy: ENV_POLICY });
+    //     helper.command.setEnv('button', envId);
+    //     helper.command.install();
+    //     componentShowParsed = helper.command.showComponentParsed('button');
+    //   });
+    //   after(() => {
+    //     helper.scopeHelper.destroy();
+    //   });
+    //   describe('affect env', () => {
+    //     let envShowParsed;
+    //     before(() => {
+    //       envShowParsed = helper.command.showComponentParsed('react-based-env');
+    //     });
+    //     it('should add peers as runtime deps of the env', () => {
+    //       expect(envShowParsed.packageDependencies).to.include({ react: '^18.0.0' });
+    //       expect(envShowParsed.packageDependencies).to.include({ 'react-dom': '^18.0.0' });
+    //       expect(envShowParsed.packageDependencies).to.include({ graphql: '14.7.0' });
+    //     });
+    //     // TODO: implement if needed
+    //     // it('should add devs as runtime / dev deps of the env', () => {
+    //     // });
+    //   });
+    //   describe('affect component', () => {
+    //     describe('peers effect', () => {
+    //       it('should take supported range from env.jsonc for used peers', () => {
+    //         expect(componentShowParsed.peerPackageDependencies).to.include({ react: '^17.0.0 || ^18.0.0' });
+    //       });
+    //       it('should not add unused peer deps from env.jsonc', () => {
+    //         const keys = Object.keys(componentShowParsed.peerPackageDependencies);
+    //         // Validate we use the correct array
+    //         expect(keys).to.be.not.empty;
+    //         expect(keys).to.not.include('graphql');
+    //       });
+    //     });
+    //     describe('devs effect', () => {
+    //       describe('used deps', () => {
+    //         it('should remove hidden devs deps configured by env.jsonc', () => {
+    //           const newDeps = helper.command.showComponentParsedHarmonyByTitle('button', 'dependencies');
+    //           expect(newDeps).to.not.be.empty;
+    //           const typesReactEntry = newDeps.find((dep) => dep.id === '@types/react');
+    //           expect(typesReactEntry).to.be.undefined;
+    //         });
+    //         it('should save used dep as hidden in the deps resolver deps', () => {
+    //           const depResolverAspectEntry = helper.command.showAspectConfig(
+    //             'button',
+    //             'teambit.dependencies/dependency-resolver'
+    //           );
+    //           const typesReactEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/react');
+    //           expect(typesReactEntry).to.include({ version: '18.0.25' });
+    //           expect(typesReactEntry).to.include({ hidden: true });
+    //         });
+    //         it('should have used dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
+    //           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/react': '18.0.25' });
+    //         });
+    //         it('should install used dev deps specified by the env dev deps', () => {
+    //           const typesReactVersion = fs.readJsonSync(
+    //             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/react/package.json'])
+    //           ).version;
+    //           expect(typesReactVersion).to.eq('18.0.25');
+    //         });
+    //       });
+    //       describe('not used deps', () => {
+    //         it('should save forced unused dep as hidden in the deps resolver deps', () => {
+    //           const depResolverAspectEntry = helper.command.showAspectConfig(
+    //             'button',
+    //             'teambit.dependencies/dependency-resolver'
+    //           );
+    //           const typesJestEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/jest');
+    //           expect(typesJestEntry).to.include({ version: '29.2.2' });
+    //           expect(typesJestEntry).to.include({ hidden: true });
+    //         });
+    //         it('should have forced unused dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
+    //           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/jest': '29.2.2' });
+    //         });
+    //         it('should install forced unused dev deps specified by the env dev deps', () => {
+    //           const typesJestVersion = fs.readJsonSync(
+    //             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/jest/package.json'])
+    //           ).version;
+    //           expect(typesJestVersion).to.eq('29.2.2');
+    //         });
+    //       });
+    //     });
+    //   });
+    //   describe('runtime effect', () => {
+    //     describe('not forced', () => {
+    //       describe('detected (used) deps', () => {
+    //         it('should take version from env.jsonc for used deps without force', () => {
+    //           expect(componentShowParsed.packageDependencies).to.include({ 'is-positive': '2.0.0' });
+    //         });
+    //         it('should install is-positive specified by the env', () => {
+    //           expect(
+    //             fs.readJsonSync(
+    //               resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-positive/package.json'])
+    //             ).version
+    //           ).to.eq('2.0.0');
+    //         });
+    //       });
+    //       describe('not detected (not used) deps', () => {
+    //         it('should not add the dep to the component deps', () => {
+    //           const keys = Object.keys(componentShowParsed.packageDependencies);
+    //           expect(keys).to.be.not.empty;
+    //           expect(keys).to.not.include('is-string');
+    //         });
+    //       });
+    //     });
+    //     describe('forced', () => {
+    //       it('should take version from env.jsonc for unused deps', () => {
+    //         expect(componentShowParsed.packageDependencies).to.include({ 'is-odd': '3.0.1' });
+    //       });
+    //       it('should install is-odd specified by the env', () => {
+    //         expect(
+    //           fs.readJsonSync(resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-odd/package.json']))
+    //             .version
+    //         ).to.eq('3.0.1');
+    //       });
+    //     });
+    //   });
+    // });
+  });
+
+  describe('env-jsonc-extends', function () {
+    let componentShowParsed;
+    let devFilesData;
+    let envIdLevel3;
+    let fullEnvIdLevel3;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      const envIdLevel1 = 'react-based-env-level1';
+      const envIdLevel1PackageName = `@${helper.scopes.remote}/react-based-env-level1`;
+      const envIdLevel2 = 'react-based-env-level2';
+      const envIdLevel2PackageName = `@${helper.scopes.remote}/react-based-env-level2`;
+      envIdLevel3 = 'react-based-env-level3';
+      fullEnvIdLevel3 = `${helper.scopes.remote}/react-based-env-level3`;
+
+      helper.env.setCustomNewEnv(undefined, undefined, ENV_JSONC_LEVEL1, false, 'react-based-env-level1', envIdLevel1);
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        generateEnvJsoncWithExtends(envIdLevel1PackageName, ENV_JSONC_LEVEL2),
+        false,
+        'react-based-env-level2',
+        envIdLevel2
+      );
+      helper.env.setCustomNewEnv(
+        undefined,
+        undefined,
+        generateEnvJsoncWithExtends(envIdLevel2PackageName, ENV_JSONC_LEVEL3),
+        false,
+        'react-based-env-level3',
+        envIdLevel3
+      );
+      helper.command.create('react', 'button', '-p button --env teambit.react/react');
+      helper.fs.prependFile('button/button.tsx', 'import "react-dom";\nimport React from "react";\n');
+      helper.fs.outputFile('button/my-file.preview.ts', '');
+      helper.fs.outputFile('button/my-file.preview-level2.ts', '');
+      helper.fs.outputFile('button/my-file.docs-level2.ts', '');
+      helper.fs.outputFile('button/my-file.preview-level3.ts', '');
+      helper.fs.outputFile('button/my-file.level3.ts', '');
+      helper.command.setEnv('button', envIdLevel3);
+      helper.command.install('@teambit/react.react-env');
+      componentShowParsed = helper.command.showComponentParsed('button');
+      const show = helper.command.showComponentParsedHarmony('button');
+      const devFilesEntry = show.find((item) => item.title === 'dev files');
+      devFilesData = devFilesEntry.json;
+    });
+    after(() => {
+      helper.scopeHelper.destroy();
+    });
+    describe('patterns merges', () => {
+      let testFiles;
+      let docsFiles;
+      let compositionFiles;
+      before(() => {
+        testFiles = devFilesData['teambit.defender/tester'];
+        docsFiles = devFilesData['teambit.docs/docs'];
+        compositionFiles = devFilesData['teambit.compositions/compositions'];
+      });
+      it('should respect patterns that exists only on first level env', () => {
+        expect(testFiles).to.include('button.spec.tsx');
+      });
+      it('should respect patterns that exists only on second level env', () => {
+        expect(docsFiles).to.include('my-file.docs-level2.ts');
+      });
+      it('should respect (custom) patterns that exists only on third level env', () => {
+        const level3Files = devFilesData[fullEnvIdLevel3];
+        expect(level3Files).to.include('my-file.level3.ts');
+      });
+      it('should not use patterns that defined by the second level and overriden by third level', () => {
+        expect(compositionFiles).to.not.include('my-file.preview-level2.ts');
+      });
+      it('should respect patterns that overriden by the third level', () => {
+        expect(compositionFiles).to.include('my-file.preview-level3.ts');
+      });
+    });
+    describe('policies merges', () => {
+      it('should respect peers that exists only on first level env', () => {
+        expect(componentShowParsed.peerPackageDependencies).to.include({ 'react-dom': '^17.0.0 || ^18.0.0' });
+      });
+      it('should respect dev deps that exists only on first level env', () => {
+        expect(componentShowParsed.devPackageDependencies).to.include({ 'is-positive': '3.1.0' });
+      });
+      it('should respect peers that overriden by the second level', () => {
+        expect(componentShowParsed.peerPackageDependencies).to.include({ react: '^17.0.0 || ^16.0.0' });
+      });
+      it('should respect deps that only defined by the second level', () => {
+        expect(componentShowParsed.packageDependencies).to.include({ 'is-odd': '3.0.1' });
+      });
+      it('should respect deps that defined by first and overridden by third but not by second', () => {
+        expect(componentShowParsed.packageDependencies).to.include({ 'is-string': '1.0.6' });
+      });
+      it('should remove deps added by second, and removed by third', () => {
+        expect(componentShowParsed.packageDependencies['is-negative']).to.be.undefined;
+      });
+      it('should respect removed by third that added as different dep type', () => {
+        expect(componentShowParsed.devPackageDependencies).to.include({ 'is-negative': '2.1.0' });
+      });
+    });
+  });
+});

--- a/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
+++ b/e2e/harmony/dependencies/env-jsonc-policies.e2e.ts
@@ -168,135 +168,133 @@ function generateEnvJsoncWithExtends(extendsName: string, envJsonc: Object) {
 describe('env-jsonc-policies', function () {
   this.timeout(0);
   let helper: Helper;
-  describe.skip('env-jsonc base policies', function () {
-    //   this.timeout(0);
-    //   let helper: Helper;
-    //   let componentShowParsed;
-    //   let envId;
-    //   before(() => {
-    //     helper = new Helper();
-    //     helper.scopeHelper.setNewLocalAndRemoteScopes();
-    //     envId = `${helper.scopes.remote}/react-based-env`;
-    //     helper.command.create('react', 'button', '-p button --env teambit.react/react');
-    //     helper.fs.prependFile('button/button.tsx', 'import isPositive from "is-positive";\n');
-    //     helper.env.setCustomNewEnv(undefined, undefined, { policy: ENV_POLICY });
-    //     helper.command.setEnv('button', envId);
-    //     helper.command.install();
-    //     componentShowParsed = helper.command.showComponentParsed('button');
-    //   });
-    //   after(() => {
-    //     helper.scopeHelper.destroy();
-    //   });
-    //   describe('affect env', () => {
-    //     let envShowParsed;
-    //     before(() => {
-    //       envShowParsed = helper.command.showComponentParsed('react-based-env');
-    //     });
-    //     it('should add peers as runtime deps of the env', () => {
-    //       expect(envShowParsed.packageDependencies).to.include({ react: '^18.0.0' });
-    //       expect(envShowParsed.packageDependencies).to.include({ 'react-dom': '^18.0.0' });
-    //       expect(envShowParsed.packageDependencies).to.include({ graphql: '14.7.0' });
-    //     });
-    //     // TODO: implement if needed
-    //     // it('should add devs as runtime / dev deps of the env', () => {
-    //     // });
-    //   });
-    //   describe('affect component', () => {
-    //     describe('peers effect', () => {
-    //       it('should take supported range from env.jsonc for used peers', () => {
-    //         expect(componentShowParsed.peerPackageDependencies).to.include({ react: '^17.0.0 || ^18.0.0' });
-    //       });
-    //       it('should not add unused peer deps from env.jsonc', () => {
-    //         const keys = Object.keys(componentShowParsed.peerPackageDependencies);
-    //         // Validate we use the correct array
-    //         expect(keys).to.be.not.empty;
-    //         expect(keys).to.not.include('graphql');
-    //       });
-    //     });
-    //     describe('devs effect', () => {
-    //       describe('used deps', () => {
-    //         it('should remove hidden devs deps configured by env.jsonc', () => {
-    //           const newDeps = helper.command.showComponentParsedHarmonyByTitle('button', 'dependencies');
-    //           expect(newDeps).to.not.be.empty;
-    //           const typesReactEntry = newDeps.find((dep) => dep.id === '@types/react');
-    //           expect(typesReactEntry).to.be.undefined;
-    //         });
-    //         it('should save used dep as hidden in the deps resolver deps', () => {
-    //           const depResolverAspectEntry = helper.command.showAspectConfig(
-    //             'button',
-    //             'teambit.dependencies/dependency-resolver'
-    //           );
-    //           const typesReactEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/react');
-    //           expect(typesReactEntry).to.include({ version: '18.0.25' });
-    //           expect(typesReactEntry).to.include({ hidden: true });
-    //         });
-    //         it('should have used dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
-    //           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/react': '18.0.25' });
-    //         });
-    //         it('should install used dev deps specified by the env dev deps', () => {
-    //           const typesReactVersion = fs.readJsonSync(
-    //             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/react/package.json'])
-    //           ).version;
-    //           expect(typesReactVersion).to.eq('18.0.25');
-    //         });
-    //       });
-    //       describe('not used deps', () => {
-    //         it('should save forced unused dep as hidden in the deps resolver deps', () => {
-    //           const depResolverAspectEntry = helper.command.showAspectConfig(
-    //             'button',
-    //             'teambit.dependencies/dependency-resolver'
-    //           );
-    //           const typesJestEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/jest');
-    //           expect(typesJestEntry).to.include({ version: '29.2.2' });
-    //           expect(typesJestEntry).to.include({ hidden: true });
-    //         });
-    //         it('should have forced unused dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
-    //           expect(componentShowParsed.devPackageDependencies).to.include({ '@types/jest': '29.2.2' });
-    //         });
-    //         it('should install forced unused dev deps specified by the env dev deps', () => {
-    //           const typesJestVersion = fs.readJsonSync(
-    //             resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/jest/package.json'])
-    //           ).version;
-    //           expect(typesJestVersion).to.eq('29.2.2');
-    //         });
-    //       });
-    //     });
-    //   });
-    //   describe('runtime effect', () => {
-    //     describe('not forced', () => {
-    //       describe('detected (used) deps', () => {
-    //         it('should take version from env.jsonc for used deps without force', () => {
-    //           expect(componentShowParsed.packageDependencies).to.include({ 'is-positive': '2.0.0' });
-    //         });
-    //         it('should install is-positive specified by the env', () => {
-    //           expect(
-    //             fs.readJsonSync(
-    //               resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-positive/package.json'])
-    //             ).version
-    //           ).to.eq('2.0.0');
-    //         });
-    //       });
-    //       describe('not detected (not used) deps', () => {
-    //         it('should not add the dep to the component deps', () => {
-    //           const keys = Object.keys(componentShowParsed.packageDependencies);
-    //           expect(keys).to.be.not.empty;
-    //           expect(keys).to.not.include('is-string');
-    //         });
-    //       });
-    //     });
-    //     describe('forced', () => {
-    //       it('should take version from env.jsonc for unused deps', () => {
-    //         expect(componentShowParsed.packageDependencies).to.include({ 'is-odd': '3.0.1' });
-    //       });
-    //       it('should install is-odd specified by the env', () => {
-    //         expect(
-    //           fs.readJsonSync(resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-odd/package.json']))
-    //             .version
-    //         ).to.eq('3.0.1');
-    //       });
-    //     });
-    //   });
-    // });
+  describe('env-jsonc base policies', function () {
+    this.timeout(0);
+    let componentShowParsed;
+    let envId;
+    before(() => {
+      helper = new Helper();
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      envId = `${helper.scopes.remote}/react-based-env`;
+      helper.command.create('react', 'button', '-p button --env teambit.react/react');
+      helper.fs.prependFile('button/button.tsx', 'import isPositive from "is-positive";\n');
+      helper.env.setCustomNewEnv(undefined, undefined, { policy: ENV_POLICY });
+      helper.command.setEnv('button', envId);
+      helper.command.install();
+      componentShowParsed = helper.command.showComponentParsed('button');
+    });
+    after(() => {
+      helper.scopeHelper.destroy();
+    });
+    describe('affect env', () => {
+      let envShowParsed;
+      before(() => {
+        envShowParsed = helper.command.showComponentParsed('react-based-env');
+      });
+      it('should add peers as runtime deps of the env', () => {
+        expect(envShowParsed.packageDependencies).to.include({ react: '^18.0.0' });
+        expect(envShowParsed.packageDependencies).to.include({ 'react-dom': '^18.0.0' });
+        expect(envShowParsed.packageDependencies).to.include({ graphql: '14.7.0' });
+      });
+      // TODO: implement if needed
+      // it('should add devs as runtime / dev deps of the env', () => {
+      // });
+    });
+    describe('affect component', () => {
+      describe('peers effect', () => {
+        it('should take supported range from env.jsonc for used peers', () => {
+          expect(componentShowParsed.peerPackageDependencies).to.include({ react: '^17.0.0 || ^18.0.0' });
+        });
+        it('should not add unused peer deps from env.jsonc', () => {
+          const keys = Object.keys(componentShowParsed.peerPackageDependencies);
+          // Validate we use the correct array
+          expect(keys).to.be.not.empty;
+          expect(keys).to.not.include('graphql');
+        });
+      });
+      describe('devs effect', () => {
+        describe('used deps', () => {
+          it('should remove hidden devs deps configured by env.jsonc', () => {
+            const newDeps = helper.command.showComponentParsedHarmonyByTitle('button', 'dependencies');
+            expect(newDeps).to.not.be.empty;
+            const typesReactEntry = newDeps.find((dep) => dep.id === '@types/react');
+            expect(typesReactEntry).to.be.undefined;
+          });
+          it('should save used dep as hidden in the deps resolver deps', () => {
+            const depResolverAspectEntry = helper.command.showAspectConfig(
+              'button',
+              'teambit.dependencies/dependency-resolver'
+            );
+            const typesReactEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/react');
+            expect(typesReactEntry).to.include({ version: '18.0.25' });
+            expect(typesReactEntry).to.include({ hidden: true });
+          });
+          it('should have used dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
+            expect(componentShowParsed.devPackageDependencies).to.include({ '@types/react': '18.0.25' });
+          });
+          it('should install used dev deps specified by the env dev deps', () => {
+            const typesReactVersion = fs.readJsonSync(
+              resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/react/package.json'])
+            ).version;
+            expect(typesReactVersion).to.eq('18.0.25');
+          });
+        });
+        describe('not used deps', () => {
+          it('should save forced unused dep as hidden in the deps resolver deps', () => {
+            const depResolverAspectEntry = helper.command.showAspectConfig(
+              'button',
+              'teambit.dependencies/dependency-resolver'
+            );
+            const typesJestEntry = depResolverAspectEntry.data.dependencies.find((dep) => dep.id === '@types/jest');
+            expect(typesJestEntry).to.include({ version: '29.2.2' });
+            expect(typesJestEntry).to.include({ hidden: true });
+          });
+          it('should have forced unused dev deps with the version configured in the env.jsonc in the legacy dev deps', () => {
+            expect(componentShowParsed.devPackageDependencies).to.include({ '@types/jest': '29.2.2' });
+          });
+          it('should install forced unused dev deps specified by the env dev deps', () => {
+            const typesJestVersion = fs.readJsonSync(
+              resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['@types/jest/package.json'])
+            ).version;
+            expect(typesJestVersion).to.eq('29.2.2');
+          });
+        });
+      });
+    });
+    describe('runtime effect', () => {
+      describe('not forced', () => {
+        describe('detected (used) deps', () => {
+          it('should take version from env.jsonc for used deps without force', () => {
+            expect(componentShowParsed.packageDependencies).to.include({ 'is-positive': '2.0.0' });
+          });
+          it('should install is-positive specified by the env', () => {
+            expect(
+              fs.readJsonSync(
+                resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-positive/package.json'])
+              ).version
+            ).to.eq('2.0.0');
+          });
+        });
+        describe('not detected (not used) deps', () => {
+          it('should not add the dep to the component deps', () => {
+            const keys = Object.keys(componentShowParsed.packageDependencies);
+            expect(keys).to.be.not.empty;
+            expect(keys).to.not.include('is-string');
+          });
+        });
+      });
+      describe('forced', () => {
+        it('should take version from env.jsonc for unused deps', () => {
+          expect(componentShowParsed.packageDependencies).to.include({ 'is-odd': '3.0.1' });
+        });
+        it('should install is-odd specified by the env', () => {
+          expect(
+            fs.readJsonSync(resolveFrom(path.join(helper.fixtures.scopes.localPath, 'button'), ['is-odd/package.json']))
+              .version
+          ).to.eq('3.0.1');
+        });
+      });
+    });
   });
 
   describe('env-jsonc-extends', function () {

--- a/scopes/component/dev-files/dev-files.main.runtime.ts
+++ b/scopes/component/dev-files/dev-files.main.runtime.ts
@@ -1,11 +1,11 @@
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
 import { MainRuntime } from '@teambit/cli';
-import { parse } from 'comment-json';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { flatten, isFunction } from 'lodash';
 import { SlotRegistry, Slot } from '@teambit/harmony';
 import { WorkspaceAspect, Workspace } from '@teambit/workspace';
-import { EnvsAspect, EnvsMain } from '@teambit/envs';
+import { EnvsAspect } from '@teambit/envs';
+import type { EnvJsonc, EnvsMain } from '@teambit/envs';
 import LegacyComponent from '@teambit/legacy/dist/consumer/component';
 import { Component, ComponentMain, ComponentAspect } from '@teambit/component';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
@@ -32,6 +32,13 @@ type DevPattern = string[] | DevPatternDescriptor;
  * dev pattern is a list of strings or a function that returns a list of strings. an example to a pattern can be "[*.spec.ts]"
  */
 export type DevPatterns = ((component: Component) => DevPattern) | DevPattern;
+
+export type EnvJsoncPatterns = {
+  compositions: string[];
+  docs: string[];
+  tests: string[];
+  [key: string]: string[];
+};
 
 /**
  * slot for dev file patterns.
@@ -131,28 +138,30 @@ export class DevFilesMain {
     return envPatternsObject;
   }
 
+  mergeEnvManifestPatterns(parent: EnvJsonc, child: EnvJsonc): Partial<EnvJsonc> {
+    const merged = {
+      patterns: { ...(parent.patterns || {}), ...(child.patterns || {}) },
+    };
+    return merged;
+  }
+
   private async computeDevPatternsFromEnvJsoncFile(
     envId: string,
     legacyFiles?: SourceFile[]
   ): Promise<string[] | undefined> {
     const isCoreEnv = this.envs.isCoreEnv(envId);
     if (isCoreEnv) return undefined;
-    let envJson;
+    let envJsonc;
     if (legacyFiles) {
-      envJson = legacyFiles.find((file) => {
-        return file.relative === 'env.jsonc' || file.relative === 'env.json';
-      });
+      envJsonc = this.envs.getEnvManifest(undefined, legacyFiles);
     } else {
       const envComponent = await this.envs.getEnvComponentByEnvId(envId, envId);
-      envJson = envComponent.filesystem.files.find((file) => {
-        return file.relative === 'env.jsonc' || file.relative === 'env.json';
-      });
+      envJsonc = this.envs.getEnvManifest(envComponent, undefined);
     }
 
-    if (!envJson) return undefined;
+    if (!envJsonc) return undefined;
 
-    const object = parse(envJson.contents.toString('utf8'));
-    return object.patterns;
+    return envJsonc.patterns;
   }
 
   /**
@@ -231,6 +240,7 @@ export class DevFilesMain {
   ) {
     const devFiles = new DevFilesMain(envs, workspace, devPatternSlot, config);
     componentAspect.registerShowFragments([new DevFilesFragment(devFiles)]);
+    envs.registerEnvJsoncMergeCustomizer(devFiles.mergeEnvManifestPatterns.bind(devFiles));
 
     const calcDevOnLoad = async (component: Component) => {
       return {

--- a/scopes/component/dev-files/dev-files.main.runtime.ts
+++ b/scopes/component/dev-files/dev-files.main.runtime.ts
@@ -34,10 +34,10 @@ type DevPattern = string[] | DevPatternDescriptor;
 export type DevPatterns = ((component: Component) => DevPattern) | DevPattern;
 
 export type EnvJsoncPatterns = {
-  compositions: string[];
-  docs: string[];
-  tests: string[];
-  [key: string]: string[];
+  compositions?: string[];
+  docs?: string[];
+  tests?: string[];
+  [key: string]: string[] | undefined;
 };
 
 /**
@@ -139,7 +139,7 @@ export class DevFilesMain {
   }
 
   mergeEnvManifestPatterns(parent: EnvJsonc, child: EnvJsonc): Partial<EnvJsonc> {
-    const merged = {
+    const merged: Partial<EnvJsonc> = {
       patterns: { ...(parent.patterns || {}), ...(child.patterns || {}) },
     };
     return merged;

--- a/scopes/component/dev-files/index.ts
+++ b/scopes/component/dev-files/index.ts
@@ -1,5 +1,5 @@
 import { DevFilesAspect } from './dev-files.aspect';
 
 export { DevFilesAspect };
-export type { DevFilesMain } from './dev-files.main.runtime';
+export type { DevFilesMain, EnvJsoncPatterns } from './dev-files.main.runtime';
 export default DevFilesAspect;

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -6,7 +6,7 @@ import { getRelativeRootComponentDir } from '@teambit/bit-roots';
 import { ComponentAspect, Component, ComponentMap, ComponentMain, IComponent } from '@teambit/component';
 import type { ConfigMain } from '@teambit/config';
 import { join } from 'path';
-import { compact, get, pick, uniq, omit } from 'lodash';
+import { compact, get, pick, uniq, omit, cloneDeep } from 'lodash';
 import { ConfigAspect } from '@teambit/config';
 import { EnvsAspect } from '@teambit/envs';
 import type { DependenciesEnv, EnvDefinition, EnvJsonc, EnvsMain } from '@teambit/envs';
@@ -1024,16 +1024,16 @@ export class DependencyResolverMain {
   mergeEnvManifestPolicy(parent: EnvJsonc, child: EnvJsonc): Object {
     const policy = {};
     ['peers', 'dev', 'runtime'].forEach((key) => {
-      policy[key] = parent.policy?.[key] || [];
-      const childEntries = child.policy?.[key] || [];
+      policy[key] = cloneDeep(parent.policy?.[key] || []);
+      const childEntries = cloneDeep(child.policy?.[key] || []);
 
       policy[key] = policy[key].filter((entry) => {
-        return !childEntries.find((childEntry) => {
+        const foundChildEntry = childEntries.find((childEntry) => {
           return childEntry.name === entry.name;
         });
+        return !foundChildEntry;
       });
       policy[key] = policy[key].concat(childEntries);
-
       policy[key] = policy[key].filter((entry) => {
         return entry.version !== '-';
       });

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -8,7 +8,8 @@ import type { ConfigMain } from '@teambit/config';
 import { join } from 'path';
 import { compact, get, pick, uniq, omit } from 'lodash';
 import { ConfigAspect } from '@teambit/config';
-import { DependenciesEnv, EnvDefinition, EnvsAspect, EnvsMain } from '@teambit/envs';
+import { EnvsAspect } from '@teambit/envs';
+import type { DependenciesEnv, EnvDefinition, EnvJsonc, EnvsMain } from '@teambit/envs';
 import { Slot, SlotRegistry, ExtensionManifest, Aspect, RuntimeManifest } from '@teambit/harmony';
 import { RequireableComponent } from '@teambit/harmony.modules.requireable-component';
 import type { LoggerMain } from '@teambit/logger';
@@ -1013,6 +1014,33 @@ export class DependencyResolverMain {
     return allPoliciesFromEnv;
   }
 
+  /**
+   * Merge policy from parent and child env.jsonc files
+   * The rule is that for each type of dependency (dev, runtime, peer) we check each item.
+   * if a dep with a name exists on the child we will take the entire object from the child (including the version,
+   * supported range, force etc')
+   * if a dep exists with a version value "-" we will remove it from the policy
+   */
+  mergeEnvManifestPolicy(parent: EnvJsonc, child: EnvJsonc): Object {
+    const policy = {};
+    ['peers', 'dev', 'runtime'].forEach((key) => {
+      policy[key] = parent.policy?.[key] || [];
+      const childEntries = child.policy?.[key] || [];
+
+      policy[key] = policy[key].filter((entry) => {
+        return !childEntries.find((childEntry) => {
+          return childEntry.name === entry.name;
+        });
+      });
+      policy[key] = policy[key].concat(childEntries);
+
+      policy[key] = policy[key].filter((entry) => {
+        return entry.version !== '-';
+      });
+    });
+    return { policy };
+  }
+
   private async getEnvPolicyFromFile(envId: string, legacyFiles?: SourceFile[]): Promise<EnvPolicy | undefined> {
     const isCoreEnv = this.envs.isCoreEnv(envId);
     if (isCoreEnv) return undefined;
@@ -1487,6 +1515,7 @@ export class DependencyResolverMain {
 
     graphql.register(dependencyResolverSchema(dependencyResolver));
     envs.registerService(new DependenciesService());
+    envs.registerEnvJsoncMergeCustomizer(dependencyResolver.mergeEnvManifestPolicy.bind(dependencyResolver));
 
     // this is needed because during tag process, the data.dependencies can be loaded and the componentId can become
     // an instance of ComponentID class. it needs to be serialized before saved into objects.

--- a/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
@@ -49,7 +49,7 @@ export class EnvPolicy extends VariantPolicy {
   }
 
   static fromConfigObject(
-    configObject,
+    configObject: EnvPolicyConfigObject,
     { includeLegacyPeersInSelfPolicy }: VariantPolicyFromConfigObjectOptions = {}
   ): EnvPolicy {
     validateEnvPolicyConfigObject(configObject);

--- a/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/env-policy/env-policy.ts
@@ -59,9 +59,12 @@ export class EnvPolicy extends VariantPolicy {
      * Always force it for the env itself
      */
     let selfPeersEntries: VariantPolicyEntry[];
+    // @ts-ignore TODO: need to fix this, the | confusing the compiler
     if (includeLegacyPeersInSelfPolicy && !configObject.peers && configObject.peerDependencies) {
+      // @ts-ignore TODO: need to fix this, the | confusing the compiler
       selfPeersEntries = handleLegacyPeers(configObject);
     } else {
+      // @ts-ignore TODO: need to fix this, the | confusing the compiler
       selfPeersEntries = entriesFromKey(configObject, 'peers', 'version', 'runtime', {
         source: 'env-own',
         force: true,
@@ -75,10 +78,12 @@ export class EnvPolicy extends VariantPolicy {
      * Those were always forced on the components as visible dependencies.
      */
     const legacyPolicy = VariantPolicy.fromConfigObject(configObject, { source: 'env', force: true, hidden: false });
+    // @ts-ignore TODO: need to fix this, the | confusing the compiler
     const componentPeersEntries = entriesFromKey(configObject, 'peers', 'supportedRange', 'peer', { source: 'env' });
     const otherKeyNames: EnvJsoncPolicyConfigKey[] = ['dev', 'runtime'];
     const otherEntries: VariantPolicyEntry[] = otherKeyNames.reduce(
       (acc: VariantPolicyEntry[], keyName: EnvJsoncPolicyConfigKey) => {
+        // @ts-ignore TODO: need to fix this, the | confusing the compiler
         const currEntries = entriesFromKey(configObject, keyName, 'version', keyName as DependencyLifecycleType, {
           source: 'env',
         });

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -326,11 +326,11 @@ export class EnvsMain {
     }
     const parentStr = readFileSync(parentEnvJsoncPath).toString('utf8');
     const parentObject: EnvJsonc = parse(parentStr, undefined, true);
-    const mergedObjects = this.mergeEnvManifests(parentObject, object);
-    if (mergedObjects.extends) {
-      return this.recursivelyMergeWithParentManifest(mergedObjects, parentEnvJsoncPath);
+    const mergedObject = this.mergeEnvManifests(parentObject, object);
+    if (mergedObject.extends) {
+      return this.recursivelyMergeWithParentManifest(mergedObject, parentEnvJsoncPath);
     }
-    return object;
+    return mergedObject;
   }
 
   mergeEnvManifests(parent: EnvJsonc, child: EnvJsonc): EnvJsonc {

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import findRoot from 'find-root';
 import { resolveFrom } from '@teambit/toolbox.modules.module-resolver';
 import { isCoreAspect } from '@teambit/bit';
@@ -33,7 +34,6 @@ import { EnvsCmd, GetEnvCmd, ListEnvsCmd } from './envs.cmd';
 import { EnvFragment } from './env.fragment';
 import { EnvNotFound, EnvNotConfiguredForComponent } from './exceptions';
 import { EnvPlugin } from './env.plugin';
-import { join } from 'path';
 
 export type EnvJsonc = {
   extends?: string;

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -7,8 +7,10 @@ import { parse } from 'comment-json';
 import { SourceFile } from '@teambit/legacy/dist/consumer/component/sources';
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import { Component, ComponentAspect, ComponentMain } from '@teambit/component';
+import type { EnvPolicyConfigObject } from '@teambit/dependency-resolver';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { IssuesAspect, IssuesMain } from '@teambit/issues';
+import type { EnvJsoncPatterns } from '@teambit/dev-files';
 import pMapSeries from 'p-map-series';
 import { IssuesClasses } from '@teambit/component-issues';
 import { Harmony, Slot, SlotRegistry } from '@teambit/harmony';
@@ -33,7 +35,16 @@ import { EnvNotFound, EnvNotConfiguredForComponent } from './exceptions';
 import { EnvPlugin } from './env.plugin';
 import { join } from 'path';
 
+export type EnvJsonc = {
+  extends?: string;
+  policy?: EnvPolicyConfigObject;
+  patterns?: EnvJsoncPatterns;
+};
+
+export type EnvJsoncMergeCustomizer = (parentObj: EnvJsonc, childObj: EnvJsonc) => Partial<EnvJsonc>;
+
 export type EnvsRegistry = SlotRegistry<Environment>;
+export type EnvJsoncMergeCustomizerRegistry = SlotRegistry<EnvJsoncMergeCustomizer>;
 
 export type EnvsConfig = {
   env: string;
@@ -135,7 +146,9 @@ export class EnvsMain {
 
     private loggerMain: LoggerMain,
 
-    private workerMain: WorkerMain
+    private workerMain: WorkerMain,
+
+    private envJsoncMergeCustomizerSlot: EnvJsoncMergeCustomizerRegistry
   ) {}
 
   /**
@@ -276,7 +289,7 @@ export class EnvsMain {
     return true;
   }
 
-  getEnvManifest(envComponent?: Component, legacyFiles?: SourceFile[]): Object | undefined {
+  getEnvManifest(envComponent?: Component, legacyFiles?: SourceFile[]): EnvJsonc | undefined {
     // TODO: maybe throw an error here?
     if (!envComponent && !legacyFiles) return undefined;
     // @ts-ignore
@@ -287,15 +300,12 @@ export class EnvsMain {
 
     if (!envJson) return undefined;
 
-    const object = parse(envJson.contents.toString('utf8'), undefined, true);
+    const object: EnvJsonc = parse(envJson.contents.toString('utf8'), undefined, true);
     const resolvedObject = this.recursivelyMergeWithParentManifest(object, envJson.path);
-    if (object.extends) {
-      throw new Error('g');
-    }
-    return object;
+    return resolvedObject;
   }
 
-  recursivelyMergeWithParentManifest(object: any, originPath: string) {
+  recursivelyMergeWithParentManifest(object: EnvJsonc, originPath: string): EnvJsonc {
     if (!object.extends) return object;
     const parentPackageName = object.extends;
     const parentPath = resolveFrom(originPath, [parentPackageName]);
@@ -315,7 +325,7 @@ export class EnvsMain {
       return object;
     }
     const parentStr = readFileSync(parentEnvJsoncPath).toString('utf8');
-    const parentObject = parse(parentStr, undefined, true);
+    const parentObject: EnvJsonc = parse(parentStr, undefined, true);
     const mergedObjects = this.mergeEnvManifests(parentObject, object);
     if (mergedObjects.extends) {
       return this.recursivelyMergeWithParentManifest(mergedObjects, parentEnvJsoncPath);
@@ -323,42 +333,18 @@ export class EnvsMain {
     return object;
   }
 
-  mergeEnvManifests(parent: object, child: object): Object {
-    let merged = {};
+  mergeEnvManifests(parent: EnvJsonc, child: EnvJsonc): EnvJsonc {
+    let merged: EnvJsonc = {};
+    const mergeCustomizer = this.getAllRegisteredEnvJsoncCustomizers();
+    for (const customizer of mergeCustomizer) {
+      const oneMerged = customizer(parent, child);
+      merged = { ...merged, ...oneMerged };
+    }
     // Take extends specifically from the parent so we can propagate it to the next parent
     if (parent.extends) {
       merged.extends = parent.extends;
     }
-    merged.patterns = { ...(parent.patterns || {}), ...(child.patterns || {}) };
-    merged.policy = this.mergeEnvManifestPolicy(parent, child);
     return merged;
-  }
-
-  /**
-   * Merge policy from parent and child env.jsonc files
-   * The rule is that for each type of dependency (dev, runtime, peer) we check each item.
-   * if a dep with a name exists on the child we will take the entire object from the child (including the version,
-   * supported range, force etc')
-   * if a dep exists with a version value "-" we will remove it from the policy
-   */
-  mergeEnvManifestPolicy(parent: object, child: object): Object {
-    const policy = {};
-    ['peers', 'dev', 'runtime'].forEach((key) => {
-      policy[key] = parent.policy?.[key] || [];
-      const childEntries = child.policy?.[key] || [];
-
-      policy[key] = policy[key].filter((entry) => {
-        return !childEntries.find((childEntry) => {
-          return childEntry.name === entry.name;
-        });
-      });
-      policy[key] = policy[key].concat(childEntries);
-
-      policy[key] = policy[key].filter((entry) => {
-        return entry.version !== '-';
-      });
-    });
-    return policy;
   }
 
   async hasEnvManifestById(envId: string, requesting: string): Promise<boolean | undefined> {
@@ -695,6 +681,10 @@ export class EnvsMain {
     return this.envSlot.toArray().map((envData) => envData[0]);
   }
 
+  getAllRegisteredEnvJsoncCustomizers(): EnvJsoncMergeCustomizer[] {
+    return this.envJsoncMergeCustomizerSlot.toArray().map((customizerEntry) => customizerEntry[1]);
+  }
+
   getEnvPlugin() {
     return new EnvPlugin(this.envSlot, this.servicesRegistry, this.loggerMain, this.workerMain, this.harmony);
   }
@@ -1015,6 +1005,13 @@ export class EnvsMain {
     return this.envSlot.register(env);
   }
 
+  /**
+   * register an env.jsonc merge customizer.
+   */
+  registerEnvJsoncMergeCustomizer(customizer: EnvJsoncMergeCustomizer) {
+    return this.envJsoncMergeCustomizerSlot.register(customizer);
+  }
+
   async addNonLoadedEnvAsComponentIssues(components: Component[]) {
     await pMapSeries(components, async (component) => {
       const envId = await this.calculateEnvId(component);
@@ -1093,7 +1090,11 @@ export class EnvsMain {
     }
   }
 
-  static slots = [Slot.withType<Environment>(), Slot.withType<EnvService<any>>()];
+  static slots = [
+    Slot.withType<Environment>(),
+    Slot.withType<EnvService<any>>(),
+    Slot.withType<EnvJsoncMergeCustomizerRegistry>(),
+  ];
 
   static dependencies = [GraphqlAspect, LoggerAspect, ComponentAspect, CLIAspect, WorkerAspect, IssuesAspect];
 
@@ -1107,11 +1108,25 @@ export class EnvsMain {
       IssuesMain
     ],
     config: EnvsConfig,
-    [envSlot, servicesRegistry]: [EnvsRegistry, ServicesRegistry],
+    [envSlot, servicesRegistry, envJsoncMergeCustomizerSlot]: [
+      EnvsRegistry,
+      ServicesRegistry,
+      EnvJsoncMergeCustomizerRegistry
+    ],
     context: Harmony
   ) {
     const logger = loggerAspect.createLogger(EnvsAspect.id);
-    const envs = new EnvsMain(config, context, envSlot, logger, servicesRegistry, component, loggerAspect, worker);
+    const envs = new EnvsMain(
+      config,
+      context,
+      envSlot,
+      logger,
+      servicesRegistry,
+      component,
+      loggerAspect,
+      worker,
+      envJsoncMergeCustomizerSlot
+    );
     component.registerShowFragments([new EnvFragment(envs)]);
     if (issues) issues.registerAddComponentsIssues(envs.addNonLoadedEnvAsComponentIssues.bind(envs));
 

--- a/scopes/envs/envs/index.ts
+++ b/scopes/envs/envs/index.ts
@@ -21,6 +21,7 @@ export type {
   Descriptor,
   RegularCompDescriptor,
   EnvCompDescriptor,
+  EnvJsonc,
 } from './environments.main.runtime';
 export { EnvsAspect };
 export { EnvsExecutionResult } from './runtime/envs-execution-result';

--- a/src/e2e-helper/e2e-fixtures-helper.ts
+++ b/src/e2e-helper/e2e-fixtures-helper.ts
@@ -13,6 +13,7 @@ import ScopeHelper from './e2e-scope-helper';
 import ScopesData from './e2e-scopes';
 
 export type GenerateEnvJsoncOptions = {
+  extends?: string;
   policy?: Record<string, any>;
   patterns?: Record<string, string[]>;
 };
@@ -295,10 +296,13 @@ export default () => 'comp${index} and ' + ${nextComp}();`;
       docs: ['**/*.docs.*'],
       tests: ['**/*.spec.*', '**/*.test.*'],
     };
-    const envJsoncFileContentJson = {
+    const envJsoncFileContentJson: GenerateEnvJsoncOptions = {
       policy: options.policy || {},
       patterns: options.patterns || defaultPatterns,
     };
+    if (options.extends) {
+      envJsoncFileContentJson.extends = options.extends;
+    }
     this.fs.outputFile(envJsoncFile, JSON.stringify(envJsoncFileContentJson, null, 2));
   }
 


### PR DESCRIPTION
## Proposed Changes

- With this feature, you can now add new `"extends"` field in your env.jsonc
- You can use extends to extends an env.jsonc that extends another env.jsonc
- The value for `extends` should be the package name of the env you want to extend.
- You need to make sure to have that env you extend as a dependency of your env.

## Merge strategy

### patterns

In the `patterns` object, each key will be overridden by the child as is (no internal merge of the arrays).
If you have a key in the parent that doesn't exist on the child it will be taken as is from the parent.

### policy
For each type of dependency (dev/peer/runtime), each object will be taken from the child by the name.
so if you have a dependency on peers in the parent like this:
```
// parent's env.jsonc
peers: [
    {
      name: 'react',
      version: '^18.0.0',
      supportedRange: '^18.0.0',
    },
]
```
and in the child
```
// parent's env.jsonc
peers: [
    {
      name: 'react',
      version: '^17.0.0',
      supportedRange: '^17.0.0,
    },
]
```
The final result will be the child, as they have the same value for name, and the same type (peers)

If an entry with a given name exists only in one of the env.jsonc, it will be taken as is.
So the final array will have entries from both the child and the parent. 

In case you want to just remove some dep from the parent you can use `"-"` as the version value.
This will not remove the dependency from the component, rather then will remove it from the env policy.
(in most cases it will, in that case, change the behavior so bit will be using the auto-resolve algorithm to resolve the version of a dependency rather than remove it (unless you don't use that dependency)

This way you can also use it in order move something from one type to another.
see the following example:
```
// parent's env.jsonc
runtime: [
    {
      name: 'lodash',
      version: '1.0.0',
      force: true
    },
]
```
and you want to move lodash to be a dev dependency
```
// child's env.jsonc
runtime: [
    {
      name: 'lodash',
      version: '-,
      force: true
    },
],
runtime: [
    {
      name: 'lodash',
      version: '1.0.0',
      force: true
    },
]
```
you are using `"-"` to remove it from runtime, and add it again in dev.


