### PR TITLE
refactor(mdx-env), move the implementation into MdxEnv class instead of patching it from the main runtime

### DIFF
--- a/scopes/mdx/mdx/mdx.env.ts
+++ b/scopes/mdx/mdx/mdx.env.ts
@@ -1,7 +1,76 @@
 import { Environment } from '@teambit/envs';
+import { ReactMain } from '@teambit/react';
+import { BabelCompiler } from '@teambit/compilation.babel-compiler';
+import { TypescriptConfigMutator } from '@teambit/typescript.modules.ts-config-mutator';
+import { TsConfigTransformer } from '@teambit/typescript';
+import { babelConfig } from './babel/babel.config';
+import { Logger } from '@teambit/logger';
+import { MultiCompilerMain } from '@teambit/multi-compiler';
+import { CompilerMain } from '@teambit/compiler';
+import { DocsMain } from '@teambit/docs';
+import { MDXAspect } from './mdx.aspect';
+import { MDXCompiler, MDXCompilerOpts } from './mdx.compiler';
 
 export const MdxEnvType = 'mdx';
 
 export class MdxEnv implements Environment {
-  // TODO: add the env here properly.
+  constructor(private react: ReactMain, private logger: Logger,
+    private multiCompiler: MultiCompilerMain, private compiler: CompilerMain, private docs: DocsMain){}
+  getCompiler() {
+    const tsTransformer: TsConfigTransformer = (tsconfig: TypescriptConfigMutator) => {
+      // set the shouldCopyNonSupportedFiles to false since we don't want ts to copy the .mdx file to the dist folder (it will conflict with the .mdx.js file created by the mdx compiler)
+      tsconfig.setCompileJs(false).setCompileJsx(false).setShouldCopyNonSupportedFiles(false);
+      return tsconfig;
+    };
+    const tsCompiler = this.react.env.getCompiler([tsTransformer]);
+
+    const babelCompiler = BabelCompiler.create(
+      {
+        babelTransformOptions: babelConfig,
+        // set the shouldCopyNonSupportedFiles to false since we don't want babel to copy the .mdx file to the dist
+        // folder (it will conflict with the .mdx.js file created by the mdx compiler)
+        shouldCopyNonSupportedFiles: false,
+      },
+      { logger: this.logger }
+    );
+
+
+    return this.multiCompiler.createCompiler(
+      [
+        babelCompiler,
+        this.createMdxCompiler({ ignoredPatterns: this.docs.getPatterns(), babelTransformOptions: babelConfig }),
+        tsCompiler,
+      ],
+      {}
+    );
+  }
+
+  getBuildPipe() {
+    const mdxCompiler = this.getCompiler();
+    return [this.compiler.createTask('MDXCompiler', mdxCompiler), ...this.react.reactEnv.createBuildPipeWithoutCompiler()];
+  }
+
+  async getDependencies() {
+    return {
+      ...this.react.reactEnv.getDependencies(),
+      dependencies: {
+        '@teambit/mdx.ui.mdx-scope-context': '1.0.0',
+        '@mdx-js/react': '1.6.22',
+      },
+    };
+  }
+
+  /**
+   * create an instance of the MDX compiler.
+   */
+  createMdxCompiler(opts: MDXCompilerOpts = {}) {
+    const mdxCompiler = new MDXCompiler(MDXAspect.id, opts);
+    return mdxCompiler;
+  }
+
+  async __getDescriptor() {
+    return {
+      type: 'mdx',
+    };
+  }
 }

--- a/scopes/mdx/mdx/mdx.env.ts
+++ b/scopes/mdx/mdx/mdx.env.ts
@@ -1,4 +1,5 @@
 import { Environment } from '@teambit/envs';
+import { merge } from 'lodash';
 import { ReactMain } from '@teambit/react';
 import { BabelCompiler } from '@teambit/compilation.babel-compiler';
 import { TypescriptConfigMutator } from '@teambit/typescript.modules.ts-config-mutator';
@@ -51,13 +52,13 @@ export class MdxEnv implements Environment {
   }
 
   async getDependencies() {
-    return {
-      ...this.react.reactEnv.getDependencies(),
+    const mdxDeps = {
       dependencies: {
         '@teambit/mdx.ui.mdx-scope-context': '1.0.0',
         '@mdx-js/react': '1.6.22',
       },
     };
+    return merge(this.react.reactEnv.getDependencies(), mdxDeps);
   }
 
   /**

--- a/scopes/mdx/mdx/mdx.main.runtime.ts
+++ b/scopes/mdx/mdx/mdx.main.runtime.ts
@@ -1,7 +1,4 @@
 import { Harmony } from '@teambit/harmony';
-import { BabelCompiler } from '@teambit/compilation.babel-compiler';
-import { TypescriptConfigMutator } from '@teambit/typescript.modules.ts-config-mutator';
-import { TsConfigTransformer } from '@teambit/typescript';
 import { MainRuntime } from '@teambit/cli';
 import { CompilerAspect, CompilerMain } from '@teambit/compiler';
 import { DependencyResolverAspect, DependencyResolverMain } from '@teambit/dependency-resolver';
@@ -14,11 +11,11 @@ import { MultiCompilerAspect, MultiCompilerMain } from '@teambit/multi-compiler'
 import { ReactAspect, ReactEnv, ReactMain } from '@teambit/react';
 import { GeneratorAspect, GeneratorMain } from '@teambit/generator';
 import { MDXAspect } from './mdx.aspect';
-import { MDXCompiler, MDXCompilerOpts } from './mdx.compiler';
+import { MDXCompilerOpts } from './mdx.compiler';
 import { MDXDependencyDetector } from './mdx.detector';
 import { MDXDocReader } from './mdx.doc-reader';
 import { getTemplates } from './mdx.templates';
-import { babelConfig } from './babel/babel.config';
+import { MdxEnv } from './mdx.env';
 
 export type MDXConfig = {
   /**
@@ -36,15 +33,14 @@ export class MDXMain {
    * create an instance of the MDX compiler.
    */
   createCompiler(opts: MDXCompilerOpts = {}) {
-    const mdxCompiler = new MDXCompiler(MDXAspect.id, opts);
-    return mdxCompiler;
+    return this.mdxEnv.createMdxCompiler(opts);
   }
 
-  _mdxEnv: ReactEnv;
+  _mdxEnv: MdxEnv;
   get mdxEnv() {
     return this._mdxEnv;
   }
-  private set mdxEnv(value: ReactEnv) {
+  private set mdxEnv(value: MdxEnv) {
     this._mdxEnv = value;
   }
 
@@ -83,52 +79,10 @@ export class MDXMain {
     harmony: Harmony
   ) {
     const mdx = new MDXMain();
-    const tsTransformer: TsConfigTransformer = (tsconfig: TypescriptConfigMutator) => {
-      // set the shouldCopyNonSupportedFiles to false since we don't want ts to copy the .mdx file to the dist folder (it will conflict with the .mdx.js file created by the mdx compiler)
-      tsconfig.setCompileJs(false).setCompileJsx(false).setShouldCopyNonSupportedFiles(false);
-      return tsconfig;
-    };
-    const tsCompiler = react.env.getCompiler([tsTransformer]);
     const logger = loggerAspect.createLogger(MDXAspect.id);
 
-    const babelCompiler = BabelCompiler.create(
-      {
-        babelTransformOptions: babelConfig,
-        // set the shouldCopyNonSupportedFiles to false since we don't want babel to copy the .mdx file to the dist
-        // folder (it will conflict with the .mdx.js file created by the mdx compiler)
-        shouldCopyNonSupportedFiles: false,
-      },
-      { logger }
-    );
-
-    const mdxCompiler = multiCompiler.createCompiler(
-      [
-        babelCompiler,
-        mdx.createCompiler({ ignoredPatterns: docs.getPatterns(), babelTransformOptions: babelConfig }),
-        tsCompiler,
-      ],
-      {}
-    );
-    const mdxEnv = envs.compose(react.reactEnv, [
-      react.overrideCompiler(mdxCompiler),
-      react.overrideDependencies({
-        dependencies: {
-          '@teambit/mdx.ui.mdx-scope-context': '1.0.0',
-          '@mdx-js/react': '1.6.22',
-        },
-      }),
-      envs.override({
-        __getDescriptor: async () => {
-          return {
-            type: 'mdx',
-          };
-        },
-        // don't use react.overrideCompilerTasks inside envs.compose to not get all babel/core loaded during bit bootstrap.
-        getBuildPipe: () => {
-          return [compiler.createTask('MDXCompiler', mdxCompiler), ...react.reactEnv.createBuildPipeWithoutCompiler()];
-        }
-      }),
-    ]);
+    const mdxEnv = envs.merge<MdxEnv, ReactEnv>(new MdxEnv(react,
+      logger, multiCompiler, compiler, docs), react.reactEnv);
 
     envs.registerEnv(mdxEnv);
     depResolver.registerDetector(new MDXDependencyDetector(config.extensions));
@@ -138,7 +92,7 @@ export class MDXMain {
       generator.registerComponentTemplate(() => getTemplates(envContext));
     }
 
-    mdx.mdxEnv = mdxEnv as ReactEnv;
+    mdx.mdxEnv = mdxEnv;
     return mdx;
   }
 }


### PR DESCRIPTION
Because the env implementation was inside the provider, it had to create the compilers and do heavy stuff to make the env ready. In hurts performance by adding 341 files every time bit is loaded. 