### PR TITLE
fix, add back src/api/scope/lib/scope-init

### DIFF
--- a/scopes/component/sources/index.ts
+++ b/scopes/component/sources/index.ts
@@ -25,3 +25,4 @@ export {
   reStructureBuildArtifacts,
 } from './artifact-files';
 export { JsonVinyl } from './json-vinyl';
+export { removeFilesAndEmptyDirsRecursively } from './remove-files-and-empty-dirs-recursively';

--- a/src/api/scope/lib/scope-init.ts
+++ b/src/api/scope/lib/scope-init.ts
@@ -1,0 +1,3 @@
+import { initScope } from '@teambit/legacy.scope-api';
+
+export default initScope;

--- a/src/utils/fs/remove-files-and-empty-dirs-recursively.ts
+++ b/src/utils/fs/remove-files-and-empty-dirs-recursively.ts
@@ -1,0 +1,2 @@
+import { removeFilesAndEmptyDirsRecursively } from '@teambit/component.sources';
+export default removeFilesAndEmptyDirsRecursively;


### PR DESCRIPTION
Turns out that this API was used as well.