### PR TITLE
feat: add Roo Code support to bit mcp-server rules command

### DIFF
--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1270,7 +1270,7 @@ export class CliMcpServerMain {
   }
 
   async writeRulesFile(editor: string, options: RulesOptions, workspaceDir?: string): Promise<void> {
-    const supportedEditors = ['vscode', 'cursor'];
+    const supportedEditors = ['vscode', 'cursor', 'roo'];
     const editorLower = editor.toLowerCase();
 
     if (!supportedEditors.includes(editorLower)) {
@@ -1287,6 +1287,8 @@ export class CliMcpServerMain {
       await McpSetupUtils.writeVSCodeRules(rulesOptions);
     } else if (editorLower === 'cursor') {
       await McpSetupUtils.writeCursorRules(rulesOptions);
+    } else if (editorLower === 'roo') {
+      await McpSetupUtils.writeRooCodeRules(rulesOptions);
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -10,13 +10,13 @@ export type McpRulesCmdOptions = {
 
 export class McpRulesCmd implements Command {
   name = 'rules [editor]';
-  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, or print to screen';
+  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, Roo Code, or print to screen';
   extendedDescription =
-    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code and Cursor. Use --print to display content on screen. Use --consumer-project for non-Bit workspaces that only consume components as packages.';
+    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code, Cursor, and Roo Code. Use --print to display content on screen. Use --consumer-project for non-Bit workspaces that only consume components as packages.';
   arguments = [
     {
       name: 'editor',
-      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor',
+      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor, roo',
     },
   ];
   options = [

--- a/scopes/mcp/cli-mcp-server/setup-utils.ts
+++ b/scopes/mcp/cli-mcp-server/setup-utils.ts
@@ -276,6 +276,20 @@ export class McpSetupUtils {
   }
 
   /**
+   * Get Roo Code prompts path based on global/workspace scope
+   */
+  static getRooCodePromptsPath(isGlobal: boolean, workspaceDir?: string): string {
+    if (isGlobal) {
+      // Global Roo Code rules
+      return path.join(homedir(), '.roo', 'rules', 'bit.instructions.md');
+    } else {
+      // Workspace-specific rules
+      const targetDir = workspaceDir || process.cwd();
+      return path.join(targetDir, '.roo', 'rules', 'bit.instructions.md');
+    }
+  }
+
+  /**
    * Get default Bit MCP rules content from template file
    */
   static getDefaultRulesContent(consumerProject: boolean = false): Promise<string> {
@@ -309,6 +323,23 @@ export class McpSetupUtils {
 
     // Determine prompts file path
     const promptsPath = this.getCursorPromptsPath(isGlobal, workspaceDir);
+
+    // Ensure directory exists
+    await fs.ensureDir(path.dirname(promptsPath));
+
+    // Write rules content
+    const rulesContent = await this.getDefaultRulesContent(consumerProject);
+    await fs.writeFile(promptsPath, rulesContent);
+  }
+
+  /**
+   * Write Bit MCP rules file for Roo Code
+   */
+  static async writeRooCodeRules(options: RulesOptions): Promise<void> {
+    const { isGlobal, workspaceDir, consumerProject = false } = options;
+
+    // Determine prompts file path
+    const promptsPath = this.getRooCodePromptsPath(isGlobal, workspaceDir);
 
     // Ensure directory exists
     await fs.ensureDir(path.dirname(promptsPath));


### PR DESCRIPTION
Adds support for Roo Code editor to the `bit mcp-server rules` command.

This change enables users to generate Bit MCP rules/instructions files for Roo Code editor, supporting both local project-specific rules (.roo/rules/) and global rules (~/.roo/rules).