### PR TITLE
deprecate "test" and "name" properties of the files in the model

### DIFF
--- a/components/legacy/bit-map/component-map.ts
+++ b/components/legacy/bit-map/component-map.ts
@@ -16,7 +16,6 @@ import {
 import {
   PathLinux,
   PathLinuxRelative,
-  PathOsBased,
   PathOsBasedAbsolute,
   PathOsBasedRelative,
   pathJoinLinux,
@@ -30,8 +29,12 @@ import { IgnoredDirectory, ComponentNotFoundInPath } from '@teambit/legacy.consu
 export type Config = { [aspectId: string]: Record<string, any> | '-' };
 
 export type ComponentMapFile = {
-  name: string;
   relativePath: PathLinux;
+  /**
+   * @deprecated should be safe to remove around August 2025
+   * you can easily get it by running `path.basename(relativePath)`
+   */
+  name?: string;
   /**
    * @deprecated should be safe to remove around August 2025
    */
@@ -196,15 +199,6 @@ export class ComponentMap {
       file.relativePath = newPath;
     });
     this.rootDir = newRootDir;
-  }
-
-  addRootDirToDistributedFiles(rootDir: PathOsBased) {
-    this.files.forEach((file) => {
-      file.relativePath = file.name;
-    });
-    this.rootDir = pathNormalizeToLinux(rootDir);
-    this.mainFile = path.basename(this.mainFile);
-    this.validate();
   }
 
   updateDirLocation(dirFrom: PathOsBasedRelative, dirTo: PathOsBasedRelative): PathChange[] {

--- a/components/legacy/consumer/consumer.ts
+++ b/components/legacy/consumer/consumer.ts
@@ -312,6 +312,22 @@ export default class Consumer {
 
       sortProperties(version);
 
+
+      // align files properties between model and filesystem.
+      // the reason is that "name" and "test" props became deprecated. we don't want discrepancies between the
+      // model and the filesystem related to these two props. they should not make a component modified. we simply
+      // don't care about them anymore.
+      const filesFromFs = version.files;
+      const filesFromModel = componentFromModel.files;
+      filesFromFs.forEach((fileFromFs) => {
+        const fileFromModel = filesFromModel.find((file) => file.relativePath === fileFromFs.relativePath);
+        if (!fileFromModel) {
+          return;
+        }
+        fileFromFs.name = fileFromModel.name;
+        fileFromFs.test = fileFromModel.test;
+      });
+
       // prefix your command with "BIT_LOG=*" to see the actual id changes
       if (process.env.BIT_LOG && componentFromModel.calculateHash().hash !== version.calculateHash().hash) {
         console.log('-------------------componentFromModel------------------------'); // eslint-disable-line no-console

--- a/scopes/component/tracker/determine-main-file.ts
+++ b/scopes/component/tracker/determine-main-file.ts
@@ -125,7 +125,7 @@ export default function determineMainFile(
       if (mainFileUsingRootDir) return mainFileUsingRootDir.relativePath;
     }
     // search for a file-name
-    const potentialMainFiles = files.filter((file) => file.name === baseMainFile);
+    const potentialMainFiles = files.filter((file) => path.basename(file.relativePath) === baseMainFile);
     if (!potentialMainFiles.length) return null;
     // when there are several files that met the criteria, choose the closer to the root
     const sortByNumOfDirs = (a, b) =>


### PR DESCRIPTION
The `test` prop is not used since Harmony. The `name` is easily calculated by `path.basename` of the `relativePath`, and it not actually used.
The reason not to simply delete them is to be forward-compatible. Meaning, a component that was tagged with the new version won't appear as "modified" by an older version.
The "modified" calculation has been changed to disregard these two props.
