### PR TITLE
fix(preview) - fix bit start when having multiple versions of the same env

### DIFF
--- a/components/modules/harmony-root-generator/harmony-root-generator.ts
+++ b/components/modules/harmony-root-generator/harmony-root-generator.ts
@@ -159,7 +159,13 @@ function getIdentifier(aspectDef: AspectDefinition, suffix: string, pathProp?: s
 }
 
 function getRegularAspectIdentifier(aspectDef: AspectDefinition, suffix: string, pathProp?: string): string {
-  const targetName = camelCase(`${parse(aspectDef.aspectPath).base.replace(/\./, '__').replace('@', '__')}${suffix}`);
+  let version = '';
+  if (aspectDef.getId) {
+    version = aspectDef.getId.split('@')[1];
+  }
+  const targetName = camelCase(
+    `${parse(aspectDef.aspectPath).base.replace(/\./, '__').replace('@', '__')}${version}${suffix}`
+  );
   const sourceName = pathProp ? getDefaultOrOnlyExport(aspectDef[pathProp]) : undefined;
   const identifier = sourceName ? `{${sourceName} as ${targetName}}` : targetName;
   return identifier;


### PR DESCRIPTION
## Proposed Changes

- before this change on the `ui-bundle-entry.<hash>` file we have duplicate entries like:
```
import {CommunityReactPreview as communityEnvsCommunityReactRuntime} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@2.1.10/node_modules/@teambit/community.envs.community-react/dist/community-react.preview.runtime.js';
import {CommunityReactPreview as communityEnvsCommunityReactRuntime} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@2.1.8/node_modules/@teambit/community.envs.community-react/dist/community-react.preview.runtime.js';
import {CommunityReactPreview as communityEnvsCommunityReactRuntime} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@1.90.7/node_modules/@teambit/community.envs.community-react/dist/community-react.preview.runtime.js';
import {CommunityReactPreview as communityEnvsCommunityReactRuntime} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@2.1.13/node_modules/@teambit/community.envs.community-react/dist/community-react.preview.runtime.js';
```
After this change it will add the version to the target name, for example:
```
import {CommunityReactAspect as communityEnvsCommunityReact215Aspect} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@2.1.5/node_modules/@teambit/community.envs.community-react/dist/community-react.aspect.js';
import {CommunityReactAspect as communityEnvsCommunityReact2113Aspect} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@2.1.13/node_modules/@teambit/community.envs.community-react/dist/community-react.aspect.js';
import {CommunityReactAspect as communityEnvsCommunityReact1950Aspect} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@1.95.0/node_modules/@teambit/community.envs.community-react/dist/community-react.aspect.js';
import {CommunityReactAspect as communityEnvsCommunityReact19512Aspect} from '/private/tmp/design/node_modules/.bit_roots/teambit.community_envs_community-react@1.95.12/node_modules/@teambit/community.envs.community-react/dist/community-react.aspect.js';
```

