### PR TITLE
chore: ensure package.json in capsules root

### DIFF
--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -626,6 +626,7 @@ export class IsolatorMain {
       await fs.emptyDir(capsulesDir);
     }
     let capsules = await this.createCapsulesFromComponents(components, capsulesDir, config);
+    this.writeRootPackageJson(capsulesDir, this.getCapsuleDirHash(opts.baseDir || ''));
     const allCapsuleList = CapsuleList.fromArray(capsules);
     let capsuleList = allCapsuleList;
     if (opts.getExistingAsIs) {
@@ -988,6 +989,10 @@ export class IsolatorMain {
     };
   }
 
+  private getCapsuleDirHash(baseDir: string): string {
+    return hash(baseDir).substring(0, CAPSULE_DIR_LENGTH);
+  }
+
   /** @deprecated use the new function signature with an object parameter instead */
   getCapsulesRootDir(baseDir: string, rootBaseDir?: string, useHash?: boolean): PathOsBasedAbsolute;
   getCapsulesRootDir(getCapsuleDirOpts: GetCapsuleDirOpts): PathOsBasedAbsolute;
@@ -1028,7 +1033,7 @@ export class IsolatorMain {
       return path.join(capsulesRootBaseDir, datedBaseDir, dateDir, hashDir);
     }
     const dir = getCapsuleDirOptsWithDefaults.useHash
-      ? hash(getCapsuleDirOptsWithDefaults.baseDir).substring(0, CAPSULE_DIR_LENGTH)
+      ? this.getCapsuleDirHash(getCapsuleDirOptsWithDefaults.baseDir)
       : getCapsuleDirOptsWithDefaults.baseDir;
     return path.join(capsulesRootBaseDir, dir);
   }
@@ -1037,6 +1042,15 @@ export class IsolatorMain {
     const dirToDelete = rootDir || this.getRootDirOfAllCapsules();
     await fs.remove(dirToDelete);
     return dirToDelete;
+  }
+
+  private writeRootPackageJson(capsulesDir: string, hashDir: string): void {
+    const rootPackageJson = path.join(capsulesDir, 'package.json');
+    const packageJson = {
+      name: `capsules-${hashDir}`,
+      'bit-capsule': true,
+    };
+    fs.outputJsonSync(rootPackageJson, packageJson);
   }
 
   private async createCapsulesFromComponents(

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1046,11 +1046,13 @@ export class IsolatorMain {
 
   private writeRootPackageJson(capsulesDir: string, hashDir: string): void {
     const rootPackageJson = path.join(capsulesDir, 'package.json');
-    const packageJson = {
-      name: `capsules-${hashDir}`,
-      'bit-capsule': true,
-    };
-    fs.outputJsonSync(rootPackageJson, packageJson);
+    if (!fs.existsSync(rootPackageJson)) {
+      const packageJson = {
+        name: `capsules-${hashDir}`,
+        'bit-capsule': true,
+      };
+      fs.outputJsonSync(rootPackageJson, packageJson);
+    }
   }
 
   private async createCapsulesFromComponents(


### PR DESCRIPTION
## Proposed Changes

- ensure every capsules root has a package.json which is necessary in some cases like running Vitest tasks

See: https://bit.cloud/teambit/vite/vitest-tester/~code/utils.ts?version=0.3.4#l142