### PR TITLE
fix(lane-merge), remove files when other lane removed them and lanes are diverged

### DIFF
--- a/e2e/harmony/lanes/merge-lanes.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes.e2e.ts
@@ -1338,6 +1338,30 @@ describe('merge lanes', function () {
       expect(path.join(helper.scopes.localPath, 'comp1/foo.js')).to.not.be.a.path();
     });
   });
+  describe('when a file was deleted on the other lane but exist current and on the base and both lanes are diverged', () => {
+    let mergeOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1, false);
+      helper.fs.outputFile('comp1/foo.js');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-a');
+      helper.fs.deletePath('comp1/foo.js');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+      mergeOutput = helper.command.mergeLane('lane-a', '-x --no-snap --no-squash');
+    });
+    it('should indicate that this file was removed in the output', () => {
+      expect(mergeOutput).to.have.string('removed foo.js');
+    });
+    it('should remove this file from the filesystem ', () => {
+      expect(path.join(helper.scopes.localPath, 'comp1/foo.js')).to.not.be.a.path();
+    });
+  });
   describe('naming conflict introduced during the merge', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();

--- a/scopes/component/checkout/checkout-version.ts
+++ b/scopes/component/checkout/checkout-version.ts
@@ -133,8 +133,8 @@ export async function removeFilesIfNeeded(
     if (!filesStatus[filename]) {
       // @ts-ignore todo: typescript has a good point here. it should be the string "removed", not chalk.green(removed).
       filesStatus[filename] = FileStatus.removed;
-      dataToPersist.removePath(new RemovePath(file.path));
     }
+    dataToPersist.removePath(new RemovePath(file.path));
   });
   await dataToPersist.persistAllToFS();
 }

--- a/scopes/component/checkout/checkout-version.ts
+++ b/scopes/component/checkout/checkout-version.ts
@@ -134,7 +134,9 @@ export async function removeFilesIfNeeded(
       // @ts-ignore todo: typescript has a good point here. it should be the string "removed", not chalk.green(removed).
       filesStatus[filename] = FileStatus.removed;
     }
-    dataToPersist.removePath(new RemovePath(file.path));
+    if (filesStatus[filename] === FileStatus.removed) {
+      dataToPersist.removePath(new RemovePath(file.path));
+    }
   });
   await dataToPersist.persistAllToFS();
 }


### PR DESCRIPTION
The use-case is as follows: lane-a and lane-b are diverged, lane-a removed some files, the workspace is checked out to lane-b and is now merging lane-b into lane-a.
What happened is that the output showed as if the file was removed during merge but it didn't really remove it.
This PR removes the file as expected.