### PR TITLE
chore, add back the import/order eslint rule and fix the files accordingly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -79,6 +79,26 @@ module.exports = {
     'prefer-object-spread': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     'import/no-cycle': 'off',
+    'import/order': [
+      'error',
+      {
+        groups: [
+          ['builtin', 'external'],
+          ['internal', 'parent', 'sibling', 'index'],
+        ],
+        pathGroups: [
+          {
+            pattern: '@teambit/**',
+            group: 'external',
+          },
+          {
+            pattern: 'react-dev-utils/**',
+            group: 'external',
+          },
+        ],
+        pathGroupsExcludedImportTypes: ['builtin'],
+      },
+    ],
     'import/no-useless-path-segments': 'off',
     'lines-between-class-members': 'off',
     radix: 'off',

--- a/e2e/harmony/deprecate.e2e.1.ts
+++ b/e2e/harmony/deprecate.e2e.1.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
+import { IssuesClasses } from '@teambit/component-issues';
 import { Extensions } from '../../src/constants';
 import Helper from '../../src/e2e-helper/e2e-helper';
-import { IssuesClasses } from '@teambit/component-issues';
 
 describe('bit deprecate and undeprecate commands', function () {
   this.timeout(0);

--- a/scopes/component/component-compare/component-compare.main.runtime.ts
+++ b/scopes/component/component-compare/component-compare.main.runtime.ts
@@ -24,10 +24,10 @@ import {
 import { diffBetweenComponentsObjects } from '@teambit/legacy/dist/consumer/component-ops/components-object-diff';
 import { TesterMain, TesterAspect } from '@teambit/tester';
 import { ComponentAspect, Component, ComponentMain } from '@teambit/component';
+import { ImporterAspect, ImporterMain } from '@teambit/importer';
 import { componentCompareSchema } from './component-compare.graphql';
 import { ComponentCompareAspect } from './component-compare.aspect';
 import { DiffCmd } from './diff-cmd';
-import { ImporterAspect, ImporterMain } from '@teambit/importer';
 
 export type ComponentCompareResult = {
   id: string;

--- a/scopes/component/deprecation/deprecation.main.runtime.ts
+++ b/scopes/component/deprecation/deprecation.main.runtime.ts
@@ -5,16 +5,16 @@ import { ScopeMain, ScopeAspect } from '@teambit/scope';
 import { WorkspaceAspect, Workspace } from '@teambit/workspace';
 import { GraphqlAspect, GraphqlMain } from '@teambit/graphql';
 import { ComponentIdObj } from '@teambit/component-id';
-import { DeprecationAspect } from './deprecation.aspect';
-import { deprecationSchema } from './deprecation.graphql';
-import { DeprecationFragment } from './deprecation.fragment';
-import { DeprecateCmd } from './deprecate-cmd';
-import { UndeprecateCmd } from './undeprecate-cmd';
 import { IssuesAspect, IssuesMain } from '@teambit/issues';
 import pMapSeries from 'p-map-series';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
 import { compact } from 'lodash';
 import { IssuesClasses } from '@teambit/component-issues';
+import { DeprecationAspect } from './deprecation.aspect';
+import { deprecationSchema } from './deprecation.graphql';
+import { DeprecationFragment } from './deprecation.fragment';
+import { DeprecateCmd } from './deprecate-cmd';
+import { UndeprecateCmd } from './undeprecate-cmd';
 
 export type DeprecationInfo = {
   isDeprecate: boolean;

--- a/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
+++ b/scopes/component/new-component-helper/new-component-helper.main.runtime.ts
@@ -13,8 +13,8 @@ import { WorkspaceAspect, Workspace } from '@teambit/workspace';
 import { PkgAspect } from '@teambit/pkg';
 import { RenamingAspect } from '@teambit/renaming';
 import { EnvsAspect } from '@teambit/envs';
-import { NewComponentHelperAspect } from './new-component-helper.aspect';
 import { incrementPathRecursively } from '@teambit/component-writer';
+import { NewComponentHelperAspect } from './new-component-helper.aspect';
 
 const aspectsConfigToIgnore: string[] = [PkgAspect.id, RenamingAspect.id];
 

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -17,13 +17,13 @@ import pMapSeries from 'p-map-series';
 import { NoHeadNoVersion } from '@teambit/legacy/dist/scope/exceptions/no-head-no-version';
 import { ComponentAspect, Component, ComponentMain } from '@teambit/component';
 import { removeComponentsFromNodeModules } from '@teambit/legacy/dist/consumer/component/package-json-utils';
+import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { RemoveCmd } from './remove-cmd';
 import { RemoveComponentsResult, removeComponents } from './remove-components';
 import { RemoveAspect } from './remove.aspect';
 import { RemoveFragment } from './remove.fragment';
 import { RecoverCmd, RecoverOptions } from './recover-cmd';
 import { DeleteCmd } from './delete-cmd';
-import { ScopeAspect, ScopeMain } from '@teambit/scope';
 
 const BEFORE_REMOVE = 'removing components';
 

--- a/scopes/component/snapping/tag-from-scope.cmd.ts
+++ b/scopes/component/snapping/tag-from-scope.cmd.ts
@@ -1,12 +1,12 @@
 import chalk from 'chalk';
 import { Command, CommandOptions } from '@teambit/cli';
-import { NOTHING_TO_TAG_MSG, AUTO_TAGGED_MSG } from './tag-cmd';
 import { DEFAULT_BIT_RELEASE_TYPE } from '@teambit/legacy/dist/constants';
 import { getHarmonyVersion } from '@teambit/legacy/dist/bootstrap';
 import { IssuesClasses } from '@teambit/component-issues';
 import { ReleaseType } from 'semver';
 import { BitError } from '@teambit/bit-error';
 import { Logger } from '@teambit/logger';
+import { NOTHING_TO_TAG_MSG, AUTO_TAGGED_MSG } from './tag-cmd';
 import { SnappingMain, TagResults } from './snapping.main.runtime';
 import { BasicTagParams } from './tag-model-component';
 

--- a/scopes/defender/mocha/mocha.main.runtime.ts
+++ b/scopes/defender/mocha/mocha.main.runtime.ts
@@ -1,7 +1,7 @@
 import { MainRuntime } from '@teambit/cli';
 import type { TransformOptions } from '@babel/core';
-import type Mocha from 'mocha';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
+import type Mocha from 'mocha';
 import { MochaAspect } from './mocha.aspect';
 import { MochaTester } from './mocha.tester';
 

--- a/scopes/defender/mocha/mocha.tester.ts
+++ b/scopes/defender/mocha/mocha.tester.ts
@@ -1,12 +1,12 @@
 import { Logger } from '@teambit/logger';
 import { ComponentsResults, Tester, CallbackFn, TesterContext, Tests } from '@teambit/tester';
-import Mocha, { Test } from 'mocha';
 import babelRegister from '@babel/register';
 import type { TransformOptions } from '@babel/core';
 import { TestResult, TestsFiles, TestsResult } from '@teambit/tests-results';
 import pMapSeries from 'p-map-series';
 import { AbstractVinyl } from '@teambit/legacy/dist/consumer/component/sources';
 import { compact } from 'lodash';
+import Mocha, { Test } from 'mocha';
 
 export class MochaTester implements Tester {
   _callback: CallbackFn | undefined;

--- a/scopes/dependencies/dependency-resolver/package-manager.ts
+++ b/scopes/dependencies/dependency-resolver/package-manager.ts
@@ -1,6 +1,6 @@
-import { PeerDependencyIssuesByProjects } from '@pnpm/core';
 import { PeerDependencyRules, ProjectManifest } from '@pnpm/types';
 import { ComponentMap } from '@teambit/component';
+import { PeerDependencyIssuesByProjects } from '@pnpm/core';
 import { Registries } from './registry';
 import { DepsFilterFn } from './manifest';
 import { NetworkConfig, ProxyConfig } from './dependency-resolver.main.runtime';

--- a/scopes/dependencies/pnpm/lynx.ts
+++ b/scopes/dependencies/pnpm/lynx.ts
@@ -16,6 +16,15 @@ import {
   PackageManagerNetworkConfig,
 } from '@teambit/dependency-resolver';
 import { BitError } from '@teambit/bit-error';
+import { createClient, ClientOptions } from '@pnpm/client';
+import { pickRegistryForPackage } from '@pnpm/pick-registry-for-package';
+import { restartWorkerPool, finishWorkers } from '@pnpm/worker';
+import { createPkgGraph } from '@pnpm/workspace.pkgs-graph';
+import { PackageManifest, ProjectManifest, ReadPackageHook } from '@pnpm/types';
+import { Logger } from '@teambit/logger';
+import { VIRTUAL_STORE_DIR_MAX_LENGTH } from '@teambit/dependencies.pnpm.dep-path';
+import toNerfDart from 'nerf-dart';
+import * as pnpm from '@pnpm/core';
 import {
   MutatedProject,
   mutateModules,
@@ -23,15 +32,6 @@ import {
   PeerDependencyIssuesByProjects,
   ProjectOptions,
 } from '@pnpm/core';
-import * as pnpm from '@pnpm/core';
-import { createClient, ClientOptions } from '@pnpm/client';
-import { pickRegistryForPackage } from '@pnpm/pick-registry-for-package';
-import { restartWorkerPool, finishWorkers } from '@pnpm/worker';
-import { createPkgGraph } from '@pnpm/workspace.pkgs-graph';
-import { PackageManifest, ProjectManifest, ReadPackageHook } from '@pnpm/types';
-import { Logger } from '@teambit/logger';
-import { VIRTUAL_STORE_DIR_MAX_LENGTH } from '@teambit/dependencies.pnpm.dep-path'
-import toNerfDart from 'nerf-dart';
 import { pnpmErrorToBitError } from './pnpm-error-to-bit-error';
 import { readConfig } from './read-config';
 

--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -13,11 +13,10 @@ import {
   PackageManagerProxyConfig,
   PackageManagerNetworkConfig,
 } from '@teambit/dependency-resolver';
-import { VIRTUAL_STORE_DIR_MAX_LENGTH } from '@teambit/dependencies.pnpm.dep-path'
+import { VIRTUAL_STORE_DIR_MAX_LENGTH } from '@teambit/dependencies.pnpm.dep-path';
 import { Logger } from '@teambit/logger';
 import fs from 'fs';
 import { memoize, omit } from 'lodash';
-import { PeerDependencyIssuesByProjects } from '@pnpm/core';
 import { readModulesManifest, Modules } from '@pnpm/modules-yaml';
 import {
   buildDependenciesHierarchy,
@@ -29,11 +28,12 @@ import { renderTree } from '@pnpm/list';
 import { readWantedLockfile } from '@pnpm/lockfile-file';
 import { ProjectManifest } from '@pnpm/types';
 import { join } from 'path';
+import { PeerDependencyIssuesByProjects } from '@pnpm/core';
 import { readConfig } from './read-config';
 import { pnpmPruneModules } from './pnpm-prune-modules';
 import type { RebuildFn } from './lynx';
 
-export type { RebuildFn }
+export type { RebuildFn };
 
 export interface InstallResult {
   dependenciesChanged: boolean;

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -6,8 +6,8 @@ import { handleErrorAndExit } from '@teambit/legacy/dist/cli/handle-errors';
 import { TOKEN_FLAG_NAME } from '@teambit/legacy/dist/constants';
 import globalFlags from '@teambit/legacy/dist/cli/global-flags';
 import { Analytics } from '@teambit/legacy/dist/analytics/analytics';
-import { OnCommandStartSlot } from './cli.main.runtime';
 import pMapSeries from 'p-map-series';
+import { OnCommandStartSlot } from './cli.main.runtime';
 
 export class CommandRunner {
   private commandName: string;

--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -10,9 +10,9 @@ import { LaneData, serializeLaneData } from '@teambit/legacy/dist/scope/lanes/la
 import { BitError } from '@teambit/bit-error';
 import { approveOperation } from '@teambit/legacy/dist/prompts';
 import { COMPONENT_PATTERN_HELP, DEFAULT_CLOUD_DOMAIN } from '@teambit/legacy/dist/constants';
+import { FetchCmd } from '@teambit/importer';
 import { CreateLaneOptions, LanesMain } from './lanes.main.runtime';
 import { SwitchCmd } from './switch.cmd';
-import { FetchCmd } from '@teambit/importer';
 
 type LaneOptions = {
   details?: boolean;

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -37,6 +37,7 @@ import ComponentsList, { DivergeDataPerId } from '@teambit/legacy/dist/consumer/
 import { NoCommonSnap } from '@teambit/legacy/dist/scope/exceptions/no-common-snap';
 import { concurrentComponentsLimit } from '@teambit/legacy/dist/utils/concurrency';
 import { SUPPORT_LANE_HISTORY, isFeatureEnabled } from '@teambit/legacy/dist/api/consumer/lib/feature-toggle';
+import { InstallAspect, InstallMain } from '@teambit/install';
 import { LanesAspect } from './lanes.aspect';
 import {
   LaneCmd,
@@ -66,7 +67,6 @@ import { createLane, createLaneInScope, throwForInvalidLaneName } from './create
 import { LanesCreateRoute } from './lanes.create.route';
 import { LanesDeleteRoute } from './lanes.delete.route';
 import { LanesRestoreRoute } from './lanes.restore.route';
-import { InstallAspect, InstallMain } from '@teambit/install';
 
 export { Lane };
 

--- a/scopes/lanes/lanes/lanes.spec.ts
+++ b/scopes/lanes/lanes/lanes.spec.ts
@@ -12,9 +12,9 @@ import { SUPPORT_LANE_HISTORY, addFeature, removeFeature } from '@teambit/legacy
 import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
 import { mockComponents, modifyMockedComponents } from '@teambit/component.testing.mock-components';
 import { ChangeType } from '@teambit/lanes.entities.lane-diff';
+import { MergeLanesAspect, MergeLanesMain } from '@teambit/merge-lanes';
 import { LanesAspect } from './lanes.aspect';
 import { LanesMain } from './lanes.main.runtime';
-import { MergeLanesAspect, MergeLanesMain } from '@teambit/merge-lanes';
 
 describe('LanesAspect', function () {
   this.timeout(0);

--- a/scopes/lanes/merge-lanes/merge-lane.spec.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.spec.ts
@@ -10,10 +10,10 @@ import {
 import { ScopeAspect } from '@teambit/scope';
 import { ExportAspect, ExportMain } from '@teambit/export';
 import { mockComponents } from '@teambit/component.testing.mock-components';
-import { MergeLanesAspect } from './merge-lanes.aspect';
-import { MergeFromScopeResult, MergeLanesMain } from './merge-lanes.main.runtime';
 import { LanesAspect, LanesMain } from '@teambit/lanes';
 import { SnappingAspect, SnappingMain } from '@teambit/snapping';
+import { MergeLanesAspect } from './merge-lanes.aspect';
+import { MergeFromScopeResult, MergeLanesMain } from './merge-lanes.main.runtime';
 
 describe('MergeLane aspect', function () {
   this.timeout(0);

--- a/scopes/lanes/merge-lanes/merge-move.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-move.cmd.ts
@@ -1,7 +1,7 @@
 import chalk from 'chalk';
 import { Command, CommandOptions } from '@teambit/cli';
-import { MergeLanesMain } from './merge-lanes.main.runtime';
 import { BitError } from '@teambit/bit-error';
+import { MergeLanesMain } from './merge-lanes.main.runtime';
 
 export type MergeAbortOpts = {
   silent?: boolean; // don't show prompt before aborting

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -31,6 +31,7 @@ import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { EslintConfigTransformer } from '@teambit/defender.eslint.config-mutator';
 import { WorkerAspect, WorkerMain } from '@teambit/worker';
 
+import { PrettierConfigTransformer } from '@teambit/defender.prettier.config-mutator';
 import { ReactAspect } from './react.aspect';
 import { ReactEnv } from './react.env';
 import { ReactAppType } from './apps/web';
@@ -39,7 +40,6 @@ import { getTemplates } from './react.templates';
 import { ReactAppOptions } from './apps/web/react-app-options';
 import { ReactSchema } from './react.schema';
 import { ReactAPITransformer } from './react.api.transformer';
-import { PrettierConfigTransformer } from '@teambit/defender.prettier.config-mutator';
 
 type ReactDeps = [
   EnvsMain,

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -16,10 +16,10 @@ import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/depen
 import { ExportAspect, ExportMain } from '@teambit/export';
 import { LanesAspect, Lane, LanesMain } from '@teambit/lanes';
 import { ExtensionDataEntry } from '@teambit/legacy/dist/consumer/config';
-import { UpdateDependenciesCmd } from './update-dependencies.cmd';
-import { UpdateDependenciesAspect } from './update-dependencies.aspect';
 import { Ref } from '@teambit/legacy/dist/scope/objects';
 import { isSnap } from '@teambit/component-version';
+import { UpdateDependenciesCmd } from './update-dependencies.cmd';
+import { UpdateDependenciesAspect } from './update-dependencies.aspect';
 
 export type UpdateDepsOptions = {
   tag?: boolean;

--- a/scopes/scope/version-history/version-history.main.runtime.ts
+++ b/scopes/scope/version-history/version-history.main.runtime.ts
@@ -1,7 +1,16 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
 import getRemoteByName from '@teambit/legacy/dist/remotes/get-remote-by-name';
 import { loadConsumerIfExist } from '@teambit/legacy/dist/consumer';
-import { VersionHistoryAspect } from './version-history.aspect';
+import { ScopeAspect, ScopeMain } from '@teambit/scope';
+import { ComponentID, ComponentIdList } from '@teambit/component-id';
+import { BitError } from '@teambit/bit-error';
+import { ModelComponent, VersionHistory } from '@teambit/legacy/dist/scope/models';
+import { Ref } from '@teambit/legacy/dist/scope/objects';
+import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
+import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
+import { compact } from 'lodash';
+import { VersionHistoryGraph } from '@teambit/legacy/dist/scope/models/version-history';
+import { BuildVersionHistoryAction } from './build-version-history-action';
 import {
   BuildOptions,
   ShowOptions,
@@ -10,16 +19,7 @@ import {
   VersionHistoryGraphCmd,
   VersionHistoryShowCmd,
 } from './version-history-cmd';
-import { ScopeAspect, ScopeMain } from '@teambit/scope';
-import { ComponentID, ComponentIdList } from '@teambit/component-id';
-import { BitError } from '@teambit/bit-error';
-import { ModelComponent, VersionHistory } from '@teambit/legacy/dist/scope/models';
-import { Ref } from '@teambit/legacy/dist/scope/objects';
-import { ExternalActions } from '@teambit/legacy/dist/api/scope/lib/action';
-import { BuildVersionHistoryAction } from './build-version-history-action';
-import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
-import { compact } from 'lodash';
-import { VersionHistoryGraph } from '@teambit/legacy/dist/scope/models/version-history';
+import { VersionHistoryAspect } from './version-history.aspect';
 
 type BuildResult = { err?: Error; added?: string[] };
 type ShowResult = { node: string; pointers: string[]; edges: Array<{ hash: string; type: string }> };

--- a/scopes/ui-foundation/ui/ui/client-context.tsx
+++ b/scopes/ui-foundation/ui/ui/client-context.tsx
@@ -5,7 +5,6 @@ import { IconFont } from '@teambit/design.theme.icons-font';
 import { LoaderRibbon } from '@teambit/base-ui.loaders.loader-ribbon';
 import { Roboto } from '@teambit/base-ui.theme.fonts.roboto';
 import { TooltipMountPoint } from '@teambit/design.ui.tooltip';
-
 import { LoaderContext, useLoaderApi } from '@teambit/ui-foundation.ui.global-loader';
 import styles from './client-context.module.scss';
 

--- a/scopes/workspace/watcher/output-formatter.ts
+++ b/scopes/workspace/watcher/output-formatter.ts
@@ -2,8 +2,8 @@ import { Logger } from '@teambit/logger';
 import { CompilerAspect } from '@teambit/compiler';
 import { OnComponentEventResult } from '@teambit/workspace';
 import chalk from 'chalk';
-import { RootDirs } from './watcher';
 import { compact } from 'lodash';
+import { RootDirs } from './watcher';
 
 export function formatWatchPathsSortByComponent(trackDirs: RootDirs) {
   const title = ` ${chalk.underline('STATUS\tCOMPONENT ID')}\n`;

--- a/src/api/consumer/lib/clear-cache.ts
+++ b/src/api/consumer/lib/clear-cache.ts
@@ -1,9 +1,9 @@
 import fs from 'fs-extra';
 // it's a hack, but I didn't find a better way to access the getCacheDir() function
 import { __TEST__ as v8CompileCache } from 'v8-compile-cache';
+import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import { Consumer, getConsumerInfo, loadConsumerIfExist } from '../../../consumer';
 import { ComponentFsCache } from '../../../consumer/component/component-fs-cache';
-import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import ScopeIndex from '../../../scope/objects/scope-index';
 
 export type CacheClearResult = { succeed: string[]; failed: string[] };

--- a/src/api/consumer/lib/doctor.ts
+++ b/src/api/consumer/lib/doctor.ts
@@ -5,6 +5,7 @@ import Stream from 'stream';
 import path from 'path';
 import tar from 'tar-stream';
 import tarFS from 'tar-fs';
+import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import { getHarmonyVersion } from '../../../bootstrap';
 import { CFG_USER_EMAIL_KEY, CFG_USER_NAME_KEY, DEBUG_LOG } from '../../../constants';
 import BitMap from '../../../consumer/bit-map';
@@ -15,7 +16,6 @@ import DoctorRegistrar from '../../../doctor/doctor-registrar';
 import registerCoreAndExtensionsDiagnoses from '../../../doctor/doctor-registrar-builder';
 import logger from '../../../logger/logger';
 import { getExt, getWithoutExt, removeChalkCharacters } from '../../../utils';
-import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 
 import DiagnosisNotFound from './exceptions/diagnosis-not-found';
 import MissingDiagnosisName from './exceptions/missing-diagnosis-name';

--- a/src/consumer/consumer.ts
+++ b/src/consumer/consumer.ts
@@ -6,6 +6,7 @@ import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { DEFAULT_LANE, LaneId } from '@teambit/lane-id';
 import { BitIdStr } from '@teambit/legacy-bit-id';
 import { BitError } from '@teambit/bit-error';
+import { sortObjectByKeys } from '@teambit/toolbox.object.sorter';
 import { Analytics } from '../analytics/analytics';
 import {
   BIT_GIT_DIR,
@@ -21,7 +22,6 @@ import { getAutoTagPending } from '../scope/component-ops/auto-tag';
 import { ComponentNotFound } from '../scope/exceptions';
 import { Lane, ModelComponent, Version } from '../scope/models';
 // import { generateRandomStr } from '@teambit/toolbox.string.random';
-import { sortObjectByKeys } from '@teambit/toolbox.object.sorter';
 import { composeComponentPath } from '../utils/bit/compose-component-path';
 import {
   PathAbsolute,


### PR DESCRIPTION
This rule was gone for some reason after upgrading eslint packages. This PR brings it back and configure it to have the external packages before the internal ones. Ignoring all other considerations. (e.g. "type", "index", "parent", etc.).