### PR TITLE
remove "caniuse-lite is outdated" message

### DIFF
--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -6,6 +6,8 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
+process.env.BROWSERSLIST_IGNORE_OLD_DATA = 'true';
+
 import './hook-require';
 
 import {


### PR DESCRIPTION
This change instructs browserlist to not print the following warning:

> Browserslist: caniuse-lite is outdated. Please run:
>   npx update-browserslist-db@latest
>   Why you should do it regularly: https://github.com/browserslist/update-db#readme

This message is not helpful to our users. Running the package-manager directory is not recommended.