### PR TITLE
fix(scope-list), filter non-scope components early in the process

### DIFF
--- a/components/legacy/scope/scope.ts
+++ b/components/legacy/scope/scope.ts
@@ -247,9 +247,13 @@ export default class Scope {
     return modelComponent.hasVersion(id.version, this.objects);
   }
 
-  async list(): Promise<ModelComponent[]> {
-    const filter = (comp: ComponentItem) => !comp.isSymlink;
+  async list(localScopeOnly = false): Promise<ModelComponent[]> {
+    const filter = (comp: ComponentItem) => {
+      if (comp.isSymlink) return false;
+      return localScopeOnly ? comp.id.scope === this.name : true;
+    };
     const results = await this.objects.listObjectsFromIndex(IndexType.components, filter);
+    logger.debug(`scope.list found ${results.length} components in the scope`);
     results.forEach((result) => {
       if (!(result instanceof ModelComponent)) {
         throw new Error(

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -768,17 +768,14 @@ export class ScopeMain implements ComponentFactory {
    * @param includeCache whether or not include components that their scope-name is different than the current scope-name
    */
   async listIds(includeCache = false, includeFromLanes = false, patterns?: string[]): Promise<ComponentID[]> {
-    const allModelComponents = await this.legacyScope.list();
+    const localScopeOnly = !includeCache;
+    const allModelComponents = await this.legacyScope.list(localScopeOnly);
     const filterByCacheAndLanes = (modelComponent: ModelComponent) => {
-      const cacheFilter = includeCache ? true : this.exists(modelComponent);
       const lanesFilter = includeFromLanes ? true : modelComponent.hasHead();
-
-      return cacheFilter && lanesFilter;
+      return lanesFilter;
     };
     const modelComponentsToList = allModelComponents.filter(filterByCacheAndLanes);
-    let ids = modelComponentsToList.map((component) =>
-      ComponentID.fromLegacy(component.toBitIdWithLatestVersion(), component.scope || this.name)
-    );
+    let ids = modelComponentsToList.map((component) => component.toComponentIdWithLatestVersion());
     if (patterns && patterns.length > 0) {
       ids = ids.filter((id) =>
         patterns?.some((pattern) => isMatchNamespacePatternItem(id.toStringWithoutVersion(), pattern).match)


### PR DESCRIPTION
Otherwise, it loads all components in the bare-scope unnecessarily.
Besides the performance gain, it also prevent errors about index.json having cache components that don't exist in the filesystem.