### PR TITLE
fix(load apps) - fix cases when components not loaded as app incorrectly

### DIFF
--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -192,9 +192,16 @@ export class ApplicationMain {
    * if poolIds is provided, it will load only the apps that are part of the pool.
    */
   async listAppsComponents(poolIds?: ComponentID[]): Promise<Component[]> {
+    const host = this.workspace || this.componentAspect.getHost();
     const components = poolIds
-      ? await this.componentAspect.getHost().getMany(poolIds)
-      : await this.componentAspect.getHost().list();
+      ? this.workspace
+        ? await this.workspace.getMany(poolIds, {
+            loadExtensions: true,
+            executeLoadSlot: true,
+            loadSeedersAsAspects: true,
+          })
+        : await host.getMany(poolIds)
+      : await host.list();
     const appTypesPatterns = this.getAppPatterns();
     const appsComponents = components.filter((component) => this.hasAppTypePattern(component, appTypesPatterns));
     return appsComponents;


### PR DESCRIPTION
## Proposed Changes

- This change will make sure that when loading apps components in a workspace we will run the load slot and the aspects to make sure: 
  - we identify them as apps
  - we don't show a warning about their not-loaded envs
- This will also fix cases when snapping components will not add the apps data into the component data
-
