### PR TITLE
feat: add --loose flag to bit lane merge command

### DIFF
--- a/scopes/component/merging/merging.main.runtime.ts
+++ b/scopes/component/merging/merging.main.runtime.ts
@@ -221,6 +221,7 @@ export class MergingMain {
     build,
     skipDependencyInstallation,
     detachHead,
+    loose,
   }: {
     mergeStrategy: MergeStrategy;
     allComponentsStatus: ComponentMergeStatus[];
@@ -233,6 +234,7 @@ export class MergingMain {
     build?: boolean;
     skipDependencyInstallation?: boolean;
     detachHead?: boolean;
+    loose?: boolean;
   }): Promise<ApplyVersionResults> {
     const consumer = this.workspace?.consumer;
     const legacyScope = this.scope.legacyScope;
@@ -336,13 +338,12 @@ export class MergingMain {
         const { taggedComponents, autoTaggedResults, removedComponents } = results;
         return { snappedComponents: taggedComponents, autoSnappedResults: autoTaggedResults, removedComponents };
       }
-      return this.snapResolvedComponents(
-        allComponentsStatus,
+      return this.snapResolvedComponents(allComponentsStatus, updatedComponents, {
         snapMessage,
         build,
-        currentLane?.toLaneId(),
-        updatedComponents
-      );
+        laneId: currentLane?.toLaneId(),
+        loose,
+      });
     };
     let mergeSnapResults: MergeSnapResults = null;
     let mergeSnapError: Error | undefined;
@@ -635,10 +636,18 @@ export class MergingMain {
 
   private async snapResolvedComponents(
     allComponentsStatus: ComponentMergeStatus[],
-    snapMessage?: string,
-    build?: boolean,
-    laneId?: LaneId,
-    updatedComponents?: ConsumerComponent[]
+    updatedComponents: ConsumerComponent[],
+    {
+      snapMessage,
+      build,
+      laneId,
+      loose,
+    }: {
+      snapMessage?: string;
+      build?: boolean;
+      laneId?: LaneId;
+      loose?: boolean;
+    }
   ): Promise<MergeSnapResults> {
     const unmergedComponents = this.scope.legacyScope.objects.unmergedComponents.getComponents();
     this.logger.debug(`merge-snaps, snapResolvedComponents, total ${unmergedComponents.length.toString()} components`);
@@ -672,6 +681,7 @@ export class MergingMain {
           lane: laneId?.toString(),
           updatedLegacyComponents: updatedComponents,
           loadAspectOnlyForIds: getLoadAspectOnlyForIds(),
+          loose,
         }
       );
       return results;
@@ -680,6 +690,7 @@ export class MergingMain {
       legacyBitIds: ids,
       build,
       message: snapMessage,
+      loose,
     });
   }
 

--- a/scopes/lanes/merge-lanes/merge-lane.cmd.ts
+++ b/scopes/lanes/merge-lanes/merge-lane.cmd.ts
@@ -63,6 +63,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
     ['', 'no-snap', 'do not pass snaps from the other lane even for non-diverged components (see command description)'],
     ['', 'tag', 'auto-tag all lane components after merging into main (or tag-merge in case of snap-merge)'],
     ['', 'build', 'in case of snap during the merge, run the build-pipeline (similar to bit snap --build)'],
+    ['', 'loose', 'relevant for --build, to allow build to succeed even if tasks like tests or lint fail'],
     ['m', 'message <message>', 'override the default message for the auto snap'],
     ['', 'keep-readme', 'skip deleting the lane readme component after merging'],
     ['', 'no-squash', 'relevant for merging lanes into main, which by default squashes all lane snaps'],
@@ -134,6 +135,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       verbose = false,
       excludeNonLaneComps = false,
       detachHead,
+      loose = false,
     }: {
       ours?: boolean;
       theirs?: boolean;
@@ -156,6 +158,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       verbose?: boolean;
       excludeNonLaneComps?: boolean;
       detachHead?: boolean;
+      loose?: boolean;
     }
   ): Promise<string> {
     build = this.configStore.getConfigBoolean(CFG_FORCE_LOCAL_BUILD) || Boolean(build);
@@ -211,6 +214,7 @@ Component pattern format: ${COMPONENT_PATTERN_HELP}`,
       includeDeps,
       excludeNonLaneComps,
       detachHead,
+      loose,
     });
 
     const mergeResult = mergeReport({ ...mergeResults, configMergeResults, verbose });

--- a/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
+++ b/scopes/lanes/merge-lanes/merge-lanes.main.runtime.ts
@@ -60,6 +60,7 @@ export type MergeLaneOptions = {
   throwIfNotUpToDate?: boolean; // relevant when merging from a scope
   fetchCurrent?: boolean; // needed when merging from a bare-scope (because it's empty)
   detachHead?: boolean;
+  loose?: boolean; // relevant for --build, to allow build to succeed even if tasks like tests or lint fail
 };
 export type ConflictPerId = { id: ComponentID; files: string[]; config?: boolean; configConflict?: string };
 
@@ -114,6 +115,7 @@ export class MergeLanesMain {
       snapMessage,
       existingOnWorkspaceOnly,
       build,
+      loose,
       keepReadme,
       squash,
       noSquash,
@@ -224,6 +226,7 @@ export class MergeLanesMain {
       build,
       skipDependencyInstallation,
       detachHead,
+      loose,
     });
 
     if (snapshot) await lastMerged?.persistSnapshot(snapshot);


### PR DESCRIPTION
This PR adds the `--loose` flag to the `bit lane merge` command, bringing consistency with other build-related commands like `bit build`, `bit snap`, and `bit test`.
As a reminder, this flag allows "--build" to succeed even if tasks like test or lint fail.