### PR TITLE
improvement(merge-from-scope), skip loading aspects when merging main to a lane

### DIFF
--- a/components/legacy/extension-data/extension-data.ts
+++ b/components/legacy/extension-data/extension-data.ts
@@ -51,6 +51,10 @@ export class ExtensionDataEntry {
     return this.rawConfig === REMOVE_EXTENSION_SPECIAL_SIGN;
   }
 
+  get idWithoutVersion(): string {
+    return this.extensionId?.toStringWithoutVersion() || this.stringId;
+  }
+
   toModelObject() {
     const extensionId =
       this.extensionId && this.extensionId.serialize ? this.extensionId.serialize() : this.extensionId;

--- a/e2e/harmony/lanes/merge-lanes-from-scope.e2e.ts
+++ b/e2e/harmony/lanes/merge-lanes-from-scope.e2e.ts
@@ -618,4 +618,59 @@ describe('merge lanes from scope', function () {
       expect(fileContent).to.include('on-main');
     });
   });
+  describe('merge from scope, main to lane when they are diverged with custom env and dependencies update', () => {
+    let bareMerge;
+    let envId: string;
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(2);
+
+      const envName = helper.env.setCustomEnv('node-env-dev-dep');
+      envId = `${helper.scopes.remote}/${envName}`;
+      helper.command.setEnv('comp1', envId);
+      helper.command.setEnv('comp2', envId);
+
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.removeComponent(envId);
+      helper.command.createLane();
+      helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
+      helper.command.export();
+
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.tagAllWithoutBuild('--unmodified -m "second tag on main"');
+      helper.command.export();
+
+      bareMerge = helper.scopeHelper.getNewBareScope('-bare-merge');
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, bareMerge.scopePath);
+      helper.command.mergeLaneFromScope(bareMerge.scopePath, 'main', `${helper.scopes.remote}/dev`);
+    });
+    it('should keep the env data correctly', () => {
+      const comp1HeadOnLane = helper.command.getHeadOfLane(`${helper.scopes.remote}/dev`, `comp1`, bareMerge.scopePath);
+      const obj = helper.command.catComponent(`comp1@${comp1HeadOnLane}`, bareMerge.scopePath);
+      const envExt = obj.extensions.find((e) => e.name === 'teambit.envs/envs');
+      expect(envExt.config.env).to.equal(envId);
+      expect(envExt.data.id).to.equal(envId);
+    });
+    it('should update the dependencies according to main', () => {
+      const comp1HeadOnLane = helper.command.getHeadOfLane(`${helper.scopes.remote}/dev`, `comp1`, bareMerge.scopePath);
+      const obj = helper.command.catComponent(`comp1@${comp1HeadOnLane}`, bareMerge.scopePath);
+      expect(obj.dependencies[0].id.name).to.equal('comp2');
+      expect(obj.dependencies[0].id.version).to.equal('0.0.2');
+      expect(obj.flattenedDependencies[0].version).to.equal('0.0.2');
+      const depsResolver = obj.extensions.find((e) => e.name === 'teambit.dependencies/dependency-resolver');
+      const comp2 = depsResolver.data.dependencies.find((d) => d.id.includes('comp2'));
+      expect(comp2.version).to.equal('0.0.2');
+    });
+    it('should save the policy and deps from policy correctly', () => {
+      const comp1HeadOnLane = helper.command.getHeadOfLane(`${helper.scopes.remote}/dev`, `comp1`, bareMerge.scopePath);
+      const obj = helper.command.catComponent(`comp1@${comp1HeadOnLane}`, bareMerge.scopePath);
+      const depsExt = obj.extensions.find((e) => e.name === 'teambit.dependencies/dependency-resolver');
+      const policy = depsExt.data.policy;
+      expect(policy).to.have.lengthOf(1);
+      expect(policy[0].dependencyId).to.equal('is-positive');
+      const isPositive = depsExt.data.dependencies.find((d) => d.id === 'is-positive');
+      expect(isPositive.source).to.equal('env');
+    });
+  });
 });

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -8,11 +8,14 @@ import { NoCommonSnap, Tmp } from '@teambit/legacy.scope';
 import { ConsumerComponent } from '@teambit/legacy.consumer-component';
 import { ImporterMain } from '@teambit/importer';
 import { Logger } from '@teambit/logger';
-import { compact } from 'lodash';
+import { compact, isEqual } from 'lodash';
 import { ComponentConfigMerger } from '@teambit/config-merger';
 import { ScopeMain } from '@teambit/scope';
 import { threeWayMerge, MergeStrategy } from './merge-version';
 import { ComponentMergeStatus, ComponentMergeStatusBeforeMergeAttempt } from './merging.main.runtime';
+import { ExtensionDataList } from '@teambit/legacy.extension-data';
+import { DependencyResolverAspect } from '@teambit/dependency-resolver';
+import { BuilderAspect } from '@teambit/builder';
 
 export type MergeStatusProviderOptions = {
   resolveUnrelated?: MergeStrategy;
@@ -21,7 +24,14 @@ export type MergeStatusProviderOptions = {
   shouldSquash?: boolean;
   handleTargetAheadAsDiverged?: boolean;
   detachHead?: boolean;
+  shouldMergeAspectsData?: boolean;
 };
+
+type ConflictedDataAspects = { [extId: string]: string }; // extId => reason
+
+export type DataMergeResult = {
+  conflictedAspects?: ConflictedDataAspects;
+}
 
 export const compIsAlreadyMergedMsg = 'component is already merged';
 export class MergeStatusProvider {
@@ -134,6 +144,9 @@ other:   ${otherLaneHead.toString()}`);
     );
     const configMergeResult = configMerger.merge();
 
+    const dataMergeResult = this.mergeExtensionsData(
+      currentComponent.extensions, baseComponent.extensions, otherComponent.extensions);
+
     const mergeResults = await threeWayMerge({
       scope: this.scope.legacyScope,
       otherComponent,
@@ -148,7 +161,67 @@ other:   ${otherLaneHead.toString()}`);
       mergeResults,
       divergeData,
       configMergeResult,
+      dataMergeResult
     };
+  }
+
+  private mergeExtensionsData(
+    currentExtensions: ExtensionDataList,
+    baseExtensions: ExtensionDataList,
+    otherExtensions: ExtensionDataList,
+  ): DataMergeResult {
+    if (!this.options.shouldMergeAspectsData) {
+      return {};
+    }
+    const conflictedAspects: { [extId: string]: string } = {}; // extId => reason
+    // these aspects handled separately
+    const aspectsToSkip = [
+      DependencyResolverAspect.id,
+      BuilderAspect.id,
+    ];
+    currentExtensions.forEach((currentExtension) => {
+      if (aspectsToSkip.includes(currentExtension.stringId)) {
+        return;
+      }
+      const baseExtension = baseExtensions.findExtension(currentExtension.idWithoutVersion , true);
+      const otherExtension = otherExtensions.findExtension(currentExtension.idWithoutVersion, true);
+      // console.log('working on ', currentExtension.stringId, baseExtension?.stringId, otherExtension?.stringId);
+      if (!otherExtension) {
+        conflictedAspects[currentExtension.stringId] = 'missing in other';
+        return;
+      }
+      // check whether the version is different.
+      if (currentExtension.extensionId?.version !== otherExtension.extensionId?.version) {
+        if (baseExtension?.extensionId?.version === otherExtension.extensionId?.version) {
+          // ext version has changed in current. we're good.
+          return;
+        }
+        conflictedAspects[currentExtension.stringId] = `version changed. base: ${baseExtension?.extensionId?.version}, other: ${otherExtension.extensionId?.version}`;
+        return;
+      }
+      if (isEqual(currentExtension.data, otherExtension.data)) return;
+      if (!baseExtension) {
+        conflictedAspects[currentExtension.stringId] = 'no base-version. conflicted in data';
+        return;
+      }
+      if (isEqual(baseExtension.data, otherExtension.data)) {
+        return; // changed in current. leave it.
+      }
+      if (isEqual(baseExtension.data, currentExtension.data)) {
+        // changed in other. copy it.
+        currentExtension.data = otherExtension.data;
+        return;
+      }
+      // changed in both. conflict.
+      conflictedAspects[currentExtension.stringId] = 'conflicted in data since base-version';
+    });
+    otherExtensions.forEach((otherExtension) => {
+      if (!currentExtensions.findExtension(otherExtension.idWithoutVersion, true)) {
+        conflictedAspects[otherExtension.stringId] = 'missing in current';
+      }
+    });
+
+    return { conflictedAspects };
   }
 
   private returnUnmerged(

--- a/scopes/component/merging/merge-status-provider.ts
+++ b/scopes/component/merging/merge-status-provider.ts
@@ -185,7 +185,6 @@ other:   ${otherLaneHead.toString()}`);
       }
       const baseExtension = baseExtensions.findExtension(currentExtension.idWithoutVersion , true);
       const otherExtension = otherExtensions.findExtension(currentExtension.idWithoutVersion, true);
-      // console.log('working on ', currentExtension.stringId, baseExtension?.stringId, otherExtension?.stringId);
       if (!otherExtension) {
         conflictedAspects[currentExtension.stringId] = 'missing in other';
         return;

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -406,6 +406,13 @@ if you're willing to lose the history from the head to the specified version, us
     if (!configObject) return;
     ExtensionDataList.adjustEnvsOnConfigObject(configObject);
     const extensionsFromConfigObject = ExtensionDataList.fromConfigObject(configObject);
+    const depsResolverFromConfig = extensionsFromConfigObject.findCoreExtension(DependencyResolverAspect.id);
+    if (depsResolverFromConfig) {
+      // @todo: merge also the scope-specific into the config here. same way we do in "addConfigDepsFromModelToConfigMerge"
+      depsResolverFromConfig.data.policy = component.state._consumer.extensions.findCoreExtension(
+        DependencyResolverAspect.id
+      )?.data.policy;
+    }
     const autoDeps = extensionsFromConfigObject.extractAutoDepsFromConfig();
     const consumerComponent: ConsumerComponent = component.state._consumer;
     const extensionDataList = ExtensionDataList.mergeConfigs([
@@ -413,7 +420,7 @@ if you're willing to lose the history from the head to the specified version, us
       consumerComponent.extensions,
     ]).filterRemovedExtensions();
     consumerComponent.extensions = extensionDataList;
-
+    // @todo: should it be copy to the aspects of the harmony components? seems like they're not in sync.
     return autoDeps;
   }
 
@@ -427,6 +434,7 @@ if you're willing to lose the history from the head to the specified version, us
       tag?: boolean;
       // in case of merging lanes, the component files are updated in-memory
       updatedLegacyComponents?: ConsumerComponent[];
+      loadAspectOnlyForIds?: ComponentIdList; // if undefined, load aspects for all components
     } & Partial<BasicTagParams>
   ): Promise<SnapFromScopeResults> {
     if (this.workspace) {
@@ -504,7 +512,6 @@ if you're willing to lose the history from the head to the specified version, us
       const foundInUpdated = updatedComponents.find((c) => c.id.isEqualWithoutVersion(id));
       return foundInUpdated || this.scope.get(id);
     }));
-
     // in case of update-dependents, align the dependencies of the dependents according to the lane
     if (params.updateDependents && laneCompIds) {
       existingComponents.forEach((comp) => {
@@ -525,7 +532,6 @@ if you're willing to lose the history from the head to the specified version, us
     await pMapSeries(components, async (component) => {
       const snapData = getSnapData(component.id);
       const autoDeps = await this.addAspectsFromConfigObject(component, snapData.aspects);
-
       // adds explicitly defined dependencies and dependencies from envs/aspects (overrides)
       await addDeps(component, snapData, this.scope, this.deps, this.dependencyResolver, this, autoDeps);
     });
@@ -544,10 +550,15 @@ if you're willing to lose the history from the head to the specified version, us
     // otherwise, when a user set a custom-env, it won't be loaded and the Version object will leave the
     // teambit.envs/envs in a weird state. the config will be set correctly but the data will be set to the default
     // node env.
-    await this.scope.loadManyCompsAspects(components);
+    const { loadAspectOnlyForIds } = params;
+    const compsToLoadAspects = loadAspectOnlyForIds
+      ? components.filter(c => loadAspectOnlyForIds.hasWithoutVersion(c.id))
+      : components;
+
+    await this.scope.loadManyCompsAspects(compsToLoadAspects);
 
     // this is similar to what happens in the workspace. the "onLoad" is running and populating the "data" of the aspects.
-    await pMapSeries(components, async (comp) => this.scope.executeOnCompAspectReCalcSlot(comp));
+    await pMapSeries(compsToLoadAspects, async (comp) => this.scope.executeOnCompAspectReCalcSlot(comp));
 
     const ids = ComponentIdList.fromArray(allCompIds);
     const shouldTag = Boolean(params.tag);

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -154,6 +154,7 @@ export class MergeLanesMain {
         mergeStrategy,
         handleTargetAheadAsDiverged: noSnap,
         detachHead,
+        shouldMergeAspectsData: true,
       },
       currentLane,
       otherLane


### PR DESCRIPTION
When merging main into a lane from scope, it has to make a new snap with 2 parents: main and lane. During the snap, we used to load aspects because when trying to avoid the aspect-loading, aspects data weren't saved correctly. 
The reason is that aspects-data gets saved on the component object during load. If aspect-loading doesn't happen, the env is not loaded and then when the component is loaded, it doesn't find the env and fallback to the default node-env.

This PR introduces a new mechanism of merging aspects-data. In case both sides: lane and main has the same env, we can simply compare the aspect-data and if there is no conflict, we can keep or copy the data as needed. 
Eventually, before snap, we check which components were merged their data properly and for them, we don't load aspects. In case of data conflicts or env changes we do load aspects.