### PR TITLE
support saving flattened-dependencies as string[] instead of Object[]

### DIFF
--- a/scopes/scope/objects/models/version.ts
+++ b/scopes/scope/objects/models/version.ts
@@ -466,7 +466,9 @@ export default class Version extends BitObject {
         docs: this.docs,
         dependencies: this.dependencies.cloneAsObject(),
         devDependencies: this.devDependencies.cloneAsObject(),
-        flattenedDependencies: this.flattenedDependencies.map((dep) => dep.toObject()),
+        // flattenedDependencies: this.flattenedDependencies.map((dep) => dep.toObject()),
+        // @todo: uncomment this in the future, once all remotes are updated to support the backward compatibility.
+        flattenedDependencies: this.flattenedDependencies.map((dep) => dep.toString()),
         flattenedEdges: this.flattenedEdgesRef ? undefined : this.flattenedEdges.map((f) => Version.depEdgeToObject(f)),
         flattenedEdgesRef: this.flattenedEdgesRef?.toString(),
         dependenciesGraphRef: this.dependenciesGraphRef?.toString(),
@@ -524,10 +526,10 @@ export default class Version extends BitObject {
       dependencies,
       devDependencies,
       flattenedDependencies,
+      flattenedDevDependencies,
       flattenedEdges,
       flattenedEdgesRef,
       dependenciesGraphRef,
-      flattenedDevDependencies,
       devPackageDependencies,
       peerPackageDependencies,
       packageDependencies,
@@ -572,15 +574,18 @@ export default class Version extends BitObject {
       });
     };
 
-    const _getFlattenedDependencies = (deps = []): ComponentID[] => {
+    // Accept both string[] and object[] for backward compatibility
+    const parseFlattenedDeps = (deps = []): ComponentID[] => {
+      if (!deps.length) return [];
+      if (typeof deps[0] === 'string') return deps.map((dep) => ComponentID.fromString(dep));
       return deps.map((dep) => ComponentID.fromObject(dep));
     };
 
     const _groupFlattenedDependencies = () => {
       // support backward compatibility. until v15, there was both flattenedDependencies and
       // flattenedDevDependencies. since then, these both were grouped to one flattenedDependencies
-      const flattenedDeps = _getFlattenedDependencies(flattenedDependencies);
-      const flattenedDevDeps = _getFlattenedDependencies(flattenedDevDependencies);
+      const flattenedDeps = parseFlattenedDeps(flattenedDependencies);
+      const flattenedDevDeps = parseFlattenedDeps(flattenedDevDependencies);
       return ComponentIdList.fromArray([...flattenedDeps, ...flattenedDevDeps]);
     };
 


### PR DESCRIPTION
The current Object representation takes much more space. 
This PR is only about supporting the new format. The cut off will be in the future, to not break old bit versions that don't support it yet. (we aim for forward compatibility here). 