### PR TITLE
fix(status), remove irrelevant snap info for outdated components when the head is the same as latest

### DIFF
--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -459,7 +459,10 @@ export default class Component extends BitObject {
     }
     await this.setDivergeData(repo, false);
     const divergeData = this.getDivergeData();
-    return divergeData.isTargetAhead() ? remoteHead.toString() : latestLocally;
+    if (divergeData.isTargetAhead()) {
+      return this.getTagOfRefIfExists(remoteHead) || remoteHead.toString();
+    }
+    return latestLocally;
   }
 
   async getRefOfAncestor(repo: Repository, generationsToGoBack: number): Promise<Ref> {


### PR DESCRIPTION
Before:
 > teambit.docs/docs-template current: 1.0.7 head: 81fafbec36995725fed26cef8feff57ef2be90e4 latest: 1.0.8

Now: 
 > teambit.docs/docs-template current: 1.0.7 head: 1.0.8