### PR TITLE
fix(snap-from-scope), support dependents recursively with --update-dependents

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -405,7 +405,7 @@ if you're willing to lose the history from the head to the specified version, us
       this.scope.legacyScope.setCurrentLaneId(laneId);
       this.scope.legacyScope.scopeImporter.shouldOnlyFetchFromCurrentLane = true;
     }
-    const laneCompIds = lane?.toComponentIds();
+    const laneCompIds = lane?.toComponentIdsIncludeUpdateDependents();
     const snapDataPerComp = snapDataPerCompRaw.map((snapData) => {
       return {
         componentId: ComponentID.fromString(snapData.componentId),

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -364,7 +364,7 @@ once done, to continue working, please run "bit cc"`
 
   async isPartOfLaneHistory(id: ComponentID, lane: Lane) {
     if (!id.version) throw new Error(`isIdOnGivenLane expects id with version, got ${id.toString()}`);
-    const laneIds = lane.toBitIds();
+    const laneIds = lane.toComponentIdsIncludeUpdateDependents();
     if (laneIds.has(id)) return true; // in the lane with the same version
     const laneIdWithDifferentVersion = laneIds.searchWithoutVersion(id);
     if (!laneIdWithDifferentVersion) return false; // not in the lane at all


### PR DESCRIPTION
Easier to explain with example: comp1 -> comp2 -> comp3. Snapping comp2 with `--update-dependents` saves comp2 inside the `updateDependents` prop of the lane with the comp3 dependency having the same version as in the lane.
Snapping comp3 now have the same effect. It saves comp2 with the version is has in the `updateDependents` prop.