### PR TITLE
fix(compositions): adjust composition panel styles

### DIFF
--- a/scopes/compositions/compositions/compositions.tsx
+++ b/scopes/compositions/compositions/compositions.tsx
@@ -88,7 +88,7 @@ export function Compositions({ menuBarWidgets, emptyState, usePreviewSandboxSlot
   useEffect(() => setSidebarOpenness(showSidebar), [showSidebar]);
   return (
     <CompositionContextProvider queryParams={compositionParams} setQueryParams={setCompositionParams}>
-      <SplitPane layout={sidebarOpenness} size="85%" className={styles.compositionsPage}>
+      <SplitPane layout={sidebarOpenness} size="80%" className={styles.compositionsPage}>
         <Pane className={styles.left}>
           <CompositionsMenuBar menuBarWidgets={menuBarWidgets} className={styles.menuBar}>
             <Tooltip content={'Open in new tab'} placement="right">

--- a/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.module.scss
+++ b/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.module.scss
@@ -7,19 +7,23 @@
   font-size: var(--bit-p-xs);
   transition: all 300ms ease-in-out;
   color: var(--on-background-color);
+  position: relative;
 
   &:hover {
     background-color: var(--border-medium-color, #ededed);
     // border-radius: 8px;
     transition: background-color 300ms ease-in-out;
+
+    .panelLink {
+      padding-right: 40px;
+    }
+
     .right {
-      visibility: unset;
+      visibility: visible;
       opacity: 1;
       color: var(--bit-text-color-light, #6c707c);
-      //TODO - fix hover effect and timing of icon
-      transition:
-        visibility 200ms,
-        opacity 100ms ease-in-out;
+      transition: opacity 100ms ease-in-out;
+
       .icon {
         &:hover {
           color: var(--bit-text-color-heavy);
@@ -27,6 +31,7 @@
       }
     }
   }
+
   &.active {
     display: flex;
     align-items: center;
@@ -43,9 +48,10 @@
     }
 
     .right {
-      visibility: unset;
+      // visibility: unset;
       opacity: 1;
       color: var(--bit-accent-bg, #eceaff);
+
       .icon {
         &:hover {
           color: var(--bit-bg-color, #ffffff);
@@ -53,7 +59,12 @@
       }
     }
   }
+
   .right {
+    position: absolute;
+    right: 12px;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     gap: 12px;
     align-items: center;
@@ -62,9 +73,10 @@
     visibility: hidden;
     font-size: 13px;
     transition:
-      visibility 200ms,
-      opacity 100ms ease-in-out;
+      opacity 100ms ease-in-out,
+      visibility 0s linear 100ms;
   }
+
   .codeLink {
     cursor: pointer;
   }
@@ -78,12 +90,21 @@
   margin-right: 11px;
   border-radius: 1px;
 }
+
 .name {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   margin-right: 8px;
 }
+
+.iconLink {
+  display: flex;
+  align-items: center;
+  color: inherit;
+  text-decoration: none;
+}
+
 .panelLink {
   display: flex;
   align-items: center;
@@ -94,6 +115,7 @@
   text-decoration: none;
   color: inherit;
   min-width: 0;
+  transition: padding-right 200ms ease-in-out;
 
   &:active {
     color: inherit;
@@ -104,12 +126,14 @@
   display: flex;
   align-items: center;
   margin-bottom: 17px;
+
   > div {
     position: relative;
     padding: 8px;
     text-transform: uppercase;
     font-size: 12px;
     font-weight: bold;
+
     &:not(:first-child) {
       color: #878c9a;
     }

--- a/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.tsx
+++ b/scopes/compositions/compositions/ui/compositions-panel/compositions-panel.tsx
@@ -83,7 +83,6 @@ export function CompositionsPanel({
             className={classNames(styles.linkWrapper, composition === active && styles.active)}
           >
             <a className={styles.panelLink} onClick={() => handleSelect(composition)}>
-              <span className={styles.box}></span>
               <span className={styles.name}>{composition.displayName}</span>
             </a>
             <div className={styles.right}>
@@ -94,7 +93,7 @@ export function CompositionsPanel({
                 onClick={onCompositionCodeClicked(composition)}
               />
               <Tooltip content="Open in new tab" placement="bottom">
-                <a className={styles.panelLink} target="_blank" rel="noopener noreferrer" href={href}>
+                <a className={styles.iconLink} target="_blank" rel="noopener noreferrer" href={href}>
                   <Icon className={styles.icon} of="open-tab" />
                 </a>
               </Tooltip>


### PR DESCRIPTION
This PR introduces two UX improvements to the compositions panel:

The panel's default width is increased from 15% to 20%.
The action icons (Code, Open in new tab) are now hidden by default and only appear when the user hovers over a composition.
These changes provide more horizontal space for composition names, preventing premature truncation for longer names and creating a cleaner, less cluttered UI.