### PR TITLE
feat(list)!: rename --scope flag to --local-scope and introduce --scope <scope-name> for filtering by scope name

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -643,8 +643,8 @@ jobs:
           # command: cd bit && bit tag --ignore-newest-version
           # command: cd bit && bit tag --increment-by 3
           # command: cd bit && bit tag --increment-by 2
-          # command: cd bit && bit tag
-          command: cd bit && bit tag --persist
+          command: cd bit && bit tag
+          # command: cd bit && bit tag --persist
           # command: cd bit && bit tag --persist --ignore-newest-version
           no_output_timeout: '25m'
           environment:

--- a/components/legacy/e2e-helper/e2e-command-helper.ts
+++ b/components/legacy/e2e-helper/e2e-command-helper.ts
@@ -182,10 +182,10 @@ export default class CommandHelper {
     return JSON.parse(output);
   }
   listLocalScope(options = '') {
-    return this.runCmd(`bit list --scope ${options}`);
+    return this.runCmd(`bit list --local-scope ${options}`);
   }
   listLocalScopeParsed(options = ''): Record<string, any>[] {
-    const output = this.runCmd(`bit list --scope --json ${options}`);
+    const output = this.runCmd(`bit list --local-scope --json ${options}`);
     return JSON.parse(output);
   }
   listRemoteScopeParsed(options = '') {

--- a/e2e/flows/sort-components-output.e2e.3.ts
+++ b/e2e/flows/sort-components-output.e2e.3.ts
@@ -38,7 +38,7 @@ describe('basic flow with dependencies', function () {
         expectComponentsToBeSortedAlphabetically(output);
       });
     });
-    it('bit list --scope should not show any component', () => {
+    it('bit list --local-scope should not show any component', () => {
       const output = helper.command.listLocalScope();
       expect(output).to.have.string('found 0 components');
     });

--- a/e2e/harmony/eject-harmony.e2e.ts
+++ b/e2e/harmony/eject-harmony.e2e.ts
@@ -65,7 +65,7 @@ describe('eject command on Harmony', function () {
         helper.command.expectStatusToBeClean();
       });
       it('should not delete the objects from the scope', () => {
-        const listScope = helper.command.listLocalScopeParsed('--scope');
+        const listScope = helper.command.listLocalScopeParsed();
         const ids = listScope.map((l) => l.id);
         expect(ids).to.include(`${helper.scopes.remote}/comp1`);
       });
@@ -100,7 +100,7 @@ describe('eject command on Harmony', function () {
         helper.command.expectStatusToBeClean();
       });
       it('should not delete the objects from the scope', () => {
-        const listScope = helper.command.listLocalScopeParsed('--scope');
+        const listScope = helper.command.listLocalScopeParsed();
         const ids = listScope.map((l) => l.id);
         expect(ids).to.include(`${helper.scopes.remote}/comp1`);
       });

--- a/e2e/harmony/extensions-config.e2e.3.ts
+++ b/e2e/harmony/extensions-config.e2e.3.ts
@@ -205,7 +205,7 @@ describe('harmony extension config', function () {
           helper.command.importComponent('bar/foo');
         });
         it('should auto-import the extensions as well', () => {
-          const scopeList = helper.command.listLocalScopeParsed('--scope');
+          const scopeList = helper.command.listLocalScopeParsed();
           const ids = scopeList.map((entry) => entry.id);
           expect(ids).to.include(`${helper.scopes.remote}/dummy-extension-without-logs`);
         });

--- a/e2e/harmony/import-harmony.e2e.ts
+++ b/e2e/harmony/import-harmony.e2e.ts
@@ -45,7 +45,7 @@ describe('import functionality on Harmony', function () {
           );
           helper.command.addComponent('bar');
           // as an intermediate step, make sure the scope is empty.
-          const localScope = helper.command.listLocalScopeParsed('--scope');
+          const localScope = helper.command.listLocalScopeParsed();
           expect(localScope).to.have.lengthOf(0);
 
           helper.command.runCmd('bit insights'); // this command happened to run the build-one-graph.
@@ -55,7 +55,7 @@ describe('import functionality on Harmony', function () {
         //   expect(importOutput).to.have.string('successfully imported one component');
         // });
         it('the scope should have the dependencies and the flattened dependencies', () => {
-          const localScope = helper.command.listLocalScopeParsed('--scope');
+          const localScope = helper.command.listLocalScopeParsed();
           expect(localScope).to.have.lengthOf(3);
         });
       });

--- a/e2e/harmony/lanes/import-lanes.e2e.ts
+++ b/e2e/harmony/lanes/import-lanes.e2e.ts
@@ -43,7 +43,7 @@ describe('import lanes', function () {
         expect(Object.keys(bitMap)).to.have.lengthOf(0);
       });
       it('should import components objects on that lane', () => {
-        const list = helper.command.listLocalScopeParsed('--scope');
+        const list = helper.command.listLocalScopeParsed();
         expect(list).to.have.lengthOf(3);
       });
       it('bit status should show a clean state', () => {

--- a/e2e/harmony/lanes/lane-eject.e2e.ts
+++ b/e2e/harmony/lanes/lane-eject.e2e.ts
@@ -64,7 +64,7 @@ describe('bit lane command', function () {
         helper.command.expectStatusToNotHaveIssues();
       });
       it('should not delete the objects from the scope', () => {
-        const listScope = helper.command.listLocalScopeParsed('--scope');
+        const listScope = helper.command.listLocalScopeParsed();
         const ids = listScope.map((l) => l.id);
         expect(ids).to.include(`${helper.scopes.remote}/comp1`);
       });

--- a/scopes/component/lister/list.cmd.ts
+++ b/scopes/component/lister/list.cmd.ts
@@ -7,7 +7,8 @@ import { ListerMain, ListScopeResult } from './lister.main.runtime';
 
 type ListFlags = {
   ids?: boolean;
-  scope?: boolean;
+  localScope?: boolean; // whether show all components in the local scope (including indirect dependencies)
+  scope?: string; // new flag for filtering by scope name
   json?: boolean;
   outdated?: boolean;
   namespace?: string;
@@ -22,11 +23,12 @@ export class ListCmd implements Command {
   alias = 'ls';
   options = [
     ['i', 'ids', 'show only component ids, unformatted'],
-    ['s', 'scope', 'show only components stored in the local scope, including indirect dependencies'],
+    ['l', 'local-scope', 'show only components stored in the local scope, including indirect dependencies'],
+    ['s', 'scope <string>', 'filter components by their scope name (e.g., teambit.workspace)'],
     ['o', 'outdated', 'highlight outdated components, in comparison with their latest remote version (if one exists)'],
     ['d', 'include-deleted', 'EXPERIMENTAL. show also deleted components'],
     ['j', 'json', 'show the output in JSON format'],
-    ['n', 'namespace <string>', "show only components in the specified namespace/s e.g. '-n ui' or '*/ui'"],
+    ['n', 'namespace <string>', "filter components by their namespace (a logical grouping within a scope, e.g., 'ui', '*/ui')"],
   ] as CommandOptions;
   loader = true;
   skipWorkspace = true;
@@ -35,6 +37,9 @@ export class ListCmd implements Command {
   constructor(private lister: ListerMain) {}
 
   async report([scopeName]: string[], listFlags: ListFlags) {
+    if (scopeName && (listFlags.localScope || listFlags.scope)) {
+      throw new Error('The --local-scope and --scope flags cannot be used when listing a remote scope.');
+    }
     const listScopeResults = await this.getListResults(scopeName, listFlags);
 
     const { ids, outdated = false } = listFlags;
@@ -54,6 +59,9 @@ export class ListCmd implements Command {
   }
 
   async json([scopeName]: string[], listFlags: ListFlags) {
+    if (scopeName && (listFlags.localScope || listFlags.scope)) {
+      throw new Error('The --local-scope and --scope flags cannot be used when listing a remote scope.');
+    }
     const listScopeResults = await this.getListResults(scopeName, listFlags);
 
     if (isEmpty(listScopeResults)) {
@@ -67,7 +75,7 @@ export class ListCmd implements Command {
 
   private async getListResults(
     scopeName?: string,
-    { namespace, scope, outdated, includeDeleted }: ListFlags = {}
+    { namespace, localScope, scope, outdated, includeDeleted }: ListFlags = {}
   ): Promise<ListScopeResult[]> {
     const getNamespaceWithWildcard = () => {
       if (!namespace) return undefined;
@@ -78,6 +86,6 @@ export class ListCmd implements Command {
 
     return scopeName
       ? this.lister.remoteList(scopeName, { namespacesUsingWildcards, includeDeleted })
-      : this.lister.localList(scope, outdated, namespacesUsingWildcards);
+      : this.lister.localList(localScope, outdated, namespacesUsingWildcards, scope);
   }
 }

--- a/scopes/component/lister/lister.main.runtime.ts
+++ b/scopes/component/lister/lister.main.runtime.ts
@@ -64,14 +64,18 @@ export class ListerMain {
   async localList(
     showAll = false,
     showRemoteVersion = false,
-    namespacesUsingWildcards?: string
+    namespacesUsingWildcards?: string,
+    scopeName?: string
   ): Promise<ListScopeResult[]> {
     if (!this.workspace) {
       throw new ConsumerNotFound();
     }
     this.logger.setStatusLine(BEFORE_LOCAL_LIST);
     const componentsList = new ComponentsList(this.workspace);
-    const results = await componentsList.listAll(showRemoteVersion, showAll, namespacesUsingWildcards);
+    let results = await componentsList.listAll(showRemoteVersion, showAll, namespacesUsingWildcards);
+    if (scopeName) {
+      results = results.filter((result) => result.id.scope === scopeName);
+    }
     return this.sortListScopeResults(results);
   }
 

--- a/scopes/component/snapping/reset-cmd.ts
+++ b/scopes/component/snapping/reset-cmd.ts
@@ -11,11 +11,7 @@ export default class ResetCmd implements Command {
     {
       name: 'component-pattern',
       description: COMPONENT_PATTERN_HELP,
-    },
-    {
-      name: 'component-version',
-      description: 'the version to untag (semver for tags. hash for snaps)',
-    },
+    }
   ];
   group = 'development';
   extendedDescription = `${BASE_DOCS_DOMAIN}components/tags#undoing-a-tag`;


### PR DESCRIPTION
## Proposed Changes

- Renamed the `--scope` flag to `--local-scope` to clarify its purpose for listing components in the local scope.
- Introduced a new `--scope <scope-name>` flag to filter components by their scope name.
- Updated command logic and help text to reflect these changes and prevent misuse of flags with remote scopes.
