### PR TITLE
fix(snap-from-scope), set a lane as new in scope.json to avoid fetching it from a remote

### DIFF
--- a/e2e/harmony/snap-from-scope.e2e.ts
+++ b/e2e/harmony/snap-from-scope.e2e.ts
@@ -353,6 +353,50 @@ export const BasicIdInput = () => {
       expect(devFiles.data.devPatterns).to.not.be.undefined;
     });
   });
+  describe('snap a new component in a new lane and existing dependency', () => {
+    let catLane;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      const bareTag = helper.scopeHelper.getNewBareScope('-bare-merge');
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareTag.scopePath);
+
+      const data = [
+        {
+          componentId: `${helper.scopes.remote}/foo`,
+          files: [
+            {
+              path: 'index.ts',
+              content: '',
+            },
+          ],
+          isNew: true,
+          aspects: {
+            'teambit.react/react': {},
+            'teambit.envs/envs': {
+              env: 'teambit.react/react',
+            },
+          },
+          newDependencies: [
+            {
+              id: `${helper.scopes.remote}/comp1`,
+              isComponent: true,
+              type: 'runtime',
+            },
+          ],
+        },
+      ];
+      // console.log('data', JSON.stringify(data));
+      helper.command.snapFromScope(bareTag.scopePath, data, `--lane ${helper.scopes.remote}/dev`);
+      catLane = helper.command.catLane('dev', bareTag.scopePath);
+    });
+    it('should create the lane and snap the new component into the new lane', () => {
+      expect(catLane.components).to.have.lengthOf(1);
+    });
+  });
   describe('adding dependents to the lane with --update-dependents flag', () => {
     let comp3HeadOnLane: string;
     let comp2HeadOnMain: string;

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -398,6 +398,10 @@ if you're willing to lose the history from the head to the specified version, us
         if (err.constructor.name !== LaneNotFound.name) throw err;
         // if the lane is not found, it's probably because it's new. create a new lane.
         lane = await createLaneInScope(laneId.name, this.scope, laneId.scope);
+        // it's important to set the lane as new in scope.json. otherwise, later, when importing and the lane is loaded
+        // from the filesystem, it looses the "isNew: true", and then it tries to fetch the lane from the remote scope.
+        // which fails with the importer.
+        this.scope.legacyScope.scopeJson.setLaneAsNew(laneId.name);
       }
       // this is critical. otherwise, later on, when loading aspects and isolating capsules, we'll try to fetch dists
       // from the original scope instead of the lane-scope.


### PR DESCRIPTION
The bug happened when snapping from scope a component with dependencies and creating a new lane. The `getLaneForFetcher` method was calling `scope.getCurrentLaneObject()`, which re-load the lane object from the filesystem and as a result, lost the `isNew: true` prop. 
This PR, mimics the behavior on the workspace, which is saving the info about the lane being new in scope.json. This way, loading the lane guarantees to have `isNew: true`. 