### PR TITLE
fix(test) - fix an issue with jest29 and uuid < 9

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -262,7 +262,7 @@
         "@teambit/react.instructions.react-native.adding-tests": "0.0.1",
         "@teambit/react.instructions.react.adding-compositions": "0.0.6",
         "@teambit/react.instructions.react.adding-tests": "0.0.6",
-        "@teambit/react.jest.react-jest": "^1.0.22",
+        "@teambit/react.jest.react-jest": "^1.0.27",
         "@teambit/react.rendering.ssr": "0.0.3",
         "@teambit/react.ui.component-highlighter": "0.2.2",
         "@teambit/react.webpack.react-webpack": "^1.0.25",


### PR DESCRIPTION
## Proposed Changes

- This added `uuid: require.resolve('uuid'),` to jest's `moduleNameMapper` 
- See the real change [here](https://bit.cloud/teambit/defender/jest-tester/~compare)
- Read more about the issue [here](https://stackoverflow.com/questions/73203367/jest-syntaxerror-unexpected-token-export-with-uuid-library)
