### PR TITLE
avoid printing "Events were dropped by the FSEvents client" during watch

### DIFF
--- a/scopes/workspace/watcher/watcher.ts
+++ b/scopes/workspace/watcher/watcher.ts
@@ -504,7 +504,10 @@ export class Watcher {
       if (msgs?.onAll) events.forEach((event) => msgs.onAll(event.type, event.path));
     }
     if (err) {
-      msgs?.onError(err);
+      if (!err.message.includes('Events were dropped by the FSEvents client')) {
+        // the message above shows up too many times and it doesn't affect the watcher.
+        msgs?.onError(err);
+      }
       if (err.message.includes('Error starting FSEvents stream')) {
         throw new Error(`failed to start the watcher: ${err.message}.
 try rerunning the command. if that doesn't help, please refer to this Watchman troubleshooting guide:


### PR DESCRIPTION
For big projects, it happens all the time when running `bit install` or any heavy command. It's because Parcel watches the workspace root and although the node-modules is ignored, it probably stills gets the events from the FSEvents (and then discard them). 
It's not helpful to show this error message constantly, so it's simply ignored.