### PR TITLE
fix(diff): improve component diff handling for deleted components

### DIFF
--- a/e2e/harmony/rename.e2e.ts
+++ b/e2e/harmony/rename.e2e.ts
@@ -288,6 +288,10 @@ describe('bit rename command', function () {
       helper.command.snapAllComponentsWithoutBuild('--unmodified');
       helper.command.export();
       helper.command.rename('comp1', 'comp11');
+
+      // intermediate steps - make sure diff is working. we got errors here before
+      expect(() => helper.command.diff()).to.not.throw();
+
       helper.command.snapAllComponentsWithoutBuild();
       headOnLane = helper.command.getHeadOfLane('my-lane', 'comp1');
       helper.command.export();


### PR DESCRIPTION
In some cases it was throwing an error: "computeDiff: fromFiles must be defined. if on workspace, consumerComponent.componentFromModel must be set. if on scope, fromVersionFiles must be set". 
This PR fixes it.