### PR TITLE
fix, avoid loading @babel/core by lazy-loading JestTester from mdx env

### DIFF
--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -117,7 +117,7 @@ export class MDXMain {
           '@mdx-js/react': '1.6.22',
         },
       }),
-      react.overrideCompilerTasks([compiler.createTask('MDXCompiler', mdxCompiler)]),
+      // react.overrideCompilerTasks([compiler.createTask('MDXCompiler', mdxCompiler)]),
       envs.override({
         __getDescriptor: async () => {
           return {
@@ -126,6 +126,10 @@ export class MDXMain {
         },
       }),
     ]);
+    // don't use react.overrideCompilerTasks inside envs.compose to not get all babel/core loaded during bit bootstrap.
+    mdxEnv.getBuildPipe = () => {
+      return [compiler.createTask('MDXCompiler', mdxCompiler), ...react.reactEnv.createBuildPipeWithoutCompiler()];
+    }
     envs.registerEnv(mdxEnv);
     depResolver.registerDetector(new MDXDependencyDetector(config.extensions));
     docs.registerDocReader(new MDXDocReader(config.extensions));


### PR DESCRIPTION
Currently, `@babel/core` are loaded during bit bootstrap. Here it the relevant chain:
Mdx-aspect provider -> react.overrideCompilerTasks -> ReactEnv.getBuildPipe → ReactEnv.getJestWorker -> '@teambit/defender.jest-tester'. 
This last component is compiled by a non-lazy-loading env, and as a result, importing this component result in getting all `@babel/core`. 

Fixed by changing the method of getting the build-pipeline.
This change reduces the number of files loaded during bootstrap by 382.