### PR TITLE
ci, save the entire "bit" dir upon bit_tag job complition for bit_export job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -606,10 +606,7 @@ jobs:
       - persist_to_workspace:
           root: .
           paths:
-            - bit/.git/bit
-            - bit/.bitmap
-            - bit/workspace.jsonc
-            - bit/scopes/harmony/cli-reference
+            - bit
       - store_artifacts:
           path: ~/Library/Caches/Bit/logs
       - store_artifacts:


### PR DESCRIPTION
This way, when `bit checkout head` changes component's files, it'll be committed and pushed to the git repo.