### PR TITLE
fix(preview): adjust height calc when onlyOverview is set

### DIFF
--- a/scopes/preview/ui/component-preview/preview.tsx
+++ b/scopes/preview/ui/component-preview/preview.tsx
@@ -129,8 +129,9 @@ export function ComponentPreview({
       methods: {
         pub: (event, message) => {
           if (message.type === 'preview-size') {
+            const previewHeight = component.preview?.onlyOverview ? message.data.height - 150 : message.data.height;
             setWidth(message.data.width);
-            setHeight(message.data.height);
+            setHeight(previewHeight);
           }
           onLoad && event && onLoad(event, { height: message.data.height, width: message.data.width });
         },


### PR DESCRIPTION
This PR fixes the calculation of height of the preview iframe when onlyOverview is set to be true. It compensates for the extra margin set in the iframe by subtracting it from the reported height it receives via the iframe pub sub. 