### PR TITLE
improvement(deps-resolver), save componentRangePrefix in the deps-resolver data

### DIFF
--- a/e2e/harmony/dependency-resolver.e2e.ts
+++ b/e2e/harmony/dependency-resolver.e2e.ts
@@ -530,11 +530,25 @@ describe('dependency-resolver extension', function () {
         expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`^0.0.1`);
       });
     });
-    describe('revert the range', () => {
+    describe('removing componentRangePrefix from the workspace', () => {
       before(() => {
         helper.scopeHelper.getClonedWorkspace(wsAfterExport);
         helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '');
         helper.command.tagComponent('comp1', undefined, '--ver 3.0.0 --unmodified');
+      });
+      it('should keep the dependency with the range', () => {
+        const comp1 = helper.command.catComponent('comp1@latest');
+        const pkgExtensionData = helper.command.getAspectsData(comp1, Extensions.pkg).data;
+        const comp2Pkg = helper.general.getPackageNameByCompName('comp2');
+        expect(pkgExtensionData.pkgJson.dependencies).to.have.property(comp2Pkg);
+        expect(pkgExtensionData.pkgJson.dependencies[comp2Pkg]).to.equal(`^0.0.1`);
+      });
+    });
+    describe('revert the range by setting the prefix to minus', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(wsAfterExport);
+        helper.workspaceJsonc.addKeyValToDependencyResolver('componentRangePrefix', '-');
+        helper.command.tagComponent('comp1', undefined, '--ver 4.0.0 --unmodified');
       });
       it('should save the dependency without the range', () => {
         const comp1 = helper.command.catComponent('comp1@latest');

--- a/scopes/component/snapping/version-maker.ts
+++ b/scopes/component/snapping/version-maker.ts
@@ -17,7 +17,7 @@ import { sha1 } from '@teambit/toolbox.crypto.sha1';
 import { BuilderMain, OnTagOpts } from '@teambit/builder';
 import { ModelComponent, Log, DependenciesGraph, Lane } from '@teambit/objects';
 import { MessagePerComponent, MessagePerComponentFetcher } from './message-per-component';
-import { DependencyResolverAspect, DependencyResolverMain, COMPONENT_DEP_TYPE } from '@teambit/dependency-resolver';
+import { DependencyResolverAspect, DependencyResolverMain, COMPONENT_DEP_TYPE, ComponentRangePrefix } from '@teambit/dependency-resolver';
 import { ScopeMain, StagedConfig } from '@teambit/scope';
 import { Workspace, AutoTagResult } from '@teambit/workspace';
 import { pMapPool } from '@teambit/toolbox.promise.map-pool';
@@ -498,8 +498,7 @@ export class VersionMaker {
     // in case we update dependencies according to the currently tagged component, we want to keep the versionRange
     // up to date with the new tags. e.g. 0.0.1 -> 0.0.2, will change the versionRange to ^0.0.2 or ~0.0.2.
     // in case componentRangePrefix is "+", we care only about packages in workspace.jsonc. so it won't be relevant.
-    const componentRangePrefix = this.dependencyResolver.componentRangePrefix();
-    const updateDepsResolverData = (component: ConsumerComponent) => {
+    const updateDepsResolverData = (component: ConsumerComponent, componentRangePrefix?: ComponentRangePrefix) => {
       const entry = component.extensions.findCoreExtension(DependencyResolverAspect.id);
       if (!entry) {
         return component;
@@ -528,6 +527,8 @@ export class VersionMaker {
     }
 
     componentsToTag.forEach((oneComponentToTag) => {
+      const componentRangePrefix = this.dependencyResolver
+        .calcComponentRangePrefixByConsumerComponent(oneComponentToTag);
       oneComponentToTag.getAllDependencies().forEach((dependency) => {
         const newDepId = getNewDependencyVersion(dependency.id);
         if (!newDepId) return;

--- a/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
+++ b/scopes/dependencies/dependencies/dependencies-loader/dependencies-versions-resolver.ts
@@ -25,8 +25,8 @@ export async function updateDependenciesVersions(
   const consumer: Consumer = workspace.consumer;
   const autoDetectConfigMerge = workspace.getAutoDetectConfigMerge(component.id) || {};
   const currentLane = await workspace.getCurrentLaneObject();
-  const componentRangePrefix  = depsResolver.componentRangePrefix();
-  const supportComponentRange = depsResolver.supportComponentRange();
+  const componentRangePrefix  = depsResolver.calcComponentRangePrefixByConsumerComponent(component);
+  const supportComponentRange = componentRangePrefix && componentRangePrefix !== '-';
   updateDependencies(component.dependencies, 'dependencies');
   updateDependencies(component.devDependencies, 'devDependencies');
   updateDependencies(component.peerDependencies, 'peerDependencies');

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -1617,21 +1617,17 @@ as an alternative, you can use "+" to keep the same version installed in the wor
     return this.config.componentRangePrefix;
   }
   calcComponentRangePrefixByConsumerComponent(component: LegacyComponent): ComponentRangePrefix | undefined {
-    const data = component.extensions?.findCoreExtension(DependencyResolverAspect.id)?.data;
-    if (data?.componentRangePrefix) { // was calculated already
-      return data.componentRangePrefix;
-    }
     const fromWs = this.getWorkspaceComponentRangePrefix();
     if (fromWs) {
       return fromWs;
     }
-    const modelComp: LegacyComponent | undefined = component.componentFromModel;
-    if (!modelComp) {
-      return undefined;
-    }
-    const modelData = modelComp.extensions.findCoreExtension(DependencyResolverAspect.id);
+    const modelData = component.componentFromModel?.extensions.findCoreExtension(DependencyResolverAspect.id);
     if (modelData?.data?.componentRangePrefix) {
       return modelData.data.componentRangePrefix;
+    }
+    const currentData = component.extensions?.findCoreExtension(DependencyResolverAspect.id)?.data;
+    if (currentData?.componentRangePrefix) {
+      return currentData.componentRangePrefix;
     }
     return undefined;
   }

--- a/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
+++ b/scopes/dependencies/dependency-resolver/dependency-resolver.main.runtime.ts
@@ -103,6 +103,7 @@ export interface DependencyResolverComponentData {
   packageName: string;
   policy: SerializedVariantPolicy;
   dependencies: SerializedDependency[];
+  componentRangePrefix?: ComponentRangePrefix;
 }
 
 export interface DependencyResolverVariantConfig {
@@ -152,6 +153,12 @@ const defaultCreateFromComponentsOptions: CreateFromComponentsOptions = {
   createManifestForComponentsWithoutDependencies: true,
 };
 
+/**
+ * see @teambit/dependencies.aspect-docs.dependency-resolver for more information about this aspect.
+ *
+ * The data of this aspect gets saved in workspace-component-loader.ts, `executeLoadSlot()`.
+ * The type of the data is `DependencyResolverComponentData`.
+ */
 export class DependencyResolverMain {
   /**
    * cache the workspace policy to improve performance. when workspace.jsonc is changed, this gets cleared.
@@ -1606,12 +1613,29 @@ as an alternative, you can use "+" to keep the same version installed in the wor
     };
   }
 
-  componentRangePrefix(): ComponentRangePrefix | undefined {
+  getWorkspaceComponentRangePrefix(): ComponentRangePrefix | undefined {
     return this.config.componentRangePrefix;
   }
-  supportComponentRange(): boolean {
-    return Boolean(this.config.componentRangePrefix && this.config.componentRangePrefix !== '-');
+  calcComponentRangePrefixByConsumerComponent(component: LegacyComponent): ComponentRangePrefix | undefined {
+    const data = component.extensions?.findCoreExtension(DependencyResolverAspect.id)?.data;
+    if (data?.componentRangePrefix) { // was calculated already
+      return data.componentRangePrefix;
+    }
+    const fromWs = this.getWorkspaceComponentRangePrefix();
+    if (fromWs) {
+      return fromWs;
+    }
+    const modelComp: LegacyComponent | undefined = component.componentFromModel;
+    if (!modelComp) {
+      return undefined;
+    }
+    const modelData = modelComp.extensions.findCoreExtension(DependencyResolverAspect.id);
+    if (modelData?.data?.componentRangePrefix) {
+      return modelData.data.componentRangePrefix;
+    }
+    return undefined;
   }
+
 
   static runtime = MainRuntime;
   static dependencies = [

--- a/scopes/dependencies/dependency-resolver/index.ts
+++ b/scopes/dependencies/dependency-resolver/index.ts
@@ -14,7 +14,7 @@ export type {
   CalcDepsGraphOptions,
   ComponentIdByPkgName,
 } from './package-manager';
-export type { DependencyResolverWorkspaceConfig, NodeLinker } from './dependency-resolver-workspace-config';
+export type { DependencyResolverWorkspaceConfig, NodeLinker, ComponentRangePrefix } from './dependency-resolver-workspace-config';
 export type {
   DependencyResolverMain,
   DependencyResolverVariantConfig,

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -938,6 +938,7 @@ export class WorkspaceComponentLoader {
       packageName: this.dependencyResolver.calcPackageName(component),
       dependencies: dependenciesList.serialize(),
       policy: policy.serialize(),
+      componentRangePrefix: this.dependencyResolver.calcComponentRangePrefixByConsumerComponent(component),
     };
 
     // Make sure we are adding the envs / deps data first because other on load events might depend on it

--- a/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
+++ b/scopes/workspace/workspace/workspace-component/workspace-component-loader.ts
@@ -938,7 +938,8 @@ export class WorkspaceComponentLoader {
       packageName: this.dependencyResolver.calcPackageName(component),
       dependencies: dependenciesList.serialize(),
       policy: policy.serialize(),
-      componentRangePrefix: this.dependencyResolver.calcComponentRangePrefixByConsumerComponent(component),
+      componentRangePrefix: this.dependencyResolver
+        .calcComponentRangePrefixByConsumerComponent(component.state._consumer),
     };
 
     // Make sure we are adding the envs / deps data first because other on load events might depend on it


### PR DESCRIPTION
This way, when importing the component to a new workspace that doesn't have any `componentRangePrefix` set , it keeps the range. 

With this change, if the user wants to remove the range-prefix, it's not enough to remove the prop from workspace.jsonc. It'll need to be set with minus. (`"componentRangePrefix": "-"`).