### PR TITLE
improvement(aspects loading) - improve error handling for aspect loading

### DIFF
--- a/scopes/component/component/component-factory.ts
+++ b/scopes/component/component/component-factory.ts
@@ -31,6 +31,12 @@ export type LoadAspectsOptions = {
   (considering throwOnError as well) */
   hideMissingModuleError?: boolean;
 
+  /* The `ignoreErrorFunc` property is an optional parameter that can be passed to the `LoadAspectsOptions` object in
+  the `ComponentFactory` interface. If provided, it will be called with the error that occurred during the loading of
+  aspects. If the function returns `true`, the method will ignore the error and continue loading the other aspects.
+  If the function returns `false`, the method will print/throw the error. */
+  ignoreErrorFunc?: (err: Error) => boolean;
+
   /* The `ignoreErrors` property is an optional boolean parameter that can be passed to the `LoadAspectsOptions` object in
   the `ComponentFactory` interface. If set to `true`, it will cause the `loadAspects` method to ignore any errors that
   occur during the loading of aspects and continue loading the other aspects. If set to `false` or not provided, the

--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -61,6 +61,7 @@ export type LoadExtByManifestContext = {
 export type LoadExtByManifestOptions = {
   throwOnError?: boolean;
   hideMissingModuleError?: boolean;
+  ignoreErrorFunc?: (err: Error) => boolean;
   ignoreErrors?: boolean;
   /**
    * If this is enabled then we will show loading error only once for a given extension
@@ -782,6 +783,8 @@ export class AspectLoaderMain {
       if (mergedOptions.ignoreErrors) return;
       if ((e.code === 'MODULE_NOT_FOUND' || e.code === 'ERR_MODULE_NOT_FOUND') && mergedOptions.hideMissingModuleError)
         return;
+
+      if (mergedOptions.ignoreErrorFunc && mergedOptions.ignoreErrorFunc(e)) return;
       // TODO: improve texts
       const errorMsg = e.message.split('\n')[0];
       const warning = UNABLE_TO_LOAD_EXTENSION_FROM_LIST(ids, errorMsg, neededFor);


### PR DESCRIPTION
## Proposed Changes

- Add new `ignoreErrorFunc` option for aspect loading option
- Use the new option to ignore `Cannot use 'import.meta' outside a module` error during bit new / install process
