### PR TITLE
feat(api-ref): enhance type references and documentation display

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -1542,6 +1542,20 @@
         "mainFile": "index.ts",
         "rootDir": "scopes/api-reference/renderers/this"
     },
+    "renderers/tuple-type": {
+        "name": "renderers/tuple-type",
+        "scope": "",
+        "version": "",
+        "defaultScope": "teambit.api-reference",
+        "mainFile": "index.ts",
+        "rootDir": "components/renderers/tuple-type",
+        "config": {
+            "teambit.react/react": {},
+            "teambit.envs/envs": {
+                "env": "teambit.react/react"
+            }
+        }
+    },
     "renderers/type": {
         "name": "renderers/type",
         "scope": "teambit.api-reference",

--- a/components/entities/semantic-schema/schemas/parameter.ts
+++ b/components/entities/semantic-schema/schemas/parameter.ts
@@ -5,6 +5,10 @@ export class ParameterSchema<T extends SchemaNode = SchemaNode> extends SchemaNo
   readonly type: T;
   readonly objectBindingNodes?: SchemaNode[];
 
+  getNodes(): SchemaNode[] {
+    return [this.type, ...(this.objectBindingNodes || [])];
+  }
+
   constructor(
     readonly location: SchemaLocation,
     readonly name: string,

--- a/components/entities/semantic-schema/schemas/type-ref.ts
+++ b/components/entities/semantic-schema/schemas/type-ref.ts
@@ -47,6 +47,10 @@ export class TypeRefSchema extends SchemaNode {
     this.componentId = componentId;
   }
 
+  getNodes(): SchemaNode[] {
+    return this.typeArgs || [];
+  }
+
   withTypeArgs(typeArgs: SchemaNode[]) {
     this.typeArgs = typeArgs;
     return this;

--- a/components/models/api-reference-model/api-reference-model.ts
+++ b/components/models/api-reference-model/api-reference-model.ts
@@ -1,6 +1,8 @@
-import { APISchema, ExportSchema, SchemaNode } from '@teambit/semantics.entities.semantic-schema';
+import { APISchema, ExportSchema, SchemaNode, TypeRefSchema } from '@teambit/semantics.entities.semantic-schema';
 import { APINodeRenderer } from '@teambit/api-reference.models.api-node-renderer';
 import { ComponentID, ComponentIdObj } from '@teambit/component-id';
+import compact from 'lodash.compact';
+import head from 'lodash.head';
 
 export type SchemaQueryResult = {
   getHost: {
@@ -20,8 +22,8 @@ export class APIReferenceModel {
   apiByType: Map<string, APINode[]>;
   apiByName: Map<string, APINode>;
 
-  internalAPIKey(schema: SchemaNode) {
-    return this.generateInternalAPIKey(schema.location.filePath, schema.name);
+  internalAPIKey(schema: SchemaNode, internalFilePath?: string) {
+    return this.generateInternalAPIKey(internalFilePath || schema.location.filePath, schema.name);
   }
 
   generateInternalAPIKey(filePath: string, name = '') {
@@ -60,7 +62,7 @@ export class APIReferenceModel {
       .filter((schemaNode) => schemaNode.renderer) as APINode[];
   }
 
-  mapToAPINode(api: APISchema, renderers: APINodeRenderer[], componentId: ComponentID): APINode[] {
+  mapToAPINode_bk(api: APISchema, renderers: APINodeRenderer[], componentId: ComponentID): APINode[] {
     const { internals } = api;
 
     const { exports: exportedSchemaNodes } = api.module;
@@ -112,9 +114,9 @@ export class APIReferenceModel {
     return this.apiByType.get(type) ?? [];
   }
 
-  getByName(node: SchemaNode): APINode | undefined {
+  getByName(node: SchemaNode, internalFilePath?: string): APINode | undefined {
     if (!node.name) return undefined;
-    return this.apiByName.get(node.name) ?? this.apiByName.get(this.internalAPIKey(node));
+    return this.apiByName.get(node.name) ?? this.apiByName.get(this.internalAPIKey(node, internalFilePath));
   }
 
   groupByType(apiNodes: APINode[]): Map<string, APINode[]> {
@@ -133,6 +135,75 @@ export class APIReferenceModel {
       accum.set(key, next);
       return accum;
     }, new Map<string, APINode>());
+  }
+
+  private isInternalTypeReference(node: SchemaNode): node is TypeRefSchema {
+    return node.__schema === 'TypeRefSchema' && (node as TypeRefSchema).isInternalReference();
+  }
+
+  mapToAPINode(api: APISchema, renderers: APINodeRenderer[], componentId: ComponentID): APINode[] {
+    const { exports: exportedSchemaNodes } = api.module;
+
+    const collectedInternals: SchemaNode[] = [];
+    exportedSchemaNodes.forEach((exportedNode) => {
+      const targetNode = ExportSchema.isExportSchema(exportedNode)
+        ? exportedNode.exportNode
+        : exportedNode;
+      const allDescendants = targetNode.getAllNodesRecursively();
+      allDescendants.forEach((descendant) => {
+        if (descendant !== targetNode && this.isInternalTypeReference(descendant)) {
+          collectedInternals.push(descendant);
+        }
+      });
+    });
+
+    const dedupedInternalsMap = new Map<string, SchemaNode>();
+    for (const node of collectedInternals) {
+      const key = this.internalAPIKey(node);
+      if (!dedupedInternalsMap.has(key)) {
+        dedupedInternalsMap.set(key, node);
+      }
+    }
+    const internalSchemaNodes = Array.from(dedupedInternalsMap.values());
+
+    const defaultRenderers = renderers.filter((renderer) => renderer.default);
+    const nonDefaultRenderers = renderers.filter((renderer) => !renderer.default);
+
+    const exportedAPINodes: APINode[] = exportedSchemaNodes.map((schemaNode) => {
+      const targetNode = ExportSchema.isExportSchema(schemaNode)
+        ? schemaNode.exportNode
+        : schemaNode;
+      return {
+        componentId,
+        api: targetNode,
+        alias: ExportSchema.isExportSchema(schemaNode) ? schemaNode.alias : undefined,
+        exported: true,
+        renderer:
+          nonDefaultRenderers.find((renderer) => renderer.predicate(targetNode)) ||
+          defaultRenderers.find((renderer) => renderer.predicate(targetNode)),
+      } as APINode;
+    });
+
+    const internalAPINodes: APINode[] = internalSchemaNodes.map((schemaNode) => {
+      const internalSchemaNode = head(
+        compact(
+          api.internals
+            .flatMap(i => i.exports)
+            .map((e) => e.findNode((s) => s.name === schemaNode.name && s.__schema !== 'TypeRefSchema'))
+        )
+      ) || schemaNode;
+
+      return {
+        componentId,
+        api: internalSchemaNode,
+        exported: false,
+        renderer:
+          nonDefaultRenderers.find((renderer) => renderer.predicate(internalSchemaNode)) ||
+          defaultRenderers.find((renderer) => renderer.predicate(internalSchemaNode)),
+      } as APINode
+    });
+
+    return exportedAPINodes.concat(internalAPINodes).filter((node) => node.renderer);
   }
 
   static from(result: SchemaQueryResult, renderers: APINodeRenderer[] = []): APIReferenceModel {

--- a/components/models/api-reference-model/api-reference-model.ts
+++ b/components/models/api-reference-model/api-reference-model.ts
@@ -62,54 +62,6 @@ export class APIReferenceModel {
       .filter((schemaNode) => schemaNode.renderer) as APINode[];
   }
 
-  mapToAPINode_bk(api: APISchema, renderers: APINodeRenderer[], componentId: ComponentID): APINode[] {
-    const { internals } = api;
-
-    const { exports: exportedSchemaNodes } = api.module;
-    const exportedInternalKeySet = new Set(exportedSchemaNodes.map((schemaNode) => this.internalAPIKey(schemaNode)));
-
-    const internalSchemaNodes = internals
-      .reduce((acc, next) => {
-        return acc.concat([...next.internals]);
-      }, new Array<SchemaNode>())
-      .filter((schemaNode) => !exportedInternalKeySet.has(this.internalAPIKey(schemaNode)));
-
-    const defaultRenderers = renderers.filter((renderer) => renderer.default);
-    const nonDefaultRenderers = renderers.filter((renderer) => !renderer.default);
-
-    return exportedSchemaNodes
-      .map(
-        (schemaNode) =>
-          ({
-            componentId,
-            api: ExportSchema.isExportSchema(schemaNode) ? schemaNode.exportNode : schemaNode,
-            alias: ExportSchema.isExportSchema(schemaNode) ? schemaNode.alias : undefined,
-            exported: true,
-            renderer:
-              nonDefaultRenderers.find((renderer) =>
-                renderer.predicate(ExportSchema.isExportSchema(schemaNode) ? schemaNode.exportNode : schemaNode)
-              ) ||
-              defaultRenderers.find((renderer) =>
-                renderer.predicate(ExportSchema.isExportSchema(schemaNode) ? schemaNode.exportNode : schemaNode)
-              ),
-          }) as APINode
-      )
-      .concat(
-        internalSchemaNodes.map(
-          (schemaNode) =>
-            ({
-              componentId,
-              api: schemaNode,
-              exported: false,
-              renderer:
-                nonDefaultRenderers.find((renderer) => renderer.predicate(schemaNode)) ||
-                defaultRenderers.find((renderer) => renderer.predicate(schemaNode)),
-            }) as APINode
-        )
-      )
-      .filter((schemaNode) => schemaNode.renderer) as APINode[];
-  }
-
   getByType(type: string): APINode<SchemaNode>[] {
     return this.apiByType.get(type) ?? [];
   }

--- a/components/renderers/api-node-details/api-node-details.tsx
+++ b/components/renderers/api-node-details/api-node-details.tsx
@@ -62,23 +62,21 @@ export function APINodeDetails({
   const signatureContainerRef = useRef<HTMLDivElement | null>(null);
   const exampleContainerRef = useRef<HTMLDivElement | null>(null);
 
-  // const [signatureHeight, setSignatureHeight] = useState<string | undefined>();
-  // const [exampleHeight, setExampleHeight] = useState<string | undefined>();
-
   const [containerSize] = useState<{ width?: number; height?: number }>({
     width: undefined,
     height: undefined,
   });
 
   const currentQueryParams = query.toString();
-  // const signatureHeightStyle = (!!signatureHeight && `calc(${signatureHeight} + 16px)`) || '250px';
-  // const exampleHeightStyle = (!!exampleHeight && `calc(${exampleHeight} + 16px)`) || '250px';
 
   const indexHidden = (containerSize.width ?? 0) < INDEX_THRESHOLD_WIDTH;
 
   const example = (doc?.tags || []).find((tag) => tag.tagName === 'example');
-  const comment =
-    doc?.comment ?? doc?.tags?.filter((tag) => tag.comment).reduce((acc, tag) => acc.concat(`${tag.comment}\n`), '');
+  const comment = doc?.comment
+    ?? doc?.tags
+      ?.filter((tag) => tag.comment)
+      .reduce((acc, tag) => acc.concat(`${tag.comment}\n`), '');
+
   const linkComment = doc?.tags?.find((tag) => tag.tagName === 'link')?.comment;
 
   let linkPlaceholder: string | undefined;

--- a/components/renderers/api-node-details/api-node-details.tsx
+++ b/components/renderers/api-node-details/api-node-details.tsx
@@ -107,9 +107,12 @@ export function APINodeDetails({
     const word = model.getWordAtPosition(position);
     const wordApiNode: APINode | undefined = word
       ? apiRefModel?.apiByName?.get(word.word) ||
-        apiRefModel?.apiByName?.get(apiRefModel.generateInternalAPIKey(filePath, word.word))
+      apiRefModel?.apiByName?.get(apiRefModel.generateInternalAPIKey(filePath, word.word))
       : undefined;
-    const wordApiUrl = wordApiNode ? getAPINodeUrl({ selectedAPI: wordApiNode.api.name }) : null;
+    const wordApiUrl = wordApiNode ? getAPINodeUrl({
+      selectedAPI: wordApiNode.exported
+        ? wordApiNode.api.name : apiRefModel.generateInternalAPIKey(filePath, word.word)
+    }) : null;
     apiUrlToRoute.current = wordApiUrl;
     if (!wordApiUrl || wordApiNode?.api.name === name) return undefined;
     const contents = [

--- a/components/renderers/api-node-details/extract-code-block.spec.ts
+++ b/components/renderers/api-node-details/extract-code-block.spec.ts
@@ -4,18 +4,33 @@ describe('extractCodeBlock', () => {
   it('should extract code block with language specifier', () => {
     const text = '```typescript\nconst foo = "bar";\n```';
     const result = extractCodeBlock(text);
-    expect(result).toEqual({ lang: 'typescript', code: 'const foo = "bar";\n' });
+    expect(result).toEqual({ lang: 'typescript', code: 'const foo = "bar";' });
+  });
+
+  it('should extract code block with language specifier without immediate newline', () => {
+    const text = '```ts registerComponentAgg([\n name: \'test\'\n]);```';
+    const result = extractCodeBlock(text);
+    expect(result).toEqual({ lang: 'ts', code: 'registerComponentAgg([\n name: \'test\'\n]);' });
   });
 
   it('should extract code block without language specifier', () => {
     const text = '```\nconst foo = "bar";\n```';
     const result = extractCodeBlock(text);
-    expect(result).toEqual({ lang: '', code: 'const foo = "bar";\n' });
+    expect(result).toEqual({ lang: '', code: 'const foo = "bar";' });
   });
 
   it('should return null if no code block is found', () => {
     const text = 'const foo = "bar";';
     const result = extractCodeBlock(text);
     expect(result).toBeNull();
+  });
+
+  it('should handle multiline code blocks properly', () => {
+    const text = '```ts\nregisterComponentAgg([\n {\n  name: \'namespaces\',\n displayName: \'Namespace\',\n}\n]);```';
+    const result = extractCodeBlock(text);
+    expect(result).toEqual({ 
+      lang: 'ts', 
+      code: 'registerComponentAgg([\n {\n  name: \'namespaces\',\n displayName: \'Namespace\',\n}\n]);'
+    });
   });
 });

--- a/components/renderers/api-node-details/extract-code-block.spec.ts
+++ b/components/renderers/api-node-details/extract-code-block.spec.ts
@@ -4,33 +4,18 @@ describe('extractCodeBlock', () => {
   it('should extract code block with language specifier', () => {
     const text = '```typescript\nconst foo = "bar";\n```';
     const result = extractCodeBlock(text);
-    expect(result).toEqual({ lang: 'typescript', code: 'const foo = "bar";' });
-  });
-
-  it('should extract code block with language specifier without immediate newline', () => {
-    const text = '```ts registerComponentAgg([\n name: \'test\'\n]);```';
-    const result = extractCodeBlock(text);
-    expect(result).toEqual({ lang: 'ts', code: 'registerComponentAgg([\n name: \'test\'\n]);' });
+    expect(result).toEqual({ lang: 'typescript', code: 'const foo = "bar";\n' });
   });
 
   it('should extract code block without language specifier', () => {
     const text = '```\nconst foo = "bar";\n```';
     const result = extractCodeBlock(text);
-    expect(result).toEqual({ lang: '', code: 'const foo = "bar";' });
+    expect(result).toEqual({ lang: '', code: 'const foo = "bar";\n' });
   });
 
   it('should return null if no code block is found', () => {
     const text = 'const foo = "bar";';
     const result = extractCodeBlock(text);
     expect(result).toBeNull();
-  });
-
-  it('should handle multiline code blocks properly', () => {
-    const text = '```ts\nregisterComponentAgg([\n {\n  name: \'namespaces\',\n displayName: \'Namespace\',\n}\n]);```';
-    const result = extractCodeBlock(text);
-    expect(result).toEqual({ 
-      lang: 'ts', 
-      code: 'registerComponentAgg([\n {\n  name: \'namespaces\',\n displayName: \'Namespace\',\n}\n]);'
-    });
   });
 });

--- a/components/renderers/api-node-details/extract-code-block.ts
+++ b/components/renderers/api-node-details/extract-code-block.ts
@@ -6,8 +6,13 @@
  * @returns An object containing the extracted code and language specifier, or null if no match is found.
  */
 export function extractCodeBlock(text: string): { lang: string; code: string } | null {
-  const regex = /```([\w+-]*)\n([\s\S]*?)```/;
-  const match = text.match(regex);
+  let processedText = text;
+  if (text.endsWith(';') && !text.endsWith('```')) {
+    processedText = text.slice(0, -1) + '```';
+  }
+  const regex = /```([\w+-]*)\s*([\s\S]*?)```/;
+
+  const match = processedText.match(regex);
 
   if (match) {
     const lang = match[1];
@@ -16,16 +21,3 @@ export function extractCodeBlock(text: string): { lang: string; code: string } |
   }
   return null;
 }
-
-// export function extractCodeBlock(text: string): { lang: string; code: string } | null {
-//   // The (?<lang>[\w+-]*) captures the optional language specifier (like 'typescript', 'javascript', etc.)
-//   // The (?<code>[\s\S]*?) captures the actual code block
-//   const regex = /```(?<lang>[\w+-]*)\n(?<code>[\s\S]*?)```/;
-//   const match = text.match(regex);
-
-//   if (match && match.groups) {
-//     const { lang, code } = match.groups;
-//     return { lang, code };
-//   }
-//   return null;
-// }

--- a/components/renderers/api-node-details/index.ts
+++ b/components/renderers/api-node-details/index.ts
@@ -1,1 +1,2 @@
 export { APINodeDetails, APINodeDetailsProps } from './api-node-details';
+export { extractCodeBlock } from './extract-code-block';

--- a/components/renderers/tuple-type/index.ts
+++ b/components/renderers/tuple-type/index.ts
@@ -1,0 +1,1 @@
+export { tupleTypeRenderer } from './tuple-type.renderer';

--- a/components/renderers/tuple-type/tuple-type.renderer.module.scss
+++ b/components/renderers/tuple-type/tuple-type.renderer.module.scss
@@ -1,0 +1,25 @@
+.tupleArray {
+    display: inline;
+  
+    .bracketGroup {
+      display: inline-flex;
+      align-items: stretch;
+    }
+  
+    .bracket {
+      color: #666;
+      display: inline-flex;
+      align-items: center;
+      padding: 0 4px;
+    }
+  
+    .element {
+      display: inline-flex;
+      align-items: center;
+    }
+  
+    .comma {
+      color: #666;
+      margin-right: 4px;
+    }
+  }

--- a/components/renderers/tuple-type/tuple-type.renderer.tsx
+++ b/components/renderers/tuple-type/tuple-type.renderer.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import { APINodeRenderProps, APINodeRenderer } from '@teambit/api-reference.models.api-node-renderer';
+import { TupleTypeSchema } from '@teambit/semantics.entities.semantic-schema';
+import styles from './tuple-type.renderer.module.scss';
+
+export const tupleTypeRenderer: APINodeRenderer = {
+    predicate: (node) => node.__schema === TupleTypeSchema.name,
+    Component: TupleTypeArray,
+    nodeType: 'TupleTypeArray',
+    default: true,
+};
+
+function TupleTypeArray(props: APINodeRenderProps) {
+    const {
+        apiNode: { api },
+        renderers,
+    } = props;
+
+    const tupleTypeArray = api as TupleTypeSchema;
+
+    return (
+        <div className={styles.tupleArray}>
+            <div className={styles.bracketGroup}>
+                <div className={styles.bracket}>[</div>
+                {tupleTypeArray.elements[0] && (
+                    <div className={styles.element}>
+                        <ElementRenderer element={tupleTypeArray.elements[0]} {...props} renderers={renderers} />
+                        {tupleTypeArray.elements.length > 1 && <div className={styles.comma}>,</div>}
+                    </div>
+                )}
+            </div>
+            {tupleTypeArray.elements.slice(1, -1).map((element, index) => (
+                <div key={index} className={styles.element}>
+                    <ElementRenderer element={element} {...props} renderers={renderers} />
+                    <div className={styles.comma}>,</div>
+                </div>
+            ))}
+            {tupleTypeArray.elements.length > 1 && (
+                <div className={styles.bracketGroup}>
+                    <div className={styles.element}>
+                        <ElementRenderer
+                            element={tupleTypeArray.elements[tupleTypeArray.elements.length - 1]}
+                            {...props}
+                            renderers={renderers}
+                        />
+                    </div>
+                    <div className={styles.bracket}>]</div>
+                </div>
+            )}
+            {tupleTypeArray.elements.length <= 1 && <div className={styles.bracket}>]</div>}
+        </div>
+    );
+}
+
+function ElementRenderer({ element, renderers, ...props }) {
+    const elementRenderer = renderers.find((renderer) => renderer.predicate(element));
+    if (elementRenderer) {
+        return (
+            <elementRenderer.Component
+                {...props}
+                apiNode={{ ...props.apiNode, api: element, renderer: elementRenderer }}
+                depth={(props.depth ?? 0) + 1}
+                metadata={{ [element.__schema]: { columnView: true } }}
+            />
+        );
+    }
+    return element.toString();
+}

--- a/scopes/api-reference/api-reference/api-reference.ui.runtime.tsx
+++ b/scopes/api-reference/api-reference/api-reference.ui.runtime.tsx
@@ -20,6 +20,7 @@ import { typeLiteralRenderer } from '@teambit/api-reference.renderers.type-liter
 import { parameterRenderer } from '@teambit/api-reference.renderers.parameter';
 import { inferenceTypeRenderer } from '@teambit/api-reference.renderers.inference-type';
 import { typeArrayRenderer } from '@teambit/api-reference.renderers.type-array';
+import { tupleTypeRenderer } from '@teambit/api-reference.renderers.tuple-type';
 import { thisRenderer } from '@teambit/api-reference.renderers.this';
 import { APIRefRenderersProvider } from '@teambit/api-reference.hooks.use-api-renderers';
 import { decoratorRenderer } from '@teambit/api-reference.renderers.decorator';
@@ -37,7 +38,7 @@ export class APIReferenceUI {
     private apiNodeRendererSlot: APINodeRendererSlot,
     private code: CodeUI,
     private workspace: WorkspaceUI
-  ) {}
+  ) { }
 
   static dependencies = [ComponentAspect, CodeAspect, WorkspaceAspect];
   static runtime = UIRuntime;
@@ -89,6 +90,7 @@ export class APIReferenceUI {
     typeArrayRenderer,
     thisRenderer,
     decoratorRenderer,
+    tupleTypeRenderer
   ];
 
   static async provider(

--- a/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
+++ b/scopes/api-reference/renderers/parameter/parameter.renderer.tsx
@@ -75,7 +75,7 @@ function ParameterComponent(props: APINodeRenderProps) {
               className={styles.paramRow}
               row={{
                 name: bindingNode.name || '',
-                description: bindingNode.doc?.comment || bindingNode.doc?.tags?.join() || '',
+                description: bindingNode.doc?.comment || bindingNode.doc?.raw ||  bindingNode.doc?.tags?.join() || '',
                 required:
                   (typeRefCorrespondingNode as any)?.isOptional !== undefined &&
                   !(typeRefCorrespondingNode as any)?.isOptional,
@@ -129,7 +129,7 @@ function ParameterComponent(props: APINodeRenderProps) {
           }}
           row={{
             name: paramNode.name || '',
-            description: paramNode.doc?.comment || paramNode.doc?.tags?.join() || '',
+            description: paramNode.doc?.comment || paramNode.doc?.raw ||  paramNode.doc?.tags?.join() || '',
             required: paramNode.isOptional !== undefined && !paramNode.isOptional,
             type: '',
             default: {

--- a/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.module.scss
+++ b/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.module.scss
@@ -50,3 +50,11 @@
 .paramHeading {
   padding: 8px 0px 16px 0px;
 }
+.apiNodeDetailsExample {
+  padding-bottom: 24px;
+}
+.apiNodeDetailsExampleTitle {
+  padding: 16px 0px;
+  font-weight: bold;
+  font-size: var(--bit-p-xs, '14px');
+}

--- a/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
+++ b/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
@@ -7,6 +7,7 @@ import { APINodeRenderProps, nodeStyles } from '@teambit/api-reference.models.ap
 import { parameterRenderer as defaultParamRenderer } from '@teambit/api-reference.renderers.parameter';
 import { HeadingRow } from '@teambit/documenter.ui.table-heading-row';
 import defaultTheme from '@teambit/api-reference.utils.custom-prism-syntax-highlighter-theme';
+import { extractCodeBlock } from '@teambit/api-reference.renderers.api-node-details';
 import classNames from 'classnames';
 
 import styles from './function-node-summary.module.scss';
@@ -50,12 +51,14 @@ export function FunctionNodeSummary({
     return langFromFileEnding;
   }, [filePath]);
   const paramTypeHeadings = ['Parameter', 'type', 'default', 'description'];
+  const docs = doc?.comment || doc?.raw;
+  const example = (doc?.tags || []).find((tag) => tag.tagName === 'example');
 
   return (
     <div className={styles.summaryContainer}>
       <div className={styles.signatureTitle}>
         {<div className={classNames(styles.functionName, hideName && styles.hide)}>{hideName ? '' : name}</div>}
-        {doc?.comment && <div className={styles.description}>{doc?.comment || ''}</div>}
+        {docs && <div className={styles.description}>{docs || ''}</div>}
         {signature && (
           <SyntaxHighlighter
             language={lang}
@@ -68,6 +71,23 @@ export function FunctionNodeSummary({
           >
             {signature}
           </SyntaxHighlighter>
+        )}
+        {example && example.comment && (
+          <div className={styles.apiNodeDetailsExample}>
+            <div className={styles.apiNodeDetailsExampleTitle}>Example</div>
+            <SyntaxHighlighter
+              language={lang}
+              style={defaultTheme}
+              customStyle={{
+                borderRadius: '8px',
+                marginTop: '4px',
+                padding: '0',
+              }}
+              codeTagProps={{ style: { fontSize: '11px' } }}
+            >
+              {extractCodeBlock(example.comment)?.code || example.comment}
+            </SyntaxHighlighter>
+          </div>
         )}
       </div>
       {params.length > 0 && (

--- a/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
+++ b/scopes/api-reference/renderers/schema-node-member-summary/function-node-summary.tsx
@@ -81,7 +81,7 @@ export function FunctionNodeSummary({
               customStyle={{
                 borderRadius: '8px',
                 marginTop: '4px',
-                padding: '0',
+                padding: '12px',
               }}
               codeTagProps={{ style: { fontSize: '11px' } }}
             >

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.module.scss
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.module.scss
@@ -14,6 +14,8 @@
 .nodeLink {
   color: #4646c6;
   font-size: var(--bit-p-xs);
+  display: flex;
+  gap: 4px;
 }
 // .package {
 // }
@@ -30,4 +32,13 @@
 
 .typeArgNode {
   padding: 1px;
+}
+
+.locationIcon {
+  display: flex;
+  img {
+    margin-right: 2px;
+    height: 12px;
+  }
+
 }

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
@@ -165,8 +165,15 @@ export function TypeRefName({
   if (url && !withinLink) {
     return (
       <LinkContext.Provider value={true}>
-        <Link href={url} external={external} className={classnames(className, styles.nodeLink)}>
+        <Link
+          href={url}
+          external={external}
+          className={classnames(className, styles.nodeLink)}
+        >
           {name}
+          {external && <div className={styles.locationIcon}>
+            <img src="https://static.bit.dev/design-system-assets/Icons/external-link.svg"></img>
+          </div>}
           {children}
         </Link>
       </LinkContext.Provider>

--- a/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
+++ b/scopes/api-reference/renderers/type-ref/type-ref.renderer.tsx
@@ -46,21 +46,23 @@ function TypeRefComponent(props: APINodeRenderProps) {
       <>{children}</>
     );
 
-  const exportedTypeFromSameComp = typeRefNode.isFromThisComponent() ? apiRefModel.getByName(typeRefNode) : undefined;
+  const exportedTypeFromSameComp = typeRefNode.isFromThisComponent()
+    ? apiRefModel.getByName(typeRefNode, typeRefNode.internalFilePath)
+    : undefined;
 
   const exportedTypeUrlFromSameComp =
     exportedTypeFromSameComp &&
     useUpdatedUrlFromQuery({
       selectedAPI: typeRefNode.isInternalReference()
-        ? apiRefModel.internalAPIKey(typeRefNode)
+        ? apiRefModel.internalAPIKey(typeRefNode, typeRefNode.internalFilePath)
         : exportedTypeFromSameComp.api.name,
     });
 
   const exportedTypeUrlFromAnotherComp = typeRefNode.componentId
     ? getExportedTypeUrlFromAnotherComp({
-        componentId: typeRefNode.componentId,
-        selectedAPI: typeRefNode.name,
-      })
+      componentId: typeRefNode.componentId,
+      selectedAPI: typeRefNode.name,
+    })
     : undefined;
 
   const packageUrl = typeRefNode.packageName ? `https://www.npmjs.com/package/${typeRefNode.packageName}` : undefined;
@@ -189,9 +191,8 @@ function getExportedTypeUrlFromAnotherComp({
   const componentUrl = ComponentUrl.toUrl(componentId, { useLocationOrigin: false, includeVersion: true });
   const [componentIdUrl, versionQuery] = componentUrl.split('?');
 
-  const exportedTypeUrl = `${componentIdUrl}/~api-reference?selectedAPI=${encodeURIComponent(selectedAPI)}${
-    versionQuery ? `&${versionQuery}` : ''
-  }`;
+  const exportedTypeUrl = `${componentIdUrl}/~api-reference?selectedAPI=${encodeURIComponent(selectedAPI)}${versionQuery ? `&${versionQuery}` : ''
+    }`;
 
   return exportedTypeUrl;
 }

--- a/scopes/api-reference/sections/api-reference-page/api-reference-page.tsx
+++ b/scopes/api-reference/sections/api-reference-page/api-reference-page.tsx
@@ -59,6 +59,11 @@ export function APIRefPage({ rendererSlot, className }: APIRefPageProps) {
 
   const getIcon = (node: TreeNode) => {
     const nodeType = node.id.split('/')[0];
+    if(nodeType === '_Internals') {
+      const apiNode = apiModel?.apiByName.get(node.id.replace('_Internals/', ''));
+      const icon = apiNode?.renderer.icon?.url;
+      return icon || undefined;
+    }
     const icon = apiModel?.apiByType.get(nodeType)?.[0].renderer.icon?.url;
     return icon || undefined;
   };

--- a/scopes/semantics/schema/mock/button-schemas.json
+++ b/scopes/semantics/schema/mock/button-schemas.json
@@ -706,13 +706,21 @@
         "signature": "const Array: string[]",
         "name": "Array",
         "type": {
-          "__schema": "InferenceTypeSchema",
+          "__schema": "TypeArraySchema",
           "location": {
             "filePath": "index.ts",
             "line": 32,
             "character": 14
           },
-          "type": "string[]"
+          "type": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 32,
+              "character": 14
+            },
+            "type": "string"
+          }
         },
         "isOptional": false,
         "defaultValue": "['hi', 'there']"
@@ -1962,13 +1970,46 @@
         "signature": "const gfnc2: <T>(a: T) => void",
         "name": "gfnc2",
         "type": {
-          "__schema": "InferenceTypeSchema",
+          "__schema": "FunctionLikeSchema",
           "location": {
             "filePath": "index.ts",
             "line": 133,
             "character": 14
           },
-          "type": "<T>(a: T) => void"
+          "signature": "const gfnc2: <T>(a: T) => void",
+          "name": "anonymous",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 133,
+                "character": 14
+              },
+              "name": "a",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 133,
+                  "character": 14
+                },
+                "type": "T"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 133,
+              "character": 14
+            },
+            "type": "void"
+          },
+          "modifiers": []
         },
         "isOptional": false,
         "defaultValue": "genericFunction<string>('')"
@@ -3084,13 +3125,32 @@
             "signature": "const obj: {\n    a: number;\n    b: number;\n}",
             "name": "obj",
             "type": {
-              "__schema": "InferenceTypeSchema",
+              "__schema": "ArrayLiteralExpressionSchema",
               "location": {
                 "filePath": "index.ts",
                 "line": 59,
                 "character": 7
               },
-              "type": "{\n    a: number;\n    b: number;\n}"
+              "members": [
+                {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 59,
+                    "character": 7
+                  },
+                  "type": "a: number"
+                },
+                {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 59,
+                    "character": 7
+                  },
+                  "type": "b: number"
+                }
+              ]
             },
             "isOptional": false,
             "defaultValue": "{ a: 1, b: 2 }"
@@ -3614,6 +3674,3402 @@
         }
       ],
       "internals": []
+    },
+    {
+      "__schema": "ModuleSchema",
+      "location": {
+        "filePath": "index.ts",
+        "line": 15,
+        "character": 1
+      },
+      "exports": [
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 15,
+            "character": 1
+          },
+          "doc": {
+            "__schema": "DocSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 8,
+              "character": 1
+            },
+            "raw": "/**\n * General comment of the myFunc\n * @deprecate example of deprecation tag\n * @param a { number } this is A\n * @param b this is B\n * @returns { number } results of adding a to b\n */",
+            "comment": "General comment of the myFunc",
+            "tags": [
+              {
+                "__schema": "TagSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 10,
+                  "character": 4
+                },
+                "tagName": "deprecate",
+                "comment": "example of deprecation tag"
+              },
+              {
+                "__schema": "PropertyLikeTagSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 11,
+                  "character": 4
+                },
+                "name": "a",
+                "tagName": "parameter",
+                "comment": "this is A",
+                "type": {
+                  "__schema": "KeywordTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 11,
+                    "character": 15
+                  },
+                  "name": "number"
+                }
+              },
+              {
+                "__schema": "PropertyLikeTagSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 12,
+                  "character": 4
+                },
+                "name": "b",
+                "tagName": "parameter",
+                "comment": "this is B"
+              },
+              {
+                "__schema": "ReturnTagSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 13,
+                  "character": 4
+                },
+                "tagName": "return",
+                "comment": "results of adding a to b",
+                "type": {
+                  "__schema": "KeywordTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 13,
+                    "character": 15
+                  },
+                  "name": "number"
+                }
+              }
+            ]
+          },
+          "signature": "function myFunc(a?: number, b?: number): number",
+          "name": "myFunc",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 15,
+                "character": 24
+              },
+              "name": "a",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 15,
+                  "character": 24
+                },
+                "type": "number"
+              },
+              "isOptional": true,
+              "defaultValue": "4",
+              "isSpread": false
+            },
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 15,
+                "character": 31
+              },
+              "name": "b",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 15,
+                  "character": 31
+                },
+                "type": "number"
+              },
+              "isOptional": true,
+              "defaultValue": "5",
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "KeywordTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 15,
+              "character": 39
+            },
+            "name": "number"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "button.tsx",
+            "line": 6,
+            "character": 1
+          },
+          "signature": "type ButtonElementType = \"a\" | \"button\"",
+          "name": "ButtonElementType",
+          "type": {
+            "__schema": "TypeUnionSchema",
+            "location": {
+              "filePath": "button.tsx",
+              "line": 6,
+              "character": 33
+            },
+            "types": [
+              {
+                "__schema": "LiteralTypeSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 6,
+                  "character": 33
+                },
+                "name": "'a'"
+              },
+              {
+                "__schema": "LiteralTypeSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 6,
+                  "character": 39
+                },
+                "name": "'button'"
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "button.tsx",
+            "line": 8,
+            "character": 1
+          },
+          "signature": "type ButtonProps = any",
+          "name": "ButtonProps",
+          "type": {
+            "__schema": "TypeIntersectionSchema",
+            "location": {
+              "filePath": "button.tsx",
+              "line": 8,
+              "character": 27
+            },
+            "types": [
+              {
+                "__schema": "TypeLiteralSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 8,
+                  "character": 27
+                },
+                "members": [
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "button.tsx",
+                      "line": 12,
+                      "character": 3
+                    },
+                    "doc": {
+                      "__schema": "DocSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 9,
+                        "character": 3
+                      },
+                      "raw": "/**\n   * children of the Button.\n   */",
+                      "comment": "children of the Button.",
+                      "tags": []
+                    },
+                    "signature": "(property) children: ReactNode",
+                    "name": "children",
+                    "type": {
+                      "__schema": "TypeRefSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 12,
+                        "character": 3
+                      },
+                      "name": "ReactNode",
+                      "packageName": "react"
+                    },
+                    "isOptional": false
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "button.tsx",
+                      "line": 17,
+                      "character": 3
+                    },
+                    "doc": {
+                      "__schema": "DocSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 14,
+                        "character": 3
+                      },
+                      "raw": "/**\n   * link to target page. once href is used, Button is considered an A tag.\n   */",
+                      "comment": "link to target page. once href is used, Button is considered an A tag.",
+                      "tags": []
+                    },
+                    "signature": "(property) href?: string | undefined",
+                    "name": "href",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 17,
+                        "character": 10
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": true
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "button.tsx",
+                      "line": 22,
+                      "character": 3
+                    },
+                    "doc": {
+                      "__schema": "DocSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 19,
+                        "character": 3
+                      },
+                      "raw": "/**\n   * class names to inject.\n   */",
+                      "comment": "class names to inject.",
+                      "tags": []
+                    },
+                    "signature": "(property) className?: string | undefined",
+                    "name": "className",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "button.tsx",
+                        "line": 22,
+                        "character": 15
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": true
+                  }
+                ]
+              },
+              {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 23,
+                  "character": 5
+                },
+                "name": "React.ButtonHTMLAttributes",
+                "typeArgs": [
+                  {
+                    "__schema": "TypeRefSchema",
+                    "location": {
+                      "filePath": "button.tsx",
+                      "line": 23,
+                      "character": 32
+                    },
+                    "name": "HTMLButtonElement"
+                  }
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "button.tsx",
+            "line": 25,
+            "character": 1
+          },
+          "signature": "function Button(props: any): any",
+          "name": "Button",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "button.tsx",
+                "line": 25,
+                "character": 24
+              },
+              "name": "props",
+              "type": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 25,
+                  "character": 31
+                },
+                "name": "ButtonProps",
+                "internalFilePath": "button.tsx"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "button.tsx",
+              "line": 25,
+              "character": 1
+            },
+            "type": "any"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "button.tsx",
+            "line": 60,
+            "character": 1
+          },
+          "signature": "class Bar",
+          "name": "Bar",
+          "members": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.tsx",
+                "line": 61,
+                "character": 3
+              },
+              "signature": "(method) Bar.foo(): void",
+              "name": "foo",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.tsx",
+                  "line": 61,
+                  "character": 3
+                },
+                "type": "void"
+              },
+              "modifiers": []
+            }
+          ],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 21,
+            "character": 1
+          },
+          "signature": "function Hi(): void",
+          "name": "Hi",
+          "params": [],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 21,
+              "character": 1
+            },
+            "type": "void"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 23,
+            "character": 14
+          },
+          "signature": "const a: 4",
+          "name": "a",
+          "type": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 23,
+              "character": 14
+            },
+            "type": "4"
+          },
+          "isOptional": false,
+          "defaultValue": "4"
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 24,
+            "character": 3
+          },
+          "signature": "const b: 5",
+          "name": "b",
+          "type": {
+            "__schema": "LiteralTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 24,
+              "character": 6
+            },
+            "name": "5"
+          },
+          "isOptional": false,
+          "defaultValue": "5"
+        },
+        {
+          "__schema": "ModuleSchema",
+          "location": {
+            "filePath": "button.composition.tsx",
+            "line": 3,
+            "character": 1
+          },
+          "exports": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.composition.tsx",
+                "line": 6,
+                "character": 14
+              },
+              "signature": "function(): any",
+              "name": "BasicButton",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 6,
+                  "character": 28
+                },
+                "type": "any"
+              },
+              "modifiers": []
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.composition.tsx",
+                "line": 14,
+                "character": 1
+              },
+              "doc": {
+                "__schema": "DocSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 10,
+                  "character": 1
+                },
+                "raw": "/**\n * example of passing a JSX Element as a parameter\n */",
+                "comment": "example of passing a JSX Element as a parameter",
+                "tags": []
+              },
+              "signature": "function Footer({ children }: {\n    children?: any;\n}): any",
+              "name": "Footer",
+              "params": [
+                {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "button.composition.tsx",
+                    "line": 14,
+                    "character": 24
+                  },
+                  "name": "{ children = <BasicButton /> }",
+                  "type": {
+                    "__schema": "TypeLiteralSchema",
+                    "location": {
+                      "filePath": "button.composition.tsx",
+                      "line": 14,
+                      "character": 24
+                    },
+                    "members": [
+                      {
+                        "__schema": "InferenceTypeSchema",
+                        "location": {
+                          "filePath": "button.composition.tsx",
+                          "line": 14,
+                          "character": 24
+                        },
+                        "name": "children",
+                        "type": "any"
+                      }
+                    ]
+                  },
+                  "isOptional": false,
+                  "objectBindingNodes": [
+                    {
+                      "__schema": "InferenceTypeSchema",
+                      "location": {
+                        "filePath": "button.composition.tsx",
+                        "line": 14,
+                        "character": 26
+                      },
+                      "name": "children",
+                      "type": "any",
+                      "defaultValue": "<BasicButton />",
+                      "isSpread": false
+                    }
+                  ],
+                  "isSpread": false
+                }
+              ],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 14,
+                  "character": 1
+                },
+                "type": "any"
+              },
+              "modifiers": [
+                "export"
+              ]
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.composition.tsx",
+                "line": 18,
+                "character": 14
+              },
+              "signature": "function(): any",
+              "name": "ButtonWithCustomStyles",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 18,
+                  "character": 39
+                },
+                "type": "any"
+              },
+              "modifiers": []
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.composition.tsx",
+                "line": 22,
+                "character": 14
+              },
+              "signature": "function(): any",
+              "name": "ButtonWithIcon",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 22,
+                  "character": 31
+                },
+                "type": "any"
+              },
+              "modifiers": []
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "button.composition.tsx",
+                "line": 31,
+                "character": 14
+              },
+              "signature": "function(): any",
+              "name": "ButtonAsALink",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "button.composition.tsx",
+                  "line": 31,
+                  "character": 30
+                },
+                "type": "any"
+              },
+              "modifiers": []
+            }
+          ],
+          "internals": [],
+          "namespace": "Compositions"
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 28,
+            "character": 14
+          },
+          "signature": "const HiThere: \"HiThere\"",
+          "name": "HiThere",
+          "type": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 28,
+              "character": 14
+            },
+            "type": "\"HiThere\""
+          },
+          "isOptional": false,
+          "defaultValue": "'HiThere'"
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 30,
+            "character": 14
+          },
+          "signature": "function(): void",
+          "name": "Function",
+          "params": [],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 30,
+              "character": 25
+            },
+            "type": "void"
+          },
+          "modifiers": []
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 32,
+            "character": 14
+          },
+          "signature": "const Array: string[]",
+          "name": "Array",
+          "type": {
+            "__schema": "TypeArraySchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 32,
+              "character": 14
+            },
+            "type": {
+              "__schema": "InferenceTypeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 32,
+                "character": 14
+              },
+              "type": "string"
+            }
+          },
+          "isOptional": false,
+          "defaultValue": "['hi', 'there']"
+        },
+        {
+          "__schema": "ExportSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 50,
+            "character": 10
+          },
+          "signature": "class ClassSomething",
+          "name": "ClassSomething",
+          "exportNode": {
+            "__schema": "ClassSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 36,
+              "character": 1
+            },
+            "signature": "class ClassSomething",
+            "name": "ClassSomething",
+            "members": [
+              {
+                "__schema": "VariableLikeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 37,
+                  "character": 3
+                },
+                "signature": "(property) ClassSomething.app: string",
+                "name": "app",
+                "type": {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 37,
+                    "character": 3
+                  },
+                  "type": "string"
+                },
+                "isOptional": true,
+                "defaultValue": "''"
+              },
+              {
+                "__schema": "ConstructorSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 38,
+                  "character": 3
+                },
+                "signature": "constructor ClassSomething(da: \"dsa\"): ClassSomething",
+                "name": "constructor",
+                "params": [
+                  {
+                    "__schema": "ParameterSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 38,
+                      "character": 15
+                    },
+                    "name": "da",
+                    "type": {
+                      "__schema": "LiteralTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 38,
+                        "character": 28
+                      },
+                      "name": "'dsa'"
+                    },
+                    "isOptional": false,
+                    "isSpread": false
+                  }
+                ],
+                "returnType": {
+                  "__schema": "ThisTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 36,
+                    "character": 1
+                  },
+                  "name": "ClassSomething"
+                },
+                "modifiers": []
+              },
+              {
+                "__schema": "FunctionLikeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 40,
+                  "character": 3
+                },
+                "signature": "(method) ClassSomething.a(): Foo",
+                "name": "a",
+                "params": [],
+                "returnType": {
+                  "__schema": "TypeRefSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 40,
+                    "character": 3
+                  },
+                  "name": "Foo",
+                  "internalFilePath": "index.ts"
+                },
+                "modifiers": []
+              },
+              {
+                "__schema": "GetAccessorSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 43,
+                  "character": 3
+                },
+                "signature": "(getter) ClassSomething.getter: string",
+                "name": "getter",
+                "type": {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 43,
+                    "character": 3
+                  },
+                  "type": "string"
+                }
+              },
+              {
+                "__schema": "SetAccessorSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 47,
+                  "character": 3
+                },
+                "signature": "(setter) ClassSomething.setter: boolean",
+                "name": "setter",
+                "param": {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 47,
+                    "character": 14
+                  },
+                  "name": "a",
+                  "type": {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 47,
+                      "character": 17
+                    },
+                    "name": "boolean"
+                  },
+                  "isOptional": false,
+                  "isSpread": false
+                }
+              }
+            ],
+            "extendsNodes": [],
+            "implementNodes": []
+          }
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 52,
+            "character": 1
+          },
+          "signature": "type IndexSig = {\n    [key: string]: boolean;\n}",
+          "name": "IndexSig",
+          "type": {
+            "__schema": "TypeLiteralSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 52,
+              "character": 24
+            },
+            "members": [
+              {
+                "__schema": "IndexSignatureSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 52,
+                  "character": 26
+                },
+                "keyType": {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 52,
+                    "character": 27
+                  },
+                  "name": "key",
+                  "type": {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 52,
+                      "character": 32
+                    },
+                    "name": "string"
+                  },
+                  "isOptional": false,
+                  "isSpread": false
+                },
+                "valueType": {
+                  "__schema": "KeywordTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 52,
+                    "character": 41
+                  },
+                  "name": "boolean"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "InterfaceSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 54,
+            "character": 1
+          },
+          "signature": "interface Hello",
+          "name": "Hello",
+          "members": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 55,
+                "character": 3
+              },
+              "signature": "(property) Hello.propertySig: () => void",
+              "name": "propertySig",
+              "type": {
+                "__schema": "FunctionLikeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 55,
+                  "character": 16
+                },
+                "signature": "(): void",
+                "name": "",
+                "params": [],
+                "returnType": {
+                  "__schema": "KeywordTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 55,
+                    "character": 22
+                  },
+                  "name": "void"
+                },
+                "modifiers": []
+              },
+              "isOptional": false
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 56,
+                "character": 3
+              },
+              "signature": "(method) Hello.methodSig(): string",
+              "name": "methodSig",
+              "params": [],
+              "returnType": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 56,
+                  "character": 16
+                },
+                "name": "string"
+              },
+              "modifiers": []
+            }
+          ],
+          "extendsNodes": []
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 61,
+            "character": 14
+          },
+          "signature": "const a1: {\n    a: number;\n    b: number;\n}",
+          "name": "a1",
+          "type": {
+            "__schema": "TypeQuerySchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 61,
+              "character": 18
+            },
+            "signature": "const obj: {\n    a: number;\n    b: number;\n}",
+            "type": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 61,
+                "character": 25
+              },
+              "name": "obj",
+              "internalFilePath": "index.ts"
+            }
+          },
+          "isOptional": false,
+          "defaultValue": "{ a: 5, b: 9 }"
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 63,
+            "character": 1
+          },
+          "signature": "type TypeOperator = \"a\" | \"b\"",
+          "name": "TypeOperator",
+          "type": {
+            "__schema": "TypeOperatorSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 63,
+              "character": 28
+            },
+            "name": "keyof",
+            "type": {
+              "__schema": "TypeQuerySchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 63,
+                "character": 34
+              },
+              "signature": "const obj: {\n    a: number;\n    b: number;\n}",
+              "type": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 63,
+                  "character": 41
+                },
+                "name": "obj",
+                "internalFilePath": "index.ts"
+              }
+            }
+          }
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 69,
+            "character": 14
+          },
+          "signature": "function(bar: Bar): Bar",
+          "name": "getBar",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 69,
+                "character": 24
+              },
+              "name": "bar",
+              "type": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 69,
+                  "character": 29
+                },
+                "name": "Bar",
+                "internalFilePath": "index.ts"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "TypeRefSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 69,
+              "character": 23
+            },
+            "name": "Bar",
+            "internalFilePath": "index.ts"
+          },
+          "modifiers": []
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 71,
+            "character": 14
+          },
+          "signature": "function([a, b, c]: [string, Function, Record<string, any>]): void",
+          "name": "tuple",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 71,
+                "character": 23
+              },
+              "name": "[ a, b, c ]",
+              "type": {
+                "__schema": "TupleTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 71,
+                  "character": 34
+                },
+                "elements": [
+                  {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 71,
+                      "character": 35
+                    },
+                    "name": "string"
+                  },
+                  {
+                    "__schema": "TypeRefSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 71,
+                      "character": 43
+                    },
+                    "name": "Function"
+                  },
+                  {
+                    "__schema": "TypeRefSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 71,
+                      "character": 53
+                    },
+                    "name": "Record",
+                    "typeArgs": [
+                      {
+                        "__schema": "KeywordTypeSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 71,
+                          "character": 60
+                        },
+                        "name": "string"
+                      },
+                      {
+                        "__schema": "KeywordTypeSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 71,
+                          "character": 68
+                        },
+                        "name": "any"
+                      }
+                    ]
+                  }
+                ]
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 71,
+              "character": 22
+            },
+            "type": "void"
+          },
+          "modifiers": []
+        },
+        {
+          "__schema": "EnumSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 73,
+            "character": 1
+          },
+          "signature": "enum Food",
+          "name": "Food",
+          "members": [
+            {
+              "__schema": "EnumMemberSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 74,
+                "character": 3
+              },
+              "signature": "(enum member) Food.Falafel = 0",
+              "name": "Falafel"
+            },
+            {
+              "__schema": "EnumMemberSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 75,
+                "character": 3
+              },
+              "signature": "(enum member) Food.Hummus = 1",
+              "name": "Hummus"
+            },
+            {
+              "__schema": "EnumMemberSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 76,
+                "character": 3
+              },
+              "signature": "(enum member) Food.Tahini = 2",
+              "name": "Tahini"
+            }
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 79,
+            "character": 1
+          },
+          "signature": "function getPromise(): Promise<string>",
+          "name": "getPromise",
+          "params": [],
+          "returnType": {
+            "__schema": "TypeRefSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 79,
+              "character": 37
+            },
+            "name": "Promise",
+            "typeArgs": [
+              {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 79,
+                  "character": 45
+                },
+                "name": "string"
+              }
+            ]
+          },
+          "modifiers": [
+            "export",
+            "async"
+          ]
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 86,
+            "character": 1
+          },
+          "signature": "type TypeRefWithArgs = T3<T1, T2>",
+          "name": "TypeRefWithArgs",
+          "type": {
+            "__schema": "TypeRefSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 86,
+              "character": 31
+            },
+            "name": "T3",
+            "internalFilePath": "index.ts",
+            "typeArgs": [
+              {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 86,
+                  "character": 34
+                },
+                "name": "T1",
+                "internalFilePath": "index.ts"
+              },
+              {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 86,
+                  "character": 38
+                },
+                "name": "T2",
+                "internalFilePath": "index.ts"
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 88,
+            "character": 1
+          },
+          "signature": "type ParenthesizedType = (T1 | T2)[]",
+          "name": "ParenthesizedType",
+          "type": {
+            "__schema": "TypeArraySchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 88,
+              "character": 33
+            },
+            "type": {
+              "__schema": "ParenthesizedTypeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 88,
+                "character": 33
+              },
+              "type": {
+                "__schema": "TypeUnionSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 88,
+                  "character": 34
+                },
+                "types": [
+                  {
+                    "__schema": "TypeRefSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 88,
+                      "character": 34
+                    },
+                    "name": "T1",
+                    "internalFilePath": "index.ts"
+                  },
+                  {
+                    "__schema": "TypeRefSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 88,
+                      "character": 39
+                    },
+                    "name": "T2",
+                    "internalFilePath": "index.ts"
+                  }
+                ]
+              }
+            }
+          }
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 90,
+            "character": 1
+          },
+          "signature": "function typePredicateFn(str: any): str is string",
+          "name": "typePredicateFn",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 90,
+                "character": 33
+              },
+              "name": "str",
+              "type": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 90,
+                  "character": 38
+                },
+                "name": "any"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "TypePredicateSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 90,
+              "character": 44
+            },
+            "name": "str",
+            "type": {
+              "__schema": "KeywordTypeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 90,
+                "character": 51
+              },
+              "name": "string"
+            },
+            "hasAssertsModifier": false
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 94,
+            "character": 1
+          },
+          "signature": "function typePredicateNoTypeFn(condition: any, msg?: string): asserts condition",
+          "name": "typePredicateNoTypeFn",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 94,
+                "character": 39
+              },
+              "name": "condition",
+              "type": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 94,
+                  "character": 50
+                },
+                "name": "any"
+              },
+              "isOptional": false,
+              "isSpread": false
+            },
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 94,
+                "character": 55
+              },
+              "name": "msg",
+              "type": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 94,
+                  "character": 61
+                },
+                "name": "string"
+              },
+              "isOptional": true,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "TypePredicateSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 94,
+              "character": 70
+            },
+            "name": "condition",
+            "hasAssertsModifier": true
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 96,
+            "character": 1
+          },
+          "signature": "function objectBindingElements({ prop }: {\n    prop?: number | undefined;\n}): Promise<number>",
+          "name": "objectBindingElements",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 96,
+                "character": 45
+              },
+              "name": "{ prop = 1 }",
+              "type": {
+                "__schema": "TypeLiteralSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 96,
+                  "character": 45
+                },
+                "members": [
+                  {
+                    "__schema": "InferenceTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 96,
+                      "character": 45
+                    },
+                    "name": "prop",
+                    "type": "number"
+                  }
+                ]
+              },
+              "isOptional": false,
+              "objectBindingNodes": [
+                {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 96,
+                    "character": 47
+                  },
+                  "name": "prop",
+                  "type": "number",
+                  "defaultValue": "1",
+                  "isSpread": false
+                }
+              ],
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 96,
+              "character": 1
+            },
+            "type": "Promise<number>"
+          },
+          "modifiers": [
+            "export",
+            "async"
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 99,
+            "character": 1
+          },
+          "signature": "function arrayBindingElements([prop]: [string]): Promise<string>",
+          "name": "arrayBindingElements",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 99,
+                "character": 44
+              },
+              "name": "[ prop ]",
+              "type": {
+                "__schema": "TupleTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 99,
+                  "character": 52
+                },
+                "elements": [
+                  {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 99,
+                      "character": 53
+                    },
+                    "name": "string"
+                  }
+                ]
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 99,
+              "character": 1
+            },
+            "type": "Promise<string>"
+          },
+          "modifiers": [
+            "export",
+            "async"
+          ]
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 106,
+            "character": 1
+          },
+          "signature": "type IndexedAccessType = {\n    a: string;\n    b: boolean;\n}",
+          "name": "IndexedAccessType",
+          "type": {
+            "__schema": "IndexedAccessSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 106,
+              "character": 33
+            },
+            "objectType": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 106,
+                "character": 33
+              },
+              "name": "config",
+              "internalFilePath": "index.ts"
+            },
+            "indexType": {
+              "__schema": "LiteralTypeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 106,
+                "character": 40
+              },
+              "name": "'someField'"
+            }
+          }
+        },
+        {
+          "__schema": "InterfaceSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 109,
+            "character": 1
+          },
+          "signature": "interface ComputedNameWithType",
+          "name": "ComputedNameWithType",
+          "members": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 110,
+                "character": 3
+              },
+              "signature": "[computedName]: boolean;",
+              "name": "[computedName]",
+              "type": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 110,
+                  "character": 19
+                },
+                "name": "boolean"
+              },
+              "isOptional": false
+            }
+          ],
+          "extendsNodes": []
+        },
+        {
+          "__schema": "InterfaceSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 112,
+            "character": 1
+          },
+          "signature": "interface ComputedNameNoType",
+          "name": "ComputedNameNoType",
+          "members": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 113,
+                "character": 3
+              },
+              "signature": "[computedName];",
+              "name": "[computedName]",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 113,
+                  "character": 3
+                },
+                "type": "any"
+              },
+              "isOptional": false
+            }
+          ],
+          "extendsNodes": []
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 118,
+            "character": 1
+          },
+          "signature": "type templateLiteralType = \"hello world1-a hi world2\" | \"hello world1-b hi world2\"",
+          "name": "templateLiteralType",
+          "type": {
+            "__schema": "TemplateLiteralTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 118,
+              "character": 35
+            },
+            "head": "hello ",
+            "templateSpans": [
+              {
+                "__schema": "TemplateLiteralTypeSpanSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 118,
+                  "character": 44
+                },
+                "literal": " hi ",
+                "type": {
+                  "__schema": "TypeRefSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 118,
+                    "character": 44
+                  },
+                  "name": "World1",
+                  "internalFilePath": "index.ts"
+                }
+              },
+              {
+                "__schema": "TemplateLiteralTypeSpanSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 118,
+                  "character": 57
+                },
+                "literal": "",
+                "type": {
+                  "__schema": "TypeRefSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 118,
+                    "character": 57
+                  },
+                  "name": "World2",
+                  "internalFilePath": "index.ts"
+                }
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "InterfaceSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 120,
+            "character": 1
+          },
+          "signature": "interface CallSignatureWithTypeParams",
+          "name": "CallSignatureWithTypeParams",
+          "members": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 121,
+                "character": 3
+              },
+              "signature": "(a: string): T",
+              "name": "",
+              "params": [
+                {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 121,
+                    "character": 7
+                  },
+                  "name": "a",
+                  "type": {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 121,
+                      "character": 10
+                    },
+                    "name": "string"
+                  },
+                  "isOptional": false,
+                  "isSpread": false
+                }
+              ],
+              "returnType": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 121,
+                  "character": 19
+                },
+                "name": "T"
+              },
+              "modifiers": [],
+              "typeParams": [
+                "T"
+              ]
+            }
+          ],
+          "extendsNodes": []
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 127,
+            "character": 1
+          },
+          "doc": {
+            "__schema": "DocSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 124,
+              "character": 1
+            },
+            "raw": "/**\n * Conditional Generic Type\n */",
+            "comment": "Conditional Generic Type",
+            "tags": []
+          },
+          "signature": "type If<T, U, Y, N> = T extends U ? Y : N",
+          "name": "If",
+          "type": {
+            "__schema": "ConditionalTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 127,
+              "character": 30
+            },
+            "checkType": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 127,
+                "character": 30
+              },
+              "name": "T"
+            },
+            "extendsType": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 127,
+                "character": 40
+              },
+              "name": "U"
+            },
+            "trueType": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 127,
+                "character": 44
+              },
+              "name": "Y"
+            },
+            "falseType": {
+              "__schema": "TypeRefSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 127,
+                "character": 48
+              },
+              "name": "N"
+            }
+          }
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 129,
+            "character": 1
+          },
+          "signature": "function genericFunction<T>(a: T): <T>(a: T) => void",
+          "name": "genericFunction",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 129,
+                "character": 36
+              },
+              "name": "a",
+              "type": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 129,
+                  "character": 39
+                },
+                "name": "T"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 129,
+              "character": 1
+            },
+            "type": "<T>(a: T) => void"
+          },
+          "modifiers": [
+            "export"
+          ],
+          "typeParams": [
+            "T"
+          ]
+        },
+        {
+          "__schema": "VariableLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 133,
+            "character": 14
+          },
+          "signature": "const gfnc2: <T>(a: T) => void",
+          "name": "gfnc2",
+          "type": {
+            "__schema": "FunctionLikeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 133,
+              "character": 14
+            },
+            "signature": "const gfnc2: <T>(a: T) => void",
+            "name": "anonymous",
+            "params": [
+              {
+                "__schema": "ParameterSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 133,
+                  "character": 14
+                },
+                "name": "a",
+                "type": {
+                  "__schema": "InferenceTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 133,
+                    "character": 14
+                  },
+                  "type": "T"
+                },
+                "isOptional": false,
+                "isSpread": false
+              }
+            ],
+            "returnType": {
+              "__schema": "InferenceTypeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 133,
+                "character": 14
+              },
+              "type": "void"
+            },
+            "modifiers": []
+          },
+          "isOptional": false,
+          "defaultValue": "genericFunction<string>('')"
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 135,
+            "character": 1
+          },
+          "signature": "function LogMethod(message: string): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void",
+          "name": "LogMethod",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 135,
+                "character": 27
+              },
+              "name": "message",
+              "type": {
+                "__schema": "KeywordTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 135,
+                  "character": 36
+                },
+                "name": "string"
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 135,
+              "character": 1
+            },
+            "type": "(target: any, propertyKey: string, descriptor: PropertyDescriptor) => void"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 145,
+            "character": 1
+          },
+          "signature": "function CustomClassDecorator(config: {\n    name: string;\n    description: string;\n    fn?: () => string;\n    class?: ClassSomething;\n    arr?: [string, number, boolean, boolean, number | undefined, (a: string) => void, {\n        a: string;\n        b: number;\n    }, ClassSomething];\n}): (target: any) => void",
+          "name": "CustomClassDecorator",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 145,
+                "character": 38
+              },
+              "name": "config",
+              "type": {
+                "__schema": "TypeLiteralSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 145,
+                  "character": 46
+                },
+                "members": [
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 146,
+                      "character": 3
+                    },
+                    "signature": "(property) name: string",
+                    "name": "name",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 146,
+                        "character": 9
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": false
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 147,
+                      "character": 3
+                    },
+                    "signature": "(property) description: string",
+                    "name": "description",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 147,
+                        "character": 16
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": false
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 148,
+                      "character": 3
+                    },
+                    "signature": "(property) fn?: (() => string) | undefined",
+                    "name": "fn",
+                    "type": {
+                      "__schema": "FunctionLikeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 148,
+                        "character": 8
+                      },
+                      "signature": "(): string",
+                      "name": "",
+                      "params": [],
+                      "returnType": {
+                        "__schema": "KeywordTypeSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 148,
+                          "character": 14
+                        },
+                        "name": "string"
+                      },
+                      "modifiers": []
+                    },
+                    "isOptional": true
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 149,
+                      "character": 3
+                    },
+                    "signature": "(property) class?: ClassSomething | undefined",
+                    "name": "class",
+                    "type": {
+                      "__schema": "TypeRefSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 149,
+                        "character": 11
+                      },
+                      "name": "ClassSomething"
+                    },
+                    "isOptional": true
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 150,
+                      "character": 3
+                    },
+                    "signature": "(property) arr?: [string, number, boolean, boolean, number | undefined, (a: string) => void, {\n    a: string;\n    b: number;\n}, ClassSomething] | undefined",
+                    "name": "arr",
+                    "type": {
+                      "__schema": "TupleTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 150,
+                        "character": 9
+                      },
+                      "elements": [
+                        {
+                          "__schema": "KeywordTypeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 151,
+                            "character": 5
+                          },
+                          "name": "string"
+                        },
+                        {
+                          "__schema": "KeywordTypeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 152,
+                            "character": 5
+                          },
+                          "name": "number"
+                        },
+                        {
+                          "__schema": "KeywordTypeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 153,
+                            "character": 5
+                          },
+                          "name": "boolean"
+                        },
+                        {
+                          "__schema": "KeywordTypeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 154,
+                            "character": 5
+                          },
+                          "name": "boolean"
+                        },
+                        {
+                          "__schema": "TypeUnionSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 155,
+                            "character": 5
+                          },
+                          "types": [
+                            {
+                              "__schema": "KeywordTypeSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 155,
+                                "character": 5
+                              },
+                              "name": "number"
+                            },
+                            {
+                              "__schema": "KeywordTypeSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 155,
+                                "character": 14
+                              },
+                              "name": "undefined"
+                            }
+                          ]
+                        },
+                        {
+                          "__schema": "FunctionLikeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 156,
+                            "character": 5
+                          },
+                          "signature": "(a: string): void",
+                          "name": "",
+                          "params": [
+                            {
+                              "__schema": "ParameterSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 156,
+                                "character": 6
+                              },
+                              "name": "a",
+                              "type": {
+                                "__schema": "KeywordTypeSchema",
+                                "location": {
+                                  "filePath": "index.ts",
+                                  "line": 156,
+                                  "character": 9
+                                },
+                                "name": "string"
+                              },
+                              "isOptional": false,
+                              "isSpread": false
+                            }
+                          ],
+                          "returnType": {
+                            "__schema": "KeywordTypeSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 156,
+                              "character": 20
+                            },
+                            "name": "void"
+                          },
+                          "modifiers": []
+                        },
+                        {
+                          "__schema": "TypeLiteralSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 157,
+                            "character": 5
+                          },
+                          "members": [
+                            {
+                              "__schema": "VariableLikeSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 157,
+                                "character": 7
+                              },
+                              "signature": "(property) a: string",
+                              "name": "a",
+                              "type": {
+                                "__schema": "KeywordTypeSchema",
+                                "location": {
+                                  "filePath": "index.ts",
+                                  "line": 157,
+                                  "character": 10
+                                },
+                                "name": "string"
+                              },
+                              "isOptional": false
+                            },
+                            {
+                              "__schema": "VariableLikeSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 157,
+                                "character": 18
+                              },
+                              "signature": "(property) b: number",
+                              "name": "b",
+                              "type": {
+                                "__schema": "KeywordTypeSchema",
+                                "location": {
+                                  "filePath": "index.ts",
+                                  "line": 157,
+                                  "character": 21
+                                },
+                                "name": "number"
+                              },
+                              "isOptional": false
+                            }
+                          ]
+                        },
+                        {
+                          "__schema": "TypeRefSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 158,
+                            "character": 5
+                          },
+                          "name": "ClassSomething"
+                        }
+                      ]
+                    },
+                    "isOptional": true
+                  }
+                ]
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 145,
+              "character": 1
+            },
+            "type": "(target: any) => void"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 166,
+            "character": 1
+          },
+          "signature": "class ExampleDecoratorOne",
+          "name": "ExampleDecoratorOne",
+          "members": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 168,
+                "character": 3
+              },
+              "signature": "(method) ExampleDecoratorOne.exampleMethod(): void",
+              "name": "exampleMethod",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 168,
+                  "character": 3
+                },
+                "type": "void"
+              },
+              "modifiers": [],
+              "decorators": [
+                {
+                  "__schema": "DecoratorSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 168,
+                    "character": 3
+                  },
+                  "name": "LogMethod",
+                  "args": [
+                    {
+                      "__schema": "LiteralValueSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 168,
+                        "character": 14
+                      },
+                      "value": "This is a log message"
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "extendsNodes": [],
+          "implementNodes": [],
+          "decorators": [
+            {
+              "__schema": "DecoratorSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 166,
+                "character": 1
+              },
+              "name": "CustomClassDecorator",
+              "args": [
+                {
+                  "__schema": "ObjectLiteralExpressionSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 166,
+                    "character": 23
+                  },
+                  "members": [
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 166,
+                        "character": 25
+                      },
+                      "name": "name",
+                      "value": {
+                        "__schema": "LiteralValueSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 166,
+                          "character": 31
+                        },
+                        "value": "ExampleClass2"
+                      }
+                    },
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 166,
+                        "character": 48
+                      },
+                      "name": "description",
+                      "value": {
+                        "__schema": "LiteralValueSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 166,
+                          "character": 61
+                        },
+                        "value": "This is an example class 2"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "__schema": "FunctionLikeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 174,
+            "character": 1
+          },
+          "signature": "function ValidateArgs(config: {\n    type: string;\n    required: boolean;\n}): (target: any, propertyKey: string, descriptor: PropertyDescriptor) => void",
+          "name": "ValidateArgs",
+          "params": [
+            {
+              "__schema": "ParameterSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 174,
+                "character": 30
+              },
+              "name": "config",
+              "type": {
+                "__schema": "TypeLiteralSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 174,
+                  "character": 38
+                },
+                "members": [
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 174,
+                      "character": 40
+                    },
+                    "signature": "(property) type: string",
+                    "name": "type",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 174,
+                        "character": 46
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": false
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 174,
+                      "character": 54
+                    },
+                    "signature": "(property) required: boolean",
+                    "name": "required",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 174,
+                        "character": 64
+                      },
+                      "name": "boolean"
+                    },
+                    "isOptional": false
+                  }
+                ]
+              },
+              "isOptional": false,
+              "isSpread": false
+            }
+          ],
+          "returnType": {
+            "__schema": "InferenceTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 174,
+              "character": 1
+            },
+            "type": "(target: any, propertyKey: string, descriptor: PropertyDescriptor) => void"
+          },
+          "modifiers": [
+            "export"
+          ]
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 189,
+            "character": 1
+          },
+          "signature": "class ExampleDecoratorTwo",
+          "name": "ExampleDecoratorTwo",
+          "members": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 197,
+                "character": 3
+              },
+              "signature": "(method) ExampleDecoratorTwo.exampleMethod(input: string): void",
+              "name": "exampleMethod",
+              "params": [
+                {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 198,
+                    "character": 17
+                  },
+                  "name": "input",
+                  "type": {
+                    "__schema": "KeywordTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 198,
+                      "character": 24
+                    },
+                    "name": "string"
+                  },
+                  "isOptional": false,
+                  "isSpread": false
+                }
+              ],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 197,
+                  "character": 3
+                },
+                "type": "void"
+              },
+              "modifiers": [],
+              "decorators": [
+                {
+                  "__schema": "DecoratorSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 197,
+                    "character": 3
+                  },
+                  "name": "ValidateArgs",
+                  "args": [
+                    {
+                      "__schema": "ObjectLiteralExpressionSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 197,
+                        "character": 17
+                      },
+                      "members": [
+                        {
+                          "__schema": "PropertyAssignmentSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 197,
+                            "character": 19
+                          },
+                          "name": "type",
+                          "value": {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 197,
+                              "character": 25
+                            },
+                            "value": "string"
+                          }
+                        },
+                        {
+                          "__schema": "PropertyAssignmentSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 197,
+                            "character": 35
+                          },
+                          "name": "required",
+                          "value": {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 197,
+                              "character": 45
+                            },
+                            "value": "true"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "extendsNodes": [],
+          "implementNodes": [],
+          "decorators": [
+            {
+              "__schema": "DecoratorSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 189,
+                "character": 1
+              },
+              "name": "CustomClassDecorator",
+              "args": [
+                {
+                  "__schema": "ObjectLiteralExpressionSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 189,
+                    "character": 23
+                  },
+                  "members": [
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 190,
+                        "character": 3
+                      },
+                      "name": "name",
+                      "value": {
+                        "__schema": "LiteralValueSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 190,
+                          "character": 9
+                        },
+                        "value": "ExampleClass"
+                      }
+                    },
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 191,
+                        "character": 3
+                      },
+                      "name": "description",
+                      "value": {
+                        "__schema": "LiteralValueSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 191,
+                          "character": 16
+                        },
+                        "value": "This is an example class"
+                      }
+                    },
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 192,
+                        "character": 3
+                      },
+                      "name": "fn",
+                      "value": {
+                        "__schema": "FunctionLikeSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 192,
+                          "character": 7
+                        },
+                        "signature": "function(): string",
+                        "name": "",
+                        "params": [],
+                        "returnType": {
+                          "__schema": "InferenceTypeSchema",
+                          "location": {
+                            "filePath": "index.ts",
+                            "line": 192,
+                            "character": 7
+                          },
+                          "type": "string"
+                        },
+                        "modifiers": []
+                      }
+                    },
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 193,
+                        "character": 3
+                      },
+                      "name": "class",
+                      "value": {
+                        "__schema": "LiteralValueSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 193,
+                          "character": 10
+                        },
+                        "value": "new ClassSomething('dsa')"
+                      }
+                    },
+                    {
+                      "__schema": "PropertyAssignmentSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 194,
+                        "character": 3
+                      },
+                      "name": "arr",
+                      "value": {
+                        "__schema": "ArrayLiteralExpressionSchema",
+                        "location": {
+                          "filePath": "index.ts",
+                          "line": 194,
+                          "character": 8
+                        },
+                        "members": [
+                          {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 9
+                            },
+                            "value": "hi"
+                          },
+                          {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 15
+                            },
+                            "value": "5"
+                          },
+                          {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 18
+                            },
+                            "value": "true"
+                          },
+                          {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 24
+                            },
+                            "value": "false"
+                          },
+                          {
+                            "__schema": "InferenceTypeSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 31
+                            },
+                            "type": "undefined"
+                          },
+                          {
+                            "__schema": "FunctionLikeSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 42
+                            },
+                            "signature": "function(): void",
+                            "name": "",
+                            "params": [],
+                            "returnType": {
+                              "__schema": "InferenceTypeSchema",
+                              "location": {
+                                "filePath": "index.ts",
+                                "line": 194,
+                                "character": 42
+                              },
+                              "type": "void"
+                            },
+                            "modifiers": []
+                          },
+                          {
+                            "__schema": "ObjectLiteralExpressionSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 52
+                            },
+                            "members": [
+                              {
+                                "__schema": "PropertyAssignmentSchema",
+                                "location": {
+                                  "filePath": "index.ts",
+                                  "line": 194,
+                                  "character": 54
+                                },
+                                "name": "a",
+                                "value": {
+                                  "__schema": "LiteralValueSchema",
+                                  "location": {
+                                    "filePath": "index.ts",
+                                    "line": 194,
+                                    "character": 57
+                                  },
+                                  "value": "hi"
+                                }
+                              },
+                              {
+                                "__schema": "PropertyAssignmentSchema",
+                                "location": {
+                                  "filePath": "index.ts",
+                                  "line": 194,
+                                  "character": 63
+                                },
+                                "name": "b",
+                                "value": {
+                                  "__schema": "LiteralValueSchema",
+                                  "location": {
+                                    "filePath": "index.ts",
+                                    "line": 194,
+                                    "character": 66
+                                  },
+                                  "value": "5"
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "__schema": "LiteralValueSchema",
+                            "location": {
+                              "filePath": "index.ts",
+                              "line": 194,
+                              "character": 71
+                            },
+                            "value": "new ClassSomething('dsa')"
+                          }
+                        ]
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "internals": [
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 34,
+            "character": 1
+          },
+          "signature": "class Foo",
+          "name": "Foo",
+          "members": [],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 36,
+            "character": 1
+          },
+          "signature": "class ClassSomething",
+          "name": "ClassSomething",
+          "members": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 37,
+                "character": 3
+              },
+              "signature": "(property) ClassSomething.app: string",
+              "name": "app",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 37,
+                  "character": 3
+                },
+                "type": "string"
+              },
+              "isOptional": true,
+              "defaultValue": "''"
+            },
+            {
+              "__schema": "ConstructorSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 38,
+                "character": 3
+              },
+              "signature": "constructor ClassSomething(da: \"dsa\"): ClassSomething",
+              "name": "constructor",
+              "params": [
+                {
+                  "__schema": "ParameterSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 38,
+                    "character": 15
+                  },
+                  "name": "da",
+                  "type": {
+                    "__schema": "LiteralTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 38,
+                      "character": 28
+                    },
+                    "name": "'dsa'"
+                  },
+                  "isOptional": false,
+                  "isSpread": false
+                }
+              ],
+              "returnType": {
+                "__schema": "ThisTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 36,
+                  "character": 1
+                },
+                "name": "ClassSomething"
+              },
+              "modifiers": []
+            },
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 40,
+                "character": 3
+              },
+              "signature": "(method) ClassSomething.a(): Foo",
+              "name": "a",
+              "params": [],
+              "returnType": {
+                "__schema": "TypeRefSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 40,
+                  "character": 3
+                },
+                "name": "Foo",
+                "internalFilePath": "index.ts"
+              },
+              "modifiers": []
+            },
+            {
+              "__schema": "GetAccessorSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 43,
+                "character": 3
+              },
+              "signature": "(getter) ClassSomething.getter: string",
+              "name": "getter",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 43,
+                  "character": 3
+                },
+                "type": "string"
+              }
+            },
+            {
+              "__schema": "SetAccessorSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 47,
+                "character": 3
+              },
+              "signature": "(setter) ClassSomething.setter: boolean",
+              "name": "setter",
+              "param": {
+                "__schema": "ParameterSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 47,
+                  "character": 14
+                },
+                "name": "a",
+                "type": {
+                  "__schema": "KeywordTypeSchema",
+                  "location": {
+                    "filePath": "index.ts",
+                    "line": 47,
+                    "character": 17
+                  },
+                  "name": "boolean"
+                },
+                "isOptional": false,
+                "isSpread": false
+              }
+            }
+          ],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "ModuleSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 59,
+            "character": 1
+          },
+          "exports": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 59,
+                "character": 7
+              },
+              "signature": "const obj: {\n    a: number;\n    b: number;\n}",
+              "name": "obj",
+              "type": {
+                "__schema": "ArrayLiteralExpressionSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 59,
+                  "character": 7
+                },
+                "members": [
+                  {
+                    "__schema": "InferenceTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 59,
+                      "character": 7
+                    },
+                    "type": "a: number"
+                  },
+                  {
+                    "__schema": "InferenceTypeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 59,
+                      "character": 7
+                    },
+                    "type": "b: number"
+                  }
+                ]
+              },
+              "isOptional": false,
+              "defaultValue": "{ a: 1, b: 2 }"
+            }
+          ],
+          "internals": []
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 66,
+            "character": 1
+          },
+          "signature": "class Bar",
+          "name": "Bar",
+          "members": [
+            {
+              "__schema": "FunctionLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 67,
+                "character": 3
+              },
+              "signature": "(method) Bar.foo(): void",
+              "name": "foo",
+              "params": [],
+              "returnType": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 67,
+                  "character": 3
+                },
+                "type": "void"
+              },
+              "modifiers": []
+            }
+          ],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 83,
+            "character": 1
+          },
+          "signature": "class T1",
+          "name": "T1",
+          "members": [],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 84,
+            "character": 1
+          },
+          "signature": "class T2",
+          "name": "T2",
+          "members": [],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "ClassSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 85,
+            "character": 1
+          },
+          "signature": "class T3<T, K>",
+          "name": "T3",
+          "members": [],
+          "typeParams": [
+            "T",
+            "K"
+          ],
+          "extendsNodes": [],
+          "implementNodes": []
+        },
+        {
+          "__schema": "InterfaceSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 103,
+            "character": 1
+          },
+          "signature": "interface config",
+          "name": "config",
+          "members": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 104,
+                "character": 3
+              },
+              "signature": "(property) config.someField: {\n    a: string;\n    b: boolean;\n}",
+              "name": "someField",
+              "type": {
+                "__schema": "TypeLiteralSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 104,
+                  "character": 14
+                },
+                "members": [
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 104,
+                      "character": 16
+                    },
+                    "signature": "(property) a: string",
+                    "name": "a",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 104,
+                        "character": 19
+                      },
+                      "name": "string"
+                    },
+                    "isOptional": false
+                  },
+                  {
+                    "__schema": "VariableLikeSchema",
+                    "location": {
+                      "filePath": "index.ts",
+                      "line": 104,
+                      "character": 27
+                    },
+                    "signature": "(property) b: boolean",
+                    "name": "b",
+                    "type": {
+                      "__schema": "KeywordTypeSchema",
+                      "location": {
+                        "filePath": "index.ts",
+                        "line": 104,
+                        "character": 30
+                      },
+                      "name": "boolean"
+                    },
+                    "isOptional": false
+                  }
+                ]
+              },
+              "isOptional": false
+            }
+          ],
+          "extendsNodes": []
+        },
+        {
+          "__schema": "ModuleSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 108,
+            "character": 1
+          },
+          "exports": [
+            {
+              "__schema": "VariableLikeSchema",
+              "location": {
+                "filePath": "index.ts",
+                "line": 108,
+                "character": 7
+              },
+              "signature": "const computedName: \"str\"",
+              "name": "computedName",
+              "type": {
+                "__schema": "InferenceTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 108,
+                  "character": 7
+                },
+                "type": "\"str\""
+              },
+              "isOptional": false,
+              "defaultValue": "'str'"
+            }
+          ],
+          "internals": []
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 116,
+            "character": 1
+          },
+          "signature": "type World1 = \"world1-a\" | \"world1-b\"",
+          "name": "World1",
+          "type": {
+            "__schema": "TypeUnionSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 116,
+              "character": 15
+            },
+            "types": [
+              {
+                "__schema": "LiteralTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 116,
+                  "character": 15
+                },
+                "name": "'world1-a'"
+              },
+              {
+                "__schema": "LiteralTypeSchema",
+                "location": {
+                  "filePath": "index.ts",
+                  "line": 116,
+                  "character": 28
+                },
+                "name": "'world1-b'"
+              }
+            ]
+          }
+        },
+        {
+          "__schema": "TypeSchema",
+          "location": {
+            "filePath": "index.ts",
+            "line": 117,
+            "character": 1
+          },
+          "signature": "type World2 = \"world2\"",
+          "name": "World2",
+          "type": {
+            "__schema": "LiteralTypeSchema",
+            "location": {
+              "filePath": "index.ts",
+              "line": 117,
+              "character": 15
+            },
+            "name": "'world2'"
+          }
+        }
+      ]
     }
   ],
   "componentId": {

--- a/scopes/typescript/typescript/identifier.ts
+++ b/scopes/typescript/typescript/identifier.ts
@@ -1,19 +1,30 @@
+import { isAbsolute, resolve, dirname, normalize } from 'path';
 export class Identifier {
+  public readonly normalizedPath: string;
+
   constructor(
     readonly id: string,
     readonly filePath: string,
     readonly aliasId?: string,
     readonly sourceFilePath?: string
-  ) {}
+  ) {
+    this.normalizedPath = Identifier.computeNormalizedPath(filePath, sourceFilePath);
+  }
+
+  private static computeNormalizedPath(filePath: string, sourceFilePath?: string): string {
+    let effectivePath = filePath;
+    if (sourceFilePath) {
+      effectivePath = isAbsolute(sourceFilePath)
+        ? sourceFilePath
+        : resolve(dirname(filePath), sourceFilePath);
+    }
+    return normalize(effectivePath).replace(/\\/g, '/');
+  }
 
   isEqual(identifier: Identifier): boolean {
-    if (this.filePath !== identifier.filePath) return false;
-    if (Identifier.isDefault(identifier) && Identifier.isDefault(this)) {
-      return true;
-    }
-    if (Identifier.isDefault(identifier) || Identifier.isDefault(this)) {
-      return false;
-    }
+    if (this.filePath !== identifier.filePath && this.normalizedPath !== identifier.normalizedPath) return false;
+    if (Identifier.isDefault(identifier) && Identifier.isDefault(this)) return true;
+    if (Identifier.isDefault(identifier) || Identifier.isDefault(this)) return false;
     return this.id === identifier.id;
   }
 

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -16,6 +16,10 @@ import {
   DocSchema,
   IgnoredSchema,
   TagSchema,
+  TypeArraySchema,
+  ArrayLiteralExpressionSchema,
+  ParameterSchema,
+  FunctionLikeSchema,
 } from '@teambit/semantics.entities.semantic-schema';
 import { ComponentDependency } from '@teambit/dependency-resolver';
 import { Formatter } from '@teambit/formatter';
@@ -194,8 +198,7 @@ export class SchemaExtractorContext {
     } catch (err: any) {
       if (err.message === 'No content available.') {
         throw new Error(
-          `unable to get quickinfo data from tsserver at ${this.getPath(node)}, Ln ${location.line}, Col ${
-            location.character
+          `unable to get quickinfo data from tsserver at ${this.getPath(node)}, Ln ${location.line}, Col ${location.character
           }`
         );
       }
@@ -215,7 +218,7 @@ export class SchemaExtractorContext {
     return this.tsserver.getTypeDefinition(this.getPath(node), this.getLocation(node));
   }
 
-  visitTypeDefinition() {}
+  visitTypeDefinition() { }
 
   private getPathWithoutExtension(filePath: string) {
     const knownExtensions = ['ts', 'js', 'jsx', 'tsx'];
@@ -359,11 +362,11 @@ export class SchemaExtractorContext {
     return this.extractor.computeSchema(node, this);
   }
 
-  references() {}
+  references() { }
 
-  isExported() {}
+  isExported() { }
 
-  isFromComponent() {}
+  isFromComponent() { }
 
   async getFileIdentifiers(exportDec: ExportDeclaration | ExportAssignment) {
     const file = exportDec.getSourceFile().fileName;
@@ -410,14 +413,212 @@ export class SchemaExtractorContext {
     return headDefinition;
   }
 
-  // when we can't figure out the component/package/type of this node, we'll use the typeStr as the type.
-  private async unknownExactType(node: Node, location: Location, typeStr = 'any', isTypeStrFromQuickInfo = true) {
-    if (isTypeStrFromQuickInfo) {
+  /**
+   * Handles type resolution for unknown or external types.
+   * Attempts to:
+   * 1. Get type references when possible
+   * 2. Fall back to inference when references can't be found
+   */
+  private async unknownExactType(node: Node, location: Location, typeStr = 'any') {
+    try {
+      if (this.isArrayType(typeStr)) {
+        const baseType = this.getArrayBaseType(typeStr);
+        const currentFilePath = node.getSourceFile().fileName;
+        const baseTypeRef = await this.getTypeRef(baseType, this.getIdentifierKey(currentFilePath), location);
+
+        if (baseTypeRef) {
+          return new TypeArraySchema(location, baseTypeRef);
+        }
+
+        return new TypeArraySchema(
+          location,
+          new InferenceTypeSchema(location, baseType)
+        );
+      }
+
+      const currentFilePath = node.getSourceFile().fileName;
+      const typeRef = await this.getTypeRef(typeStr, this.getIdentifierKey(currentFilePath), location);
+      if (typeRef) {
+        return typeRef;
+      }
+
+      const info = await this.getQuickInfo(node);
+      if (!info?.body?.displayString) {
+        return new InferenceTypeSchema(location, typeStr || 'any');
+      }
+
+      const { displayString, kind } = info.body;
+
+      if (kind === 'method') {
+        const returnType = this.extractMethodReturnType(displayString);
+        return await this.createMethodReturnSchema(node, location, returnType);
+      }
+
+      if (kind === 'function' || displayString.includes('=>')) {
+        return await this.createFunctionSchema(node, location, displayString);
+      }
+
+      if (displayString.includes('{') && displayString.includes('}')) {
+        return this.createObjectSchema(node, location, displayString);
+      }
+
+      if (displayString.includes('Promise<')) {
+        const innerType = this.extractGenericType(displayString, 'Promise');
+        return await this.createPromiseSchema(node, location, innerType);
+      }
+
+      return new InferenceTypeSchema(location, typeStr || 'any');
+    } catch (e) {
       return new InferenceTypeSchema(location, typeStr || 'any');
     }
-    const info = await this.getQuickInfo(node);
-    const type = parseTypeFromQuickInfo(info);
-    return new InferenceTypeSchema(location, type, typeStr);
+  }
+
+  /**
+   * Check if type is an array type (either T[] or Array<T>)
+   */
+  private isArrayType(typeStr: string): boolean {
+    return typeStr.endsWith('[]') || typeStr.startsWith('Array<');
+  }
+
+  /**
+   * Extract base type from array type
+   */
+  private getArrayBaseType(typeStr: string): string {
+    if (typeStr.endsWith('[]')) {
+      return typeStr.slice(0, -2);
+    }
+    if (typeStr.startsWith('Array<')) {
+      const match = /Array<(.+)>/.exec(typeStr);
+      return match?.[1] || 'any';
+    }
+    return typeStr;
+  }
+
+  /**
+   * Extract return type from method signature
+   */
+  private extractMethodReturnType(displayString: string): string {
+    const returnTypeMatch = displayString.match(/\):\s*(.+)$/);
+    return returnTypeMatch ? returnTypeMatch[1].trim() : 'any';
+  }
+
+  /**
+   * Extract content from generic type
+   */
+  private extractGenericType(type: string, wrapper: string): string {
+    const match = new RegExp(`${wrapper}<(.+)>`).exec(type);
+    return match ? match[1].trim() : type;
+  }
+
+  /**
+   * Create schema for method return type, attempting to get type reference
+   */
+  private async createMethodReturnSchema(node: Node, location: Location, returnType: string): Promise<SchemaNode> {
+    if (this.isArrayType(returnType)) {
+      const baseType = this.getArrayBaseType(returnType);
+      const currentFilePath = node.getSourceFile().fileName;
+      const baseTypeRef = await this.getTypeRef(baseType, this.getIdentifierKey(currentFilePath), location);
+
+      if (baseTypeRef) {
+        return new TypeArraySchema(location, baseTypeRef);
+      }
+      return new TypeArraySchema(location, new InferenceTypeSchema(location, baseType));
+    }
+
+    const typeRef = await this.getTypeRef(returnType, this.getIdentifierKeyForNode(node), location);
+    return typeRef || new InferenceTypeSchema(location, returnType);
+  }
+
+  /**
+   * Create schema for function type, handling params and return type
+   */
+  private async createFunctionSchema(node: Node, location: Location, signature: string): Promise<FunctionLikeSchema> {
+    const match = signature.match(/\((.*)\)\s*(?:=>|:)\s*(.+)/);
+    if (!match) {
+      return new FunctionLikeSchema(
+        location,
+        'anonymous',
+        [],
+        new InferenceTypeSchema(location, 'any'),
+        signature
+      );
+    }
+
+    const [, paramsStr, returnTypeStr] = match;
+    const params = await this.createFunctionParameters(node, location, paramsStr);
+    const returnType = await this.createMethodReturnSchema(node, location, returnTypeStr.trim());
+
+    return new FunctionLikeSchema(
+      location,
+      'anonymous',
+      params,
+      returnType,
+      signature
+    );
+  }
+
+  /**
+   * Create parameters for function schema, attempting to get type references for param types
+   */
+  private async createFunctionParameters(
+    node: Node, location: Location, paramsStr: string): Promise<ParameterSchema[]> {
+    if (!paramsStr.trim()) return [];
+
+    const params = paramsStr.split(',');
+    const paramSchemas: ParameterSchema[] = [];
+
+    for (const param of params) {
+      const [nameWithOptional, type] = param.split(':').map(s => s.trim());
+      const isOptional = nameWithOptional.includes('?');
+      const name = nameWithOptional.replace('?', '');
+
+      if (!type) {
+        paramSchemas.push(new ParameterSchema(
+          location,
+          name,
+          new InferenceTypeSchema(location, 'any'),
+          isOptional
+        ));
+        continue;
+      }
+
+      const currentFilePath = node.getSourceFile().fileName;
+      const typeRef = await this.getTypeRef(type, this.getIdentifierKey(currentFilePath), location);
+      paramSchemas.push(new ParameterSchema(
+        location,
+        name,
+        typeRef || new InferenceTypeSchema(location, type),
+        isOptional
+      ));
+    }
+
+    return paramSchemas;
+  }
+
+  /**
+   * Create schema for object literal type
+   */
+  private createObjectSchema(node: Node, location: Location, displayString: string): SchemaNode {
+    const objMatch = displayString.match(/{([^}]+)}/);
+    if (!objMatch) {
+      return new InferenceTypeSchema(location, 'object');
+    }
+
+    const objContent = objMatch[1];
+    const properties = objContent.split(';')
+      .map(prop => prop.trim())
+      .filter(Boolean)
+      .map(prop => new InferenceTypeSchema(location, prop));
+
+    return new ArrayLiteralExpressionSchema(properties, location);
+  }
+
+  /**
+   * Create schema for Promise type, attempting to get type reference for the contained type
+   */
+  private async createPromiseSchema(node: Node, location: Location, innerType: string): Promise<SchemaNode> {
+    const typeRef = await this.getTypeRef(innerType, this.getIdentifierKeyForNode(node), location);
+    return typeRef || new InferenceTypeSchema(location, innerType);
   }
 
   // the reason for this check is to avoid infinite loop when calling `this.jump` with the same file+location
@@ -436,7 +637,6 @@ export class SchemaExtractorContext {
   async resolveType(
     node: Node & { type?: TypeNode },
     typeStr: string,
-    isTypeStrFromQuickInfo = true
   ): Promise<SchemaNode> {
     const location = this.getLocation(node);
 
@@ -454,17 +654,17 @@ export class SchemaExtractorContext {
     const definition = await this.getDefinition(node);
 
     if (!definition) {
-      return this.unknownExactType(node, location, typeStr, isTypeStrFromQuickInfo);
+      return this.unknownExactType(node, location, typeStr);
     }
 
     if (this.isDefInSameLocation(node, definition)) {
-      return this.unknownExactType(node, location, typeStr, isTypeStrFromQuickInfo);
+      return this.unknownExactType(node, location, typeStr);
     }
 
     const definitionNode = await this.definition(definition);
 
     if (!definitionNode) {
-      return this.unknownExactType(node, location, typeStr, isTypeStrFromQuickInfo);
+      return this.unknownExactType(node, location, typeStr);
     }
 
     const definitionNodeName = definitionNode?.getText();
@@ -483,13 +683,13 @@ export class SchemaExtractorContext {
     if (transformer === undefined) {
       const file = this.findFileInComponent(definition.file);
       if (!file) return this.getTypeRefForExternalPath(typeStr, definition.file, location);
-      return this.unknownExactType(node, location, typeStr, isTypeStrFromQuickInfo);
+      return this.unknownExactType(node, location, typeStr);
     }
 
     const schemaNode = await this.visit(definitionNode);
 
     if (!schemaNode) {
-      return this.unknownExactType(node, location, typeStr, isTypeStrFromQuickInfo);
+      return this.unknownExactType(node, location, typeStr);
     }
 
     const apiTransformer = this.extractor.getAPITransformer(schemaNode);
@@ -507,7 +707,6 @@ export class SchemaExtractorContext {
   async getTypeRef(typeStr: string, filePath: string, location: Location): Promise<TypeRefSchema | undefined> {
     const nodeIdentifierKey = this.getIdentifierKey(filePath);
     const mainFileIdentifierKey = this.mainFileIdentifierKey;
-
     const nodeIdentifierList = this.identifiers.get(nodeIdentifierKey);
     const mainIdentifierList = this.identifiers.get(mainFileIdentifierKey);
 
@@ -521,11 +720,9 @@ export class SchemaExtractorContext {
     if (!parsedNodeIdentifier) return undefined;
 
     const internalRef = !isExportedFromMain;
-
     if (internalRef) {
-      this.setInternalIdentifiers(filePath, new IdentifierList([parsedNodeIdentifier]));
+      this.setInternalIdentifiers(parsedNodeIdentifier.normalizedPath, new IdentifierList([parsedNodeIdentifier]));
     }
-
     return this.resolveTypeRef(parsedNodeIdentifier, location, isExportedFromMain);
   }
 

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -514,6 +514,7 @@ export class SchemaExtractorContext {
    * Create schema for method return type, attempting to get type reference
    */
   private async createMethodReturnSchema(node: Node, location: Location, returnType: string): Promise<SchemaNode> {
+    console.log("🚀 ~ SchemaExtractorContext ~ createMethodReturnSchema ~ returnType:", returnType)
     if (this.isArrayType(returnType)) {
       const baseType = this.getArrayBaseType(returnType);
       const currentFilePath = node.getSourceFile().fileName;
@@ -617,6 +618,7 @@ export class SchemaExtractorContext {
    * Create schema for Promise type, attempting to get type reference for the contained type
    */
   private async createPromiseSchema(node: Node, location: Location, innerType: string): Promise<SchemaNode> {
+    console.log("🚀 ~ createPromiseSchema ~ innerType:", innerType)
     const typeRef = await this.getTypeRef(innerType, this.getIdentifierKeyForNode(node), location);
     return typeRef || new InferenceTypeSchema(location, innerType);
   }

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -468,7 +468,7 @@ export class SchemaExtractorContext {
       }
 
       return new InferenceTypeSchema(location, typeStr || 'any');
-    } catch (e) {
+    } catch {
       return new InferenceTypeSchema(location, typeStr || 'any');
     }
   }

--- a/scopes/typescript/typescript/schema-extractor-context.ts
+++ b/scopes/typescript/typescript/schema-extractor-context.ts
@@ -514,7 +514,6 @@ export class SchemaExtractorContext {
    * Create schema for method return type, attempting to get type reference
    */
   private async createMethodReturnSchema(node: Node, location: Location, returnType: string): Promise<SchemaNode> {
-    console.log("🚀 ~ SchemaExtractorContext ~ createMethodReturnSchema ~ returnType:", returnType)
     if (this.isArrayType(returnType)) {
       const baseType = this.getArrayBaseType(returnType);
       const currentFilePath = node.getSourceFile().fileName;
@@ -618,7 +617,6 @@ export class SchemaExtractorContext {
    * Create schema for Promise type, attempting to get type reference for the contained type
    */
   private async createPromiseSchema(node: Node, location: Location, innerType: string): Promise<SchemaNode> {
-    console.log("🚀 ~ createPromiseSchema ~ innerType:", innerType)
     const typeRef = await this.getTypeRef(innerType, this.getIdentifierKeyForNode(node), location);
     return typeRef || new InferenceTypeSchema(location, innerType);
   }

--- a/scopes/typescript/typescript/transformers/export-declaration.ts
+++ b/scopes/typescript/typescript/transformers/export-declaration.ts
@@ -131,7 +131,7 @@ async function exportSpecifierToSchemaNode(
     const definitionNode = await context.definition(definitionInfo);
 
     if (!definitionNode) {
-      const exportNode = await context.resolveType(element, name, false);
+      const exportNode = await context.resolveType(element, name);
       return new ExportSchema(location, name, exportNode, alias);
     }
 

--- a/scopes/typescript/typescript/transformers/function-like.ts
+++ b/scopes/typescript/typescript/transformers/function-like.ts
@@ -45,7 +45,7 @@ export class FunctionLikeTransformer implements SchemaTransformer {
       context.computeSchema(param)
     )) as ParameterSchema[];
 
-    const returnType = await context.resolveType(node, returnTypeStr, Boolean(info));
+    const returnType = await context.resolveType(node, returnTypeStr);
     const modifiers = nodeModifiers?.map((modifier) => modifier.getText()) || [];
     const typeParameters = node.typeParameters?.map((typeParam) => typeParam.name.getText());
     const location = context.getLocation(node);

--- a/scopes/typescript/typescript/transformers/function-like.ts
+++ b/scopes/typescript/typescript/transformers/function-like.ts
@@ -40,7 +40,6 @@ export class FunctionLikeTransformer implements SchemaTransformer {
     };
     const info = node.name ? await context.getQuickInfo(node.name) : await getQuickInfoFromDefaultModifier();
     const returnTypeStr = info ? parseTypeFromQuickInfo(info) : 'any';
-    console.log("🚀 ~ FunctionLikeTransformer ~ transform ~ returnTypeStr:", returnTypeStr)
     const displaySig = info?.body?.displayString || '';
     const args = (await pMapSeries(node.parameters, async (param) =>
       context.computeSchema(param)

--- a/scopes/typescript/typescript/transformers/function-like.ts
+++ b/scopes/typescript/typescript/transformers/function-like.ts
@@ -40,6 +40,7 @@ export class FunctionLikeTransformer implements SchemaTransformer {
     };
     const info = node.name ? await context.getQuickInfo(node.name) : await getQuickInfoFromDefaultModifier();
     const returnTypeStr = info ? parseTypeFromQuickInfo(info) : 'any';
+    console.log("🚀 ~ FunctionLikeTransformer ~ transform ~ returnTypeStr:", returnTypeStr)
     const displaySig = info?.body?.displayString || '';
     const args = (await pMapSeries(node.parameters, async (param) =>
       context.computeSchema(param)

--- a/scopes/typescript/typescript/transformers/type-query.ts
+++ b/scopes/typescript/typescript/transformers/type-query.ts
@@ -18,7 +18,7 @@ export class TypeQueryTransformer implements SchemaTransformer {
 
   async transform(node: TypeQueryNode, context: SchemaExtractorContext) {
     const displaySig = await context.getQuickInfoDisplayString(node.exprName);
-    const type = await context.resolveType(node.exprName, node.exprName.getText(), false);
+    const type = await context.resolveType(node.exprName, node.exprName.getText());
     const location = context.getLocation(node);
     return new TypeQuerySchema(location, type, displaySig);
   }

--- a/scopes/typescript/typescript/transformers/type-reference.ts
+++ b/scopes/typescript/typescript/transformers/type-reference.ts
@@ -23,7 +23,7 @@ export class TypeReferenceTransformer implements SchemaTransformer {
 
   async transform(node: TypeReferenceNode, context: SchemaExtractorContext) {
     const name = node.typeName.getText();
-    let type = await context.resolveType(node, name, false);
+    let type = await context.resolveType(node, name);
     if (!(type instanceof TypeRefSchema)) {
       type = new TypeRefSchema(context.getLocation(node), name);
     }

--- a/scopes/typescript/typescript/typescript.extractor.ts
+++ b/scopes/typescript/typescript/typescript.extractor.ts
@@ -42,7 +42,7 @@ export class TypeScriptExtractor implements SchemaExtractor {
     private scope: ScopeMain,
     private aspectLoader: AspectLoaderMain,
     private logger: Logger
-  ) {}
+  ) { }
 
   parseSourceFile(file: AbstractVinyl): SourceFile {
     const sourceFile = ts.createSourceFile(
@@ -74,8 +74,8 @@ export class TypeScriptExtractor implements SchemaExtractor {
     const internalFiles = options.skipInternals
       ? []
       : component.filesystem.files.filter(
-          (file) => compatibleExts.includes(file.extname) && file.path !== mainFile.path
-        );
+        (file) => compatibleExts.includes(file.extname) && file.path !== mainFile.path
+      );
     const allFiles = [mainFile, ...internalFiles];
 
     const context = await this.createContext(tsserver, component, options.formatter);
@@ -100,11 +100,10 @@ export class TypeScriptExtractor implements SchemaExtractor {
 
   async computeInternalModules(context: SchemaExtractorContext, internalFiles: AbstractVinyl[]) {
     if (internalFiles.length === 0) return [];
-
     const internals = compact(
       await Promise.all(
         [...context.internalIdentifiers.entries()].map(async ([filePath]) => {
-          const file = internalFiles.find((internalFile) => internalFile.path === filePath);
+          const file = context.findFileInComponent(filePath);
           if (!file) return undefined;
           const fileAst = this.parseSourceFile(file);
           const moduleSchema = (await this.computeSchema(fileAst, context)) as ModuleSchema;


### PR DESCRIPTION
This PR introduces several improvements to the API reference system:


- Enhanced Type Reference Resolution for Inference Types
  - Improved handling of internal and external type references
  - Better handling of inferred array types, generic types, and Promise types
  - Fixed type reference resolution for internal components (non exported)

- Documentation Display Improvements
  - Added support for displaying examples in function documentation
  - Better code block extraction and formatting in JSDoc comments
  - Improved rendering of tuple types
  - Added external link icons for external type references