### PR TITLE
improvement(list), improve list output to show [deleted] in red when applicable

### DIFF
--- a/scopes/component/lister/list-template.ts
+++ b/scopes/component/lister/list-template.ts
@@ -16,10 +16,13 @@ export function listTemplate(listScopeResults: ListScopeResult[], json: boolean,
       version = color ? c[color](version) : version;
     }
     const getFormattedId = () => {
-      const { deprecated, laneReadmeOf } = listScopeResult;
+      const { deprecated, laneReadmeOf, removed } = listScopeResult;
       let formattedId = c.white(`${id}`);
       if (deprecated) {
-        formattedId = c.white(`${formattedId} [Deprecated]`);
+        formattedId = c.yellow(`${formattedId} [Deprecated]`);
+      }
+      if (removed) {
+        formattedId = c.red(`${formattedId} [Deleted]`);
       }
       if (laneReadmeOf && laneReadmeOf.length > 0) {
         formattedId = `${formattedId}\n`;
@@ -58,6 +61,7 @@ export function listTemplate(listScopeResults: ListScopeResult[], json: boolean,
       deprecated: listScopeResult.deprecated,
       currentVersion: listScopeResult.currentlyUsedVersion || 'N/A',
       remoteVersion: listScopeResult.remoteVersion || 'N/A',
+      removed: listScopeResult.removed,
     };
     return data;
   }


### PR DESCRIPTION
Another [PR](https://github.com/teambit/bit/pull/9041) just merged introduced a new flag `--include-deleted` to include deleted components in the list output. This PR shows them with a red mark `[deleted]`. Also, it changes the `[deprecated]` to be yellow. 

<img width="696" alt="Screenshot 2024-07-16 at 7 09 47 PM" src="https://github.com/user-attachments/assets/2a22f359-7e85-4836-bb40-69547abaf041">
