### PR TITLE
feat(remote): add "list" sub-command as an alias to "bit remote"

### DIFF
--- a/scopes/harmony/cli/help.ts
+++ b/scopes/harmony/cli/help.ts
@@ -8,7 +8,7 @@ import { getCommandId } from './get-command-id';
 const SPACE = ' ';
 const TITLE_LEFT_SPACES_NUMBER = 2;
 const COMMAND_LEFT_SPACES_NUMBER = 4;
-const NAME_WITH_SPACES_LENGTH = 15;
+const NAME_WITH_SPACES_LENGTH = 16;
 
 type HelpProps = {
   [groupName: string]: GroupContent;

--- a/scopes/harmony/global-config/remote-cmd.ts
+++ b/scopes/harmony/global-config/remote-cmd.ts
@@ -34,16 +34,14 @@ class RemoteRm implements Command {
   }
 }
 
-export class RemoteCmd implements Command {
-  name = 'remote';
-  description = 'manage set of tracked bit scope(s)';
+export class RemoteList implements Command {
+  name = 'list';
+  description = 'list all configured remotes';
   group = 'collaborate';
   helpUrl = 'reference/scope/remote-scopes';
   alias = '';
   loadAspects = false;
   options = [['g', 'global', 'see globally configured remotes']] as CommandOptions;
-  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
-  commands = [new RemoteAdd(), new RemoteRm()];
 
   async report(args: string[], { global }: { global: boolean }) {
     const remotes: { [key: string]: string } = await list(global);
@@ -55,5 +53,21 @@ export class RemoteCmd implements Command {
     });
 
     return table.toString();
+  }
+}
+
+export class RemoteCmd implements Command {
+  name = 'remote';
+  description = 'manage set of tracked bit scope(s)';
+  group = 'collaborate';
+  helpUrl = 'reference/scope/remote-scopes';
+  alias = '';
+  loadAspects = false;
+  options = [['g', 'global', 'see globally configured remotes']] as CommandOptions;
+  // @ts-ignore AUTO-ADDED-AFTER-MIGRATION-PLEASE-FIX!
+  commands = [new RemoteAdd(), new RemoteRm(), new RemoteList()];
+
+  async report(args: string[], { global }: { global: boolean }) {
+    return new RemoteList().report(args, { global });
   }
 }

--- a/scopes/scope/importer/fetch-cmd.ts
+++ b/scopes/scope/importer/fetch-cmd.ts
@@ -9,6 +9,7 @@ export class FetchCmd implements Command {
   name = 'fetch [ids...]';
   description = `fetch remote objects and store locally`;
   extendedDescription = `for lanes, use "/" as a separator between the remote and the lane name, e.g. teambit.ui/fix-button`;
+  group = 'collaborate';
   alias = '';
   private = true;
   options = [


### PR DESCRIPTION
Agents try using the non-exist "bit remote list". This PR helps them by introducing it. 