### PR TITLE
fix, consider Version.origin to determine whether a snap is part of a lane

### DIFF
--- a/src/scope/models/version.ts
+++ b/src/scope/models/version.ts
@@ -692,6 +692,10 @@ export default class Version extends BitObject {
     return !this.schema || this.schema === SchemaName.Legacy;
   }
 
+  get originLaneId(): LaneId | undefined {
+    return this.origin?.lane ? new LaneId({ name: this.origin.lane.name, scope: this.origin.lane.scope }) : undefined;
+  }
+
   setDist(dist: Source | undefined) {
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
     this.dist = dist

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -372,6 +372,8 @@ once done, to continue working, please run "bit cc"`
     // component is in the lane object but with a different version.
     // we have to figure out whether this version is part of the lane history
     const component = await this.getModelComponent(id.changeVersion(undefined));
+    const version = await component.loadVersion(id.version as string, this.objects, false);
+    if (version?.originLaneId?.isEqual(lane.toLaneId())) return true;
     const laneVersionRef = Ref.from(laneIdWithDifferentVersion.version as string);
     const verHistory = await component.getAndPopulateVersionHistory(this.objects, laneVersionRef);
     const verRef = component.getRef(id.version);


### PR DESCRIPTION
It's faster than checking history graph. Also, in some (unclear) cases when the history has missing parts, this check is more accurate. Keep in mind that this works only when the "origin" is set. (this prop was added a few months ago).