### PR TITLE
track LICENSE files

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -241,7 +241,6 @@ export const IGNORE_LIST = [
   '**/node_modules/**',
   '**/package-lock.json',
   '**/yarn.lock',
-  '**/LICENSE',
 ];
 
 /**


### PR DESCRIPTION
Currently, LICENSE files are ignored for historical reasons which are not relevant anymore. This PR makes them trackable.