### PR TITLE
fix(watcher), avoid throwing when parcel returns errors

### DIFF
--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -494,7 +494,6 @@ export class Watcher {
   }
 
   private async onParcelWatch(err: Error | null, allEvents: Event[]) {
-    totalEvents += allEvents.length;
     const events = allEvents.filter((event) => !this.shouldIgnoreFromLocalScopeParcel(event.path));
     if (!events.length) {
       return;


### PR DESCRIPTION
Simply log them to the watcher console and to the debug.log. The watcher should continue working.