### PR TITLE
fix(import), do not stop the import if one of the wildcard result in an empty list

### DIFF
--- a/scopes/scope/importer/import-components.ts
+++ b/scopes/scope/importer/import-components.ts
@@ -32,7 +32,7 @@ import { compact, difference, fromPairs } from 'lodash';
 import { WorkspaceConfigUpdateResult } from '@teambit/config-merger';
 import { Logger } from '@teambit/logger';
 import { DependentsGetter } from './dependents-getter';
-import { ListerMain } from '@teambit/lister';
+import { ListerMain, NoIdMatchWildcard } from '@teambit/lister';
 
 export type ImportOptions = {
   ids: string[]; // array might be empty
@@ -426,8 +426,16 @@ if you just want to get a quick look into this snap, create a new workspace and 
     await Promise.all(
       this.options.ids.map(async (idStr: string) => {
         if (hasWildcard(idStr)) {
-          const ids = await this.lister.getRemoteCompIdsByWildcards(idStr, this.options.includeDeprecated);
-          this.logger.setStatusLine(BEFORE_IMPORT_ACTION); // it stops the previous loader of BEFORE_REMOTE_LIST
+          let ids: ComponentID[] = [];
+          try {
+            ids = await this.lister.getRemoteCompIdsByWildcards(idStr, this.options.includeDeprecated);
+          } catch (err: any) {
+            if (err instanceof NoIdMatchWildcard) {
+              this.logger.consoleWarning(err.message);
+            } else {
+              throw err;
+            }
+          }
           bitIds.push(...ids);
         } else {
           const id = await this.getIdFromStr(idStr);
@@ -435,6 +443,8 @@ if you just want to get a quick look into this snap, create a new workspace and 
         }
       })
     );
+
+    this.logger.setStatusLine(BEFORE_IMPORT_ACTION); // it stops the previous loader of BEFORE_REMOTE_LIST
 
     return bitIds;
   }


### PR DESCRIPTION
For example: `import "scope-a/**" "scope-b/**"`. 
Currently, if scope-a has no components, it throws immediately. With this PR it only shows a warning about it and continue importing from scope-b.