### PR TITLE
revert #9601 for backward compatibility of old scopes

### DIFF
--- a/scopes/scope/objects/models/version.ts
+++ b/scopes/scope/objects/models/version.ts
@@ -430,8 +430,8 @@ export default class Version extends BitObject {
   }
   static flattenedEdgeToSource(flattenedEdges?: DepEdge[]): Source | undefined {
     if (!flattenedEdges) return undefined;
-    const flattenedEdgesObj = flattenedEdges.map((f) => Version.depEdgeToArray(f));
-    // const flattenedEdgesObj = flattenedEdges.map((f) => Version.depEdgeToObject(f));
+    // const flattenedEdgesObj = flattenedEdges.map((f) => Version.depEdgeToArray(f));
+    const flattenedEdgesObj = flattenedEdges.map((f) => Version.depEdgeToObject(f));
     const flattenedEdgesBuffer = Buffer.from(JSON.stringify(flattenedEdgesObj));
     return Source.from(flattenedEdgesBuffer);
   }


### PR DESCRIPTION
Some of the remote scopes have a version older than 1.6.97, which doesn't support the new format. We'll wait until all of them are updated to re-do this change.