### PR TITLE
feat(cli): init with default name from path

### DIFF
--- a/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
+++ b/scopes/harmony/host-initializer/host-initializer.main.runtime.ts
@@ -1,4 +1,5 @@
 import fs from 'fs-extra';
+import * as path from 'path';
 import { findScopePath } from '@teambit/scope.modules.find-scope-path';
 import { Consumer, getConsumerInfo } from '@teambit/legacy/dist/consumer';
 import { Scope } from '@teambit/legacy/dist/scope';
@@ -43,6 +44,11 @@ export class HostInitializerMain {
       );
     }
     const consumerPath = consumerInfo?.path || absPath || process.cwd();
+
+    workspaceConfigProps = {
+      ...workspaceConfigProps,
+      name: workspaceConfigProps.name || path.basename(consumerPath),
+    };
 
     if (reset || resetHard) {
       await resetConsumer(consumerPath, resetHard, noGit);

--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -61,12 +61,6 @@ export class InitCmd implements Command {
 
   constructor(private hostInitializer: HostInitializerMain) {}
 
-  private pathToName(path: string) {
-    const directories = pathlib.normalize(path).split(pathlib.sep);
-    const lastDir = directories[directories.length - 1];
-    return lastDir;
-  }
-
   async report([path]: [string], flags: Record<string, any>) {
     const {
       name,
@@ -99,7 +93,7 @@ export class InitCmd implements Command {
     const workspaceExtensionProps: WorkspaceExtensionProps = {
       defaultDirectory: defaultDirectory ?? getSync(CFG_INIT_DEFAULT_DIRECTORY),
       defaultScope: defaultScope ?? getSync(CFG_INIT_DEFAULT_SCOPE),
-      name: name || this.pathToName(path),
+      name,
     };
 
     const { created } = await HostInitializerMain.init(

--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -62,7 +62,7 @@ export class InitCmd implements Command {
   constructor(private hostInitializer: HostInitializerMain) {}
 
   private pathToName(path: string) {
-    const directories = path.split('/');
+    const directories = pathlib.normalize(path).split(pathlib.sep);
     const lastDir = directories[directories.length - 1];
     return lastDir;
   }

--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -61,6 +61,12 @@ export class InitCmd implements Command {
 
   constructor(private hostInitializer: HostInitializerMain) {}
 
+  private pathToName(path: string) {
+    const directories = path.split('/');
+    const lastDir = directories[directories.length - 1];
+    return lastDir;
+  }
+
   async report([path]: [string], flags: Record<string, any>) {
     const {
       name,
@@ -89,11 +95,13 @@ export class InitCmd implements Command {
     if (reset && resetHard) {
       throw new BitError('cannot use both --reset and --reset-hard, please use only one of them');
     }
+
     const workspaceExtensionProps: WorkspaceExtensionProps = {
       defaultDirectory: defaultDirectory ?? getSync(CFG_INIT_DEFAULT_DIRECTORY),
       defaultScope: defaultScope ?? getSync(CFG_INIT_DEFAULT_SCOPE),
-      name,
+      name: name || this.pathToName(path),
     };
+
     const { created } = await HostInitializerMain.init(
       path,
       standalone,


### PR DESCRIPTION
## Proposed Changes

Default workspace name to the name of the folder.
Keep existing behaviour given greater priority to the name defined with the `--name`.

Example
- `bit init foo` ➡️ workspace name `foo` 
- `bit init foor/bar/baz` ➡️ workspace name `baz` 
- `bit init foo --name qux` or `bit init foor/bar/baz --name qux` ➡️ workspace name `qux`
