### PR TITLE
fix(delete), avoid deleting main component when on lane

### DIFF
--- a/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
+++ b/e2e/harmony/lanes/bit-remove-on-lanes.e2e.ts
@@ -174,7 +174,7 @@ describe('bit lane command', function () {
       expect(() => helper.command.export()).to.not.throw();
     });
   });
-  describe('soft-remove main component when on a lane', () => {
+  describe('delete main component when on a lane', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
       helper.fixtures.populateComponents(2);
@@ -183,12 +183,19 @@ describe('bit lane command', function () {
       helper.command.createLane();
       helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
       helper.command.export();
-      helper.command.softRemoveOnLane('comp2');
     });
-    it('should remove the component from the workspace', () => {
-      const list = helper.command.listParsed();
-      expect(list).to.have.lengthOf(1);
-      expect(list[0].id).to.not.have.string('comp2');
+    it('should throw an error suggesting to switch to main or using --update-main flag', () => {
+      expect(() => helper.command.softRemoveOnLane('comp2')).to.throw('unable to delete');
+    });
+    describe('using --update-main flag', () => {
+      before(() => {
+        helper.command.softRemoveOnLane('comp2', '--update-main');
+      });
+      it('should remove the component from the workspace', () => {
+        const list = helper.command.listParsed();
+        expect(list).to.have.lengthOf(1);
+        expect(list[0].id).to.not.have.string('comp2');
+      });
     });
   });
   describe('soft remove on lane when a forked lane is merging this lane', () => {

--- a/scopes/component/remove/delete-cmd.ts
+++ b/scopes/component/remove/delete-cmd.ts
@@ -26,7 +26,7 @@ this command marks the components as deleted, and after snap/tag and export they
   alias = '';
   options = [
     ['', 'lane', 'when on a lane, delete the component from this lane only. avoid merging it to main or other lanes'],
-    ['', 'update-main', 'EXPERIMENTAL. delete component/s on the main lane after merging this lane into main'],
+    ['', 'update-main', 'delete component/s on the main lane after merging this lane into main'],
     [
       '',
       'range <string>',

--- a/scopes/component/remove/remove.main.runtime.ts
+++ b/scopes/component/remove/remove.main.runtime.ts
@@ -24,6 +24,7 @@ import { RecoverCmd, RecoverOptions } from './recover-cmd';
 import { DeleteCmd } from './delete-cmd';
 import { ScopeAspect, ScopeMain } from '@teambit/scope';
 import { ListerAspect, ListerMain } from '@teambit/lister';
+import chalk from 'chalk';
 
 const BEFORE_REMOVE = 'removing components';
 
@@ -149,7 +150,18 @@ export class RemoveMain {
     if (currentLane && !updateMain && opts.range) {
       throw new BitError(`--range is not needed when deleting components from a lane, unless --update-main is used`);
     }
-
+    if (currentLane && !updateMain) {
+      const laneComp = currentLane.toComponentIds();
+      const compIdsNotOnLane = componentIds.filter((id) => !laneComp.hasWithoutVersion(id));
+      if (compIdsNotOnLane.length) {
+        throw new BitError(
+          `unable to delete the following component(s) because they are not part of the current lane.
+${chalk.bold(compIdsNotOnLane.map((id) => id.toString()).join('\n'))}
+to simply remove them from the workspace, use "bit remove".
+to delete them eventually from main, use "--update-main" flag and make sure to remove all occurrences from the code.`
+        );
+      }
+    }
     return this.markRemoveComps(componentIds, opts);
   }
 


### PR DESCRIPTION
Unless `--update-main` was used. Otherwise, the user is probably unaware that this component is not part of the lane.