### PR TITLE
fix(docs): gracefully handle missing compositions

### DIFF
--- a/scopes/docs/docs/docs.preview.runtime.tsx
+++ b/scopes/docs/docs/docs.preview.runtime.tsx
@@ -9,7 +9,7 @@ export type DocsRootProps = {
   Provider: React.ComponentType | undefined;
   componentId: string;
   docs: Docs | undefined;
-  compositions: any;
+  compositions?: any;
   context: RenderingContext;
 };
 

--- a/scopes/docs/docs/docs.preview.runtime.tsx
+++ b/scopes/docs/docs/docs.preview.runtime.tsx
@@ -25,10 +25,11 @@ export class DocsPreview {
     componentId: ComponentID,
     envId: string,
     modules: PreviewModule,
-    [compositions]: [any],
+    [compositionsFromParams]: [any],
     context: RenderingContext
   ) => {
     const docsModule = this.selectPreviewModel(componentId.fullName, modules);
+    const compositions = compositionsFromParams || [];
 
     const mainModule = modules.modulesMap[envId] || modules.modulesMap.default;
     let defaultExports = mainModule.default;

--- a/scopes/html/html/html-docs-app.ts
+++ b/scopes/html/html/html-docs-app.ts
@@ -3,7 +3,7 @@ import { DocsRootProps } from '@teambit/docs';
 import DocsRoot from '@teambit/react.ui.docs-app';
 import { htmlToReact } from './html-to-react';
 
-const htmlDocsRoot = function ({ compositions, ...rest }: DocsRootProps) {
+const htmlDocsRoot = function ({ compositions = {}, ...rest }: DocsRootProps) {
   // should be mapObject<Record<string, any>, Record<string, () => any>>
   // @ts-ignore TODO fix
   const reactCompositions = mapObject(compositions, (key, value) => [key, htmlToReact(value as HTMLElement)]);


### PR DESCRIPTION
This PR updates the docs preview runtime by gracefully handling missing compositions. When the onlyOverview param is true, compositions in the docs iframe are mounted from the client side - which results in the docs preview runtime receiving an empty array of compositions. Before this fix, the docs preview runtime would just try to extract the first element from the compositions array and forward it to the mounters - which resulted them in receiving it as undefined during runtime (even though the docs props indicated that the compositions prop is not optional)

With this fix, we fallback to an empty array when there are missing compositions so the mounters don't get undefined for compositions prop. 