### PR TITLE
fix(lane-eject), show a descriptive error when ejecting a component on a lane when there is no main version

### DIFF
--- a/e2e/harmony/lanes/lane-eject.e2e.ts
+++ b/e2e/harmony/lanes/lane-eject.e2e.ts
@@ -70,4 +70,17 @@ describe('bit lane command', function () {
       });
     });
   });
+  describe('eject when there is no main version', () => {
+    before(() => {
+      helper.scopeHelper.setNewLocalAndRemoteScopes();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+    });
+    it('should throw an error saying it has no main version', () => {
+      const error = helper.general.runWithTryCatch('bit lane eject comp1');
+      expect(error).to.have.string('it has no main version');
+    });
+  });
 });

--- a/scopes/lanes/lanes/lanes.main.runtime.ts
+++ b/scopes/lanes/lanes/lanes.main.runtime.ts
@@ -497,6 +497,14 @@ please create a new lane instead, which will include all components of this lane
     if (!this.workspace) {
       throw new BitError(`unable to eject a component outside of Bit workspace`);
     }
+    const ids = await this.workspace.idsByPattern(pattern);
+    await Promise.all(ids.map(async (id) => {
+      const modelComp = await this.scope.getBitObjectModelComponent(id, true);
+      if (!modelComp!.head) {
+        throw new BitError(`unable to eject "${id.toString()}" as it has no main version`);
+      }
+    }));
+
     const deletedComps = await this.remove.deleteComps(pattern);
     const packages = deletedComps.map((c) => c.getPackageName());
     await this.install.install(packages);

--- a/scopes/workspace/eject/eject.main.runtime.ts
+++ b/scopes/workspace/eject/eject.main.runtime.ts
@@ -15,6 +15,9 @@ export class EjectMain {
   ) {}
   async eject(componentIds: ComponentID[], ejectOptions: EjectOptions = {}): Promise<EjectResults> {
     if (!this.workspace) throw new OutsideWorkspaceError();
+    if (this.workspace.isOnLane()) {
+      throw new Error('unable to eject when the workspace is on a lane, please use "bit lane eject" to delete the component from the lane and install the main version');
+    }
     const componentEjector = new ComponentsEjector(
       this.workspace,
       this.install,


### PR DESCRIPTION
Also, disable `bit eject` command when checked out to a lane.