### PR TITLE
fix(compositions): remove default viewport prop from component compositions 

### DIFF
--- a/scopes/compositions/compositions/ui/composition-preview.tsx
+++ b/scopes/compositions/compositions/ui/composition-preview.tsx
@@ -30,9 +30,6 @@ export function ComponentComposition({ composition, component, queryParams = [],
       style={{ width: '100%', height: '100%' }}
       previewName="compositions"
       queryParams={compositionParams}
-      loading={'lazy'}
-      includeEnv={false}
-      viewport={1280}
     />
   );
 }

--- a/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
+++ b/scopes/preview/ui/preview-placeholder/preview-placeholder.tsx
@@ -83,7 +83,7 @@ export function PreviewPlaceholder({
 
   return (
     <>
-      <ComponentComposition component={component} composition={selectedPreview} pubsub={false} />
+      <ComponentComposition component={component} composition={selectedPreview} pubsub={false} includeEnv={false} loading={'lazy'} viewport={1280}/>
       <div className={styles.previewOverlay} />
     </>
   );


### PR DESCRIPTION
This PR fixes a regression introduced in PR #9531, specifically where a default viewport of `1280px` was incorrectly applied to all component compositions.

The regression occurred because the viewport prop was being passed unconditionally, causing all preview renders to use `width: fit-content` and `maxWidth: 1280px`. This resulted in truncated displays in the full Preview Tab where components should expand to fill the available space.

The fix ensures that:
- Component Preview in the Preview Tab uses `width: 100%` without any maxWidth constraint
- Viewport constraints (`width: fit-content` and `maxWidth`) are only applied when viewing compositions in contained contexts like Composition Cards in the Workspace Overview grid

This restores the intended behaviour where components can properly expand to fill the Preview Tab while maintaining controlled dimensions in grid views.