### PR TITLE
fix(api-ref): correctly extract params for function node summary

### DIFF
--- a/scopes/api-reference/renderers/grouped-schema-nodes-summary/grouped-schema-nodes-summary.tsx
+++ b/scopes/api-reference/renderers/grouped-schema-nodes-summary/grouped-schema-nodes-summary.tsx
@@ -123,9 +123,10 @@ export function GroupedSchemaNodesSummary({
               groupedMembersByType.map((member) => {
                 if (!type) return null;
                 const params =
-                  (member as any).params || (member as any).props || (member as any).param
-                    ? [(member as any).param]
-                    : [];
+                  (member as any).params ||
+                  (member as any).props ||
+                  ((member as any).param && [(member as any).param]) ||
+                  [];
 
                 return (
                   <FunctionNodeSummary


### PR DESCRIPTION
This PR fixes the extraction of params to be rendered as part of the function node summary in the API Ref page. 