### PR TITLE
feat(list), introduce "--include-deleted" flag

### DIFF
--- a/e2e/harmony/http.e2e.ts
+++ b/e2e/harmony/http.e2e.ts
@@ -75,10 +75,16 @@ import { HttpHelper } from '../http-helper';
       helper.command.snapAllComponentsWithoutBuild();
       helper.command.export();
     });
-    it('bit list -r should show not show the removed component', () => {
+    it('bit list should not show the removed component', () => {
       const list = helper.command.listRemoteScopeParsed();
       expect(list).to.have.lengthOf(1);
       expect(list[0].id).to.not.have.string('comp2');
+    });
+    it('bit list --include-deleted should show the removed component', () => {
+      const list = helper.command.listRemoteScopeParsed('--include-deleted');
+      expect(list).to.have.lengthOf(2);
+      const ids = list.map((c) => c.id);
+      expect(ids).to.include(`${helper.scopes.remote}/comp2`);
     });
     it('bit import of the entire scope should not bring in the deleted components', () => {
       helper.command.importComponent('*', '-x');

--- a/scopes/component/lister/list.cmd.ts
+++ b/scopes/component/lister/list.cmd.ts
@@ -11,6 +11,7 @@ type ListFlags = {
   json?: boolean;
   outdated?: boolean;
   namespace?: string;
+  includeDeleted?: boolean;
 };
 
 export class ListCmd implements Command {
@@ -23,6 +24,7 @@ export class ListCmd implements Command {
     ['i', 'ids', 'show only component ids, unformatted'],
     ['s', 'scope', 'show only components stored in the local scope, including indirect dependencies'],
     ['o', 'outdated', 'highlight outdated components, in comparison with their latest remote version (if one exists)'],
+    ['d', 'include-deleted', 'EXPERIMENTAL. show also deleted components'],
     ['j', 'json', 'show the output in JSON format'],
     ['n', 'namespace <string>', "show only components in the specified namespace/s e.g. '-n ui' or '*/ui'"],
   ] as CommandOptions;
@@ -65,7 +67,7 @@ export class ListCmd implements Command {
 
   private async getListResults(
     scopeName?: string,
-    { namespace, scope, outdated }: ListFlags = {}
+    { namespace, scope, outdated, includeDeleted }: ListFlags = {}
   ): Promise<ListScopeResult[]> {
     const getNamespaceWithWildcard = () => {
       if (!namespace) return undefined;
@@ -75,7 +77,7 @@ export class ListCmd implements Command {
     const namespacesUsingWildcards = getNamespaceWithWildcard();
 
     return scopeName
-      ? this.lister.remoteList(scopeName, { namespacesUsingWildcards })
+      ? this.lister.remoteList(scopeName, { namespacesUsingWildcards, includeDeleted })
       : this.lister.localList(scope, outdated, namespacesUsingWildcards);
   }
 }

--- a/scopes/component/lister/lister.main.runtime.ts
+++ b/scopes/component/lister/lister.main.runtime.ts
@@ -29,14 +29,16 @@ export class ListerMain {
     {
       namespacesUsingWildcards,
       includeDeprecated = true,
+      includeDeleted = false,
     }: {
       namespacesUsingWildcards?: string;
       includeDeprecated?: boolean;
+      includeDeleted?: boolean;
     }
   ): Promise<ListScopeResult[]> {
     const remote: Remote = await getRemoteByName(scopeName, this.workspace?.consumer);
     this.logger.setStatusLine(BEFORE_REMOTE_LIST);
-    const listResult = await remote.list(namespacesUsingWildcards);
+    const listResult = await remote.list(namespacesUsingWildcards, includeDeleted);
     return includeDeprecated ? listResult : listResult.filter((r) => !r.deprecated);
   }
 

--- a/scopes/scope/scope/scope.graphql.ts
+++ b/scopes/scope/scope/scope.graphql.ts
@@ -25,7 +25,13 @@ export function scopeSchema(scopeMain: ScopeMain) {
         path: String
 
         # list of components contained in the scope.
-        components(offset: Int, limit: Int, includeCache: Boolean, namespaces: [String!]): [Component]
+        components(
+          offset: Int
+          limit: Int
+          includeCache: Boolean
+          includeDeleted: Boolean
+          namespaces: [String!]
+        ): [Component]
 
         # get a specific component.
         get(id: String!): Component
@@ -83,10 +89,16 @@ export function scopeSchema(scopeMain: ScopeMain) {
         },
         components: (
           scope: ScopeMain,
-          props?: { offset: number; limit: number; includeCache?: boolean; namespaces?: string[] }
+          props?: {
+            offset: number;
+            limit: number;
+            includeCache?: boolean;
+            namespaces?: string[];
+            includeDeleted?: boolean;
+          }
         ) => {
           if (!props) return scope.list();
-          return scope.list({ ...props }, props.includeCache);
+          return scope.list({ ...props }, props.includeCache, undefined, props.includeDeleted);
         },
 
         get: async (scope: ScopeMain, { id }: { id: string }) => {

--- a/src/remotes/remote.ts
+++ b/src/remotes/remote.ts
@@ -50,8 +50,8 @@ export default class Remote {
     });
   }
 
-  list(namespacesUsingWildcards?: string): Promise<ListScopeResult[]> {
-    return this.connect().then((network) => network.list(namespacesUsingWildcards));
+  list(namespacesUsingWildcards?: string, includeDeleted = false): Promise<ListScopeResult[]> {
+    return this.connect().then((network) => network.list(namespacesUsingWildcards, includeDeleted));
   }
 
   show(bitId: ComponentID): Promise<Component | null | undefined> {

--- a/src/scope/network/fs/fs.ts
+++ b/src/scope/network/fs/fs.ts
@@ -64,9 +64,9 @@ export default class Fs implements Network {
       .then((componentsIds) => componentsIds.map((componentId) => componentId.toString()));
   }
 
-  list(namespacesUsingWildcards?: string): Promise<ListScopeResult[]> {
+  list(namespacesUsingWildcards?: string, includeDeleted = false): Promise<ListScopeResult[]> {
     // @ts-ignore todo: remove after deleting teambit.legacy
-    return ComponentsList.listLocalScope(this.getScope(), namespacesUsingWildcards);
+    return ComponentsList.listLocalScope(this.getScope(), namespacesUsingWildcards, includeDeleted);
   }
 
   show(bitId: ComponentID): Promise<Component> {

--- a/src/scope/network/http/http.ts
+++ b/src/scope/network/http/http.ts
@@ -466,7 +466,7 @@ export class Http implements Network {
     });
   }
 
-  async list(namespacesUsingWildcards?: string | undefined): Promise<ListScopeResult[]> {
+  async listBackwardCompatible(namespacesUsingWildcards?: string | undefined): Promise<ListScopeResult[]> {
     const LIST_HARMONY = gql`
       query list($namespaces: [String!]) {
         scope {
@@ -491,6 +491,58 @@ export class Http implements Network {
     data.scope.components.forEach((comp) => {
       comp.id = ComponentID.fromObject(comp.id);
       comp.deprecated = comp.deprecation.isDeprecate;
+    });
+
+    return data.scope.components;
+  }
+
+  async list(namespacesUsingWildcards?: string | undefined, includeDeleted = false): Promise<ListScopeResult[]> {
+    if (!includeDeleted) return this.listBackwardCompatible(namespacesUsingWildcards);
+    const LIST_HARMONY = gql`
+      query list($namespaces: [String!], $includeDeleted: Boolean) {
+        scope {
+          components(namespaces: $namespaces, includeDeleted: $includeDeleted) {
+            id {
+              scope
+              version
+              name
+            }
+            aspects(include: ["teambit.component/remove"]) {
+              id
+              config
+            }
+            deprecation {
+              isDeprecate
+            }
+          }
+        }
+      }
+    `;
+
+    let data: any;
+    try {
+      data = await this.graphClientRequest(LIST_HARMONY, Verb.READ, {
+        namespaces: namespacesUsingWildcards ? [namespacesUsingWildcards] : undefined,
+        includeDeleted,
+      });
+    } catch (err: any) {
+      if (err.message.includes('Unknown argument' && err.message.includes('includeDeleted'))) {
+        loader.stop();
+        logger.console(
+          `error: the remote does not support the include-deleted flag yet, falling back to listing without deleted components`,
+          'error',
+          'red'
+        );
+        return this.listBackwardCompatible(namespacesUsingWildcards);
+      }
+      throw err;
+    }
+
+    data.scope.components.forEach((comp) => {
+      const removeAspect = comp.aspects.find((aspect) => aspect.id === 'teambit.component/remove');
+      comp.id = ComponentID.fromObject(comp.id);
+      comp.deprecated = comp.deprecation.isDeprecate;
+      comp.removed = removeAspect?.config?.removed;
     });
 
     return data.scope.components;

--- a/src/scope/network/network.ts
+++ b/src/scope/network/network.ts
@@ -23,7 +23,7 @@ export interface Network {
   fetch(ids: string[], fetchOptions: FETCH_OPTIONS, context?: Record<string, any>): Promise<ObjectItemsStream>;
   pushMany(objectList: ObjectList, pushOptions: PushOptions, context?: Record<string, any>): Promise<string[]>;
   action<Options extends Record<string, any>, Result>(name: string, options: Options): Promise<Result>;
-  list(namespacesUsingWildcards?: string): Promise<ListScopeResult[]>;
+  list(namespacesUsingWildcards?: string, includeDeleted?: boolean): Promise<ListScopeResult[]>;
   show(bitId: ComponentID): Promise<Component | null | undefined>;
   log(id: ComponentID): Promise<ComponentLog[]>;
   latestVersions(bitIds: ComponentIdList): Promise<string[]>;


### PR DESCRIPTION
By default, deleted components are not shown in `bit list` output.
This new flag `--include-deleted` includes them. Keep in mind that the remotes must update the code in order for the client to get it.