### PR TITLE
fix, avoid overriding this.workspace.localAspects

### DIFF
--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -107,7 +107,7 @@ ids: ${ids.join(', ')}
 needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts, null, 2)}`);
     const [localAspects, nonLocalAspects] = partition(ids, (id) => id.startsWith('file:'));
     const localAspectsMap = await this.aspectLoader.loadAspectFromPath(localAspects);
-    this.workspace.localAspects = localAspectsMap;
+    this.workspace.localAspects = { ...this.workspace.localAspects, ...localAspectsMap };
 
     let notLoadedIds = nonLocalAspects;
     if (!mergedOpts.forceLoad) {


### PR DESCRIPTION
Instead, concat to the same object when found more local aspects