### PR TITLE
fix(graph), fix getSchemas API to always return Schema[]

### DIFF
--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -87,21 +87,24 @@ export class GraphqlMain {
   /**
    * returns the schema for a specific aspect by its id.
    */
-  getSchema(aspectId: string) {
-    return this.moduleSlot.get(aspectId);
+  getSchema(aspectId: string): Schema | undefined {
+    const schemaOrFunc = this.moduleSlot.get(aspectId);
+    if (!schemaOrFunc) return undefined;
+    const schema = typeof schemaOrFunc === 'function' ? schemaOrFunc() : schemaOrFunc;
+    return schema;
   }
 
   /**
    * get multiple schema by aspect ids.
    */
-  getSchemas(aspectIds: string[]) {
+  getSchemas(aspectIds: string[]): Schema[] {
     return this.moduleSlot
       .toArray()
       .filter(([aspectId]) => {
         return aspectIds.includes(aspectId);
       })
-      .map(([, schema]) => {
-        return schema;
+      .map(([, schemaOrFunc]) => {
+        return typeof schemaOrFunc === 'function' ? schemaOrFunc() : schemaOrFunc;
       });
   }
 

--- a/scopes/harmony/graphql/graphql.main.runtime.ts
+++ b/scopes/harmony/graphql/graphql.main.runtime.ts
@@ -96,6 +96,7 @@ export class GraphqlMain {
 
   /**
    * get multiple schema by aspect ids.
+   * used by the cloud.
    */
   getSchemas(aspectIds: string[]): Schema[] {
     return this.moduleSlot

--- a/scopes/harmony/graphql/graphql.spec.ts
+++ b/scopes/harmony/graphql/graphql.spec.ts
@@ -1,0 +1,39 @@
+import chai, { expect } from 'chai';
+import { loadManyAspects } from '@teambit/harmony.testing.load-aspect';
+import { WorkspaceAspect } from '@teambit/workspace';
+import { mockWorkspace, destroyWorkspace, WorkspaceData } from '@teambit/workspace.testing.mock-workspace';
+import { GraphqlAspect } from './graphql.aspect';
+import { GraphqlMain } from './graphql.main.runtime';
+import { LanesAspect } from '@teambit/lanes';
+
+chai.use(require('chai-fs'));
+
+describe('GraphQL Aspect', function () {
+  this.timeout(0);
+
+  describe('getSchemas and getSchema APIs', () => {
+    let graphql: GraphqlMain;
+    let workspaceData: WorkspaceData;
+    before(async () => {
+      workspaceData = mockWorkspace();
+      const { workspacePath } = workspaceData;
+      const harmony = await loadManyAspects([WorkspaceAspect, GraphqlAspect, LanesAspect], workspacePath);
+      graphql = harmony.get<GraphqlMain>(GraphqlAspect.id);
+    });
+    after(async () => {
+      await destroyWorkspace(workspaceData);
+    });
+    it('should bring the schemas when calling getSchemas API', async () => {
+      const schemas = graphql.getSchemas([LanesAspect.id]);
+      expect(schemas).to.be.an('array');
+      expect(schemas).to.have.lengthOf(1);
+      expect(schemas[0]).to.be.an('object');
+      expect(schemas[0]).to.not.be.an('function');
+    });
+    it('should bring the schemas when calling getSchema API', async () => {
+      const schema = graphql.getSchema(LanesAspect.id);
+      expect(schema).to.be.an('object');
+      expect(schema).to.not.be.an('function');
+    });
+  });
+});


### PR DESCRIPTION
This regression was introduced by #9588. The `register` method allows a function to return a schema, but the getSchemas method was not updated to support this change.