### PR TITLE
reduce logs related to individual component loading

### DIFF
--- a/components/legacy/consumer-component/component-loader.ts
+++ b/components/legacy/consumer-component/component-loader.ts
@@ -116,9 +116,7 @@ export class ComponentLoader {
     throwOnFailure = true,
     loadOpts?: ComponentLoadOptions
   ): Promise<LoadManyResult> {
-    logger.debugAndAddBreadCrumb('ComponentLoader', 'loading consumer-components from the file-system, ids: {ids}', {
-      ids: ids.toString(),
-    });
+    logger.trace(`ComponentLoader, loading consumer-components from the file-system, ids: ${ids.toString()}`);
     const loadOptsWithDefaults: ComponentLoadOptions = Object.assign(
       { loadExtensions: true, executeLoadSlot: true },
       loadOpts || {}
@@ -142,10 +140,8 @@ export class ComponentLoader {
         idsToProcess.push(idWithVersion);
       }
     });
-    logger.debugAndAddBreadCrumb(
-      'ComponentLoader',
-      `the following ${alreadyLoadedComponents.length} components have been already loaded, get them from the cache. {idsStr}`,
-      { idsStr: alreadyLoadedComponents.map((c) => c.id.toString()).join(', ') }
+    logger.trace(
+      `ComponentLoader, the following ${alreadyLoadedComponents.length} components have been already loaded, get them from the cache. ${alreadyLoadedComponents.map((c) => c.id.toString()).join(', ')}`,
     );
     if (!idsToProcess.length) return { components: alreadyLoadedComponents, invalidComponents, removedComponents };
     const storeInCache = loadOptsWithDefaults?.storeInCache ?? true;
@@ -166,9 +162,7 @@ export class ComponentLoader {
           if (storeInCache) {
             this.componentsCache.set(component.id.toString(), component);
           }
-          logger.debugAndAddBreadCrumb('ComponentLoader', 'Finished loading the component "{id}"', {
-            id: component.id.toString(),
-          });
+          logger.trace(`ComponentLoader', 'Finished loading the component "${component.id.toString()}"`);
           allComponents.push(component);
         }
       },

--- a/components/legacy/consumer-config/component-config.ts
+++ b/components/legacy/consumer-config/component-config.ts
@@ -83,7 +83,7 @@ export class ComponentConfig extends AbstractConfig {
     id: ComponentID,
     loadOpts?: ComponentConfigLoadOptions
   ): Promise<any[]> {
-    logger.debugAndAddBreadCrumb('componentConfigLoad', `running on load event for component ${id.toString()}`);
+    logger.trace(`componentConfigLoad, running on load event for component ${id.toString()}`);
     try {
       const res = await mapSeries(Object.keys(subscribers), async (extId: string) => {
         const func = subscribers[extId];

--- a/components/legacy/logger/logger.ts
+++ b/components/legacy/logger/logger.ts
@@ -166,11 +166,11 @@ class BitLogger implements IBitLogger {
    * [2020-12-04 16:24:46.100 -0500] INFO	 (31641): loadingComponent: 14ms. (total repeating 14ms)
    * [2020-12-04 16:24:46.110 -0500] INFO	 (31641): loadingComponent: 18ms. (total repeating 32ms)
    */
-  profile(id: string, console?: boolean) {
+  profile(id: string, console?: boolean, level: Level = 'info') {
     const msg = this.profiler.profile(id);
     if (!msg) return;
     const fullMsg = `${id}: ${msg}`;
-    console || this.shouldConsoleProfiler ? this.console(fullMsg) : this.info(fullMsg);
+    console || this.shouldConsoleProfiler ? this.console(fullMsg) : this[level](fullMsg);
   }
 
   registerOnBeforeExitFn(fn: Function) {

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-loader.ts
@@ -135,7 +135,7 @@ export class DependenciesLoader {
       }
       return null; // cache is invalid.
     }
-    this.logger.debug(`dependencies-loader, getting the dependencies data for ${this.idStr} from the cache`);
+    this.logger.trace(`dependencies-loader, getting the dependencies data for ${this.idStr} from the cache`);
     return DependenciesData.deserialize(cacheData.data);
   }
 

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -78,7 +78,7 @@ export async function updateDependenciesVersions(
     for (const strategy of strategies) {
       const strategyId = strategy();
       if (strategyId) {
-        logger.debug(
+        logger.trace(
           `found dependency version ${strategyId.version} for ${id.toString()} in strategy ${strategy.name}`
         );
         if (debugDep) {

--- a/scopes/harmony/logger/logger.ts
+++ b/scopes/harmony/logger/logger.ts
@@ -142,6 +142,13 @@ export class Logger implements IBitLogger {
   }
 
   /**
+   * by default, the "profile" writes the message as "info". use this method to write it as "trace".
+   */
+  profileTrace(id: string) {
+    logger.profile(id, false, 'trace');
+  }
+
+  /**
    * print to the screen with a red `✖` prefix. if message is empty, print the last logged message.
    */
   consoleFailure(message?: string) {

--- a/scopes/scope/scope/scope-component-loader.ts
+++ b/scopes/scope/scope/scope-component-loader.ts
@@ -25,7 +25,7 @@ export class ScopeComponentLoader {
       return fromCache;
     }
     const idStr = id.toString();
-    this.logger.debug(`ScopeComponentLoader.get, loading ${idStr}`);
+    this.logger.trace(`ScopeComponentLoader.get, loading ${idStr}`);
     const legacyId = id;
     let modelComponent = await this.scope.legacyScope.getModelComponentIfExist(id);
     // import if missing

--- a/scopes/workspace/workspace/filter.ts
+++ b/scopes/workspace/workspace/filter.ts
@@ -14,7 +14,7 @@ export const statesFilter = [
   'codeModified',
   'localOnly',
 ] as const;
-export type StatesFilter = (typeof statesFilter)[number];
+export type StatesFilter = typeof statesFilter[number];
 
 export class Filter {
   constructor(private workspace: Workspace) {}

--- a/scopes/workspace/workspace/workspace-aspects-loader.ts
+++ b/scopes/workspace/workspace/workspace-aspects-loader.ts
@@ -102,7 +102,7 @@ export class WorkspaceAspectsLoader {
     // generate a random callId to be able to identify the call from the logs
     const callId = Math.floor(Math.random() * 1000);
     const loggerPrefix = `[${callId}] loadAspects,`;
-    this.logger.profile(`[${callId}] workspace.loadAspects`);
+    this.logger.profileTrace(`[${callId}] workspace.loadAspects`);
     this.logger.info(`${loggerPrefix} loading ${ids.length} aspects.
 ids: ${ids.join(', ')}
 needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts, null, 2)}`);
@@ -115,7 +115,7 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
       notLoadedIds = nonLocalAspects.filter((id) => !this.aspectLoader.isAspectLoaded(id));
     }
     if (!notLoadedIds.length) {
-      this.logger.profile(`[${callId}] workspace.loadAspects`);
+      this.logger.profileTrace(`[${callId}] workspace.loadAspects`);
       return [];
     }
     const coreAspectsStringIds = this.aspectLoader.getCoreAspectIds();
@@ -181,7 +181,7 @@ needed-for: ${neededFor || '<unknown>'}. using opts: ${JSON.stringify(mergedOpts
     await this.aspectLoader.loadExtensionsByManifests(pluginsManifests, undefined, { throwOnError });
     const manifestIds = manifests.map((manifest) => manifest.id);
     this.logger.debug(`${loggerPrefix} finish loading aspects`);
-    this.logger.profile(`[${callId}] workspace.loadAspects`);
+    this.logger.profileTrace(`[${callId}] workspace.loadAspects`);
     return compact(manifestIds.concat(scopeAspectIds));
   }
 

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -738,7 +738,7 @@ it's possible that the version ${component.id.version} belong to ${idStr.split('
     storeInCache = true,
     loadOpts?: ComponentLoadOptions
   ): Promise<Component> {
-    this.logger.debug(`get ${componentId.toString()}`);
+    this.logger.trace(`get ${componentId.toString()}`);
     const component = await this.componentLoader.get(componentId, legacyComponent, useCache, storeInCache, loadOpts);
     // When loading a component if it's an env make sure to load it as aspect as well
     // We only want to try load it as aspect if it's the first time we load the component
@@ -1139,7 +1139,9 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
   }
 
   async getMany(ids: Array<ComponentID>, loadOpts?: ComponentLoadOptions, throwOnFailure = true): Promise<Component[]> {
+    this.logger.debug(`getMany, started. ${ids.length} components`);
     const { components } = await this.componentLoader.getMany(ids, loadOpts, throwOnFailure);
+    this.logger.debug(`getMany, completed. ${components.length} components`);
     return components;
   }
 


### PR DESCRIPTION
The log is too verbose in the component-load mechanism, logging each component load steps. The log level has been changed from "debug" to "trace", resulting in 70% reduction in logs for `bit status` on 17 components.