### PR TITLE
fix(import), do not remove the local env config in component.json

### DIFF
--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -437,4 +437,23 @@ describe('import functionality on Harmony', function () {
       expect(bitMap).to.not.have.property('comp-b');
     });
   });
+  describe('import when component.json has a local env', () => {
+    let envId: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      envId = helper.env.setCustomEnv();
+      helper.fixtures.populateComponents(1);
+      helper.command.setEnv('comp1', 'node-env');
+      helper.command.ejectConf('comp1');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.importComponent('comp1', '-x');
+    });
+    it('should not modified the component.json of the other component to add invalid env info', () => {
+      const fullEnvId = `${helper.scopes.remote}/${envId}`;
+      const componentJson = helper.componentJson.read('comp1');
+      expect(componentJson.extensions).to.have.property(fullEnvId);
+      expect(componentJson.extensions).to.not.have.property(`${fullEnvId}@0.0.1`);
+    });
+  });
 });

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -5,7 +5,7 @@ import { ComponentID } from '@teambit/component-id';
 import { EnvsAspect } from '@teambit/envs';
 import { DependencyResolverAspect } from '@teambit/dependency-resolver';
 import { ExtensionDataList, getCompareExtPredicate } from '@teambit/legacy/dist/consumer/config/extension-data';
-import { partition, mergeWith, merge, uniq, uniqWith } from 'lodash';
+import { partition, mergeWith, merge, uniq, uniqWith, compact } from 'lodash';
 import { MergeConfigConflict } from './exceptions/merge-config-conflict';
 import { AspectSpecificField, ExtensionsOrigin, Workspace } from './workspace';
 import { MergeConflictFile } from './merge-conflict-file';
@@ -290,7 +290,7 @@ export class AspectsMerger {
       )
       .map((aspect) => aspect.stringId);
     if (envWasFoundPreviously && (envAspect || aspectsRegisteredAsEnvs.length)) {
-      const nonEnvs = extensionDataList.filter((e) => {
+      const nonEnvs = extensionDataList.map((e) => {
         // normally the env-id inside the envs aspect doesn't have a version, but the aspect itself has a version.
         // also, the env-id inside the envs aspect includes the default-scope, but the aspect itself doesn't.
         if (
@@ -298,13 +298,18 @@ export class AspectsMerger {
           (envFromEnvsAspect && e.extensionId?.toStringWithoutVersion() === envFromEnvsAspect) ||
           aspectsRegisteredAsEnvs.includes(e.stringId)
         ) {
-          return false;
+          return undefined;
         }
-        return true;
+        if (e.stringId === envAspect?.stringId) {
+          // must clone the env aspect to avoid mutating the original data
+          const clonedEnvAspect = e.clone();
+          delete clonedEnvAspect.config.env; // aspect env may have other data other then config.env.
+          return clonedEnvAspect;
+        }
+        return e;
       });
-      // still, aspect env may have other data other then config.env.
-      if (envAspect) delete envAspect.config.env;
-      return { extensionDataListFiltered: new ExtensionDataList(...nonEnvs), envIsCurrentlySet: true };
+
+      return { extensionDataListFiltered: new ExtensionDataList(...compact(nonEnvs)), envIsCurrentlySet: true };
     }
     if (envFromEnvsAspect && (origin === 'ModelNonSpecific' || origin === 'ModelSpecific')) {
       // if env was found, search for this env in the workspace and if found, replace the env-id with the one from the workspace


### PR DESCRIPTION
Currently, when the component.json of a component is written and the env is set to a local one, it gets removed upon `bit import` unexpectedly. 
After a long debugging, it turned out that the culprit was the aspect-merger. In order to remove multiple envs, it mutated the original `ExtensionData` of the scope component and deleted the env from there. 
This PR fixes it by cloning the entry before modifying it.

(for future reference - use `Proxy` to catch this issues, specifically the `deleteProperty` method of the Proxy).