### PR TITLE
feat: add Roo Code extension support to MCP server setup

### DIFF
--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1237,13 +1237,15 @@ export class CliMcpServerMain {
       return McpSetupUtils.getCursorSettingsPath(isGlobal, workspaceDir);
     } else if (editorLower === 'windsurf') {
       return McpSetupUtils.getWindsurfSettingsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'roo') {
+      return McpSetupUtils.getRooCodeSettingsPath(isGlobal, workspaceDir);
     }
 
     throw new Error(`Editor "${editor}" is not supported yet.`);
   }
 
   async setupEditor(editor: string, options: SetupOptions, workspaceDir?: string): Promise<void> {
-    const supportedEditors = ['vscode', 'cursor', 'windsurf'];
+    const supportedEditors = ['vscode', 'cursor', 'windsurf', 'roo'];
     const editorLower = editor.toLowerCase();
 
     if (!supportedEditors.includes(editorLower)) {
@@ -1262,6 +1264,8 @@ export class CliMcpServerMain {
       await McpSetupUtils.setupCursor(setupOptions);
     } else if (editorLower === 'windsurf') {
       await McpSetupUtils.setupWindsurf(setupOptions);
+    } else if (editorLower === 'roo') {
+      await McpSetupUtils.setupRooCode(setupOptions);
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.spec.ts
@@ -509,7 +509,7 @@ describe('CliMcpServer Direct Aspect Tests', function () {
       } catch (error) {
         expect(error).to.exist;
         expect((error as Error).message).to.include('Editor "unsupported-editor" is not supported yet');
-        expect((error as Error).message).to.include('Currently supported: vscode, cursor, windsurf');
+        expect((error as Error).message).to.include('Currently supported: vscode, cursor, windsurf, roo');
       }
     });
 
@@ -605,6 +605,48 @@ describe('CliMcpServer Direct Aspect Tests', function () {
         command: 'bit',
         args: ['mcp-server', 'start'],
       });
+    });
+
+    it('should setup Roo Code integration directly', async () => {
+      await setupMcpServer.setupEditor(
+        'roo',
+        {
+          isGlobal: false,
+        },
+        setupWorkspacePath
+      );
+
+      // Verify that the mcp.json file was created in the workspace directory
+      const rooConfigPath = path.join(setupWorkspacePath, '.roo', 'mcp.json');
+      const configExists = await fs.pathExists(rooConfigPath);
+      expect(configExists).to.be.true;
+
+      // Verify the content of the config file
+      const config = await fs.readJson(rooConfigPath);
+      expect(config).to.have.property('mcpServers');
+      expect(config.mcpServers).to.have.property('bit');
+      expect(config.mcpServers.bit).to.deep.equal({
+        type: 'stdio',
+        command: 'bit',
+        args: ['mcp-server', 'start'],
+      });
+    });
+
+    it('should throw error when trying to setup Roo Code globally', async () => {
+      try {
+        await setupMcpServer.setupEditor(
+          'roo',
+          {
+            isGlobal: true,
+          },
+          setupWorkspacePath
+        );
+        expect.fail('Should have thrown an error for global Roo Code setup');
+      } catch (error) {
+        expect(error).to.exist;
+        expect((error as Error).message).to.include('Roo Code global configuration is not supported');
+        expect((error as Error).message).to.include('VS Code internal storage that cannot be accessed');
+      }
     });
 
     it('should merge with existing VS Code settings', async () => {

--- a/scopes/mcp/cli-mcp-server/setup-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/setup-cmd.ts
@@ -10,13 +10,13 @@ export type McpSetupCmdOptions = {
 
 export class McpSetupCmd implements Command {
   name = 'setup [editor]';
-  description = 'Setup MCP integration with VS Code, Cursor, Windsurf, or other editors';
+  description = 'Setup MCP integration with VS Code, Cursor, Windsurf, Roo Code, or other editors';
   extendedDescription =
-    'Creates or updates configuration files to integrate Bit MCP server with supported editors. Currently supports VS Code, Cursor, and Windsurf.';
+    'Creates or updates configuration files to integrate Bit MCP server with supported editors. Currently supports VS Code, Cursor, Windsurf, and Roo Code.';
   arguments = [
     {
       name: 'editor',
-      description: 'Editor to setup (default: vscode). Available: vscode, cursor, windsurf',
+      description: 'Editor to setup (default: vscode). Available: vscode, cursor, windsurf, roo',
     },
   ];
   options = [


### PR DESCRIPTION
Adds support for Roo Code extension to the `bit mcp-server setup` command. 

- Implements local `.roo/mcp.json` configuration support
- Shows warning for global configuration (uses VS Code internal storage)