### PR TITLE
fix(watch), fix EMFILE error by monkey patching core fs by graceful-fs

### DIFF
--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -5,6 +5,11 @@ process.on('uncaughtException', (err) => {
   process.exit(1);
 });
 
+import fs from 'fs';
+import gracefulFs from 'graceful-fs';
+// monkey patch fs module to avoid EMFILE error (especially when running watch operation)
+gracefulFs.gracefulify(fs);
+
 import './hook-require';
 import { bootstrap } from './bootstrap';
 import { handleErrorAndExit } from '@teambit/cli';


### PR DESCRIPTION
The issue started once chokidar has upgraded from 3.x to 4.x. See https://github.com/paulmillr/chokidar/issues/1369 for more info. 