### PR TITLE
fix(overview): revert onlyOverview height fix

### DIFF
--- a/scopes/preview/ui/component-preview/preview.tsx
+++ b/scopes/preview/ui/component-preview/preview.tsx
@@ -129,9 +129,10 @@ export function ComponentPreview({
       methods: {
         pub: (event, message) => {
           if (message.type === 'preview-size') {
-            const previewHeight = component.preview?.onlyOverview ? message.data.height - 150 : message.data.height;
+            // const previewHeight = component.preview?.onlyOverview ? message.data.height - 150 : message.data.height;
             setWidth(message.data.width);
-            setHeight(previewHeight);
+            // setHeight(previewHeight);
+            setHeight(message.data.height);
           }
           onLoad && event && onLoad(event, { height: message.data.height, width: message.data.width });
         },

--- a/scopes/preview/ui/component-preview/preview.tsx
+++ b/scopes/preview/ui/component-preview/preview.tsx
@@ -129,6 +129,7 @@ export function ComponentPreview({
       methods: {
         pub: (event, message) => {
           if (message.type === 'preview-size') {
+            // disable this for now until we figure out how to correctly calculate the height
             // const previewHeight = component.preview?.onlyOverview ? message.data.height - 150 : message.data.height;
             setWidth(message.data.width);
             // setHeight(previewHeight);


### PR DESCRIPTION
This PR reverts change introduced by this PR https://github.com/teambit/bit/pull/9119
which resulted in some components get an incorrect height. 

We expected this change to fix it universally for all components but it doesn't cover all cases. 