### PR TITLE
fix(tag), exit immediately when a pre-release id is invalid

### DIFF
--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -361,6 +361,23 @@ describe('tag components on Harmony', function () {
       expect(tagOutput).to.have.string('comp1@0.0.2-dev.0');
     });
   });
+  describe('invalid pre-release after normal tag', () => {
+    let result: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      result = helper.general.runWithTryCatch(`bit tag --unmodified --pre-release "h?h"`);
+    });
+    it('should throw an error', () => {
+      expect(result).to.have.string('is not a valid semantic version');
+    });
+    it('should not create a new version', () => {
+      const comp = helper.command.catComponent('comp1');
+      const ver1Hash = comp.versions['0.0.1'];
+      expect(comp.head).to.equal(ver1Hash);
+    });
+  });
   describe('soft-tag pre-release', () => {
     let tagOutput: string;
     before(() => {

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -17,7 +17,7 @@ import ComponentOverrides from '../../consumer/config/component-overrides';
 import ValidationError from '../../error/validation-error';
 import logger from '../../logger/logger';
 import { getStringifyArgs } from '@teambit/legacy.utils';
-import { getLatestVersion } from '@teambit/pkg.modules.semver-helper';
+import { getLatestVersion, validateVersion } from '@teambit/pkg.modules.semver-helper';
 import ComponentObjects from '../component-objects';
 import { SnapsDistance } from '../component-ops/snaps-distance';
 import { getDivergeData } from '../component-ops/get-diverge-data';
@@ -602,7 +602,9 @@ export default class Component extends BitObject {
     if (exactVersion && this.versions[exactVersion]) {
       throw new VersionAlreadyExists(exactVersion, this.id());
     }
-    return exactVersion || this.version(releaseType, incrementBy, preReleaseId);
+    const version = exactVersion || this.version(releaseType, incrementBy, preReleaseId);
+    validateVersion(version);
+    return version;
   }
 
   isEqual(component: Component, considerOrphanedVersions = true): boolean {

--- a/src/scope/version-validator.ts
+++ b/src/scope/version-validator.ts
@@ -1,10 +1,11 @@
+/* eslint-disable complexity */
 import { PackageJsonValidator as PJV } from '@teambit/pkg.package-json.validator';
 import R from 'ramda';
 import { lt, gt } from 'semver';
 import packageNameValidate from 'validate-npm-package-name';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
 import { BitError } from '@teambit/bit-error';
-import { isSnap } from '@teambit/component-version';
+import { isSnap, isTag } from '@teambit/component-version';
 import { DEPENDENCIES_FIELDS } from '../constants';
 import { SchemaName } from '../consumer/component/component-schema';
 import { Dependencies } from '../consumer/component/dependencies';
@@ -316,6 +317,11 @@ ${duplicationStr}`);
       });
     });
   }
+  const ver = version.componentId?.version;
+  if (ver && !isSnap(ver) && !isTag(ver)) {
+    throw new VersionInvalid(`${message}, the version "${ver}" is invalid. it's not a hash (snap) nor a tag`);
+  }
+
   if (version.isLegacy) {
     // mainly to make sure that all Harmony components are saved with schema
     // if they don't have schema, they'll fail on this test


### PR DESCRIPTION
Currently it saves the objects and throws in a later phase, which make the `Version` object corrupted. 