### PR TITLE
perf, lazy-load Mutex

### DIFF
--- a/components/legacy/scope/lanes/remote-lanes.ts
+++ b/components/legacy/scope/lanes/remote-lanes.ts
@@ -19,9 +19,15 @@ export class RemoteLanes {
   basePath: string;
   private remotes: { [remoteName: string]: Lanes } = {};
   private changed: { [remoteName: string]: { [laneName: string]: boolean } } = {};
-  writeMutex = new Mutex();
+  private _writeMutex?: Mutex;
   constructor(scopePath: string) {
     this.basePath = path.join(scopePath, REMOTE_REFS_DIR);
+  }
+  get writeMutex() {
+    if (!this._writeMutex) {
+      this._writeMutex = new Mutex();
+    }
+    return this._writeMutex;
   }
   async addEntry(remoteLaneId: LaneId, componentId: ComponentID, head?: Ref) {
     if (!remoteLaneId) throw new TypeError('addEntry expects to get remoteLaneId');

--- a/scopes/scope/objects/models/model-component.ts
+++ b/scopes/scope/objects/models/model-component.ts
@@ -142,7 +142,7 @@ export default class Component extends BitObject {
   schema: string | undefined;
   detachedHeads: DetachedHeads;
   private divergeData?: SnapsDistance;
-  private populateVersionHistoryMutex = new Mutex();
+  private _populateVersionHistoryMutex?: Mutex;
   constructor(props: ComponentProps) {
     super();
     if (!props.name) throw new TypeError('Model Component constructor expects to get a name parameter');
@@ -161,6 +161,13 @@ export default class Component extends BitObject {
     this.head = props.head;
     this.schema = props.schema;
     this.detachedHeads = props.detachedHeads || new DetachedHeads();
+  }
+
+  private get populateVersionHistoryMutex() {
+    if (!this._populateVersionHistoryMutex) {
+      this._populateVersionHistoryMutex = new Mutex();
+    }
+    return this._populateVersionHistoryMutex;
   }
 
   get versionArray(): Ref[] {

--- a/scopes/scope/objects/objects/repository.ts
+++ b/scopes/scope/objects/objects/repository.ts
@@ -44,13 +44,20 @@ export default class Repository {
   protected cache: InMemoryCache<BitObject>;
   remoteLanes!: RemoteLanes;
   unmergedComponents!: UnmergedComponents;
-  persistMutex = new Mutex();
+  _persistMutex?:  Mutex;
   constructor(scopePath: string, scopeJson: ScopeJson) {
     this.scopePath = scopePath;
     this.scopeJson = scopeJson;
     this.onRead = onRead(scopePath, scopeJson);
     this.onPersist = onPersist(scopePath, scopeJson);
     this.cache = createInMemoryCache({ maxSize: getMaxSizeForObjects() });
+  }
+
+  get persistMutex() {
+    if (!this._persistMutex) {
+      this._persistMutex = new Mutex();
+    }
+    return this._persistMutex;
   }
 
   static async load({ scopePath, scopeJson }: { scopePath: string; scopeJson: ScopeJson }): Promise<Repository> {

--- a/scopes/scope/objects/objects/scope-index.ts
+++ b/scopes/scope/objects/objects/scope-index.ts
@@ -57,10 +57,16 @@ type Index = { [IndexType.components]: ComponentItem[]; [IndexType.lanes]: LaneI
 export class ScopeIndex {
   indexPath: string;
   index: Index;
-  writeIndexMutex = new Mutex();
+  _writeIndexMutex?: Mutex;
   constructor(indexPath: string, index: Index = { [IndexType.components]: [], [IndexType.lanes]: [] }) {
     this.indexPath = indexPath;
     this.index = index;
+  }
+  get writeIndexMutex() {
+    if (!this._writeIndexMutex) {
+      this._writeIndexMutex = new Mutex();
+    }
+    return this._writeIndexMutex;
   }
   static async load(basePath: string): Promise<ScopeIndex> {
     const indexPath = this._composePath(basePath);


### PR DESCRIPTION
In classes where the Mutex object were initialized in the constructor, it was moved to a getter function.