### PR TITLE
fix: --no-browser in bit start dev mode

### DIFF
--- a/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
+++ b/scopes/ui-foundation/ui/webpack/webpack.dev.config.ts
@@ -93,7 +93,6 @@ export function devConfig(workspaceDir, entryFiles, title): WebpackConfigWithDev
     },
 
     devServer: {
-      open: true,
       allowedHosts: 'all',
 
       static: [


### PR DESCRIPTION
## Proposed Changes

- remove `devServer.open` flag
- it should be only controlled by the noBrowser flag in `start.cmd.tsx`

