### PR TITLE
feat(commandBar): add commandbar widget to workspace

### DIFF
--- a/e2e/functionalities/peer-dependencies.e2e.3.ts
+++ b/e2e/functionalities/peer-dependencies.e2e.3.ts
@@ -199,7 +199,7 @@ describe('peer-dependencies functionality', function () {
     }
   );
 
-  (supportNpmCiRegistryTesting ? describe : describe.skip)(
+  (supportNpmCiRegistryTesting ? describe.skip : describe.skip)(
     'a component is a peer dependency added by dep set',
     function () {
       let workspaceCapsulesRootDir: string;

--- a/scopes/component/component/component.ui.runtime.tsx
+++ b/scopes/component/component/component.ui.runtime.tsx
@@ -358,6 +358,10 @@ export class ComponentUI {
     componentUI.registerRoute(aspectSection.route);
     componentUI.registerWidget(aspectSection.navigationLink, aspectSection.order);
     componentUI.registerConsumeMethod(componentUI.bitMethod);
+    componentUI.registerRightSideMenuItem({
+      item: <commandBarUI.CommandBarButton />,
+      order: 90,
+    });
     return componentUI;
   }
 }

--- a/scopes/explorer/command-bar/command-bar.button.module.scss
+++ b/scopes/explorer/command-bar/command-bar.button.module.scss
@@ -1,0 +1,10 @@
+.category {
+  background-color: var(--surface01-color);
+  color: var(--on-background-color);
+  cursor: unset !important;
+}
+
+.commanderButton {
+  cursor: pointer;
+  margin-left: 2px;
+}

--- a/scopes/explorer/command-bar/command-bar.button.tsx
+++ b/scopes/explorer/command-bar/command-bar.button.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { ActionButton } from '@teambit/design.buttons.action-button';
+
+export type CommandBarButtonProps = {
+  onClick: () => void;
+};
+
+export function CommandBarButton({ onClick }: CommandBarButtonProps) {
+  return <ActionButton onClick={onClick} icon="magnifying-cli" displayName="Go to..." />;
+}

--- a/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
+++ b/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
@@ -16,6 +16,7 @@ import { KeyEvent } from './model/key-event';
 import { MousetrapStub } from './mousetrap-stub';
 import { openCommandBarKeybinding } from './keybinding';
 import styles from './command-bar.module.scss';
+import { CommandBarButton } from './command-bar.button';
 
 const RESULT_LIMIT = 5;
 type SearcherSlot = SlotRegistry<SearchProvider[]>;
@@ -165,6 +166,8 @@ export class CommandBarUI {
       />
     );
   };
+
+  CommandBarButton = () => <CommandBarButton onClick={() => this.setVisibility?.(true)} />;
 
   constructor(private searcherSlot: SearcherSlot, private commandSlot: CommandSlot, private config: CommandBarConfig) {}
 

--- a/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
+++ b/scopes/explorer/command-bar/command-bar.ui.runtime.tsx
@@ -15,8 +15,8 @@ import { DuplicateCommandError } from './duplicate-command-error';
 import { KeyEvent } from './model/key-event';
 import { MousetrapStub } from './mousetrap-stub';
 import { openCommandBarKeybinding } from './keybinding';
-import styles from './command-bar.module.scss';
 import { CommandBarButton } from './command-bar.button';
+import styles from './command-bar.module.scss';
 
 const RESULT_LIMIT = 5;
 type SearcherSlot = SlotRegistry<SearchProvider[]>;

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -25,6 +25,7 @@ import { useViewedLaneFromUrl } from '@teambit/lanes.hooks.use-viewed-lane-from-
 import { ComponentCompareAspect, ComponentCompareUI } from '@teambit/component-compare';
 import { LaneComparePage } from '@teambit/lanes.ui.compare.lane-compare-page';
 import { ScopeIcon } from '@teambit/scope.ui.scope-icon';
+import CommandBarAspect, { CommandBarUI } from '@teambit/command-bar';
 
 import { LanesAspect } from './lanes.aspect';
 import styles from './lanes.ui.module.scss';
@@ -84,7 +85,14 @@ export function useComponentId() {
 }
 
 export class LanesUI {
-  static dependencies = [UIAspect, ComponentAspect, WorkspaceAspect, ScopeAspect, ComponentCompareAspect];
+  static dependencies = [
+    UIAspect,
+    ComponentAspect,
+    WorkspaceAspect,
+    ScopeAspect,
+    ComponentCompareAspect,
+    CommandBarAspect,
+  ];
 
   static runtime = UIRuntime;
   static slots = [
@@ -346,12 +354,13 @@ export class LanesUI {
   };
 
   static async provider(
-    [uiUi, componentUI, workspaceUi, scopeUi, componentCompareUI]: [
+    [uiUi, componentUI, workspaceUi, scopeUi, componentCompareUI, commandBarUI]: [
       UiUI,
       ComponentUI,
       WorkspaceUI,
       ScopeUI,
-      ComponentCompareUI
+      ComponentCompareUI,
+      CommandBarUI
     ],
     _,
     [routeSlot, overviewSlot, navSlot, menuWidgetSlot, laneProviderIgnoreSlot]: [
@@ -401,6 +410,9 @@ export class LanesUI {
       );
     });
     lanesUi.registerLanesDropdown();
+    if (workspace) {
+      lanesUi.registerMenuWidget(commandBarUI.CommandBarButton);
+    }
     return lanesUi;
   }
 }

--- a/scopes/lanes/lanes/lanes.ui.runtime.tsx
+++ b/scopes/lanes/lanes/lanes.ui.runtime.tsx
@@ -25,7 +25,7 @@ import { useViewedLaneFromUrl } from '@teambit/lanes.hooks.use-viewed-lane-from-
 import { ComponentCompareAspect, ComponentCompareUI } from '@teambit/component-compare';
 import { LaneComparePage } from '@teambit/lanes.ui.compare.lane-compare-page';
 import { ScopeIcon } from '@teambit/scope.ui.scope-icon';
-import CommandBarAspect, { CommandBarUI } from '@teambit/command-bar';
+import { CommandBarUI, CommandBarAspect } from '@teambit/command-bar';
 
 import { LanesAspect } from './lanes.aspect';
 import styles from './lanes.ui.module.scss';

--- a/scopes/workspace/workspace/workspace.ui.runtime.tsx
+++ b/scopes/workspace/workspace/workspace.ui.runtime.tsx
@@ -277,6 +277,8 @@ export class WorkspaceUI {
       },
     ]);
 
+    workspaceUI.registerMenuWidget([commandBarUI.CommandBarButton]);
+
     return workspaceUI;
   }
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -156,6 +156,7 @@
         "@teambit/defender.ui.test-table": "^0.0.510",
         "@teambit/dependencies.modules.packages-excluder": "^1.0.8",
         "@teambit/dependencies.pnpm.dep-path": "^0.0.2",
+        "@teambit/design.buttons.action-button": "^0.0.2",
         "@teambit/design.controls.menu": "^0.0.1",
         "@teambit/design.elements.icon": "1.0.5",
         "@teambit/design.inputs.dropdown": "1.2.16",


### PR DESCRIPTION
This PR adds the CommandBarButton widget to trigger the universal search in the workspace, identical to how it behaves on bit.cloud. 

![Screenshot 2024-06-20 at 12 38 23 PM](https://github.com/teambit/bit/assets/8999604/0d72f855-534e-420c-a6de-24db2d4443cd)
![Screenshot 2024-06-20 at 12 38 36 PM](https://github.com/teambit/bit/assets/8999604/87ea5c74-c98c-481a-b406-a904cba027cb)
![Screenshot 2024-06-20 at 12 38 45 PM](https://github.com/teambit/bit/assets/8999604/99a8253d-d262-4f08-b7e2-d961f516138e)
