### PR TITLE
fix(component-loading) - limit component loading concurrency to 1 when deps cache is empty

### DIFF
--- a/src/consumer/component/component-fs-cache.ts
+++ b/src/consumer/component/component-fs-cache.ts
@@ -1,5 +1,6 @@
 import cacache, { GetCacheObject } from 'cacache';
 import path from 'path';
+import { isEmpty } from 'lodash';
 import fs from 'fs-extra';
 import { isFeatureEnabled, NO_FS_CACHE_FEATURE } from '../../api/consumer/lib/feature-toggle';
 import { PathOsBasedAbsolute } from '../../utils/path';
@@ -64,6 +65,11 @@ export class ComponentFsCache {
 
   async listDependenciesDataCache() {
     return cacache.ls(this.getCachePath(DEPS));
+  }
+
+  async isDependenciesDataCacheEmpty() {
+    const cache = await cacache.ls(this.getCachePath(DEPS));
+    return isEmpty(cache);
   }
 
   async getVersionsDataFromCache(idStr: string): Promise<{ timestamp: number; data: string } | null> {


### PR DESCRIPTION
## Proposed Changes

- Limit component loading concurrency to 1 when deps cache is empty
- This should also fix some issues for large workspaces when there are race conditions when loading the deps for all components.
- This should also improve performance in some cases (like loading during `bit install` after the package manager finish its work)
