### PR TITLE
improvement(create), provide an infra for interactive templates

### DIFF
--- a/scopes/generator/generator/component-template.ts
+++ b/scopes/generator/generator/component-template.ts
@@ -52,6 +52,10 @@ export interface BaseComponentTemplateOptions {
    * namespace of the component.
    */
   namespace?: string;
+  /**
+   * when a template implements the promptOptions function, this object will be populated with the user responses.
+   */
+  promptResults?: PromptResults;
 }
 
 /**
@@ -143,8 +147,37 @@ export interface ComponentTemplateOptions {
   installMissingDependencies?: boolean;
 }
 
+/**
+ * PromptOption is shown to the user before calling the generateFiles function.
+ * The prompt is using enquirer under the hood. see https://www.npmjs.com/package/enquirer.
+ * Examples:
+ * - input: {name: 'name', message: 'enter your name', type: 'input'}
+ * - confirm: {name: 'isHappy', message: 'are you happy?', type: 'confirm'}
+ * - select: {name: 'color', message: 'pick a color', type: 'select', choices: ['red', 'blue', 'green']}
+ */
+export type PromptOption = {
+  name: string;
+  message: string;
+  type: 'input' | 'confirm' | 'select';
+  choices?: string[]; // for select type
+  skip?: (previousResults: PromptResults) => boolean; // skip this prompt if this function returns true
+}
+
+/**
+ * PromptResults is the result of the user input received from the promptOptions.
+ * The key is the name of the prompt option and the value is the user input.
+ * in case the prompt-option is of type 'confirm', the value will be a boolean.
+ */
+export type PromptResults = Record<string, string | boolean>;
+
 export interface ComponentTemplate extends ComponentTemplateOptions {
   name: string;
+
+  /**
+   * in case the template requires user input, this function will be called to prompt the user.
+   * the results will be passed to the generateFiles function.
+   */
+  promptOptions?: () => PromptOption[];
 
   /**
    * template function for generating the file of a certain component.,

--- a/scopes/generator/generator/index.ts
+++ b/scopes/generator/generator/index.ts
@@ -7,6 +7,8 @@ export type {
   ComponentFile,
   ComponentConfig,
   ConfigContext,
+  PromptOption,
+  PromptResults,
 } from './component-template';
 export type {
   WorkspaceContext,

--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -13,7 +13,7 @@ import { ApplyVersionResults } from '@teambit/merging';
 import { ComponentLogMain, FileHashDiffFromParent } from '@teambit/component-log';
 import { LaneLog } from '@teambit/objects';
 import { ComponentCompareMain } from '@teambit/component-compare';
-import { GeneratorMain } from '@teambit/generator';
+import { GeneratorMain, PromptOption, PromptResults } from '@teambit/generator';
 import { getParsedHistoryMetadata } from '@teambit/legacy.consumer';
 import { RemovedObjects } from '@teambit/legacy.scope';
 import { RemoveMain } from '@teambit/remove';
@@ -423,7 +423,12 @@ export class APIForIDE {
     return templates;
   }
 
-  async createComponent(templateName: string, idIncludeScope: string) {
+  async getPromptOptionsForTemplate(templateName: string): Promise<PromptOption[] | undefined> {
+    const template = await this.generator.getTemplateWithId(templateName);
+    return template.template.promptOptions?.();
+  }
+
+  async createComponent(templateName: string, idIncludeScope: string, promptResults?: PromptResults) {
     if (!idIncludeScope.includes('/')) {
       throw new Error('id should include the scope name');
     }
@@ -432,7 +437,8 @@ export class APIForIDE {
       [nameSplit.join('/')],
       templateName,
       { scope },
-      { optimizeReportForNonTerminal: true }
+      { optimizeReportForNonTerminal: true },
+      promptResults
     );
   }
 

--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -407,7 +407,7 @@
         "doctrine": "2.1.0",
         "dreidels": "0.6.1",
         "enhanced-resolve": "4.5.0",
-        "enquirer": "2.3.6",
+        "enquirer": "2.4.1",
         "eslint": "8.56.0",
         "eslint-config-airbnb-typescript": "17.1.0",
         "eslint-config-prettier": "8.5.0",


### PR DESCRIPTION
## Proposed Changes

- Provide an API for component-templates creator `promptOptions`. If implemented, `bit create` will show the prompts, gather the info needed, and then pass this info to the `generateFiles()` of the template.
- Support adding the prompt-options as flags. (e.g. bit create comp some-template -- --bundler webpack).
- This infrastructure eliminates the need from templates creator to import a prompt library and implement all of it themselves.
- The main reason of implementing this is to enable the IDE extension to display prompts within the IDE UI and create the components according to the user's input.
