### PR TITLE
fix(create), optimize pnpm output when running from the IDE

### DIFF
--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -246,6 +246,7 @@ export class InstallMain {
       addMissingDeps: installMissing,
       skipIfExisting: true,
       writeConfigFiles: false,
+      optimizeReportForNonTerminal: !process.stdout.isTTY,
       // skipPrune: true,
     });
   }


### PR DESCRIPTION
This PR is only for the installation during `bit create`. The output of `bit install` was fine. 