### PR TITLE
feat, recognize typescipt import-type syntax as dev-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -161,7 +161,7 @@
     "@teambit/toolbox.string.random": "~0.0.1",
     "@teambit/cloud.models.cloud-user": "~0.0.5",
     "@teambit/component-id": "^1.2.0",
-    "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.6",
+    "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.8",
     "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.1",
     "@teambit/toolbox.fs.readdir-skip-system-files": "~0.0.2",
     "@teambit/scope.modules.find-scope-path": "~0.0.1",

--- a/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/auto-detect-deps.ts
@@ -428,6 +428,9 @@ export class AutoDetectDeps {
         }
       }
       const currentComponentsDeps = new Dependency(existingId, [], compDep.name, peerVersionRange);
+      if (this.tree[originFile].devDeps.includes(compDep.name)) {
+        fileType.isTestFile = true;
+      }
       this._pushToDependenciesIfNotExist(currentComponentsDeps, {
         fileType,
         depDebug,
@@ -486,11 +489,14 @@ export class AutoDetectDeps {
     const packageNames = Object.keys(packages).concat(this.tree[originFile].missing?.packages ?? []);
     this._addTypesPackagesForTypeScript(packageNames, originFile);
     if (!packages || isEmpty(packages)) return;
-    if (fileType.isTestFile) {
-      Object.assign(this.allPackagesDependencies.devPackageDependencies, packages);
-    } else {
-      Object.assign(this.allPackagesDependencies.packageDependencies, packages);
-    }
+    Object.keys(packages).forEach((packageName) => {
+      const isDev = fileType.isTestFile || this.tree[originFile].devDeps.includes(packageName);
+      if (isDev) {
+        Object.assign(this.allPackagesDependencies.devPackageDependencies, { [packageName]: packages[packageName] });
+      } else {
+        Object.assign(this.allPackagesDependencies.packageDependencies, { [packageName]: packages[packageName] });
+      }
+    });
   }
 
   private processMissing(originFile: PathLinuxRelative, fileType: FileType) {

--- a/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/dependency-tree/index.ts
@@ -141,6 +141,8 @@ module.exports._getDependencies = function (config) {
     if (!isDependenciesArray && dependenciesRaw[dependency].importSpecifiers) {
       // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
       pathMap.importSpecifiers = dependenciesRaw[dependency].importSpecifiers;
+      // @ts-ignore
+      pathMap.isTypeImport = dependenciesRaw[dependency].isTypeImport;
     }
 
     // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!

--- a/scopes/dependencies/dependencies/files-dependency-builder/path-map.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/path-map.ts
@@ -13,6 +13,7 @@ export type PathMapDependency = {
   importSource: string; // dependency path as it has been received from dependency-tree lib
   resolvedDep: string; // path relative to consumer root (after convertPathMapToRelativePaths() )
   importSpecifiers?: Specifier[]; // relevant for ES6 and TS
+  isTypeImport?: boolean; // relevant for TS. (e.g. import type x from 'y')
 };
 
 /**

--- a/scopes/dependencies/dependencies/files-dependency-builder/precinct/index.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/precinct/index.ts
@@ -179,15 +179,17 @@ const getJsDetector = (fileInfo: FileInfo, options?: Options): Detective | undef
   return detector;
 };
 
-/**
- * Normalize the deps into an array.
- */
-const normalizeDeps = (deps: BuiltinDeps, includeCore?: boolean): string[] => {
-  const normalizedDeps = Array.isArray(deps) ? deps : Object.keys(deps);
-  return includeCore ? normalizedDeps : normalizedDeps.filter((d) => !isBuiltin(d));
+const removeCoreDeps = (deps: BuiltinDeps, includeCore?: boolean): BuiltinDeps => {
+  if (includeCore) return deps;
+  return Array.isArray(deps)
+    ? deps.filter((d) => !isBuiltin(d))
+    : Object.keys(deps).reduce((acc, key) => {
+        if (!isBuiltin(key)) acc[key] = deps[key];
+        return acc;
+      }, {});
 };
 
-const getDepsFromFile = (filename: string, options?: Options): string[] => {
+const getDepsFromFile = (filename: string, options?: Options): BuiltinDeps => {
   const normalizedOptions: Options = assign({ includeCore: true }, options || {});
   const fileInfo = getFileInfo(filename);
   if (
@@ -207,7 +209,7 @@ const getDepsFromFile = (filename: string, options?: Options): string[] => {
 
   const deps = detective(fileInfo.ast, normalizedOptions[fileInfo.type]);
 
-  return normalizeDeps(deps, normalizedOptions?.includeCore);
+  return removeCoreDeps(deps, normalizedOptions?.includeCore);
 };
 
 /**

--- a/scopes/dependencies/dependencies/files-dependency-builder/types/dependency-tree-type.ts
+++ b/scopes/dependencies/dependencies/files-dependency-builder/types/dependency-tree-type.ts
@@ -18,6 +18,7 @@ export class DependenciesTreeItem {
   components: ResolvedPackageData[] = [];
   error?: Error; // error.code is either PARSING_ERROR or RESOLVE_ERROR
   missing?: { [key in MissingType]: string[] };
+  devDeps: string[] = []; // components/packages that are used as types only. e.g. `import type x from 'y'`. components are saved by their pkgName.
 
   isEmpty() {
     return (

--- a/scopes/dependencies/dependencies/resolve-pkg-data.ts
+++ b/scopes/dependencies/dependencies/resolve-pkg-data.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import readPkgUp from 'read-pkg-up';
 import { PACKAGE_JSON } from '@teambit/legacy/dist/constants';
 import { PackageJsonFile } from '@teambit/component.sources';
-import { PathLinuxAbsolute, PathOsBased, PathOsBasedAbsolute } from '@teambit/toolbox.path.path';
+import { PathOsBased, PathOsBasedAbsolute } from '@teambit/toolbox.path.path';
 import { resolvePackageNameByPath } from '@teambit/legacy.utils';
 
 export interface ResolvedPackageData {
@@ -29,7 +29,7 @@ export interface ResolvedPackageData {
  */
 export function resolvePackageData(
   dependentDir: string,
-  packageFullPath: PathLinuxAbsolute
+  packageFullPath: PathOsBasedAbsolute
 ): ResolvedPackageData | undefined {
   const packageData: ResolvedPackageData = {
     fullPath: packageFullPath,

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -726,7 +726,7 @@ export default class CommandHelper {
     return show.find((_) => _.title === 'configuration').json.find((_) => _.id === aspectId);
   }
 
-  showDependenciesData(compId: string): Array<{ id: string; version: string; packageName: string }> {
+  showDependenciesData(compId: string): Array<{ id: string; version: string; packageName: string; lifecycle: string }> {
     const showConfig = this.showAspectConfig(compId, Extensions.dependencyResolver);
     return showConfig.data.dependencies;
   }

--- a/src/e2e-helper/e2e-fixtures-helper.ts
+++ b/src/e2e-helper/e2e-fixtures-helper.ts
@@ -220,15 +220,13 @@ module.exports = () => 'comp${index}${additionalStr} and ' + ${nextComp}();`;
     }
   }
 
-  populateComponentsTS(numOfComponents = 3, owner = '@bit', isHarmony = true): string {
-    let nmPathPrefix = `${owner}/${this.scopes.remote}.`;
-    if (isHarmony) {
-      const remoteSplit = this.scopes.remote.split('.');
-      if (remoteSplit.length === 1) {
-        nmPathPrefix = `@${this.scopes.remote}/`;
-      } else {
-        nmPathPrefix = `@${remoteSplit[0]}/${remoteSplit[1]}.`;
-      }
+  populateComponentsTS(numOfComponents = 3): string {
+    let nmPathPrefix: string;
+    const remoteSplit = this.scopes.remote.split('.');
+    if (remoteSplit.length === 1) {
+      nmPathPrefix = `@${this.scopes.remote}/`;
+    } else {
+      nmPathPrefix = `@${remoteSplit[0]}/${remoteSplit[1]}.`;
     }
     const getImp = (index) => {
       if (index === numOfComponents) return `export default () => 'comp${index}';`;


### PR DESCRIPTION
Until now, the distinguish between dependencies and dev-dependencies was determined by the origin file. If it was a test-file, then the dependency was considered as a dev-dependency.
This PR introduces another criteria. If the dependency was imported with `import type` syntax, then it's considered a dev-dependency.
The AST part was done in the following CR - https://bit.cloud/teambit/typescript/~ripple-ci/job/teambit-releasing-change-request-feat-distinguish-between-import-and-import-type