### PR TITLE
fix(ui/code): improve file path resolution for imports and navigation in code viewer

### DIFF
--- a/components/ui/code-tab-page/code-tab-page.tsx
+++ b/components/ui/code-tab-page/code-tab-page.tsx
@@ -66,16 +66,6 @@ export function CodePage({ className, fileIconSlot, host, codeViewClassName }: C
   const [searchParams] = useSearchParams();
   const scopeFromQueryParams = searchParams.get('scope');
   const component = useContext(ComponentContext);
-  // const [fileParam, setFileParam] = useState<{
-  //   current?: string;
-  //   prev?: string;
-  // }>({ current: urlParams.file });
-
-  // React.useEffect(() => {
-  //   if (urlParams.file !== fileParam.current) {
-  //     setFileParam((prev) => ({ current: urlParams.file, prev: prev.current }));
-  //   }
-  // }, [urlParams.file, fileParam.current]);
 
   const { mainFile, fileTree = [], dependencies, devFiles, loading: loadingCode } = useCode(component.id);
   const { data: artifacts = [] } = useComponentArtifacts(host, component.id.toString());

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -448,6 +448,7 @@
         "p-limit": "3.1.0",
         "p-locate": "5.0.0",
         "parse-package-name": "0.1.0",
+        "path-browserify": "^1.0.1",
         "path-to-regexp": "6.2.0",
         "penpal": "6.2.2",
         "pino-pretty": "9.1.1",


### PR DESCRIPTION
This PR fixes the code viewer to properly resolve file paths, when navigating between files via imports. 

https://github.com/user-attachments/assets/ab0318f3-4084-406c-8d13-38c62a89ca31

