### PR TITLE
enable skipping port validation for "bit server" by a flag

### DIFF
--- a/scopes/harmony/bit/server-commander.ts
+++ b/scopes/harmony/bit/server-commander.ts
@@ -58,6 +58,7 @@ import { getPidByPort, getSocketPort } from './server-forever';
 const CMD_SERVER_PORT = 'cli-server-port';
 const CMD_SERVER_PORT_DELETE = 'cli-server-port-delete';
 const CMD_SERVER_SOCKET_PORT = 'cli-server-socket-port';
+const SKIP_PORT_VALIDATION_ARG = '--skip-port-validation';
 
 class ServerPortFileNotFound extends Error {
   constructor(filePath: string) {
@@ -291,7 +292,8 @@ Please run the command "bit server-forever" first to start the server.`)
 
   private async getExistingUsedPort(): Promise<number> {
     const port = await this.getExistingPort();
-    const isPortInUse = await this.isPortInUseForCurrentDir(port);
+    const shouldSkipPortValidation = process.argv.includes(SKIP_PORT_VALIDATION_ARG);
+    const isPortInUse = shouldSkipPortValidation ? true : await this.isPortInUseForCurrentDir(port);
     if (!isPortInUse) {
       await this.deleteServerPortFile();
       throw new ServerIsNotRunning(port);


### PR DESCRIPTION
In some systems, there is no good option to get the pid by the port without having sudo access. Also, there are other ways to ensure the system has only one workspace.
Using the flag `--skip-port-validation` the validation of the dir by port is skipped. 