### PR TITLE
improvement(watch), enable triggering onComponentChange on another component

### DIFF
--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -56,6 +56,7 @@ export type WatchOptions = {
   preCompile?: boolean; // whether compile all components before start watching
   compile?: boolean; // whether compile modified/added components during watch process
   import?: boolean; // whether import objects when .bitmap got version changes
+  trigger?: ComponentID; // trigger onComponentChange for the specified component-id. helpful when this comp must be a bundle, and needs to be recompile on any dep change.
 };
 
 export type RootDirs = { [dir: PathLinux]: ComponentID };
@@ -290,6 +291,10 @@ export class Watcher {
       removedFiles,
       true
     );
+    if (this.options.trigger && !updatedComponentId.isEqual(this.options.trigger)) {
+      await this.workspace.triggerOnComponentChange(this.options.trigger, [], [], this.options);
+    }
+
     return buildResults;
   }
 


### PR DESCRIPTION
Introduced a new flag `--trigger <component-id>`, when any change is happening, it runs the `workspace.onComponentChange` for the specified component-id.
A real use case when this is needed is developing a vscode extension component. Because a vscode-extension must be bundled, its dependencies are always in the dist of the extension. As a result, when a dependency in the workspace is changed, the extension is not aware of it and not getting updated. 
This flag is more like a workaround and not the best solution. Ideally, the flag would be "trigger-dependents" which would traverse the graph and trigger accordingly, but it's not worth it to implement as this point as it's an edge use-case. 