### PR TITLE
fix(log), throw an error when a component was not found

### DIFF
--- a/scopes/component/component-log/component-log.main.runtime.ts
+++ b/scopes/component/component-log/component-log.main.runtime.ts
@@ -51,7 +51,7 @@ export class ComponentLogMain {
     }
     if (!this.workspace) throw new OutsideWorkspaceError();
     const componentId = await this.workspace.resolveComponentId(id);
-    const logs = await this.workspace.scope.getLogs(componentId, shortHash);
+    const logs = await this.workspace.scope.getLogs(componentId, shortHash, undefined, true);
     logs.forEach((log) => {
       log.date = log.date ? moment(new Date(parseInt(log.date))).format('YYYY-MM-DD HH:mm:ss') : undefined;
       log.message = shortMessage ? log.message.split('\n')[0] : log.message;

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -850,8 +850,13 @@ export class ScopeMain implements ComponentFactory {
   /**
    * get component log sorted by the timestamp in ascending order (from the earliest to the latest)
    */
-  async getLogs(id: ComponentID, shortHash = false, startsFrom?: string): Promise<ComponentLog[]> {
-    return this.legacyScope.loadComponentLogs(id, shortHash, startsFrom);
+  async getLogs(
+    id: ComponentID,
+    shortHash = false,
+    startsFrom?: string,
+    throwIfMissing = false
+  ): Promise<ComponentLog[]> {
+    return this.legacyScope.loadComponentLogs(id, shortHash, startsFrom, throwIfMissing);
   }
 
   async getStagedConfig() {

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -530,8 +530,13 @@ once done, to continue working, please run "bit cc"`
     return removeNils(components);
   }
 
-  async loadComponentLogs(id: ComponentID, shortHash = false, startFrom?: string): Promise<ComponentLog[]> {
-    const componentModel = await this.getModelComponentIfExist(id);
+  async loadComponentLogs(
+    id: ComponentID,
+    shortHash = false,
+    startFrom?: string,
+    throwIfMissing = false
+  ): Promise<ComponentLog[]> {
+    const componentModel = throwIfMissing ? await this.getModelComponent(id) : await this.getModelComponentIfExist(id);
     if (!componentModel) return [];
     const startFromRef = startFrom ? componentModel.getRef(startFrom) ?? undefined : undefined;
     const logs = await componentModel.collectLogs(this, shortHash, startFromRef);


### PR DESCRIPTION
Currently it shows an empty line. This PR throws an error saying the component was not found.