### PR TITLE
fix(semantics): prevent false positives in ClassDeclarationTransformer

### DIFF
--- a/components/entities/semantic-schema/schema-node.ts
+++ b/components/entities/semantic-schema/schema-node.ts
@@ -1,4 +1,5 @@
 import { pickBy } from 'lodash';
+import pluralize from 'pluralize';
 import { DocSchema } from './schemas';
 
 export interface ISchemaNode {
@@ -23,13 +24,12 @@ export interface ISchemaNode {
  */
 export abstract class SchemaNode implements ISchemaNode {
   readonly __schema = this.constructor.name;
-  readonly displaySchemaName = this.constructor.name
-    .replace(/Schema$/, '')
-    .replace(/([A-Z])/g, ' $1')
-    .trim()
-    .replace(/s$/, 'ses')
-    .replace(/([^s]s)$/, '$1es')
-    .replace(/([^s])$/, '$1s');
+  readonly displaySchemaName = pluralize(
+    this.constructor.name
+      .replace(/Schema$/, '')
+      .replace(/([A-Z])/g, ' $1')
+      .trim()
+  );
 
   abstract readonly location: SchemaLocation;
   readonly doc?: DocSchema;

--- a/scopes/typescript/typescript/transformers/class-declaration.ts
+++ b/scopes/typescript/typescript/transformers/class-declaration.ts
@@ -12,7 +12,14 @@ import { Identifier } from '../identifier';
 
 export class ClassDeclarationTransformer implements SchemaTransformer {
   predicate(node: Node) {
-    return node.kind === ts.SyntaxKind.ClassDeclaration;
+    if (node.kind !== ts.SyntaxKind.ClassDeclaration) {
+      return false;
+    }
+    const classNode = node as ClassDeclaration;
+    if (!classNode.members || (classNode.members as any).isMissingList) {
+      return false;
+    }
+    return true;
   }
 
   // @todo: in case of `export default class` the class has no name.


### PR DESCRIPTION
This PR fixes an issue where the ClassDeclarationTransformer in the schema extractor was incorrectly identifying HTML class attributes within Vue Single File Components (SFCs) as TypeScript class declarations. This resulted in malformed schema being generated.

The fix improves the predicate function of the transformer by adding stricter checks for – A valid members list in the class declaration node, ensuring it's not flagged as isMissingList.