### PR TITLE
chore, remove @teambit/harmony.content.cli-reference from teambit.harmony/bit config

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -639,7 +639,6 @@
         "policy": {
           "dependencies": {
             "@teambit/base-react.navigation.link": "2.0.31",
-            "@teambit/harmony.content.cli-reference": "^2.0.279",
             "@teambit/ui-foundation.ui.navigation.react-router-adapter": "6.1.1",
             "@apollo/client": "3.6.9",
             "@teambit/legacy": "1.0.767",


### PR DESCRIPTION
This was needed probably in the past when we didn't auto-detect some "require" scenario. From a quick check, seems like we are able to auto-detect this dependency, so there is no need to have it forced in the variant. 