### PR TITLE
fix(merge-from-scope), save dependencies data after merging config

### DIFF
--- a/components/legacy/extension-data/extension-data-list.ts
+++ b/components/legacy/extension-data/extension-data-list.ts
@@ -7,8 +7,8 @@ import {
   reStructureBuildArtifacts,
 } from '@teambit/component.sources';
 import { ExtensionDataEntry, REMOVE_EXTENSION_SPECIAL_SIGN } from './extension-data';
-import EnvsAspect from '@teambit/envs';
-import DependencyResolverAspect from '@teambit/dependency-resolver';
+import { EnvsAspect } from '@teambit/envs';
+import { DependencyResolverAspect, VariantPolicyConfigArr } from '@teambit/dependency-resolver';
 
 type ExtensionConfig = { [extName: string]: any } | RemoveExtensionSpecialSign;
 type ConfigOnlyEntry = {
@@ -156,11 +156,11 @@ export class ExtensionDataList extends Array<ExtensionDataEntry> {
    * 1. force: true, which gets saved into the config.
    * 2. force: false, which gets saved into the data.dependencies later on. see the workspace.getAutoDetectOverrides()
    */
-  removeAutoDepsFromConfig() {
+  extractAutoDepsFromConfig(): VariantPolicyConfigArr | undefined {
     const policy = this.findCoreExtension(DependencyResolverAspect.id)?.config.policy;
     if (!policy) return;
 
-    const autoDepsObj = {};
+    const autoDepsObj: VariantPolicyConfigArr = {};
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach((key) => {
       if (!policy[key]) return;
       // this is only relevant when it is saved as an array. otherwise, it's always force: true.

--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -626,7 +626,10 @@ export class MergingMain {
     const ids = ComponentIdList.fromArray(unmergedComponents.map((r) => ComponentID.fromObject(r.id)));
     if (!this.workspace) {
       const results = await this.snapping.snapFromScope(
-        ids.map((id) => ({ componentId: id.toString() })),
+        ids.map((id) => ({
+          componentId: id.toString(),
+          aspects: this.scope.legacyScope.objects.unmergedComponents.getEntry(id)?.mergedConfig,
+        })),
         {
           message: snapMessage,
           build,

--- a/scopes/component/snapping/generate-comp-from-scope.ts
+++ b/scopes/component/snapping/generate-comp-from-scope.ts
@@ -6,7 +6,7 @@ import { ComponentOverrides } from '@teambit/legacy.consumer-config';
 import { ExtensionDataList } from '@teambit/legacy.extension-data';
 import { Component } from '@teambit/component';
 import { DependenciesMain } from '@teambit/dependencies';
-import { DependencyResolverMain } from '@teambit/dependency-resolver';
+import { DependencyResolverMain, VariantPolicyConfigArr } from '@teambit/dependency-resolver';
 import { FileData } from './snap-from-scope.cmd';
 import { SnappingMain, SnapDataParsed } from './snapping.main.runtime';
 
@@ -109,7 +109,8 @@ export async function addDeps(
   scope: ScopeMain,
   deps: DependenciesMain,
   depsResolver: DependencyResolverMain,
-  snapping: SnappingMain
+  snapping: SnappingMain,
+  autoDetect?: VariantPolicyConfigArr
 ) {
   const newDeps = snapData.newDependencies || [];
   const updateDeps = snapData.dependencies || [];
@@ -125,6 +126,13 @@ export async function addDeps(
   const getPkgObj = (type: 'runtime' | 'dev' | 'peer') => {
     return toPackageObj(packageDeps.filter((dep) => dep.type === type));
   };
+  const allAutoDeps: { [pkgName: string]: string } = {};
+  ['dependencies', 'devDependencies', 'peerDependencies'].forEach((depType) => {
+    autoDetect?.[depType]?.forEach((dep) => {
+      allAutoDeps[dep.name] = dep.version;
+    });
+  });
+
   const manipulateCurrentPkgs = (pkgs: Record<string, string>) => {
     snapData.removeDependencies?.forEach((pkg) => {
       delete pkgs[pkg];
@@ -145,6 +153,10 @@ export async function addDeps(
       const found = updateDeps.find((d) => d.startsWith(`${dep.id.toStringWithoutVersion()}@`));
       if (found) {
         dep.id = dep.id.changeVersion(found.replace(`${dep.id.toStringWithoutVersion()}@`, ''));
+      }
+      const foundInAutoDeps = dep.packageName ? allAutoDeps[dep.packageName] : undefined;
+      if (foundInAutoDeps) {
+        dep.id = dep.id.changeVersion(allAutoDeps[dep.packageName!]);
       }
     });
     return afterRemoval;

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -526,7 +526,6 @@ export class ApplyOverrides {
         const existsInCompsPeerDeps = this.allDependencies.peerDependencies.find((dep) => {
           return dep.packageName === pkgName;
         });
-
         if (
           // We are checking originAllPackagesDependencies instead of allPackagesDependencies
           // as it might be already removed from allPackagesDependencies at this point if it was set with
@@ -557,7 +556,6 @@ export class ApplyOverrides {
         }
         originallyExists.push(pkgName);
         const key = DepsKeysToAllPackagesDepsKeys[field];
-
         delete this.allPackagesDependencies[key][pkgName];
         // When changing peer dependency we want it to be stronger than the other types
         if (field === 'peerDependencies') {

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -49,6 +49,7 @@ export type {
   SerializedVariantPolicy,
   WorkspacePolicyConfigKeysNames,
   EnvPolicyConfigObject,
+  VariantPolicyConfigArr,
 } from './policy';
 export { DependencyLinker } from './dependency-linker';
 export type {

--- a/scopes/dependencies/dependency-resolver/policy/index.ts
+++ b/scopes/dependencies/dependency-resolver/policy/index.ts
@@ -12,6 +12,7 @@ export {
   VariantPolicyEntryValue,
   VariantPolicyConfigObject,
   SerializedVariantPolicy,
+  VariantPolicyConfigArr,
 } from './variant-policy';
 
 export { EnvPolicy, EnvPolicyConfigObject } from './env-policy';

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/index.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/index.ts
@@ -7,4 +7,5 @@ export {
   VariantPolicyEntryValue,
   createVariantPolicyEntry,
   DependencySource,
+  VariantPolicyConfigArr,
 } from './variant-policy';

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
@@ -25,6 +25,9 @@ type VariantPolicyLifecycleConfigEntryObject = {
   optional?: boolean;
 };
 
+export type VariantPolicyConfigArr = Partial<Record<PolicyConfigKeysNames, VariantPolicyLifecycleConfigEntryObject[]>>;
+type VariantPolicyConfigObj = Partial<Record<PolicyConfigKeysNames, Record<string, VariantPolicyConfigEntryValue>>>;
+
 export type VariantPolicyConfigEntryValue = VariantPolicyEntryValue | VariantPolicyEntryVersion;
 
 /**
@@ -229,7 +232,10 @@ export class VariantPolicy implements Policy<VariantPolicyConfigObject> {
     return res;
   }
 
-  static fromConfigObject(configObject, options: VariantPolicyFromConfigObjectOptions = {}): VariantPolicy {
+  static fromConfigObject(
+    configObject: VariantPolicyConfigArr | VariantPolicyConfigObj,
+    options: VariantPolicyFromConfigObjectOptions = {}
+  ): VariantPolicy {
     const runtimeEntries = entriesFromKey(configObject, 'dependencies', options);
     const devEntries = entriesFromKey(configObject, 'devDependencies', options);
     const peerEntries = entriesFromKey(configObject, 'peerDependencies', options);
@@ -268,7 +274,7 @@ function uniqEntries(entries: Array<VariantPolicyEntry>): Array<VariantPolicyEnt
 }
 
 function entriesFromKey(
-  configObject: VariantPolicyConfigObject,
+  configObject: VariantPolicyConfigArr | VariantPolicyConfigObj,
   keyName: PolicyConfigKeysNames,
   options: VariantPolicyFromConfigObjectOptions
 ): VariantPolicyEntry[] {

--- a/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
+++ b/scopes/dependencies/dependency-resolver/policy/variant-policy/variant-policy.ts
@@ -233,7 +233,7 @@ export class VariantPolicy implements Policy<VariantPolicyConfigObject> {
   }
 
   static fromConfigObject(
-    configObject: VariantPolicyConfigArr | VariantPolicyConfigObj,
+    configObject: any, // VariantPolicyConfigArr | VariantPolicyConfigObj,
     options: VariantPolicyFromConfigObjectOptions = {}
   ): VariantPolicy {
     const runtimeEntries = entriesFromKey(configObject, 'dependencies', options);

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -315,6 +315,9 @@ export class MergeLanesMain {
     }
     const configMergeResults = compact(allComponentsStatus.map((c) => c.configMergeResult));
 
+    const mergedSnapIds = ComponentIdList.fromArray(
+      mergeResults.mergeSnapResults?.snappedComponents.map((c) => c.id) || []
+    );
     const componentsWithConfigConflicts = configMergeResults.filter((c) => c.hasConflicts()).map((c) => c.compIdStr);
     const conflicts: ConflictPerId[] = [];
     const mergedSuccessfullyIds: ComponentID[] = [];
@@ -325,7 +328,10 @@ export class MergeLanesMain {
       const config = componentsWithConfigConflicts.includes(c.id.toStringWithoutVersion());
       if (files.length || config) {
         conflicts.push({ id: c.id, files, config });
-      } else mergedSuccessfullyIds.push(c.id);
+      } else {
+        const snappedId = mergedSnapIds.searchWithoutVersion(c.id);
+        mergedSuccessfullyIds.push(snappedId || c.id);
+      }
     });
 
     await this.workspace?.consumer.onDestroy(`lane-merge (${otherLaneId.name})`);

--- a/scopes/scope/scope/scope.main.runtime.ts
+++ b/scopes/scope/scope/scope.main.runtime.ts
@@ -1160,15 +1160,6 @@ export class ScopeMain implements ComponentFactory {
     await this.loadAspects(aspectIds, true, component.id.toString());
   }
 
-  async addAspectsFromConfigObject(component: Component, configObject: Record<string, any>) {
-    const extensionsFromConfigObject = ExtensionDataList.fromConfigObject(configObject);
-    const extensionDataList = ExtensionDataList.mergeConfigs([
-      extensionsFromConfigObject,
-      component.state._consumer.extensions,
-    ]).filterRemovedExtensions();
-    component.state._consumer.extensions = extensionDataList;
-  }
-
   public async createAspectListFromExtensionDataList(extensionDataList: ExtensionDataList) {
     const entries = await Promise.all(extensionDataList.map((entry) => this.extensionDataEntryToAspectEntry(entry)));
     return this.componentExtension.createAspectListFromEntries(entries);

--- a/scopes/workspace/workspace/aspects-merger.ts
+++ b/scopes/workspace/workspace/aspects-merger.ts
@@ -3,7 +3,7 @@ import { Component } from '@teambit/component';
 import { UnmergedComponent } from '@teambit/legacy.scope';
 import { ComponentID } from '@teambit/component-id';
 import { EnvsAspect } from '@teambit/envs';
-import { DependencyResolverAspect } from '@teambit/dependency-resolver';
+import { DependencyResolverAspect, VariantPolicyConfigArr } from '@teambit/dependency-resolver';
 import { ExtensionDataList, getCompareExtPredicate } from '@teambit/legacy.extension-data';
 import { partition, mergeWith, merge, uniq, uniqWith, compact } from 'lodash';
 import { MergeConfigConflict } from './exceptions/merge-config-conflict';
@@ -12,7 +12,7 @@ import { MergeConflictFile } from './merge-conflict-file';
 
 export class AspectsMerger {
   readonly mergeConflictFile: MergeConflictFile;
-  private mergeConfigDepsResolverDataCache: { [compIdStr: string]: Record<string, any> } = {};
+  private mergeConfigDepsResolverDataCache: { [compIdStr: string]: VariantPolicyConfigArr } = {};
   constructor(
     private workspace: Workspace,
     private harmony: Harmony
@@ -20,7 +20,7 @@ export class AspectsMerger {
     this.mergeConflictFile = new MergeConflictFile(workspace.path);
   }
 
-  getDepsDataOfMergeConfig(id: ComponentID) {
+  getDepsDataOfMergeConfig(id: ComponentID): VariantPolicyConfigArr {
     return this.mergeConfigDepsResolverDataCache[id.toString()];
   }
 
@@ -205,7 +205,7 @@ export class AspectsMerger {
    */
   private removeAutoDepsFromConfig(componentId: ComponentID, conf?: ExtensionDataList, fromScope = false) {
     if (!conf) return;
-    const autoDepsObj = conf.removeAutoDepsFromConfig();
+    const autoDepsObj = conf.extractAutoDepsFromConfig();
     if (!autoDepsObj) return;
     if (!fromScope) {
       if (!this.mergeConfigDepsResolverDataCache[componentId.toString()]) {

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -22,6 +22,7 @@ import {
   DependencyResolverAspect,
   VariantPolicy,
   DependencyList,
+  VariantPolicyConfigArr,
 } from '@teambit/dependency-resolver';
 import { EnvsMain, EnvsAspect, EnvJsonc } from '@teambit/envs';
 import { GraphqlMain } from '@teambit/graphql';
@@ -1366,7 +1367,7 @@ the following envs are used in this workspace: ${availableEnvs.join(', ')}`);
     return this.aspectsMerger.mergeConflictFile;
   }
 
-  getDepsDataOfMergeConfig(id: ComponentID): Record<string, any> | undefined {
+  getDepsDataOfMergeConfig(id: ComponentID): VariantPolicyConfigArr {
     return this.aspectsMerger.getDepsDataOfMergeConfig(id);
   }
 


### PR DESCRIPTION
In case of merging main into an out-of-date lane, we compare the config and if there is no conflict, we generate `.bit/unmerged.json` file with the config to update. 
When running from the workspace, as soon as the components are re-loaded to be snapped during the process, it picks up this unmerged file and combine the config from this file into the aspect data of the componet.
However, when running from the scope, there is no concept of aspect-merge from different sources.  As a result, the config from this file are not integrated into the component. 
This PR fixes it by loading the unmerged file and adding the data to the component object.