### PR TITLE
fix, fix typescript-estree warning about typescript version mismatch

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -265,7 +265,7 @@
         "@teambit/toolbox.fs.readdir-skip-system-files": "~0.0.2",
         "@teambit/toolbox.network.agent": "~0.0.554",
         "@teambit/toolbox.object.sorter": "~0.0.2",
-        "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.6",
+        "@teambit/typescript.deps-detectors.detective-typescript": "~0.0.9",
         "@teambit/typescript.deps-lookups.lookup-typescript": "~0.0.1",
         "@teambit/typescript.typescript-compiler": "^2.0.46",
         "@teambit/ui-foundation.ui.constants.z-indexes": "^0.0.504",


### PR DESCRIPTION
by upgrading `@teambit/typescript.deps-detectors.detective-typescript` which has been updated to use the same version of `typescript` and `@typescript-eslint/typescript-estree` as this repo.