### PR TITLE
feat(component sizer): do not show size for locally modified comps

### DIFF
--- a/scopes/component/component-sizer/component-sizer.module.scss
+++ b/scopes/component/component-sizer/component-sizer.module.scss
@@ -1,0 +1,11 @@
+.componentSizeTooltip {
+  padding: 0;
+  // need to add !important to override the inline style added by Tippy.js
+  max-width: fit-content !important;
+}
+.componentSizeTooltipContent {
+  font-size: var(--bit-p-xs, '14px');
+}
+.label {
+  padding: 4px 8px;
+}

--- a/scopes/component/component-sizer/component-sizer.ui.runtime.tsx
+++ b/scopes/component/component-sizer/component-sizer.ui.runtime.tsx
@@ -1,9 +1,14 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { UIRuntime } from '@teambit/ui';
 import { ComponentModel } from '@teambit/component';
 import { DocsAspect, DocsUI } from '@teambit/docs';
 import { ComponentSize } from '@teambit/component.ui.component-size';
+import { WorkspaceContext } from '@teambit/workspace';
+import { PillLabel } from '@teambit/design.ui.pill-label';
+import { Tooltip } from '@teambit/design.ui.tooltip';
 import { ComponentSizerAspect } from './component-sizer.aspect';
+
+import styles from './component-sizer.module.scss';
 
 /**
  * Component size aspect.
@@ -16,6 +21,38 @@ export class SizerUIRuntime {
   static async provider([docs]: [DocsUI]) {
     docs.registerTitleBadge({
       component: function badge({ legacyComponentModel }: { legacyComponentModel: ComponentModel }) {
+        const workspace = useContext(WorkspaceContext);
+        const workspaceComponent = workspace?.getComponent(legacyComponentModel.id);
+        const size = legacyComponentModel.size;
+        const isModified = Boolean(
+          workspaceComponent?.status?.modifyInfo?.hasModifiedFiles ||
+            workspaceComponent?.status?.modifyInfo?.hasModifiedDependencies
+        );
+        const sizeExistsBuComponentModified = Boolean(size && isModified);
+
+        if (sizeExistsBuComponentModified) {
+          return (
+            <Tooltip
+              className={styles.componentSizeTooltip}
+              placement="top"
+              content={
+                <div className={styles.componentSizeTooltipContent}>
+                  Component is modified. Size is calculated upon build
+                </div>
+              }
+            >
+              <div>
+                <PillLabel className={styles.label}>
+                  <img
+                    style={{ width: '16px', marginRight: '4px' }}
+                    src="https://static.bit.dev/bit-icons/weight.svg"
+                  />
+                </PillLabel>
+              </div>
+            </Tooltip>
+          );
+        }
+
         return <ComponentSize legacyComponentModel={legacyComponentModel} />;
       },
       weight: 30,

--- a/scopes/workspace/workspace/ui/workspace/index.ts
+++ b/scopes/workspace/workspace/ui/workspace/index.ts
@@ -1,1 +1,4 @@
 export * from './workspace';
+export { WorkspaceContext } from './workspace-context';
+export { WorkspaceProvider } from './workspace-provider';
+export type { WorkspaceProviderProps } from './workspace-provider';


### PR DESCRIPTION
This PR updates the component size badge in the Overview page to not render the size when a component has been locally modified in the workspace. 