### PR TITLE
refactor, populate consumerComponent.overrides later in the process

### DIFF
--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -16,6 +16,7 @@ import OverridesDependencies from './overrides-dependencies';
 import { DependenciesData } from './dependencies-data';
 import { DebugDependencies, FileType } from './auto-detect-deps';
 import { Logger } from '@teambit/logger';
+import ComponentOverrides from '@teambit/legacy/dist/consumer/config/component-overrides';
 
 export type AllDependencies = {
   dependencies: Dependency[];
@@ -77,6 +78,23 @@ export class ApplyOverrides {
     this.debugDependenciesData = { components: [] };
   }
 
+  private async setOverridesDependencies() {
+    const overrides = await this.getOverridesData();
+    this.component.overrides = overrides;
+  }
+
+  private async getOverridesData() {
+    if (this.component.overrides) return this.component.overrides;
+    const overrides = await ComponentOverrides.loadFromConsumer(
+      this.component.id,
+      this.workspace!.consumer.config,
+      this.component.componentFromModel?.overrides,
+      this.component.bitJson!,
+      this.component.files
+    );
+    return overrides;
+  }
+
   get consumer(): Consumer | undefined {
     return this.workspace?.consumer;
   }
@@ -86,6 +104,7 @@ export class ApplyOverrides {
     overridesDependencies: OverridesDependencies;
     autoDetectOverrides?: Record<string, any>;
   }> {
+    await this.setOverridesDependencies();
     await this.populateDependencies();
     const dependenciesData = new DependenciesData(
       this.allDependencies,

--- a/src/consumer/component/consumer-component.ts
+++ b/src/consumer/component/consumer-component.ts
@@ -18,7 +18,7 @@ import { ComponentMap } from '@teambit/legacy.bit-map';
 import { IgnoredDirectory } from './exceptions/ignored-directory';
 import ComponentsPendingImport from '../exceptions/components-pending-import';
 import { Dist, License, SourceFile, PackageJsonFile, DataToPersist } from '@teambit/component.sources';
-import ComponentConfig, { ComponentConfigLoadOptions, ILegacyWorkspaceConfig } from '../config';
+import ComponentConfig, { ComponentConfigLoadOptions } from '../config';
 import ComponentOverrides from '../config/component-overrides';
 import { ExtensionDataList } from '../config/extension-data';
 import Consumer from '../consumer';
@@ -498,7 +498,6 @@ export default class Component {
     consumer: Consumer;
     loadOpts?: ComponentLoadOptions;
   }): Promise<Component> {
-    const workspaceConfig: ILegacyWorkspaceConfig = consumer.config;
     const modelComponent = await consumer.scope.getModelComponentIfExist(id);
     const componentFromModel = await consumer.loadComponentFromModelIfExist(id);
     if (!componentFromModel && id._legacy.hasScope()) {
@@ -530,16 +529,7 @@ export default class Component {
 
     const bindingPrefix = componentFromModel?.bindingPrefix;
 
-    const overridesFromModel = componentFromModel ? componentFromModel.overrides.componentOverridesData : undefined;
     const files = await getLoadedFiles(consumer, componentMap, id, compDirAbs);
-
-    const overrides = await ComponentOverrides.loadFromConsumer(
-      id,
-      workspaceConfig,
-      overridesFromModel,
-      componentConfig,
-      files
-    );
     const packageJsonFile = (componentConfig && componentConfig.packageJsonFile) || undefined;
     const packageJsonChangedProps = componentFromModel ? componentFromModel.packageJsonChangedProps : undefined;
     const docsP = _getDocsForFiles(files, consumer.componentFsCache);
@@ -569,7 +559,6 @@ export default class Component {
       componentMap,
       docs: flattenedDocs,
       deprecated,
-      overrides,
       schema: getSchema(),
       defaultScope: defaultScope || null,
       packageJsonFile,


### PR DESCRIPTION
when it's actually needed - in the apply-overrides file.