### PR TITLE
feat, support saving components with range in package.json

### DIFF
--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -754,7 +754,8 @@ export default class CommandHelper {
     return show.find((_) => _.title === 'configuration').json.find((_) => _.id === aspectId);
   }
 
-  showDependenciesData(compId: string): Array<{ id: string; version: string; packageName: string }> {
+  showDependenciesData(compId: string): Array<{ id: string; version: string; packageName: string;
+    versionRange?: string }> {
     const showConfig = this.showAspectConfig(compId, Extensions.dependencyResolver);
     return showConfig.data.dependencies;
   }

--- a/e2e/functionalities/peer-dependencies.e2e.3.ts
+++ b/e2e/functionalities/peer-dependencies.e2e.3.ts
@@ -293,8 +293,9 @@ describe('peer-dependencies functionality', function () {
       const pkgJson = fs.readJsonSync(
         path.join(workspaceCapsulesRootDir, `${helper.scopes.remote}_comp1@${head}/package.json`)
       );
+      const comp2Head = helper.command.getHead('comp2');
       expect(pkgJson.peerDependencies).to.deep.equal({
-        [`@${helper.scopes.remote}/comp2`]: '+',
+        [`@${helper.scopes.remote}/comp2`]: `0.0.0-${comp2Head}`, // it can't be `+` as it's invalid in package.json.
       });
     });
   });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -480,5 +480,23 @@ describe('dependency-resolver extension', function () {
       const pkgJson = helper.fs.readJsonFile(`node_modules/${comp1Pkg}/package.json`);
       expect(pkgJson.dependencies[helper.general.getPackageNameByCompName('comp2')]).to.equal('^0.0.1');
     });
+    describe('workspace with only the dependent', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        npmCiRegistry.setResolver();
+        helper.command.importComponent('comp1');
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '^');
+
+        helper.command.tagAllComponents('--unmodified');
+      });
+      it('should keep the dependency with the range', () => {
+        const comp1 = helper.command.catComponent('comp1@latest');
+        const pkgExtensionData = helper.command.getAspectsData(comp1, Extensions.pkg).data;
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        expect(pkgExtensionData.pkgJson.dependencies).to.have.property(comp2Pkg);
+        expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`^0.0.1`);
+      });
+    });
   });
 });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -524,5 +524,19 @@ describe('dependency-resolver extension', function () {
         expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`^0.0.1`);
       });
     });
+    describe('revert the range', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(wsAfterExport);
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '');
+        helper.command.tagComponent('comp1', undefined, '--ver 3.0.0 --unmodified');
+      });
+      it('should save the dependency without the range', () => {
+        const comp1 = helper.command.catComponent('comp1@latest');
+        const pkgExtensionData = helper.command.getAspectsData(comp1, Extensions.pkg).data;
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        expect(pkgExtensionData.pkgJson.dependencies).to.have.property(comp2Pkg);
+        expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`0.0.1`);
+      });
+    });
   });
 });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -518,7 +518,6 @@ describe('dependency-resolver extension', function () {
         npmCiRegistry.setResolver();
         helper.command.importComponent('comp1');
         helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '^');
-        helper.workspaceJsonc.addKeyValToDependencyResolver('enableComponentRanges', true);
         const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
         helper.command.install(`${comp2Pkg}@^0.0.1`);
         helper.command.tagAllComponents();
@@ -543,6 +542,25 @@ describe('dependency-resolver extension', function () {
         const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
         expect(pkgExtensionData.pkgJson.dependencies).to.have.property(comp2Pkg);
         expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`0.0.1`);
+      });
+    });
+    describe('range in config conflicts the actual range in policy', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        npmCiRegistry.setResolver();
+        helper.command.importComponent('comp1');
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '^');
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        helper.command.install(`${comp2Pkg}@~0.0.1`);
+        helper.command.tagAllWithoutBuild('--unmodified');
+      });
+      it('the range in policy should win', () => {
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        const depsData = helper.command.showDependenciesData('comp1');
+        const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
+        expect(comp2Dep).to.have.property('versionRange');
+        expect(comp2Dep!.versionRange).to.equal('~0.0.1');
       });
     });
   });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -548,6 +548,7 @@ describe('dependency-resolver extension', function () {
   });
   (supportNpmCiRegistryTesting ? describe : describe.skip)('component range as "+"', () => {
     let npmCiRegistry: NpmCiRegistry;
+    let wsAfterExport: string;
     before(async () => {
       helper = new Helper({ scopesOptions: { remoteScopeWithDot: true } });
       helper.scopeHelper.setWorkspaceWithRemoteScope();
@@ -557,28 +558,45 @@ describe('dependency-resolver extension', function () {
       helper.fixtures.populateComponents(2);
       helper.command.tagAllComponents();
       helper.command.export();
-
-      helper.scopeHelper.reInitWorkspace();
-      helper.scopeHelper.addRemoteScope();
-      npmCiRegistry.setResolver();
-      helper.command.importComponent('comp1');
-
-      const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
-      helper.command.dependenciesSet('comp1', `${comp2Pkg}@~0.0.1`);
-      helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '+');
-
-      helper.command.tagAllComponents('--unmodified');
+      wsAfterExport = helper.scopeHelper.cloneWorkspace();
     });
     after(() => {
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
-    it('should save the prefix according to how the user saved it via bit-deps-set', () => {
-      const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
-      const depsData = helper.command.showDependenciesData('comp1');
-      const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
-      expect(comp2Dep).to.have.property('versionRange');
-      expect(comp2Dep!.versionRange).to.equal('~0.0.1');
+    describe('tagging the dependent only', () => {
+      before(() => {
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        npmCiRegistry.setResolver();
+        helper.command.importComponent('comp1');
+
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        helper.command.dependenciesSet('comp1', `${comp2Pkg}@~0.0.1`);
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '+');
+
+        helper.command.tagAllWithoutBuild('--unmodified');
+      });
+      it('should save the prefix according to how the user saved it via bit-deps-set', () => {
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        const depsData = helper.command.showDependenciesData('comp1');
+        const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
+        expect(comp2Dep).to.have.property('versionRange');
+        expect(comp2Dep!.versionRange).to.equal('~0.0.1');
+      });
+    });
+    describe('tagging both the dependent and the dependency', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(wsAfterExport);
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '+');
+        helper.command.tagAllWithoutBuild('--unmodified');
+      });
+      it('should not save any prefix', () => {
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        const depsData = helper.command.showDependenciesData('comp1');
+        const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
+        expect(comp2Dep).to.not.have.property('versionRange');
+      });
     });
   });
 });

--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -474,6 +474,13 @@ describe('dependency-resolver extension', function () {
       npmCiRegistry.destroy();
       helper.scopeHelper.destroy();
     });
+    it('should save the dependencies with rangePrefix', () => {
+      const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+      const depsData = helper.command.showDependenciesData('comp1');
+      const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
+      expect(comp2Dep).to.have.property('versionRange');
+      expect(comp2Dep!.versionRange).to.equal('^0.0.1');
+    });
     it('installing a component should have the dependencies with range in the package.json', () => {
       helper.scopeHelper.reInitWorkspace();
       helper.scopeHelper.addRemoteScope();
@@ -571,7 +578,7 @@ describe('dependency-resolver extension', function () {
       const depsData = helper.command.showDependenciesData('comp1');
       const comp2Dep = depsData.find((d) => d.packageName === comp2Pkg);
       expect(comp2Dep).to.have.property('versionRange');
-      expect(comp2Dep!.versionRange).to.equal('~0.0.1')
+      expect(comp2Dep!.versionRange).to.equal('~0.0.1');
     });
   });
 });

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1290,7 +1290,7 @@ export class IsolatorMain {
           return acc;
         }
         const fromDepsResolver = compDeps.find((dep) => dep.componentId.isEqualWithoutVersion(depId));
-        const versionWithRange = fromDepsResolver?.source === 'auto' && fromDepsResolver?.versionRange;
+        const versionWithRange = fromDepsResolver?.versionRange;
 
         const packageDependency = depId.version;
         const packageName = componentIdToPackageName({

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1177,7 +1177,7 @@ export class IsolatorMain {
         const keyName = KEY_NAME_BY_LIFECYCLE_TYPE[dep.lifecycle];
         const entry = dep.toManifest();
         if (entry) {
-          manifest[keyName][entry.packageName] = keyName === 'peerDependencies' ? dep.versionRange : dep.versionRange || version;
+          manifest[keyName][entry.packageName] = dep.versionRange && dep.versionRange !== '+' ? dep.versionRange : version;
         }
       });
       await Promise.all(promises);

--- a/scopes/component/isolator/isolator.main.runtime.ts
+++ b/scopes/component/isolator/isolator.main.runtime.ts
@@ -1177,7 +1177,7 @@ export class IsolatorMain {
         const keyName = KEY_NAME_BY_LIFECYCLE_TYPE[dep.lifecycle];
         const entry = dep.toManifest();
         if (entry) {
-          manifest[keyName][entry.packageName] = keyName === 'peerDependencies' ? dep.versionRange : version;
+          manifest[keyName][entry.packageName] = keyName === 'peerDependencies' ? dep.versionRange : dep.versionRange || version;
         }
       });
       await Promise.all(promises);
@@ -1218,7 +1218,7 @@ export class IsolatorMain {
     const packageJson = this.preparePackageJsonToWrite(
       component,
       writeToPath,
-      ids // this.ignoreBitDependencies,
+      ids
     );
     if (!legacyComp.id.hasVersion()) {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1279,21 +1279,26 @@ export class IsolatorMain {
   private preparePackageJsonToWrite(
     component: Component,
     bitDir: string,
-    ignoreBitDependencies: ComponentIdList | boolean = true
+    componentDepsToIgnore: ComponentIdList
   ): PackageJsonFile {
     const legacyComp: ConsumerComponent = component.state._consumer;
+    const compDeps = this.dependencyResolver.getComponentDependencies(component);
     this.logger.debug(`package-json.preparePackageJsonToWrite. bitDir ${bitDir}.`);
     const getBitDependencies = (dependencies: ComponentIdList) => {
-      if (ignoreBitDependencies === true) return {};
       return dependencies.reduce((acc, depId: ComponentID) => {
-        if (Array.isArray(ignoreBitDependencies) && ignoreBitDependencies.searchWithoutVersion(depId)) return acc;
+        if (componentDepsToIgnore.searchWithoutVersion(depId)) {
+          return acc;
+        }
+        const fromDepsResolver = compDeps.find((dep) => dep.componentId.isEqualWithoutVersion(depId));
+        const versionWithRange = fromDepsResolver?.source === 'auto' && fromDepsResolver?.versionRange;
+
         const packageDependency = depId.version;
         const packageName = componentIdToPackageName({
           ...legacyComp,
           id: depId,
           isDependency: true,
         });
-        acc[packageName] = packageDependency;
+        acc[packageName] = versionWithRange || packageDependency;
         return acc;
       }, {});
     };

--- a/scopes/component/snapping/index.ts
+++ b/scopes/component/snapping/index.ts
@@ -11,6 +11,6 @@ export type {
 } from './snapping.main.runtime';
 export default SnappingAspect;
 export { SnappingAspect };
-export { VersionMaker, onTagIdTransformer, BasicTagParams, VersionMakerParams, BasicTagSnapParams } from './version-maker';
+export { VersionMaker, BasicTagParams, VersionMakerParams, BasicTagSnapParams } from './version-maker';
 export { AUTO_TAGGED_MSG, NOTHING_TO_TAG_MSG, tagCmdOptions, TagParams, validateOptions, tagResultOutput } from './tag-cmd';
 

--- a/scopes/component/snapping/version-maker.ts
+++ b/scopes/component/snapping/version-maker.ts
@@ -496,6 +496,7 @@ export class VersionMaker {
       });
     };
     const componentRangePrefix = this.dependencyResolver.componentRangePrefix();
+    const supportComponentRange = this.dependencyResolver.supportComponentRange();
     const updateDepsResolverData = (component: ConsumerComponent) => {
       const entry = component.extensions.findCoreExtension(DependencyResolverAspect.id);
       if (!entry) {
@@ -515,8 +516,12 @@ export class VersionMaker {
         dep.componentId = (newDepId || depId).serialize();
         dep.id = (newDepId || depId).toString();
         dep.version = (newDepId || depId).version;
-        if (!componentRangePrefix) return;
-        dep.versionRange = `${componentRangePrefix}${dep.version}`;
+        if (!supportComponentRange) return;
+        // if dep.versionRange exists, it was resolved previously by the dependency-loader.
+        // @todo: maybe this part can be removed, and the dependency-loader already takes care of what needed.
+        if (!dep.versionRange && (componentRangePrefix === '^' || componentRangePrefix === '~')) {
+          dep.versionRange = `${componentRangePrefix}${dep.version}`;
+        }
       });
       return component;
     }

--- a/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/apply-overrides.ts
@@ -50,7 +50,11 @@ export class ApplyOverrides {
   processedFiles: string[];
   overridesDependencies: OverridesDependencies;
   debugDependenciesData: DebugDependencies;
-  autoDetectOverrides: Record<string, any> | undefined;
+  /**
+   * see workspace.getAutoDetectOverrides docs.
+   * these overrides are from env/variants/merge-config. not ones with "force: true".
+   */
+  public autoDetectOverrides: Record<string, any> | undefined;
   constructor(
     private component: Component,
     private depsResolver: DependencyResolverMain,
@@ -513,31 +517,26 @@ export class ApplyOverrides {
     }
     ['dependencies', 'devDependencies', 'peerDependencies'].forEach((field) => {
       forEach(autoDetectOverrides[field], (pkgVal, pkgName) => {
-        if (this.overridesDependencies.shouldIgnorePeerPackage(pkgName)) return;
+        if (this.overridesDependencies.shouldIgnorePeerPackage(pkgName)) {
+          return;
+        }
+
+        const existsInCompsDeps = this.allDependencies.dependencies.find((dep) => dep.packageName === pkgName);
+        const existsInCompsDevDeps = this.allDependencies.devDependencies.find((dep) => dep.packageName === pkgName);
+        const existsInCompsPeerDeps = this.allDependencies.peerDependencies.find((dep) => dep.packageName === pkgName);
+
         // Validate it was auto detected, we only affect stuff that were detected
-        const existsInCompsDeps = this.allDependencies.dependencies.find((dep) => {
-          return dep.packageName === pkgName;
-        });
-
-        const existsInCompsDevDeps = this.allDependencies.devDependencies.find((dep) => {
-          return dep.packageName === pkgName;
-        });
-
-        const existsInCompsPeerDeps = this.allDependencies.peerDependencies.find((dep) => {
-          return dep.packageName === pkgName;
-        });
-        if (
+        const isAutoDetected = existsInCompsDeps ||
+          existsInCompsDevDeps ||
+          existsInCompsPeerDeps ||
           // We are checking originAllPackagesDependencies instead of allPackagesDependencies
           // as it might be already removed from allPackagesDependencies at this point if it was set with
           // "-" in runtime/dev
           // in such case we still want to apply it here
-          !this.originAllPackagesDependencies.packageDependencies[pkgName] &&
-          !this.originAllPackagesDependencies.devPackageDependencies[pkgName] &&
-          !this.originAllPackagesDependencies.peerPackageDependencies[pkgName] &&
-          !existsInCompsDeps &&
-          !existsInCompsDevDeps &&
-          !existsInCompsPeerDeps &&
-          // Check if it was orignally exists in the component
+          this.originAllPackagesDependencies.packageDependencies[pkgName] ||
+          this.originAllPackagesDependencies.devPackageDependencies[pkgName] ||
+          this.originAllPackagesDependencies.peerPackageDependencies[pkgName] ||
+          // Check if it was originally exists in the component
           // as we might have a policy which looks like this:
           // "components": {
           //   "dependencies": {
@@ -549,9 +548,10 @@ export class ApplyOverrides {
           // }
           // in that case we might remove it before getting to the devDeps then we will think that it wasn't required in the component
           // which is incorrect
-          !originallyExists.includes(pkgName) &&
-          !missingPackages.includes(pkgName)
-        ) {
+          originallyExists.includes(pkgName) ||
+          missingPackages.includes(pkgName)
+
+        if (!isAutoDetected) {
           return;
         }
         originallyExists.push(pkgName);

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -101,6 +101,8 @@ export async function updateDependenciesVersions(
       dependency.id = dependency.id.changeVersion(resolvedVersion);
       if (componentRangePrefix) {
         dependency.versionRange = `${componentRangePrefix}${resolvedVersion}`;
+      } else if (dependency.versionRange && depType !== 'peerDependencies' && dependency.versionRange !== '+') {
+        dependency.versionRange = undefined;
       }
     }
   }

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -101,7 +101,7 @@ export async function updateDependenciesVersions(
       dependency.id = dependency.id.changeVersion(resolvedVersion);
       if (supportComponentRange) {
         if (range) dependency.versionRange = range;
-        else if (componentRangePrefix === '^' || componentRangePrefix === '~') {
+        else if (resolvedVersion !== 'latest' && (componentRangePrefix === '^' || componentRangePrefix === '~')) {
           dependency.versionRange = `${componentRangePrefix}${resolvedVersion}`;
         }
       } else if (dependency.versionRange && depType !== 'peerDependencies' && dependency.versionRange !== '+') {

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -25,6 +25,8 @@ export async function updateDependenciesVersions(
   const autoDetectConfigMerge = workspace.getAutoDetectConfigMerge(component.id) || {};
   const currentLane = await workspace.getCurrentLaneObject();
 
+  const depsResolverConfig = depsResolver.config;
+  const componentRangePrefix  = depsResolverConfig.componentRangePrefix;
   updateDependencies(component.dependencies, 'dependencies');
   updateDependencies(component.devDependencies, 'devDependencies');
   updateDependencies(component.peerDependencies, 'peerDependencies');
@@ -97,6 +99,9 @@ export async function updateDependenciesVersions(
     const resolvedVersion = resolveVersion(id, depType, packageName);
     if (resolvedVersion) {
       dependency.id = dependency.id.changeVersion(resolvedVersion);
+      if (componentRangePrefix) {
+        dependency.versionRange = `${componentRangePrefix}${resolvedVersion}`;
+      }
     }
   }
   function updateDependencies(dependencies: Dependencies, depType: DepType) {

--- a/scopes/dependencies/dependency-resolver/dependency-resolver-workspace-config.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver-workspace-config.ts
@@ -208,4 +208,17 @@ export interface DependencyResolverWorkspaceConfig {
    * Tells pnpm to automatically install peer dependencies. It is true by default.
    */
   autoInstallPeers?: boolean;
+
+  /**
+   * When true, dependencies will be saved with range in the package.json.
+   * The range is determined by the "componentRangePrefix" config. In case the workspace.jsonc has a policy,
+   * the range is determined by the policy.
+   */
+  enableComponentRanges?: boolean;
+
+  /**
+   * This config works in conjunction with the "enableComponentRanges" config.
+   * It determines the prefix (for the range) to use for the dependencies when generating the package.json.
+   */
+  componentRangePrefix?: string;
 }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver-workspace-config.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver-workspace-config.ts
@@ -4,6 +4,8 @@ import { PackageImportMethod } from './package-manager';
 
 export type NodeLinker = 'hoisted' | 'isolated';
 
+export type ComponentRangePrefix = '~' | '^' | '+' | '-';
+
 export interface DependencyResolverWorkspaceConfig {
   policy: WorkspacePolicyConfigObject;
   /**
@@ -210,15 +212,12 @@ export interface DependencyResolverWorkspaceConfig {
   autoInstallPeers?: boolean;
 
   /**
-   * When true, dependencies will be saved with range in the package.json.
-   * The range is determined by the "componentRangePrefix" config. In case the workspace.jsonc has a policy,
-   * the range is determined by the policy.
+   * By default, Bit saves component dependencies with exact versions (pinned) in the package.json,
+   * even if the dependency-resolver policy specifies a version range.
+   *
+   * To preserve the range defined in the policy, set this value to "+".
+   * To apply a predefined range ("~" or "^") to other component dependencies not covered by the policy,
+   * set this to the desired range symbol.
    */
-  enableComponentRanges?: boolean;
-
-  /**
-   * This config works in conjunction with the "enableComponentRanges" config.
-   * It determines the prefix (for the range) to use for the dependencies when generating the package.json.
-   */
-  componentRangePrefix?: string;
+  componentRangePrefix?: ComponentRangePrefix;
 }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -52,7 +52,7 @@ import {
 import { DependencyResolverAspect } from './dependency-resolver.aspect';
 import { DependencyVersionResolver } from './dependency-version-resolver';
 import { DepLinkerContext, DependencyLinker, LinkingOptions } from './dependency-linker';
-import { DependencyResolverWorkspaceConfig, NodeLinker } from './dependency-resolver-workspace-config';
+import { ComponentRangePrefix, DependencyResolverWorkspaceConfig, NodeLinker } from './dependency-resolver-workspace-config';
 import { ComponentModelVersion, getAllPolicyPkgs, OutdatedPkg, CurrentPkgSource } from './get-all-policy-pkgs';
 import { InvalidVersionWithPrefix, PackageManagerNotFound } from './exceptions';
 import {
@@ -1223,6 +1223,7 @@ export class DependencyResolverMain {
     });
     const currentExtension = configuredExtensions.findExtension(DependencyResolverAspect.id);
     const currentConfig = currentExtension?.config as unknown as DependencyResolverVariantConfig;
+
     if (currentConfig && currentConfig.policy) {
       policiesFromConfig = VariantPolicy.fromConfigObject(currentConfig.policy, { source: 'config' });
     }
@@ -1235,6 +1236,7 @@ export class DependencyResolverMain {
       policiesFromSlots,
       policiesFromConfig,
     ]);
+
     return result;
   }
 
@@ -1550,11 +1552,11 @@ as an alternative, you can use "+" to keep the same version installed in the wor
     };
   }
 
-  supportComponentRanges(): boolean {
-    return Boolean(this.config.enableComponentRanges);
-  }
-  componentRangePrefix(): string | undefined {
+  componentRangePrefix(): ComponentRangePrefix | undefined {
     return this.config.componentRangePrefix;
+  }
+  supportComponentRange(): boolean {
+    return Boolean(this.config.componentRangePrefix && this.config.componentRangePrefix !== '-');
   }
 
   static runtime = MainRuntime;

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -25,7 +25,7 @@ export type {
   ProxyConfig as PackageManagerProxyConfig,
   NetworkConfig as PackageManagerNetworkConfig,
 } from './dependency-resolver.main.runtime';
-export { DependencyList, BaseDependency, ComponentDependency, KEY_NAME_BY_LIFECYCLE_TYPE } from './dependencies';
+export { DependencyList, BaseDependency, ComponentDependency, KEY_NAME_BY_LIFECYCLE_TYPE, COMPONENT_DEP_TYPE } from './dependencies';
 export type {
   DependencyLifecycleType,
   WorkspaceDependencyLifecycleType,

--- a/scopes/workspace/workspace/workspace.ts
+++ b/scopes/workspace/workspace/workspace.ts
@@ -113,6 +113,7 @@ import {
 } from './workspace-component/component-status-loader';
 import { getAutoTagInfo, getAutoTagPending } from './auto-tag';
 import { ConfigStoreAspect, ConfigStoreMain, Store } from '@teambit/config-store';
+import type { DependenciesOverridesData } from '@teambit/legacy.consumer-config';
 
 export type EjectConfResult = {
   configPath: string;
@@ -2264,12 +2265,17 @@ the following envs are used in this workspace: ${uniq(availableEnvs).join(', ')}
     );
   }
 
+  /**
+   * the dependencies returned from this method will override the auto-detected dependencies. (done by "applyAutoDetectOverridesOnComponent")
+   * to calculate this, we merge several sources: env, env-for-itself, config from variant, and the merge-config.
+   * keep in mind that component-config (coming from .bitmap or component.json) is not included in this merge.
+   */
   async getAutoDetectOverrides(
     configuredExtensions: ExtensionDataList,
     id: ComponentID,
     legacyFiles: SourceFile[],
     envExtendedDeps?: LegacyDependency[]
-  ) {
+  ): Promise<DependenciesOverridesData> {
     let policy = await this.dependencyResolver.mergeVariantPolicies(
       configuredExtensions,
       id,


### PR DESCRIPTION
- Support new `componentRangePrefix` property under the "dependency-resolver" section in `workspace.jsonc`, accepting `^`, `~`, or `+`.
- `^ / ~`  → writes that prefix in package.json for every component dependency.
- `+`  → copies the exact range from the workspace’s dependency policy instead of applying a global prefix.
- if a workspace doesn’t define `componentRangePrefix`, dependencies revert to pinned versions.
- If a dependency has an exact range defined in the workspace’s dependency policy, prioritize it over the componentPolicyPrefix value, even if they conflict.