### PR TITLE
chore: update live-control utils to fix cross-origin messages

### DIFF
--- a/workspace.jsonc
+++ b/workspace.jsonc
@@ -140,7 +140,7 @@
         "@teambit/component.ui.version-label": "^0.0.509",
         "@teambit/compositions.ui.composition-compare": "^0.0.258",
         "@teambit/compositions.ui.composition-compare-section": "^0.0.101",
-        "@teambit/compositions.ui.composition-live-controls": "^0.0.2",
+        "@teambit/compositions.ui.composition-live-controls": "^0.0.3",
         "@teambit/compositions.ui.compositions-menu-bar": "^0.0.177",
         "@teambit/compositions.ui.compositions-overview": "^0.0.10",
         "@teambit/compositions.ui.hooks.use-composition": "^0.0.177",


### PR DESCRIPTION
## Proposed Changes

- update live control utils to add the second param in `postMessage(data, '*')` to support cross-origin messages on bit cloud preview pages

relevant CR: https://bit.cloud/teambit/vite/~change-requests/fix-live-controls-type-20250524