### PR TITLE
refactor(mdx-env), move getBuildPipe to the envs.override

### DIFF
--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -117,19 +117,19 @@ export class MDXMain {
           '@mdx-js/react': '1.6.22',
         },
       }),
-      // react.overrideCompilerTasks([compiler.createTask('MDXCompiler', mdxCompiler)]),
       envs.override({
         __getDescriptor: async () => {
           return {
             type: 'mdx',
           };
         },
+        // don't use react.overrideCompilerTasks inside envs.compose to not get all babel/core loaded during bit bootstrap.
+        getBuildPipe: () => {
+          return [compiler.createTask('MDXCompiler', mdxCompiler), ...react.reactEnv.createBuildPipeWithoutCompiler()];
+        }
       }),
     ]);
-    // don't use react.overrideCompilerTasks inside envs.compose to not get all babel/core loaded during bit bootstrap.
-    mdxEnv.getBuildPipe = () => {
-      return [compiler.createTask('MDXCompiler', mdxCompiler), ...react.reactEnv.createBuildPipeWithoutCompiler()];
-    }
+
     envs.registerEnv(mdxEnv);
     depResolver.registerDetector(new MDXDependencyDetector(config.extensions));
     docs.registerDocReader(new MDXDocReader(config.extensions));


### PR DESCRIPTION
a minor change related to the previously merged PR: https://github.com/teambit/bit/pull/9576
