### PR TITLE
fix(component drawer): correctly handle recursive state updates

### DIFF
--- a/components/ui/component-filters/component-filter-context/component-filter-context.tsx
+++ b/components/ui/component-filters/component-filter-context/component-filter-context.tsx
@@ -62,7 +62,7 @@ export function useComponentFilter<T>(
       const initialFilterState = { ...filterFromContext, state: defaultState };
       updateFilter(filterContext, initialFilterState);
     }
-  }, [filterId, filterContext, defaultState]);
+  }, [filterId, defaultState]);
 
   type Setter = Dispatch<SetStateAction<ComponentFilterCriteria<any>>>;
 
@@ -91,17 +91,15 @@ export const ComponentFiltersProvider = ({
   filters?: ComponentFilters;
 }) => {
   const [filtersState, setFilters] = useState<ComponentFilters>(filters || []);
-
-  return (
-    <ComponentFilterContext.Provider
-      value={{
-        filters: filtersState,
-        setFilters,
-      }}
-    >
-      {children}
-    </ComponentFilterContext.Provider>
+  const contextValue = React.useMemo(
+    () => ({
+      filters: filtersState,
+      setFilters,
+    }),
+    [filtersState, setFilters]
   );
+
+  return <ComponentFilterContext.Provider value={contextValue}>{children}</ComponentFilterContext.Provider>;
 };
 
 export const runAllFilters: (

--- a/components/ui/component-filters/component-filter-context/component-filter-context.tsx
+++ b/components/ui/component-filters/component-filter-context/component-filter-context.tsx
@@ -91,15 +91,17 @@ export const ComponentFiltersProvider = ({
   filters?: ComponentFilters;
 }) => {
   const [filtersState, setFilters] = useState<ComponentFilters>(filters || []);
-  const contextValue = React.useMemo(
-    () => ({
-      filters: filtersState,
-      setFilters,
-    }),
-    [filtersState, setFilters]
-  );
 
-  return <ComponentFilterContext.Provider value={contextValue}>{children}</ComponentFilterContext.Provider>;
+  return (
+    <ComponentFilterContext.Provider
+      value={{
+        filters: filtersState,
+        setFilters,
+      }}
+    >
+      {children}
+    </ComponentFilterContext.Provider>
+  );
 };
 
 export const runAllFilters: (

--- a/components/ui/component-filters/component-filter-context/component-filter-context.tsx
+++ b/components/ui/component-filters/component-filter-context/component-filter-context.tsx
@@ -62,7 +62,7 @@ export function useComponentFilter<T>(
       const initialFilterState = { ...filterFromContext, state: defaultState };
       updateFilter(filterContext, initialFilterState);
     }
-  }, [filterId, defaultState]);
+  }, [filterId]);
 
   type Setter = Dispatch<SetStateAction<ComponentFilterCriteria<any>>>;
 


### PR DESCRIPTION
This PR fixes the component filter context to correctly handle recursive state updates by correctly memoizing the deps it need to re trigger the useEffect