### PR TITLE
fix(api-ide), send server-event of post-export

### DIFF
--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -75,6 +75,10 @@ export class ApiServerMain {
       sendEventsToClients('onWorkspaceConfigChange', {});
     });
 
+    this.workspace.scope.registerOnPostExport(async () => {
+      sendEventsToClients('onPostExport', {});
+    });
+
     this.installer.registerPostInstall(async () => {
       sendEventsToClients('onPostInstall', {});
     });

--- a/scopes/harmony/modules/send-server-sent-events/send-sse.ts
+++ b/scopes/harmony/modules/send-server-sent-events/send-sse.ts
@@ -19,6 +19,7 @@ type EventName =
   | 'onBitmapChange'
   | 'onWorkspaceConfigChange'
   | 'onPostInstall'
+  | 'onPostExport'
   | 'onLoader'
   | 'onLogWritten';
 


### PR DESCRIPTION
Without this, the IDE is not aware of `bit export` that was running from the cli. 