### PR TITLE
fix, delete index.json on the remote if it is outdated

### DIFF
--- a/src/scope/objects/repository.ts
+++ b/src/scope/objects/repository.ts
@@ -322,12 +322,6 @@ export default class Repository {
         const bitObject = await this.load(new Ref(hash));
         if (!bitObject) {
           const indexJsonPath = this.scopeIndex.getPath();
-          if (this.scopeIndex.isFileOnBitHub()) {
-            logger.error(
-              `repository._getBitObjectsByHashes, indexJson at "${indexJsonPath}" is outdated and needs to be deleted`
-            );
-            return null;
-          }
           const indexItem = this.scopeIndex.find(hash);
           if (!indexItem) throw new Error(`_getBitObjectsByHashes failed finding ${hash}`);
           await this.scopeIndex.deleteFile();


### PR DESCRIPTION
This PR reverts https://github.com/teambit/bit/pull/1624.
In case the remote encounters an outdated index.json it wasn't throw an error about it. The problem is that some functions calling it expect to get objects. (e.g. `loadLane`). This PR, removes the check whether it's a remote, and whenever an index.json file is outdated, it deletes it and throw an error telling the user to re-run the command.