### PR TITLE
chore, update node-babel-mocha to the latest 0.0.33

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -231,7 +231,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.60",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "builder": {
         "name": "builder",
@@ -392,7 +395,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.57",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "component-log": {
         "name": "component-log",
@@ -546,7 +552,10 @@
         "scope": "teambit.semantics",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "docs": {
         "name": "docs",
@@ -567,7 +576,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.3",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/e2e-helper"
+        "rootDir": "components/legacy/e2e-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "eject": {
         "name": "eject",
@@ -651,7 +663,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.5",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "forking": {
         "name": "forking",
@@ -1666,7 +1681,10 @@
         "scope": "teambit.component",
         "version": "0.0.55",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "stash": {
         "name": "stash",
@@ -2261,7 +2279,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.9",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.33": {}
+        }
     },
     "utils/code-editor-options": {
         "name": "utils/code-editor-options",

--- a/e2e/harmony/install-and-compile.e2e.ts
+++ b/e2e/harmony/install-and-compile.e2e.ts
@@ -165,8 +165,7 @@ describe('skipping compilation on install', function () {
     expect(path.join(helper.scopes.localPath, `node_modules/@${helper.scopes.remote}/comp1/dist`)).to.not.be.a.path();
   });
 });
-// todo: fix after merging #9359
-describe.skip('do not fail on environment loading files from a location inside node_modules that does not exist', function () {
+describe('do not fail on environment loading files from a location inside node_modules that does not exist', function () {
   this.timeout(0);
   let helper: Helper;
   before(() => {


### PR DESCRIPTION
Currently, for some reason, some of the components using this env got an older version '0.0.10' of this env. This PR aligns them all to the same (latest) version.