### PR TITLE
fix(bit-cli-server), support all args types and subcommands

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -26,6 +26,7 @@ import { IDERoute } from './ide.route';
 import { APIForIDE } from './api-for-ide';
 import { SSEEventsRoute } from './sse-events.route';
 import { join } from 'path';
+import { CLIRawRoute } from './cli-raw.route';
 
 export class ApiServerMain {
   constructor(
@@ -228,11 +229,12 @@ export class ApiServerMain {
       config
     );
     const cliRoute = new CLIRoute(logger, cli, apiForIDE);
-    const vscodeRoute = new IDERoute(logger, apiForIDE);
+    const cliRawRoute = new CLIRawRoute(logger, cli, apiForIDE);
+    const ideRoute = new IDERoute(logger, apiForIDE);
     const sseEventsRoute = new SSEEventsRoute(logger, cli);
     // register only when the workspace is available. don't register this on a remote-scope, for security reasons.
     if (workspace) {
-      express.register([cliRoute, vscodeRoute, sseEventsRoute]);
+      express.register([cliRoute, cliRawRoute, ideRoute, sseEventsRoute]);
     }
 
     return apiServer;

--- a/scopes/harmony/api-server/cli-raw.route.ts
+++ b/scopes/harmony/api-server/cli-raw.route.ts
@@ -1,0 +1,66 @@
+import { CLIMain, CLIParser } from '@teambit/cli';
+import chalk from 'chalk';
+import { Route, Request, Response } from '@teambit/express';
+import { Logger } from '@teambit/logger';
+import legacyLogger from '@teambit/legacy/dist/logger/logger';
+import { APIForIDE } from './api-for-ide';
+
+/**
+ * example usage:
+ * post to http://localhost:3000/api/cli
+ * with the following json as the body
+ *
+{
+    "command": ["tag comp1 --build"]
+}
+ */
+export class CLIRawRoute implements Route {
+  constructor(private logger: Logger, private cli: CLIMain, private apiForIDE: APIForIDE) {}
+
+  method = 'post';
+  route = '/cli-raw';
+
+  middlewares = [
+    async (req: Request, res: Response) => {
+      const { command, pwd } = req.body;
+      this.logger.debug(`cli-raw server: got request for ${command}`);
+      if (pwd && !process.cwd().startsWith(pwd)) {
+        throw new Error(`bit-server is running on a different directory. bit-server: ${process.cwd()}, pwd: ${pwd}`);
+      }
+
+      const randomNumber = Math.floor(Math.random() * 10000); // helps to distinguish between commands in the log
+      const cmdStrLog = `${randomNumber} ${command}`;
+      await this.apiForIDE.logStartCmdHistory(cmdStrLog);
+      legacyLogger.isDaemon = true;
+      enableChalk();
+      const cliParser = new CLIParser(this.cli.commands, this.cli.groups, this.cli.onCommandStartSlot);
+      try {
+        const commandRunner = await cliParser.parse(command.split(' '));
+        const result = await commandRunner.runCommand(true);
+        await this.apiForIDE.logFinishCmdHistory(cmdStrLog, 0);
+        res.json(result);
+      } catch (err: any) {
+        await this.apiForIDE.logFinishCmdHistory(cmdStrLog, 1);
+        res.status(500);
+        res.jsonp({
+          message: err.message,
+          error: err,
+        });
+      } finally {
+        this.logger.clearStatusLine();
+        // change chalk back to false, otherwise, the IDE will have colors. (this is a global setting)
+        chalk.enabled = false;
+      }
+    },
+  ];
+}
+
+/**
+ * because this gets called from the express server, which gets spawn from a script, chalk defaults to false.
+ * changing only the "level" is not enough, it must be enabled as well.
+ * only when calling this route from the terminal, we want colors. on the IDE, we don't want colors.
+ */
+function enableChalk() {
+  chalk.enabled = true;
+  chalk.level = 3;
+}

--- a/scopes/harmony/api-server/cli.route.ts
+++ b/scopes/harmony/api-server/cli.route.ts
@@ -32,7 +32,9 @@ export class CLIRoute implements Route {
         const command = this.cli.getCommandByNameOrAlias(req.params.cmd);
         if (!command) throw new Error(`command "${req.params.cmd}" was not found`);
         const body = req.body;
-        const { args, options, format, isTerminal } = body;
+        const { args, options, format, isTerminal, pwd } = body;
+        if (pwd && !process.cwd().startsWith(pwd))
+          throw new Error(`bit-server is running on a different directory. bit-server: ${process.cwd()}, pwd: ${pwd}`);
         if (format && format !== 'json' && format !== 'report') throw new Error(`format "${format}" is not supported`);
         const outputMethod: 'json' | 'report' = format || 'json';
         if (!command[outputMethod])

--- a/scopes/harmony/api-server/cli.route.ts
+++ b/scopes/harmony/api-server/cli.route.ts
@@ -29,7 +29,7 @@ export class CLIRoute implements Route {
       this.logger.debug(`cli server: got request for ${req.params.cmd}`);
       let cmdStrLog: string | undefined;
       try {
-        const command = this.cli.getCommand(req.params.cmd);
+        const command = this.cli.getCommandByNameOrAlias(req.params.cmd);
         if (!command) throw new Error(`command "${req.params.cmd}" was not found`);
         const body = req.body;
         const { args, options, format, isTerminal } = body;

--- a/scopes/harmony/api-server/cli.route.ts
+++ b/scopes/harmony/api-server/cli.route.ts
@@ -1,9 +1,7 @@
-import { CLIMain, CLIParser } from '@teambit/cli';
+import { CLIMain } from '@teambit/cli';
 import prettyTime from 'pretty-time';
-import chalk from 'chalk';
 import { Route, Request, Response } from '@teambit/express';
 import { Logger } from '@teambit/logger';
-import legacyLogger from '@teambit/legacy/dist/logger/logger';
 import { camelCase } from 'lodash';
 import { APIForIDE } from './api-for-ide';
 
@@ -33,9 +31,7 @@ export class CLIRoute implements Route {
         const command = this.cli.getCommandByNameOrAlias(req.params.cmd);
         if (!command) throw new Error(`command "${req.params.cmd}" was not found`);
         const body = req.body;
-        const { args, options, format, isTerminal, pwd, raw } = body;
-        if (pwd && !process.cwd().startsWith(pwd))
-          throw new Error(`bit-server is running on a different directory. bit-server: ${process.cwd()}, pwd: ${pwd}`);
+        const { args, options, format } = body;
         if (format && format !== 'json' && format !== 'report') throw new Error(`format "${format}" is not supported`);
         const outputMethod: 'json' | 'report' = format || 'json';
         if (!command[outputMethod])
@@ -46,7 +42,7 @@ export class CLIRoute implements Route {
         const argsStr = args ? ` ${args.join(' ')}` : '';
         const optsStr = optsToString ? ` ${optsToString}` : '';
         const cmdStr = req.params.cmd + argsStr + optsStr;
-        if (!isTerminal) this.logger.console(`[*] started a new ${outputMethod} command: ${cmdStr}`);
+        this.logger.console(`[*] started a new ${outputMethod} command: ${cmdStr}`);
         const randomNumber = Math.floor(Math.random() * 10000); // helps to distinguish between commands in the log
         cmdStrLog = `${randomNumber} ${cmdStr}`;
         await this.apiForIDE.logStartCmdHistory(cmdStrLog);
@@ -56,50 +52,23 @@ export class CLIRoute implements Route {
           return acc;
         }, {});
         const startTask = process.hrtime();
-        // because this gets called from the express server, which gets spawn from a script, chalk defaults to false.
-        // changing only the "level" is not enough, it must be enabled as well.
-        // only when calling this route from the terminal, we want colors. on the IDE, we don't want colors.
-        if (isTerminal) {
-          chalk.enabled = true;
-          chalk.level = 3;
-        }
-
-        if (isTerminal && raw) {
-          legacyLogger.isDaemon = true;
-          const cliParser = new CLIParser(this.cli.commands, this.cli.groups, this.cli.onCommandStartSlot);
-          try {
-            const commandRunner = await cliParser.parse(raw);
-            const result = await commandRunner.runCommand(true);
-            res.json(result);
-          } catch (err: any) {
-            res.status(500);
-            res.jsonp({
-              message: err.message,
-              error: err,
-            });
-          }
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        const result = await command[outputMethod]!(args || [], optionsAsCamelCase);
+        this.logger.clearStatusLine();
+        const duration = prettyTime(process.hrtime(startTask));
+        this.logger.consoleSuccess(`command "${req.params.cmd}" had been completed in ${duration}`);
+        await this.apiForIDE.logFinishCmdHistory(cmdStrLog, 0);
+        if (outputMethod === 'json') {
+          res.json(result);
         } else {
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-          const result = await command[outputMethod]!(args || [], optionsAsCamelCase);
-          this.logger.clearStatusLine();
-          const duration = prettyTime(process.hrtime(startTask));
-          if (!isTerminal) this.logger.consoleSuccess(`command "${req.params.cmd}" had been completed in ${duration}`);
-          await this.apiForIDE.logFinishCmdHistory(cmdStrLog, 0);
-          // change chalk back to false, otherwise, the IDE will have colors. (this is a global setting)
-          chalk.enabled = false;
-          if (outputMethod === 'json') {
-            res.json(result);
-          } else {
-            const data = typeof result === 'string' ? result : result.data;
-            const exitCode = typeof result === 'string' ? 0 : result.code;
-            res.json({ data, exitCode });
-          }
+          const data = typeof result === 'string' ? result : result.data;
+          const exitCode = typeof result === 'string' ? 0 : result.code;
+          res.json({ data, exitCode });
         }
       } catch (err: any) {
         this.logger.error(`command "${req.params.cmd}" had failed`, err);
         this.logger.consoleFailure(`command "${req.params.cmd}" had failed. ${err.message}`);
         if (cmdStrLog) await this.apiForIDE.logFinishCmdHistory(cmdStrLog, 1);
-        chalk.enabled = false;
         res.status(500);
         res.jsonp({
           message: err.message,

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -17,24 +17,19 @@ export class ServerNotFound extends Error {
   }
 }
 
+type CommandResult = { data: any; exitCode: number };
+
 export class ServerCommander {
-  private isJson = false;
   async execute() {
     try {
       const results = await this.runCommandWithHttpServer();
       if (results) {
-        if (this.isJson) {
-          const code = results.code || 0;
-          const data = results.data || results;
-          // eslint-disable-next-line no-console
-          console.log(JSON.stringify(data, null, 2));
-          process.exit(code);
-        } else {
-          loader.off();
-          // eslint-disable-next-line no-console
-          console.log(results.data);
-          process.exit(results.exitCode);
-        }
+        const { data, exitCode } = results;
+        loader.off();
+        const dataToPrint = typeof data === 'string' ? data : JSON.stringify(data, undefined, 2);
+        // eslint-disable-next-line no-console
+        console.log(dataToPrint);
+        process.exit(exitCode);
       }
 
       process.exit(0);
@@ -46,28 +41,16 @@ export class ServerCommander {
     }
   }
 
-  async runCommandWithHttpServer(): Promise<Record<string, any> | undefined> {
+  async runCommandWithHttpServer(): Promise<CommandResult | undefined> {
     const port = await this.getExistingUsedPort();
     const url = `http://localhost:${port}/api`;
     this.initSSE(url);
     // parse the args and options from the command
-    const [cmd, ...rest] = process.argv.slice(2);
-    const args = rest.filter((arg) => !arg.startsWith('-'));
-    const options = rest
-      .filter((arg) => arg.startsWith('-'))
-      .reduce((acc, curr) => {
-        const opt = curr.startsWith('--') ? curr.slice(2) : curr.slice(1);
-        const [key, val] = opt.split('=');
-        acc[key] = val || true;
-        return acc;
-      }, {} as Record<string, boolean | string>);
+    const command = process.argv.slice(2).join(' ');
 
-    this.isJson = Boolean(options.json || options.j);
-    if (!this.isJson) loader.on();
-    const endpoint = `cli/${cmd}`;
-    const format = this.isJson ? 'json' : 'report';
+    const endpoint = `cli-raw`;
     const pwd = process.cwd();
-    const body = { args, options, format, isTerminal: true, pwd, raw: process.argv.slice(2) };
+    const body = { command, pwd };
     let res;
     try {
       res = await fetch(`${url}/${endpoint}`, {
@@ -79,7 +62,7 @@ export class ServerCommander {
       if (err.code === 'ECONNREFUSED') {
         throw new ServerNotFound(port);
       }
-      throw new Error(`failed to run command "${cmd}" on the server. ${err.message}`);
+      throw new Error(`failed to run command "${command}" on the server. ${err.message}`);
     }
 
     if (res.ok) {

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -46,8 +46,11 @@ export class ServerCommander {
     const url = `http://localhost:${port}/api`;
     this.initSSE(url);
     // parse the args and options from the command
-    const command = process.argv.slice(2).join(' ');
-
+    const args = process.argv.slice(2);
+    if (!args.includes('--json') && !args.includes('-j')) {
+      loader.on();
+    }
+    const command = args.join(' ');
     const endpoint = `cli-raw`;
     const pwd = process.cwd();
     const body = { command, pwd };

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -66,7 +66,8 @@ export class ServerCommander {
     if (!this.isJson) loader.on();
     const endpoint = `cli/${cmd}`;
     const format = this.isJson ? 'json' : 'report';
-    const body = { args, options, format, isTerminal: true };
+    const pwd = process.cwd();
+    const body = { args, options, format, isTerminal: true, pwd };
     let res;
     try {
       res = await fetch(`${url}/${endpoint}`, {
@@ -92,10 +93,7 @@ export class ServerCommander {
     } catch (e: any) {
       // the response is not json, ignore the body.
     }
-    const errMsg = `${jsonResponse?.message || jsonResponse || res.statusText}. (error from bit-server, endpoint: ${
-      res.url
-    })`;
-    throw new Error(errMsg);
+    throw new Error(jsonResponse?.message || jsonResponse || res.statusText);
   }
 
   /**

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -146,7 +146,7 @@ export class ServerCommander {
 }
 
 export function shouldUseBitServer() {
-  const commandsToSkip = ['start', 'run', 'watch', 'init'];
+  const commandsToSkip = ['start', 'run', 'watch', 'init', 'server'];
   return (
     process.env.BIT_CLI_SERVER &&
     !process.argv.includes('--help') &&

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -109,9 +109,11 @@ export class ServerCommander {
    */
   private initSSE(url: string) {
     const eventSource = new EventSource(`${url}/sse-events`);
-    eventSource.onerror = (error: any) => {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    eventSource.onerror = (_error: any) => {
       // eslint-disable-next-line no-console
-      console.error('Error occurred in SSE connection:', error);
+      // console.error('Error occurred in SSE connection:', _error);
+      // probably was unable to connect to the server and will throw ServerNotFound right after. no need to show this error.
       eventSource.close();
     };
     eventSource.addEventListener('onLoader', (event: any) => {

--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -67,7 +67,7 @@ export class ServerCommander {
     const endpoint = `cli/${cmd}`;
     const format = this.isJson ? 'json' : 'report';
     const pwd = process.cwd();
-    const body = { args, options, format, isTerminal: true, pwd };
+    const body = { args, options, format, isTerminal: true, pwd, raw: process.argv.slice(2) };
     let res;
     try {
       res = await fetch(`${url}/${endpoint}`, {

--- a/scopes/harmony/cli/cli.cmd.ts
+++ b/scopes/harmony/cli/cli.cmd.ts
@@ -72,7 +72,8 @@ export class CliCmd implements Command {
       rl.on('line', async (line) => {
         const cmd = line.trim().split(' ');
         try {
-          await cliParser.parse(cmd);
+          const commandRunner = await cliParser.parse(cmd);
+          await commandRunner.runCommand();
         } catch (err: any) {
           await handleErrorAndExit(err, cmd[0]);
         }

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -138,7 +138,8 @@ export class CLIMain {
   async run(hasWorkspace: boolean) {
     await this.invokeOnStart(hasWorkspace);
     const CliParser = new CLIParser(this.commands, this.groups, this.onCommandStartSlot);
-    await CliParser.parse();
+    const commandRunner = await CliParser.parse();
+    await commandRunner.runCommand();
   }
 
   private async invokeOnStart(hasWorkspace: boolean) {

--- a/scopes/harmony/cli/cli.main.runtime.ts
+++ b/scopes/harmony/cli/cli.main.runtime.ts
@@ -74,6 +74,12 @@ export class CLIMain {
     return this.commands.find((command) => getCommandId(command.name) === name);
   }
 
+  getCommandByNameOrAlias(name: string): Command | undefined {
+    const command = this.getCommand(name);
+    if (command) return command;
+    return this.commands.find((cmd) => cmd.alias === name);
+  }
+
   /**
    * when running `bit help`, commands are grouped by categories.
    * this method helps registering a new group by providing its name and a description.

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -22,21 +22,22 @@ export class CommandRunner {
   /**
    * run command using one of the handler, "json"/"report"/"render". once done, exit the process.
    */
-  async runCommand() {
+  async runCommand(shouldReturnResult = false) {
     try {
       this.bootstrapCommand();
       await this.invokeOnCommandStart();
       this.determineConsoleWritingDuringCommand();
       if (this.flags.json) {
-        return await this.runJsonHandler();
+        return await this.runJsonHandler(shouldReturnResult);
       }
       if (this.command.report) {
-        return await this.runReportHandler();
+        return await this.runReportHandler(shouldReturnResult);
       }
       if (this.command.wait) {
         return await this.runWaitHandler();
       }
     } catch (err: any) {
+      if (shouldReturnResult) throw err;
       return handleErrorAndExit(err, this.commandName);
     }
 
@@ -64,21 +65,23 @@ export class CommandRunner {
    * this works for both, Harmony commands and Legacy commands (the legacy-command-adapter
    * implements json() method)
    */
-  private async runJsonHandler() {
+  private async runJsonHandler(shouldReturnResult = false) {
     if (!this.flags.json) return null;
     if (!this.command.json) throw new Error(`command "${this.commandName}" doesn't implement "json" method`);
     const result = await this.command.json(this.args, this.flags);
     const code = result.code || 0;
     const data = result.data || result;
+    if (shouldReturnResult) return { data, exitCode: code };
     return this.writeAndExit(JSON.stringify(data, null, 2), code);
   }
 
-  private async runReportHandler() {
+  private async runReportHandler(shouldReturnResult = false) {
     if (!this.command.report) throw new Error('runReportHandler expects command.report to be implemented');
     const result = await this.command.report(this.args, this.flags);
     loader.off();
     const data = typeof result === 'string' ? result : result.data;
     const exitCode = typeof result === 'string' ? 0 : result.code;
+    if (shouldReturnResult) return { data, exitCode };
     return this.writeAndExit(`${data}\n`, exitCode);
   }
 

--- a/scopes/harmony/cli/index.ts
+++ b/scopes/harmony/cli/index.ts
@@ -1,5 +1,5 @@
 import { CLIAspect, MainRuntime } from './cli.aspect';
-
+export { CLIParser } from './cli-parser';
 export type { CLIMain, CommandList, CommandsSlot } from './cli.main.runtime';
 export { handleUnhandledRejection, handleErrorAndExit } from './handle-errors';
 export type { Command, CLIArgs, Flags, GenericObject, CommandOptions } from '@teambit/legacy/dist/cli/command';

--- a/scopes/harmony/cli/yargs-adapter.ts
+++ b/scopes/harmony/cli/yargs-adapter.ts
@@ -12,6 +12,7 @@ export class YargsAdapter implements CommandModule {
   command: string;
   describe?: string;
   aliases?: string;
+  commandRunner?: CommandRunner;
   constructor(private commanderCommand: Command, private onCommandStartSlot: OnCommandStartSlot) {
     this.command = commanderCommand.name;
     this.describe = commanderCommand.description;
@@ -45,7 +46,7 @@ export class YargsAdapter implements CommandModule {
     this.commanderCommand._packageManagerArgs = (argv['--'] || []) as string[];
 
     const commandRunner = new CommandRunner(this.commanderCommand, argsValues, flags, this.onCommandStartSlot);
-    return commandRunner.runCommand();
+    this.commandRunner = commandRunner;
   }
 
   get positional() {


### PR DESCRIPTION
Related to the [new bit-cli-server feature](https://github.com/teambit/bit/pull/9076). Turns out that cli args that accept array were parsed as non-array. Also, sub-commands weren't working.

This PR changes the way how it communicates with bit-server. Instead of parsing the args from the cli and sending the parsed data into `api/cli/:cmd` route, it sends them as is to a new `api/cli-raw` route. 
The new route, instead of calling the `report` or `json` command method directly, it goes to Yargs, let it finds the command and then returns the `CommandRunner` instance which the return result can be retrieved from. 