### PR TITLE
feat: add external package manager mode with --external-package-manager flag

### DIFF
--- a/scopes/harmony/host-initializer/init-cmd.ts
+++ b/scopes/harmony/host-initializer/init-cmd.ts
@@ -57,6 +57,7 @@ export class InitCmd implements Command {
     ['f', 'force', 'force workspace initialization without clearing local objects'],
     ['b', 'bare [name]', 'initialize an empty bit bare scope'],
     ['s', 'shared <groupname>', 'add group write permissions to a scope properly'],
+    ['', 'external-package-manager', 'enable external package manager mode (npm/yarn/pnpm)'],
   ] as CommandOptions;
 
   constructor(private hostInitializer: HostInitializerMain) {}
@@ -77,6 +78,7 @@ export class InitCmd implements Command {
       force,
       defaultDirectory,
       defaultScope,
+      externalPackageManager,
     } = flags;
     if (path) path = pathlib.resolve(path);
     if (bare) {
@@ -94,6 +96,7 @@ export class InitCmd implements Command {
       defaultDirectory: defaultDirectory ?? getConfig(CFG_INIT_DEFAULT_DIRECTORY),
       defaultScope: defaultScope ?? getConfig(CFG_INIT_DEFAULT_SCOPE),
       name,
+      externalPackageManager,
     };
 
     const { created } = await HostInitializerMain.init(

--- a/scopes/workspace/install/install.main.runtime.ts
+++ b/scopes/workspace/install/install.main.runtime.ts
@@ -143,7 +143,7 @@ export class InstallMain {
     private ipcEvents: IpcEventsMain,
 
     private harmony: Harmony
-  ) { }
+  ) {}
   /**
    * Install dependencies for all components in the workspace
    *
@@ -151,6 +151,15 @@ export class InstallMain {
    * @memberof Workspace
    */
   async install(packages?: string[], options?: WorkspaceInstallOptions): Promise<ComponentMap<string>> {
+    // Check if external package manager mode is enabled
+    const workspaceConfig = this.workspace.getWorkspaceConfig();
+    const workspaceExtConfig = workspaceConfig.extensions.findExtension(WorkspaceAspect.id);
+    if (workspaceExtConfig?.config.externalPackageManager) {
+      throw new Error(
+        'External package manager mode is enabled. Please use your preferred package manager (npm, yarn, pnpm) to install dependencies instead of "bit install".'
+      );
+    }
+
     // set workspace in install context
     this.workspace.inInstallContext = true;
     this.workspace.inInstallAfterPmContext = false;
@@ -1241,7 +1250,7 @@ export class InstallMain {
     WorkspaceConfigFilesAspect,
     AspectLoaderAspect,
     BundlerAspect,
-    UIAspect
+    UIAspect,
   ];
 
   static runtime = MainRuntime;
@@ -1262,24 +1271,24 @@ export class InstallMain {
       wsConfigFiles,
       aspectLoader,
       bundler,
-      ui
+      ui,
     ]: [
-        DependencyResolverMain,
-        Workspace,
-        LoggerMain,
-        VariantsMain,
-        CLIMain,
-        CompilerMain,
-        IssuesMain,
-        EnvsMain,
-        ApplicationMain,
-        IpcEventsMain,
-        GeneratorMain,
-        WorkspaceConfigFilesMain,
-        AspectLoaderMain,
-        BundlerMain,
-        UiMain
-      ],
+      DependencyResolverMain,
+      Workspace,
+      LoggerMain,
+      VariantsMain,
+      CLIMain,
+      CompilerMain,
+      IssuesMain,
+      EnvsMain,
+      ApplicationMain,
+      IpcEventsMain,
+      GeneratorMain,
+      WorkspaceConfigFilesMain,
+      AspectLoaderMain,
+      BundlerMain,
+      UiMain,
+    ],
     _,
     [preLinkSlot, preInstallSlot, postInstallSlot]: [PreLinkSlot, PreInstallSlot, PostInstallSlot],
     harmony: Harmony

--- a/scopes/workspace/workspace/types.ts
+++ b/scopes/workspace/workspace/types.ts
@@ -74,4 +74,14 @@ export interface WorkspaceExtConfig {
    * when set to true, bit will try to load MyDepAspect automatically.
    */
   autoLoadAspectsDeps?: boolean;
+
+  /**
+   * If set to `true`, enables external package manager mode. When enabled:
+   * - resolveAspectsFromNodeModules will be set to false
+   * - resolveEnvsFromRoots will be set to false
+   * - enableWorkspaceConfigWrite will be set to false
+   * - bit install will throw an error suggesting to use external package manager
+   * - commands with -x flag will skip dependency installation by default
+   */
+  externalPackageManager?: boolean;
 }


### PR DESCRIPTION
This PR implements external package manager mode for Bit workspaces.

**Changes:**
- Added `--external-package-manager` flag to `bit init` command
- Added `externalPackageManager` property to workspace configuration  
- Modified workspace creation to set compatible defaults automatically
- Added validation to prevent conflicting configuration
- Enhanced `bit install` to throw clear error in external package manager mode

**Key Features:**
- When enabled, automatically sets conflicting properties to false (resolveAspectsFromNodeModules, resolveEnvsFromRoots, enableWorkspaceConfigWrite)
- Validates configuration on workspace load to prevent manual conflicts
- Provides clear error messages when `bit install` is used inappropriately