### PR TITLE
improvement(diff), introduce "--parent" flag to display changes of the specified version

### DIFF
--- a/components/legacy/component-diff/components-diff.ts
+++ b/components/legacy/component-diff/components-diff.ts
@@ -30,6 +30,7 @@ export type DiffOptions = {
   verbose?: boolean; // whether show internal components diff, such as sourceRelativePath
   formatDepsAsTable?: boolean; // show dependencies output as table
   color?: boolean; // pass this option to git to return a colorful diff, default = true.
+  compareToParent?: boolean; // compare to the parent (previous) version
 };
 
 export async function getOneFileDiff(

--- a/scopes/component/component-compare/component-compare.main.runtime.ts
+++ b/scopes/component/component-compare/component-compare.main.runtime.ts
@@ -1,4 +1,5 @@
 import { CLIAspect, CLIMain, MainRuntime } from '@teambit/cli';
+import { compact } from 'lodash';
 import { BitError } from '@teambit/bit-error';
 import { WorkspaceAspect, OutsideWorkspaceError, Workspace } from '@teambit/workspace';
 import { ComponentID, ComponentIdList } from '@teambit/component-id';
@@ -111,7 +112,7 @@ export class ComponentCompareMain {
     pattern?: string,
     version?: string,
     toVersion?: string,
-    { verbose, table }: { verbose?: boolean; table?: boolean } = {}
+    { verbose, table, parent }: { verbose?: boolean; table?: boolean; parent?: boolean } = {}
   ): Promise<any> {
     if (!this.workspace) throw new OutsideWorkspaceError();
     const ids = pattern ? await this.workspace.idsByPattern(pattern) : await this.workspace.listTagPendingIds();
@@ -122,6 +123,7 @@ export class ComponentCompareMain {
     const diffResults = await this.componentsDiff(ids, version, toVersion, {
       verbose,
       formatDepsAsTable: table,
+      compareToParent: parent,
     });
     await consumer.onDestroy('diff');
     return diffResults;
@@ -162,100 +164,91 @@ export class ComponentCompareMain {
 
   private async componentsDiff(
     ids: ComponentID[],
-    version: string | null | undefined,
-    toVersion: string | null | undefined,
+    version: string | undefined,
+    toVersion: string | undefined,
     diffOpts: DiffOptions
   ): Promise<DiffResults[]> {
     if (!this.workspace) throw new OutsideWorkspaceError();
-    const consumer = this.workspace?.consumer;
     const components = await this.workspace.getMany(ids);
     if (!components.length) throw new BitError('failed loading the components');
-
-    const getResults = (): Promise<DiffResults[]> => {
-      if (version && toVersion) {
-        return Promise.all(ids.map((id) => getComponentDiffBetweenVersions(id)));
-      }
-      if (version) {
-        return Promise.all(components.map((component) => getComponentDiffOfVersion(component)));
-      }
-      return Promise.all(components.map((component) => getComponentDiff(component)));
-    };
-    const componentsDiffResults = await getResults();
+    if (toVersion && !version)
+      throw new BitError('error: componentsDiff expects to get version when toVersion is entered');
+    const componentsDiffResults = await Promise.all(
+      components.map((component) => this.computeDiff(component, version, toVersion, diffOpts))
+    );
     return componentsDiffResults;
+  }
 
-    async function getComponentDiffOfVersion(component: Component): Promise<DiffResults> {
-      if (!version) throw new Error('getComponentDiffOfVersion expects to get version');
-      const consumerComponent = component.state._consumer as ConsumerComponent;
-      const diffResult: DiffResults = { id: component.id, hasDiff: false };
-      const modelComponent = await consumer.scope.getModelComponentIfExist(component.id);
-      if (!modelComponent) {
+  // eslint-disable-next-line complexity
+  private async computeDiff(
+    component: Component,
+    version: string | undefined,
+    toVersion: string | undefined,
+    diffOpts: DiffOptions
+  ) {
+    if (!this.workspace) throw new OutsideWorkspaceError();
+    const consumer = this.workspace.consumer;
+    // if (!version) throw new Error('getComponentDiffOfVersion expects to get version');
+    const consumerComponent = component.state._consumer as ConsumerComponent;
+    const diffResult: DiffResults = { id: component.id, hasDiff: false };
+    const modelComponent =
+      consumerComponent.modelComponent || (await consumer.scope.getModelComponentIfExist(component.id));
+
+    if (!modelComponent || !consumerComponent.componentFromModel) {
+      if (version || toVersion) {
         throw new BitError(`component ${component.id.toString()} doesn't have any version yet`);
       }
-      const repository = consumer.scope.objects;
-      const idList = ComponentIdList.fromArray([component.id.changeVersion(version)]);
-      await consumer.scope.scopeImporter.importWithoutDeps(idList, { cache: true, reason: 'to show diff' });
-      const fromVersionObject: Version = await modelComponent.loadVersion(version, repository);
-      const versionFiles = await fromVersionObject.modelFilesToSourceFiles(repository);
-      const fsFiles = consumerComponent.files;
-      // version must be defined as the component.componentFromModel do exist
-      const versionB: string = component.id.version;
-      // this function gets called only when version is set
-      diffResult.filesDiff = await getFilesDiff(versionFiles, fsFiles, version, versionB);
-      const fromVersionComponent = await modelComponent.toConsumerComponent(version, consumer.scope.name, repository);
-      await updateFieldsDiff(fromVersionComponent, consumerComponent, diffResult, diffOpts);
-
-      return diffResult;
-    }
-
-    async function getComponentDiffBetweenVersions(id: ComponentID): Promise<DiffResults> {
-      if (!version || !toVersion)
-        throw new Error('getComponentDiffBetweenVersions expects to get version and toVersion');
-      const diffResult: DiffResults = { id, hasDiff: false };
-      const modelComponent = await consumer.scope.getModelComponentIfExist(id);
-      if (!modelComponent) {
-        throw new BitError(`component ${id.toString()} doesn't have any version yet`);
-      }
-      const repository = consumer.scope.objects;
-      const idList = ComponentIdList.fromArray([id.changeVersion(version), id.changeVersion(toVersion)]);
-      await consumer.scope.scopeImporter.importWithoutDeps(idList, { cache: true, reason: 'to show diff' });
-      const fromVersionObject: Version = await modelComponent.loadVersion(version, repository);
-      const toVersionObject: Version = await modelComponent.loadVersion(toVersion, repository);
-      const fromVersionFiles = await fromVersionObject.modelFilesToSourceFiles(repository);
-      const toVersionFiles = await toVersionObject.modelFilesToSourceFiles(repository);
-      diffResult.filesDiff = await getFilesDiff(fromVersionFiles, toVersionFiles, version, toVersion);
-      const fromVersionComponent = await modelComponent.toConsumerComponent(version, consumer.scope.name, repository);
-      const toVersionComponent = await modelComponent.toConsumerComponent(toVersion, consumer.scope.name, repository);
-      await updateFieldsDiff(fromVersionComponent, toVersionComponent, diffResult, diffOpts);
-
-      return diffResult;
-    }
-
-    async function getComponentDiff(component: Component): Promise<DiffResults> {
-      const diffResult: DiffResults = { id: component.id, hasDiff: false };
-      const consumerComponent = component.state._consumer as ConsumerComponent;
-      if (!consumerComponent.componentFromModel) {
-        if (component.isDeleted()) {
-          // component exists in the model but not in the filesystem, show all files as deleted
-          // the reason it is loaded without componentFromModel is because it was loaded from the scope, not workspace.
-          // as a proof, consumerComponent.loadedFromFileSystem is false.
-          const modelFiles = consumerComponent.files;
-          diffResult.filesDiff = await getFilesDiff(modelFiles, [], component.id.version, component.id.version);
-          if (hasDiff(diffResult)) diffResult.hasDiff = true;
-          return diffResult;
-        }
-        // it's a new component. not modified. show all files as new.
-        const fsFiles = consumerComponent.files;
-        diffResult.filesDiff = await getFilesDiff([], fsFiles, component.id.version, component.id.version);
+      if (component.isDeleted()) {
+        // component exists in the model but not in the filesystem, show all files as deleted
+        // the reason it is loaded without componentFromModel is because it was loaded from the scope, not workspace.
+        // as a proof, consumerComponent.loadedFromFileSystem is false.
+        const modelFiles = consumerComponent.files;
+        diffResult.filesDiff = await getFilesDiff(modelFiles, [], component.id.version, component.id.version);
         if (hasDiff(diffResult)) diffResult.hasDiff = true;
         return diffResult;
       }
-      const modelFiles = consumerComponent.componentFromModel.files;
+      // it's a new component. not modified. show all files as new.
       const fsFiles = consumerComponent.files;
-      diffResult.filesDiff = await getFilesDiff(modelFiles, fsFiles, component.id.version, component.id.version);
-      await updateFieldsDiff(consumerComponent.componentFromModel, consumerComponent, diffResult, diffOpts);
-
+      diffResult.filesDiff = await getFilesDiff([], fsFiles, component.id.version, component.id.version);
+      if (hasDiff(diffResult)) diffResult.hasDiff = true;
       return diffResult;
     }
+    const repository = consumer.scope.objects;
+    const idsToImport = compact([
+      version ? component.id.changeVersion(version) : undefined,
+      toVersion ? component.id.changeVersion(toVersion) : undefined,
+    ]);
+    const idList = ComponentIdList.fromArray(idsToImport);
+    await consumer.scope.scopeImporter.importWithoutDeps(idList, { cache: true, reason: 'to show diff' });
+    if (diffOpts.compareToParent) {
+      if (!version) throw new BitError('--parent flag expects to get version');
+      if (toVersion) throw new BitError('--parent flag expects to get only one version');
+      const versionObject = version ? await modelComponent.loadVersion(version, repository) : undefined;
+      const parent = versionObject!.parents[0];
+      toVersion = version;
+      version = parent ? modelComponent.getTagOfRefIfExists(parent) : undefined;
+    }
+    const fromVersionObject = version ? await modelComponent.loadVersion(version, repository) : undefined;
+    const toVersionObject = toVersion ? await modelComponent.loadVersion(toVersion, repository) : undefined;
+    const fromVersionFiles = await fromVersionObject?.modelFilesToSourceFiles(repository);
+    const toVersionFiles = await toVersionObject?.modelFilesToSourceFiles(repository);
+
+    const fromFiles = fromVersionFiles || consumerComponent.componentFromModel.files;
+    const toFiles = toVersionFiles || consumerComponent.files;
+    const fromVersionLabel = version || component.id.version;
+    const toVersionLabel = toVersion || component.id.version;
+
+    diffResult.filesDiff = await getFilesDiff(fromFiles, toFiles, fromVersionLabel, toVersionLabel);
+    const fromVersionComponent = version
+      ? await modelComponent.toConsumerComponent(version, consumer.scope.name, repository)
+      : consumerComponent.componentFromModel;
+
+    const toVersionComponent = toVersion
+      ? await modelComponent.toConsumerComponent(toVersion, consumer.scope.name, repository)
+      : consumerComponent;
+    await updateFieldsDiff(fromVersionComponent, toVersionComponent, diffResult, diffOpts);
+
+    return diffResult;
   }
 
   async diffBetweenVersionsObjects(

--- a/scopes/component/component-compare/diff-cmd.ts
+++ b/scopes/component/component-compare/diff-cmd.ts
@@ -17,15 +17,17 @@ export class DiffCmd implements Command {
     },
     {
       name: 'version',
-      description: 'specific version to compare against',
+      description: `the base version to compare from. if omitted, compares the workspace's current files to the component's latest version.`,
     },
     {
       name: 'to-version',
-      description: 'specific version to compare to',
+      description: `the target version to compare against "version".
+if both "version" and "to-version" are provided, compare those two versions directly (ignoring the workspace).`,
     },
   ];
   alias = '';
   options = [
+    ['p', 'parent', 'compare the specified "version" to its immediate parent instead of comparing to the current one'],
     ['v', 'verbose', 'show a more verbose output where possible'],
     ['t', 'table', 'show tables instead of plain text for dependencies diff'],
   ] as CommandOptions;
@@ -38,6 +40,10 @@ export class DiffCmd implements Command {
       cmd: "diff '$codeModified' ",
       description: 'show diff only for components with modified files. ignore config changes',
     },
+    {
+      cmd: 'diff foo 0.0.2 --parent',
+      description: 'compare "foo@0.0.2" to its parent version. showing what changed in 0.0.2',
+    },
   ];
   loader = true;
 
@@ -45,11 +51,12 @@ export class DiffCmd implements Command {
 
   async report(
     [pattern, version, toVersion]: [string, string, string],
-    { verbose = false, table = false }: { verbose?: boolean; table: boolean }
+    { verbose = false, table = false, parent }: { verbose?: boolean; table: boolean; parent?: boolean }
   ) {
     const diffResults: DiffResults[] = await this.componentCompareMain.diffByCLIValues(pattern, version, toVersion, {
       verbose,
       table,
+      parent,
     });
     if (!diffResults.length) {
       return chalk.yellow('there are no modified components to diff');


### PR DESCRIPTION
Until now, to check what changes were done in a certain version, for example foo@0.0.2, you had to find out what was the previous version and then run `bit diff foo 0.0.1 0.0.2`.
With this PR, you can simply run `bit diff foo 0.0.2 --parent`. 