### PR TITLE
improvement(workspace-API), provide one complete API "hasId" for different scenarios

### DIFF
--- a/scopes/component/forking/forking.main.runtime.ts
+++ b/scopes/component/forking/forking.main.runtime.ts
@@ -69,7 +69,7 @@ export class ForkingMain {
   async fork(sourceId: string, targetId?: string, options?: ForkOptions): Promise<ComponentID> {
     if (!this.workspace) throw new OutsideWorkspaceError();
     const sourceCompId = await this.workspace.resolveComponentId(sourceId);
-    const exists = this.workspace.exists(sourceCompId);
+    const exists = this.workspace.hasId(sourceCompId, { ignoreVersion: true });
     if (exists) {
       const existingInWorkspace = await this.workspace.get(sourceCompId);
       return this.forkExistingInWorkspace(existingInWorkspace, targetId, options);

--- a/scopes/generator/generator/component-generator.ts
+++ b/scopes/generator/generator/component-generator.ts
@@ -181,7 +181,7 @@ export class ComponentGenerator {
     const userEnv = this.options.env;
 
     if (!config && this.envId && !userEnv) {
-      const isInWorkspace = this.workspace.exists(this.envId);
+      const isInWorkspace = this.workspace.hasId(this.envId, { ignoreVersion: true });
       config = {
         [isInWorkspace ? this.envId.toStringWithoutVersion() : this.envId.toString()]: {},
         'teambit.envs/envs': {
@@ -226,7 +226,7 @@ export class ComponentGenerator {
     // eslint-disable-next-line prefer-const
     let { envId, setBy } = getEnvData();
     if (envId) {
-      const isInWorkspace = this.workspace.exists(envId);
+      const isInWorkspace = this.workspace.hasId(envId, { ignoreVersion: true });
       const isSameAsThisEnvId = envId === this.envId?.toString() || envId === this.envId?.toStringWithoutVersion();
       if (isSameAsThisEnvId && this.envId) {
         envId = isInWorkspace ? this.envId.toStringWithoutVersion() : this.envId.toString();


### PR DESCRIPTION
Until now we had two APIs in the Workspace aspect:
```
hasId(componentId: ComponentID): boolean;
exists(componentId: ComponentID, opts: { includeDeleted?: boolean } = {}): boolean;
```
Both methods check whether a component ID is part of the workspace. The former checks for an exact match, while the latter ignores the version and provides an option to include deleted components. This is obviously confusing because the method names do not clearly indicate the type of comparison being performed.

In this PR, the exists method is deprecated, and hasId is modified (without a breaking change) to include all options:
```
hasId(componentId: ComponentID, opts?: { includeDeleted?: boolean, ignoreVersion?: boolean }): boolean;
```