### PR TITLE
fix(export), fix output to show the exported lane in case no new snaps added

### DIFF
--- a/e2e/harmony/lanes/lanes.e2e.ts
+++ b/e2e/harmony/lanes/lanes.e2e.ts
@@ -978,7 +978,7 @@ describe('bit lane command', function () {
       expect(status.invalidComponents[0].error.name).to.equal('NoCommonSnap');
     });
     it('should be able to export with no error', () => {
-      expect(() => helper.command.export('--fork-lane-new-scope')).to.not.throw();
+      expect(() => helper.command.export('--fork-lane-new-scope --all')).to.not.throw();
     });
   });
   describe('snapping and un-tagging on a lane', () => {

--- a/scopes/scope/export/export-cmd.ts
+++ b/scopes/scope/export/export-cmd.ts
@@ -89,11 +89,12 @@ export class ExportCmd implements Command {
         ignoreMissingArtifacts,
         forkLaneNewScope,
       });
-    if (isEmpty(componentsIds) && isEmpty(nonExistOnBitMap) && isEmpty(missingScope)) {
+    if (isEmpty(componentsIds) && isEmpty(nonExistOnBitMap) && isEmpty(missingScope) && !exportedLanes.length) {
       return chalk.yellow('nothing to export');
     }
+    const exportedLane = exportedLanes[0]?.id();
     const exportOutput = () => {
-      if (isEmpty(componentsIds)) return '';
+      if (isEmpty(componentsIds)) return exportedLane ? `exported the lane ${chalk.bold(exportedLane)}` : '';
       const lanesOutput = exportedLanes.length ? ` the lane ${chalk.bold(exportedLanes[0].id())} and` : '';
       return chalk.green(
         `exported${lanesOutput} the following ${componentsIds.length} component(s):\n${chalk.bold(

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -136,7 +136,7 @@ export class ExportMain {
       includeNonStaged || headOnly
     );
 
-    if (!idsToExport.length) {
+    if (!idsToExport.length && !laneObject) {
       return {
         updatedIds: [],
         nonExistOnBitMap: [],

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -148,6 +148,10 @@ export class ExportMain {
         rippleJobs: [],
       };
     }
+    if (!idsToExport.length && laneObject && params.forkLaneNewScope) {
+      throw new BitError(`the forked lane "${laneObject.name}" has no changes, to export all its components, please use "--all" flag
+if the export fails with missing objects/versions/components, run "bit fetch --lanes <lane-name> --all-history", to make sure you have the full history locally`);
+    }
 
     // validate lane readme component and ensure it has been snapped
     if (laneObject?.readmeComponent) {


### PR DESCRIPTION
In some cases, the export doesn't bring any new component or snap/tag to the remote, but it does update the lane object. It happens for example in the following two cases:
1. when a lane has forked from another lane and exported immediately to the same scope, without adding new snaps. 
2. when merging another lane where all snaps already in the remote.

Until now, it was showing "nothing to export" for both cases above. The first case actually didn't do any action and nothing was exported, the second case the message is misleading because the lane object itself was exported.

This PR fix both cases. The first case is now exporting the new lane to the remote and for both cases it shows the message "exported the lane xxx/yyy" in the output.