### PR TITLE
fix(eject-conf), remove env-version if exists locally in the workspace

### DIFF
--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -494,6 +494,22 @@ describe('custom env', function () {
       helper.command.status();
     });
   });
+  describe('ejecting conf when current env exists locally', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.env.setCustomEnv();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.setEnv('comp1', 'node-env');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.ejectConf('comp1');
+    });
+    it('should write the env aspect without a version to the component.json file', () => {
+      const compJson = helper.componentJson.read('comp1');
+      expect(compJson.extensions).to.have.property(`${helper.scopes.remote}/node-env`);
+      expect(compJson.extensions).to.not.have.property(`${helper.scopes.remote}/node-env@0.0.1`);
+    });
+  });
 });
 
 function getEnvIdFromModel(compModel: any): string {

--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -168,7 +168,7 @@ export interface ComponentFactory {
    */
   idsByPattern(pattern: string, throwForNoMatch?: boolean): Promise<ComponentID[]>;
 
-  hasId(componentId: ComponentID): Promise<boolean>;
+  hasId(componentId: ComponentID): Promise<boolean> | boolean;
 
   /**
    * Check if the host has the id, if no, search for the id in inner host (for example, workspace will search in the scope)


### PR DESCRIPTION
Same issue currently exists when switching to another lane. It writes the env with the specific version, which can be incorrect and belong to the origin lane and not the current one.