### PR TITLE
perf, limit accessing git-config for git-related keys only

### DIFF
--- a/components/config-store/config-getter.ts
+++ b/components/config-store/config-getter.ts
@@ -58,7 +58,12 @@ export class ConfigGetter {
     if (!isNil(val)) {
       return val;
     }
-
+    const gitKeys = ['user.name', 'user.email'];
+    if (gitKeys.includes(key)) {
+      return this.getFromGit(key);
+    }
+  }
+  private getFromGit(key: string): string | undefined {
     if (key in this.gitStore) {
       return this.gitStore[key];
     }


### PR DESCRIPTION
Only for "user.email" and "user.name" search in git-config. 
It helps reducing the files loaded every bootstrap by 54 files.