### PR TITLE
fix(tag-from-scope), avoid publishing artifacts in the package

### DIFF
--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -598,8 +598,8 @@ export default class CommandHelper {
     return output;
   }
 
-  capsuleListParsed() {
-    const capsulesJson = this.runCmd('bit capsule list -j');
+  capsuleListParsed(cwd?: string) {
+    const capsulesJson = this.runCmd('bit capsule list -j', cwd);
     return JSON.parse(capsulesJson);
   }
 

--- a/e2e/harmony/tag-from-scope.e2e.ts
+++ b/e2e/harmony/tag-from-scope.e2e.ts
@@ -1,8 +1,10 @@
 import chai, { expect } from 'chai';
 import path from 'path';
+import fs from 'fs-extra';
 import { Extensions } from '@teambit/legacy.constants';
 import { Helper } from '@teambit/legacy.e2e-helper';
 import NpmCiRegistry, { supportNpmCiRegistryTesting } from '../npm-ci-registry';
+import tar from 'tar';
 
 chai.use(require('chai-fs'));
 
@@ -352,6 +354,61 @@ describe('tag components on Harmony', function () {
       expect(blame).to.have.string('1.0.0');
       expect(blame).to.have.string('message from _tag command');
       expect(blame).to.not.have.string('message from the snap command');
+    });
+  });
+
+  describe('ignoring artifacts from the package', () => {
+    let bareTag;
+    let capsuleDir: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes({ disablePreview: false });
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponents('-m "message from the snap command"');
+      helper.command.export();
+
+      bareTag = helper.scopeHelper.getNewBareScope('-bare-tag');
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareTag.scopePath);
+      const data = [
+        {
+          componentId: `${helper.scopes.remote}/comp1`,
+          versionToTag: `1.0.0`,
+          message: `message from _tag command`,
+        },
+      ];
+      // console.log('data', `bit _tag '${JSON.stringify(data)}' --push`);
+      helper.command.tagFromScope(bareTag.scopePath, data);
+
+      const capsuleRootDir = helper.command.capsuleListParsed(bareTag.scopePath).scopeCapsulesRootDir;
+      capsuleDir = path.join(capsuleRootDir, `${helper.scopes.remote}_comp1@1.0.0`);
+    });
+    it('should have .npmignore file with "artifacts" entry', () => {
+      expect(capsuleDir).to.be.a.directory();
+      const npmIgnore = path.join(capsuleDir, '.npmignore');
+      expect(npmIgnore).to.be.a.file();
+
+      const npmIgnoreContent = fs.readFileSync(npmIgnore, 'utf-8');
+      expect(npmIgnoreContent).to.have.string('artifacts');
+    });
+    it('should save the schema.json inside the artifacts dir', () => {
+      const schemaJson = path.join(capsuleDir, 'artifacts/schema.json');
+      expect(schemaJson).to.be.a.file();
+    });
+    it('should save the preview inside the artifacts dir', () => {
+      const schemaJson = path.join(capsuleDir, 'artifacts/preview');
+      expect(schemaJson).to.be.a.directory();
+    });
+    it('should not add the artifacts into the package tar', () => {
+      const pkgDir = path.join(capsuleDir, 'package-tar');
+      const tarFile = path.join(capsuleDir, 'package-tar', `${helper.scopes.remote}-comp1-1.0.0.tgz`);
+      expect(tarFile).to.be.a.file();
+      tar.x({ file: tarFile, C: pkgDir, sync: true });
+      const extractedDir = path.join(pkgDir, 'package');
+      expect(extractedDir).to.be.a.directory();
+      expect(path.join(extractedDir, 'dist')).to.be.a.directory();
+      expect(path.join(extractedDir, 'artifacts')).to.not.be.a.path();
+      const files = fs.readdirSync(extractedDir);
+      expect(files).to.have.lengthOf(3);
+      expect(files).to.deep.equal(['dist', 'index.js', 'package.json']);
     });
   });
 });

--- a/scopes/defender/tester/tester.task.ts
+++ b/scopes/defender/tester/tester.task.ts
@@ -1,4 +1,4 @@
-import { BuildContext, BuiltTaskResult, BuildTask, CAPSULE_ARTIFACTS_DIR } from '@teambit/builder';
+import { BuildContext, BuiltTaskResult, BuildTask, CAPSULE_ARTIFACTS_DIR, ArtifactDefinition } from '@teambit/builder';
 import fs from 'fs-extra';
 import { join } from 'path';
 import { Compiler, CompilerAspect } from '@teambit/compiler';
@@ -108,12 +108,11 @@ export function getJUnitArtifactPath() {
   return join(CAPSULE_ARTIFACTS_DIR, '__bit_junit.xml');
 }
 
-export function getArtifactDef() {
+export function getArtifactDef(): ArtifactDefinition[] {
   return [
     {
       name: 'junit',
       globPatterns: [getJUnitArtifactPath()],
-      rootDir: CAPSULE_ARTIFACTS_DIR,
     },
   ];
 }

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -166,6 +166,7 @@ export class PkgMain {
     // const dryRunTask = new PublishDryRunTask(PkgAspect.id, publisher, packer, logPublisher);
     const preparePackagesTask = new PreparePackagesTask(PkgAspect.id, logPublisher, envs);
     // dryRunTask.dependencies = [BuildTaskHelper.serializeId(preparePackagesTask)];
+    builder.registerBuildTasks([preparePackagesTask]);
     builder.registerTagTasks([preparePackagesTask, packTask, publishTask]);
     builder.registerSnapTasks([preparePackagesTask, packTask]);
 

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -166,9 +166,8 @@ export class PkgMain {
     // const dryRunTask = new PublishDryRunTask(PkgAspect.id, publisher, packer, logPublisher);
     const preparePackagesTask = new PreparePackagesTask(PkgAspect.id, logPublisher, envs);
     // dryRunTask.dependencies = [BuildTaskHelper.serializeId(preparePackagesTask)];
-    builder.registerBuildTasks([preparePackagesTask]);
-    builder.registerTagTasks([packTask, publishTask]);
-    builder.registerSnapTasks([packTask]);
+    builder.registerTagTasks([preparePackagesTask, packTask, publishTask]);
+    builder.registerSnapTasks([preparePackagesTask, packTask]);
 
     const calcPkgOnLoad = async (component: Component) => {
       const data = await pkg.mergePackageJsonProps(component);

--- a/scopes/pkg/pkg/write-npm-ignore.ts
+++ b/scopes/pkg/pkg/write-npm-ignore.ts
@@ -10,9 +10,6 @@ export async function writeNpmIgnore(capsule: Capsule, envs: EnvsMain): Promise<
   const env = envs.getEnv(capsule.component).env as PackageEnv;
   const envIgnoreEntries = env.getNpmIgnore?.({ component: capsule.component, capsule });
   const npmIgnoreEntries = DEFAULT_NPM_IGNORE_ENTRIES.concat(envIgnoreEntries || []);
-  if (!npmIgnoreEntries || !npmIgnoreEntries.length) {
-    return;
-  }
   const NPM_IGNORE_FILE = '.npmignore';
   const npmIgnorePath = join(capsule.path, NPM_IGNORE_FILE);
   const npmIgnoreEntriesStr = `\n${npmIgnoreEntries.join('\n')}`;

--- a/scopes/preview/preview/env-preview-template.task.ts
+++ b/scopes/preview/preview/env-preview-template.task.ts
@@ -5,6 +5,7 @@ import {
   TaskLocation,
   ComponentResult,
   CAPSULE_ARTIFACTS_DIR,
+  ArtifactDefinition,
 } from '@teambit/builder';
 import { MainRuntime } from '@teambit/cli';
 import mapSeries from 'p-map-series';
@@ -268,12 +269,11 @@ export function getArtifactDirectory() {
   return join(CAPSULE_ARTIFACTS_DIR, 'env-template');
 }
 
-export function getArtifactDef() {
+export function getArtifactDef(): ArtifactDefinition[] {
   return [
     {
       name: 'env-template',
-      globPatterns: ['**'],
-      rootDir: getArtifactDirectory(),
+      globPatterns: [getArtifactDirectory()],
     },
   ];
 }

--- a/scopes/preview/preview/strategies/component-strategy.ts
+++ b/scopes/preview/preview/strategies/component-strategy.ts
@@ -6,7 +6,7 @@ import { flatten, isEmpty, chunk } from 'lodash';
 import { Compiler } from '@teambit/compiler';
 import type { AbstractVinyl } from '@teambit/component.sources';
 import type { Capsule } from '@teambit/isolator';
-import { CAPSULE_ARTIFACTS_DIR, ComponentResult } from '@teambit/builder';
+import { ArtifactDefinition, CAPSULE_ARTIFACTS_DIR, ComponentResult } from '@teambit/builder';
 import { BitError } from '@teambit/bit-error';
 import type { DependencyResolverMain } from '@teambit/dependency-resolver';
 import { Logger } from '@teambit/logger';
@@ -334,7 +334,7 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
     return componentsResults;
   }
 
-  private getArtifactDef() {
+  private getArtifactDef(): ArtifactDefinition[] {
     // eslint-disable-next-line @typescript-eslint/prefer-as-const
     // const env: 'env' = 'env';
     // const rootDir = this.getDirName(context);
@@ -342,8 +342,7 @@ export class ComponentBundlingStrategy implements BundlingStrategy {
     return [
       {
         name: COMPONENT_STRATEGY_ARTIFACT_NAME,
-        globPatterns: ['**'],
-        rootDir: this.getArtifactDirectory(),
+        globPatterns: [this.getArtifactDirectory()],
         // context: env,
       },
     ];

--- a/scopes/preview/preview/strategies/env-strategy.ts
+++ b/scopes/preview/preview/strategies/env-strategy.ts
@@ -5,7 +5,7 @@ import { ComponentMap } from '@teambit/component';
 import { Compiler } from '@teambit/compiler';
 import { AbstractVinyl } from '@teambit/component.sources';
 import { Capsule } from '@teambit/isolator';
-import { ComponentResult } from '@teambit/builder';
+import { ArtifactDefinition, ComponentResult } from '@teambit/builder';
 import { BundlerContext, BundlerHtmlConfig, BundlerResult } from '@teambit/bundler';
 import { DependencyResolverMain } from '@teambit/dependency-resolver';
 import { PkgMain } from '@teambit/pkg';
@@ -86,7 +86,7 @@ export class EnvBundlingStrategy implements BundlingStrategy {
     };
   }
 
-  private getArtifactDef(context: ComputeTargetsContext) {
+  private getArtifactDef(context: ComputeTargetsContext): ArtifactDefinition[] {
     // eslint-disable-next-line @typescript-eslint/prefer-as-const
     const env: 'env' = 'env';
     const rootDir = this.getDirName(context);
@@ -94,8 +94,7 @@ export class EnvBundlingStrategy implements BundlingStrategy {
     return [
       {
         name: ENV_STRATEGY_ARTIFACT_NAME,
-        globPatterns: ['public/**'],
-        rootDir,
+        globPatterns: [`${rootDir}/public`],
         context: env,
       },
     ];

--- a/scopes/semantics/schema/schema.task.ts
+++ b/scopes/semantics/schema/schema.task.ts
@@ -74,11 +74,10 @@ export function getSchemaArtifactPath() {
   return join(CAPSULE_ARTIFACTS_DIR, 'schema.json');
 }
 
-export function getSchemaArtifactDef() {
+export function getSchemaArtifactDef(): ArtifactDefinition {
   const def: ArtifactDefinition = {
     name: SCHEMA_ARTIFACT_NAME,
-    rootDir: CAPSULE_ARTIFACTS_DIR,
-    globPatterns: ['schema.json'],
+    globPatterns: [getSchemaArtifactPath()],
   };
 
   return def;


### PR DESCRIPTION
When tagging from scope, the artifacts from the last snap are written into the capsule as part of the pipeline execution. The paths are the same as they're saved in the model (`Version` object). 
Currently, the preview/schema/test artifacts have relativePath without the `artifacts/` prefix. It's happening due to the usage of the deprecated `rootDir`. 
This fix removes the `rootDir` from their artifact definition and use `globPatterns` instead. The paths are now written correctly to the model, and then when tagging from scope, they're written into `artifacts` dir properly.

Another issue was the `.npmignore` which wasn't get written at all when tagging from scope because it was part of the build pipeline not snap/tag. This PR copies it to the snap/tag pipeline. 