### PR TITLE
feat(mcp-server): display config file path in setup command output

### DIFF
--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1225,6 +1225,23 @@ export class CliMcpServerMain {
     return McpSetupUtils.getEditorDisplayName(editor);
   }
 
+  /**
+   * Get the path to the editor config file based on editor type and scope
+   */
+  getEditorConfigPath(editor: string, isGlobal: boolean, workspaceDir?: string): string {
+    const editorLower = editor.toLowerCase();
+
+    if (editorLower === 'vscode') {
+      return McpSetupUtils.getVSCodeSettingsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'cursor') {
+      return McpSetupUtils.getCursorSettingsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'windsurf') {
+      return McpSetupUtils.getWindsurfSettingsPath(isGlobal, workspaceDir);
+    }
+
+    throw new Error(`Editor "${editor}" is not supported yet.`);
+  }
+
   async setupEditor(editor: string, options: SetupOptions, workspaceDir?: string): Promise<void> {
     const supportedEditors = ['vscode', 'cursor', 'windsurf'];
     const editorLower = editor.toLowerCase();

--- a/scopes/mcp/cli-mcp-server/setup-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/setup-cmd.ts
@@ -44,7 +44,14 @@ export class McpSetupCmd implements Command {
 
       const scope = isGlobal ? 'global' : 'workspace';
       const editorName = this.mcpServerMain.getEditorDisplayName(editor);
-      return chalk.green(`✓ Successfully configured ${editorName} MCP integration (${scope})`);
+
+      // Get the config file path based on the editor type
+      const configPath = this.mcpServerMain.getEditorConfigPath(editor, isGlobal);
+
+      return chalk.green(
+        `✓ Successfully configured ${editorName} MCP integration (${scope})\n` +
+          `  Configuration written to: ${chalk.cyan(configPath)}`
+      );
     } catch (error) {
       const editorName = this.mcpServerMain.getEditorDisplayName(editor);
       return chalk.red(`Error setting up ${editorName} integration: ${(error as Error).message}`);


### PR DESCRIPTION
This PR enhances the `bit mcp-server setup` command to display the path where configuration was written. 

The improved output makes it easier for users to locate and manually adjust configuration files if needed after setup is complete.