### PR TITLE
fix: don't export dependencies graph from workspace that doesn't use root components

### DIFF
--- a/scopes/dependencies/pnpm/pnpm.package-manager.ts
+++ b/scopes/dependencies/pnpm/pnpm.package-manager.ts
@@ -104,7 +104,7 @@ export class PnpmPackageManager implements PackageManager {
     // eslint-disable-next-line global-require, import/no-dynamic-require
     const { install } = require('./lynx');
 
-    if (installOptions.dependenciesGraph && isFeatureEnabled(DEPS_GRAPH)) {
+    if (installOptions.dependenciesGraph && isFeatureEnabled(DEPS_GRAPH) && installOptions.rootComponents) {
       await this.dependenciesGraphToLockfile(installOptions.dependenciesGraph, manifests, rootDir);
     }
 


### PR DESCRIPTION
## Proposed Changes

-
-
-
