### PR TITLE
Introducing Bit Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 <a href="https://circleci.com/gh/teambit/bit/tree/master"><img alt="Circle Status" src="https://circleci.com/gh/teambit/bit/tree/master.svg?style=shield">
 <a href="https://github.com/prettier/prettier"><img alt ="Styled with Prettier" src="https://img.shields.io/badge/styled_with-prettier-ff69b4.svg">
 <a href="https://join.slack.com/t/bit-dev-community/shared_invite/zt-1vq1vcxxu-CEVobR1p9BurmW8QnQFh1w" ><img alt="Join Slack" src="https://img.shields.io/badge/Slack-Join%20Bit%20Slack-blueviolet"/></a>
+<a href="https://gurubase.io/g/bit"><img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Bit%20Guru-006BFF"></a>
 
 [Bit](https://bit.dev) is a complete solution for building **composable software**. It simplifies the creation, maintenance and reuse of software using independent and reusable components.
 


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [Bit Guru](https://gurubase.io/g/bit) has been manually added to Gurubase. Bit Guru uses the data from this repo and data from the [docs](https://bit.dev/docs/) to answer questions by leveraging the LLM.

This PR introduces the "Bit Guru", showcasing that Bit now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "Bit Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the Bit documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable Bit Guru in Gurubase, just let us know that's totally fine.
