### PR TITLE
fix(application): handle undefined host to prevent property access error

### DIFF
--- a/scopes/harmony/application/application.main.runtime.ts
+++ b/scopes/harmony/application/application.main.runtime.ts
@@ -134,6 +134,7 @@ export class ApplicationMain {
    */
   async loadAllAppsAsAspects(poolIds?: ComponentID[]): Promise<ComponentID[]> {
     const apps = await this.listAppsComponents(poolIds);
+    if (!apps.length) return [];
     // do not load apps that their env was not loaded yet. their package-json may not be up to date. e.g. it could be
     // cjs, when the env needs it as esm. once it is loaded, node.js saved the package.json in the cache with no way to
     // refresh it.
@@ -193,6 +194,7 @@ export class ApplicationMain {
    */
   async listAppsComponents(poolIds?: ComponentID[]): Promise<Component[]> {
     const host = this.workspace || this.componentAspect.getHost();
+    if (!host) return [];
     const components = poolIds
       ? this.workspace
         ? await this.workspace.getMany(poolIds, {

--- a/scopes/mcp/cli-mcp-server/bit-rules-template.md
+++ b/scopes/mcp/cli-mcp-server/bit-rules-template.md
@@ -51,6 +51,7 @@ This is the decision-making process for executing any Bit operation.
   - `bit lint`
   - `bit check-types`
   - `bit run` (long-running processes)
+  - any command with `--build` flag.
 
 ## Core Workflows
 


### PR DESCRIPTION
Fixes the issue where accessing properties on undefined host throws "Cannot read properties of undefined (reading 'list')" error.

Added null checks in two methods:
- `loadAllAppsAsAspects`: return early if no apps are found
- `listAppsComponents`: return early if no host is available (no workspace nor scope)