### PR TITLE
fix(plugins) - fix resolution of plugins paths which leads to files not found errors

### DIFF
--- a/scopes/harmony/aspect-loader/plugin.ts
+++ b/scopes/harmony/aspect-loader/plugin.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'fs';
+import { realpathSync, existsSync } from 'fs';
 import { Aspect } from '@teambit/harmony';
 import { PluginDefinition } from './plugin-definition';
 
@@ -28,7 +28,9 @@ export class Plugin {
     const mod = require(this.path);
     this._instance = mod.default as any;
     this._instance.__path = this.path;
-    const realPath = realpathSync(this.path);
+    const exists = existsSync(this.path);
+    // In case the path not exists we don't need to resolve it (it will throw an error)
+    const realPath = exists ? realpathSync(this.path) : this.path;
     const resolvedPathFromRealPath = require.resolve(realPath);
     this._instance.__resolvedPath = resolvedPathFromRealPath
     return this._instance;

--- a/scopes/harmony/aspect-loader/plugin.ts
+++ b/scopes/harmony/aspect-loader/plugin.ts
@@ -1,3 +1,4 @@
+import { realpathSync } from 'fs';
 import { Aspect } from '@teambit/harmony';
 import { PluginDefinition } from './plugin-definition';
 
@@ -27,7 +28,9 @@ export class Plugin {
     const mod = require(this.path);
     this._instance = mod.default as any;
     this._instance.__path = this.path;
-    this._instance.__resolvedPath = require.resolve(this.path);
+    const realPath = realpathSync(this.path);
+    const resolvedPathFromRealPath = require.resolve(realPath);
+    this._instance.__resolvedPath = resolvedPathFromRealPath
     return this._instance;
   }
 }

--- a/scopes/harmony/aspect-loader/plugins.ts
+++ b/scopes/harmony/aspect-loader/plugins.ts
@@ -1,4 +1,4 @@
-import { realpathSync } from 'fs';
+import { realpathSync, existsSync } from 'fs';
 import { Component } from '@teambit/component';
 import esmLoader from '@teambit/node.utils.esm-loader';
 import { Logger } from '@teambit/logger';
@@ -55,10 +55,12 @@ export class Plugins {
   }
 
   async loadModule(path: string) {
+    const exists = existsSync(path);
     // We manually resolve the path to avoid issues with symlinks
     // the require.resolve and import inside the esmLoader will sometime uses cached resolved paths
     // which lead to errors about file not found as it's trying to load the file from the wrong path
-    const realPath = realpathSync(path);
+    // In case the path not exists we don't need to resolve it (it will throw an error)
+    const realPath = exists ? realpathSync(path) : path;
     const resolvedPathFromRealPath = require.resolve(realPath);
     const module = await esmLoader(realPath, true);
     const defaultModule = module.default;


### PR DESCRIPTION
## Proposed Changes

- This fixes errors such as
```
Cannot find package '<wsPath>/node_modules/.pnpm/@bitdev+node.node-env@4.0.1_@babel+core@7.11.6_@babel+traverse@7.26.9_@testing-library+react@_bk5xnj5gsuxhmwvf6rvucqnsi4/node_modules/@bitdev/react.react-env/index.js' imported from <wsPath>/node_modules/.pnpm/@bitdev+node.node-env@4.0.1_@babel+core@7.11.6_@babel+traverse@7.26.9_@testing-library+react@_bk5xnj5gsuxhmwvf6rvucqnsi4/node_modules/@bitdev/node.node-env/dist/node-env.bit-env.js
```

