### PR TITLE
feat(show): add package name field to legacy show command output

### DIFF
--- a/components/legacy/component-diff/components-object-diff.ts
+++ b/components/legacy/component-diff/components-object-diff.ts
@@ -9,6 +9,7 @@ import { compact, find, get, isEmpty, isNil, union } from 'lodash';
 import { lt, gt } from 'semver';
 import { ConsumerComponent as Component } from '@teambit/legacy.consumer-component';
 import { ExtensionDataList } from '@teambit/legacy.extension-data';
+import { componentIdToPackageName } from '@teambit/pkg.modules.component-package-name';
 import { DiffOptions, FieldsDiff, getOneFileDiff } from './components-diff';
 
 type ConfigDiff = {
@@ -62,6 +63,12 @@ export function componentToPrintableForDiff(component: Component): Record<string
   const overrides = component.overrides.componentOverridesData;
 
   obj.id = component.id._legacy.toStringWithoutScope();
+  obj.packageName = componentIdToPackageName({
+    id: component.id,
+    bindingPrefix,
+    defaultScope: component.id.scope,
+    extensions: extensions || new ExtensionDataList()
+  });
   obj.language = lang;
   obj.bindingPrefix = bindingPrefix;
   obj.mainFile = mainFile ? normalize(mainFile) : null;

--- a/scopes/component/component/show/legacy-show/show-legacy-cmd.ts
+++ b/scopes/component/component/show/legacy-show/show-legacy-cmd.ts
@@ -170,6 +170,7 @@ function paintComponent(component: ConsumerComponent, componentModel: ConsumerCo
   function getFields() {
     const fields = [
       'id',
+      'packageName',
       'compiler',
       'tester',
       'language',


### PR DESCRIPTION
This PR adds a "Package Name" field to the legacy `bit show --legacy --remote` command output.