### PR TITLE
fix(merge-from-scope), fix VersionNotFound error when merging main into a lane in some edge cases

### DIFF
--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -514,10 +514,8 @@ export class MergeLanesMain {
         allVersions: false,
         // no need to export anything else other than the head. the normal calculation of what to export won't apply here
         // as it is done from the scope.
-        // @todo: if we merge main to a lane, then no need to export all main history, it'll be fetched later by fetchMissingHistory.
-        // once a change is done in the exporter about this, uncomment the next line.
-        // exportHeadsOnly: shouldSquash || fromLaneId.isDefault(),
-        exportHeadsOnly: shouldSquash,
+        // when merging main to a lane, no need to export all main history, it'll be fetched later by fetchMissingHistory.
+        exportHeadsOnly: shouldSquash || fromLaneId.isDefault(),
         // when merging main into a lane, because `shouldSquash` is false, we don't export head only, but all the snaps
         // in between. chances are that a) many of them are already exported, b) those that are not head, are not in
         // the local bare-scope, so trying to export them result in VersionNotFoundOnFS error.


### PR DESCRIPTION
In some cases, when merging main to a lane from a bare-scope, it throws an error about not finding the Version object of a squashed one in the history. 
This is happening when exporting the lane to the remote. Bit tries to export the missing history from main into the lane's scope. 
Due to recent changes in the remote, it's not needed anymore, and the remote itself fetches the missing history once the lane is exported. 
Instead, this PR, only pushes the head into the lane's scope, and doesn't try to fetch missing history. 