### PR TITLE
fix(component tree): correctly generate lane component url when the env is on a lane 

### DIFF
--- a/components/ui/side-bar/component-tree/component-view/component-view.tsx
+++ b/components/ui/side-bar/component-tree/component-view/component-view.tsx
@@ -47,15 +47,25 @@ export function ComponentView(props: ComponentViewProps) {
   component = component as ComponentModel;
 
   const envId = !isMissingCompOrEnvId ? ComponentID.fromString(component.environment?.id as string) : undefined;
+  const isEnvOnCurrentLane = envId
+    ? lanesModel?.isComponentOnLaneButNotOnMain(envId, false, lanesModel.viewedLane?.id)
+    : false;
+
+  const envUrl = !envId
+    ? undefined
+    : (isEnvOnCurrentLane &&
+        lanesModel?.viewedLane?.id &&
+        `${window.location.origin}${LanesModel.getLaneComponentUrl(envId, lanesModel.viewedLane?.id)}`) ||
+      ComponentUrl.toUrl(envId, {
+        includeVersion: true,
+        useLocationOrigin: !window.location.host.startsWith('localhost'),
+      });
 
   const envTooltip = envId ? (
     <Link
       external
       className={styles.envLink}
-      href={ComponentUrl.toUrl(envId, {
-        includeVersion: true,
-        useLocationOrigin: !window.location.host.startsWith('localhost'),
-      })}
+      href={envUrl}
       onClick={(event) => {
         // do not trigger component selection
         event.stopPropagation();


### PR DESCRIPTION
This PR fixes the issue in the Component Tree where if the component is tagged with an env that belongs to a lane it would incorrectly generate the envId url on main instead to be the one on the lane. 

https://github.com/user-attachments/assets/969fef74-4f3b-497d-bf3d-3928757ce3cd

