### PR TITLE
improvement(build), stop the build as soon as a tag-blocker component-issue is found

### DIFF
--- a/e2e/functionalities/peer-dependencies.e2e.3.ts
+++ b/e2e/functionalities/peer-dependencies.e2e.3.ts
@@ -91,7 +91,7 @@ describe('peer-dependencies functionality', function () {
       helper.workspaceJsonc.addPolicyToDependencyResolver({
         peerDependencies: { [`@${helper.scopes.remote}/comp2`]: '*' },
       });
-      helper.command.build();
+      helper.command.build(undefined, '--ignore-issues="DuplicateComponentAndPackage"');
       workspaceCapsulesRootDir = helper.command.capsuleListParsed().workspaceCapsulesRootDir;
     });
     it('should save the peer dependency in the model', () => {

--- a/e2e/harmony/preview.e2e.ts
+++ b/e2e/harmony/preview.e2e.ts
@@ -38,7 +38,7 @@ describe('preview feature (during build)', function () {
       );
       helper.fs.outputFile('index.js', `export { Button } from './button';`);
       helper.command.addComponent('button');
-      helper.command.install();
+      helper.command.install('--add-missing-deps');
       helper.command.compile();
     });
     it('bit build should run successfully without preview errors', () => {

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -20,7 +20,6 @@ import { Ref } from '@teambit/legacy/dist/scope/objects';
 import { mockComponents } from '@teambit/component.testing.mock-components';
 import { SnappingMain } from './snapping.main.runtime';
 import { SnappingAspect } from './snapping.aspect';
-import { ComponentsHaveIssues } from './components-have-issues';
 import { SnapDataPerCompRaw } from './snap-from-scope.cmd';
 
 describe('Snapping aspect', function () {
@@ -44,7 +43,7 @@ describe('Snapping aspect', function () {
       try {
         await snapping.tag({ ids: ['comp1'] });
       } catch (err: any) {
-        expect(err.constructor.name).to.equal(ComponentsHaveIssues.name);
+        expect(err.constructor.name).to.equal('ComponentsHaveIssues');
       }
     });
     // @todo: this test fails during "bit build" for some reason. It passes on "bit test";

--- a/scopes/pipelines/builder/build.cmd.ts
+++ b/scopes/pipelines/builder/build.cmd.ts
@@ -5,6 +5,7 @@ import { OutsideWorkspaceError, Workspace } from '@teambit/workspace';
 import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
 import chalk from 'chalk';
 import { BuilderMain } from './builder.main.runtime';
+import { IssuesClasses } from '@teambit/component-issues';
 
 type BuildOpts = {
   unmodified?: boolean;
@@ -21,6 +22,7 @@ type BuildOpts = {
   failFast?: boolean;
   includeSnap?: boolean;
   includeTag?: boolean;
+  ignoreIssues?: string;
 };
 
 export class BuilderCmd implements Command {
@@ -81,6 +83,13 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
       'include-tag',
       'EXPERIMENTAL. include tag pipeline tasks. Warning: this may deploy/publish if you have such tasks',
     ],
+    [
+      'i',
+      'ignore-issues <issues>',
+      `ignore component issues (shown in "bit status" as "issues found"), issues to ignore:
+[${Object.keys(IssuesClasses).join(', ')}]
+to ignore multiple issues, separate them by a comma and wrap with quotes. to ignore all issues, specify "*".`,
+    ],
   ] as CommandOptions;
 
   constructor(private builder: BuilderMain, private workspace: Workspace, private logger: Logger) {}
@@ -101,6 +110,7 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
       failFast,
       includeSnap,
       includeTag,
+      ignoreIssues,
     }: BuildOpts
   ): Promise<string> {
     if (rewrite && !reuseCapsules) throw new Error('cannot use --rewrite without --reuse-capsules');
@@ -141,6 +151,7 @@ specify the task-name (e.g. "TypescriptCompiler") or the task-aspect-id (e.g. te
       {
         includeSnap,
         includeTag,
+        ignoreIssues,
       }
     );
     this.logger.console(`build output can be found in path: ${envsExecutionResults.capsuleRootDir}`);

--- a/scopes/pipelines/builder/builder.main.runtime.ts
+++ b/scopes/pipelines/builder/builder.main.runtime.ts
@@ -129,7 +129,8 @@ export class BuilderMain {
         ...builderOptions,
         // even when build is skipped (in case of tag-from-scope), the pre-build/post-build and teambit.harmony/aspect tasks are needed
         tasks: populateArtifactsFrom ? [AspectAspect.id] : undefined,
-      }
+      },
+      { ignoreIssues: '*' }
     );
     if (throwOnError && !forceDeploy) buildEnvsExecutionResults.throwErrorsIfExist();
     allTasksResults.push(...buildEnvsExecutionResults.tasksResults);

--- a/scopes/pipelines/builder/exceptions/components-have-issues.ts
+++ b/scopes/pipelines/builder/exceptions/components-have-issues.ts
@@ -17,7 +17,7 @@ ${issuesColored}
 to get the list of component-issues names and suggestions how to resolve them, run "bit component-issues".
 
 while highly not recommended, it's possible to ignore issues in two ways:
-1) temporarily ignore for this tag/snap command by entering "--ignore-issues" flag, e.g. \`bit tag --ignore-issues "${allIssueNames.join(
+1) temporarily ignore for this tag/snap/build command by entering "--ignore-issues" flag, e.g. \`bit tag --ignore-issues "${allIssueNames.join(
       ', '
     )}" \`
 2) ignore the issue completely by configuring it in the workspace.jsonc file. e.g:


### PR DESCRIPTION
Allow to ignore the issue by `--ignore-issues` flag. (similar to `bit tag` and `bit snap`).