### PR TITLE
feat(stash), introduce a new flag "--include-new" for new components

### DIFF
--- a/e2e/harmony/stash.e2e.ts
+++ b/e2e/harmony/stash.e2e.ts
@@ -106,4 +106,31 @@ describe('bit stash command', function () {
       expect(index).to.not.have.string('hello');
     });
   });
+  describe('stash new components along with modified', () => {
+    before(() => {
+      helper.scopeHelper.reInitLocalScope();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagWithoutBuild('comp2');
+      helper.fixtures.populateComponents(2, undefined, 'version2');
+      helper.command.stash('--include-new');
+    });
+    it('should stash both of them', () => {
+      const stashList = helper.command.stashList();
+      expect(stashList).to.have.string('2 components');
+    });
+    it('should remove the new component from .bitmap', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap).to.have.property('comp2');
+      expect(bitMap).to.not.have.property('comp1');
+    });
+    describe('stash load them', () => {
+      before(() => {
+        helper.command.stashLoad();
+      });
+      it('should re-create the new component', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap).to.have.property('comp1');
+      });
+    });
+  });
 });

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -96,6 +96,7 @@ export type ApplyVersionResults = {
   failedComponents?: FailedComponents[];
   removedComponents?: ComponentID[];
   addedComponents?: ComponentID[]; // relevant when restoreMissingComponents is true (e.g. bit lane merge-abort)
+  newComponents?: ComponentID[]; // relevant for "bit stash load". (stashedBitmapEntries is populated)
   resolvedComponents?: ConsumerComponent[]; // relevant for bit merge --resolve
   abortedComponents?: ApplyVersionResult[]; // relevant for bit merge --abort
   mergeSnapResults?: MergeSnapResults;

--- a/scopes/component/stash/stash-data.ts
+++ b/scopes/component/stash/stash-data.ts
@@ -1,7 +1,8 @@
 import { ComponentID, ComponentIdObj } from '@teambit/component-id';
 
-export type StashCompData = { id: ComponentID; hash: string; bitmapEntry: Record<string, any> };
-export type StashCompDataWithIdObj = { id: ComponentIdObj; hash: string; bitmapEntry: Record<string, any> };
+type StashCompBase = { hash: string; isNew: boolean; bitmapEntry: Record<string, any> };
+export type StashCompData = { id: ComponentID } & StashCompBase;
+export type StashCompDataWithIdObj = { id: ComponentIdObj } & StashCompBase;
 export type StashMetadata = { message?: string };
 export type StashDataObj = {
   metadata: StashMetadata;
@@ -17,10 +18,11 @@ export class StashData {
   toObject(): StashDataObj {
     return {
       metadata: this.metadata,
-      stashCompsData: this.stashCompsData.map(({ id, hash, bitmapEntry }) => ({
+      stashCompsData: this.stashCompsData.map(({ id, hash, bitmapEntry, isNew }) => ({
         id: id.changeVersion(undefined).toObject(),
         hash,
         bitmapEntry,
+        isNew,
       })),
     };
   }
@@ -33,6 +35,7 @@ export class StashData {
           id,
           hash: compData.hash,
           bitmapEntry: compData.bitmapEntry,
+          isNew: compData.isNew,
         };
       })
     );

--- a/scopes/component/stash/stash-data.ts
+++ b/scopes/component/stash/stash-data.ts
@@ -1,7 +1,7 @@
 import { ComponentID, ComponentIdObj } from '@teambit/component-id';
 
-export type StashCompData = { id: ComponentID; hash: string };
-export type StashCompDataWithIdObj = { id: ComponentIdObj; hash: string };
+export type StashCompData = { id: ComponentID; hash: string; bitmapEntry: Record<string, any> };
+export type StashCompDataWithIdObj = { id: ComponentIdObj; hash: string; bitmapEntry: Record<string, any> };
 export type StashMetadata = { message?: string };
 export type StashDataObj = {
   metadata: StashMetadata;
@@ -17,9 +17,10 @@ export class StashData {
   toObject(): StashDataObj {
     return {
       metadata: this.metadata,
-      stashCompsData: this.stashCompsData.map(({ id, hash }) => ({
+      stashCompsData: this.stashCompsData.map(({ id, hash, bitmapEntry }) => ({
         id: id.changeVersion(undefined).toObject(),
         hash,
+        bitmapEntry,
       })),
     };
   }
@@ -31,6 +32,7 @@ export class StashData {
         return {
           id,
           hash: compData.hash,
+          bitmapEntry: compData.bitmapEntry,
         };
       })
     );

--- a/scopes/component/stash/stash.cmd.ts
+++ b/scopes/component/stash/stash.cmd.ts
@@ -14,6 +14,11 @@ export class StashSaveCmd implements Command {
   group = 'development';
   options = [
     ['p', 'pattern', COMPONENT_PATTERN_HELP],
+    [
+      '',
+      'include-new',
+      'EXPERIMENTAL. by default, only modified components are stashed. use this flag to include new components',
+    ],
     ['m', 'message <string>', 'message to be attached to the stashed components'],
   ] as CommandOptions;
   loader = true;
@@ -25,12 +30,14 @@ export class StashSaveCmd implements Command {
     {
       pattern,
       message,
+      includeNew,
     }: {
       pattern?: string;
       message?: string;
+      includeNew?: boolean;
     }
   ) {
-    const compIds = await this.stash.save({ pattern, message });
+    const compIds = await this.stash.save({ pattern, message, includeNew });
     return chalk.green(`stashed ${compIds.length} components`);
   }
 }

--- a/scopes/component/stash/stash.main.runtime.ts
+++ b/scopes/component/stash/stash.main.runtime.ts
@@ -62,6 +62,7 @@ export class StashMain {
           id: comp.id,
           hash: versionObj.hash().toString(),
           bitmapEntry: this.workspace.bitMap.getBitmapEntry(comp.id).toPlainObject(),
+          isNew: !comp.id.hasVersion(),
         };
       })
     );
@@ -105,8 +106,8 @@ export class StashMain {
       throw new BitError('no stashed components found');
     }
     const stashData = await this.stashFiles.getStashData(stashFile);
-    const stashModifiedCompsData = stashData.stashCompsData.filter((c) => !c.bitmapEntry.defaultScope);
-    const stashNewCompsData = stashData.stashCompsData.filter((c) => c.bitmapEntry.defaultScope);
+    const stashModifiedCompsData = stashData.stashCompsData.filter((c) => !c.isNew);
+    const stashNewCompsData = stashData.stashCompsData.filter((c) => c.isNew);
     const compIds = stashModifiedCompsData.map((c) => c.id);
     const versionPerId = stashModifiedCompsData.map((c) => c.id.changeVersion(c.hash.toString()));
     const stashedBitmapEntries = stashNewCompsData.map((s) => ({

--- a/src/e2e-helper/e2e-command-helper.ts
+++ b/src/e2e-helper/e2e-command-helper.ts
@@ -637,8 +637,12 @@ export default class CommandHelper {
     return this.runCmd(`bit revert ${pattern} ${to} ${flags}`);
   }
 
-  stash() {
-    return this.runCmd('bit stash save');
+  stash(flags = '') {
+    return this.runCmd(`bit stash save ${flags}`);
+  }
+
+  stashList(flags = '') {
+    return this.runCmd(`bit stash list ${flags}`);
   }
 
   stashLoad(flags = '') {


### PR DESCRIPTION
By default, only modified components are stashed. With this flag, new components are stashed as well and then get removed from the workspace. Upon `bit stash load`, they are re-created. 