### PR TITLE
refactor, reduce the usage of legacy scope/comp for snapping API

### DIFF
--- a/components/legacy/scope/component-ops/scope-components-importer.ts
+++ b/components/legacy/scope/component-ops/scope-components-importer.ts
@@ -479,7 +479,7 @@ export class ScopeComponentsImporter {
 
   async importLanes(remoteLaneIds: LaneId[], includeLaneHistory = false): Promise<Lane[]> {
     const remotes = await getScopeRemotes(this.scope);
-    const objectsStreamPerRemote = await remotes.fetch(groupByScopeName(remoteLaneIds), this.scope, {
+    const objectsStreamPerRemote = await remotes.fetch(groupByScopeName(remoteLaneIds), {
       type: 'lane',
       includeLaneHistory,
     });
@@ -540,7 +540,7 @@ export class ScopeComponentsImporter {
     const remotes: Remotes = await getScopeRemotes(this.scope);
     const remote = await remotes.resolve(remoteName);
     const getExistingLegacy = async () => {
-      const multipleStreams = await remotes.fetch({ [remoteName]: hashes }, this.scope, { type: 'object' });
+      const multipleStreams = await remotes.fetch({ [remoteName]: hashes }, { type: 'object' });
       const existing = await this.streamToHashes(remoteName, multipleStreams[remoteName]);
       return existing;
     };
@@ -673,7 +673,7 @@ export class ScopeComponentsImporter {
     const remotes = await getScopeRemotes(this.scope);
     let bitObjectsList: BitObjectList;
     try {
-      const streams = await remotes.fetch({ [id.scope as string]: [id.toString()] }, this.scope);
+      const streams = await remotes.fetch({ [id.scope as string]: [id.toString()] });
       bitObjectsList = await this.multipleStreamsToBitObjects(streams);
     } catch (err: any) {
       logger.error(`getRemoteComponent, failed to get ${id.toString()}`, err);
@@ -695,7 +695,7 @@ export class ScopeComponentsImporter {
     });
     const remotes = await getScopeRemotes(this.scope);
     const grouped = groupByScopeName(ids);
-    const streams = await remotes.fetch(grouped, this.scope);
+    const streams = await remotes.fetch(grouped);
     return this.multipleStreamsToBitObjects(streams);
   }
 

--- a/components/legacy/scope/objects-fetcher/objects-fetcher.ts
+++ b/components/legacy/scope/objects-fetcher/objects-fetcher.ts
@@ -158,7 +158,7 @@ ${failedScopesErr.join('\n')}`);
     const shouldThrowOnUnavailableScope = this.throwOnUnavailableScope && !this.fetchOptions.withoutDependencies;
     let remote: Remote;
     try {
-      remote = await this.remotes.resolve(scopeName, this.scope);
+      remote = await this.remotes.resolve(scopeName);
     } catch (err: any) {
       if (err instanceof ScopeNotFoundOrDenied) {
         throw new Error(`unable to import the following component(s): ${ids.join(', ')}.

--- a/components/scope/remotes/get-remote-by-name.ts
+++ b/components/scope/remotes/get-remote-by-name.ts
@@ -6,7 +6,7 @@ import { Remotes } from './remotes';
 export async function getRemoteByName(remoteName: string, consumer?: Consumer): Promise<Remote> {
   if (consumer) {
     const remotes: Remotes = await getScopeRemotes(consumer.scope);
-    return remotes.resolve(remoteName, consumer.scope);
+    return remotes.resolve(remoteName);
   }
   return Remotes.getScopeRemote(remoteName);
 }

--- a/components/scope/remotes/remotes.ts
+++ b/components/scope/remotes/remotes.ts
@@ -6,7 +6,7 @@ import pMap from 'p-map';
 import { CURRENT_FETCH_SCHEMA, FETCH_OPTIONS } from '@teambit/legacy.scope-api';
 import { GlobalRemotes } from './global-remotes';
 import { logger } from '@teambit/legacy.logger';
-import { Scope, ScopeNotFound } from '@teambit/legacy.scope';
+import { Scope as LegacyScope, ScopeNotFound } from '@teambit/legacy.scope';
 import { DependencyGraph } from '@teambit/legacy.dependency-graph';
 import { prependBang } from '@teambit/legacy.utils';
 import { concurrentFetchLimit } from '@teambit/harmony.modules.concurrency';
@@ -18,7 +18,10 @@ import { ObjectItemsStream } from '@teambit/scope.objects';
 import { ScopeNotFoundOrDenied } from './exceptions/scope-not-found-or-denied';
 
 export class Remotes extends Map<string, Remote> {
-  constructor(remotes: [string, Remote][] = []) {
+  constructor(
+    remotes: [string, Remote][] = [],
+    protected thisScope?: LegacyScope
+  ) {
     super(remotes);
   }
 
@@ -29,11 +32,11 @@ export class Remotes extends Map<string, Remote> {
     return this.forEach((remote) => remote.validate());
   }
 
-  async resolve(scopeName: string, thisScope?: Scope | undefined): Promise<Remote> {
+  async resolve(scopeName: string): Promise<Remote> {
     const remote = super.get(scopeName);
     if (remote) return Promise.resolve(remote);
-    const scopeHost = await remoteResolver(scopeName, thisScope);
-    return new Remote(scopeHost, scopeName, undefined, thisScope?.name);
+    const scopeHost = await remoteResolver(scopeName, this.thisScope);
+    return new Remote(scopeHost, scopeName, undefined, this.thisScope?.name);
   }
 
   isHub(scope: string): boolean {
@@ -43,7 +46,6 @@ export class Remotes extends Map<string, Remote> {
 
   async fetch(
     idsGroupedByScope: { [scopeName: string]: string[] }, // option.type determines the id: component-id/lane-id/object-id (hash)
-    thisScope: Scope,
     options: Partial<FETCH_OPTIONS> = {},
     context?: Record<string, any>
   ): Promise<{ [remoteName: string]: ObjectItemsStream }> {
@@ -66,7 +68,7 @@ export class Remotes extends Map<string, Remote> {
       Object.keys(idsGroupedByScope),
       async (scopeName) => {
         try {
-          const remote = await this.resolve(scopeName, thisScope);
+          const remote = await this.resolve(scopeName);
           const objectsStream = await remote.fetch(idsGroupedByScope[scopeName], fetchOptions, context);
           objectsStreamPerRemote[scopeName] = objectsStream;
           return objectsStream;
@@ -107,11 +109,11 @@ ${failedScopesErr.join('\n')}`);
     return objectsStreamPerRemote;
   }
 
-  async latestVersions(ids: ComponentID[], thisScope: Scope): Promise<ComponentID[]> {
+  async latestVersions(ids: ComponentID[]): Promise<ComponentID[]> {
     const groupedIds = this._groupByScopeName(ids);
 
     const promises = Object.entries(groupedIds).map(([scopeName, scopeIds]) =>
-      this.resolve(scopeName, thisScope).then((remote) => remote.latestVersions(scopeIds))
+      this.resolve(scopeName).then((remote) => remote.latestVersions(scopeIds))
     );
 
     const components = await Promise.all(promises);
@@ -125,10 +127,10 @@ ${failedScopesErr.join('\n')}`);
    * entire scope graph. however, when asking for multiple ids in the same scope, which is more
    * likely to happen, it'll harm the performance.
    */
-  async scopeGraphs(ids: ComponentID[], thisScope: Scope): Promise<DependencyGraph[]> {
+  async scopeGraphs(ids: ComponentID[]): Promise<DependencyGraph[]> {
     const groupedIds = this._groupByScopeName(ids);
     const graphsP = Object.keys(groupedIds).map(async (scopeName) => {
-      const remote = await this.resolve(scopeName, thisScope);
+      const remote = await this.resolve(scopeName);
       const dependencyGraph = await remote.graph();
       dependencyGraph.setScopeName(scopeName);
       return dependencyGraph;
@@ -173,10 +175,10 @@ ${failedScopesErr.join('\n')}`);
     return Remotes.load(remotes);
   }
 
-  static load(remotes: { [key: string]: string }, thisScope?: Scope): Remotes {
+  static load(remotes: { [key: string]: string }, thisScope?: LegacyScope): Remotes {
     const models = [];
 
-    if (!remotes) return new Remotes();
+    if (!remotes) return new Remotes(undefined, thisScope);
 
     forEach(remotes, (name, host) => {
       const remote = Remote.load(name, host, thisScope);
@@ -184,6 +186,6 @@ ${failedScopesErr.join('\n')}`);
       models.push([remote.name, remote]);
     });
 
-    return new Remotes(models);
+    return new Remotes(models, thisScope);
   }
 }

--- a/components/scope/remotes/scope-remotes.ts
+++ b/components/scope/remotes/scope-remotes.ts
@@ -1,16 +1,16 @@
 import { ComponentID } from '@teambit/component-id';
 import { GlobalRemotes } from './global-remotes';
-import { Scope } from '@teambit/legacy.scope';
+import { Scope as LegacyScope } from '@teambit/legacy.scope';
 import { Remotes } from './remotes';
 
-export async function getScopeRemotes(scope: Scope): Promise<Remotes> {
+export async function getScopeRemotes(scope: LegacyScope): Promise<Remotes> {
   const globalRemotes = await GlobalRemotes.load();
   const globalObj = globalRemotes.toPlainObject();
   return Remotes.load({ ...globalObj, ...scope.scopeJson.remotes }, scope);
 }
 
-export async function fetchRemoteVersions(scope: Scope, componentIds: ComponentID[]): Promise<ComponentID[]> {
+export async function fetchRemoteVersions(scope: LegacyScope, componentIds: ComponentID[]): Promise<ComponentID[]> {
   const externals = componentIds.filter((id) => !scope.isLocal(id));
   const remotes = await getScopeRemotes(scope);
-  return remotes.latestVersions(externals, scope);
+  return remotes.latestVersions(externals);
 }

--- a/scopes/cloud/cloud/cloud.main.runtime.ts
+++ b/scopes/cloud/cloud/cloud.main.runtime.ts
@@ -602,7 +602,7 @@ export class CloudMain {
   static PRESET_ORGS = ['bitdev', 'teambit', 'bitdesign', 'frontend', 'backend'];
 
   async getCloudScopes(scopes: string[]): Promise<ScopeDescriptor[]> {
-    const remotes = await this.scope._legacyRemotes();
+    const remotes = await this.scope.getRemoteScopes();
     const filteredScopesToFetch = scopes.filter((scope) => {
       return ScopeID.isValid(scope) && remotes.isHub(scope);
     });

--- a/scopes/component/remove/remove-components.ts
+++ b/scopes/component/remove/remove-components.ts
@@ -8,7 +8,7 @@ import { CENTRAL_BIT_HUB_NAME, CENTRAL_BIT_HUB_URL, LATEST_BIT_VERSION } from '@
 import { BitError } from '@teambit/bit-error';
 import { logger } from '@teambit/legacy.logger';
 import { Http } from '@teambit/scope.network';
-import { Remotes, getScopeRemotes } from '@teambit/scope.remotes';
+import { Remotes } from '@teambit/scope.remotes';
 import { deleteComponentsFiles } from './delete-component-files';
 import { ComponentsList } from '@teambit/legacy.component-list';
 import { RemovedObjects } from '@teambit/legacy.scope';
@@ -77,7 +77,7 @@ async function removeRemote(
   force: boolean
 ): Promise<RemovedObjects[]> {
   const groupedBitsByScope = groupArray(bitIds, 'scope');
-  const remotes = workspace ? await getScopeRemotes(workspace.scope.legacyScope) : await Remotes.getGlobalRemotes();
+  const remotes = workspace ? await workspace.scope.getRemoteScopes() : await Remotes.getGlobalRemotes();
   const shouldGoToCentralHub = remotes.shouldGoToCentralHub(Object.keys(groupedBitsByScope));
   if (shouldGoToCentralHub) {
     const http = await Http.connect(CENTRAL_BIT_HUB_URL, CENTRAL_BIT_HUB_NAME);
@@ -88,7 +88,7 @@ async function removeRemote(
   }
   const context = {};
   const removeP = Object.keys(groupedBitsByScope).map(async (key) => {
-    const resolvedRemote = await remotes.resolve(key, workspace?.scope.legacyScope);
+    const resolvedRemote = await remotes.resolve(key);
     const idsStr = groupedBitsByScope[key].map((id) => id.toStringWithoutVersion());
     return resolvedRemote.deleteMany(idsStr, force, context);
   });

--- a/scopes/component/snapping/tag-model-component.ts
+++ b/scopes/component/snapping/tag-model-component.ts
@@ -371,7 +371,7 @@ export async function tagModelComponent({
 
       addIntegritiesToConsumerComponentsGraphs(packageIntegritiesByPublishedPackages, allComponentsToTag);
       addBuildStatus(componentsToBuild, BuildStatus.Succeed);
-      await mapSeries(componentsToBuild, (consumerComponent) => snapping._enrichComp(consumerComponent));
+      await mapSeries(harmonyComps, (comp) => snapping.enrichComp(comp));
       if (populateArtifactsFrom) await updateHiddenProp(scope, populateArtifactsFrom);
     }
   }

--- a/scopes/component/tracker/tracker.main.runtime.ts
+++ b/scopes/component/tracker/tracker.main.runtime.ts
@@ -109,8 +109,7 @@ export class TrackerMain {
    * otherwise, it is self-hosted
    */
   private async isHostedByBit(scopeName: string): Promise<boolean> {
-    // TODO: once scope create a new API for this, replace it with the new one
-    const remotes = await this.workspace.scope._legacyRemotes();
+    const remotes = await this.workspace.scope.getRemoteScopes();
     return remotes.isHub(scopeName);
   }
 

--- a/scopes/lanes/lanes/remove-lanes.ts
+++ b/scopes/lanes/lanes/remove-lanes.ts
@@ -31,7 +31,7 @@ async function removeRemoteLanes(consumer: Consumer | undefined, lanes: LaneId[]
   const context = {};
   const groupedLanesByScope = groupArray(lanes, 'scope');
   const removeP = Object.keys(groupedLanesByScope).map(async (key) => {
-    const resolvedRemote = await remotes.resolve(key, consumer?.scope);
+    const resolvedRemote = await remotes.resolve(key);
     const idsStr = groupedLanesByScope[key].map((id) => id.toString());
     return resolvedRemote.deleteMany(idsStr, force, context, true);
   });

--- a/scopes/scope/export/export-scope-components.ts
+++ b/scopes/scope/export/export-scope-components.ts
@@ -375,7 +375,7 @@ export async function persistRemotes(manyObjectsPerRemote: RemotesForPersist[], 
 
 export async function resumeExport(scope: Scope, exportId: string, remotes: string[]): Promise<string[]> {
   const scopeRemotes: Remotes = await getScopeRemotes(scope);
-  const remotesObj = await Promise.all(remotes.map((r) => scopeRemotes.resolve(r, scope)));
+  const remotesObj = await Promise.all(remotes.map((r) => scopeRemotes.resolve(r)));
   const remotesForPersist: RemotesForPersist[] = remotesObj.map((remote) => ({ remote }));
   await validateRemotes(remotesObj, exportId);
   await persistRemotes(remotesForPersist, exportId);

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -44,7 +44,7 @@ const BEFORE_LOADING_COMPONENTS = 'loading components';
 
 type ModelComponentAndObjects = { component: ModelComponent; objects: BitObject[] };
 type ObjectListPerName = { [name: string]: ObjectList };
-type ObjectsPerRemote = {
+export type ObjectsPerRemote = {
   remote: Remote;
   objectList: ObjectList;
   exportedIds?: string[];
@@ -300,7 +300,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
           return;
         }
         // by getting the remote we also validate that this scope actually exists.
-        const remote = await scopeRemotes.resolve(scopeName, scope);
+        const remote = await scopeRemotes.resolve(scopeName);
         const list = await remote.list();
         const listIds = ComponentIdList.fromArray(list.map((listItem) => listItem.id));
         newIdsGrouped[scopeName].forEach((id) => {
@@ -362,7 +362,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
       lane?: Lane
     ): Promise<ObjectsPerRemoteExtended> => {
       bitIds.throwForDuplicationIgnoreVersion();
-      const remote: Remote = await scopeRemotes.resolve(remoteNameStr, scope);
+      const remote: Remote = await scopeRemotes.resolve(remoteNameStr);
       const idsToChangeLocally = ComponentIdList.fromArray(bitIds.filter((id) => !scope.isExported(id)));
       const componentsAndObjects: ModelComponentAndObjects[] = [];
       const objectList = new ObjectList();

--- a/scopes/scope/export/index.ts
+++ b/scopes/scope/export/index.ts
@@ -1,4 +1,4 @@
-export type { ExportMain, ExportResult } from './export.main.runtime';
+export type { ExportMain, ExportResult, ObjectsPerRemote } from './export.main.runtime';
 export { ExportAspect } from './export.aspect';
 export type { Network } from '@teambit/scope.network';
 export type { PushOptions } from '@teambit/legacy.scope-api';

--- a/scopes/scope/scope/run-action/run-action.ts
+++ b/scopes/scope/scope/run-action/run-action.ts
@@ -4,6 +4,6 @@ import { getScopeRemotes } from '@teambit/scope.remotes';
 export async function runAction(actionName: string, remote: string, options = {}): Promise<any> {
   const scope: Scope = await loadScope();
   const scopeRemotes = await getScopeRemotes(scope);
-  const remoteObj = await scopeRemotes.resolve(remote, scope);
+  const remoteObj = await scopeRemotes.resolve(remote);
   return remoteObj.action(actionName, options);
 }

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1059,8 +1059,13 @@ export class ScopeMain implements ComponentFactory {
     return this.resolveComponentId(id);
   }
 
-  // TODO: add new API for this
+  /**
+   * @deprecated use `this.getRemoteScopes()` instead.
+   */
   async _legacyRemotes(): Promise<Remotes> {
+    return getScopeRemotes(this.legacyScope);
+  }
+  async getRemoteScopes(): Promise<Remotes> {
     return getScopeRemotes(this.legacyScope);
   }
 
@@ -1068,8 +1073,8 @@ export class ScopeMain implements ComponentFactory {
    * list all component ids from a remote-scope
    */
   async listRemoteScope(scopeName: string): Promise<ComponentID[]> {
-    const remotes = await this._legacyRemotes();
-    const remote = await remotes.resolve(scopeName, this.legacyScope);
+    const remotes = await this.getRemoteScopes();
+    const remote = await remotes.resolve(scopeName);
     const results = await remote.list();
     return results.map(({ id }) => id);
   }

--- a/scopes/scope/sign/sign.main.runtime.ts
+++ b/scopes/scope/sign/sign.main.runtime.ts
@@ -12,7 +12,6 @@ import { getBasicLog } from '@teambit/harmony.modules.get-basic-log';
 import { BuildStatus, CENTRAL_BIT_HUB_URL, CENTRAL_BIT_HUB_NAME } from '@teambit/legacy.constants';
 import { PostSign } from '@teambit/scope.remote-actions';
 import { Version, Log, Lane, ObjectList } from '@teambit/scope.objects';
-import { Remotes, Remote, getScopeRemotes } from '@teambit/scope.remotes';
 import { ComponentIdList } from '@teambit/component-id';
 import { Http } from '@teambit/scope.network';
 import { LanesAspect, LanesMain } from '@teambit/lanes';
@@ -20,13 +19,7 @@ import { BitError } from '@teambit/bit-error';
 import { LaneId } from '@teambit/lane-id';
 import { SignCmd, SignOptions } from './sign.cmd';
 import { SignAspect } from './sign.aspect';
-import { ExportAspect, ExportMain } from '@teambit/export';
-
-type ObjectsPerRemote = {
-  remote: Remote;
-  objectList: ObjectList;
-  exportedIds?: string[];
-};
+import { ExportAspect, ExportMain, ObjectsPerRemote } from '@teambit/export';
 
 export type SignResult = {
   components: Component[];
@@ -131,14 +124,14 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     const buildStatus = pipeWithError ? BuildStatus.Failed : BuildStatus.Succeed;
     if (push) {
       if (originalScope) {
-        await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+        await this.saveExtensionsDataIntoScope(components, buildStatus);
         await this.clearScopesCaches(legacyComponents);
       } else {
-        await this.exportExtensionsDataIntoScopes(legacyComponents, buildStatus, lane);
+        await this.exportExtensionsDataIntoScopes(components, buildStatus, lane);
       }
     }
     if (saveLocally) {
-      await this.saveExtensionsDataIntoScope(legacyComponents, buildStatus);
+      await this.saveExtensionsDataIntoScope(components, buildStatus);
     }
     await this.triggerOnPostSign(components);
 
@@ -184,20 +177,20 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
   private async clearScopesCaches(components: ConsumerComponent[]) {
     const bitIds = ComponentIdList.fromArray(components.map((c) => c.id));
     const idsGroupedByScope = bitIds.toGroupByScopeName();
-    const scopeRemotes: Remotes = await getScopeRemotes(this.scope.legacyScope);
+    const scopeRemotes = await this.scope.getRemoteScopes();
     await Promise.all(
       Object.keys(idsGroupedByScope).map(async (scopeName) => {
-        const remote = await scopeRemotes.resolve(scopeName, this.scope.legacyScope);
+        const remote = await scopeRemotes.resolve(scopeName);
         return remote.action(PostSign.name, { ids: idsGroupedByScope[scopeName].map((id) => id.toString()) });
       })
     );
   }
 
-  private async saveExtensionsDataIntoScope(components: ConsumerComponent[], buildStatus: BuildStatus) {
+  private async saveExtensionsDataIntoScope(components: Component[], buildStatus: BuildStatus) {
     const modifiedLog = await this.getModifiedLog(buildStatus);
     await mapSeries(components, async (component) => {
-      component.buildStatus = buildStatus;
-      await this.snapping._enrichComp(component, modifiedLog);
+      this.snapping.setBuildStatus(component, buildStatus);
+      await this.snapping.enrichComp(component, modifiedLog);
     });
     await this.scope.legacyScope.objects.persist();
   }
@@ -207,20 +200,20 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     return { ...log, message: `sign. buildStatus: ${buildStatus}` };
   }
 
-  private async exportExtensionsDataIntoScopes(components: ConsumerComponent[], buildStatus: BuildStatus, lane?: Lane) {
+  private async exportExtensionsDataIntoScopes(components: Component[], buildStatus: BuildStatus, lane?: Lane) {
     const objectList = new ObjectList();
     const modifiedLog = await this.getModifiedLog(buildStatus);
     const idsHashMaps = {};
     const signComponents = await mapSeries(components, async (component) => {
-      component.buildStatus = buildStatus;
-      const objects = await this.snapping._getObjectsToEnrichComp(component, modifiedLog);
+      this.snapping.setBuildStatus(component, buildStatus);
+      const objects = await this.snapping.getObjectsToEnrichComp(component, modifiedLog);
       const versionHash = objects
         .find((obj) => obj instanceof Version)
         ?.hash()
         .toString();
       if (!versionHash) throw new Error(`Version object is missing for ${component.id.toString()}`);
       idsHashMaps[versionHash] = component.id.toString();
-      const scopeName = component.scope as string;
+      const scopeName = component.id.scope;
       const objectToMerge = await ObjectList.fromBitObjects(objects);
       objectToMerge.addScopeName(scopeName);
       objectList.mergeObjectList(objectToMerge);
@@ -231,7 +224,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
       objectList.addScopeName(lane.scope);
     }
 
-    const scopeRemotes = await getScopeRemotes(this.scope.legacyScope);
+    const scopeRemotes = await this.scope.getRemoteScopes();
     const objectsPerRemote = objectList.objects.reduce((acc, current) => {
       const scope: string = current.scope as string;
       if (acc[scope]) acc[scope].push(current);
@@ -240,7 +233,7 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     }, {});
     const manyObjectsPerRemote: ObjectsPerRemote[] = await Promise.all(
       Object.keys(objectsPerRemote).map(async (scopeName) => {
-        const remote = await scopeRemotes.resolve(scopeName, this.scope.legacyScope);
+        const remote = await scopeRemotes.resolve(scopeName);
         return { remote, objectList: new ObjectList(objectsPerRemote[scopeName]) };
       })
     );
@@ -275,9 +268,9 @@ ${componentsToSkip.map((c) => c.toString()).join('\n')}\n`);
     const componentsToSign: ComponentID[] = [];
     const componentsToSkip: ComponentID[] = [];
     components.forEach((component) => {
-      if (component.state._consumer.buildStatus === BuildStatus.Skipped) {
+      if (component.buildStatus === BuildStatus.Skipped) {
         componentsToSkip.push(component.id);
-      } else if (component.state._consumer.buildStatus === BuildStatus.Succeed) {
+      } else if (component.buildStatus === BuildStatus.Succeed) {
         rebuild ? componentsToSign.push(component.id) : componentsToSkip.push(component.id);
       } else {
         componentsToSign.push(component.id);

--- a/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
+++ b/scopes/scope/update-dependencies/update-dependencies.main.runtime.ts
@@ -199,8 +199,8 @@ to bypass this error, use --skip-new-scope-validation flag (not recommended. it 
   }
 
   private addBuildStatus() {
-    this.legacyComponents.forEach((c) => {
-      c.buildStatus = BuildStatus.Pending;
+    this.components.forEach((c) => {
+      this.snapping.setBuildStatus(c, BuildStatus.Pending);
     });
   }
 
@@ -301,9 +301,9 @@ to bypass this error, use --skip-new-scope-validation flag (not recommended. it 
   }
 
   private async saveDataIntoLocalScope(buildStatus: BuildStatus) {
-    await mapSeries(this.legacyComponents, async (component) => {
-      component.buildStatus = buildStatus;
-      await this.snapping._enrichComp(component);
+    await mapSeries(this.components, async (component) => {
+      this.snapping.setBuildStatus(component, buildStatus);
+      await this.snapping.enrichComp(component);
     });
     if (this.laneObj) {
       const laneHistory = await this.scope.legacyScope.lanes.updateLaneHistory(this.laneObj, 'update-dependencies');

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -1157,8 +1157,7 @@ export class InstallMain {
    * so no reason to try to install them (it will fail)
    */
   private async generateFilterFnForDepsFromLocalRemote() {
-    // TODO: once scope create a new API for this, replace it with the new one
-    const remotes = await this.workspace.scope._legacyRemotes();
+    const remotes = await this.workspace.scope.getRemoteScopes();
     const reg = await this.dependencyResolver.getRegistries();
     const packageScopes = Object.keys(reg.scopes);
     return (dependencyList: DependencyList): DependencyList => {


### PR DESCRIPTION
Improve the Snapping API by changing from ConsumerComponent to Component and prefer using Scope over LegacyScope when working with Remotes.