### PR TITLE
improvement, avoid deleting index.json when it has missing objects

### DIFF
--- a/components/legacy/scope/exceptions/outdated-index-json.ts
+++ b/components/legacy/scope/exceptions/outdated-index-json.ts
@@ -1,15 +1,9 @@
 import chalk from 'chalk';
 
 export default class OutdatedIndexJson extends Error {
-  id: string;
-  indexJsonPath: string;
-  showDoctorMessage: boolean;
-
-  constructor(id: string, indexJsonPath: string) {
-    super(`error: ${chalk.bold(id)} found in the index.json file, however, is missing from the scope.
-the cache is deleted and will be rebuilt on the next command. please re-run the command.`);
-    this.id = id;
-    this.indexJsonPath = indexJsonPath;
-    this.showDoctorMessage = true;
+  constructor(missingObjects: string[]) {
+    super(`Error: The following object IDs were found in the index.json file but are missing from the filesystem.
+The index has been updated to remove these objects. Please re-run the command to proceed.
+${missingObjects.map((id) => chalk.bold(id)).join('\n')}`);
   }
 }

--- a/e2e/functionalities/components-index.e2e.2.ts
+++ b/e2e/functionalities/components-index.e2e.2.ts
@@ -136,10 +136,7 @@ describe('scope components index mechanism', function () {
       });
       it('bit status should throw an error for the first time and then should work on the second run', () => {
         // used to show "Cannot read property 'scope' of null"
-        const error = new OutdatedIndexJson(
-          `component "${helper.scopes.remote}/bar/foo"`,
-          helper.general.indexJsonPath()
-        );
+        const error = new OutdatedIndexJson([`component "${helper.scopes.remote}/bar/foo"`]);
         const statusCmd = () => helper.command.status();
         helper.general.expectToThrow(statusCmd, error);
 

--- a/scopes/scope/objects/objects/scope-index.ts
+++ b/scopes/scope/objects/objects/scope-index.ts
@@ -13,7 +13,7 @@ import { difference } from 'lodash';
 
 const COMPONENTS_INDEX_FILENAME = 'index.json';
 
-interface IndexItem {
+export interface IndexItem {
   hash: string;
   toIdentifierString(): string;
 }


### PR DESCRIPTION
Currently, when an object (lane/component) exists in index.json but missing from the filesystem, bit deletes the index.json assuming it's corrupted and re-create it on the next command. 
For large scopes, it takes long time to re-create the file because it needs to parse each and every object file.
This PR approaches it differently. It updates the index.json file, removes the missing objects and then throws an error telling the user to re-run the command. 