### PR TITLE
fix, fix OOM when ArtifactStorageError throws

### DIFF
--- a/scopes/pipelines/builder/artifact/artifact-list.ts
+++ b/scopes/pipelines/builder/artifact/artifact-list.ts
@@ -105,18 +105,19 @@ export class ArtifactList<T extends Artifact> extends Array<T> {
    */
   async store(component: Component) {
     const byResolvers = this.groupByResolver();
-    const promises = Object.keys(byResolvers).map(async (key) => {
-      const artifacts = byResolvers[key];
-      if (!artifacts.length) return;
-      const storageResolver = artifacts[0].storageResolver;
-      const artifactList = ArtifactList.fromArray(artifacts);
-      const artifactPromises = artifactList.map(async (artifact) => {
-        return this.storeArtifact(storageResolver, artifact, component);
-      });
-      await Promise.all(artifactPromises);
-    });
-
-    return Promise.all(promises);
+    await Promise.all(
+      Object.keys(byResolvers).map(async (key) => {
+        const artifacts = byResolvers[key];
+        if (!artifacts.length) return;
+        const storageResolver = artifacts[0].storageResolver;
+        const artifactList = ArtifactList.fromArray(artifacts);
+        await Promise.all(
+          artifactList.map(async (artifact) => {
+            await this.storeArtifact(storageResolver, artifact, component);
+          })
+        );
+      })
+    );
   }
 
   private async storeArtifact(storageResolver: ArtifactStorageResolver, artifact: Artifact, component: Component) {

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -80,18 +80,19 @@ export class BuilderMain {
 
   private async storeArtifacts(tasksResults: TaskResults[]) {
     const artifacts = tasksResults.flatMap((t) => (t.artifacts ? [t.artifacts] : []));
-    const storeP = artifacts.map(async (artifactMap: ComponentMap<ArtifactList<FsArtifact>>) => {
-      return Promise.all(
-        artifactMap.toArray().map(async ([component, artifactList]) => {
-          try {
-            return await artifactList.store(component);
-          } catch (err: any) {
-            throw new ArtifactStorageError(err, component);
-          }
-        })
-      );
-    });
-    await Promise.all(storeP);
+    await Promise.all(
+      artifacts.map(async (artifactMap: ComponentMap<ArtifactList<FsArtifact>>) => {
+        await Promise.all(
+          artifactMap.toArray().map(async ([component, artifactList]) => {
+            try {
+              await artifactList.store(component);
+            } catch (err: any) {
+              throw new ArtifactStorageError(err, component.id.toString());
+            }
+          })
+        );
+      })
+    );
   }
 
   pipelineResultsToBuilderData(

--- a/scopes/pipelines/builder/exceptions/artifact-storage-error.ts
+++ b/scopes/pipelines/builder/exceptions/artifact-storage-error.ts
@@ -1,9 +1,8 @@
 import { BitError } from '@teambit/bit-error';
-import { Component } from '@teambit/component';
 
 export class ArtifactStorageError extends BitError {
-  constructor(private originalError: Error, private component: Component) {
-    super(`failed to store artifacts for component ${component.id.toString()}.
+  constructor(originalError: Error, idStr: string) {
+    super(`failed to store artifacts for component ${idStr}.
 Error: ${originalError.message}`);
   }
 }


### PR DESCRIPTION
This is one of the most bizarre things I have even seen in node. When an error of type `ArtifactStorageError` is thrown, node exits with out of memory. (I'll attach the stack trace in a comment). 
However, if I make the following simple change to this class, it shows the error nicely.
```
- constructor(private originalError: Error, private component: Component) {  
+ constructor(private originalError: Error, component: Component) {
```
This change basically tells JS to ignore the component object and don't store it in this error class. The component object is indeed huge and has some circular references. Still, it doesn't explain the strange memory leak here. 
I found out that the "factory" property of the component object is the culprit. If I only set a simple object with the component.factory it throws OOM. The factory is the `Workspace` object. 
I stopped the investigation here as it's time consuming. It's probably a node.js bug, but will be very difficult to provide steps to reproduce, so I'll just leave it. 

For this bug, the fix is simple, we don't really need the component object, so I'm only passing the ID. 