### PR TITLE
fix(doctor), no need to run "bit init" after untar doctor archive with exclude-local-scope

### DIFF
--- a/scopes/harmony/doctor/doctor.main.runtime.ts
+++ b/scopes/harmony/doctor/doctor.main.runtime.ts
@@ -228,7 +228,10 @@ export class DoctorMain {
       const isGit = fileName.startsWith(`.git${path.sep}`);
       const isLocalScope =
         fileName.startsWith(`.bit${path.sep}`) || fileName.startsWith(`.git${path.sep}bit${path.sep}`);
-      if (excludeLocalScope && isLocalScope) return true;
+      if (excludeLocalScope && isLocalScope) {
+        const scopeDirsToExclude = ['objects', 'cache', 'tmp'];
+        if (scopeDirsToExclude.some((dir) => fileName.includes(`${path.sep}${dir}${path.sep}`))) return true;
+      }
       if (isGit && !isLocalScope) return true;
       return false;
     };


### PR DESCRIPTION
Also, when using this flag, only exclude the "objects" and "cache" directories which can be huge. Others are not important and can be actually useful for debugging.