### PR TITLE
add type getPreviewConfig onto PreviewEnv

### DIFF
--- a/scopes/preview/preview/preview-env.ts
+++ b/scopes/preview/preview/preview-env.ts
@@ -1,5 +1,6 @@
 import { Bundler, BundlerContext, DevServer, DevServerContext } from '@teambit/bundler';
 import { AsyncEnvHandler, EnvHandler } from '@teambit/envs';
+import { EnvPreviewConfig } from './preview.main.runtime';
 
 /**
  * interface for implementing component previews
@@ -43,4 +44,9 @@ export type Preview = {
    * for dev server these dependencies will be aliased
    */
   getHostDependencies: () => string[];
+
+  /**
+   * Returns preview config like the strategy name to use when bundling the components for the preview
+   */
+  getPreviewConfig: () => EnvPreviewConfig;
 };


### PR DESCRIPTION
## Proposed Changes

The `getPreviewConfig()` should be a required member in `type Preview {}` since it would be called in `preview.service.tsx` https://github.com/teambit/bit/blob/master/scopes/preview/preview/preview.service.tsx#L42