### PR TITLE
improvement(pattern), support multiple states in AND, support env with versions

### DIFF
--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -957,34 +957,35 @@ export class ScopeMain implements ComponentFactory {
     throwForNoMatch = true,
     filterByStateFunc?: (state: any, poolIds: ComponentID[]) => Promise<ComponentID[]>
   ) {
-    const patterns = pattern
-      .split(',')
-      .map((p) => p.trim())
-      .map((p) => p.split('@')[0]); // no need for the version
+    const patterns = pattern.split(',').map((p) => p.trim());
+
     if (patterns.every((p) => p.startsWith('!'))) {
       // otherwise it'll never match anything. don't use ".push()". it must be the first item in the array.
       patterns.unshift('**');
     }
     // check also as legacyId.toString, as it doesn't have the defaultScope
     const idsToCheck = (id: ComponentID) => [id._legacy.toStringWithoutVersion(), id.toStringWithoutVersion()];
-    const [statePatterns, nonStatePatterns] = partition(patterns, (p) => p.startsWith('$'));
-    const idsFiltered = nonStatePatterns.length
-      ? ids.filter((id) => multimatch(idsToCheck(id), nonStatePatterns).length)
+    const [statePatterns, nonStatePatterns] = partition(patterns, (p) => p.startsWith('$') || p.includes(' AND '));
+    const nonStatePatternsNoVer = nonStatePatterns.map((p) => p.split('@')[0]); // no need for the version
+    const idsFiltered = nonStatePatternsNoVer.length
+      ? ids.filter((id) => multimatch(idsToCheck(id), nonStatePatternsNoVer).length)
       : [];
 
     const idsStateFiltered = await mapSeries(statePatterns, async (statePattern) => {
       if (!filterByStateFunc) {
         throw new Error(`filter by a state (${statePattern}) is currently supported on the workspace only`);
       }
-      statePattern = statePattern.replace('$', '');
       if (statePattern.includes(' AND ')) {
-        const statePatternSplit = statePattern.split(' AND ').map((p) => p.trim());
-        if (statePatternSplit.length !== 2) throw new Error('invalid state pattern, can have only one "AND"');
-        const [stateF, nonStateF] = statePatternSplit;
-        const filteredByNonState = ids.filter((id) => multimatch(idsToCheck(id), [nonStateF]).length);
-        return filterByStateFunc(stateF, filteredByNonState);
+        let filteredByAnd: ComponentID[] = ids;
+        const patternSplit = statePattern.split(' AND ').map((p) => p.trim());
+        for await (const onePattern of patternSplit) {
+          filteredByAnd = onePattern.startsWith('$')
+            ? await filterByStateFunc(onePattern.replace('$', ''), filteredByAnd)
+            : filteredByAnd.filter((id) => multimatch(idsToCheck(id), [onePattern.split('@')[0]]).length);
+        }
+        return filteredByAnd;
       }
-      return filterByStateFunc(statePattern, ids);
+      return filterByStateFunc(statePattern.replace('$', ''), ids);
     });
     const idsStateFilteredFlat = idsStateFiltered.flat();
     const combineFilteredIds = () => {

--- a/scopes/workspace/workspace/filter.ts
+++ b/scopes/workspace/workspace/filter.ts
@@ -53,10 +53,12 @@ export class Filter {
   }
 
   async byEnv(env: string, withinIds?: ComponentID[]): Promise<ComponentID[]> {
-    const ids = withinIds || (await this.workspace.listIds());
+    const ids = withinIds || this.workspace.listIds();
     const comps = await this.workspace.getMany(ids);
     const compsUsingEnv = comps.filter((c) => {
       const envId = this.workspace.envs.getEnvId(c);
+      if (envId === env) return true;
+      // try without version
       const envIdWithoutVer = ComponentID.getStringWithoutVersion(envId);
       return envIdWithoutVer === env;
     });

--- a/scopes/workspace/workspace/pattern.cmd.ts
+++ b/scopes/workspace/workspace/pattern.cmd.ts
@@ -19,7 +19,7 @@ to filter by a state or attribute, prefix the pattern with "$". e.g. '$deprecate
 list of supported states: [${statesFilter.join(', ')}].
 to filter by multi-params state/attribute, separate the params with ":", e.g. '$env:teambit.react/react'.
 list of supported multi-params states: [env].
-to match a state and another criteria, use " AND " keyword. e.g. '$modified AND teambit.workspace/**'. note that the state must be first.
+to match a state and another criteria, use " AND " keyword. e.g. '$modified AND teambit.workspace/** AND $env:teambit.react/react'.
 `;
   examples = [
     { cmd: "bit pattern '**'", description: 'matches all components' },


### PR DESCRIPTION
Fixes https://github.com/teambit/bit/issues/9232.

## Proposed Changes

- support unlimited `AND` clauses. (until now, only one AND was permitted).
- enable multiple states-filter in the AND statement. (until now, it was permitted one state-filter and one non-state-filter).
- support filtering by a specific env version. (until now, the version was ignored).
