### PR TITLE
feat, support saving policy.peer version as "+" in env.jsonc

### DIFF
--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -320,4 +320,72 @@ describe('dependency-resolver extension', function () {
       });
     });
   });
+  (supportNpmCiRegistryTesting ? describe : describe.skip)('env.jsonc with policy.peer version="+"', () => {
+    let npmCiRegistry: NpmCiRegistry;
+    before(async () => {
+      helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      await npmCiRegistry.init();
+      npmCiRegistry.configureCiInPackageJsonHarmony();
+
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllComponents();
+      helper.env.setEmptyEnv();
+      helper.fs.outputFile('empty-env/env.jsonc', `{
+  "policy": {
+    "peers": [
+      {
+        "name": "${helper.general.getPackageNameByCompName('comp1')}",
+        "version": "+",
+        "supportedRange": "^0.0.1"
+      }
+    ]
+  }
+}
+`);
+      helper.command.tagAllComponents(); // it'll tag only empty-env.
+      helper.command.export();
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+    });
+    function validateDepData(expectedVersion: string) {
+      const comp = helper.command.catComponent(`${helper.scopes.remote}/empty-env@latest`);
+      const depResolverExt = comp.extensions.find((e) => e.name === Extensions.dependencyResolver);
+      const policy = depResolverExt.data.policy.find(p => p.dependencyId === helper.general.getPackageNameByCompName('comp1'));
+      expect(policy.value.version).to.equal('+');
+      const data =  depResolverExt.data.dependencies.find(p => p.packageName === helper.general.getPackageNameByCompName('comp1'));
+      expect(data.version).to.equal(expectedVersion);
+      expect(data.componentId.version).to.equal(expectedVersion);
+    }
+    it('should not break and save the policy correctly with the plus', () => {
+      validateDepData('0.0.1');
+    });
+    describe('making a new version of the env dep', () => {
+      before(() => {
+        helper.command.tagAllComponents('--unmodified');
+        helper.command.export();
+      });
+      it('should update the dep in the env model', () => {
+        validateDepData('0.0.2');
+      });
+      it('should be able to install the env on a new workspace with no errors', () => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.install(helper.general.getPackageNameByCompName('empty-env'));
+        const pkgJson = helper.fs.readJsonFile(`node_modules/${helper.general.getPackageNameByCompName('empty-env')}/package.json`);
+        expect(pkgJson.dependencies[`${helper.general.getPackageNameByCompName('comp1')}`]).to.equal('0.0.2');
+      });
+      // this is an important test. in case the env is imported without the dep, it is unable to resolve the dep-version
+      // from the local workspace and it falls back to other strategies, in this case, to the version from the model.
+      it('should be able to import the env on a new workspace and tag with no errors', () => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.command.importComponent(`empty-env`);
+        helper.command.tagAllComponents('--unmodified');
+        validateDepData('0.0.2');
+      });
+    });
+  });
 });

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -624,9 +624,49 @@ export class ApplyOverrides {
         }
       });
     });
+    const resolvedEnvPolicyManifest = Object.keys(envPolicyManifest).reduce((acc, pkgName) => {
+      const version = envPolicyManifest[pkgName];
+      if (version !== '+') {
+        acc[pkgName] = version;
+        return acc;
+      }
+      acc[pkgName] = this.resolveEnvPeerDepVersion(pkgName);
+      return acc;
+    }, {});
     Object.assign(deps, envPolicyManifest);
     // TODO: handle component deps once we support peers between components
-    this.allPackagesDependencies.packageDependencies = deps;
+    this.allPackagesDependencies.packageDependencies = resolvedEnvPolicyManifest;
+  }
+
+  /**
+   * in the env.jsonc file, a policy-peer package can have `+` sign in the version. it means that it should be resolved
+   * from the workspace. whatever version is installed/imported in the workspace, it should be used here.
+   * in some cases, the package is not installed in the workspace, for example, the env is now imported without the
+   * dep. so the dep is not in the node_modules.
+   * strategy should be: .bitmap, workspace.jsonc, then model.
+   * it's not in .bitmap, otherwise, it was linked and `_resolvePackageData` would have found it.
+   * so either, it's in the workspace.jsonc or in the model.
+   */
+  private resolveEnvPeerDepVersion(pkgName: string): string {
+    const resolved = this._resolvePackageData(pkgName);
+    if (resolved && resolved.concreteVersion) {
+      return resolved.concreteVersion;
+    }
+    const wsPolicy = this.depsResolver.getWorkspacePolicyManifest();
+    const wsVersion = wsPolicy?.dependencies?.[pkgName] || wsPolicy?.peerDependencies?.[pkgName];
+    if (wsVersion) {
+      return wsVersion;
+    }
+    const fromModelDep = this.componentFromModel?.dependencies.get().find((dep) => dep.packageName === pkgName);
+    if (fromModelDep) {
+      return fromModelDep.id.version;
+    }
+    const fromModelPkg = this.componentFromModel?.packageDependencies[pkgName];
+    if (fromModelPkg) {
+      return fromModelPkg;
+    }
+    // no where to be found. instead of throwing an error, return the "latest" version
+    return '*';
   }
 
   /**

--- a/scopes/dependencies/dependency-resolver/manifest/update-dependency-version.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/update-dependency-version.ts
@@ -32,9 +32,11 @@ export function updateDependencyVersion(
   if (dependency.getPackageName) {
     const packageName = dependency.getPackageName();
     const variantVersion = variantPolicy?.getDepVersion(packageName, dependency.lifecycle);
-    const variantVersionWithoutMinus = variantVersion && variantVersion !== '-' ? variantVersion : undefined;
+    const variantVersionWithoutSpecialChar = variantVersion && variantVersion !== '-' && variantVersion !== '+'
+      ? variantVersion
+      : undefined;
     const version =
-      variantVersionWithoutMinus ||
+      variantVersionWithoutSpecialChar ||
       rootPolicy?.getValidSemverDepVersion(packageName, dependency.lifecycle === 'peer' ? 'peer' : 'runtime') ||
       snapToSemver(dependency.version) ||
       '0.0.1-new';


### PR DESCRIPTION
Using the `+` syntax, it resolves to the version installed locally, which could be either a component listed in `.bitmap` or an installed package.
This is particularly useful when an env has a dependency that is often snapped/tagged along with it. As a result, the version automatically updates based on the latest tag/snap.