### PR TITLE
fix(overview): disable scroll on composition card 

### DIFF
--- a/scopes/compositions/composition-card/composition-card.tsx
+++ b/scopes/compositions/composition-card/composition-card.tsx
@@ -41,10 +41,7 @@ function _CompositionCard({
 
   return (
     <div {...rest} key={composition.identifier} className={classnames(styles.compositionCard, className)}>
-      <div className={styles.compositionPreview}>
-        {Composition}
-        <div className={styles.previewOverlay} />
-      </div>
+      <div className={styles.compositionPreview}>{Composition}</div>
       <div className={styles.bottom}>
         <span className={classnames(ellipsis, styles.displayName)}>{composition.displayName}</span>
         {openCompositionLink && (

--- a/scopes/compositions/composition-card/composition-card.tsx
+++ b/scopes/compositions/composition-card/composition-card.tsx
@@ -27,13 +27,13 @@ function _CompositionCard({
   const Composition = React.useMemo(() => {
     return (
       <ComponentComposition
+        disableScroll
         className={previewClass}
         includeEnv={false}
         loading={'lazy'}
         composition={composition}
         component={component}
         viewport={1280}
-        scrolling="no"
         previewName="compositions"
       />
     );
@@ -41,7 +41,10 @@ function _CompositionCard({
 
   return (
     <div {...rest} key={composition.identifier} className={classnames(styles.compositionCard, className)}>
-      <div className={styles.compositionPreview}>{Composition}</div>
+      <div className={styles.compositionPreview}>
+        {Composition}
+        <div className={styles.previewOverlay} />
+      </div>
       <div className={styles.bottom}>
         <span className={classnames(ellipsis, styles.displayName)}>{composition.displayName}</span>
         {openCompositionLink && (


### PR DESCRIPTION
This PR fixes the issue in the Compositions Card rendered as part of the Overview page. With this fix, the iframe mounted in the composition card prevents scrolling. 