### PR TITLE
fix a regression that cause all components to be shown as modified

### DIFF
--- a/components/legacy/bit-map/component-map.ts
+++ b/components/legacy/bit-map/component-map.ts
@@ -32,6 +32,10 @@ export type Config = { [aspectId: string]: Record<string, any> | '-' };
 export type ComponentMapFile = {
   name: string;
   relativePath: PathLinux;
+  /**
+   * @deprecated should be safe to remove around August 2025
+   */
+  test?: boolean;
 };
 
 export type NextVersion = {

--- a/components/legacy/consumer-component/consumer-component.ts
+++ b/components/legacy/consumer-component/consumer-component.ts
@@ -593,7 +593,7 @@ async function getLoadedFiles(
   await componentMap.trackDirectoryChangesHarmony(consumer.getPath());
   const sourceFiles = componentMap.files.map((file) => {
     const filePath = path.join(bitDir, file.relativePath);
-    const sourceFile = SourceFile.load(filePath, bitDir, consumer.getPath());
+    const sourceFile = SourceFile.load(filePath, bitDir, consumer.getPath(), { test: file.test || false });
     return sourceFile;
   });
   const filePaths = componentMap.getAllFilesPaths();


### PR DESCRIPTION
Caused by https://github.com/teambit/bit/pull/9661 which removed the "test" prop. This PR adds it back for now.