### PR TITLE
debug, add an option to debug filesystem read during bit-commands

### DIFF
--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -107,20 +107,22 @@ export default class CommandHelper {
     cwd: string = this.scopes.localPath,
     stdio: StdioOptions = 'pipe',
     overrideFeatures?: string,
-    getStderrAsPartOfTheOutput = false // needed to get Jest output as they write to the stderr for some reason. see https://github.com/facebook/jest/issues/5064
+    getStderrAsPartOfTheOutput = false, // needed to get Jest output as they write to the stderr for some reason. see https://github.com/facebook/jest/issues/5064
+    envVariables?: Record<string, string>
   ): string {
     if (this.debugMode) console.log(rightpad(chalk.green('cwd: '), 20, ' '), cwd); // eslint-disable-line no-console
     const isBitCommand = cmd.startsWith('bit ');
     if (isBitCommand) cmd = cmd.replace('bit', this.bitBin);
     const featuresTogglePrefix = isBitCommand ? this._getFeatureToggleCmdPrefix(overrideFeatures) : '';
     const cmdWithFeatures = featuresTogglePrefix + cmd;
+    const env = envVariables ? { ...process.env, ...envVariables } : undefined;
     if (this.debugMode) console.log(rightpad(chalk.green('command: '), 20, ' '), cmdWithFeatures); // eslint-disable-line no-console
     // `spawnSync` gets the data from stderr, `shell: true` is needed for Windows to get the output.
     const cmdOutput = getStderrAsPartOfTheOutput
       ? childProcess
-          .spawnSync(cmd.split(' ')[0], cmd.split(' ').slice(1), { cwd, stdio, shell: true })
+          .spawnSync(cmd.split(' ')[0], cmd.split(' ').slice(1), { cwd, stdio, shell: true, env })
           .output.toString()
-      : childProcess.execSync(cmdWithFeatures, { cwd, stdio, maxBuffer: EXEC_SYNC_MAX_BUFFER });
+      : childProcess.execSync(cmdWithFeatures, { cwd, stdio, maxBuffer: EXEC_SYNC_MAX_BUFFER, env });
     if (this.debugMode) console.log(rightpad(chalk.green('output: '), 20, ' '), chalk.cyan(cmdOutput.toString())); // eslint-disable-line no-console
     return cmdOutput.toString();
   }

--- a/e2e/performance/filesystem-read.e2e.ts
+++ b/e2e/performance/filesystem-read.e2e.ts
@@ -1,10 +1,14 @@
+/* eslint no-console: 0 */
+
 import { expect } from 'chai';
 import { Helper } from '@teambit/legacy.e2e-helper';
 
 const MAX_FILES_READ = 1050;
+const MAX_FILES_READ_STATUS = 1500;
 
 /**
  * as of now (2025/03/03) 1,030 files are loaded during bit-bootstrap.
+ * for "bit status", around 1,433 files are loaded.
  *
  * two weeks ago we were at 2,964 files. a few PRs helped to reduce the number of files. among them:
  * #9568, #9572, #9576, #9577, #9578, #9584, #9587, #9588, #9590, #9593, #9594, #9598.
@@ -20,21 +24,45 @@ describe('Filesystem read count', function () {
     helper.scopeHelper.destroy();
   });
   describe('basic commands', () => {
-    before(() => {
-      helper.scopeHelper.setNewLocalAndRemoteScopes();
+    describe('bit --help', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+      });
+      it('should not exceed a reasonable file-count number', () => {
+        const output = helper.command.runCmd('bit --help', undefined, undefined, undefined, undefined, { 'BIT_DEBUG_READ_FILE': 'true' });
+        expect(output).to.have.string('0');
+        expect(output).to.have.string('package.json');
+        expect(output).to.have.string('node_modules');
+        expect(output).to.not.have.string(`#${MAX_FILES_READ}`);
+      });
+      it('should take less than a second to run bit --help', () => {
+        const start = process.hrtime();
+        helper.command.runCmd('bit --help');
+        const [timeInSeconds, nanoseconds] = process.hrtime(start);
+        expect(timeInSeconds).to.be.lessThan(1);
+        const timeInMs = timeInSeconds * 1000 + nanoseconds / 1_000_000;
+        // On my Mac M1, as of 2025/03/03, it takes 312ms.
+        console.log('bit --help load time in milliseconds: ', Math.floor(timeInMs));
+      });
     });
-    it('should not exceed a reasonable file-count number', () => {
-      const output = helper.command.runCmd('bit --help', undefined, undefined, undefined, undefined, { 'BIT_DEBUG_READ_FILE': 'true' });
-      expect(output).to.have.string('0');
-      expect(output).to.have.string('package.json');
-      expect(output).to.have.string('node_modules');
-      expect(output).to.not.have.string(`#${MAX_FILES_READ}`);
-    });
-    it('should take less than a second to run bit --help', () => {
-      const start = process.hrtime();
-      helper.command.runCmd('bit --help');
-      const [timeInSeconds] = process.hrtime(start);
-      expect(timeInSeconds).to.be.lessThan(1);
+    describe('bit status', () => {
+      before(() => {
+        helper.scopeHelper.setNewLocalAndRemoteScopes();
+        helper.fixtures.populateComponents(1);
+      });
+      it('should not exceed a reasonable file-count number', () => {
+        const output = helper.command.runCmd('bit status', undefined, undefined, undefined, undefined, { 'BIT_DEBUG_READ_FILE': 'true' });
+        expect(output).to.not.have.string(`#${MAX_FILES_READ_STATUS}`);
+      });
+      it('should take less than 2 seconds', () => {
+        const start = process.hrtime();
+        helper.command.runCmd('bit status');
+        const [timeInSeconds, nanoseconds] = process.hrtime(start);
+        expect(timeInSeconds).to.be.lessThan(2);
+        const timeInMs = timeInSeconds * 1000 + nanoseconds / 1_000_000;
+        // On my Mac M1, as of 2025/03/03, it takes 500ms.
+        console.log('bit status load time in milliseconds: ', Math.floor(timeInMs));
+      });
     });
   });
 });

--- a/e2e/performance/filesystem-read.e2e.ts
+++ b/e2e/performance/filesystem-read.e2e.ts
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+const MAX_FILES_READ = 1050;
+
+/**
+ * as of now (2025/03/03) 1,030 files are loaded during bit-bootstrap.
+ *
+ * two weeks ago we were at 2,964 files. a few PRs helped to reduce the number of files. among them:
+ * #9568, #9572, #9576, #9577, #9578, #9584, #9587, #9588, #9590, #9593, #9594, #9598.
+ * it can be helpful to take a look into those PRs in the future in case the number grows.
+ */
+describe('Filesystem read count', function () {
+  this.timeout(0);
+  let helper: Helper;
+  before(() => {
+    helper = new Helper();
+  });
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+  describe('basic commands', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+    });
+    it('should not exceed a reasonable file-count number', () => {
+      const output = helper.command.runCmd('bit --help', undefined, undefined, undefined, undefined, { 'BIT_DEBUG_READ_FILE': 'true' });
+      expect(output).to.have.string('0');
+      expect(output).to.have.string('package.json');
+      expect(output).to.have.string('node_modules');
+      expect(output).to.not.have.string(`#${MAX_FILES_READ}`);
+    });
+    it('should take less than a second to run bit --help', () => {
+      const start = process.hrtime();
+      helper.command.runCmd('bit --help');
+      const [timeInSeconds] = process.hrtime(start);
+      expect(timeInSeconds).to.be.lessThan(1);
+    });
+  });
+});

--- a/scopes/harmony/bit/app.ts
+++ b/scopes/harmony/bit/app.ts
@@ -6,6 +6,8 @@ process.on('uncaughtException', (err) => {
 });
 
 import fs from 'fs';
+consoleFileReadUsages();
+
 import gracefulFs from 'graceful-fs';
 // monkey patch fs module to avoid EMFILE error (especially when running watch operation)
 gracefulFs.gracefulify(fs);
@@ -44,5 +46,32 @@ async function initApp() {
   } catch (err: any) {
     const originalError = err.originalError || err;
     await handleErrorAndExit(originalError, process.argv[2]);
+  }
+}
+
+function consoleFileReadUsages() {
+  if (!process.env.BIT_DEBUG_READ_FILE) {
+    return;
+  }
+  let numR = 0;
+  const print = (filename: string) => {
+    // eslint-disable-next-line no-console
+    console.log(`#${numR}`, filename);
+  }
+  const originalReadFile = fs.readFile;
+  const originalReadFileSync = fs.readFileSync;
+  // @ts-ignore
+  fs.readFile = (...args) => {
+    numR++;
+    print(args[0]);
+    // @ts-ignore
+    return originalReadFile(...args);
+  }
+
+  fs.readFileSync = (...args) => {
+    numR++;
+    print(args[0]);
+    // @ts-ignore
+    return originalReadFileSync(...args);
   }
 }


### PR DESCRIPTION
Also, add an e2e-test to ensure the number of files loaded during bit are kept reasonable