### PR TITLE
refactoring, remove idsWithFutureScope from exportMany

### DIFF
--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -363,7 +363,6 @@ if you're willing to lose the history from the head to the specified version, us
       const { exported } = await this.exporter.exportMany({
         scope: this.scope.legacyScope,
         ids: componentIds,
-        idsWithFutureScope: componentIds,
         exportHeadsOnly: true,
         includeParents: true, // in order to export the previous snaps with "hidden" prop changed.
         exportOrigin: 'tag',
@@ -546,7 +545,6 @@ if you're willing to lose the history from the head to the specified version, us
       const { exported } = await this.exporter.exportMany({
         scope: this.scope.legacyScope,
         ids,
-        idsWithFutureScope: ids,
         allVersions: false,
         laneObject: updatedLane,
         // no need other snaps. only the latest one. without this option, when snapping on lane from another-scope, it
@@ -720,7 +718,6 @@ if you're willing to lose the history from the head to the specified version, us
       const { exported } = await this.exporter.exportMany({
         scope: this.scope.legacyScope,
         ids,
-        idsWithFutureScope: ids,
         allVersions: false,
         laneObject: updatedLane,
         // no need other snaps. only the latest one. without this option, when snapping on lane from another-scope, it
@@ -1523,7 +1520,7 @@ another option, in case this dependency is not in main yet is to remove all refe
     DependenciesMain,
     ApplicationMain,
     ForkingMain,
-    InstallMain
+    InstallMain,
   ]) {
     const logger = loggerMain.createLogger(SnappingAspect.id);
     const snapping = new SnappingMain(

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -479,7 +479,6 @@ please create a new lane instead, which will include all components of this lane
       scope: this.scope.legacyScope,
       laneObject: lane,
       ids: new ComponentIdList(),
-      idsWithFutureScope: new ComponentIdList(),
       allVersions: false,
     });
   }

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -406,7 +406,6 @@ export class MergeLanesMain {
       const { exported } = await this.exporter.exportMany({
         scope: this.scope.legacyScope,
         ids: compIdsList,
-        idsWithFutureScope: compIdsList,
         laneObject: laneToExport,
         allVersions: false,
         // no need to export anything else other than the head. the normal calculation of what to export won't apply here

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -316,7 +316,6 @@ to bypass this error, use --skip-new-scope-validation flag (not recommended. it 
     await this.exporter.exportMany({
       scope: this.scope.legacyScope,
       ids,
-      idsWithFutureScope: ids,
       laneObject: this.laneObj,
       allVersions: false,
       exportOrigin: 'update-dependencies',


### PR DESCRIPTION
This is not in use since all code was changed from using BitId to use ComponentID.