### PR TITLE
feat: support npm alias in env.jsonc

### DIFF
--- a/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
+++ b/scopes/dependencies/dependency-resolver/manifest/deduping/hoist-dependencies.ts
@@ -450,7 +450,7 @@ function groupByRangeOrVersion(indexItems: PackageNameIndexComponentItem[]): Ite
 export function isRange(version: string, compIdStr: string) {
   const validRange = semver.validRange(version);
   if (!validRange) {
-    if (!isHash(version) && !version.startsWith('workspace:')) {
+    if (!isHash(version) && !version.startsWith('workspace:') && !version.startsWith('npm:')) {
       throw new Error(
         `fatal: the version "${version}" originated from a dependent "${compIdStr}" is invalid semver range and not a hash`
       );


### PR DESCRIPTION
## Proposed Changes

- support npm alias in env.jsonc e.g.:
  ```
  {
    "name": "vite",
    "version": "npm:rolldown-vite@latest",
    "supportedRange": "npm:rolldown-vite@latest"
  },
  ```
