### PR TITLE
fix(checkout), respect --auto-merge-resolve flag when finding workspace.jsonc conflicts

### DIFF
--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -32,7 +32,7 @@ export type CheckoutProps = {
   latest?: boolean;
   main?: boolean; // relevant for "revert" only
   promptMergeOptions?: boolean;
-  mergeStrategy?: MergeStrategy | null; // strategy to use in case of conflicts
+  mergeStrategy?: MergeStrategy; // strategy to use in case of conflicts
   forceOurs?: boolean; // regardless of conflicts, use ours
   forceTheirs?: boolean; // regardless of conflicts, use theirs
   verbose?: boolean;
@@ -168,6 +168,7 @@ export class CheckoutMain {
         skipUpdatingBitMap: checkoutProps.skipUpdatingBitmap || checkoutProps.revert,
         shouldUpdateWorkspaceConfig: true,
         reasonForBitmapChange: 'checkout',
+        mergeStrategy: checkoutProps.mergeStrategy,
       };
       componentWriterResults = await this.componentWriter.writeMany(manyComponentsWriterOpts);
     }

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -16,6 +16,7 @@ import ComponentMap from '@teambit/legacy/dist/consumer/bit-map/component-map';
 import { COMPONENT_CONFIG_FILE_NAME } from '@teambit/legacy/dist/constants';
 import DataToPersist from '@teambit/legacy/dist/consumer/component/sources/data-to-persist';
 import { ConfigMergerAspect, ConfigMergerMain, WorkspaceConfigUpdateResult } from '@teambit/config-merger';
+import { MergeStrategy } from '@teambit/legacy/dist/consumer/versions-ops/merge-version';
 import Consumer from '@teambit/legacy/dist/consumer/consumer';
 import ComponentWriter, { ComponentWriterProps } from './component-writer';
 import { ComponentWriterAspect } from './component-writer.aspect';
@@ -33,6 +34,7 @@ export interface ManyComponentsWriterParams {
   skipWriteConfigFiles?: boolean;
   reasonForBitmapChange?: string; // optional. will be written in the bitmap-history-metadata
   shouldUpdateWorkspaceConfig?: boolean; // whether it should update dependencies policy (or leave conflicts) in workspace.jsonc
+  mergeStrategy?: MergeStrategy; // needed for workspace.jsonc conflicts
 }
 
 export type ComponentWriterResults = {
@@ -66,7 +68,10 @@ export class ComponentWriterMain {
     let compilationError: Error | undefined;
     let workspaceConfigUpdateResult: WorkspaceConfigUpdateResult | undefined;
     if (opts.shouldUpdateWorkspaceConfig) {
-      workspaceConfigUpdateResult = await this.configMerge.updateDepsInWorkspaceConfig(opts.components);
+      workspaceConfigUpdateResult = await this.configMerge.updateDepsInWorkspaceConfig(
+        opts.components,
+        opts.mergeStrategy
+      );
     }
     if (!opts.skipDependencyInstallation) {
       installationError = await this.installPackagesGracefully(opts.skipWriteConfigFiles);


### PR DESCRIPTION
Currently, `bit checkout head` writes dependencies conflicts into workspace.jsonc even when `--auto-merge-resolve` was used (with either `ours` or `theirs`).
This PR uses the merge strategy to conclude whether a dependency should be updated.