### PR TITLE
feat(mcp): add rules subcommand for AI assistant instruction files

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -179,3 +179,47 @@ bit mcp-server --consumer-project
 # Add specific tools to the consumer project set
 bit mcp-server --consumer-project --include-additional "deps,get,preview"
 ```
+
+### Writing AI Assistant Rules
+
+The MCP server provides a `rules` command to create instruction files for AI assistants:
+
+```bash
+bit mcp-server rules [vscode|cursor|windsurf] [options]
+```
+
+This command creates rules/instructions markdown files that provide guidance to AI assistants on how to effectively use the Bit MCP server and follow best practices when working with Bit components.
+
+#### Supported Editors
+
+- **VS Code**: `bit mcp-server rules vscode` (or just `bit mcp-server rules`)
+- **Cursor**: `bit mcp-server rules cursor`
+- **Windsurf**: `bit mcp-server rules windsurf`
+
+#### Configuration Options
+
+- `--global`: Write rules to global configuration (default: workspace-specific)
+
+#### Examples
+
+```bash
+# Basic VS Code rules (workspace level)
+bit mcp-server rules
+
+# Global rules for Cursor
+bit mcp-server rules cursor --global
+
+# Rules for Windsurf (workspace level)
+bit mcp-server rules windsurf
+```
+
+#### Rules File Locations
+
+- **VS Code (workspace)**: `.vscode/prompts/bit.instructions.md`
+- **VS Code (global)**: `~/.vscode/prompts/bit.instructions.md`
+- **Cursor (workspace)**: `.cursorrules` (legacy format, widely supported)
+- **Cursor (global)**: `~/.cursor/global_rules.md`
+- **Windsurf (workspace)**: `.windsurf/rules/bit.md`
+- **Windsurf (global)**: `~/.windsurf/global_rules.md`
+
+The generated file contains placeholder content that should be customized with specific Bit workflow instructions, component creation guidelines, and MCP tool usage examples.

--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -214,14 +214,3 @@ bit mcp-server rules cursor --global
 # Rules for Windsurf (workspace level)
 bit mcp-server rules windsurf
 ```
-
-#### Rules File Locations
-
-- **VS Code (workspace)**: `.vscode/prompts/bit.instructions.md`
-- **VS Code (global)**: `~/.vscode/prompts/bit.instructions.md`
-- **Cursor (workspace)**: `.cursorrules` (legacy format, widely supported)
-- **Cursor (global)**: `~/.cursor/global_rules.md`
-- **Windsurf (workspace)**: `.windsurf/rules/bit.md`
-- **Windsurf (global)**: `~/.windsurf/global_rules.md`
-
-The generated file contains placeholder content that should be customized with specific Bit workflow instructions, component creation guidelines, and MCP tool usage examples.

--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -202,6 +202,7 @@ This command creates rules/instructions markdown files that provide guidance to 
 
 - `--global`: Write rules to global configuration (default: workspace-specific)
 - `--print`: Print rules content to screen instead of writing to file
+- `--consumer-project`: Generate rules for consumer projects that only use Bit components as packages
 
 #### Examples
 
@@ -212,9 +213,12 @@ bit mcp-server rules
 # Global rules for Cursor
 bit mcp-server rules cursor --global
 
+# Consumer project rules for VS Code
+bit mcp-server rules --consumer-project
+
 # Print rules content to screen for manual setup
 bit mcp-server rules --print
 
-# Print content for Windsurf (requires manual addition to .windsurfrules)
-bit mcp-server rules windsurf --print
+# Print consumer project content for Windsurf (requires manual addition to .windsurfrules)
+bit mcp-server rules windsurf --print --consumer-project
 ```

--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -76,8 +76,8 @@ bit mcp-server setup
 # Global setup for Cursor
 bit mcp-server setup cursor --global
 
-# Setup for Windsurf with consumer project mode
-bit mcp-server setup windsurf --consumer-project
+# Setup with consumer project mode
+bit mcp-server setup --consumer-project
 ```
 
 #### Manual Configuration
@@ -201,6 +201,7 @@ This command creates rules/instructions markdown files that provide guidance to 
 #### Configuration Options
 
 - `--global`: Write rules to global configuration (default: workspace-specific)
+- `--print`: Print rules content to screen instead of writing to file
 
 #### Examples
 
@@ -211,6 +212,9 @@ bit mcp-server rules
 # Global rules for Cursor
 bit mcp-server rules cursor --global
 
-# Rules for Windsurf (workspace level)
-bit mcp-server rules windsurf
+# Print rules content to screen for manual setup
+bit mcp-server rules --print
+
+# Print content for Windsurf (requires manual addition to .windsurfrules)
+bit mcp-server rules windsurf --print
 ```

--- a/scopes/mcp/cli-mcp-server/bit-rules-consumer-template.md
+++ b/scopes/mcp/cli-mcp-server/bit-rules-consumer-template.md
@@ -1,0 +1,11 @@
+---
+applyTo: '**'
+---
+
+## How to Install Use and Bit Components
+
+- Bit Components are reusable pieces of code in the form of node packages.
+- Search for Bit Components using `bit_remote_search` tool.
+- Use `bit_show` only on Bit Components to get information like package name (to use when installing, e.g. `npm install <package-name>`), APIs and documentation (to use when using in code).
+- If a user is requesting functionality, you can search if there are available components that implement it using `bit_remote_search`.
+- Filter my search with my account name "ACCOUNT" to find components you have created or are a maintainer of.

--- a/scopes/mcp/cli-mcp-server/bit-rules-template.md
+++ b/scopes/mcp/cli-mcp-server/bit-rules-template.md
@@ -1,0 +1,108 @@
+---
+applyTo: '**'
+---
+
+# Bit MCP Agent Instructions
+
+## Core Objectives
+
+- Your goal is to efficiently automate Bit workflows and help users manage and reuse components.
+- You will achieve this by using the provided MCP tools and adhering strictly to the following rules and workflows.
+
+## Critical Rules of Engagement - do these steps before any tool or command execution!!!
+
+1.  **Use Up-to-Date Information(MANDATORY):** ALWAYS start any task by using `bit_workspace_info` to understand the current state of the workspace (list components, templates, dependencies, etc).
+2.  **MCP Tools First:** You MUST use the provided MCP tools to interact with Bit. Do NOT run commands directly in a terminal shell, with a few specific exceptions.
+3.  **Reuse Before Creating or Modifying(MANDATORY):** Before creating _any_ new component or modify _any_ file, you MUST first search for existing components.
+    - Use `bit_workspace_info` to check for local and existing components.
+    - Use `bit_remote_search` to find components on the remote scope.
+    - Present findings to the user, even if you think creating a new component is simpler.
+4.  **Do not rely on cached knowledge:** Always run `bit_command_help` for command details.
+5.  **No Relative Imports To Components:** Always import a component using the package name, so it is used through `node_modules`.
+6.  **Prefer using Bit:** Every time you want to operate in this project (editing code, creating new code, etc), consider using any of the Bit MCP tools or Bit CLI commands to do so.
+7.  **Prioritize creating Bit components and composing over adding functionality to existing components:** New functionality should be a dependency, unless the user specifically asks for a new functionality added to an existing component.
+8.  **Use the `bit_commands_list` to understand available commands:** This will help you decide which command to use for a specific operation.
+9.  **User may use different terms to describe components:** Be flexible and understand that users may refer to components as "features", "apps", "modules", "pages" or "services". Always clarify with the user what they mean.
+
+## Tooling & Command Execution Hierarchy
+
+This is the decision-making process for executing any Bit operation.
+
+### Step 1: Choose the Correct Generic Execution Tool
+
+- If no dedicated tool exists, you must use one of the generic execution tools. Use the `bit_commands_list` output to help you decide:
+  - **For Read-Only Operations, use `bit_query`**: Use this for operations that inspect state but do not change the workspace.
+  - **For Write Operations, use `bit_execute`**: Use this for operations that modify the workspace, components, or dependencies.
+
+### Step 2: Check for Terminal Exceptions
+
+- The following commands have rich, interactive, or streaming output and should be run directly in the user's terminal. You should construct the command and advise the user to run it.
+  - `bit test`
+  - `bit build`
+  - `bit start` (long-running processes)
+  - `bit watch` (long-running processes)
+  - `bit lint`
+  - `bit check-types`
+  - `bit run` (long-running processes)
+
+## Core Workflows
+
+### Workflow: Error Diagnosis in a Bit Workspace
+
+- `bit_workspace_info` with the "warnings" option to detect errors. Output includes possible solutions, follow them.
+- Rerun `bit_workspace_info` to validate fixes. If error persists, use `bit_component_details` on relevant component(s) for more information.
+
+### Workflow: In-Component Code Issues
+
+- For code issues (compile, lint, test, type checking), run the relevant terminal command and pass the component ID (e.g. `bit test COMPONENT_ID`).
+- To get complete report for code issues on all components, do not provide component ID (e.g. `bit test`).
+- Adding `--log` CLI option gives more details on errors.
+
+### Workflow: Generating New Components, Feature or Apps
+
+- **Follow Critical Rule #3 Reuse Before Creating or Modifying.**
+- `bit_workspace_info` lists templates for new components.
+- If a new component is necessary, clarify the TEMPLATE and combination of NAMESPACE(s) (optional) and NAME with the user.
+- Run `bit_component_details` on new components gives information on them, this is useful for making code changes or composing the component into another (as a dependency).
+- After generating a new component, ask if to add implementation to the new component and remember to update all relevant files (e.g. `*.composition.*`, `*.docs.mdx`, `*.spec.*`).
+
+### Workflow: Adding Functionality (feature, page, module, function, etc) to Bit Components and Apps
+
+- **Follow Critical Rule #3 Reuse Before Creating.**
+- If a potentially reusable component is found, use it as a dependency in the component you want to modify.
+  **Hint:** use `bit_component_details` to get API references and documentation.
+  **Follow Critical Rule #5 No Relative Imports Between Components**.
+- Validate with user if they want the new functionality to be in a new component before generating any code in any component.
+  - If need to create a new component, clarify the TEMPLATE and combination of NAMESPACE(s) (optional) and NAME with the user.
+- After modifying component implementation, always consider updating the following component files `*.composition.*`, `*.docs.mdx`, `*.spec.*`.
+
+### Workflow: USE or DEVELOP a Component
+
+- Use `bit_component_details` to get the component location.
+- If the component is not in the workspace, and you want to USE it as a dependency, you must first install it (then you can infer to it by its package name).
+- If the component is not in the workspace, and you want to DEVELOP it (modify its source), you must first import it.
+
+### Workflow: Collaboration, Change Management and Version Control
+
+- Bit uses a concept called "Lanes" to manage changes across components, this is similar to Git branches.
+- Use `bit_workspace_info` to identify the current active lane.
+- You must not snap or export components directly to the `main` lane.
+- Use `bit_execute` for "Bit Lane" commands.
+- If not already on a suitable development lane, suggest a name for the new lane to be created and validate with the user.
+- The workspace automatically switches to a new lane once created.
+- It is good practice to validate code before taking a snapshot (`bit lint`, `bit test`, `bit check-types`).
+- Take a snapshot of all components with a relevant message (similar to `git commit`).
+- Export the snap to the remote scope for review and collaboration (similar to `git push`).
+
+## Glossary
+
+- **Bit Component:** An extensible, portable software container. Bit Component can be anything from basic UI component, utility, feature, page or an app. Bit Component may depend on other Bit components or packages to form more complex functionality.
+- **Workspace:** A Bit-initialized directory containing components.
+- **Scope:** A collaboration server for components that defines ownership.
+- **Application (App):** A Bit Component with its own runtime. It is usually composed from various features and components.
+- **Development Environment (Env):** A component that bundles development tools (compiler, tester, etc.).
+- **Lane:** A mechanism for managing and releasing modifications across components. `main` is the default lane. Lane is similar in concept to a Git Branch.
+
+## Pointers to remember:
+
+- For generating ESlint or TypeScript configuration files execute the command `bit workspace-config write --clean`

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -18,7 +18,8 @@ import { Http } from '@teambit/scope.network';
 import { CENTRAL_BIT_HUB_NAME, SYMPHONY_GRAPHQL } from '@teambit/legacy.constants';
 import fetch from 'node-fetch';
 import { McpSetupCmd } from './setup-cmd';
-import { McpSetupUtils, SetupOptions } from './setup-utils';
+import { McpRulesCmd } from './rules-cmd';
+import { McpSetupUtils, SetupOptions, RulesOptions } from './setup-utils';
 
 interface CommandFilterOptions {
   additionalCommandsSet?: Set<string>;
@@ -1192,6 +1193,29 @@ export class CliMcpServerMain {
     }
   }
 
+  async writeRulesFile(editor: string, options: RulesOptions, workspaceDir?: string): Promise<void> {
+    const supportedEditors = ['vscode', 'cursor', 'windsurf'];
+    const editorLower = editor.toLowerCase();
+
+    if (!supportedEditors.includes(editorLower)) {
+      throw new Error(`Editor "${editor}" is not supported yet. Currently supported: ${supportedEditors.join(', ')}`);
+    }
+
+    // Add workspaceDir to options if provided
+    const rulesOptions: RulesOptions = { ...options };
+    if (workspaceDir) {
+      rulesOptions.workspaceDir = workspaceDir;
+    }
+
+    if (editorLower === 'vscode') {
+      await McpSetupUtils.writeVSCodeRules(rulesOptions);
+    } else if (editorLower === 'cursor') {
+      await McpSetupUtils.writeCursorRules(rulesOptions);
+    } else if (editorLower === 'windsurf') {
+      await McpSetupUtils.writeWindsurfRules(rulesOptions);
+    }
+  }
+
   static slots = [];
   static dependencies = [CLIAspect, LoggerAspect];
   static runtime = MainRuntime;
@@ -1199,7 +1223,7 @@ export class CliMcpServerMain {
     const logger = loggerMain.createLogger(CliMcpServerAspect.id);
     const mcpServer = new CliMcpServerMain(cli, logger);
     const mcpServerCmd = new McpServerCmd(mcpServer);
-    mcpServerCmd.commands = [new McpStartCmd(mcpServer), new McpSetupCmd(mcpServer)];
+    mcpServerCmd.commands = [new McpStartCmd(mcpServer), new McpSetupCmd(mcpServer), new McpRulesCmd(mcpServer)];
     cli.register(mcpServerCmd);
     return mcpServer;
   }

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1218,8 +1218,8 @@ export class CliMcpServerMain {
     }
   }
 
-  async getRulesContent(): Promise<string> {
-    return McpSetupUtils.getDefaultRulesContent();
+  async getRulesContent(consumerProject: boolean = false): Promise<string> {
+    return McpSetupUtils.getDefaultRulesContent(consumerProject);
   }
 
   static slots = [];

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1198,7 +1198,7 @@ export class CliMcpServerMain {
   }
 
   async writeRulesFile(editor: string, options: RulesOptions, workspaceDir?: string): Promise<void> {
-    const supportedEditors = ['vscode', 'cursor', 'windsurf'];
+    const supportedEditors = ['vscode', 'cursor'];
     const editorLower = editor.toLowerCase();
 
     if (!supportedEditors.includes(editorLower)) {
@@ -1215,9 +1215,11 @@ export class CliMcpServerMain {
       await McpSetupUtils.writeVSCodeRules(rulesOptions);
     } else if (editorLower === 'cursor') {
       await McpSetupUtils.writeCursorRules(rulesOptions);
-    } else if (editorLower === 'windsurf') {
-      await McpSetupUtils.writeWindsurfRules(rulesOptions);
     }
+  }
+
+  async getRulesContent(): Promise<string> {
+    return McpSetupUtils.getDefaultRulesContent();
   }
 
   static slots = [];

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -5,13 +5,14 @@ import { CliMcpServerMain } from './cli-mcp-server.main.runtime';
 export type McpRulesCmdOptions = {
   global?: boolean;
   print?: boolean;
+  consumerProject?: boolean;
 };
 
 export class McpRulesCmd implements Command {
   name = 'rules [editor]';
   description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, or print to screen';
   extendedDescription =
-    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code and Cursor. Use --print to display content on screen.';
+    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code and Cursor. Use --print to display content on screen. Use --consumer-project for non-Bit workspaces that only consume components as packages.';
   arguments = [
     {
       name: 'editor',
@@ -21,13 +22,14 @@ export class McpRulesCmd implements Command {
   options = [
     ['g', 'global', 'Write rules to global configuration (default: workspace-specific)'],
     ['p', 'print', 'Print rules content to screen instead of writing to file'],
+    ['', 'consumer-project', 'Generate rules for consumer projects that only use Bit components as packages'],
   ] as CommandOptions;
 
   constructor(private mcpServerMain: CliMcpServerMain) {}
 
   async report(
     [editor = 'vscode']: [string],
-    { global: isGlobal = false, print: shouldPrint = false }: McpRulesCmdOptions
+    { global: isGlobal = false, print: shouldPrint = false, consumerProject = false }: McpRulesCmdOptions
   ): Promise<string> {
     try {
       // Handle Windsurf requests by directing to print option
@@ -42,12 +44,13 @@ export class McpRulesCmd implements Command {
       }
 
       if (shouldPrint) {
-        const rulesContent = await this.mcpServerMain.getRulesContent();
+        const rulesContent = await this.mcpServerMain.getRulesContent(consumerProject);
         return rulesContent;
       }
 
       await this.mcpServerMain.writeRulesFile(editor, {
         isGlobal,
+        consumerProject,
       });
 
       const scope = isGlobal ? 'global' : 'workspace';

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -4,25 +4,48 @@ import { CliMcpServerMain } from './cli-mcp-server.main.runtime';
 
 export type McpRulesCmdOptions = {
   global?: boolean;
+  print?: boolean;
 };
 
 export class McpRulesCmd implements Command {
   name = 'rules [editor]';
-  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, Windsurf, or other editors';
+  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, or print to screen';
   extendedDescription =
-    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code, Cursor, and Windsurf.';
+    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code and Cursor. Use --print to display content on screen.';
   arguments = [
     {
       name: 'editor',
-      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor, windsurf',
+      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor',
     },
   ];
-  options = [['g', 'global', 'Write rules to global configuration (default: workspace-specific)']] as CommandOptions;
+  options = [
+    ['g', 'global', 'Write rules to global configuration (default: workspace-specific)'],
+    ['p', 'print', 'Print rules content to screen instead of writing to file'],
+  ] as CommandOptions;
 
   constructor(private mcpServerMain: CliMcpServerMain) {}
 
-  async report([editor = 'vscode']: [string], { global: isGlobal = false }: McpRulesCmdOptions): Promise<string> {
+  async report(
+    [editor = 'vscode']: [string],
+    { global: isGlobal = false, print: shouldPrint = false }: McpRulesCmdOptions
+  ): Promise<string> {
     try {
+      // Handle Windsurf requests by directing to print option
+      if (editor.toLowerCase() === 'windsurf') {
+        if (!shouldPrint) {
+          return chalk.yellow(
+            '⚠️  Windsurf uses a single-file configuration (.windsurfrules) that is complex to manage automatically.\n' +
+              'Please use --print flag to get the rules content and manually add it to your .windsurfrules file.'
+          );
+        }
+        // If print is requested, we'll show the content below
+      }
+
+      if (shouldPrint) {
+        const rulesContent = await this.mcpServerMain.getRulesContent();
+        return rulesContent;
+      }
+
       await this.mcpServerMain.writeRulesFile(editor, {
         isGlobal,
       });

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -1,0 +1,38 @@
+import { Command, CommandOptions } from '@teambit/cli';
+import chalk from 'chalk';
+import { CliMcpServerMain } from './cli-mcp-server.main.runtime';
+
+export type McpRulesCmdOptions = {
+  global?: boolean;
+};
+
+export class McpRulesCmd implements Command {
+  name = 'rules [editor]';
+  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, Windsurf, or other editors';
+  extendedDescription =
+    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code, Cursor, and Windsurf.';
+  arguments = [
+    {
+      name: 'editor',
+      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor, windsurf',
+    },
+  ];
+  options = [['g', 'global', 'Write rules to global configuration (default: workspace-specific)']] as CommandOptions;
+
+  constructor(private mcpServerMain: CliMcpServerMain) {}
+
+  async report([editor = 'vscode']: [string], { global: isGlobal = false }: McpRulesCmdOptions): Promise<string> {
+    try {
+      await this.mcpServerMain.writeRulesFile(editor, {
+        isGlobal,
+      });
+
+      const scope = isGlobal ? 'global' : 'workspace';
+      const editorName = this.mcpServerMain.getEditorDisplayName(editor);
+      return chalk.green(`✓ Successfully wrote ${editorName} Bit MCP rules file (${scope})`);
+    } catch (error) {
+      const editorName = this.mcpServerMain.getEditorDisplayName(editor);
+      return chalk.red(`Error writing ${editorName} rules file: ${(error as Error).message}`);
+    }
+  }
+}

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -18,6 +18,7 @@ export interface SetupOptions {
 export interface RulesOptions {
   isGlobal: boolean;
   workspaceDir?: string;
+  consumerProject?: boolean;
 }
 
 /**
@@ -275,8 +276,9 @@ export class McpSetupUtils {
   /**
    * Get default Bit MCP rules content from template file
    */
-  static getDefaultRulesContent(): Promise<string> {
-    const templatePath = path.join(__dirname, 'bit-rules-template.md');
+  static getDefaultRulesContent(consumerProject: boolean = false): Promise<string> {
+    const templateName = consumerProject ? 'bit-rules-consumer-template.md' : 'bit-rules-template.md';
+    const templatePath = path.join(__dirname, templateName);
     return fs.readFile(templatePath, 'utf8');
   }
 
@@ -284,7 +286,7 @@ export class McpSetupUtils {
    * Write Bit MCP rules file for VS Code
    */
   static async writeVSCodeRules(options: RulesOptions): Promise<void> {
-    const { isGlobal, workspaceDir } = options;
+    const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
     const promptsPath = this.getVSCodePromptsPath(isGlobal, workspaceDir);
@@ -293,7 +295,7 @@ export class McpSetupUtils {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent();
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 
@@ -301,7 +303,7 @@ export class McpSetupUtils {
    * Write Bit MCP rules file for Cursor
    */
   static async writeCursorRules(options: RulesOptions): Promise<void> {
-    const { isGlobal, workspaceDir } = options;
+    const { isGlobal, workspaceDir, consumerProject = false } = options;
 
     // Determine prompts file path
     const promptsPath = this.getCursorPromptsPath(isGlobal, workspaceDir);
@@ -310,7 +312,7 @@ export class McpSetupUtils {
     await fs.ensureDir(path.dirname(promptsPath));
 
     // Write rules content
-    const rulesContent = await this.getDefaultRulesContent();
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
     await fs.writeFile(promptsPath, rulesContent);
   }
 }

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -233,23 +233,30 @@ export class McpSetupUtils {
    */
   static getVSCodePromptsPath(isGlobal: boolean, workspaceDir?: string): string {
     if (isGlobal) {
-      // Global VS Code prompts - there isn't a standard global prompts directory
-      // So we'll use the User directory with a .vscode/prompts subdirectory
+      // Global VS Code prompts - use the official User Data prompts directory
       const platform = process.platform;
       switch (platform) {
         case 'win32':
-          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+          return path.join(homedir(), 'AppData', 'Roaming', 'Code', 'User', 'prompts', 'bit.instructions.md');
         case 'darwin':
-          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+          return path.join(
+            homedir(),
+            'Library',
+            'Application Support',
+            'Code',
+            'User',
+            'prompts',
+            'bit.instructions.md'
+          );
         case 'linux':
-          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+          return path.join(homedir(), '.config', 'Code', 'User', 'prompts', 'bit.instructions.md');
         default:
           throw new Error(`Unsupported platform: ${platform}`);
       }
     } else {
       // Workspace-specific prompts
       const targetDir = workspaceDir || process.cwd();
-      return path.join(targetDir, '.vscode', 'prompts', 'bit.instructions.md');
+      return path.join(targetDir, '.github', 'instructions', 'bit.instructions.md');
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -13,6 +13,14 @@ export interface SetupOptions {
 }
 
 /**
+ * Options for writing rules/instructions files
+ */
+export interface RulesOptions {
+  isGlobal: boolean;
+  workspaceDir?: string;
+}
+
+/**
  * Utility class for setting up MCP server configurations across different editors
  */
 export class McpSetupUtils {
@@ -218,5 +226,118 @@ export class McpSetupUtils {
 
     // Write updated MCP configuration
     await fs.writeFile(mcpConfigPath, JSON.stringify(mcpConfig, null, 2));
+  }
+
+  /**
+   * Get VS Code prompts path based on global/workspace scope
+   */
+  static getVSCodePromptsPath(isGlobal: boolean, workspaceDir?: string): string {
+    if (isGlobal) {
+      // Global VS Code prompts - there isn't a standard global prompts directory
+      // So we'll use the User directory with a .vscode/prompts subdirectory
+      const platform = process.platform;
+      switch (platform) {
+        case 'win32':
+          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+        case 'darwin':
+          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+        case 'linux':
+          return path.join(homedir(), '.vscode', 'prompts', 'bit.instructions.md');
+        default:
+          throw new Error(`Unsupported platform: ${platform}`);
+      }
+    } else {
+      // Workspace-specific prompts
+      const targetDir = workspaceDir || process.cwd();
+      return path.join(targetDir, '.vscode', 'prompts', 'bit.instructions.md');
+    }
+  }
+
+  /**
+   * Get Cursor prompts path based on global/workspace scope
+   */
+  static getCursorPromptsPath(isGlobal: boolean, workspaceDir?: string): string {
+    if (isGlobal) {
+      // Global Cursor rules - use bit.rules.md in home directory
+      return path.join(homedir(), '.cursor', 'bit.rules.md');
+    } else {
+      // Workspace-specific rules - use .cursorrules file for legacy compatibility
+      // This is the most widely supported format for Cursor rules
+      const targetDir = workspaceDir || process.cwd();
+      return path.join(targetDir, '.cursorrules');
+    }
+  }
+
+  /**
+   * Get Windsurf prompts path based on global/workspace scope
+   */
+  static getWindsurfPromptsPath(isGlobal: boolean, workspaceDir?: string): string {
+    if (isGlobal) {
+      // Global Windsurf rules - use bit.rules.md in home directory
+      return path.join(homedir(), '.windsurf', 'bit.rules.md');
+    } else {
+      // Workspace-specific rules - use .windsurf/rules directory with bit.rules.md file
+      const targetDir = workspaceDir || process.cwd();
+      return path.join(targetDir, '.windsurf', 'rules', 'bit.rules.md');
+    }
+  }
+
+  /**
+   * Get default Bit MCP rules content from template file
+   */
+  static getDefaultRulesContent(): Promise<string> {
+    const templatePath = path.join(__dirname, 'bit-rules-template.md');
+    return fs.readFile(templatePath, 'utf8');
+  }
+
+  /**
+   * Write Bit MCP rules file for VS Code
+   */
+  static async writeVSCodeRules(options: RulesOptions): Promise<void> {
+    const { isGlobal, workspaceDir } = options;
+
+    // Determine prompts file path
+    const promptsPath = this.getVSCodePromptsPath(isGlobal, workspaceDir);
+
+    // Ensure directory exists
+    await fs.ensureDir(path.dirname(promptsPath));
+
+    // Write rules content
+    const rulesContent = await this.getDefaultRulesContent();
+    await fs.writeFile(promptsPath, rulesContent);
+  }
+
+  /**
+   * Write Bit MCP rules file for Cursor
+   */
+  static async writeCursorRules(options: RulesOptions): Promise<void> {
+    const { isGlobal, workspaceDir } = options;
+
+    // Determine prompts file path
+    const promptsPath = this.getCursorPromptsPath(isGlobal, workspaceDir);
+
+    // Ensure directory exists
+    await fs.ensureDir(path.dirname(promptsPath));
+
+    // Write rules content
+    const rulesContent = await this.getDefaultRulesContent();
+    await fs.writeFile(promptsPath, rulesContent);
+  }
+
+  /**
+   * Write Bit MCP rules file for Windsurf
+   */
+  static async writeWindsurfRules(options: RulesOptions): Promise<void> {
+    const { isGlobal, workspaceDir } = options;
+
+    // Determine prompts file path
+    const promptsPath = this.getWindsurfPromptsPath(isGlobal, workspaceDir);
+
+    // Ensure directory exists
+    await fs.ensureDir(path.dirname(promptsPath));
+
+    // Write rules content
+    const rulesContent = await this.getDefaultRulesContent();
+    await fs.writeFile(promptsPath, rulesContent);
   }
 }

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -265,13 +265,10 @@ export class McpSetupUtils {
    */
   static getCursorPromptsPath(isGlobal: boolean, workspaceDir?: string): string {
     if (isGlobal) {
-      // Global Cursor rules - use bit.rules.md in home directory
-      return path.join(homedir(), '.cursor', 'bit.rules.md');
+      throw new Error('Cursor does not support global prompts configuration in a file');
     } else {
-      // Workspace-specific rules - use .cursorrules file for legacy compatibility
-      // This is the most widely supported format for Cursor rules
       const targetDir = workspaceDir || process.cwd();
-      return path.join(targetDir, '.cursorrules');
+      return path.join(targetDir, '.cursor', 'rules', 'bit.rules.mdc');
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -273,20 +273,6 @@ export class McpSetupUtils {
   }
 
   /**
-   * Get Windsurf prompts path based on global/workspace scope
-   */
-  static getWindsurfPromptsPath(isGlobal: boolean, workspaceDir?: string): string {
-    if (isGlobal) {
-      // Global Windsurf rules - use bit.rules.md in home directory
-      return path.join(homedir(), '.windsurf', 'bit.rules.md');
-    } else {
-      // Workspace-specific rules - use .windsurf/rules directory with bit.rules.md file
-      const targetDir = workspaceDir || process.cwd();
-      return path.join(targetDir, '.windsurf', 'rules', 'bit.rules.md');
-    }
-  }
-
-  /**
    * Get default Bit MCP rules content from template file
    */
   static getDefaultRulesContent(): Promise<string> {
@@ -319,23 +305,6 @@ export class McpSetupUtils {
 
     // Determine prompts file path
     const promptsPath = this.getCursorPromptsPath(isGlobal, workspaceDir);
-
-    // Ensure directory exists
-    await fs.ensureDir(path.dirname(promptsPath));
-
-    // Write rules content
-    const rulesContent = await this.getDefaultRulesContent();
-    await fs.writeFile(promptsPath, rulesContent);
-  }
-
-  /**
-   * Write Bit MCP rules file for Windsurf
-   */
-  static async writeWindsurfRules(options: RulesOptions): Promise<void> {
-    const { isGlobal, workspaceDir } = options;
-
-    // Determine prompts file path
-    const promptsPath = this.getWindsurfPromptsPath(isGlobal, workspaceDir);
 
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));


### PR DESCRIPTION
Adds a new `rules` subcommand to the `bit mcp-server` command that creates rule/instruction files for AI assistants working with Bit components.

## Features

- Supports workspace and global rule file creation
- Editor-specific file paths and formats. Supports VS Code and Cursor.
- Template-based content generation for easy customization
- Consumer project mode with `--consumer-project` flag for projects that only consume Bit components as packages
- `--print` flag to simply print the instructions. Useful for unsupported IDEs, such as Windsurf that use one file for instructions. 