### PR TITLE
decouple the teambit.harmony/bit dependency from core aspects

### DIFF
--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -2,7 +2,6 @@ import multimatch from 'multimatch';
 import mapSeries from 'p-map-series';
 import { DEPS_GRAPH, isFeatureEnabled } from '@teambit/harmony.modules.feature-toggle';
 import { MainRuntime } from '@teambit/cli';
-import { getAllCoreAspectsIds } from '@teambit/bit';
 import { getRootComponentDir } from '@teambit/workspace.root-components';
 import { ComponentAspect, Component, ComponentMap, ComponentMain, IComponent } from '@teambit/component';
 import type { ConfigMain } from '@teambit/config';
@@ -701,7 +700,7 @@ export class DependencyResolverMain {
    * returns component-ids string without a version.
    */
   getCompIdsThatShouldNotBeInPolicy(): string[] {
-    return [...getAllCoreAspectsIds(), 'teambit.harmony/harmony'];
+    return [...this.aspectLoader.getCoreAspectIds(), 'teambit.harmony/harmony'];
   }
 
   /**

--- a/scopes/envs/envs/environments.main.runtime.ts
+++ b/scopes/envs/envs/environments.main.runtime.ts
@@ -1,7 +1,6 @@
 import { join } from 'path';
 import findRoot from 'find-root';
 import { resolveFrom } from '@teambit/toolbox.modules.module-resolver';
-import { isCoreAspect } from '@teambit/bit';
 import { existsSync, readFileSync } from 'fs-extra';
 import pLocate from 'p-locate';
 import { parse } from 'comment-json';
@@ -113,6 +112,8 @@ export class EnvsMain {
 
   private alreadyShownWarning = {};
 
+  private coreAspectIds: string[] = [];
+
   /**
    * icon of the extension.
    */
@@ -156,6 +157,13 @@ export class EnvsMain {
    */
   async createEnvironment(components: Component[]): Promise<Runtime> {
     return this.createRuntime(components);
+  }
+
+  setCoreAspectIds(ids: string[]) {
+    this.coreAspectIds = ids;
+  }
+  isCoreAspect(id: string) {
+    return this.coreAspectIds.includes(id);
   }
 
   /**
@@ -858,7 +866,7 @@ export class EnvsMain {
     const envId = await pLocate(ids, async (id) => {
       const idWithoutVersion = id.split('@')[0];
       if (this.isCoreEnv(idWithoutVersion)) return true;
-      if (isCoreAspect(idWithoutVersion)) return false;
+      if (this.isCoreAspect(idWithoutVersion)) return false;
       const envDef = this.getEnvDefinitionByStringId(id);
       if (envDef) return true;
       const envDefWithoutVersion = this.getEnvDefinitionByStringId(idWithoutVersion);

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -9,8 +9,9 @@ import { ComponentConfig } from '@teambit/legacy.consumer-config';
 import { WorkspaceConfigFilesAspect, WorkspaceConfigFilesMain } from '@teambit/workspace-config-files';
 import { ComponentAspect, ComponentID } from '@teambit/component';
 import type { ComponentMain, Component } from '@teambit/component';
-import { isCoreAspect, loadBit, restoreGlobalsFromSnapshot } from '@teambit/bit';
-import { Slot, SlotRegistry } from '@teambit/harmony';
+import { Scope as LegacyScope } from '@teambit/legacy.scope';
+import { ScopeAspect, ScopeMain } from '@teambit/scope';
+import { Harmony, Slot, SlotRegistry } from '@teambit/harmony';
 import { GitAspect, GitMain } from '@teambit/git';
 import { BitError } from '@teambit/bit-error';
 import { AspectLoaderAspect, AspectLoaderMain } from '@teambit/aspect-loader';
@@ -38,6 +39,7 @@ import { BasicWorkspaceStarter } from './templates/basic';
 import { StarterPlugin } from './starter.plugin';
 import { GeneratorService } from './generator.service';
 import { WorkspacePathExists } from './exceptions/workspace-path-exists';
+import { GLOBAL_SCOPE } from '@teambit/legacy.constants';
 
 export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
 export type WorkspaceTemplateSlot = SlotRegistry<WorkspaceTemplate[]>;
@@ -55,6 +57,14 @@ type TemplateWithId = { id: string; envName?: string };
 type WorkspaceTemplateWithId = TemplateWithId & { template: WorkspaceTemplate };
 type ComponentTemplateWithId = TemplateWithId & { template: ComponentTemplate };
 type AnyTemplateWithId = TemplateWithId & { template: ComponentTemplate | WorkspaceTemplate };
+
+type LegacyGlobal = { classInstance: any; methodName: string; value: any; empty: any };
+export type BitApi = {
+  isCoreAspect: (id: string) => boolean;
+  loadBit: (path?: string) => Promise<Harmony>;
+  restoreGlobalsFromSnapshot: (globals: LegacyGlobal[]) => void;
+  takeLegacyGlobalsSnapshot: () => LegacyGlobal[];
+};
 
 export type GenerateWorkspaceTemplateResult = { workspacePath: string; appName?: string };
 
@@ -78,6 +88,7 @@ export type GeneratorConfig = {
 
 export class GeneratorMain {
   private aspectLoaded = false;
+  private bitApi: BitApi;
   constructor(
     private componentTemplateSlot: ComponentTemplateSlot,
     private workspaceTemplateSlot: WorkspaceTemplateSlot,
@@ -94,6 +105,10 @@ export class GeneratorMain {
     private wsConfigFiles: WorkspaceConfigFilesMain,
     private deprecation: DeprecationMain
   ) {}
+
+  setBitApi(bitApi: BitApi) {
+    this.bitApi = bitApi;
+  }
 
   /**
    * register a new component template.
@@ -130,7 +145,7 @@ export class GeneratorMain {
   private getTemplateDescriptor = ({ id, template }: AnyTemplateWithId): TemplateDescriptor => {
     const shouldBeHidden = () => {
       if (template.hidden) return true;
-      if (this.config.hideCoreTemplates && isCoreAspect(id)) return true;
+      if (this.config.hideCoreTemplates && this.bitApi.isCoreAspect(id)) return true;
       return false;
     };
     return {
@@ -194,18 +209,57 @@ export class GeneratorMain {
   }
 
   /**
+   * get or create a global scope, import the non-core aspects, load bit from that scope, create
+   * capsules for the aspects and load them from the capsules.
+   */
+  private async loadAspectsFromGlobalScope(
+    aspectIds: string[]
+  ): Promise<{ components: Component[]; globalScopeHarmony: Harmony; legacyGlobalsSnapshot: LegacyGlobal[] }> {
+    const globalScope = await LegacyScope.ensure(GLOBAL_SCOPE, 'global-scope');
+    await globalScope.ensureDir();
+    const legacyGlobalsSnapshot = this.bitApi.takeLegacyGlobalsSnapshot();
+    const globalScopeHarmony = await this.bitApi.loadBit(globalScope.path);
+    const scope = globalScopeHarmony.get<ScopeMain>(ScopeAspect.id);
+    const aspectLoader = globalScopeHarmony.get<AspectLoaderMain>(AspectLoaderAspect.id);
+    const ids = aspectIds.map((id) => ComponentID.fromString(id));
+    const hasVersions = ids.every((id) => id.hasVersion());
+    const useCache = hasVersions; // if all components has versions, try to use the cached aspects
+    await scope.import(ids, { useCache, reason: 'to load aspects from global scope' });
+    const components = await scope.getMany(ids, true);
+
+    // don't use `await scope.loadAspectsFromCapsules(components, true);`
+    // it won't work for globalScope because `this !== scope.aspectLoader` (this instance
+    // is not the same as the aspectLoader instance Scope has)
+    const resolvedAspects = await scope.getResolvedAspects(components, { workspaceName: 'global-scope' });
+    try {
+      await aspectLoader.loadRequireableExtensions(resolvedAspects, true);
+    } catch (err: any) {
+      if (err?.error?.code === 'MODULE_NOT_FOUND') {
+        const resolvedAspectsAgain = await scope.getResolvedAspects(components, {
+          skipIfExists: false,
+          workspaceName: 'global-scope',
+        });
+        await aspectLoader.loadRequireableExtensions(resolvedAspectsAgain, true);
+      } else {
+        throw err;
+      }
+    }
+
+    return { components, globalScopeHarmony, legacyGlobalsSnapshot };
+  }
+
+  /**
    * Get the generator aspect and the envs aspect from an harmony instance of the global scope
    */
   private async getGlobalGeneratorEnvs(
     aspectId: string
   ): Promise<{ remoteGenerator: GeneratorMain; fullAspectId: string; remoteEnvsAspect: EnvsMain; aspect: any }> {
-    const { globalScopeHarmony, components, legacyGlobalsSnapshot } =
-      await this.aspectLoader.loadAspectsFromGlobalScope([aspectId]);
+    const { globalScopeHarmony, components, legacyGlobalsSnapshot } = await this.loadAspectsFromGlobalScope([aspectId]);
     const remoteGenerator = globalScopeHarmony.get<GeneratorMain>(GeneratorAspect.id);
     const remoteEnvsAspect = globalScopeHarmony.get<EnvsMain>(EnvsAspect.id);
     const aspect = components[0];
     const fullAspectId = aspect.id.toString();
-    restoreGlobalsFromSnapshot(legacyGlobalsSnapshot);
+    this.bitApi.restoreGlobalsFromSnapshot(legacyGlobalsSnapshot);
 
     return { remoteGenerator, fullAspectId, remoteEnvsAspect, aspect };
   }
@@ -233,7 +287,7 @@ export class GeneratorMain {
       throw new BitError(
         `to load a template from a different workspace, please provide the aspect-id using --aspect flag`
       );
-    const harmony = await loadBit(workspacePath);
+    const harmony = await this.bitApi.loadBit(workspacePath);
     let workspace: Workspace;
     try {
       workspace = harmony.get<Workspace>(WorkspaceAspect.id);
@@ -383,7 +437,14 @@ the reason is that after refactoring, the code will have this invalid class: "cl
       : await this.getWorkspaceTemplate(templateName, aspectId);
 
     if (!workspaceTemplate) throw new BitError(`template "${templateName}" was not found`);
-    const workspaceGenerator = new WorkspaceGenerator(workspaceName, workspacePath, options, workspaceTemplate, aspect);
+    const workspaceGenerator = new WorkspaceGenerator(
+      workspaceName,
+      workspacePath,
+      options,
+      workspaceTemplate,
+      this.bitApi,
+      aspect
+    );
     await this.warnAboutDeprecation(aspect);
     await workspaceGenerator.generate();
     return { workspacePath, appName: workspaceTemplate.appName };

--- a/scopes/generator/generator/workspace-generator.ts
+++ b/scopes/generator/generator/workspace-generator.ts
@@ -1,5 +1,4 @@
 import fs from 'fs-extra';
-import { loadBit } from '@teambit/bit';
 import { Harmony } from '@teambit/harmony';
 import { Component } from '@teambit/component';
 import execa from 'execa';
@@ -22,7 +21,7 @@ import { WorkspaceConfigFilesAspect, WorkspaceConfigFilesMain } from '@teambit/w
 import { WorkspaceTemplate, WorkspaceContext } from './workspace-template';
 import { NewOptions } from './new.cmd';
 import { GeneratorAspect } from './generator.aspect';
-import { GeneratorMain } from './generator.main.runtime';
+import { BitApi, GeneratorMain } from './generator.main.runtime';
 
 export type GenerateResult = { id: ComponentID; dir: string; files: string[]; envId: string };
 
@@ -42,6 +41,7 @@ export class WorkspaceGenerator {
     private workspacePath: string,
     private options: NewOptions & { currentDir?: boolean },
     private template: WorkspaceTemplate,
+    private bitApi: BitApi,
     private aspectComponent?: Component
   ) {}
 
@@ -147,7 +147,7 @@ export class WorkspaceGenerator {
   }
 
   private async reloadBitInWorkspaceDir() {
-    this.harmony = await loadBit(this.workspacePath);
+    this.harmony = await this.bitApi.loadBit(this.workspacePath);
     this.workspace = this.harmony.get<Workspace>(WorkspaceAspect.id);
     this.install = this.harmony.get<InstallMain>(InstallAspect.id);
     const loggerMain = this.harmony.get<LoggerMain>(LoggerAspect.id);

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -11,7 +11,8 @@ process.env.BROWSERSLIST_IGNORE_OLD_DATA = 'true';
 
 import './hook-require';
 
-import AspectLoaderAspect, {
+import {
+  AspectLoaderAspect,
   getAspectDir,
   getAspectDistDir,
   AspectLoaderMain,
@@ -48,7 +49,7 @@ import { getAllCoreAspectsIds, isCoreAspect, manifestsMap } from './manifests';
 import { BitAspect } from './bit.aspect';
 import { registerCoreExtensions } from './bit.main.runtime';
 import { BitConfig } from './bit.provider';
-import EnvsAspect, { EnvsMain } from '@teambit/envs';
+import { EnvsAspect, EnvsMain } from '@teambit/envs';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 
 async function loadLegacyConfig(config: any) {

--- a/scopes/harmony/bit/load-bit.ts
+++ b/scopes/harmony/bit/load-bit.ts
@@ -11,7 +11,7 @@ process.env.BROWSERSLIST_IGNORE_OLD_DATA = 'true';
 
 import './hook-require';
 
-import {
+import AspectLoaderAspect, {
   getAspectDir,
   getAspectDistDir,
   AspectLoaderMain,
@@ -44,10 +44,12 @@ import { logger } from '@teambit/legacy.logger';
 import { ExternalActions } from '@teambit/legacy.scope-api';
 import { readdir, readFile } from 'fs-extra';
 import { resolve, join } from 'path';
-import { manifestsMap } from './manifests';
+import { getAllCoreAspectsIds, isCoreAspect, manifestsMap } from './manifests';
 import { BitAspect } from './bit.aspect';
 import { registerCoreExtensions } from './bit.main.runtime';
 import { BitConfig } from './bit.provider';
+import EnvsAspect, { EnvsMain } from '@teambit/envs';
+import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 
 async function loadLegacyConfig(config: any) {
   const harmony = await Harmony.load([ConfigAspect], ConfigRuntime.name, config.toObject());
@@ -277,9 +279,18 @@ export async function loadBit(path = process.cwd()) {
 
   await harmony.run(async (aspect: Extension, runtime: RuntimeDefinition) => requireAspects(aspect, runtime));
   if (loadCLIOnly) return harmony;
-  const aspectLoader = harmony.get<AspectLoaderMain>('teambit.harmony/aspect-loader');
+  const aspectLoader = harmony.get<AspectLoaderMain>(AspectLoaderAspect.id);
   aspectLoader.setCoreAspects(Object.values(manifestsMap));
   aspectLoader.setMainAspect(getMainAspect());
+  const envs = harmony.get<EnvsMain>(EnvsAspect.id);
+  envs.setCoreAspectIds(getAllCoreAspectsIds());
+  const generator = harmony.get<GeneratorMain>(GeneratorAspect.id);
+  generator.setBitApi({
+    loadBit,
+    takeLegacyGlobalsSnapshot,
+    restoreGlobalsFromSnapshot,
+    isCoreAspect,
+  });
   return harmony;
 }
 


### PR DESCRIPTION
Bit aspect (`teambit.harmony/bit`) depends on all core aspects. This is needed because this aspect is the main entry of bit, it loads all those core aspects and also we want to this aspect to get a new version every time a core-aspect has changed, so then when running bit, all the core aspect are always up to date.

However, some core aspects, e.g. `Generator` aspect were depended on Bit aspect (practically forming a circular dependency) for mainly two tasks: loadBit() and getting core-ids. Because of this circular, changing core aspects triggers an auto-tag of most of the core aspects. Leading to unnecessary tags and slow deployment. 

This PR breaks this direction of dependency by injecting the APIs needed to those aspects from the loadBit function. It's not pretty, but it's much better than how it is now.