### PR TITLE
feat(mcp): enhance bit_component_details with URL, location status, and improved dependencies

### DIFF
--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -28,6 +28,8 @@ import { GraphMain } from '@teambit/graph';
 import { ComponentNotFound, ScopeMain } from '@teambit/scope';
 import { ComponentMain } from '@teambit/component';
 import { SchemaMain } from '@teambit/schema';
+import { ComponentUrl } from '@teambit/component.modules.component-url';
+import { Logger } from '@teambit/logger';
 
 const FILES_HISTORY_DIR = 'files-history';
 const ENV_ICONS_DIR = 'env-icons';
@@ -100,7 +102,8 @@ export class APIForIDE {
     private graph: GraphMain,
     private scope: ScopeMain,
     private component: ComponentMain,
-    private schema: SchemaMain
+    private schema: SchemaMain,
+    private logger: Logger
   ) {}
 
   async logStartCmdHistory(op: string) {
@@ -588,6 +591,7 @@ export class APIForIDE {
   }
 
   async getCompDetails(id: string, includeSchema = false) {
+    this.logger.debug(`getCompDetails(${id}, ${includeSchema})`);
     const compId = await this.workspace.resolveComponentId(id);
     const existsLocally = this.workspace.hasId(compId);
     const getComp = async () => {
@@ -601,15 +605,24 @@ export class APIForIDE {
     const comp = await getComp();
 
     const fragments = this.component.getShowFragments();
-    const titlesToInclude = ['id', 'env', 'package name', 'files', 'dev files', 'dependencies', 'deprecated'];
+    const titlesToInclude = ['id', 'env', 'package name', 'files', 'dev files', 'deprecated'];
     const showResults: Record<string, any> = {};
     await Promise.all(
       fragments.map(async (fragment) => {
         const result = fragment.json ? await fragment.json(comp) : undefined;
         if (!result || !titlesToInclude.includes(result.title)) return;
+        if (result.title === 'deprecated' && !result.json.isDeprecate) return; // skip if not deprecated
         showResults[result.title] = result.json;
       })
     );
+
+    const deps = comp.getDependencies();
+    showResults.dependencies = deps.map((dep) => {
+      const pkg = dep.getPackageName?.() || dep.id;
+      const pkgWithVer = `${pkg}@${dep.version}`;
+      const compIdStr = dep.type === 'component' ? `, component-id: ${dep.id}` : '';
+      return `${pkgWithVer} (lifecycle: ${dep.lifecycle}, type: ${dep.type}, source: ${dep.source}${compIdStr})`;
+    });
 
     if (includeSchema) {
       try {
@@ -657,6 +670,37 @@ export class APIForIDE {
       // If composition extraction fails, add error info but don't crash
       showResults.usageExamples = `Error fetching usage examples: ${(error as Error).message}`;
     }
+
+    showResults.url = ComponentUrl.toUrl(compId, { includeVersion: false });
+
+    // Add component location status
+    // Check if component exists as a package by looking it up in the pnpm lock file
+    const packageName = comp.getPackageName();
+    let componentLocation: string;
+
+    if (existsLocally) {
+      const compDir = this.workspace.componentDir(compId, { ignoreVersion: true }, { relative: true });
+      componentLocation = `exists locally in the workspace at '${compDir}'`;
+    } else {
+      let isInstalledAsPackage = false;
+
+      try {
+        const lockFilePath = path.join(this.workspace.path, 'node_modules', '.pnpm', 'lock.yaml');
+        if (await fs.pathExists(lockFilePath)) {
+          const lockFileContent = await fs.readFile(lockFilePath, 'utf8');
+          // Check if the package name exists in the lock file
+          isInstalledAsPackage = lockFileContent.includes(packageName);
+        }
+      } catch (error) {
+        this.logger.warn(`Error checking package existence for ${packageName}: ${(error as Error).message}`);
+        // If error occurs during package check, default to false
+        isInstalledAsPackage = false;
+      }
+
+      componentLocation = isInstalledAsPackage ? 'installed as a package' : 'a remote component';
+    }
+
+    showResults.componentLocation = componentLocation;
 
     return showResults;
   }

--- a/scopes/harmony/api-server/api-server.main.runtime.ts
+++ b/scopes/harmony/api-server/api-server.main.runtime.ts
@@ -306,7 +306,8 @@ export class ApiServerMain {
       graph,
       scope,
       component,
-      schema
+      schema,
+      logger
     );
     const cliRoute = new CLIRoute(logger, cli, apiForIDE);
     const cliRawRoute = new CLIRawRoute(logger, cli, apiForIDE);

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -641,10 +641,7 @@ export class CliMcpServerMain {
         .describe(
           `Search query string - Don't try to search with too many keywords. It will try to find components that match all keywords, which is often too restrictive. Instead, search with a single keyword or a few broad keywords`
         ),
-      cwd: z
-        .string()
-        .optional()
-        .describe('Path to workspace directory'),
+      cwd: z.string().optional().describe('Path to workspace directory'),
       owners: z
         .array(z.string())
         .optional()
@@ -828,12 +825,7 @@ export class CliMcpServerMain {
           params.cwd
         );
 
-        // IDE API returns the result directly, not wrapped in success/error structure
-        const componentDetails: any = {
-          show: ideApiResult,
-        };
-
-        return this.formatAsCallToolResult(componentDetails);
+        return this.formatAsCallToolResult(ideApiResult);
       } catch (error) {
         this.logger.error(`[MCP-DEBUG] Error in bit_component_details tool: ${(error as Error).message}`);
         return this.formatErrorAsCallToolResult(error as Error, 'getting component details');

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -299,7 +299,7 @@ export class CliMcpServerMain {
         let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
         try {
           const errorJson = await response.json();
-          errorMessage = errorJson.message || errorMessage;
+          errorMessage = errorJson.message || errorJson || errorMessage;
         } catch {
           // Ignore JSON parse errors
         }

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -132,7 +132,8 @@ describe('CliMcpServer Integration Tests', function () {
       expect(result.content[0]).to.have.property('type', 'text');
 
       const content = JSON.parse((result.content[0] as any).text);
-      expect(content).to.have.property('show');
+      expect(content).to.have.property('id');
+      expect(content).to.have.property('env');
     });
 
     it('should get component details with schema', async () => {
@@ -152,7 +153,8 @@ describe('CliMcpServer Integration Tests', function () {
       expect(result.content[0]).to.have.property('type', 'text');
 
       const content = JSON.parse((result.content[0] as any).text);
-      expect(content).to.have.property('show');
+      expect(content).to.have.property('id');
+      expect(content).to.have.property('publicAPI');
     });
 
     it('should handle non-existent component gracefully', async () => {


### PR DESCRIPTION
This PR enhances the `getCompDetails` MCP tool with several improvements:

## Changes Made

### 1. Added Component URL
- Components now include a `url` field pointing to the component's web page
- Uses `ComponentUrl.toUrl()` to generate the URL without version

### 2. Component Location Status
- Added `componentLocation` field that indicates where the component exists:
  - "exists locally in the workspace at '{path}'" for local components
  - "installed as a package" for components installed via package manager
  - "a remote component" for components only available remotely

### 3. Improved Dependencies Format
- Enhanced dependency information to include lifecycle, type, source, and component ID
- Format: `{package}@{version} (lifecycle: {lifecycle}, type: {type}, source: {source}, component-id: {id})`