### PR TITLE
feat, introduce "local-only" feature to keep components locally for local debugging/test purposes

### DIFF
--- a/components/legacy/bit-map/component-map.ts
+++ b/components/legacy/bit-map/component-map.ts
@@ -54,6 +54,7 @@ export type ComponentMapData = {
   wrapDir?: PathLinux;
   exported?: boolean;
   onLanesOnly?: boolean;
+  localOnly?: boolean;
   isAvailableOnCurrentLane?: boolean;
   nextVersion?: NextVersion;
   config?: Config;
@@ -86,6 +87,7 @@ export class ComponentMap {
    * this is still here for projects that loaded .bitmap with schema 16 and then downgraded bit to a version with schema 15.
    */
   onLanesOnly? = false;
+  localOnly?: boolean; // whether the component is local only and should not be snapped/tagged/exported
   nextVersion?: NextVersion; // for soft-tag (harmony only), this data is used in the CI to persist
   recentlyTracked?: boolean; // eventually the timestamp is saved in the filesystem cache so it won't be re-tracked if not changed
   name: string; // name of the component (including namespace)
@@ -102,6 +104,7 @@ export class ComponentMap {
     trackDir,
     wrapDir,
     onLanesOnly,
+    localOnly,
     isAvailableOnCurrentLane,
     nextVersion,
     config,
@@ -114,6 +117,7 @@ export class ComponentMap {
     this.trackDir = trackDir;
     this.wrapDir = wrapDir;
     this.onLanesOnly = onLanesOnly;
+    this.localOnly = localOnly;
     this.isAvailableOnCurrentLane = typeof isAvailableOnCurrentLane === 'undefined' ? true : isAvailableOnCurrentLane;
     this.nextVersion = nextVersion;
     this.config = config;
@@ -138,6 +142,7 @@ export class ComponentMap {
       onLanesOnly: this.onLanesOnly || null, // if false, change to null so it won't be written
       isAvailableOnCurrentLane: this.isAvailableOnCurrentLane,
       nextVersion: this.nextVersion,
+      localOnly: this.localOnly || null, // if false, change to null so it won't be written
       config: this.configToObject(),
     };
     const notNil = (val) => {

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -165,7 +165,7 @@ describe('Snapping aspect', function () {
       await destroyWorkspace(workspaceData);
     });
     it('should be able to list it', async () => {
-      const list = workspace.bitMap.listLocalOnly();
+      const list = workspace.listLocalOnly();
       expect(list).to.have.lengthOf(1);
       expect(list[0].toString()).to.include('comp1');
     });

--- a/scopes/component/snapping/snapping.spec.ts
+++ b/scopes/component/snapping/snapping.spec.ts
@@ -21,6 +21,7 @@ import { mockComponents } from '@teambit/component.testing.mock-components';
 import { SnappingMain } from './snapping.main.runtime';
 import { SnappingAspect } from './snapping.aspect';
 import { SnapDataPerCompRaw } from './snap-from-scope.cmd';
+import { WorkspaceAspect, Workspace } from '@teambit/workspace';
 
 describe('Snapping aspect', function () {
   this.timeout(0);
@@ -145,6 +146,51 @@ describe('Snapping aspect', function () {
     });
     after(async () => {
       await destroyWorkspace(workspaceData);
+    });
+  });
+  describe('local-only', () => {
+    let harmony: Harmony;
+    let workspace: Workspace;
+    let workspaceData: WorkspaceData;
+    before(async () => {
+      workspaceData = mockWorkspace();
+      const { workspacePath } = workspaceData;
+      await mockComponents(workspacePath, { numOfComponents: 3 });
+      harmony = await loadManyAspects([WorkspaceAspect, SnappingAspect], workspacePath);
+      workspace = harmony.get<Workspace>(WorkspaceAspect.id);
+      const comp1Id = await workspace.idsByPattern('comp1');
+      await workspace.setLocalOnly(comp1Id);
+    });
+    after(async () => {
+      await destroyWorkspace(workspaceData);
+    });
+    it('should be able to list it', async () => {
+      const list = workspace.bitMap.listLocalOnly();
+      expect(list).to.have.lengthOf(1);
+      expect(list[0].toString()).to.include('comp1');
+    });
+    it('should be ignored by tag command', async () => {
+      const snapping = harmony.get<SnappingMain>(SnappingAspect.id);
+      const tagResults = await snapping.tag({});
+      expect(tagResults?.taggedComponents).to.have.lengthOf(2);
+      const taggedNames = tagResults?.taggedComponents.map((c) => c.name);
+      expect(taggedNames).to.not.include('comp1');
+    });
+    it('should be ignored by snap command', async () => {
+      const snapping = harmony.get<SnappingMain>(SnappingAspect.id);
+      const tagResults = await snapping.snap({ unmodified: true });
+      expect(tagResults?.snappedComponents).to.have.lengthOf(2);
+      const taggedNames = tagResults?.snappedComponents.map((c) => c.name);
+      expect(taggedNames).to.not.include('comp1');
+    });
+    it('should never be exported even when tagged with --include-local-only', async () => {
+      const snapping = harmony.get<SnappingMain>(SnappingAspect.id);
+      const tagResults = await snapping.tag({ unmodified: true, includeLocalOnly: true });
+      expect(tagResults?.taggedComponents).to.have.lengthOf(3);
+
+      const exportAspect = harmony.get<ExportMain>(ExportAspect.id);
+      const result = await exportAspect.export();
+      expect(result.componentsIds).to.have.lengthOf(2);
     });
   });
 });

--- a/scopes/component/snapping/tag-cmd.ts
+++ b/scopes/component/snapping/tag-cmd.ts
@@ -93,6 +93,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       'stop pipeline execution on the first failed task (by default a task is skipped only when its dependency failed)',
     ],
     ['b', 'build', 'locally run the build pipeline (i.e. not via rippleCI) and complete the tag'],
+    ['', 'include-local-only', 'include local-only components in the tag process'],
   ] as CommandOptions;
   remoteOp = true; // In case a compiler / tester is not installed
   examples = [{ cmd: 'tag --ver 1.0.0', description: 'tag all components to version 1.0.0' }];
@@ -129,6 +130,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       rebuildDepsGraph,
       failFast = false,
       incrementBy = 1,
+      includeLocalOnly,
     }: {
       snapped?: boolean;
       unmerged?: boolean;
@@ -232,6 +234,7 @@ To undo local tag use the "bit reset" command.`
       incrementBy,
       version: ver,
       failFast,
+      includeLocalOnly,
     };
 
     const results = await this.snapping.tag(params);

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -39,6 +39,7 @@ export type BasicTagSnapParams = {
   build?: boolean;
   ignoreBuildErrors?: boolean;
   rebuildDepsGraph?: boolean;
+  includeLocalOnly?: boolean;
 };
 
 export type BasicTagParams = BasicTagSnapParams & {

--- a/scopes/component/status/status-cmd.ts
+++ b/scopes/component/status/status-cmd.ts
@@ -50,6 +50,7 @@ type StatusJsonResults = {
   componentsDuringMergeState: string[];
   softTaggedComponents: string[];
   snappedComponents: string[];
+  localOnly: string[];
   pendingUpdatesFromMain: Array<{
     id: string;
     divergeData: any;
@@ -103,6 +104,7 @@ export class StatusCmd implements Command {
       currentLaneId,
       forkedLaneId,
       workspaceIssues,
+      localOnly,
     }: StatusResult = await this.status.status({ lanes, ignoreCircularDependencies });
     return {
       newComponents: newComponents.map((c) => c.toStringWithoutVersion()),
@@ -123,6 +125,7 @@ export class StatusCmd implements Command {
       componentsDuringMergeState: componentsDuringMergeState.map((id) => id.toStringWithoutVersion()),
       softTaggedComponents: softTaggedComponents.map((s) => s.toStringWithoutVersion()),
       snappedComponents: snappedComponents.map((s) => s.toStringWithoutVersion()),
+      localOnly: localOnly.map((id) => id.toStringWithoutVersion()),
       pendingUpdatesFromMain: pendingUpdatesFromMain.map((p) => ({
         id: p.id.toStringWithoutVersion(),
         divergeData: p.divergeData,
@@ -155,6 +158,7 @@ export class StatusCmd implements Command {
       softTaggedComponents,
       snappedComponents,
       pendingUpdatesFromMain,
+      localOnly,
       updatesFromForked,
       unavailableOnMain,
       currentLaneId,
@@ -316,6 +320,10 @@ or use "bit merge [component-id] --abort" (for prior "bit merge" command)`;
     const stagedComps = stagedComponents.map((c) => format(c.id, false, undefined, c.versions));
     const stagedComponentsOutput = formatCategory('staged components', stagedDesc, stagedComps);
 
+    const localOnlyDesc = '(these components are excluded from tag/snap/export commands)';
+    const localOnlyComps = localOnly.map((c) => format(c)).sort();
+    const localOnlyComponentsOutput = formatCategory('local-only components', localOnlyDesc, localOnlyComps);
+
     const softTaggedDesc = '(use "bit tag --persist" to complete the tag)';
     const softTaggedComps = softTaggedComponents.map((id) => format(id, false, undefined, undefined, false));
     const softTaggedComponentsOutput = formatCategory('soft-tagged components', softTaggedDesc, softTaggedComps);
@@ -395,6 +403,7 @@ use "bit fetch ${forkedLaneId.toString()} --lanes" to update ${forkedLaneId.name
         updatesFromMainOutput,
         updatesFromForkedOutput,
         compDuringMergeStr,
+        localOnlyComponentsOutput,
         newComponentsOutput,
         modifiedComponentOutput,
         snappedComponentsOutput,

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -124,7 +124,7 @@ export class StatusMain {
     const currentLane = await consumer.getCurrentLaneObject();
     const forkedLaneId = currentLane?.forkedFrom;
     const workspaceIssues = this.workspace.getWorkspaceIssues();
-    const localOnly = this.workspace.bitMap.listLocalOnly();
+    const localOnly = this.workspace.listLocalOnly();
 
     const sortObjectsWithId = <T>(objectsWithId: Array<T & { id: ComponentID }>): Array<T & { id: ComponentID }> => {
       return objectsWithId.sort((a, b) => a.id.toString().localeCompare(b.id.toString()));

--- a/scopes/component/status/status.main.runtime.ts
+++ b/scopes/component/status/status.main.runtime.ts
@@ -43,6 +43,7 @@ export type StatusResult = {
   currentLaneId: LaneId;
   forkedLaneId?: LaneId;
   workspaceIssues: string[];
+  localOnly: ComponentID[];
 };
 
 export type MiniStatusResults = {
@@ -123,6 +124,7 @@ export class StatusMain {
     const currentLane = await consumer.getCurrentLaneObject();
     const forkedLaneId = currentLane?.forkedFrom;
     const workspaceIssues = this.workspace.getWorkspaceIssues();
+    const localOnly = this.workspace.bitMap.listLocalOnly();
 
     const sortObjectsWithId = <T>(objectsWithId: Array<T & { id: ComponentID }>): Array<T & { id: ComponentID }> => {
       return objectsWithId.sort((a, b) => a.id.toString().localeCompare(b.id.toString()));
@@ -158,6 +160,7 @@ export class StatusMain {
       currentLaneId,
       forkedLaneId,
       workspaceIssues: workspaceIssues.map((err) => err.message),
+      localOnly,
     };
   }
 

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -764,7 +764,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     const filterLocalOnlyIfNeeded = async (
       bitIds: ComponentIdList
     ): Promise<{ idsToExport: ComponentIdList; missingScope: ComponentID[]; idsWithFutureScope: ComponentIdList }> => {
-      const localOnlyComponents = ComponentIdList.fromArray(this.workspace.filter.byLocalOnly(bitIds));
+      const localOnlyComponents = this.workspace.listLocalOnly();
       const idsToExport = bitIds.filter((id) => !localOnlyComponents.hasWithoutScopeAndVersion(id));
       return { idsToExport: ComponentIdList.fromArray(idsToExport), missingScope: [], idsWithFutureScope: bitIds };
     };

--- a/scopes/workspace/workspace/bit-map.ts
+++ b/scopes/workspace/workspace/bit-map.ts
@@ -135,6 +135,29 @@ export class BitMap {
     this.legacyBitMap.markAsChanged();
   }
 
+  setLocalOnly(ids: ComponentID[]) {
+    ids.forEach((id) => {
+      const bitMapEntry = this.getBitmapEntry(id);
+      bitMapEntry.localOnly = true;
+    });
+    this.legacyBitMap.markAsChanged();
+  }
+  unsetLocalOnly(ids: ComponentID[]): ComponentID[] {
+    const successfullyUnset: ComponentID[] = [];
+    ids.forEach((id) => {
+      const bitMapEntry = this.getBitmapEntry(id);
+      if (!bitMapEntry.localOnly) return;
+      bitMapEntry.localOnly = false;
+      successfullyUnset.push(id);
+    });
+    this.legacyBitMap.markAsChanged();
+    return successfullyUnset;
+  }
+  listLocalOnly() {
+    const allIds = this.legacyBitMap.getAllBitIds();
+    return allIds.filter((id) => this.getBitmapEntry(id).localOnly);
+  }
+
   /**
    * write .bitmap object to the filesystem
    * optionally pass a reason for the change to be saved in the local scope `bitmap-history-metadata.txt` file.

--- a/scopes/workspace/workspace/commands/local-only-cmd.ts
+++ b/scopes/workspace/workspace/commands/local-only-cmd.ts
@@ -1,0 +1,85 @@
+/* eslint max-classes-per-file: 0 */
+import chalk from 'chalk';
+import { COMPONENT_PATTERN_HELP } from '@teambit/legacy/dist/constants';
+import { Command, CommandOptions } from '@teambit/cli';
+import { Workspace } from '../workspace';
+
+export class LocalOnlySetCmd implements Command {
+  name = 'set <component-pattern>';
+  description = 'set a component as local-only';
+  arguments = [
+    {
+      name: 'component-pattern',
+      description: COMPONENT_PATTERN_HELP,
+    },
+  ];
+  alias = '';
+  options = [] as CommandOptions;
+
+  constructor(private workspace: Workspace) {}
+
+  async report([pattern]: [string]) {
+    const ids = await this.workspace.idsByPattern(pattern);
+    await this.workspace.setLocalOnly(ids);
+    const title = chalk.bold(`successfully set the following components as local-only`);
+    return `${title}:\n${ids.map((id) => id.toString()).join('\n')}`;
+  }
+}
+
+export class LocalOnlyUnsetCmd implements Command {
+  name = 'unset <component-pattern>';
+  description = 'remove a component from local-only';
+  arguments = [
+    {
+      name: 'component-pattern',
+      description: COMPONENT_PATTERN_HELP,
+    },
+  ];
+  alias = '';
+  options = [] as CommandOptions;
+
+  constructor(private workspace: Workspace) {}
+
+  async report([pattern]: [string]) {
+    const ids = await this.workspace.idsByPattern(pattern);
+    const successfullyUnset = await this.workspace.unsetLocalOnly(ids);
+    if (successfullyUnset.length === 0) {
+      return chalk.yellow('no local-only components were found');
+    }
+    const title = chalk.bold(`successfully unset the following component(s)`);
+    return `${title}:\n${successfullyUnset.map((id) => id.toString()).join('\n')}`;
+  }
+}
+
+export class LocalOnlyListCmd implements Command {
+  name = 'list';
+  description = 'list all local-only components';
+  alias = '';
+  options = [] as CommandOptions;
+
+  constructor(private workspace: Workspace) {}
+
+  async report() {
+    const ids = this.workspace.bitMap.listLocalOnly();
+    if (ids.length === 0) {
+      return chalk.yellow('no local-only components were found');
+    }
+    const title = chalk.bold(`the following component(s) are local-only`);
+    return `${title}:\n${ids.map((id) => id.toString()).join('\n')}`;
+  }
+}
+
+export class LocalOnlyCmd implements Command {
+  name = 'local-only <sub-command>';
+  description = 'manage local-only components, which reside only in the workspace and are not snapped/tagged';
+  group = 'development';
+  alias = '';
+  commands: Command[] = [];
+  options = [] as CommandOptions;
+
+  async report([unrecognizedSubcommand]: [string]) {
+    return chalk.red(
+      `"${unrecognizedSubcommand}" is not a subcommand of "local-only", please run "bit local-only --help" to list the subcommands`
+    );
+  }
+}

--- a/scopes/workspace/workspace/commands/local-only-cmd.ts
+++ b/scopes/workspace/workspace/commands/local-only-cmd.ts
@@ -60,7 +60,7 @@ export class LocalOnlyListCmd implements Command {
   constructor(private workspace: Workspace) {}
 
   async report() {
-    const ids = this.workspace.bitMap.listLocalOnly();
+    const ids = this.workspace.listLocalOnly();
     if (ids.length === 0) {
       return chalk.yellow('no local-only components were found');
     }

--- a/scopes/workspace/workspace/workspace.main.runtime.ts
+++ b/scopes/workspace/workspace/workspace.main.runtime.ts
@@ -39,6 +39,7 @@ import { ScopeSetCmd } from './scope-subcommands/scope-set.cmd';
 import { UseCmd } from './use.cmd';
 import { EnvsUpdateCmd } from './envs-subcommands/envs-update.cmd';
 import { UnuseCmd } from './unuse.cmd';
+import { LocalOnlyCmd, LocalOnlyListCmd, LocalOnlySetCmd, LocalOnlyUnsetCmd } from './commands/local-only-cmd';
 
 export type WorkspaceDeps = [
   PubsubMain,
@@ -269,6 +270,13 @@ export class WorkspaceMain {
     ];
 
     commands.push(new PatternCommand(workspace));
+    const localOnlyCmd = new LocalOnlyCmd();
+    localOnlyCmd.commands = [
+      new LocalOnlySetCmd(workspace),
+      new LocalOnlyUnsetCmd(workspace),
+      new LocalOnlyListCmd(workspace),
+    ];
+    commands.push(localOnlyCmd);
     cli.register(...commands);
     component.registerHost(workspace);
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -409,6 +409,7 @@ export class Workspace implements ComponentFactory {
 
   /**
    * get ids of all workspace components.
+   * deleted components are filtered out. (use this.listIdsIncludeRemoved() if you need them)
    */
   listIds(): ComponentIdList {
     return this.consumer.bitmapIdsFromCurrentLane;
@@ -514,7 +515,7 @@ export class Workspace implements ComponentFactory {
    */
   async listPotentialTagIds(): Promise<ComponentID[]> {
     const deletedIds = await this.locallyDeletedIds();
-    const allIdsWithoutDeleted = await this.listIds();
+    const allIdsWithoutDeleted = this.listIds();
     return [...deletedIds, ...allIdsWithoutDeleted];
   }
 
@@ -2141,6 +2142,16 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
 
   async getComponentStatusById(id: ComponentID): Promise<ComponentStatusLegacy> {
     return this.componentStatusLoader.getComponentStatusById(id);
+  }
+
+  async setLocalOnly(ids: ComponentID[]) {
+    this.bitMap.setLocalOnly(ids);
+    await this.bitMap.write('setLocalOnly');
+  }
+  async unsetLocalOnly(ids: ComponentID[]): Promise<ComponentID[]> {
+    const successfullyUnset = this.bitMap.unsetLocalOnly(ids);
+    await this.bitMap.write('unsetLocalOnly');
+    return successfullyUnset;
   }
 }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -2153,6 +2153,9 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     await this.bitMap.write('unsetLocalOnly');
     return successfullyUnset;
   }
+  listLocalOnly(): ComponentIdList {
+    return ComponentIdList.fromArray(this.bitMap.listLocalOnly());
+  }
 }
 
 /**

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -267,6 +267,15 @@ export default class CommandHelper {
   renameScopeOwner(oldScope: string, newScope: string, flags = '') {
     return this.runCmd(`bit scope rename-owner ${oldScope} ${newScope} ${flags}`);
   }
+  setLocalOnly(pattern: string) {
+    return this.runCmd(`bit local-only set ${pattern}`);
+  }
+  unsetLocalOnly(pattern: string) {
+    return this.runCmd(`bit local-only unset ${pattern}`);
+  }
+  listLocalOnly() {
+    return this.runCmd(`bit local-only list`);
+  }
   envs() {
     return this.runCmd(`bit envs`);
   }


### PR DESCRIPTION
## Proposed Changes 

- mark components as local-only by `bit local-only set <pattern>` (undo by `local-only unset`, list by `local-only list`).
- these local-only components are excluded from snap/tag/export commands. (unless `--include-local-only` was used for snap/tag).
- all other commands work as normal for these local-only components.
- `bit status` shows a new section "local only components".
- added a new state-filter `$localOnly`. Can be used for all commands that support pattern.
