### PR TITLE
feat: support general dev server events listener

### DIFF
--- a/scopes/preview/preview/preview.start-plugin.tsx
+++ b/scopes/preview/preview/preview.start-plugin.tsx
@@ -3,7 +3,8 @@ import { BundlerMain, ComponentServer } from '@teambit/bundler';
 import { PubsubMain } from '@teambit/pubsub';
 import { ProxyEntry, StartPlugin, StartPluginOptions, UiMain } from '@teambit/ui';
 import { Workspace } from '@teambit/workspace';
-import { SubscribeToWebpackEvents, CompilationResult } from '@teambit/preview.cli.webpack-events-listener';
+import { SubscribeToEvents } from '@teambit/preview.cli.dev-server-events-listener';
+import { SubscribeToWebpackEvents } from '@teambit/preview.cli.webpack-events-listener';
 import { CompilationInitiator } from '@teambit/compiler';
 import { Logger } from '@teambit/logger';
 import { CheckTypes, WatcherMain } from '@teambit/watcher';
@@ -82,6 +83,16 @@ export class PreviewStartPlugin implements StartPlugin {
   // TODO: this should be a part of the devServer
   private listenToDevServers() {
     // keep state changes immutable!
+    SubscribeToEvents(this.pubsub, {
+      onStart: (id) => {
+        this.handleOnStartCompiling(id);
+      },
+      onDone: (id, results) => {
+        this.handleOnDoneCompiling(id, results);
+      },
+    });
+    // @deprecated
+    // for legacy webpack bit report plugin
     SubscribeToWebpackEvents(this.pubsub, {
       onStart: (id) => {
         this.handleOnStartCompiling(id);
@@ -102,7 +113,7 @@ export class PreviewStartPlugin implements StartPlugin {
     }
   }
 
-  private handleOnDoneCompiling(id: string, results: CompilationResult) {
+  private handleOnDoneCompiling(id: string, results) {
     this.serversState[id] = {
       isCompiling: false,
       isReady: true,

--- a/scopes/webpack/webpack/plugins/webpack-bit-reporter-plugin.ts
+++ b/scopes/webpack/webpack/plugins/webpack-bit-reporter-plugin.ts
@@ -1,6 +1,10 @@
 import type { Compiler, Stats } from 'webpack';
-import { WebpackCompilationDoneEvent, WebpackCompilationStartedEvent } from '../events';
-import { WebpackAspect } from '../webpack.aspect';
+
+import { BundlerAspect } from '@teambit/bundler';
+import {
+  DevServerCompilationStartedEvent,
+  DevServerCompilationDoneEvent,
+} from '@teambit/preview.cli.dev-server-events-listener';
 
 const PLUGIN_NAME = 'webpack-compiler-started-plugin';
 
@@ -20,14 +24,22 @@ export class WebpackBitReporterPlugin {
   apply(compiler: Compiler | any) {
     // "Called before a new compilation is created."
     compiler.hooks.compile.tap(PLUGIN_NAME, () => {
-      const event = new WebpackCompilationStartedEvent(Date.now(), { devServerID: this.devServerID });
-      this.pubsub.pub(WebpackAspect.id, event);
+      const event = new DevServerCompilationStartedEvent(Date.now(), this.devServerID);
+      this.pubsub.pub(BundlerAspect.id, event);
     });
 
     // "Executed when the compilation has completed."
     compiler.hooks.done.tap(PLUGIN_NAME, (stats: Stats) => {
-      const event = new WebpackCompilationDoneEvent(Date.now(), stats, this.devServerID);
-      this.pubsub.pub(WebpackAspect.id, event);
+      const results = {
+        errors: stats.compilation.errors,
+        warnings: stats.compilation.warnings,
+        compiling: false,
+      };
+      const event = new DevServerCompilationDoneEvent(Date.now(), this.devServerID, results);
+      this.pubsub.pub(BundlerAspect.id, event);
     });
   }
+
+  // flag to indicate whether the plugin uses the dev server events or the legacy webpack events
+  static readonly USE_DEV_SERVER_EVENTS = true;
 }

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -260,6 +260,7 @@
         "@teambit/mdx.ui.mdx-scope-context": "^1.0.5",
         "@teambit/node.utils.esm-loader": "^0.0.7",
         "@teambit/pkg.content.packages-overview": "1.95.9",
+        "@teambit/preview.cli.dev-server-events-listener": "^0.0.1",
         "@teambit/preview.modules.preview-modules": "^1.0.3",
         "@teambit/react.content.react-overview": "1.95.0",
         "@teambit/react.generator.react-native-templates": "^1.0.11",


### PR DESCRIPTION
## Proposed Changes

- installed new dev server events listener
- update preview start plugin to subscribe both legacy webpack events and dev server events
- update webpack bit report plugin to use dev server events
- add a flag on webpack bit report plugin that indicates using dev server events (this is used for outside compatibility check. see: https://bit.cloud/teambit/vite/vite-dev-server/~code/reporter.ts?version=0.1.21#l17)

https://bit.cloud/teambit/vite/~change-requests/dev-server-pubsub-20241113-9GYlr_1uj
https://bit.cloud/teambit/vite/~change-requests/vite-pubsub-20241113