### PR TITLE
fix(npm-ignore), fix ignore of artifacts dir

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -14,7 +14,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.69",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/analytics"
+        "rootDir": "components/legacy/analytics",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "api-reference": {
         "name": "api-reference",
@@ -210,7 +213,10 @@
         "scope": "teambit.react",
         "version": "1.0.29",
         "mainFile": "index.ts",
-        "rootDir": "scopes/react/bit-react-transformer"
+        "rootDir": "scopes/react/bit-react-transformer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "bit": {
         "name": "bit",
@@ -224,7 +230,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.84",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/bit-map"
+        "rootDir": "components/legacy/bit-map",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "builder": {
         "name": "builder",
@@ -238,7 +247,10 @@
         "scope": "teambit.pipelines",
         "version": "0.0.394",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/builder-data"
+        "rootDir": "scopes/pipelines/modules/builder-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "bundler": {
         "name": "bundler",
@@ -371,21 +383,30 @@
         "scope": "teambit.legacy",
         "version": "0.0.81",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-diff"
+        "rootDir": "components/legacy/component-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "component-issues": {
         "name": "component-issues",
         "scope": "teambit.component",
         "version": "0.0.154",
         "mainFile": "index.ts",
-        "rootDir": "components/component-issues"
+        "rootDir": "components/component-issues",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "component-list": {
         "name": "component-list",
         "scope": "teambit.legacy",
         "version": "0.0.81",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/component-list"
+        "rootDir": "components/legacy/component-list",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "component-log": {
         "name": "component-log",
@@ -399,7 +420,10 @@
         "scope": "teambit.component",
         "version": "0.0.436",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-package-version"
+        "rootDir": "scopes/component/component-package-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "component-sizer": {
         "name": "component-sizer",
@@ -455,28 +479,40 @@
         "scope": "teambit.legacy",
         "version": "0.0.9",
         "mainFile": "constants.ts",
-        "rootDir": "components/legacy/constants"
+        "rootDir": "components/legacy/constants",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "consumer": {
         "name": "consumer",
         "scope": "teambit.legacy",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer"
+        "rootDir": "components/legacy/consumer",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "consumer-component": {
         "name": "consumer-component",
         "scope": "teambit.legacy",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-component"
+        "rootDir": "components/legacy/consumer-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "consumer-config": {
         "name": "consumer-config",
         "scope": "teambit.legacy",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/consumer-config"
+        "rootDir": "components/legacy/consumer-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "content/cli-reference": {
         "name": "content/cli-reference",
@@ -510,7 +546,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.30",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/dependency-graph"
+        "rootDir": "components/legacy/dependency-graph",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "dependency-resolver": {
         "name": "dependency-resolver",
@@ -545,7 +584,10 @@
         "scope": "teambit.semantics",
         "version": "0.0.35",
         "mainFile": "index.ts",
-        "rootDir": "components/semantics/doc-parser"
+        "rootDir": "components/semantics/doc-parser",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "docs": {
         "name": "docs",
@@ -566,7 +608,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/e2e-helper"
+        "rootDir": "components/legacy/e2e-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "eject": {
         "name": "eject",
@@ -580,14 +625,20 @@
         "scope": "teambit.lanes",
         "version": "0.0.172",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/entities/lane-diff"
+        "rootDir": "scopes/lanes/entities/lane-diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "entities/semantic-schema": {
         "name": "entities/semantic-schema",
         "scope": "teambit.semantics",
         "version": "0.0.79",
         "mainFile": "index.ts",
-        "rootDir": "components/entities/semantic-schema"
+        "rootDir": "components/entities/semantic-schema",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "env": {
         "name": "env",
@@ -615,14 +666,20 @@
         "scope": "teambit.react",
         "version": "1.0.228",
         "mainFile": "index.js",
-        "rootDir": "scopes/react/eslint-config-bit-react"
+        "rootDir": "scopes/react/eslint-config-bit-react",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "eslint/config-mutator": {
         "name": "eslint/config-mutator",
         "scope": "teambit.defender",
         "version": "0.0.109",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/eslint-config-mutator"
+        "rootDir": "scopes/defender/eslint-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "explorer/api-reference-explorer": {
         "name": "explorer/api-reference-explorer",
@@ -650,7 +707,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.29",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/extension-data"
+        "rootDir": "components/legacy/extension-data",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "forking": {
         "name": "forking",
@@ -730,7 +790,10 @@
         "scope": "teambit.dependencies",
         "version": "0.0.20",
         "mainFile": "index.ts",
-        "rootDir": "scopes/dependencies/fs/linked-dependencies"
+        "rootDir": "scopes/dependencies/fs/linked-dependencies",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "fs/remove-empty-dir": {
         "name": "fs/remove-empty-dir",
@@ -757,7 +820,10 @@
         "scope": "teambit.bit",
         "version": "0.0.4",
         "mainFile": "index.ts",
-        "rootDir": "components/bit/get-bit-version"
+        "rootDir": "components/bit/get-bit-version",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "git": {
         "name": "git",
@@ -813,14 +879,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.7",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-cloud-scopes"
+        "rootDir": "scopes/cloud/hooks/use-cloud-scopes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "hooks/use-current-user": {
         "name": "hooks/use-current-user",
         "scope": "teambit.cloud",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-current-user"
+        "rootDir": "scopes/cloud/hooks/use-current-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "hooks/use-lane-components": {
         "name": "hooks/use-lane-components",
@@ -841,14 +913,20 @@
         "scope": "teambit.cloud",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/hooks/use-logout"
+        "rootDir": "scopes/cloud/hooks/use-logout",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "hooks/use-viewed-lane-from-url": {
         "name": "hooks/use-viewed-lane-from-url",
         "scope": "teambit.lanes",
         "version": "0.0.234",
         "mainFile": "index.ts",
-        "rootDir": "components/hooks/use-viewed-lane-from-url_1"
+        "rootDir": "components/hooks/use-viewed-lane-from-url_1",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "host-initializer": {
         "name": "host-initializer",
@@ -918,7 +996,10 @@
         "scope": "teambit.component",
         "version": "0.0.406",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy-component-log"
+        "rootDir": "components/legacy-component-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "linter": {
         "name": "linter",
@@ -939,7 +1020,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/loader"
+        "rootDir": "components/legacy/loader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "mdx": {
         "name": "mdx",
@@ -981,7 +1065,10 @@
         "scope": "teambit.compositions",
         "version": "0.0.507",
         "mainFile": "index.ts",
-        "rootDir": "scopes/compositions/model/composition-type"
+        "rootDir": "scopes/compositions/model/composition-type",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "models/api-node-renderer": {
         "name": "models/api-node-renderer",
@@ -995,28 +1082,40 @@
         "scope": "teambit.api-reference",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "components/models/api-reference-model"
+        "rootDir": "components/models/api-reference-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "models/cloud-scope": {
         "name": "models/cloud-scope",
         "scope": "teambit.cloud",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-scope"
+        "rootDir": "scopes/cloud/models/cloud-scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "models/cloud-user": {
         "name": "models/cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.8",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/models/cloud-user"
+        "rootDir": "scopes/cloud/models/cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "models/scope-model": {
         "name": "models/scope-model",
         "scope": "teambit.scope",
         "version": "0.0.524",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/models/scope-model"
+        "rootDir": "scopes/scope/models/scope-model",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/babel-compiler": {
         "name": "modules/babel-compiler",
@@ -1030,21 +1129,30 @@
         "scope": "teambit.pkg",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/component-package-name"
+        "rootDir": "components/modules/component-package-name",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/component-url": {
         "name": "modules/component-url",
         "scope": "teambit.component",
         "version": "0.0.172",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/component-url"
+        "rootDir": "scopes/component/component-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/concurrency": {
         "name": "modules/concurrency",
         "scope": "teambit.harmony",
         "version": "0.0.10",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/concurrency"
+        "rootDir": "scopes/harmony/modules/concurrency",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/config-mutator": {
         "name": "modules/config-mutator",
@@ -1058,21 +1166,30 @@
         "scope": "teambit.html",
         "version": "0.0.113",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/create-element-from-string"
+        "rootDir": "scopes/html/modules/create-element-from-string",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/create-lane": {
         "name": "modules/create-lane",
         "scope": "teambit.lanes",
         "version": "0.0.61",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/modules/create-lane"
+        "rootDir": "scopes/lanes/modules/create-lane",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/diff": {
         "name": "modules/diff",
         "scope": "teambit.lanes",
         "version": "0.0.525",
         "mainFile": "index.ts",
-        "rootDir": "scopes/lanes/diff"
+        "rootDir": "scopes/lanes/diff",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/feature-toggle": {
         "name": "modules/feature-toggle",
@@ -1086,98 +1203,140 @@
         "scope": "teambit.html",
         "version": "0.0.113",
         "mainFile": "index.ts",
-        "rootDir": "scopes/html/modules/fetch-html-from-url"
+        "rootDir": "scopes/html/modules/fetch-html-from-url",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/find-scope-path": {
         "name": "modules/find-scope-path",
         "scope": "teambit.scope",
         "version": "0.0.10",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/find-scope-path"
+        "rootDir": "components/modules/find-scope-path",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/fs-cache": {
         "name": "modules/fs-cache",
         "scope": "teambit.workspace",
         "version": "0.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/fs-cache"
+        "rootDir": "scopes/workspace/modules/fs-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/generate-expose-loaders": {
         "name": "modules/generate-expose-loaders",
         "scope": "teambit.webpack",
         "version": "0.0.20",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-expose-loaders"
+        "rootDir": "scopes/webpack/modules/generate-expose-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/generate-externals": {
         "name": "modules/generate-externals",
         "scope": "teambit.webpack",
         "version": "0.0.20",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-externals"
+        "rootDir": "scopes/webpack/modules/generate-externals",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/generate-style-loaders": {
         "name": "modules/generate-style-loaders",
         "scope": "teambit.webpack",
         "version": "1.0.17",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/modules/generate-style-loaders"
+        "rootDir": "scopes/webpack/modules/generate-style-loaders",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/get-basic-log": {
         "name": "modules/get-basic-log",
         "scope": "teambit.harmony",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/get-basic-log"
+        "rootDir": "scopes/harmony/modules/get-basic-log",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/get-cloud-user": {
         "name": "modules/get-cloud-user",
         "scope": "teambit.cloud",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/cloud/modules/get-cloud-user"
+        "rootDir": "scopes/cloud/modules/get-cloud-user",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/git-executable": {
         "name": "modules/git-executable",
         "scope": "teambit.git",
         "version": "0.0.10",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/git-executable"
+        "rootDir": "scopes/git/modules/git-executable",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/harmony-root-generator": {
         "name": "modules/harmony-root-generator",
         "scope": "teambit.harmony",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "components/modules/harmony-root-generator"
+        "rootDir": "components/modules/harmony-root-generator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/ignore-file-reader": {
         "name": "modules/ignore-file-reader",
         "scope": "teambit.git",
         "version": "0.0.10",
         "mainFile": "index.ts",
-        "rootDir": "scopes/git/modules/ignore-file-reader"
+        "rootDir": "scopes/git/modules/ignore-file-reader",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/in-memory-cache": {
         "name": "modules/in-memory-cache",
         "scope": "teambit.harmony",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/in-memory-cache"
+        "rootDir": "scopes/harmony/modules/in-memory-cache",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/match-pattern": {
         "name": "modules/match-pattern",
         "scope": "teambit.workspace",
         "version": "0.0.508",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/match-pattern"
+        "rootDir": "scopes/workspace/modules/match-pattern",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/merge-component-results": {
         "name": "modules/merge-component-results",
         "scope": "teambit.pipelines",
         "version": "0.0.501",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pipelines/modules/merge-component-results"
+        "rootDir": "scopes/pipelines/modules/merge-component-results",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/module-resolver": {
         "name": "modules/module-resolver",
@@ -1197,42 +1356,60 @@
         "scope": "teambit.workspace",
         "version": "0.0.255",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/node-modules-linker"
+        "rootDir": "scopes/workspace/modules/node-modules-linker",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/requireable-component": {
         "name": "modules/requireable-component",
         "scope": "teambit.harmony",
         "version": "0.0.501",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/requireable-component"
+        "rootDir": "scopes/harmony/modules/requireable-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/resolved-component": {
         "name": "modules/resolved-component",
         "scope": "teambit.harmony",
         "version": "0.0.501",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/resolved-component"
+        "rootDir": "scopes/harmony/modules/resolved-component",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/semver-helper": {
         "name": "modules/semver-helper",
         "scope": "teambit.pkg",
         "version": "0.0.5",
         "mainFile": "index.ts",
-        "rootDir": "scopes/pkg/modules/semver-helper"
+        "rootDir": "scopes/pkg/modules/semver-helper",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/send-server-sent-events": {
         "name": "modules/send-server-sent-events",
         "scope": "teambit.harmony",
         "version": "0.0.6",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/modules/send-server-sent-events"
+        "rootDir": "scopes/harmony/modules/send-server-sent-events",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/style-regexps": {
         "name": "modules/style-regexps",
         "scope": "teambit.webpack",
         "version": "1.0.9",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/style-regexps"
+        "rootDir": "scopes/webpack/style-regexps",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "modules/ts-config-mutator": {
         "name": "modules/ts-config-mutator",
@@ -1246,7 +1423,10 @@
         "scope": "teambit.workspace",
         "version": "0.0.10",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/modules/workspace-locator"
+        "rootDir": "scopes/workspace/modules/workspace-locator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "mover": {
         "name": "mover",
@@ -1274,7 +1454,10 @@
         "scope": "teambit.scope",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/network"
+        "rootDir": "scopes/scope/network",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "network/get-port": {
         "name": "network/get-port",
@@ -1409,7 +1592,10 @@
         "scope": "teambit.webpack",
         "version": "0.0.13",
         "mainFile": "index.ts",
-        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin"
+        "rootDir": "scopes/webpack/plugins/inject-head-webpack-plugin",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "pnpm": {
         "name": "pnpm",
@@ -1430,7 +1616,10 @@
         "scope": "teambit.defender",
         "version": "0.0.104",
         "mainFile": "index.ts",
-        "rootDir": "scopes/defender/prettier-config-mutator"
+        "rootDir": "scopes/defender/prettier-config-mutator",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "preview": {
         "name": "preview",
@@ -1492,14 +1681,20 @@
         "scope": "teambit.scope",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "scopes/scope/remote-actions"
+        "rootDir": "scopes/scope/remote-actions",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "remotes": {
         "name": "remotes",
         "scope": "teambit.scope",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components/scope/remotes"
+        "rootDir": "components/scope/remotes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "remove": {
         "name": "remove",
@@ -1674,7 +1869,10 @@
         "scope": "teambit.legacy",
         "version": "0.0.82",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope-api"
+        "rootDir": "components/legacy/scope-api",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "sections/api-reference-page": {
         "name": "sections/api-reference-page",
@@ -1709,7 +1907,10 @@
         "scope": "teambit.component",
         "version": "0.0.28",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/snap-distance"
+        "rootDir": "scopes/component/snap-distance",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "snapping": {
         "name": "snapping",
@@ -1723,7 +1924,10 @@
         "scope": "teambit.component",
         "version": "0.0.79",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/sources"
+        "rootDir": "scopes/component/sources",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "stash": {
         "name": "stash",
@@ -1843,21 +2047,30 @@
         "scope": "teambit.legacy",
         "version": "0.0.9",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/global-config"
+        "rootDir": "components/legacy/global-config",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "teambit.legacy/logger": {
         "name": "logger",
         "scope": "teambit.legacy",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/logger"
+        "rootDir": "components/legacy/logger",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "teambit.legacy/scope": {
         "name": "scope",
         "scope": "teambit.legacy",
         "version": "0.0.27",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/scope"
+        "rootDir": "components/legacy/scope",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "teambit.scope/scope": {
         "name": "scope",
@@ -1878,21 +2091,30 @@
         "scope": "teambit.harmony",
         "version": "0.0.282",
         "mainFile": "index.ts",
-        "rootDir": "scopes/harmony/testing/load-aspect"
+        "rootDir": "scopes/harmony/testing/load-aspect",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "testing/mock-components": {
         "name": "testing/mock-components",
         "scope": "teambit.component",
         "version": "0.0.287",
         "mainFile": "index.ts",
-        "rootDir": "scopes/component/testing/mock-components"
+        "rootDir": "scopes/component/testing/mock-components",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "testing/mock-workspace": {
         "name": "testing/mock-workspace",
         "scope": "teambit.workspace",
         "version": "0.0.54",
         "mainFile": "index.ts",
-        "rootDir": "scopes/workspace/testing/mock-workspace"
+        "rootDir": "scopes/workspace/testing/mock-workspace",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "time/time-format": {
         "name": "time/time-format",
@@ -1932,7 +2154,10 @@
         "scope": "teambit.typescript",
         "version": "0.0.61",
         "mainFile": "index.ts",
-        "rootDir": "scopes/typescript/ts-server"
+        "rootDir": "scopes/typescript/ts-server",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "types/serializable": {
         "name": "types/serializable",
@@ -2384,49 +2609,70 @@
         "scope": "teambit.legacy",
         "version": "0.0.16",
         "mainFile": "index.ts",
-        "rootDir": "components/legacy/utils"
+        "rootDir": "components/legacy/utils",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/code-editor-options": {
         "name": "utils/code-editor-options",
         "scope": "teambit.api-reference",
         "version": "0.0.11",
         "mainFile": "index.ts",
-        "rootDir": "components/utils/code-editor-options"
+        "rootDir": "components/utils/code-editor-options",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/copy-schema-node": {
         "name": "utils/copy-schema-node",
         "scope": "teambit.api-reference",
         "version": "0.0.32",
         "mainFile": "index.ts",
-        "rootDir": "components/utils/copy-schema-node"
+        "rootDir": "components/utils/copy-schema-node",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/custom-prism-syntax-highlighter-theme": {
         "name": "utils/custom-prism-syntax-highlighter-theme",
         "scope": "teambit.api-reference",
         "version": "0.0.12",
         "mainFile": "index.ts",
-        "rootDir": "scopes/api-reference/utils/custom-prism-syntax-highlighter-theme"
+        "rootDir": "scopes/api-reference/utils/custom-prism-syntax-highlighter-theme",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/group-schema-node-by-signature": {
         "name": "utils/group-schema-node-by-signature",
         "scope": "teambit.api-reference",
         "version": "0.0.32",
         "mainFile": "index.ts",
-        "rootDir": "components/utils/group-schema-node-by-signature"
+        "rootDir": "components/utils/group-schema-node-by-signature",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/schema-node-signature-transform": {
         "name": "utils/schema-node-signature-transform",
         "scope": "teambit.api-reference",
         "version": "0.0.34",
         "mainFile": "index.ts",
-        "rootDir": "components/utils/schema-node-signature-transform"
+        "rootDir": "components/utils/schema-node-signature-transform",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "utils/sort-api-nodes": {
         "name": "utils/sort-api-nodes",
         "scope": "teambit.api-reference",
         "version": "0.0.37",
         "mainFile": "index.ts",
-        "rootDir": "components/utils/sort-api-nodes"
+        "rootDir": "components/utils/sort-api-nodes",
+        "config": {
+            "teambit.node/envs/node-babel-mocha@0.1.5": {}
+        }
     },
     "variants": {
         "name": "variants",

--- a/scopes/harmony/aspect/aspect.env.ts
+++ b/scopes/harmony/aspect/aspect.env.ts
@@ -161,7 +161,7 @@ export class AspectEnv implements DependenciesEnv, PackageEnv, PreviewEnv {
   }
 
   getNpmIgnore() {
-    return [`${CAPSULE_ARTIFACTS_DIR}/`];
+    return [`${CAPSULE_ARTIFACTS_DIR}/*`];
   }
 
   getPreviewConfig() {

--- a/scopes/react/react/react.env.ts
+++ b/scopes/react/react/react.env.ts
@@ -496,7 +496,7 @@ export class ReactEnv
   }
 
   getNpmIgnore() {
-    return [`${CAPSULE_ARTIFACTS_DIR}/`];
+    return [`${CAPSULE_ARTIFACTS_DIR}/*`];
   }
 
   /**


### PR DESCRIPTION
Added `/*` at the end of "artifacts" entry of `.npmignore` file. This way, when there are negative entries (`!`) this dir is still excluded. 