### PR TITLE
perf, imporove bootstrap performance by making it unnecessary to add apps to workspace.jsonc

### DIFF
--- a/scopes/component/status/mini-status-cmd.ts
+++ b/scopes/component/status/mini-status-cmd.ts
@@ -56,7 +56,7 @@ this command only checks source code changes, it doesn't check for config/aspect
     return `${modifiedOutput}\n\n${newOutput}${compWithIssuesOutput}`;
   }
 
-  async json([pattern]: [string], opts: MiniStatusOpts) {
+  async json([pattern]: [string], opts: MiniStatusOpts): Promise<Record<string, any>> {
     const { modified, newComps, compWithIssues } = await this.status.statusMini(pattern, opts);
     return {
       modified: modified.map((m) => m.toStringWithoutVersion()),

--- a/scopes/harmony/application/app.cmd.ts
+++ b/scopes/harmony/application/app.cmd.ts
@@ -16,6 +16,7 @@ export class AppListCmd implements Command {
   constructor(private applicationAspect: ApplicationMain) {}
 
   async report(args: [string], { json }: { json: boolean }) {
+    await this.applicationAspect.loadAllAppsAsAspects();
     const appComponents = this.applicationAspect.mapApps();
     if (json) return JSON.stringify(appComponents, null, 2);
     if (!appComponents.length) return chalk.yellow('no apps found');

--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -113,7 +113,17 @@ export class ApplicationMain {
   }
 
   /**
+   * instead of adding apps to workspace.jsonc, this method gets all apps components and load them as aspects so then
+   * they could register to the apps slots and be available to list/run etc.
+   */
+  async loadAllAppsAsAspects() {
+    const apps = await this.listAppsComponents();
+    await this.componentAspect.getHost().loadAspects(apps.map((a) => a.id.toString()));
+  }
+
+  /**
    * list apps by a component id.
+   * make sure to call `this.loadAllAppsAsAspects` before calling this method in case the app is not listed in workspace.jsonc
    */
   listAppsById(id?: ComponentID): Application[] | undefined {
     if (!id) return undefined;
@@ -122,6 +132,7 @@ export class ApplicationMain {
 
   /**
    * get an application by a component id.
+   * make sure to call `this.loadAllAppsAsAspects` before calling this method in case the app is not listed in workspace.jsonc
    */
   async getAppById(id: ComponentID) {
     const apps = await this.listAppsById(id);
@@ -232,6 +243,7 @@ export class ApplicationMain {
 
   /**
    * get an app.
+   * make sure to call `this.loadAllAppsAsAspects` before calling this method in case the app is not listed in workspace.jsonc
    */
   getApp(appName: string, id?: ComponentID): Application | undefined {
     const apps = id ? this.listAppsById(id) : this.listApps();
@@ -279,6 +291,7 @@ export class ApplicationMain {
 
   /**
    * get app to throw.
+   * make sure to call `this.loadAllAppsAsAspects` before calling this method in case the app is not listed in workspace.jsonc
    */
   getAppOrThrow(appName: string): Application {
     const app = this.getAppByNameOrId(appName);
@@ -305,6 +318,10 @@ export class ApplicationMain {
     return this;
   }
 
+  /**
+   * run an app.
+   * make sure to call `this.loadAllAppsAsAspects` before calling this method in case the app is not listed in workspace.jsonc
+   */
   async runApp(
     appName: string,
     options?: ServeAppOptions

--- a/scopes/harmony/application/run.cmd.ts
+++ b/scopes/harmony/application/run.cmd.ts
@@ -42,6 +42,7 @@ export class RunCmd implements Command {
   ) {}
 
   async wait([appName]: [string], { dev, watch, ssr, port: exactPort }: RunOptions) {
+    await this.application.loadAllAppsAsAspects();
     // remove wds logs until refactoring webpack to a worker through the Worker aspect.
     this.logger.off();
     const { port, errors, isOldApi } = await this.application.runApp(appName, {


### PR DESCRIPTION
Instead, before `bit app list` or `bit app run`, the apps components are loaded as aspects to have them registered to the apps slots.