### PR TITLE
fix: remove invalid lint-staged exclude pattern from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "node": ">=12.22.0"
   },
   "lint-staged": {
-    "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}, !excluded-fixtures": "oxlint --deny-warnings",
-    "*.{ts,js,jsx,tsx,css,scss,md,mdx}, !excluded-fixtures": [
+    "**/*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,vue,astro,svelte}": "oxlint --deny-warnings",
+    "*.{ts,js,jsx,tsx,css,scss,md,mdx}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
This PR removes an invalid exclude pattern from the lint-staged configuration in package.json to fix lint-staged execution.