### PR TITLE
fix(watcher), rollback chokidar from 4.0.1 back to 3.6.0 due to EMFILE error

### DIFF
--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
     "cacache": "15.0.5",
     "chalk": "2.4.2",
     "checksum": "0.1.1",
-    "chokidar": "4.0.1",
+    "chokidar": "3.6.0",
     "cli-spinners": "1.3.1",
     "comment-json": "3.0.3",
     "core-js": "3.9.0",

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -439,10 +439,6 @@ export class Watcher {
     const usePolling = usePollingConf === 'true';
     const workspacePathLinux = pathNormalizeToLinux(this.workspace.path);
     const ignoreLocalScope = (pathToCheck: string) => {
-      // chokidar 4 doesn't support glob patterns. so we we have to check it with a function.
-      if (pathToCheck.endsWith('/node_modules')) return true;
-      // if (pathToCheck.includes('/node_modules/')) return true;
-      if (pathToCheck.endsWith('/package.json')) return true;
       if (pathToCheck.startsWith(this.ipcEventsDir) || pathToCheck.endsWith(UNMERGED_FILENAME)) return false;
       return (
         pathToCheck.startsWith(`${workspacePathLinux}/.git/`) || pathToCheck.startsWith(`${workspacePathLinux}/.bit/`)
@@ -452,7 +448,7 @@ export class Watcher {
       ignoreInitial: true,
       // `chokidar` matchers have Bash-parity, so Windows-style backslashes are not supported as separators.
       // (windows-style backslashes are converted to forward slashes)
-      ignored: [ignoreLocalScope],
+      ignored: ['**/node_modules/**', '**/package.json', ignoreLocalScope],
       usePolling,
       // useFsEvents,
       persistent: true,


### PR DESCRIPTION
See https://github.com/paulmillr/chokidar/issues/1369 for more info about this error.
For reference, the upgrade to 4.x was done in this PR https://github.com/teambit/bit/pull/9221.