### PR TITLE
fix(merge-from-scope), enable auto-snap when merging main into a lane

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -656,7 +656,7 @@ export class MergingMain {
           loadAspectOnlyForIds: getLoadAspectOnlyForIds(),
         }
       );
-      return { ...results, autoSnappedResults: [] };
+      return results;
     }
     return this.snapping.snap({
       legacyBitIds: ids,

--- a/scopes/component/snapping/snap-from-scope.cmd.ts
+++ b/scopes/component/snapping/snap-from-scope.cmd.ts
@@ -135,6 +135,7 @@ ${inputDataDescription}
       rebuildDepsGraph,
       updateDependents,
       tag,
+      skipAutoTag: true
     });
 
     const { snappedIds, exportedIds } = results;
@@ -184,6 +185,7 @@ ${inputDataDescription}
         rebuildDepsGraph,
         updateDependents,
         tag,
+        skipAutoTag: true
       });
 
       return {

--- a/scopes/component/snapping/snapping.main.runtime.ts
+++ b/scopes/component/snapping/snapping.main.runtime.ts
@@ -110,6 +110,7 @@ export type SnapResults = BasicTagResults & {
 export type SnapFromScopeResults = {
   snappedIds: ComponentID[];
   exportedIds?: ComponentID[];
+  autoSnappedResults: AutoTagResult[];
   snappedComponents: ConsumerComponent[];
 };
 
@@ -574,7 +575,6 @@ if you're willing to lose the history from the head to the specified version, us
         dependencies: [],
         versionToTag: shouldTag ? s.version || 'patch' : undefined,
       })),
-      skipAutoTag: true,
       persist: true,
       isSnap: !shouldTag,
       message: params.message as string,
@@ -602,6 +602,7 @@ if you're willing to lose the history from the head to the specified version, us
     return {
       snappedComponents: taggedComponents,
       snappedIds: taggedComponents.map((comp) => comp.id),
+      autoSnappedResults: results.autoTaggedResults,
       exportedIds,
     };
   }

--- a/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane-from-scope.cmd.ts
@@ -83,7 +83,8 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
 
     const titleBase64Decoded = titleBase64 ? fromBase64(titleBase64) : undefined;
 
-    const { mergedNow, unmerged, exportResult, conflicts, mergeSnapError } = await this.mergeLanes.mergeFromScope(
+    const { mergedNow, snappedIds, autoSnappedIds,
+      unmerged, exportResult, conflicts, mergeSnapError } = await this.mergeLanes.mergeFromScope(
       fromLane,
       toLane || DEFAULT_LANE,
       {
@@ -102,6 +103,13 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
       `successfully merged ${mergedNow.length} components from ${fromLane} to ${toLane || DEFAULT_LANE}`
     );
     const mergedOutput = mergedNow.length ? `${mergedTitle}\n${mergedNow.join('\n')}` : '';
+
+    const snappedOutput = snappedIds?.length
+      ? chalk.bold(`the following ${snappedIds.length} components were snapped\n`) + snappedIds.join('\n')
+      : '';
+    const autoSnappedOutput = autoSnappedIds?.length
+      ? chalk.bold(`the following ${autoSnappedIds.length} components were auto snapped\n`) + autoSnappedIds.join('\n')
+      : '';
 
     const nonMergedTitle = chalk.bold(`the following ${unmerged.length} components were not merged`);
     const nonMergedOutput = unmerged.length
@@ -124,7 +132,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
     const exportedTitle = chalk.bold(`successfully exported ${exportedIds.length} components`);
     const exportedOutput = exportedIds.length ? `${exportedTitle}\n${exportedIds.join('\n')}` : '';
 
-    return compact([mergedOutput, nonMergedOutput, conflictsOutput, mergeSnapErrorOutput, exportedOutput]).join('\n\n');
+    return compact([mergedOutput, snappedOutput, autoSnappedOutput, nonMergedOutput, conflictsOutput, mergeSnapErrorOutput, exportedOutput]).join('\n\n');
   }
   async json(
     [fromLane, toLane]: [string, string],
@@ -162,6 +170,7 @@ the lane must be up-to-date with the other lane, otherwise, conflicts might occu
           unmerged: results.unmerged.map(({ id, reason }) => ({ id: id.toString(), reason })),
           conflicts: results.conflicts?.map(({ id, ...rest }) => ({ id: id.toString(), ...rest })),
           snappedIds: results.snappedIds?.map((id) => id.toString()),
+          autoSnappedIds: results.autoSnappedIds?.map((id) => id.toString()),
           mergeSnapError: results.mergeSnapError
             ? { message: results.mergeSnapError.message, stack: results.mergeSnapError.stack }
             : undefined,

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -71,6 +71,7 @@ export type MergeFromScopeResult = {
   unmerged: { id: ComponentID; reason: string }[]; // reasons currently are: ahead / already-merge / removed
   conflicts?: ConflictPerId[]; // relevant in case of diverge (currently possible only when merging from main to a lane)
   snappedIds?: ComponentID[]; // relevant in case of diverge (currently possible only when merging from main to a lane)
+  autoSnappedIds?: ComponentID[]; // relevant in case of diverge (currently possible only when merging from main to a lane)
   mergedPreviously: ComponentID[];
   mergeSnapError?: Error;
 };
@@ -559,6 +560,7 @@ export class MergeLanesMain {
     }
 
     const snappedIds = mergeSnapResults?.snappedComponents.map((c) => c.id) || [];
+    const autoSnappedIds = mergeSnapResults?.autoSnappedResults.map((c) => c.component.id) || [];
 
     const laneToExport = toLaneId.isDefault() ? undefined : await this.lanes.loadLane(toLaneId); // needs to be loaded again after the merge as it changed
     const exportResult =
@@ -579,9 +581,11 @@ export class MergeLanesMain {
       unmerged: failedComponents?.map((c) => ({ id: c.id, reason: c.unchangedMessage })) || [],
       conflicts,
       snappedIds,
+      autoSnappedIds,
       mergeSnapError,
     };
   }
+
   private async throwIfNotUpToDate(fromLaneId: LaneId, toLaneId: LaneId) {
     const status = await this.lanes.diffStatus(fromLaneId, toLaneId, { skipChanges: true });
     const compsNotUpToDate = status.componentsStatus.filter((s) => !s.upToDate);


### PR DESCRIPTION
When merging main into a lane, the merged components are snapped. This PR finds the other components in the lane that depend on the snapped components and auto-snap them. This way, the lane is kept up-to-date, and components in the lane always have the dependencies with the same versions they appear on the lane. 