### PR TITLE
fix(api-ref/component-compare): style fixes

### DIFF
--- a/components/renderers/inference-type/inference-type.module.scss
+++ b/components/renderers/inference-type/inference-type.module.scss
@@ -13,3 +13,7 @@
     font-style: italic;
   }
 }
+
+.syntaxTooltip {
+  background-color: rgb(241, 242, 244);
+}

--- a/components/renderers/inference-type/inference-type.module.scss
+++ b/components/renderers/inference-type/inference-type.module.scss
@@ -1,5 +1,6 @@
 .inferenceWrapper {
   position: relative;
+
   > pre {
     > code {
       // override syntax highlighter code font size
@@ -16,4 +17,15 @@
 
 .syntaxTooltip {
   background-color: rgb(241, 242, 244);
+}
+
+.infoIcon {
+  font-style: normal;
+  padding-left: 4px;
+}
+
+.infoIconWrapper {
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/components/renderers/inference-type/inference-type.renderer.tsx
+++ b/components/renderers/inference-type/inference-type.renderer.tsx
@@ -46,7 +46,9 @@ function InferenceTypeComponent(props: APINodeRenderProps) {
     >
       {isSpread && (
         <Tooltip
+          className={styles.syntaxTooltip}
           placement={'bottom-end'}
+          theme="light"
           content={
             <SyntaxHighlighter
               language={lang}

--- a/components/renderers/inference-type/inference-type.renderer.tsx
+++ b/components/renderers/inference-type/inference-type.renderer.tsx
@@ -5,6 +5,7 @@ import SyntaxHighlighter from 'react-syntax-highlighter/dist/esm/prism-light';
 import tsxSyntax from 'react-syntax-highlighter/dist/esm/languages/prism/tsx';
 import defaultTheme from '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme';
 import classNames from 'classnames';
+import { Icon } from '@teambit/evangelist.elements.icon';
 import { Tooltip } from '@teambit/design.ui.tooltip';
 
 import styles from './inference-type.module.scss';
@@ -64,7 +65,10 @@ function InferenceTypeComponent(props: APINodeRenderProps) {
             </SyntaxHighlighter>
           }
         >
-          {`...rest`}
+          <div className={styles.infoIconWrapper}>
+            {'...rest'}
+            <Icon of="information" className={styles.infoIcon} />
+          </div>
         </Tooltip>
       )}
       {!isSpread &&

--- a/components/ui/component-compare/version-picker/component-compare-version-picker.module.scss
+++ b/components/ui/component-compare/version-picker/component-compare-version-picker.module.scss
@@ -13,7 +13,7 @@
   min-width: 400px;
 }
 .showMenuOverNav {
-  z-index: $topBar-zIndex;
+  z-index: $modal-z-index + 1 !important;
 }
 
 .dropdownContainer {


### PR DESCRIPTION
This PR fixes, 

- z-index of version picker dropdown in Component Compare page so it doesnt hide behind the loader
- background color for tooltip when it renders the inference rest type in API Reference


<img width="1214" alt="Screenshot 2024-12-06 at 12 05 25 PM" src="https://github.com/user-attachments/assets/38818c8e-3d98-4a48-94cc-48585363e74a">

![Screenshot 2024-12-06 at 12 57 51 PM](https://github.com/user-attachments/assets/5b826b79-0ee1-47a0-9c02-978038506f70)
