### PR TITLE
fix(new), fix env-not-found regression error by not requiring the env to be loaded

### DIFF
--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -492,7 +492,7 @@ export class PkgMain {
   ): Promise<Record<string, any>> {
     const newProps = this.getPackageJsonModifications(component);
     const pkgJsonObj = Object.assign(packageJsonObject, newProps);
-    const env = this.envs.getEnv(component).env;
+    const env = this.envs.getOrCalculateEnv(component)?.env;
     if (env.modifyPackageJson) {
       return env.modifyPackageJson(component, pkgJsonObj);
     }

--- a/scopes/pkg/pkg/pkg.main.runtime.ts
+++ b/scopes/pkg/pkg/pkg.main.runtime.ts
@@ -492,7 +492,7 @@ export class PkgMain {
   ): Promise<Record<string, any>> {
     const newProps = this.getPackageJsonModifications(component);
     const pkgJsonObj = Object.assign(packageJsonObject, newProps);
-    const env = this.envs.getOrCalculateEnv(component)?.env;
+    const env = this.envs.getOrCalculateEnv(component).env;
     if (env.modifyPackageJson) {
       return env.modifyPackageJson(component, pkgJsonObj);
     }

--- a/scopes/scope/export/export.main.runtime.ts
+++ b/scopes/scope/export/export.main.runtime.ts
@@ -220,7 +220,7 @@ if the export fails with missing objects/versions/components, run "bit fetch --l
     );
     const updatedIds = _updateIdsOnBitMap(consumer.bitMap, updatedLocally);
     // re-generate the package.json, this way, it has the correct data in the componentId prop.
-    await linkToNodeModulesByIds(this.workspace, updatedIds);
+    await linkToNodeModulesByIds(this.workspace, updatedIds, true);
     await this.removeFromStagedConfig(exported);
     // ideally we should delete the staged-snaps only for the exported snaps. however, it's not easy, and it's ok to
     // delete them all because this file is mainly an optimization for the import process.


### PR DESCRIPTION
This is a regression caused by https://github.com/teambit/bit/pull/9530.
That API needed the env to be loaded when writing the package.json. In some cases, this is hard to achieve. For `bit new`, when the env is not there, it threw an error:

> environment with ID: X configured on component Y was not found

This PR fixes it by not throwing an error in such case.