### PR TITLE
fix(server-forever), use the @lydell/node-pty pkg instead of node-pty

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,6 +169,7 @@
     "@teambit/pkg.package-json.validator": "0.0.1",
     "@viz-js/viz": "^3.4.0",
     "@types/normalize-path": "^3.0.0",
+    "@lydell/node-pty": "^1.0.0",
     "array-difference": "0.0.2",
     "async-mutex": "0.3.1",
     "bluebird": "3.7.2",

--- a/scopes/harmony/bit/server-forever.ts
+++ b/scopes/harmony/bit/server-forever.ts
@@ -9,7 +9,7 @@
 
 import net from 'net';
 import crypto from 'crypto';
-import { spawn } from 'node-pty';
+import { spawn } from '@lydell/node-pty';
 
 export function spawnPTY() {
   // Create a PTY (terminal emulation) running the 'bit server' process

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -439,7 +439,6 @@
         "mousetrap": "1.6.5",
         "multimatch": "5.0.0",
         "nerf-dart": "1.0.0",
-        "@lydell/node-pty": "^1.0.0",
         "npm": "6.14.17",
         "p-limit": "3.1.0",
         "p-locate": "5.0.0",


### PR DESCRIPTION
The change was done in a previous PR: https://github.com/teambit/bit/pull/9259 however, the "import" statement wasn't changed. Also, the pkg moved from workspace.jsonc to the package.json.