### PR TITLE
fix(checkout-reset), write deleted main-component when on a lane

### DIFF
--- a/e2e/harmony/checkout-harmony.e2e.ts
+++ b/e2e/harmony/checkout-harmony.e2e.ts
@@ -695,4 +695,22 @@ describe('bit checkout command', function () {
       expect(bitmap.comp1.version).to.equal('0.0.1');
     });
   });
+  describe('checkout reset of main component when on a lane and the component-dir is deleted', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('dev');
+      helper.fs.deletePath('comp1');
+      helper.command.checkoutReset('--all');
+    });
+    it('should re-write the component', () => {
+      expect(path.join(helper.scopes.localPath, 'comp1')).to.be.a.directory();
+    });
+    it('status should not have invalid components', () => {
+      const status = helper.command.statusJson();
+      expect(status.invalidComponents).to.have.lengthOf(0);
+    });
+  });
 });

--- a/scopes/component/checkout/checkout.main.runtime.ts
+++ b/scopes/component/checkout/checkout.main.runtime.ts
@@ -349,7 +349,7 @@ export class CheckoutMain {
     // when no ids were given and the user is on a lane, return lane-ids only.
     // it's relevant for cases like "bit checkout head" when on a lane to not checkout main components. (see https://github.com/teambit/bit/pull/6853)
     const ids =
-      currentLaneIds && !componentPattern
+      currentLaneIds && !componentPattern && checkoutProps.head
         ? idsOnWorkspace.filter((id) => currentLaneIds.hasWithoutVersion(id))
         : idsOnWorkspace;
     checkoutProps.ids = ids.map((id) => (checkoutProps.head || checkoutProps.latest ? id.changeVersion(LATEST) : id));


### PR DESCRIPTION
`bit checkout reset --all` rewrites deleted component dirs.
Currently, when running it and a non-lane component is deleted when the workspace is on a lane, this component is not written. 
The reason is that when on a lane, the ids used by this command are the ids from the lane. While this is the expected behavior for `bit checkout head`, it's not the case for `bit checkout reset`. 
This PR changes it so that all workspace ids are used for the checkout-reset.