### PR TITLE
fix(api-ref): internal type ref in object binding nodes

### DIFF
--- a/components/models/api-reference-model/api-reference-model.ts
+++ b/components/models/api-reference-model/api-reference-model.ts
@@ -109,6 +109,11 @@ export class APIReferenceModel {
     return this.apiByType.get(type) ?? [];
   }
 
+  getByName(node: SchemaNode): APINode | undefined {
+    if (!node.name) return undefined;
+    return this.apiByName.get(node.name) ?? this.apiByName.get(this.internalAPIKey(node));
+  }
+
   groupByType(apiNodes: APINode[]): Map<string, APINode[]> {
     return apiNodes.reduce((accum, next) => {
       const existing = accum.get(next.renderer.nodeType) || [];

--- a/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
+++ b/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { APINodeRenderProps, APINodeRenderer, nodeStyles } from '@teambit/api-reference.models.api-node-renderer';
-import { InferenceTypeSchema, ParameterSchema } from '@teambit/semantics.entities.semantic-schema';
+import { InferenceTypeSchema, ParameterSchema, TypeRefSchema } from '@teambit/semantics.entities.semantic-schema';
 import { TableRow } from '@teambit/documenter.ui.table-row';
 import { HeadingRow } from '@teambit/documenter.ui.table-heading-row';
 
@@ -43,7 +43,13 @@ function ParameterComponent(props: APINodeRenderProps) {
             const matchesAlias = (_bindingNode as any).alias && node.name === (_bindingNode as any).alias;
             return matchesName || matchesAlias;
           });
-          const bindingNode = typeRefCorrespondingNode || _bindingNode;
+          const isTypeRefCorrespondingNodeReference =
+            (typeRefCorrespondingNode as any)?.type?.__schema === TypeRefSchema.name;
+
+          const bindingNode = isTypeRefCorrespondingNodeReference
+            ? (typeRefCorrespondingNode as any).type
+            : _bindingNode;
+
           const bindingNodeRenderer = renderers.find((renderer) => renderer.predicate(bindingNode));
 
           const customBindingNodeTypeRow = (bindingNodeRenderer && (

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
@@ -46,14 +46,14 @@ function TypeRefComponent(props: APINodeRenderProps) {
       <>{children}</>
     );
 
-  const exportedTypeFromSameComp = typeRefNode.isFromThisComponent()
-    ? apiRefModel.apiByName.get(typeRefNode.name)
-    : undefined;
+  const exportedTypeFromSameComp = typeRefNode.isFromThisComponent() ? apiRefModel.getByName(typeRefNode) : undefined;
 
   const exportedTypeUrlFromSameComp =
     exportedTypeFromSameComp &&
     useUpdatedUrlFromQuery({
-      selectedAPI: exportedTypeFromSameComp.api.name,
+      selectedAPI: typeRefNode.isInternalReference()
+        ? apiRefModel.internalAPIKey(typeRefNode)
+        : exportedTypeFromSameComp.api.name,
     });
 
   const exportedTypeUrlFromAnotherComp = typeRefNode.componentId


### PR DESCRIPTION
This PR fixes the API Reference parameter renderer to correctly extract and render non-exported internal references as part of the object binding node. 