### PR TITLE
perf, lazy-load component-templates

### DIFF
--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -160,3 +160,5 @@ export interface ComponentTemplate extends ComponentTemplateOptions {
    */
   config?: ComponentConfig | ((context: ConfigContext) => ComponentConfig);
 }
+
+export type GetComponentTemplates = () => ComponentTemplate[];

--- a/scopes/generator/generator/generator.main.runtime.ts
+++ b/scopes/generator/generator/generator.main.runtime.ts
@@ -20,7 +20,7 @@ import { NewComponentHelperAspect, NewComponentHelperMain } from '@teambit/new-c
 import { compact, uniq } from 'lodash';
 import { Logger, LoggerAspect, LoggerMain } from '@teambit/logger';
 import { DeprecationAspect, DeprecationMain } from '@teambit/deprecation';
-import { ComponentTemplate } from './component-template';
+import { ComponentTemplate, GetComponentTemplates } from './component-template';
 import { GeneratorAspect } from './generator.aspect';
 import { CreateCmd, CreateOptions } from './create.cmd';
 import { TemplatesCmd } from './templates.cmd';
@@ -41,7 +41,7 @@ import { GeneratorService } from './generator.service';
 import { WorkspacePathExists } from './exceptions/workspace-path-exists';
 import { GLOBAL_SCOPE } from '@teambit/legacy.constants';
 
-export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[]>;
+export type ComponentTemplateSlot = SlotRegistry<ComponentTemplate[] | GetComponentTemplates>;
 export type WorkspaceTemplateSlot = SlotRegistry<WorkspaceTemplate[]>;
 export type OnComponentCreateSlot = SlotRegistry<OnComponentCreateFn>;
 
@@ -112,8 +112,10 @@ export class GeneratorMain {
 
   /**
    * register a new component template.
+   * @param templates array of component templates or a function that returns an array of component templates.
+   * prefer to use the function to improve performance by loading the templates only when needed.
    */
-  registerComponentTemplate(templates: ComponentTemplate[]) {
+  registerComponentTemplate(templates: ComponentTemplate[] | GetComponentTemplates) {
     this.componentTemplateSlot.register(templates);
     return this;
   }
@@ -171,7 +173,10 @@ export class GeneratorMain {
    * get all component templates registered by a specific aspect ID.
    */
   getComponentTemplateByAspect(aspectId: string): ComponentTemplate[] {
-    return this.componentTemplateSlot.get(aspectId) || [];
+    const result = this.componentTemplateSlot.get(aspectId);
+    if (!result) return [];
+    if (Array.isArray(result)) return result;
+    return result();
   }
 
   /**
@@ -475,7 +480,8 @@ the reason is that after refactoring, the code will have this invalid class: "cl
   private getAllComponentTemplatesFlattened(): Array<{ id: string; template: ComponentTemplate }> {
     const templatesByAspects = this.componentTemplateSlot.toArray();
     const flattened = templatesByAspects.flatMap(([id, componentTemplates]) => {
-      return componentTemplates.map((template) => ({
+      const resolvedComponentTemplates = Array.isArray(componentTemplates) ? componentTemplates : componentTemplates();
+      return resolvedComponentTemplates.map((template) => ({
         id,
         template,
       }));
@@ -680,7 +686,7 @@ the reason is that after refactoring, the code will have this invalid class: "cl
     envs.registerService(new GeneratorService());
 
     if (generator)
-      generator.registerComponentTemplate([
+      generator.registerComponentTemplate(() => [
         componentGeneratorTemplate,
         componentGeneratorTemplateStandalone,
         starterTemplate,

--- a/scopes/generator/generator/index.ts
+++ b/scopes/generator/generator/index.ts
@@ -3,6 +3,7 @@ export type {
   ComponentContext,
   ComponentTemplate,
   ComponentTemplateOptions,
+  GetComponentTemplates,
   ComponentFile,
   ComponentConfig,
   ConfigContext,

--- a/scopes/harmony/aspect/aspect.main.runtime.ts
+++ b/scopes/harmony/aspect/aspect.main.runtime.ts
@@ -260,7 +260,7 @@ export class AspectMain {
     envs.registerEnv(aspectEnv);
     if (generator) {
       const envContext = new EnvContext(ComponentID.fromString(ReactAspect.id), loggerMain, workerMain, harmony);
-      generator.registerComponentTemplate(getTemplates(envContext));
+      generator.registerComponentTemplate(() => getTemplates(envContext));
     }
     const aspectMain = new AspectMain(aspectEnv as AspectEnv, envs, workspace, aspectLoader);
     const aspectCmd = new AspectCmd();

--- a/scopes/harmony/node/node.main.runtime.ts
+++ b/scopes/harmony/node/node.main.runtime.ts
@@ -181,7 +181,7 @@ export class NodeMain {
     application.registerAppType(nodeAppType);
     if (generator) {
       const envContext = new EnvContext(ComponentID.fromString(ReactAspect.id), loggerAspect, workerMain, harmony);
-      generator.registerComponentTemplate(getTemplates(envContext));
+      generator.registerComponentTemplate(() => getTemplates(envContext));
     }
     return new NodeMain(react, tsAspect, nodeEnv, envs);
   }

--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -131,7 +131,7 @@ export class MDXMain {
     docs.registerDocReader(new MDXDocReader(config.extensions));
     if (generator) {
       const envContext = new EnvContext(ComponentID.fromString(ReactAspect.id), loggerAspect, workerMain, harmony);
-      generator.registerComponentTemplate(getTemplates(envContext));
+      generator.registerComponentTemplate(() => getTemplates(envContext));
     }
 
     mdx.mdxEnv = mdxEnv as ReactEnv;

--- a/scopes/react/react/react.main.runtime.ts
+++ b/scopes/react/react/react.main.runtime.ts
@@ -462,7 +462,7 @@ export class ReactMain {
     envs.registerEnv(reactEnv);
     if (generator) {
       const envContext = new EnvContext(ComponentID.fromString(ReactAspect.id), loggerMain, workerMain, harmony);
-      generator.registerComponentTemplate(getTemplates(envContext));
+      generator.registerComponentTemplate(() => getTemplates(envContext));
     }
 
     if (application) application.registerAppType(appType);


### PR DESCRIPTION
Currently, many templates are loaded during Bit’s bootstrap process. This occurs because aspects call `generator.registerComponentTemplate` inside their `provider` function, which is invoked whenever the aspect is loaded.
It's addressed by changing the `registerComponentTemplate` to accept also a function that returns the templates. This way, the templates are retrieved only when needed. 
This change reduces the number of files loaded during bootstrap by 229.