### PR TITLE
fix, reload env instance in Harmony upon changes

### DIFF
--- a/scopes/harmony/aspect-loader/plugins.ts
+++ b/scopes/harmony/aspect-loader/plugins.ts
@@ -56,7 +56,7 @@ export class Plugins {
 
   async loadModule(path: string) {
     NativeCompileCache.uninstall();
-    const module = await esmLoader(path);
+    const module = await esmLoader(path, true);
     const defaultModule = module.default;
     defaultModule.__path = path;
     defaultModule.__resolvedPath = require.resolve(path);

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1213,6 +1213,13 @@ export class InstallMain {
     }
   }
 
+  async onComponentChange(component: Component) {
+    const isEnv = this.envs.isEnv(component);
+    if (isEnv) {
+      await this.reloadEnvs([component.id]);
+    }
+  }
+
   static slots = [Slot.withType<PreLinkSlot>(), Slot.withType<PreInstallSlot>(), Slot.withType<PostInstallSlot>()];
   static dependencies = [
     DependencyResolverAspect,
@@ -1305,6 +1312,7 @@ export class InstallMain {
     // workspace.registerOnAspectsResolve(installExt.onAspectsResolveSubscriber.bind(installExt));
     if (workspace) {
       workspace.registerOnRootAspectAdded(installExt.onRootAspectAddedSubscriber.bind(installExt));
+      workspace.registerOnComponentChange(installExt.onComponentChange.bind(installExt));
     }
     cli.register(...commands);
     return installExt;

--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -242,7 +242,7 @@ export class Watcher {
     files: PathOsBasedAbsolute[]
   ): Promise<OnComponentEventResult[]> {
     let updatedComponentId: ComponentID | undefined = componentId;
-    if (!(await this.workspace.hasId(componentId))) {
+    if (!this.workspace.hasId(componentId)) {
       // bitmap has changed meanwhile, which triggered `handleBitmapChanges`, which re-loaded consumer and updated versions
       // so the original componentId might not be in the workspace now, and we need to find the updated one
       const ids = this.workspace.listIds();

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -258,7 +258,7 @@
         "@teambit/mdx.ui.docs.snippet": "^0.0.509",
         "@teambit/mdx.ui.mdx-layout": "^1.0.9",
         "@teambit/mdx.ui.mdx-scope-context": "^1.0.5",
-        "@teambit/node.utils.esm-loader": "^0.0.6",
+        "@teambit/node.utils.esm-loader": "^0.0.7",
         "@teambit/pkg.content.packages-overview": "1.95.9",
         "@teambit/preview.modules.preview-modules": "^1.0.3",
         "@teambit/react.content.react-overview": "1.95.0",


### PR DESCRIPTION
When bit-server (or watcher) is running in the background and an env is changed, although it gets compiled, its instance in Harmony remains the same. As a result, these changes are not reflected when running `bit build` or any command that uses the env.
This PR fixes the issue by re-registering the plugins when an env is changed. It makes Harmony use the new dists. 