### PR TITLE
fix(import), improve error when importing a component on existing dir

### DIFF
--- a/components/legacy/bit-map/bit-map.ts
+++ b/components/legacy/bit-map/bit-map.ts
@@ -866,6 +866,10 @@ export class BitMap {
     return caseSensitive ? this.paths[componentPath] : this.pathsLowerCase[componentPath.toLowerCase()];
   }
 
+  getComponentIdByRootPath(componentPath: PathLinux): ComponentID | undefined {
+    return this.components.find((component) => component.rootDir === componentPath)?.id;
+  }
+
   _populateAllPaths() {
     if (R.isEmpty(this.paths)) {
       this.components.forEach((component) => {
@@ -893,13 +897,12 @@ export class BitMap {
 
   getAllTrackDirs() {
     if (!this.allTrackDirs) {
-      this.allTrackDirs = {};
+      const allTrackDirs = {};
       this.components.forEach((component) => {
         const trackDir = component.getRootDir();
-        if (!trackDir) return;
-        // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-        this.allTrackDirs[trackDir] = component.id;
+        allTrackDirs[trackDir] = component.id;
       });
+      this.allTrackDirs = allTrackDirs;
     }
     return this.allTrackDirs;
   }

--- a/scopes/component/component-writer/component-writer.main.runtime.ts
+++ b/scopes/component/component-writer/component-writer.main.runtime.ts
@@ -252,7 +252,7 @@ export class ComponentWriterMain {
       const componentMap = this.consumer.bitMap.getComponentIfExist(component.id, {
         ignoreVersion: true,
       });
-      this.throwErrorWhenDirectoryNotEmpty(this.consumer.toAbsolutePath(componentRootDir), componentMap, opts);
+      this.throwErrorWhenDirectoryNotEmpty(componentRootDir, componentMap, opts);
       return {
         existingComponentMap: componentMap,
       };
@@ -288,7 +288,7 @@ to move all component files to a different directory, run bit remove and then bi
     }
   }
   private throwErrorWhenDirectoryNotEmpty(
-    componentDir: PathOsBasedAbsolute,
+    componentDirRelative: PathOsBasedAbsolute,
     componentMap: ComponentMap | null | undefined,
     opts: ManyComponentsWriterParams
   ) {
@@ -299,15 +299,24 @@ to move all component files to a different directory, run bit remove and then bi
     // if writeToPath specified and that directory is already used for that component, it's ok to override
     if (opts.writeToPath && componentMap && componentMap.rootDir && componentMap.rootDir === opts.writeToPath) return;
 
-    if (fs.pathExistsSync(componentDir)) {
-      if (!isDir(componentDir)) {
-        throw new BitError(`unable to import to ${componentDir} because it's a file`);
-      }
-      if (!isDirEmptySync(componentDir) && opts.throwForExistingDir) {
+    const componentDir = this.consumer.toAbsolutePath(componentDirRelative);
+    if (!fs.pathExistsSync(componentDir)) return;
+    if (!componentMap) {
+      const compInTheSameDir = this.consumer.bitMap.getComponentIdByRootPath(componentDirRelative);
+      if (compInTheSameDir) {
         throw new BitError(
-          `unable to import to ${componentDir}, the directory is not empty. use --override flag to delete the directory and then import`
+          `unable to import to ${componentDir}, the directory is already used by ${compInTheSameDir.toString()}.
+either use --path to specify a different directory or modify "defaultDirectory" prop in the workspace.jsonc file to "{scopeId}/{name}"`
         );
       }
+    }
+    if (!isDir(componentDir)) {
+      throw new BitError(`unable to import to ${componentDir} because it's a file`);
+    }
+    if (!isDirEmptySync(componentDir) && opts.throwForExistingDir) {
+      throw new BitError(
+        `unable to import to ${componentDir}, the directory is not empty. use --override flag to delete the directory and then import`
+      );
     }
   }
 


### PR DESCRIPTION
In case the current component is using the same dir of an existing one, suggest using `--path` or modifying workspace.jsonc at defaultDirectory. Currently, it suggests using `--override` incorrectly. 