### PR TITLE
fix(log), show log of core aspects

### DIFF
--- a/scopes/component/component-log/component-log.main.runtime.ts
+++ b/scopes/component/component-log/component-log.main.runtime.ts
@@ -74,7 +74,12 @@ export class ComponentLogMain {
     }
     if (!this.workspace) throw new OutsideWorkspaceError();
     const componentId = await this.workspace.resolveComponentId(id);
-    if (!componentId.hasVersion()) return []; // component is new
+    if (!componentId.hasVersion()) {
+      const inWs = this.workspace.getIdIfExist(componentId);
+      if (inWs && !inWs.hasVersion()) {
+        return []; // component is new
+      }
+    }
     const logs = await this.workspace.scope.getLogs(componentId, shortHash, undefined, true);
     logs.forEach((log) => {
       log.date = log.date ? moment(new Date(parseInt(log.date))).format('YYYY-MM-DD HH:mm:ss') : undefined;


### PR DESCRIPTION
`workspace.resolveComponentId` of core-aspects returns the component-id without version, as a result, bit assumes the component is new and doesn't show the log for it.
This PR fixes it by getting the component from .bitmap and checking whether it has a version.