### PR TITLE
move node-pty from package.json to workspace.jsonc

### DIFF
--- a/package.json
+++ b/package.json
@@ -169,7 +169,6 @@
     "@teambit/pkg.package-json.validator": "0.0.1",
     "@viz-js/viz": "^3.4.0",
     "@types/normalize-path": "^3.0.0",
-    "@lydell/node-pty": "^1.0.0",
     "array-difference": "0.0.2",
     "async-mutex": "0.3.1",
     "bluebird": "3.7.2",

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -362,6 +362,7 @@
         "@yarnpkg/parsers": "2.5.1",
         "@yarnpkg/plugin-npm": "2.7.4",
         "@yarnpkg/plugin-pack": "3.2.0",
+        "@lydell/node-pty": "^1.0.0",
         "ansi-to-html": "0.6.14",
         "apollo-link-context": "1.0.20",
         "apollo-link-http": "1.5.17",


### PR DESCRIPTION
It's part of teambit.harmony/bit component, so it should be in workspace.jsonc. 