### PR TITLE
fix(export), improve error when a component was deleted and another one exported with the same name

### DIFF
--- a/components/legacy/scope/component-ops/model-components-merger.ts
+++ b/components/legacy/scope/component-ops/model-components-merger.ts
@@ -1,7 +1,7 @@
 import { logger } from '@teambit/legacy.logger';
 import { MergeConflict } from '../exceptions';
 import ComponentNeedsUpdate from '../exceptions/component-needs-update';
-import { ModelComponent } from '@teambit/objects';
+import { ModelComponent, Repository } from '@teambit/objects';
 
 /**
  * the base component to save is the existingComponent because it might contain local data that
@@ -15,7 +15,8 @@ export class ModelComponentMerger {
     private incomingComponent: ModelComponent,
     private isImport: boolean,
     private isIncomingFromOrigin: boolean, // import: incoming from original scope. export: component belong to current scope
-    private existingHeadIsMissingInIncomingComponent?: boolean // needed for export only
+    private existingHeadIsMissingInIncomingComponent?: boolean, // needed for export only
+    private repo?: Repository,
   ) {
     this.isExport = !this.isImport;
   }
@@ -26,9 +27,9 @@ export class ModelComponentMerger {
    */
   async merge(): Promise<{ mergedComponent: ModelComponent; mergedVersions: string[] }> {
     logger.debug(`model-component-merger.merge component ${this.incomingComponent.id()}`);
-    this.throwComponentNeedsUpdateIfNeeded();
+    await this.throwComponentNeedsUpdateIfNeeded();
     const locallyChanged = this.existingComponent.isLocallyChangedRegardlessOfLanes();
-    this.throwMergeConflictIfNeeded(locallyChanged);
+    await this.throwMergeConflictIfNeeded(locallyChanged);
     this.replaceTagHashIfDifferentOnIncoming();
     this.moveTagToOrphanedIfNotExistOnOrigin();
     this.addNonExistTagFromIncoming();
@@ -38,6 +39,11 @@ export class ModelComponentMerger {
     this.mergeDetachedHeads();
 
     return { mergedComponent: this.existingComponent, mergedVersions: this.mergedVersions };
+  }
+
+  private async isDeletedInOrigin() {
+    const result = this.repo && this.isExport ? await this.existingComponent.isRemoved(this.repo) : false;
+    return Boolean(result);
   }
 
   private mergeDetachedHeads() {
@@ -59,7 +65,7 @@ export class ModelComponentMerger {
     }
   }
 
-  private throwMergeConflictIfNeeded(locallyChanged: boolean) {
+  private async throwMergeConflictIfNeeded(locallyChanged: boolean) {
     if (!this.isIncomingFromOrigin) {
       return; // if it's not from origin, the tag is not going to save in "versions" anyway.
     }
@@ -68,19 +74,22 @@ export class ModelComponentMerger {
       return;
     }
     if (!this.incomingComponent.compatibleWith(this.existingComponent, this.isImport)) {
+      const isDeleted = this.existingHeadIsMissingInIncomingComponent && await this.isDeletedInOrigin();
       const conflictVersions = this.incomingComponent.diffWith(this.existingComponent, this.isImport);
-      throw new MergeConflict(this.incomingComponent.id(), conflictVersions);
+      throw new MergeConflict(this.incomingComponent.id(), conflictVersions, isDeleted);
     }
   }
 
-  private throwComponentNeedsUpdateIfNeeded() {
+  private async throwComponentNeedsUpdateIfNeeded() {
     if (
       this.isExport &&
       this.existingHeadIsMissingInIncomingComponent &&
       this.incomingComponent.compatibleWith(this.existingComponent, this.isImport) // otherwise, it should throw MergeConflict below
     ) {
+      const isDeleted = await this.isDeletedInOrigin();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      throw new ComponentNeedsUpdate(this.incomingComponent.id(), this.existingComponent.head!.toString());
+      throw new ComponentNeedsUpdate(this.incomingComponent.id(), this.existingComponent.head!.toString(), undefined,
+      isDeleted);
     }
   }
 

--- a/components/legacy/scope/exceptions/component-needs-update.ts
+++ b/components/legacy/scope/exceptions/component-needs-update.ts
@@ -1,14 +1,7 @@
 import { BitError } from '@teambit/bit-error';
 
 export default class ComponentNeedsUpdate extends BitError {
-  id: string;
-  hash: string;
-  lane?: string;
-
-  constructor(id: string, hash: string, lane?: string) {
+  constructor(readonly id: string, readonly hash: string, readonly lane?: string, readonly isDeleted = false) {
     super();
-    this.id = id;
-    this.hash = hash;
-    this.lane = lane;
   }
 }

--- a/components/legacy/scope/exceptions/merge-conflict-on-remote.ts
+++ b/components/legacy/scope/exceptions/merge-conflict-on-remote.ts
@@ -1,16 +1,32 @@
 import chalk from 'chalk';
 import { BitError } from '@teambit/bit-error';
 
-type IdAndVersions = { id: string; versions: string[] };
-type IdAndLane = { id: string; lane?: string };
+type IdAndVersions = { id: string; versions: string[], isDeleted?: boolean };
+type IdAndLane = { id: string; lane?: string, isDeleted?: boolean };
 
 export default class MergeConflictOnRemote extends BitError {
   code: number;
 
-  constructor(idsAndVersionsWithConflicts: IdAndVersions[], idsNeedUpdate: IdAndLane[]) {
+  constructor(readonly idsAndVersionsWithConflicts: IdAndVersions[], readonly idsNeedUpdate: IdAndLane[]) {
+    const deletedIds = [...idsAndVersionsWithConflicts, ...idsNeedUpdate].filter((i) => i.isDeleted).map((i) => i.id);
     let output = '';
-    if (idsAndVersionsWithConflicts.length) {
-      output += `error: versions conflict occurred when exporting the component(s) ${idsAndVersionsWithConflicts
+    if (deletedIds.length){
+      output += `error: the following component(s) were marked as deleted on the remote scope: ${deletedIds
+        .map((i) => chalk.bold(i))
+        .join(', ')}.
+the current components seem to be re-created and have a different history.
+to resolve this error, you'll need to recover the deleted components, re-do your changes, then tag/snap and export.
+here is a step-by-step guide:
+1) backup your current component to another directory.
+2) run "bit recover <component-id>". it'll restore the deleted component.
+3) re-do your changes on the restored component.
+4) run "bit tag" or "bit snap" to create a new version of the component.
+5) run "bit export" to export the new version to the remote scope.
+`;
+    }
+    const idsAndVersionsWithConflictsWithoutDeleted = idsAndVersionsWithConflicts.filter((i) => !i.isDeleted);
+    if (idsAndVersionsWithConflictsWithoutDeleted.length) {
+      output += `error: versions conflict occurred when exporting the component(s) ${idsAndVersionsWithConflictsWithoutDeleted
         .map((i) => `${chalk.bold(i.id)} (version(s): ${i.versions.join(', ')})`)
         .join(', ')} to the remote scope.
 to resolve this conflict and merge your remote and local changes, please do the following:
@@ -18,8 +34,9 @@ to resolve this conflict and merge your remote and local changes, please do the 
 2) bit checkout head [component-pattern]
 once your changes are merged with the new remote version, please tag and export a new version of the component to the remote scope.`;
     }
-    if (idsNeedUpdate.length) {
-      output += `merge error occurred when exporting the component(s) ${idsNeedUpdate
+    const idsNeedUpdateWithoutDeleted = idsNeedUpdate.filter((i) => !i.isDeleted);
+    if (idsNeedUpdateWithoutDeleted.length) {
+      output += `merge error occurred when exporting the component(s) ${idsNeedUpdateWithoutDeleted
         .map((i) => `${chalk.bold(i.id)}${i.lane ? ` (lane: ${i.lane})` : ''}`)
         .join(', ')} to the remote scope.
 to resolve this error, please re-import the above components.

--- a/components/legacy/scope/exceptions/merge-conflict.ts
+++ b/components/legacy/scope/exceptions/merge-conflict.ts
@@ -1,10 +1,14 @@
 import { BitError } from '@teambit/bit-error';
 
 export default class MergeConflict extends BitError {
-  id: string;
-  versions: string[];
-
-  constructor(id: string, versions: string[]) {
+  constructor(
+    readonly id: string,
+    readonly versions: string[],
+    /**
+     * this prop is relevant only for export.
+     */
+    readonly isDeleted = false
+  ) {
     super(`error: versions conflict occurred while importing the component ${id}. conflict version(s): ${versions.join(
       ', '
     )}
@@ -13,7 +17,5 @@ to resolve it and merge your local and remote changes, please do the following:
 2) bit import
 3) bit checkout head ${id}
 once your changes are merged with the new remote version, you can tag and export a new version of the component to the remote scope.`);
-    this.id = id;
-    this.versions = versions;
   }
 }

--- a/components/legacy/scope/repositories/sources.ts
+++ b/components/legacy/scope/repositories/sources.ts
@@ -515,7 +515,8 @@ please either remove the component (bit remove) or remove the lane.`);
       incomingComp,
       false,
       isIncomingFromOrigin,
-      existingHeadIsMissingInIncomingComponent
+      existingHeadIsMissingInIncomingComponent,
+      this.scope.objects
     );
     const { mergedComponent, mergedVersions } = await modelComponentMerger.merge();
     if (existingComponentHead || mergedComponent.hasHead()) {

--- a/e2e/harmony/delete.e2e.ts
+++ b/e2e/harmony/delete.e2e.ts
@@ -290,4 +290,25 @@ describe('bit delete command', function () {
       expect(bitmap.comp1).to.deep.equal(bitmapEntryBefore);
     });
   });
+  describe('deleting component then creating a new one with the same name', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.command.softRemoveComponent('comp1');
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitLocalScope();
+      helper.scopeHelper.addRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+    });
+    it('should throw a descriptive error', () => {
+      const err = helper.general.runWithTryCatch('bit export');
+      expect(err).to.include('were marked as deleted on the remote scope');
+    });
+  });
 });

--- a/scopes/scope/export/export-scope-components.ts
+++ b/scopes/scope/export/export-scope-components.ts
@@ -226,10 +226,11 @@ export async function mergeObjects(
   ] as ComponentNeedsUpdate[];
   const componentsWithConflicts = errors.filter((result) => result instanceof MergeConflict) as MergeConflict[];
   if (componentsWithConflicts.length || componentsNeedUpdate.length) {
-    const idsAndVersions = componentsWithConflicts.map((c) => ({ id: c.id, versions: c.versions }));
+    const idsAndVersions = componentsWithConflicts.map((c) => ({ id: c.id, versions: c.versions,
+      isDeleted: c.isDeleted }));
     const idsAndVersionsWithConflicts = sortBy(idsAndVersions, property('id'));
     const idsOfNeedUpdateComps = sortBy(
-      componentsNeedUpdate.map((c) => ({ id: c.id, lane: c.lane })),
+      componentsNeedUpdate.map((c) => ({ id: c.id, lane: c.lane, isDeleted: c.isDeleted })),
       property('id')
     );
     scope.objects.clearObjectsFromCache(); // just in case this error is caught. we don't want to persist anything by mistake.

--- a/scopes/scope/network/remote-error-handler.ts
+++ b/scopes/scope/network/remote-error-handler.ts
@@ -22,9 +22,11 @@ export function remoteErrorHandler(code: number, parsedError: Record<string, any
     case 130:
       return new PermissionDenied(remotePath);
     case 131: {
-      const idsWithConflicts = parsedError && parsedError.idsAndVersions ? parsedError.idsAndVersions : [];
+      const idsAndVersionsWithConflicts = parsedError && parsedError.idsAndVersionsWithConflicts
+        ? parsedError.idsAndVersionsWithConflicts
+        : [];
       const idsNeedUpdate = parsedError && parsedError.idsNeedUpdate ? parsedError.idsNeedUpdate : [];
-      return new MergeConflictOnRemote(idsWithConflicts, idsNeedUpdate);
+      return new MergeConflictOnRemote(idsAndVersionsWithConflicts, idsNeedUpdate);
     }
     case 132:
       return new CustomError(parsedError && parsedError.message ? parsedError.message : err);


### PR DESCRIPTION
Currently it shows merge-conflict or out-of-date errors, which are misleading. 