### PR TITLE
feat(workspace): minimal workspace mode

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -2025,6 +2025,20 @@
         "mainFile": "index.ts",
         "rootDir": "components/ui/pages/static-error"
     },
+    "ui/preserve-workspace-mode": {
+        "name": "ui/preserve-workspace-mode",
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.workspace",
+        "mainFile": "index.ts",
+        "rootDir": "components/ui/preserve-workspace-mode",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
+    },
     "ui/preview-placeholder": {
         "name": "ui/preview-placeholder",
         "scope": "teambit.preview",
@@ -2087,6 +2101,27 @@
         "version": "0.0.371",
         "mainFile": "index.ts",
         "rootDir": "components/ui/tooltip"
+    },
+    "ui/top-bar": {
+        "name": "ui/top-bar",
+        "scope": "teambit.ui-foundation",
+        "version": "0.0.514",
+        "mainFile": "index.ts",
+        "rootDir": "components/ui/top-bar"
+    },
+    "ui/use-workspace-mode": {
+        "name": "ui/use-workspace-mode",
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.workspace",
+        "mainFile": "index.ts",
+        "rootDir": "components/ui/use-workspace-mode",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
     },
     "ui/user-bar": {
         "name": "ui/user-bar",

--- a/components/ui/preserve-workspace-mode/index.ts
+++ b/components/ui/preserve-workspace-mode/index.ts
@@ -1,0 +1,1 @@
+export { PreserveWorkspaceMode } from './preserve-workspace-mode';

--- a/components/ui/preserve-workspace-mode/preserve-workspace-mode.tsx
+++ b/components/ui/preserve-workspace-mode/preserve-workspace-mode.tsx
@@ -1,0 +1,27 @@
+import React, { useEffect } from 'react';
+import { useSearchParams, useLocation } from 'react-router-dom';
+
+export const PreserveWorkspaceMode: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [, setSearchParams] = useSearchParams();
+  const location = useLocation();
+
+  useEffect(() => {
+    const currentParams = new URLSearchParams(location.search);
+    const minimalModeParam = currentParams.get('minimal-mode');
+    const storedMinimalMode = sessionStorage.getItem('workspace-minimal-mode');
+
+    if (minimalModeParam === 'true') {
+      sessionStorage.setItem('workspace-minimal-mode', 'true');
+    } else {
+      sessionStorage.removeItem('workspace-minimal-mode');
+    }
+
+    const shouldRestore = !minimalModeParam && storedMinimalMode;
+    if (!shouldRestore) return;
+
+    currentParams.set('minimal-mode', 'true');
+    setSearchParams(currentParams, { replace: true });
+  }, [location.search, setSearchParams]);
+
+  return <>{children}</>;
+};

--- a/components/ui/top-bar/index.ts
+++ b/components/ui/top-bar/index.ts
@@ -1,0 +1,1 @@
+export { TopBar, TopBarProps } from './top-bar';

--- a/components/ui/top-bar/top-bar.module.scss
+++ b/components/ui/top-bar/top-bar.module.scss
@@ -1,0 +1,14 @@
+@import '@teambit/ui-foundation.ui.constants.z-indexes/z-indexes.module.scss';
+$topbarHeight: 56px;
+
+.topbar {
+  display: flex;
+  align-items: center;
+
+  height: $topbarHeight;
+  background: var(--bit-bg-heaviest, #ededed);
+  box-sizing: border-box;
+  font-size: var(--bit-p-xs, 14px);
+  // top bar needs to be with higher zindex in order for the menu to go over collapser button and splitter
+  z-index: $topBar-zIndex;
+}

--- a/components/ui/top-bar/top-bar.tsx
+++ b/components/ui/top-bar/top-bar.tsx
@@ -1,0 +1,28 @@
+import { RouteSlot, SlotRouter } from '@teambit/ui-foundation.ui.react-router.slot-router';
+import cn from 'classnames';
+import React from 'react';
+import styles from './top-bar.module.scss';
+
+export interface TopBarProps extends React.HTMLAttributes<HTMLDivElement> {
+  /**
+   * top left corner of the top bar.
+   */
+  Corner: React.ComponentType;
+
+  /**
+   * slot for registering menus to the top-bar.
+   */
+  menu: RouteSlot;
+}
+
+/**
+ * Top bar with corner and contextual menu.
+ */
+export function TopBar({ Corner, menu, className, ...rest }: TopBarProps) {
+  return (
+    <div {...rest} className={cn(styles.topbar, className)}>
+      <Corner />
+      <SlotRouter slot={menu} />
+    </div>
+  );
+}

--- a/components/ui/use-workspace-mode/index.ts
+++ b/components/ui/use-workspace-mode/index.ts
@@ -1,0 +1,1 @@
+export { useWorkspaceMode } from './use-workspace-mode';

--- a/components/ui/use-workspace-mode/use-workspace-mode.ts
+++ b/components/ui/use-workspace-mode/use-workspace-mode.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export const useWorkspaceMode = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const isMinimal = searchParams.get('minimal-mode') === 'true';
+
+  const setMinimalMode = useCallback(
+    (value: boolean) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('minimal-mode', value.toString());
+      setSearchParams(newParams, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  const toggleMinimalMode = useCallback(() => {
+    setMinimalMode(!isMinimal);
+  }, [isMinimal, setMinimalMode]);
+
+  return { isMinimal, setMinimalMode, toggleMinimalMode };
+};

--- a/scopes/cloud/cloud/cloud.ui.runtime.tsx
+++ b/scopes/cloud/cloud/cloud.ui.runtime.tsx
@@ -157,8 +157,8 @@ export class CloudUI {
       //   },
       // },
     ]);
-    workspace.registerMenuWidget([cloudUI.CloudUserBar]);
     if (workspace) {
+      workspace.registerMenuWidget([cloudUI.CloudUserBar]);
       lanes.registerMenuWidget(cloudUI.CloudUserBar);
       component.registerRightSideMenuItem({
         item: <cloudUI.CloudUserBar key={'cloud-user-bar-comp-menu'} />,

--- a/scopes/cloud/ui/user-bar/user-bar.tsx
+++ b/scopes/cloud/ui/user-bar/user-bar.tsx
@@ -7,6 +7,7 @@ import { CurrentUser } from '@teambit/cloud.ui.current-user';
 import { useCurrentUser } from '@teambit/cloud.hooks.use-current-user';
 import { useLogout } from '@teambit/cloud.hooks.use-logout';
 import { Menu, MenuItemType } from '@teambit/design.controls.menu';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 import { UserBarSection } from './section';
 import { UserBarItem } from './item';
 
@@ -25,10 +26,13 @@ export type UserBarProps = {
 };
 
 export function UserBar({ sections = [], items = [] }: UserBarProps) {
+  const { isMinimal } = useWorkspaceMode();
   const { currentUser, loginUrl, loading, isLoggedIn } = useCurrentUser();
   const { logout, loading: loadingLoggingOut, loggedOut } = useLogout();
 
   const navigate = useNavigate();
+
+  if (isMinimal) return null;
 
   if (loading || loadingLoggingOut) {
     return <CircleSkeleton className={styles.loader} />;

--- a/scopes/component/component/aspect.section.tsx
+++ b/scopes/component/component/aspect.section.tsx
@@ -12,6 +12,7 @@ export class AspectSection implements Section {
     href: '~aspect',
     children: <MenuWidgetIcon icon="configuration" tooltipContent="Configuration" />,
     displayName: 'Configuration',
+    hideInMinimalMode: true,
   };
   order = 50;
 }

--- a/scopes/component/component/section/section.tsx
+++ b/scopes/component/component/section/section.tsx
@@ -9,4 +9,5 @@ export interface Section {
    */
   displayName?: string;
   order?: number;
+  hideInMinimalMode?: boolean;
 }

--- a/scopes/component/component/ui/menu/menu-nav.tsx
+++ b/scopes/component/component/ui/menu/menu-nav.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import classnames from 'classnames';
 import { ResponsiveNavbar } from '@teambit/design.navigation.responsive-navbar';
 import type { TabProps } from '@teambit/design.navigation.responsive-navbar';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 import { TopBarNav } from '../top-bar-nav';
 import styles from './menu.module.scss';
 import { NavPlugin, OrderedNavigationSlot } from './nav-plugin';
@@ -54,14 +55,22 @@ export function CollapsibleMenuNav({
   alwaysShowActiveTab,
   children,
 }: MenuNavProps) {
+  const { isMinimal } = useWorkspaceMode();
   const plugins = useMemo(() => {
     const _navPlugins = navPlugins.length > 0 ? navPlugins : navigationSlot?.toArray();
-    return (_navPlugins || []).sort(sortFn);
-  }, [navigationSlot, navPlugins]);
+    if (!isMinimal) {
+      return (_navPlugins || []).sort(sortFn);
+    }
+    return (_navPlugins || []).filter((widget) => !widget[1].props.hideInMinimalMode).sort(sortFn);
+  }, [navigationSlot, navPlugins, isMinimal]);
+
   const widgets = useMemo(() => {
     const _widgetPlugins = widgetPlugins.length > 0 ? widgetPlugins : widgetSlot?.toArray();
-    return (_widgetPlugins || []).sort(sortFn);
-  }, [widgetSlot, widgetPlugins]);
+    if (!isMinimal) {
+      return (_widgetPlugins || []).sort(sortFn);
+    }
+    return (_widgetPlugins || []).filter((widget) => !widget[1].props.hideInMinimalMode).sort(sortFn);
+  }, [widgetSlot, widgetPlugins, isMinimal]);
 
   const links = [...plugins, ...widgets].map(([, menuItem], index) => {
     // these styles keep plugins to the left and widgets to the right.

--- a/scopes/component/component/ui/menu/menu.tsx
+++ b/scopes/component/component/ui/menu/menu.tsx
@@ -14,6 +14,7 @@ import { useLanes as defaultUseLanes } from '@teambit/lanes.hooks.use-lanes';
 import { LanesModel } from '@teambit/lanes.ui.models.lanes-model';
 import { Menu as ConsumeMethodsMenu } from '@teambit/ui-foundation.ui.use-box.menu';
 import { LegacyComponentLog } from '@teambit/legacy-component-log';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 import { useComponent as useComponentQuery, UseComponentType, Filters } from '../use-component';
 import { CollapsibleMenuNav } from './menu-nav';
 import { OrderedNavigationSlot, ConsumeMethodSlot, ConsumePluginProps } from './nav-plugin';
@@ -96,6 +97,7 @@ export function ComponentMenu({
   useComponentFilters,
   authToken,
 }: MenuProps) {
+  const { isMinimal } = useWorkspaceMode();
   const idFromLocation = useIdFromLocation();
   const componentIdStrWithScopeFromLocation = useIdFromLocation(undefined, true);
   const _componentIdStr = getComponentIdStr(componentIdStr);
@@ -125,7 +127,7 @@ export function ComponentMenu({
             // loading={loading}
           />
           {rightSideItems.map(({ item }) => item)}
-          <MainDropdown className={styles.hideOnMobile} menuItems={mainMenuItems} />
+          {!isMinimal && <MainDropdown className={styles.hideOnMobile} menuItems={mainMenuItems} />}
         </>
       )}
     </div>

--- a/scopes/component/component/ui/menu/nav-plugin.tsx
+++ b/scopes/component/component/ui/menu/nav-plugin.tsx
@@ -8,6 +8,7 @@ import { ComponentModel } from '../component-model';
 export type NavPluginProps = {
   displayName?: string;
   ignoreQueryParams?: boolean;
+  hideInMinimalMode?: boolean;
 } & LinkProps;
 
 export type NavPlugin = {

--- a/scopes/explorer/command-bar/command-bar.button.tsx
+++ b/scopes/explorer/command-bar/command-bar.button.tsx
@@ -1,10 +1,13 @@
 import React from 'react';
 import { ActionButton } from '@teambit/design.buttons.action-button';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 
 export type CommandBarButtonProps = {
   onClick: () => void;
 };
 
 export function CommandBarButton({ onClick }: CommandBarButtonProps) {
+  const { isMinimal } = useWorkspaceMode();
+  if (isMinimal) return null;
   return <ActionButton onClick={onClick} icon="magnifying-cli" displayName="Go to..." />;
 }

--- a/scopes/workspace/workspace/ui/index.ts
+++ b/scopes/workspace/workspace/ui/index.ts
@@ -1,1 +1,2 @@
 export { Workspace } from './workspace';
+export { WorkspaceMenu } from './workspace/workspace-menu';

--- a/scopes/workspace/workspace/ui/workspace/use-workspace-mode.ts
+++ b/scopes/workspace/workspace/ui/workspace/use-workspace-mode.ts
@@ -1,0 +1,23 @@
+import { useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+export const useWorkspaceMode = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const isMinimal = searchParams.get('minimal-mode') === 'true';
+
+  const setMinimalMode = useCallback(
+    (value: boolean) => {
+      const newParams = new URLSearchParams(searchParams);
+      newParams.set('minimal-mode', value.toString());
+      setSearchParams(newParams, { replace: true });
+    },
+    [searchParams, setSearchParams]
+  );
+
+  const toggleMinimalMode = useCallback(() => {
+    setMinimalMode(!isMinimal);
+  }, [isMinimal, setMinimalMode]);
+
+  return { isMinimal, setMinimalMode, toggleMinimalMode };
+};

--- a/scopes/workspace/workspace/ui/workspace/workspace-menu.tsx
+++ b/scopes/workspace/workspace/ui/workspace/workspace-menu.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Menu, MenuProps } from '@teambit/ui-foundation.ui.menu';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
+
+export const WorkspaceMenu = ({ menuSlot, widgetSlot, menuItemSlot, className }: MenuProps) => {
+  const { isMinimal } = useWorkspaceMode();
+
+  return (
+    <Menu
+      menuSlot={menuSlot}
+      widgetSlot={widgetSlot}
+      menuItemSlot={isMinimal ? undefined : menuItemSlot}
+      className={className}
+    />
+  );
+};

--- a/scopes/workspace/workspace/ui/workspace/workspace-overview/workspace-overview.tsx
+++ b/scopes/workspace/workspace/ui/workspace/workspace-overview/workspace-overview.tsx
@@ -10,12 +10,14 @@ import { ScopeID } from '@teambit/scopes.scope-id';
 import { compact } from 'lodash';
 import { WorkspaceComponentCard } from '@teambit/workspace.ui.workspace-component-card';
 import type { ComponentCardPluginType, PluginProps } from '@teambit/explorer.ui.component-card';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 import { WorkspaceContext } from '../workspace-context';
 import styles from './workspace-overview.module.scss';
 import { LinkPlugin } from './link-plugin';
 
 export function WorkspaceOverview() {
   const workspace = useContext(WorkspaceContext);
+  const { isMinimal } = useWorkspaceMode();
   const compModelsById = new Map(workspace.components.map((comp) => [comp.id.toString(), comp]));
   const { components, componentDescriptors } = workspace;
   const uniqueScopes = new Set(components.map((c) => c.id.scope));
@@ -23,7 +25,7 @@ export function WorkspaceOverview() {
   const { cloudScopes = [] } = useCloudScopes(uniqueScopesArr);
   const cloudScopesById = new Map(cloudScopes.map((scope) => [scope.id.toString(), scope]));
 
-  const plugins = useCardPlugins({ compModelsById });
+  const plugins = useCardPlugins({ compModelsById, showPreview: isMinimal });
 
   if (!components || components.length === 0) return <EmptyWorkspace name={workspace.name} />;
 
@@ -64,8 +66,10 @@ export function WorkspaceOverview() {
 
 export function useCardPlugins({
   compModelsById,
+  showPreview,
 }: {
   compModelsById: Map<string, ComponentModel>;
+  showPreview?: boolean;
 }): ComponentCardPluginType<PluginProps>[] {
   const plugins = React.useMemo(
     () => [
@@ -77,7 +81,7 @@ export function useCardPlugins({
             <PreviewPlaceholder
               componentDescriptor={component}
               component={compModel}
-              shouldShowPreview={shouldShowPreview}
+              shouldShowPreview={showPreview || shouldShowPreview}
             />
           );
         },

--- a/scopes/workspace/workspace/ui/workspace/workspace.module.scss
+++ b/scopes/workspace/workspace/ui/workspace/workspace.module.scss
@@ -12,6 +12,14 @@
   }
 }
 
+.minimalCorner {
+  width: 130px;
+  &.dark {
+    --bit-border-color-lightest: #333333;
+    --bit-text-color-heavy: white;
+  }
+}
+
 .workspaceWrapper {
   display: flex;
   flex-direction: column;

--- a/scopes/workspace/workspace/ui/workspace/workspace.tsx
+++ b/scopes/workspace/workspace/ui/workspace/workspace.tsx
@@ -13,7 +13,9 @@ import { SplitPane, Pane, Layout } from '@teambit/base-ui.surfaces.split-pane.sp
 import { useThemePicker } from '@teambit/base-react.themes.theme-switcher';
 import { HoverSplitter } from '@teambit/base-ui.surfaces.split-pane.hover-splitter';
 import { TopBar } from '@teambit/ui-foundation.ui.top-bar';
+import { PreserveWorkspaceMode } from '@teambit/workspace.ui.preserve-workspace-mode';
 import classNames from 'classnames';
+import { useWorkspaceMode } from '@teambit/workspace.ui.use-workspace-mode';
 
 import { useWorkspace } from './use-workspace';
 import { WorkspaceOverview } from './workspace-overview';
@@ -33,6 +35,7 @@ export type WorkspaceProps = {
  * main workspace component.
  */
 export function Workspace({ routeSlot, menuSlot, sidebar, workspaceUI, onSidebarTogglerChange }: WorkspaceProps) {
+  const { isMinimal } = useWorkspaceMode();
   const reactions = useComponentNotifications();
   const { workspace } = useWorkspace(reactions);
   const theme = useThemePicker();
@@ -57,38 +60,41 @@ export function Workspace({ routeSlot, menuSlot, sidebar, workspaceUI, onSidebar
 
   return (
     <WorkspaceProvider workspace={workspace}>
-      <div className={styles.workspaceWrapper}>
-        <TopBar
-          className={classNames(styles.topbar, styles[themeName])}
-          Corner={() => (
-            <Corner
-              className={classNames(styles.corner, styles[themeName])}
-              name={workspace.name}
-              icon={workspace.icon}
+      <PreserveWorkspaceMode>
+        <div className={styles.workspaceWrapper}>
+          {
+            <TopBar
+              className={classNames(styles.topbar, styles[themeName])}
+              Corner={() => (
+                <Corner
+                  className={classNames((isMinimal && styles.minimalCorner) || styles.corner, styles[themeName])}
+                  name={workspace.name}
+                  icon={workspace.icon}
+                />
+              )}
+              menu={menuSlot}
             />
-          )}
-          menu={menuSlot}
-        />
-
-        <SplitPane className={styles.main} size={246} layout={sidebarOpenness}>
-          <Pane className={classNames(styles.sidebar, styles[themeName], !isSidebarOpen && styles.closed)}>
-            {sidebar}
-          </Pane>
-          <HoverSplitter className={styles.splitter}>
-            <Collapser
-              isOpen={isSidebarOpen}
-              onMouseDown={(e) => e.stopPropagation()} // avoid split-pane drag
-              onClick={handleSidebarToggle}
-              tooltipContent={`${isSidebarOpen ? 'Hide' : 'Show'} side panel`}
-            />
-          </HoverSplitter>
-          <Pane>
-            <SlotRouter slot={routeSlot}>
-              <Route index element={<WorkspaceOverview />} />
-            </SlotRouter>
-          </Pane>
-        </SplitPane>
-      </div>
+          }
+          <SplitPane className={styles.main} size={246} layout={sidebarOpenness}>
+            <Pane className={classNames(styles.sidebar, styles[themeName], !isSidebarOpen && styles.closed)}>
+              {sidebar}
+            </Pane>
+            <HoverSplitter className={styles.splitter}>
+              <Collapser
+                isOpen={isSidebarOpen}
+                onMouseDown={(e) => e.stopPropagation()} // avoid split-pane drag
+                onClick={handleSidebarToggle}
+                tooltipContent={`${isSidebarOpen ? 'Hide' : 'Show'} side panel`}
+              />
+            </HoverSplitter>
+            <Pane>
+              <SlotRouter slot={routeSlot}>
+                <Route index element={<WorkspaceOverview />} />
+              </SlotRouter>
+            </Pane>
+          </SplitPane>
+        </div>
+      </PreserveWorkspaceMode>
     </WorkspaceProvider>
   );
 }

--- a/scopes/workspace/workspace/workspace.ui.runtime.tsx
+++ b/scopes/workspace/workspace/workspace.ui.runtime.tsx
@@ -3,7 +3,7 @@ import { compact, flatten } from 'lodash';
 import { ComponentTreeAspect, ComponentTreeUI, ComponentTreeNode } from '@teambit/component-tree';
 import { Slot, SlotRegistry } from '@teambit/harmony';
 import type { RouteSlot } from '@teambit/ui-foundation.ui.react-router.slot-router';
-import { Menu, MenuWidgetSlot, MenuWidget } from '@teambit/ui-foundation.ui.menu';
+import { MenuWidgetSlot, MenuWidget } from '@teambit/ui-foundation.ui.menu';
 import { SidebarAspect, SidebarUI, SidebarItem, SidebarItemSlot } from '@teambit/sidebar';
 import { MenuItemSlot, MenuItem } from '@teambit/ui-foundation.ui.main-dropdown';
 import { UIAspect, UIRootUI as UIRoot, UIRuntime, UiUI } from '@teambit/ui';
@@ -24,7 +24,7 @@ import {
   ComponentFiltersSlot,
 } from '@teambit/component.ui.component-drawer';
 import { ComponentTreeWidget } from './component-tree.widget';
-import { Workspace } from './ui';
+import { Workspace, WorkspaceMenu } from './ui';
 import { WorkspaceAspect } from './workspace.aspect';
 import { workspaceDrawer } from './workspace.ui.drawer';
 
@@ -262,7 +262,7 @@ export class WorkspaceUI {
     workspaceUI.registerMenuRoutes([
       {
         path: '/',
-        element: <Menu menuItemSlot={workspaceUI.menuItemSlot} widgetSlot={workspaceUI.menuWidgetSlot} />,
+        element: <WorkspaceMenu menuItemSlot={workspaceUI.menuItemSlot} widgetSlot={workspaceUI.menuWidgetSlot} />,
       },
       {
         path: workspaceUI.componentUi.routePath,

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -306,7 +306,6 @@
         "@teambit/ui-foundation.ui.notifications.store": "^0.0.500",
         "@teambit/ui-foundation.ui.react-router.extend-path": "^0.0.486",
         "@teambit/ui-foundation.ui.react-router.use-query": "^0.0.501",
-        "@teambit/ui-foundation.ui.top-bar": "^0.0.514",
         "@teambit/ui-foundation.ui.tree.drawer": "^0.0.518",
         "@teambit/ui-foundation.ui.tree.file-tree": "0.0.524",
         "@teambit/ui-foundation.ui.tree.folder-tree-node": "0.0.510",


### PR DESCRIPTION
This PR adds a new `minimal` workspace mode that provides a more focused, distraction free view of the workspace. 

The minimal mode, 

- renders preview cards by default in the workspace overview
- hides user avatar, search icon and other top level menu widgets
- removes aspect config page from component navigation
 