### PR TITLE
refactor: remove defaultTools from MCP server and make remote-search always available

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -34,7 +34,7 @@ Options:
 - `-e, --extended`: Enable the full set of Bit CLI commands as MCP tools
 - `--consumer-project`: For non-Bit workspaces that only consume Bit component packages. Enables only "schema", "show", and "remote-search" tools and automatically adds the "--remote" flag to relevant commands.
 - `--include-only <commands>`: Specify a subset of commands to expose as MCP tools (comma-separated list)
-- `--include-additional <commands>`: Add specific commands to the default set (comma-separated list)
+- `--include-additional <commands>`: Add specific commands to the available tools (comma-separated list)
 - `--exclude <commands>`: Prevent specific commands from being exposed (comma-separated list)
 
 ### Integrating with IDEs
@@ -70,7 +70,7 @@ This command automatically configures the MCP server settings in your chosen edi
 - `--extended`: Configure with extended mode enabled
 - `--consumer-project`: Configure for consumer projects
 - `--include-only <commands>`: Specify subset of commands to expose
-- `--include-additional <commands>`: Add specific commands to the default set
+- `--include-additional <commands>`: Add specific commands to the available tools
 - `--exclude <commands>`: Prevent specific commands from being exposed
 
 #### Examples
@@ -129,26 +129,19 @@ The Bit CLI MCP Server operates in three modes and provides several specialized 
 
 ### Default Mode
 
-In default mode, the server exposes a minimal set of essential tools focused on component discovery and creation. This ensures optimal performance and safety:
+In default mode, the server exposes a minimal set of essential tools focused on core functionality. This ensures optimal performance and safety:
 
-- **Individual CLI Command Tools:**
+- **Always Available Tools:**
 
-  - `bit_create`: Generate components from templates
-  - `bit_schema`: Retrieve component API schema from workspace or remote scopes
   - `bit_remote_search`: Search for components in remote scopes
-
-- **Specialized Composite Tools:**
-
   - `bit_workspace_info`: Get comprehensive workspace information including status, components list, apps, templates, and dependency graph
   - `bit_component_details`: Get detailed information about a specific component including basic info and optionally its public API schema
+  - `bit_query`: Execute read-only Bit commands that safely inspect workspace and component state without making modifications
+  - `bit_execute`: Execute any Bit command, including those that modify workspace or repository state (use with caution)
   - `bit_commands_list`: Get all available Bit commands with descriptions and groups (for command discovery)
   - `bit_command_help`: Get detailed help for a specific Bit command including syntax, arguments, flags, and usage examples
 
 > **Command Discovery vs. Command Help**: Use `bit_commands_list` to discover what commands are available in Bit, then use `bit_command_help` with a specific command name to get detailed usage information including arguments, flags, and examples.
-
-- **Generic Execution Tools:**
-  - `bit_query`: Execute read-only Bit commands that safely inspect workspace and component state without making modifications
-  - `bit_execute`: Execute any Bit command, including those that modify workspace or repository state (use with caution)
 
 ### Consumer Project Mode (--consumer-project)
 
@@ -156,7 +149,6 @@ This mode is designed for applications or projects that are not Bit workspaces b
 
 - `bit_schema`: Retrieves component API schema from remote scopes (automatically adds `--remote` flag)
 - `bit_show`: Displays component information from remote scopes (automatically adds `--remote` flag)
-- `bit_remote_search`: Searches for components in remote scopes
 
 In this mode:
 
@@ -201,8 +193,8 @@ To customize the available tools beyond the default set or extended mode:
 # Include only specific tools
 bit mcp-server --include-only "status,show,tag,snap,import,export"
 
-# Add specific tools to the default set
-bit mcp-server --include-additional "build,lint,format"
+# Add specific tools to the available tools
+bit mcp-server --include-additional "build,lint,format,create,schema"
 
 # For consumer projects (non-Bit workspaces)
 bit mcp-server --consumer-project

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -581,10 +581,10 @@ export class CliMcpServerMain {
   }
 
   private registerRemoteSearchTool(server: McpServer) {
-    const toolName = this.getToolName('remote-search');
-    const description = 'Search for components in remote scopes';
+    const toolName = 'bit_remote_search';
+    const description = 'Search for components in remote scopes. Use this tool to find existing components before creating new ones. Essential for component reuse and discovery. Returns component IDs that can be converted to package names for installation (e.g., "teambit.design/ui/button" becomes "@teambit/design.ui.button"). Use broad keywords rather than multiple specific terms for better results.';
     const schema: Record<string, any> = {
-      queryStr: z.string().describe('Search query string'),
+      queryStr: z.string().describe('Search query string - use broad keywords like "button", "form", "card" rather than multiple specific terms'),
     };
     server.tool(toolName, description, schema, async (params: any) => {
       const http = await this.getHttp();


### PR DESCRIPTION
## Summary
Refactors the MCP server to remove the `defaultTools` concept and simplifies the tool registration logic.

## Changes Made
- Removed `defaultTools` Set that previously included `['create', 'schema', 'remote-search']`
- Made `remote-search` tool always register (like `bit_query`, `bit_execute`, and `bit_workspace_info`)

## Rationale
Since `bit_query` and `bit_execute` can handle any Bit command, having default tools for `schema` and `create` is redundant. The `remote-search` tool should always be available as it's essential for component discovery.