### PR TITLE
improvement(merge-from-scope), introduce --allow-deps-outdated flag

### DIFF
--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -887,13 +887,14 @@ please create a new lane instead, which will include all components of this lane
         changed.push(ChangeType.SOURCE_CODE);
       }
 
-      if (compare.fields.length > 0) {
-        changed.push(ChangeType.ASPECTS);
-      }
-
       const depsFields = ['dependencies', 'devDependencies', 'extensionDependencies'];
       if (compare.fields.some((field) => depsFields.includes(field.fieldName))) {
         changed.push(ChangeType.DEPENDENCY);
+      }
+
+      const compareFieldsWithoutDeps = compare.fields.filter((field) => !depsFields.includes(field.fieldName));
+      if (compareFieldsWithoutDeps.length > 0) {
+        changed.push(ChangeType.ASPECTS);
       }
 
       return changed;

--- a/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
@@ -15,6 +15,7 @@ type Flags = {
   title?: string;
   titleBase64?: string;
   reMerge?: boolean;
+  allowOutdatedDeps?: boolean;
 };
 
 /**
@@ -50,6 +51,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
     ['', 'no-squash', 'relevant for merging lanes into main, which by default squash.'],
     ['', 'include-deps', 'relevant for "--pattern". merge also dependencies of the given components'],
     ['', 're-merge', 'helpful when last merge failed during export. do not skip components that seemed to be merged'],
+    ['', 'allow-outdated-deps', 'if a component is out of date but has only dependencies changes, allow the merge'],
     ['j', 'json', 'output as json format'],
   ] as CommandOptions;
   loader = true;
@@ -69,6 +71,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
       title,
       titleBase64,
       reMerge,
+      allowOutdatedDeps,
     }: Flags
   ): Promise<string> {
     if (includeDeps && !pattern) {
@@ -91,6 +94,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
         includeDeps,
         snapMessage: titleBase64Decoded || title,
         reMerge,
+        throwIfNotUpToDateForCodeChanges: allowOutdatedDeps
       }
     );
 


### PR DESCRIPTION
This way, it's possible to merge (from a bare-scope) a lane into main even when the lane is out of date. The only requirement is that the out-of-date components have only deps changes, not code changes. 