### PR TITLE
fix(sign), support --push to a local scope

### DIFF
--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -214,8 +214,7 @@ describe('sign command', function () {
       const version = pkgAspectData.data.pkgJson.version;
       expect(version).to.equal(`0.0.0-${firstSnapHash}`);
     });
-    // todo: support exporting to a non-hub
-    it.skip('should sign the last successfully and export', () => {
+    it('should sign the last successfully and export', () => {
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, signRemote.scopePath);
       signOutput = helper.command.sign(
         [`${secondScopeName}/comp1@${snapHash}`],
@@ -225,7 +224,7 @@ describe('sign command', function () {
       expect(signOutput).to.include('the following 1 component(s) were signed with build-status "succeed"');
     });
   });
-  describe.skip('circular dependencies between two scopes', () => {
+  describe('circular dependencies between two scopes', () => {
     let signOutput: string;
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
@@ -239,14 +238,14 @@ describe('sign command', function () {
       helper.workspaceJsonc.addToVariant('comp2', 'defaultScope', secondRemote.scopeName);
       helper.command.addComponent('comp2');
       helper.command.linkAndCompile();
-      helper.command.tagAllWithoutBuild();
+      helper.command.tagAllWithoutBuild('--ignore-issues="CircularDependencies"');
       helper.command.export();
 
       const signRemote = helper.scopeHelper.getNewBareScope('-remote-sign');
       helper.scopeHelper.addRemoteScope(secondRemote.scopePath, signRemote.scopePath);
       signOutput = helper.command.sign(
         [`${helper.scopes.remote}/comp1`, `${secondRemote.scopeName}/comp2`],
-        '',
+        '--push',
         signRemote.scopePath
       );
     });

--- a/e2e/harmony/sign.e2e.ts
+++ b/e2e/harmony/sign.e2e.ts
@@ -215,6 +215,7 @@ describe('sign command', function () {
       expect(version).to.equal(`0.0.0-${firstSnapHash}`);
     });
     it('should sign the last successfully and export', () => {
+      signRemote = helper.scopeHelper.getNewBareScope('-remote-sign');
       helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, signRemote.scopePath);
       signOutput = helper.command.sign(
         [`${secondScopeName}/comp1@${snapHash}`],

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -573,7 +573,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     return ejectResults;
   }
 
-  private async pushToRemotesCarefully(manyObjectsPerRemote: ObjectsPerRemote[], resumeExportId?: string) {
+  async pushToRemotesCarefully(manyObjectsPerRemote: ObjectsPerRemote[], resumeExportId?: string) {
     const remotes = manyObjectsPerRemote.map((o) => o.remote);
     const clientId = resumeExportId || Date.now().toString();
     await this.pushRemotesPendingDir(clientId, manyObjectsPerRemote, resumeExportId);
@@ -611,7 +611,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     });
   }
 
-  private shouldPushToCentralHub(
+  shouldPushToCentralHub(
     manyObjectsPerRemote: ObjectsPerRemote[],
     scopeRemotes: Remotes,
     originDirectly = false


### PR DESCRIPTION
Until now, `bit sign --push` was supported only on the cloud. With this PR, `--push` works also on a local bare scope.