### PR TITLE
fix(cli-server-pty), remove --pty flag, simplify spinner

### DIFF
--- a/scopes/harmony/api-server/cli-raw.route.ts
+++ b/scopes/harmony/api-server/cli-raw.route.ts
@@ -106,7 +106,8 @@ export class CLIRawRoute implements Route {
           delete process.env.BIT_CLI_SERVER_NO_TTY;
           loader.shouldSendServerEvents = false;
         }
-        this.logger.clearStatusLine();
+        // for Pty, this line causes an error "Error: read ECONNRESET" on the socket
+        if (!isPty) this.logger.clearStatusLine();
         // change chalk back to false, otherwise, the IDE will have colors. (this is a global setting)
         chalk.enabled = false;
         if (shouldReloadFeatureToggle) {

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -113,9 +113,12 @@ export class WorkspaceComponentLoader {
   }
 
   async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions, throwOnFailure = true): Promise<GetManyRes> {
+    const idsWithoutEmpty = compact(ids);
+    if (!idsWithoutEmpty.length) {
+      return { components: [], invalidComponents: [] };
+    }
     const callId = Math.floor(Math.random() * 1000); // generate a random callId to be able to identify the call from the logs
     this.logger.profile(`getMany-${callId}`);
-    const idsWithoutEmpty = compact(ids);
     this.logger.setStatusLine(`loading ${ids.length} component(s)`);
     const loadOptsWithDefaults: ComponentLoadOptions = Object.assign(
       // We don't want to load extension or execute the load slot at this step
@@ -162,6 +165,7 @@ export class WorkspaceComponentLoader {
         idsWithEmptyStrs.includes(comp.id.toString()) || idsWithEmptyStrs.includes(comp.id.toStringWithoutVersion())
     );
     this.logger.profile(`getMany-${callId}`);
+    this.logger.clearStatusLine();
     return { components: requestedComponents, invalidComponents };
   }
 

--- a/src/cli/loader/loader.ts
+++ b/src/cli/loader/loader.ts
@@ -1,10 +1,9 @@
-import { platform } from 'os';
 import ora, { Ora, PersistOptions } from 'ora';
 import cliSpinners from 'cli-spinners';
 import prettyTime from 'pretty-time';
 import { sendEventsToClients } from '@teambit/harmony.modules.send-server-sent-events';
 
-const SPINNER_TYPE = platform() === 'win32' ? cliSpinners.dots : cliSpinners.dots12;
+const SPINNER_TYPE = cliSpinners.dots;
 
 export class Loader {
   shouldSendServerEvents = false;


### PR DESCRIPTION
## Proposed Changes

- fix `bit server-forever` to remove the non-exist `--pty` flag of `bit server`.
- show an error message when `bit server-forever` fails to start.
- change non-Win to have the same spinner "dots" as Win OS. this way, it's easier to ignore strings coming from a socket that start with the spinner character.
