### PR TITLE
fix(forking): check if forkedFrom info exists in forking aspect data before extracting forked from info 

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -83,7 +83,7 @@ export class ForkingMain {
    */
   getForkInfo(component: Component): ForkInfo | null {
     const forkConfig = component.state.aspects.get(ForkingAspect.id)?.config as ForkConfig | undefined;
-    if (!forkConfig) return null;
+    if (!forkConfig?.forkedFrom) return null;
     return {
       forkedFrom: ComponentID.fromObject(forkConfig.forkedFrom),
     };


### PR DESCRIPTION
This PR fixes the `getForkingInfo` api in the forking aspect by making sure the forking aspect data has the forkedFrom data before trying to extract the forked from component id from it. 