### PR TITLE
fix(bit-server), reload staged-snaps after export

### DIFF
--- a/scopes/harmony/ipc-events/ipc-events.main.runtime.ts
+++ b/scopes/harmony/ipc-events/ipc-events.main.runtime.ts
@@ -79,7 +79,9 @@ export class IpcEventsMain {
       });
       ipcEventsMain.registerGotEventSlot(async (eventName) => {
         if (eventName === 'onPostObjectsPersist') {
+          logger.debug('got an event onPostObjectsPersist, clearing the cache and reloading staged-snaps');
           scope.legacyScope.objects.clearObjectsFromCache();
+          scope.legacyScope.setStagedSnaps(); // "bit export" deletes the staged-snaps file, so it should be reloaded
         }
       });
     }

--- a/src/scope/scope.ts
+++ b/src/scope/scope.ts
@@ -143,6 +143,10 @@ export default class Scope {
     this.lanes = new Lanes(this.objects, this.scopeJson);
     this.isBare = scopeProps.isBare ?? false;
     this.scopeImporter = ScopeComponentsImporter.getInstance(this);
+    this.setStagedSnaps();
+  }
+
+  setStagedSnaps() {
     this.stagedSnaps = StagedSnaps.load(this.path);
   }
 


### PR DESCRIPTION
to avoid `ENOENT` error during `bit lane merge`.