### PR TITLE
improvement(global-aspect), allow aspects from .bitrc.jsonc to have main.runtime and no static-id

### DIFF
--- a/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
+++ b/scopes/harmony/aspect-loader/aspect-loader.main.runtime.ts
@@ -783,9 +783,18 @@ export class AspectLoaderMain {
         res[manifest.id] = localAspect;
         return manifest;
       }
-      // eslint-disable-next-line global-require, import/no-dynamic-require
       const module = require(dirPath);
       const manifest = module.default || module;
+      const mainRuntime = this.findRuntime(dirPath, 'main');
+      if (mainRuntime) {
+        // eslint-disable-next-line global-require, import/no-dynamic-require
+        const mainRuntimeModule = require(join(dirPath, 'dist', mainRuntime));
+        const mainRuntimeManifest = mainRuntimeModule.default || mainRuntimeModule;
+        // manifest has the "id" prop. the mainRuntimeManifest doesn't have it normally.
+        mainRuntimeManifest.id = manifest.id;
+        res[mainRuntimeManifest.id] = localAspect;
+        return mainRuntimeManifest;
+      }
       res[manifest.id] = localAspect;
       return manifest;
     });


### PR DESCRIPTION
Currently, these global-aspects from .bitrc.jsonc file must have `scope.runtime` instead of the `main.runtime`. It causes issues when testing via `loadAspect` API, which searches for "main.runtime" files.
They also have to have `static id` prop in their runtime file in addition to the aspect file. 

This PR fixes these two issues. Normal aspects can work out of the box with no modifications. 