### PR TITLE
feat(mcp): remove extended, include-only, and exclude flags from MCP server

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -31,11 +31,8 @@ bit mcp-server [options]
 
 Options:
 
-- `-e, --extended`: Enable the full set of Bit CLI commands as MCP tools
 - `--consumer-project`: For non-Bit workspaces that only consume Bit component packages. Enables only "schema", "show", and "remote-search" tools and automatically adds the "--remote" flag to relevant commands.
-- `--include-only <commands>`: Specify a subset of commands to expose as MCP tools (comma-separated list)
 - `--include-additional <commands>`: Add specific commands to the available tools (comma-separated list)
-- `--exclude <commands>`: Prevent specific commands from being exposed (comma-separated list)
 
 ### Integrating with IDEs
 
@@ -67,11 +64,8 @@ This command automatically configures the MCP server settings in your chosen edi
 #### Configuration Options
 
 - `--global`: Apply configuration globally (user settings) instead of workspace settings
-- `--extended`: Configure with extended mode enabled
 - `--consumer-project`: Configure for consumer projects
-- `--include-only <commands>`: Specify subset of commands to expose
 - `--include-additional <commands>`: Add specific commands to the available tools
-- `--exclude <commands>`: Prevent specific commands from being exposed
 
 #### Examples
 
@@ -79,8 +73,8 @@ This command automatically configures the MCP server settings in your chosen edi
 # Basic VS Code setup (workspace level)
 bit mcp-server setup
 
-# Global setup for Cursor with extended mode
-bit mcp-server setup cursor --global --extended
+# Global setup for Cursor
+bit mcp-server setup cursor --global
 
 # Setup for Windsurf with consumer project mode
 bit mcp-server setup windsurf --consumer-project
@@ -125,7 +119,7 @@ async function example() {
 
 ## Available Tools
 
-The Bit CLI MCP Server operates in three modes and provides several specialized tools:
+The Bit CLI MCP Server operates in two modes and provides several specialized tools:
 
 ### Default Mode
 
@@ -157,20 +151,6 @@ In this mode:
 3. The `cwd` parameter is still required but can be any directory (not necessarily a Bit workspace)
 4. You can still add additional tools with the `--include-additional` flag
 
-### Extended Mode (--extended)
-
-When started with the `--extended` flag, the server exposes nearly all Bit CLI commands as MCP tools, including:
-
-- All lane sub-commands (remove, alias, rename, diff, change-scope, import, fetch, eject, history, etc.)
-- Development tools (build, lint, format)
-- Package management (uninstall, update)
-- Component operations (recover, fork, rename)
-- Workspace management (ws-config, stash, aspect)
-- Analysis tools (insight, deps, why)
-- And many more
-
-> **Note:** When using extended mode, some AI models (particularly Gemini and ChatGPT) may struggle with the high number of available tools and respond with "400 Bad Request" or "500 Server Error" errors. This is not due to any issue with specific tools, but rather with how these models handle large tool sets. Claude Sonnet tends to handle extended mode better. If you encounter these errors, try using default mode or selectively adding only the tools you need via the `--include-additional` flag.
-
 ## Tool Parameters
 
 All tools accept a `cwd` parameter specifying the workspace path. Additional parameters vary by command.
@@ -187,12 +167,9 @@ Example tool call for `bit_status`:
 
 ## Custom Tool Selection
 
-To customize the available tools beyond the default set or extended mode:
+To customize the available tools:
 
 ```
-# Include only specific tools
-bit mcp-server --include-only "status,show,tag,snap,import,export"
-
 # Add specific tools to the available tools
 bit mcp-server --include-additional "build,lint,format,create,schema"
 
@@ -201,7 +178,4 @@ bit mcp-server --consumer-project
 
 # Add specific tools to the consumer project set
 bit mcp-server --consumer-project --include-additional "deps,get,preview"
-
-# Exclude specific tools from being available
-bit mcp-server --extended --exclude "checkout,remove"
 ```

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -198,7 +198,7 @@ describe('CliMcpServer Integration Tests', function () {
       expect(firstCommand).to.have.property('description');
     });
 
-    it('should get extended commands info', async () => {
+    it('should get commands info with extended description', async () => {
       const result = (await mcpClient.callTool({
         name: 'bit_commands_list',
         arguments: {
@@ -466,13 +466,12 @@ describe('CliMcpServer Direct Aspect Tests', function () {
       });
     });
 
-    it('should setup VS Code integration with extended options', async () => {
+    it('should setup VS Code integration with consumer project options', async () => {
       await setupMcpServer.setupEditor(
         'vscode',
         {
-          extended: true,
           consumerProject: true,
-          includeOnly: 'status,list',
+          includeAdditional: 'status,list',
           isGlobal: false,
         },
         setupWorkspacePath
@@ -481,9 +480,8 @@ describe('CliMcpServer Direct Aspect Tests', function () {
       const vscodeSettingsPath = path.join(setupWorkspacePath, '.vscode', 'settings.json');
       const settings = await fs.readJson(vscodeSettingsPath);
 
-      expect(settings.mcp.servers['bit-cli'].args).to.include('--extended');
       expect(settings.mcp.servers['bit-cli'].args).to.include('--consumer-project');
-      expect(settings.mcp.servers['bit-cli'].args).to.include('--include-only');
+      expect(settings.mcp.servers['bit-cli'].args).to.include('--include-additional');
       expect(settings.mcp.servers['bit-cli'].args).to.include('status,list');
     });
 

--- a/scopes/mcp/cli-mcp-server/mcp-server.cmd.ts
+++ b/scopes/mcp/cli-mcp-server/mcp-server.cmd.ts
@@ -3,10 +3,7 @@ import { CLIArgs, Command, CommandOptions } from '@teambit/cli';
 import { CliMcpServerMain } from './cli-mcp-server.main.runtime';
 
 export type McpStartCmdOptions = {
-  extended?: boolean;
-  includeOnly?: string;
   includeAdditional?: string;
-  exclude?: string;
   bitBin?: string;
   consumerProject?: boolean;
 };
@@ -19,21 +16,10 @@ export class McpServerCmd implements Command {
   group = 'advanced';
   loader = false;
   options = [
-    ['e', 'extended', 'Enable the full set of Bit CLI commands as MCP tools'],
-    [
-      '',
-      'include-only <commands>',
-      'Specify a subset of commands to expose as MCP tools. Use comma-separated list in quotes, e.g. "status,install,compile"',
-    ],
     [
       '',
       'include-additional <commands>',
-      'Add specific commands to the default MCP tools set. Use comma-separated list in quotes. Only applies when --extended is not used',
-    ],
-    [
-      '',
-      'exclude <commands>',
-      'Prevent specific commands from being exposed as MCP tools. Use comma-separated list in quotes',
+      'Add specific commands to the default MCP tools set. Use comma-separated list in quotes',
     ],
     ['', 'bit-bin <binary>', 'Specify the binary to use for running Bit commands (default: "bit")'],
     [
@@ -65,21 +51,10 @@ export class McpStartCmd implements Command {
   group = 'advanced';
   loader = false;
   options = [
-    ['e', 'extended', 'Enable the full set of Bit CLI commands as MCP tools'],
-    [
-      '',
-      'include-only <commands>',
-      'Specify a subset of commands to expose as MCP tools. Use comma-separated list in quotes, e.g. "status,install,compile"',
-    ],
     [
       '',
       'include-additional <commands>',
-      'Add specific commands to the default MCP tools set. Use comma-separated list in quotes. Only applies when --extended is not used',
-    ],
-    [
-      '',
-      'exclude <commands>',
-      'Prevent specific commands from being exposed as MCP tools. Use comma-separated list in quotes',
+      'Add specific commands to the default MCP tools set. Use comma-separated list in quotes',
     ],
     ['', 'bit-bin <binary>', 'Specify the binary to use for running Bit commands (default: "bit")'],
     [

--- a/scopes/mcp/cli-mcp-server/setup-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/setup-cmd.ts
@@ -3,11 +3,8 @@ import chalk from 'chalk';
 import { CliMcpServerMain } from './cli-mcp-server.main.runtime';
 
 export type McpSetupCmdOptions = {
-  extended?: boolean;
   consumerProject?: boolean;
-  includeOnly?: string;
   includeAdditional?: string;
-  exclude?: string;
   global?: boolean;
 };
 
@@ -23,22 +20,11 @@ export class McpSetupCmd implements Command {
     },
   ];
   options = [
-    ['e', 'extended', 'Enable the full set of Bit CLI commands as MCP tools'],
     ['', 'consumer-project', 'Configure for non-Bit workspaces that only consume Bit component packages'],
-    [
-      '',
-      'include-only <commands>',
-      'Specify a subset of commands to expose as MCP tools. Use comma-separated list in quotes',
-    ],
     [
       '',
       'include-additional <commands>',
       'Add specific commands to the default MCP tools set. Use comma-separated list in quotes',
-    ],
-    [
-      '',
-      'exclude <commands>',
-      'Prevent specific commands from being exposed as MCP tools. Use comma-separated list in quotes',
     ],
     ['g', 'global', 'Setup global configuration (default: workspace-specific)'],
   ] as CommandOptions;
@@ -47,15 +33,12 @@ export class McpSetupCmd implements Command {
 
   async report(
     [editor = 'vscode']: [string],
-    { extended, consumerProject, includeOnly, includeAdditional, exclude, global: isGlobal = false }: McpSetupCmdOptions
+    { consumerProject, includeAdditional, global: isGlobal = false }: McpSetupCmdOptions
   ): Promise<string> {
     try {
       await this.mcpServerMain.setupEditor(editor, {
-        extended,
         consumerProject,
-        includeOnly,
         includeAdditional,
-        exclude,
         isGlobal,
       });
 

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -6,11 +6,8 @@ import { homedir } from 'os';
  * Options for setting up MCP server configuration
  */
 export interface SetupOptions {
-  extended?: boolean;
   consumerProject?: boolean;
-  includeOnly?: string;
   includeAdditional?: string;
-  exclude?: string;
   isGlobal: boolean;
   workspaceDir?: string;
 }
@@ -23,27 +20,15 @@ export class McpSetupUtils {
    * Build MCP server arguments based on provided options
    */
   static buildMcpServerArgs(options: SetupOptions): string[] {
-    const { extended, consumerProject, includeOnly, includeAdditional, exclude } = options;
+    const { consumerProject, includeAdditional } = options;
     const args = ['mcp-server'];
-
-    if (extended) {
-      args.push('--extended');
-    }
 
     if (consumerProject) {
       args.push('--consumer-project');
     }
 
-    if (includeOnly) {
-      args.push('--include-only', includeOnly);
-    }
-
     if (includeAdditional) {
       args.push('--include-additional', includeAdditional);
-    }
-
-    if (exclude) {
-      args.push('--exclude', exclude);
     }
 
     return args;


### PR DESCRIPTION
This PR removes the `extended` (`-e, --extended`), `include-only` (`--include-only`), and `exclude` (`--exclude`) flags from the Bit CLI MCP Server component as they are no longer needed.