### PR TITLE
feat(schema | api-ref): @link support and alias support for object binding nodes

### DIFF
--- a/components/entities/semantic-schema/schemas/docs/tag.ts
+++ b/components/entities/semantic-schema/schemas/docs/tag.ts
@@ -54,4 +54,5 @@ export enum TagName {
   return = 'return',
   deprecated = 'deprecated',
   exports = 'exports',
+  link = 'link',
 }

--- a/components/entities/semantic-schema/schemas/inference-type.ts
+++ b/components/entities/semantic-schema/schemas/inference-type.ts
@@ -9,7 +9,8 @@ export class InferenceTypeSchema extends SchemaNode {
     readonly type: string,
     readonly name?: string,
     readonly defaultValue?: string,
-    readonly isSpread?: boolean
+    readonly isSpread?: boolean,
+    readonly alias?: string
   ) {
     super();
   }
@@ -27,6 +28,7 @@ export class InferenceTypeSchema extends SchemaNode {
       type: this.type,
       defaultValue: this.defaultValue,
       isSpread: this.isSpread,
+      alias: this.alias,
     };
   }
 
@@ -36,6 +38,7 @@ export class InferenceTypeSchema extends SchemaNode {
     const name = obj.name;
     const defaultValue = obj.defaultValue;
     const isSpread = obj.isSpread;
-    return new InferenceTypeSchema(location, type, name, defaultValue, isSpread);
+    const alias = obj.alias;
+    return new InferenceTypeSchema(location, type, name, defaultValue, isSpread, alias);
   }
 }

--- a/components/renderers/api-node-details/api-node-details.module.scss
+++ b/components/renderers/api-node-details/api-node-details.module.scss
@@ -89,3 +89,8 @@
 .apiNodeDetailsMembersContainer {
   padding-bottom: 16px;
 }
+
+.apiNodeDetailsLink {
+  font-size: var(--bit-p-xs);
+  padding-bottom: 24px;
+}

--- a/components/renderers/api-node-details/api-node-details.tsx
+++ b/components/renderers/api-node-details/api-node-details.tsx
@@ -81,6 +81,21 @@ export function APINodeDetails({
   const comment =
     doc?.comment ??
     doc?.tags?.filter((tag) => tag.comment).reduce((acc, tag) => acc.concat(`${tag.comment}\n` ?? ''), '');
+  const linkComment = doc?.tags?.find((tag) => tag.tagName === 'link')?.comment;
+
+  let linkPlaceholder: string | undefined;
+  let linkURL: string | undefined;
+
+  if (linkComment) {
+    const parts = linkComment.split(' ');
+    linkURL = parts.find((part) => part.startsWith('http'));
+    if (linkURL) {
+      linkPlaceholder = parts.filter((part) => part !== linkURL).join(' ');
+    } else {
+      linkPlaceholder = parts.join(' ');
+    }
+  }
+
   const signature = displaySignature || defaultSignature;
 
   const getAPINodeUrl = useCallback((queryParams: APIRefQueryParams) => {
@@ -252,6 +267,14 @@ export function APINodeDetails({
     >
       <div className={styles.apiDetails} ref={apiRef}>
         {comment && <div className={styles.apiNodeDetailsComment}>{comment}</div>}
+        {linkComment && (
+          <div className={styles.apiNodeDetailsLink}>
+            {linkPlaceholder && <span>{linkPlaceholder}: </span>}
+            <a href={linkURL} target="_blank" rel="noopener noreferrer">
+              {linkURL}
+            </a>
+          </div>
+        )}
         {signature && (
           <div
             className={classnames(styles.apiNodeDetailsSignatureContainer, styles.codeEditorContainer)}

--- a/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
+++ b/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
@@ -38,7 +38,11 @@ function ParameterComponent(props: APINodeRenderProps) {
       <React.Fragment key={`${name}-param-object-binding-wrapper`}>
         {!skipHeadings && <HeadingRow className={styles.paramHeading} headings={headings} colNumber={4} />}
         {objectBindingNodes.map((_bindingNode) => {
-          const typeRefCorrespondingNode = typeRef?.api.findNode((node) => node.name === _bindingNode.name);
+          const typeRefCorrespondingNode = typeRef?.api.findNode((node) => {
+            const matchesName = node.name === _bindingNode.name;
+            const matchesAlias = (_bindingNode as any).alias && node.name === (_bindingNode as any).alias;
+            return matchesName || matchesAlias;
+          });
           const bindingNode = typeRefCorrespondingNode || _bindingNode;
           const bindingNodeRenderer = renderers.find((renderer) => renderer.predicate(bindingNode));
 
@@ -65,7 +69,7 @@ function ParameterComponent(props: APINodeRenderProps) {
               className={styles.paramRow}
               row={{
                 name: bindingNode.name || '',
-                description: bindingNode.doc?.comment || '',
+                description: bindingNode.doc?.comment || bindingNode.doc?.tags?.join() || '',
                 required:
                   (typeRefCorrespondingNode as any)?.isOptional !== undefined &&
                   !(typeRefCorrespondingNode as any)?.isOptional,
@@ -119,7 +123,7 @@ function ParameterComponent(props: APINodeRenderProps) {
           }}
           row={{
             name: paramNode.name || '',
-            description: paramNode.doc?.comment || '',
+            description: paramNode.doc?.comment || paramNode.doc?.tags?.join() || '',
             required: paramNode.isOptional !== undefined && !paramNode.isOptional,
             type: '',
             default: {

--- a/scopes/api-reference/renderers/schema-node-member-summary/variable-node-summary.tsx
+++ b/scopes/api-reference/renderers/schema-node-member-summary/variable-node-summary.tsx
@@ -65,7 +65,7 @@ export function VariableNodeSummary({
       }}
       row={{
         name: sanitizedName,
-        description: doc?.comment || '',
+        description: doc?.comment || doc?.tags?.join() || '',
         required: isOptional !== undefined && !isOptional,
         type: '',
         default:

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -15,6 +15,7 @@ import {
   Location,
   DocSchema,
   IgnoredSchema,
+  TagSchema,
 } from '@teambit/semantics.entities.semantic-schema';
 import isRelativeImport from '@teambit/legacy/dist/utils/is-relative-import';
 import { ComponentDependency } from '@teambit/dependency-resolver';
@@ -616,15 +617,36 @@ export class SchemaExtractorContext {
       return undefined;
     }
     const jsDocs = getJsDoc(node);
+
     if (!jsDocs.length) {
       return undefined;
     }
     // not sure how common it is to have multiple JSDocs. never seen it before.
     // regardless, in typescript implementation of methods like `getJSDocDeprecatedTag()`, they use the first one. (`getFirstJSDocTag()`)
     const jsDoc = jsDocs[0];
+
     const location = this.getLocation(jsDoc);
-    const comment = getTextOfJSDocComment(jsDoc.comment);
-    const tags = jsDoc.tags ? await pMapSeries(jsDoc.tags, (tag) => tagParser(tag, this, this.formatter)) : undefined;
+    // Extract link comments and filter them out from the main comment
+    const linkComments = (
+      typeof jsDoc.comment !== 'string' ? jsDoc.comment?.filter((c) => c.kind === ts.SyntaxKind.JSDocLink) ?? [] : []
+    ) as ts.JSDocLink[];
+    const linkTags = linkComments.map((linkComment) => {
+      const tagName = 'link';
+      const tagText = `${linkComment.name?.getText() ?? ''}${linkComment.text ?? ''}`;
+      const tagLocation = this.getLocation(linkComment);
+      return new TagSchema(tagLocation, tagName, tagText);
+    });
+
+    const commentsWithoutLink = (typeof jsDoc.comment !== 'string'
+      ? jsDoc.comment?.filter((c) => c.kind !== ts.SyntaxKind.JSDocLink) ?? ''
+      : jsDoc.comment) as unknown as ts.NodeArray<ts.JSDocComment>;
+
+    const comment = getTextOfJSDocComment(commentsWithoutLink);
+
+    const tags = (jsDoc.tags ? await pMapSeries(jsDoc.tags, (tag) => tagParser(tag, this, this.formatter)) : []).concat(
+      linkTags
+    );
+
     return new DocSchema(location, jsDoc.getText(), comment, tags);
   }
 }

--- a/scopes/typescript/typescript/transformers/parameter.ts
+++ b/scopes/typescript/typescript/transformers/parameter.ts
@@ -5,6 +5,7 @@ import ts, {
   ParameterDeclaration,
   SyntaxKind,
   ArrayBindingElement,
+  isComputedPropertyName,
 } from 'typescript';
 import {
   InferenceTypeSchema,
@@ -102,12 +103,19 @@ export class ParameterTransformer implements SchemaTransformer {
       const info = await context.getQuickInfo(elem.name);
       const parsed = info ? parseTypeFromQuickInfo(info) : elem.getText();
       const defaultValue = elem.initializer ? elem.initializer.getText() : undefined;
+      const alias =
+        elem.propertyName && isComputedPropertyName(elem.propertyName)
+          ? elem.propertyName?.expression.getText()
+          : undefined;
+
+      const name = elem.name.getText();
       return new InferenceTypeSchema(
         context.getLocation(elem.name),
         parsed,
-        elem.name.getText(),
+        name,
         defaultValue,
-        Boolean(elem.dotDotDotToken)
+        Boolean(elem.dotDotDotToken),
+        alias
       );
     });
   }


### PR DESCRIPTION
This PR adds the ability to extract @link from jsdoc comments and render them as part of the API Reference of the node. It also adds the ability to track aliases for object binding references and propagates their js doc descriptions from the source to the binding reference. 