### PR TITLE
fix: preview entries on Windows particularly for Vite

### DIFF
--- a/scopes/preview/preview/pre-bundle.ts
+++ b/scopes/preview/preview/pre-bundle.ts
@@ -8,7 +8,7 @@ import {
   getIdentifiers,
 } from '@teambit/harmony.modules.harmony-root-generator';
 import { sha1 } from '@teambit/toolbox.crypto.sha1';
-import { toWindowsCompatiblePath } from '@teambit/toolbox.path.to-windows-compatible-path';
+import normalizePath from 'normalize-path';
 import webpack from 'webpack';
 import { promisify } from 'util';
 import { PreviewAspect } from './preview.aspect';
@@ -125,7 +125,7 @@ export async function generateBundlePreviewEntry(rootAspectId: string, previewPr
   const manifest = readJsonSync(manifestPath);
   const imports = manifest.entrypoints
     .map((entry: string) => {
-      const entryPath = toWindowsCompatiblePath(join(previewPreBundlePath, entry));
+      const entryPath = normalizePath(join(previewPreBundlePath, entry));
       return entry.endsWith('.js') || entry.endsWith('.cjs') || entry.endsWith('.mjs')
         ? `import { run } from '${entryPath}';`
         : `import '${entryPath}';`;


### PR DESCRIPTION
## Proposed Changes

- Change preview entries from `C:\\xxx\\yyy.js` to `C:/xxx/yyy.js` which is particularly for Vite compatibility. See: https://github.com/vitejs/vite/issues/17897

Related issue: #9122