### PR TITLE
fix(compositions): revert preview overlay in composition card

### DIFF
--- a/scopes/compositions/composition-card/composition-card.tsx
+++ b/scopes/compositions/composition-card/composition-card.tsx
@@ -41,10 +41,7 @@ function _CompositionCard({
 
   return (
     <div {...rest} key={composition.identifier} className={classnames(styles.compositionCard, className)}>
-      <div className={styles.compositionPreview}>
-        {Composition}
-        <div className={styles.previewOverlay} />
-      </div>
+      <div className={styles.compositionPreview}>{Composition}</div>
       <div className={styles.bottom}>
         <span className={classnames(ellipsis, styles.displayName)}>{composition.displayName}</span>
         {openCompositionLink && (


### PR DESCRIPTION
This PR reverts the addition of a overlay component that prevent interaction with the underlying preview from the composition card component. This revert aligns the current behaviour to be the same as the composition cards in the overview when overviewOnly is set to be false. 