### PR TITLE
fix(install) - fix package.json generation during bit install for esm components

### DIFF
--- a/scopes/harmony/aspect-loader/plugins.ts
+++ b/scopes/harmony/aspect-loader/plugins.ts
@@ -36,7 +36,6 @@ export class Plugins {
     const aspect = Aspect.create({
       id: this.component.id.toString(),
     });
-
     aspect.addRuntime({
       provider: async () => {
         await Promise.all(
@@ -63,10 +62,10 @@ export class Plugins {
   }
 
   async registerPluginWithTryCatch(plugin: Plugin, aspect: Aspect) {
-    const isModule = isEsmModule(plugin.path);
-    const module = isModule ? await this.loadModule(plugin.path) : undefined;
-
     try {
+      const isModule = isEsmModule(plugin.path);
+      const module = isModule ? await this.loadModule(plugin.path) : undefined;
+
       if (isModule && !module) {
         this.logger.consoleFailure(
           `failed to load plugin ${plugin.path}, make sure to use 'export default' to expose your plugin`
@@ -124,7 +123,8 @@ export class Plugins {
           : component.filesystem.byRegex(pluginDef.pattern);
 
       return files.map((file) => {
-        return new Plugin(pluginDef, resolvePath ? resolvePath(file.relative) : file.path);
+        const resolvedPath = resolvePath ? resolvePath(file.relative) : file.path;
+        return new Plugin(pluginDef, resolvedPath);
       });
     });
 


### PR DESCRIPTION
## Proposed Changes

- This fixes a use case when you have a component that is compiled to esm with a `type:module` in its `package.json`.
and its env is not part of the workspace.
Before this fix, the env of the component was not loaded properly resulting in missing `type: modules` in the `package.json`.
If that component is used by another env which is part of the workspace, it will always be loaded during bit component loading. but since the type: module is missing, the component won't be loaded correctly, resulting in the env not loaded.
This means the workspace is in a deadlock, and the only way to unblock it from any command, is to manually go to the relevant components and add the `type: module` to the `package.json`

