### PR TITLE
fix, always try to load objects from repo.objects before going to cache or fs

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -1013,7 +1013,7 @@ another option, in case this dependency is not in main yet is to remove all refe
     const component =
       consumerComponent.modelComponent || // @todo: fix the ts error here with "source"
       (await this.scope.legacyScope.sources.findOrAddComponent(consumerComponent as any));
-    const version = await component.loadVersion(consumerComponent.id.version as string, this.objectsRepo, true, true);
+    const version = await component.loadVersion(consumerComponent.id.version as string, this.objectsRepo, true);
     if (modifiedLog) version.addModifiedLog(modifiedLog);
     const artifactFiles = getArtifactsFiles(consumerComponent.extensions);
     const artifacts = this.transformArtifactsFromVinylToSource(artifactFiles);

--- a/scopes/harmony/modules/in-memory-cache/in-memory-cache.ts
+++ b/scopes/harmony/modules/in-memory-cache/in-memory-cache.ts
@@ -16,9 +16,9 @@ export type CacheOptions = {
 };
 
 export function getMaxSizeForComponents(): number {
-  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_COMPONENTS) || 1000;
+  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_COMPONENTS) || 500;
 }
 
 export function getMaxSizeForObjects(): number {
-  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_OBJECTS) || 5000;
+  return getNumberFromConfig(CFG_CACHE_MAX_ITEMS_OBJECTS) || 3000;
 }

--- a/src/scope/models/model-component.ts
+++ b/src/scope/models/model-component.ts
@@ -790,15 +790,10 @@ export default class Component extends BitObject {
     return componentObject;
   }
 
-  async loadVersion(
-    versionStr: string,
-    repository: Repository,
-    throws = true,
-    preferInMemoryObjects = false
-  ): Promise<Version> {
+  async loadVersion(versionStr: string, repository: Repository, throws = true): Promise<Version> {
     const versionRef = this.getRef(versionStr);
     if (!versionRef) throw new VersionNotFound(versionStr, this.id());
-    const version = await repository.load(versionRef, false, preferInMemoryObjects);
+    const version = await repository.load(versionRef, false);
     if (!version && throws) throw new VersionNotFoundOnFS(versionStr, this.id());
     return version as Version;
   }

--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -165,14 +165,12 @@ export default class Repository {
     return compact(existingRefs);
   }
 
-  async load(ref: Ref, throws = false, preferInMemoryObjects = false): Promise<BitObject> {
-    if (preferInMemoryObjects) {
-      // during tag, the updated objects are in `this.objects`.
-      // `this.cache` is less reliable, because if it reaches its max, then it loads from the filesystem, which may not
-      // be there yet (in case of "version" object), or may be out-of-date (in case of "component" object).
-      const inMemoryObjects = this.objects[ref.hash.toString()];
-      if (inMemoryObjects) return inMemoryObjects;
-    }
+  async load(ref: Ref, throws = false): Promise<BitObject> {
+    // during tag, the updated objects are in `this.objects`.
+    // `this.cache` is less reliable, because if it reaches its max, then it loads from the filesystem, which may not
+    // be there yet (in case of "version" object), or may be out-of-date (in case of "component" object).
+    const inMemoryObjects = this.objects[ref.hash.toString()];
+    if (inMemoryObjects) return inMemoryObjects;
     if (ref.hash.length < HASH_SIZE) {
       ref = await this.getFullRefFromShortHash(ref);
     }


### PR DESCRIPTION
See a previous PR for more context - https://github.com/teambit/bit/pull/6404/files.
It's about tag/snap where the component version is changed to a future version and later on during the process the workspace/scope asking for this component by the ID. 
Turned out that in some cases this is still an issue. It fails in different places than the PR above.
In this PR, instead of passing the `preferInMemoryObjects` argument in more places, and then potentially failing in different places in the future, we simply go to the `objects` array in all cases and only if not found, we try other sources. 
