### PR TITLE
fix(code): validate path extensions against known file types

### DIFF
--- a/components/ui/code-tab-page/code-tab-page.tsx
+++ b/components/ui/code-tab-page/code-tab-page.tsx
@@ -59,7 +59,8 @@ export function resolveFilePath(
 
   if (fileTree.includes(normalized)) return normalized;
 
-  const requestedExt = path.extname(normalized);
+  const extension = path.extname(normalized);
+  const requestedExt = ['.js', '.jsx', '.ts', '.tsx', '.mjs', '.cjs'].includes(extension) ? extension : '';
   const basePathWithoutExt = requestedExt ? normalized.slice(0, -requestedExt.length) : normalized;
 
   const getTypeScriptVariants = (ext: string): string[] => {


### PR DESCRIPTION
When resolving file paths with multiple dots without an extension (e.g. `file.ui.runtime`), path.extname() incorrectly treated '.runtime' as the extension. Now it validates extensions against known file types before processing.