### PR TITLE
feat(mcp): combine bit_show and bit_schema into bit_remote_component_details in consumer project mode

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -31,7 +31,7 @@ bit mcp-server start [options]
 
 Options:
 
-- `--consumer-project`: For non-Bit workspaces that only consume Bit component packages. Enables only "schema", "show", and "remote_search" tools and automatically adds the "--remote" flag to relevant commands.
+- `--consumer-project`: For non-Bit workspaces that only consume Bit component packages. Enables only "bit_remote_search" and "bit_remote_component_details" tools and automatically adds the "--remote" flag to relevant commands.
 - `--include-additional <commands>`: Add specific commands to the available tools (comma-separated list)
 
 ### Integrating with IDEs
@@ -142,14 +142,13 @@ In default mode, the server exposes a minimal set of essential tools focused on 
 This mode is designed for applications or projects that are not Bit workspaces but need to consume or work with Bit components as packages. It provides a minimal set of tools focused on component discovery and information:
 
 - `bit_remote_search`: Search for components in remote scopes
-- `bit_schema`: Retrieves component API schema from remote scopes (automatically adds `--remote` flag)
-- `bit_show`: Displays component information from remote scopes (automatically adds `--remote` flag)
+- `bit_remote_component_details`: Get detailed information about a remote component including basic info and its public API schema (combines the functionality of show and schema commands)
 
 In this mode:
 
 1. You don't need a Bit workspace initialization
-2. Only these 3 tools are available (no workspace-specific tools)
-3. The `--remote` flag is automatically added to `show` and `schema` commands
+2. Only these 2 tools are available (no workspace-specific tools)
+3. The `--remote` flag is automatically added to component detail queries
 4. The `cwd` parameter is still required but can be any directory (not necessarily a Bit workspace)
 5. You can still add additional tools with the `--include-additional` flag
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -107,17 +107,16 @@ describe('CliMcpServer Integration Tests', function () {
       }
     });
 
-    it('should only enable bit_remote_search, bit_show, and bit_schema tools', async () => {
+    it('should only enable bit_remote_search and bit_remote_component_details tools', async () => {
       const response = await consumerProjectClient.listTools();
 
       expect(response.tools).to.be.an('array');
 
       const toolNames = response.tools.map((tool) => tool.name);
 
-      // Should include only these three tools
+      // Should include only these two tools
       expect(toolNames).to.include('bit_remote_search');
-      expect(toolNames).to.include('bit_show');
-      expect(toolNames).to.include('bit_schema');
+      expect(toolNames).to.include('bit_remote_component_details');
 
       // Should NOT include these tools that are available in regular mode
       expect(toolNames).to.not.include('bit_workspace_info');
@@ -127,8 +126,12 @@ describe('CliMcpServer Integration Tests', function () {
       expect(toolNames).to.not.include('bit_query');
       expect(toolNames).to.not.include('bit_execute');
 
-      // Should have exactly 3 tools
-      expect(toolNames).to.have.lengthOf(3);
+      // Should NOT include the old separate tools
+      expect(toolNames).to.not.include('bit_show');
+      expect(toolNames).to.not.include('bit_schema');
+
+      // Should have exactly 2 tools
+      expect(toolNames).to.have.lengthOf(2);
     });
 
     it('should work with bit_remote_search tool', async () => {


### PR DESCRIPTION
Combines the two existing MCP tools `bit_show` and `bit_schema` in consumer project mode into a single new tool called `bit_remote_component_details`. This simplifies the API for non-Bit workspaces that only consume Bit component packages.