### PR TITLE
feat, introduce "--stream" for --json commands to print loader as json strings

### DIFF
--- a/scopes/component/snapping/snap-from-scope.cmd.ts
+++ b/scopes/component/snapping/snap-from-scope.cmd.ts
@@ -84,6 +84,7 @@ to ignore multiple issues, separate them by a comma and wrap with quotes. to ign
       'when snapped on a lane, mark it as update-dependents so it will be skipped from the workspace',
     ],
     ['', 'tag', 'make a tag instead of a snap'],
+    ['', 'stream', 'relevant for --json only. stream loader as json strings'],
     ['j', 'json', 'output as json format'],
   ] as CommandOptions;
   loader = true;

--- a/scopes/harmony/cli/command-runner.ts
+++ b/scopes/harmony/cli/command-runner.ts
@@ -74,7 +74,10 @@ export class CommandRunner {
     const code = result.code || 0;
     const data = result.data || result;
     if (shouldReturnResult) return { data, exitCode: code };
-    await this.writeAndExit(JSON.stringify(data, null, 2), code);
+    const isJsonStream = Boolean(this.flags.stream);
+    if (isJsonStream) data.end = true;
+    const jsonStr = isJsonStream ? `${JSON.stringify(data)}\n` : JSON.stringify(data, null, 2);
+    await this.writeAndExit(jsonStr, code);
   }
 
   private async runReportHandler(shouldReturnResult = false): Promise<CommandResult | undefined> {

--- a/src/cli/loader/loader.ts
+++ b/src/cli/loader/loader.ts
@@ -49,6 +49,9 @@ export class Loader {
       this.spinner.stop();
       this.spinner.text = text;
       this.spinner.start();
+    } else if (process.argv.includes('--stream')) {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify({ loader: text }));
     }
     return this;
   }


### PR DESCRIPTION
This can be used by any command by simply adding `--stream` to the `options` prop.
It's useful for processes that run bit commands with `--json` and need to show some feedback to the user during the command run. 
Normally, `--json` disables the loader to keep the output a valid JSON. When adding this `--stream`, the loader is printed in JSON format with a new line. The consuming process knows to consume one line at a time. The final output includes `end: true` to indicate this is the last output of the command.

Output example:
```
{"loader":"loading 3 component(s)"}
{"loader":"linking components"}
{"loader":"loading 3 component(s)"}
{"loader":"deduping dependencies for installation"}
{"loader":"loading 3 component(s)"}
{"loader":"running pre install subscribers"}
{"loader":"running post install subscribers"}
{"loader":"loading 3 component(s)"}
{"loader":"compiling components"}
{"loader":"loading 3 component(s)"}
{"snappedIds":["7b0e2371-remote/compa@0.0.1","7b0e2371-remote/compb@0.0.1","7b0e2371-remote/compc@0.0.1"],"end":true}
```