### PR TITLE
improvement, log the progress of creating the index.json file

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1379,7 +1379,13 @@
         "scope": "teambit.toolbox",
         "version": "0.0.2",
         "mainFile": "index.ts",
-        "rootDir": "scopes/toolbox/promise/map-pool"
+        "rootDir": "scopes/toolbox/promise/map-pool",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.0.37": {},
+            "teambit.envs/envs": {
+                "env": "teambit.node/envs/node-babel-mocha"
+            }
+        }
     },
     "pubsub": {
         "name": "pubsub",

--- a/scopes/toolbox/promise/map-pool/promise-with-concurrent.spec.ts
+++ b/scopes/toolbox/promise/map-pool/promise-with-concurrent.spec.ts
@@ -1,0 +1,70 @@
+import { expect } from 'chai';
+import { pMapPool } from './promise-with-concurrent';
+// import pMapPool from 'p-map';
+
+describe('pMapPool Tests', () => {
+  it('should return an empty array if the input is empty', async () => {
+    const result = await pMapPool([], async (item) => item, { concurrency: 2 });
+    expect(result).to.deep.equal([]);
+  });
+
+  it('should process all items with concurrency = Infinity', async () => {
+    const items = [1, 2, 3, 4, 5];
+    const mapper = async (value: number) => value * 2;
+    const result = await pMapPool(items, mapper, { concurrency: Infinity });
+
+    // Since concurrency is infinite, it just behaves like Promise.all(mapper(...))
+    // Expect each item doubled
+    expect(result).to.deep.equal([2, 4, 6, 8, 10]);
+  });
+
+  it('should process all items with concurrency = 2', async () => {
+    const items = [1, 2, 3, 4];
+    const mapper = async (value: number) => {
+      // Simulate a small delay
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      return value + 10;
+    };
+    const result = await pMapPool(items, mapper, { concurrency: 2 });
+
+    // Expect each item incremented by 10
+    expect(result).to.deep.equal([11, 12, 13, 14]);
+  });
+
+  it('should handle concurrency larger than the array size', async () => {
+    const items = [10, 20, 30];
+    const mapper = async (value: number) => value / 10;
+    // concurrency is 10, but only 3 items
+    const result = await pMapPool(items, mapper, { concurrency: 10 });
+
+    // Expect each item divided by 10
+    expect(result).to.deep.equal([1, 2, 3]);
+  });
+
+  it('should preserve stack traces when an error is thrown', async () => {
+    const items = [1, 2, 3];
+    // This mapper will throw an error on the second item
+    const mapper = async (value: number) => {
+      if (value === 2) {
+        throw new Error('Test error for concurrency function');
+      }
+      return value;
+    };
+
+    let caughtError: Error | null = null;
+
+    try {
+      await pMapPool(items, mapper, { concurrency: 2 });
+    } catch (error: any) {
+      caughtError = error;
+    }
+
+    expect(caughtError).to.not.be.null;
+    expect(caughtError).to.be.an.instanceOf(Error);
+    expect(caughtError!.message).to.equal('Test error for concurrency function');
+    expect(caughtError!.stack).to.include('mapper');
+    // for p-map it's 3.
+    // for p-map-pool it's 15.
+    expect(caughtError!.stack?.split('\n').length).to.be.greaterThan(5);
+  });
+});

--- a/scopes/toolbox/promise/map-pool/promise-with-concurrent.ts
+++ b/scopes/toolbox/promise/map-pool/promise-with-concurrent.ts
@@ -2,7 +2,6 @@
  * the reason for not using p-map package is because the stacktrace is lost.
  * see here: https://github.com/sindresorhus/p-map/issues/34
  */
-
 import { chunk } from 'lodash';
 
 export async function pMapPool<T, X>(
@@ -20,10 +19,8 @@ export async function pMapPool<T, X>(
 
   const results: X[] = [];
   const chunks = chunk(iterable, concurrency);
-  // console.log("🚀 ~ chunks:", chunks)
 
   for (const currentChunk of chunks) {
-    // console.log("🚀 ~ currentChunk:", currentChunk)
     const batchResults = await Promise.all(currentChunk.map((item) => mapper(item)));
     results.push(...batchResults);
     onCompletedChunk(results.length);

--- a/scopes/toolbox/promise/map-pool/promise-with-concurrent.ts
+++ b/scopes/toolbox/promise/map-pool/promise-with-concurrent.ts
@@ -3,25 +3,31 @@
  * see here: https://github.com/sindresorhus/p-map/issues/34
  */
 
-export async function pMapPool<T, X>(iterable: T[], mapper: (item: T) => Promise<X>, { concurrency = Infinity } = {}) {
+import { chunk } from 'lodash';
+
+export async function pMapPool<T, X>(
+  iterable: T[],
+  mapper: (item: T) => Promise<X>,
+  {
+    concurrency = Infinity,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    onCompletedChunk = (_completed: number) => {},
+  } = {}
+) {
+  if (concurrency === Infinity) {
+    return Promise.all(iterable.map((item) => mapper(item)));
+  }
+
   const results: X[] = [];
-  const iterator = iterable[Symbol.iterator]();
-  let completed = false;
-  const runBatch = async () => {
-    const items: T[] = [];
-    for (let i = 0; i < concurrency; i += 1) {
-      const iterableResult = iterator.next();
-      if (iterableResult.done) {
-        completed = true;
-        break;
-      }
-      items.push(iterableResult.value);
-    }
-    const batchResults = await Promise.all(items.map((item) => mapper(item)));
+  const chunks = chunk(iterable, concurrency);
+  // console.log("🚀 ~ chunks:", chunks)
+
+  for (const currentChunk of chunks) {
+    // console.log("🚀 ~ currentChunk:", currentChunk)
+    const batchResults = await Promise.all(currentChunk.map((item) => mapper(item)));
     results.push(...batchResults);
-    if (!completed) await runBatch();
-  };
-  await runBatch();
+    onCompletedChunk(results.length);
+  }
 
   return results;
 }


### PR DESCRIPTION
For large scopes, when index.json is deleted it takes a while to create a new one (because it needs to read every object file). In the meanwhile, there is no indication that something is happening. This PR logs to the debug.log the progress every 1,000 files.
Also, the implementation of p-map-pool is simplified by using `chunk` from `lodash`.