### PR TITLE
perf, complete the graphql lazy-load by fixing another instance in workspace aspect

### DIFF
--- a/scopes/workspace/workspace/workspace.main.runtime.ts
+++ b/scopes/workspace/workspace/workspace.main.runtime.ts
@@ -258,12 +258,11 @@ export class WorkspaceMain {
       };
     });
 
-    const workspaceSchema = getWorkspaceSchema(workspace, graphql);
     ui.registerUiRoot(new WorkspaceUIRoot(workspace, bundler));
     ui.registerPreStart(async () => {
       return workspace.setComponentPathsRegExps();
     });
-    graphql.register(() => workspaceSchema);
+    graphql.register(() => getWorkspaceSchema(workspace, graphql));
     const capsuleCmd = getCapsulesCommands(isolator, scope, workspace);
     const commands: CommandList = [
       new EjectConfCmd(workspace),


### PR DESCRIPTION
This is a follow-up to a previously merged PR: https://github.com/teambit/bit/pull/9588.

One instance was missed and has been fixed here, increasing the number of files saved during loading by an additional 131. This brings the total file reduction to 189!