### PR TITLE
fix, clear all dependency caches upon env.jsonc changes

### DIFF
--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -768,6 +768,11 @@ export default class CommandHelper {
     return aspectConf.data.dependencies.map((dep) => dep.id);
   }
 
+  getCompDepsDataFromData(compId: string): {id: string, version: string, lifecycle: string, source: string}[] {
+    const aspectConf = this.showAspectConfig(compId, Extensions.dependencyResolver);
+    return aspectConf.data.dependencies;
+  }
+
   showComponentParsedHarmonyByTitle(compId: string, title: string) {
     const show = this.showComponentParsedHarmony(compId);
     return show.find((_) => _.title === title).json;

--- a/components/legacy/e2e-helper/e2e-env-helper.ts
+++ b/components/legacy/e2e-helper/e2e-env-helper.ts
@@ -143,6 +143,18 @@ export default class EnvHelper {
     return EXTENSIONS_BASE_FOLDER;
   }
 
+  setEmptyEnv() {
+    this.fs.outputFile(
+      'empty-env/empty-env.bit-env.ts',
+      `export class EmptyEnv {}
+export default new EmptyEnv();
+`
+    );
+    this.fs.outputFile('empty-env/index.ts', `export { EmptyEnv } from './empty-env.bit-env';`);
+    this.command.addComponent('empty-env');
+    this.command.setEnv('empty-env', 'teambit.envs/env');
+  }
+
   setCustomEnv(extensionsBaseFolder = 'node-env', options: SetCustomEnvOpts = {}): string {
     this.fixtures.copyFixtureExtensions(extensionsBaseFolder);
     this.command.addComponent(extensionsBaseFolder);

--- a/e2e/harmony/custom-env.e2e.ts
+++ b/e2e/harmony/custom-env.e2e.ts
@@ -549,15 +549,7 @@ describe('custom env', function () {
   describe('an empty env. nothing is configured, not even a compiler', () => {
     before(() => {
       helper.scopeHelper.setNewLocalAndRemoteScopes();
-      helper.fs.outputFile(
-        'empty-env/empty-env.bit-env.ts',
-        `export class EmptyEnv {}
-export default new EmptyEnv();
-`
-      );
-      helper.fs.outputFile('empty-env/index.ts', `export { EmptyEnv } from './empty-env.bit-env';`);
-      helper.command.addComponent('empty-env');
-      helper.command.setEnv('empty-env', 'teambit.envs/env');
+      helper.env.setEmptyEnv();
 
       helper.fixtures.populateComponents(1, false);
       helper.command.setEnv('comp1', 'empty-env');

--- a/e2e/harmony/dependencies.e2e.ts
+++ b/e2e/harmony/dependencies.e2e.ts
@@ -146,4 +146,23 @@ const isPositive = require('is-positive');
       helper.command.expectStatusToNotHaveIssue(IssuesClasses.MissingDependenciesOnFs.name);
     });
   });
+  describe('changing files to be dev-files from env.jsonc', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.env.setEmptyEnv();
+      helper.fixtures.populateComponents(1, false);
+      helper.fs.outputFile('comp1/some.content.tsx', `import lodash from 'lodash';`);
+      helper.command.setEnv('comp1', 'empty-env');
+      helper.command.install(undefined, { a: ''});
+      helper.command.status(); // makes sure the comp is loaded and its deps are in the filesystem cache.
+      helper.fs.outputFile('empty-env/env.jsonc', JSON.stringify({ patterns: { contents: ['**/*.content.tsx'] } }, null, 2));
+    });
+    // previously, it was needed to run `bit cc` to see lodash as dev. it was showing as a realtime dep.
+    it('should clear all components caches and show the dep as a dev-dep', () => {
+      const depsData = helper.command.getCompDepsDataFromData('comp1')
+      const lodash = depsData.find(d => d.id === 'lodash');
+      expect(lodash).to.exist;
+      expect(lodash?.lifecycle).to.equal('dev');
+    });
+  });
 });

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { uniq } from 'lodash';
 import { IssuesClasses } from '@teambit/component-issues';
-import { getLastModifiedComponentTimestampMs } from '@teambit/toolbox.fs.last-modified';
+import { getLastModifiedComponentTimestampMs, getLastModifiedPathsTimestampMs } from '@teambit/toolbox.fs.last-modified';
 import { ExtensionDataEntry } from '@teambit/legacy.extension-data';
 import { DependencyLoaderOpts, ConsumerComponent as Component } from '@teambit/legacy.consumer-component';
 import { COMPONENT_CONFIG_FILE_NAME } from '@teambit/legacy.constants';
@@ -119,7 +119,20 @@ export class DependenciesLoader {
     filesPaths.push(componentConfigPath);
     const lastModifiedComponent = await getLastModifiedComponentTimestampMs(rootDir, filesPaths);
     const wasModifiedAfterCache = lastModifiedComponent > cacheData.timestamp;
+
     if (wasModifiedAfterCache) {
+      // in case the env.jsonc was modified, all components using this env should be invalidated as well.
+      // we don't have a fast way to check which are those components so we clear them all.
+      // in terms of performance, it's not that bad because this file is not modified often.
+      const envJsonFile = this.component.files.find((file) => file.relative === 'env.jsonc');
+      if (envJsonFile) {
+        const lastModifiedEnvJsonc = await getLastModifiedPathsTimestampMs([envJsonFile.path]);
+        const wasEnvJsonModifiedAfterCache = lastModifiedEnvJsonc > cacheData.timestamp;
+        if (wasEnvJsonModifiedAfterCache) {
+          this.logger.debug(`dependencies-loader, the env ${this.idStr} was modified after the cache was created, clearing all deps caches`);
+          await workspace.consumer.componentFsCache.deleteAllDependenciesDataCache();
+        }
+      }
       return null; // cache is invalid.
     }
     this.logger.debug(`dependencies-loader, getting the dependencies data for ${this.idStr} from the cache`);


### PR DESCRIPTION
Currently, when an env.jsonc is changed, for example, a file pattern becomes a dev-file, the components of this env are loaded with the old cached dependencies-data. 
This PR checks if a component contains an `env.jsonc` file and, if the file has been modified recently, deletes all dependency caches from the filesystem.