### PR TITLE
add a proxy from bit-server to graphql in the cloud

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -412,6 +412,7 @@
         "html-escaper": "3.0.0",
         "html-webpack-plugin": "5.3.2",
         "http-proxy": "1.18.1",
+        "http-proxy-middleware": "^3.0.0",
         "humanize-duration": "3.23.1",
         "humanize-string": "2.1.0",
         "inject-body-webpack-plugin": "1.3.0",


### PR DESCRIPTION
This way it'll be possible to make graphql queries from vscode extension to the cloud.