### PR TITLE
feat(schema), introduce --remote flag

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -118,8 +118,8 @@ In default mode, the server exposes a focused set of essential Bit CLI commands 
 - `bit_templates`: List available templates
 - `bit_reset`: Revert tags or snaps
 - `bit_checkout`: Switch versions or remove changes
+- `bit_schema`: Retrieve component API schema from workspace or remote scopes
 - `bit_remote_search`: Search for components in remote scopes
-- `bit_remote_get_schema`: Retrieve component API schema from remote scopes
 
 ### Extended Mode (--extended)
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -79,8 +79,8 @@ export class CliMcpServerMain {
       'templates',
       'reset',
       'checkout',
+      'schema',
       'remote-search',
-      'remote-get-schema',
     ]);
 
     // Tools to always exclude
@@ -144,7 +144,7 @@ export class CliMcpServerMain {
       }
     });
 
-    const remoteCommands = ['remote-search', 'remote-get-schema'];
+    const remoteCommands = ['remote-search'];
     remoteCommands.forEach((cmdName) => {
       if (this.shouldIncludeCommand(cmdName, filterOptions)) {
         this.registerToolForRemote(server, cmdName);
@@ -273,8 +273,6 @@ export class CliMcpServerMain {
   private registerToolForRemote(server: McpServer, name: string) {
     if (name === 'remote-search') {
       this.registerRemoteSearchTool(server);
-    } else if (name === 'remote-get-schema') {
-      this.registerGetSchemaTool(server);
     }
   }
 
@@ -296,19 +294,6 @@ export class CliMcpServerMain {
         text: result,
       }));
       return { content: formattedResults } as CallToolResult;
-    });
-  }
-
-  private registerGetSchemaTool(server: McpServer) {
-    const toolName = this.getToolName('remote-get-schema');
-    const description = 'Get the schema of a component from the remote scope. (the schema is the API of the component)';
-    const schema: Record<string, any> = {
-      id: z.string().describe('Component ID'),
-    };
-    server.tool(toolName, description, schema, async (params: any) => {
-      const http = await this.getHttp();
-      const response = await http.getSchema(params.id);
-      return { content: [{ type: 'text', text: JSON.stringify(response) }] } as CallToolResult;
     });
   }
 

--- a/scopes/semantics/schema/schema.cmd.ts
+++ b/scopes/semantics/schema/schema.cmd.ts
@@ -8,10 +8,17 @@ import type { SchemaMain } from './schema.main.runtime';
 
 export class SchemaCommand implements Command {
   name = 'schema <pattern>';
-  description = 'shows the API schema of the specified component/s.';
-  extendedDescription = `${PATTERN_HELP('schema')}`;
+  description =
+    'extracts and displays the API schema (types, functions, classes, interfaces) of the specified component/s.';
+  extendedDescription = `Extracts TypeScript definitions to provide a comprehensive view of a component's public API.
+Shows detailed information about exported elements including classes, interfaces, functions, types, and enums with their respective signatures and documentation.
+
+${PATTERN_HELP('schema')}`;
   group = 'development';
-  options = [['j', 'json', 'return the component schema in json format']] as CommandOptions;
+  options = [
+    ['r', 'remote', 'fetch schema from remote scope (works for components not in workspace)'],
+    ['j', 'json', 'return the component schema in json format'],
+  ] as CommandOptions;
 
   constructor(
     private schema: SchemaMain,
@@ -19,17 +26,21 @@ export class SchemaCommand implements Command {
     private logger: Logger
   ) {}
 
-  async report([pattern]: [string]) {
-    const schemas = await this.getSchemas([pattern]);
+  async report([pattern]: [string], { remote }: { remote: boolean }): Promise<string> {
+    const schemas = await this.getSchemas([pattern], remote);
     return schemas.map((schema) => schema.toStringPerType()).join('\n\n\n');
   }
 
-  async json([pattern]: [string]): Promise<Record<string, any>> {
-    const schemas = await this.getSchemas([pattern]);
+  async json([pattern]: [string], { remote }: { remote: boolean }): Promise<Record<string, any>> {
+    const schemas = await this.getSchemas([pattern], remote);
     return schemas.map((schema) => schema.toObject());
   }
 
-  private async getSchemas([pattern]: [string]): Promise<APISchema[]> {
+  private async getSchemas([pattern]: [string], remote = false): Promise<APISchema[]> {
+    if (remote) {
+      const schema = await this.schema.getSchemaFromRemote(pattern);
+      return [schema];
+    }
     const host = this.component.getHost();
     const ids = await host.idsByPattern(pattern, true);
     const components = await host.getMany(ids);


### PR DESCRIPTION
Enable displaying schema for remote components from the CLI.

This helps the MCP server accepting id as a package name. When it was a GraphQL query, it didn't have the Workspace object, so this ability to convert a package into a component wasn't available. 