### PR TITLE
feat(mcp): add laneId property to bit_workspace_info tool

### DIFF
--- a/scopes/harmony/api-server/api-for-ide.ts
+++ b/scopes/harmony/api-server/api-for-ide.ts
@@ -569,8 +569,11 @@ export class APIForIDE {
     return results;
   }
 
-  getCurrentLaneName(): string {
-    return this.workspace.getCurrentLaneId().name;
+  getCurrentLaneName(includeScope = false): string {
+    const currentLaneId = this.workspace.getCurrentLaneId();
+    if (!includeScope) return currentLaneId.name;
+    if (currentLaneId.isDefault()) return currentLaneId.name;
+    return currentLaneId.toString();
   }
 
   async tagOrSnap(message = '') {

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -795,6 +795,17 @@ export class CliMcpServerMain {
           };
         }
 
+        // Get current lane name with scope
+        try {
+          const laneId = await this.callBitServerIDEAPI('getCurrentLaneName', [true], params.cwd);
+          workspaceInfo.laneId = laneId;
+        } catch (error) {
+          this.logger.error(`[MCP-DEBUG] Error getting current lane name: ${(error as Error).message}`);
+          workspaceInfo.laneId = {
+            error: `Failed to get current lane name: ${(error as Error).message}`,
+          };
+        }
+
         return this.formatAsCallToolResult(workspaceInfo);
       } catch (error) {
         this.logger.error(`[MCP-DEBUG] Error in bit_workspace_info tool: ${(error as Error).message}`);


### PR DESCRIPTION
This PR adds a new `laneId` property to the `bit_workspace_info` MCP tool that returns the current lane name with scope included.