### PR TITLE
fix(bit-cli-server), delete the server-port file in case the port is not available

### DIFF
--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -71,6 +71,7 @@ export class ServerCommander {
       });
     } catch (err: any) {
       if (err.code === 'ECONNREFUSED') {
+        await this.deleteServerPortFile();
         throw new ServerNotFound(port);
       }
       throw new Error(`failed to run command "${command}" on the server. ${err.message}`);
@@ -128,6 +129,11 @@ export class ServerCommander {
       }
       throw err;
     }
+  }
+
+  async deleteServerPortFile() {
+    const filePath = this.getServerPortFilePath();
+    await fs.remove(filePath);
   }
 
   private getServerPortFilePath() {


### PR DESCRIPTION
This way, on the next run, it does't have to try to re-connect again.