### PR TITLE
fix(env-update), update to env from main if deleted on the current lane

### DIFF
--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -85,13 +85,16 @@ export class ScopeComponentLoader {
   /**
    * get a component from a remote without importing it
    */
-  async getRemoteComponent(id: ComponentID): Promise<Component> {
+  async getRemoteComponent(id: ComponentID, fromMain = false): Promise<Component> {
     const compImport = this.scope.legacyScope.scopeImporter;
     const objectList = await compImport.getRemoteComponent(id);
     // it's crucial to add all objects to the Repository cache. otherwise, later, when it asks
     // for the consumerComponent from the legacyScope, it won't work.
     objectList?.getAll().forEach((obj) => this.scope.legacyScope.objects.setCache(obj));
-    const consumerComponent = await this.scope.legacyScope.getConsumerComponent(id);
+    const modelComponent = await this.scope.legacyScope.getModelComponent(id);
+    const headAsTag = modelComponent.getHeadAsTagIfExist();
+    const idToLoad = fromMain && headAsTag ? id.changeVersion(headAsTag) : id;
+    const consumerComponent = await this.scope.legacyScope.getConsumerComponent(idToLoad);
     return this.getFromConsumerComponent(consumerComponent);
   }
 

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -721,9 +721,10 @@ export class ScopeMain implements ComponentFactory {
 
   /**
    * get a component from a remote without importing it
+   * by default, when on a lane, it loads the component from the lane. unless `fromMain` is set to true.
    */
-  async getRemoteComponent(id: ComponentID): Promise<Component> {
-    return this.componentLoader.getRemoteComponent(id);
+  async getRemoteComponent(id: ComponentID, fromMain = false): Promise<Component> {
+    return this.componentLoader.getRemoteComponent(id, fromMain);
   }
 
   /**


### PR DESCRIPTION
If the env is in the current lane and marked as deleted, `bit env update` currently sets the env to the deleted version.
This PR resolves this issue by ensuring the env is set to the main version instead. 