### PR TITLE
fix(tag), include snapped components when specifying ids

### DIFF
--- a/e2e/flows/out-of-sync-componets.e2e.3.ts
+++ b/e2e/flows/out-of-sync-componets.e2e.3.ts
@@ -194,7 +194,7 @@ describe('components that are not synced between the scope and the consumer', fu
     describe('bit tag', () => {
       it('should stop the tagging process and throw an error suggesting to import the components', () => {
         const err = new ComponentsPendingImport([`${helper.scopes.remote}/bar/foo@0.0.1`]);
-        helper.general.expectToThrow(() => helper.command.tagWithoutBuild('bar/foo'), err);
+        helper.general.expectToThrow(() => helper.command.tagWithoutBuild('bar/foo', '--unmodified'), err);
       });
     });
     describe('bit status', () => {

--- a/e2e/harmony/tag-harmony.e2e.ts
+++ b/e2e/harmony/tag-harmony.e2e.ts
@@ -460,4 +460,16 @@ describe('tag components on Harmony', function () {
       expect(pkgJson.componentId.version).to.equal('0.0.1');
     });
   });
+  describe('tagging a snapped component by specifying the id', () => {
+    let tagOutput: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      tagOutput = helper.command.tagWithoutBuild('comp1');
+    });
+    it('should tag successfully without needing to add --unmodified', () => {
+      expect(tagOutput).to.have.string('comp1@0.0.1');
+    });
+  });
 });

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -1222,6 +1222,11 @@ another option, in case this dependency is not in main yet is to remove all refe
       id.changeVersion(undefined)
     );
 
+    const tagPendingBitIdsIncludeSnapped = ComponentIdList.fromArray([
+      ...tagPendingComponentsIds,
+      ...snappedComponentsIds,
+    ]);
+
     if (snappedComponentsIds.length) {
       const localOnlyIds = this.workspace.filter.byLocalOnly(snappedComponentsIds);
       const localOnlyListIds = ComponentIdList.fromArray(localOnlyIds);
@@ -1238,13 +1243,15 @@ another option, in case this dependency is not in main yet is to remove all refe
         const [idWithoutVer, version] = id.split('@');
         const idIsPattern = this.workspace.isPattern(id);
         if (idIsPattern) {
-          const allIds = await this.workspace.filterIdsFromPoolIdsByPattern(idWithoutVer, tagPendingComponentsIds);
+          const allIds = await this.workspace.filterIdsFromPoolIdsByPattern(
+            idWithoutVer,
+            tagPendingBitIdsIncludeSnapped
+          );
           return allIds.map((componentId) => componentId.changeVersion(version));
         }
         const componentId = await this.workspace.resolveComponentId(idWithoutVer);
         if (!includeUnmodified) {
-          const componentStatus = await this.workspace.getComponentStatusById(componentId);
-          if (componentStatus.modified === false) return null;
+          if (!tagPendingBitIdsIncludeSnapped.hasWithoutVersion(componentId)) return null;
         }
         return componentId.changeVersion(version);
       });
@@ -1259,8 +1266,6 @@ another option, in case this dependency is not in main yet is to remove all refe
     if (unmerged) {
       return { bitIds: componentsList.listDuringMergeStateComponents(), warnings };
     }
-
-    const tagPendingBitIdsIncludeSnapped = [...tagPendingComponentsIds, ...snappedComponentsIds];
 
     if (includeUnmodified && exactVersion) {
       const tagPendingComponentsLatest = await this.workspace.scope.legacyScope.latestVersions(


### PR DESCRIPTION
currently, when tagging a snapped component by specifying the id, it requires adding `--unmodified` flag unnecessarily. 