### PR TITLE
feat(mcp): update VS Code MCP server configuration for new location

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -82,7 +82,26 @@ bit mcp-server setup --consumer-project
 
 #### Manual Configuration
 
-If you need to manually configure the settings, here's a basic example for VS Code:
+If you need to manually configure the settings, here's how to set up VS Code MCP integration:
+
+**For workspace-specific configuration:**
+
+1. Create a `.vscode/mcp.json` file in your workspace folder
+2. Add the following configuration:
+
+```json
+{
+  "servers": {
+    "bit-cli": {
+      "type": "stdio",
+      "command": "bit",
+      "args": ["mcp-server", "start"]
+    }
+  }
+}
+```
+
+**For global configuration:**
 
 1. Open VS Code settings (JSON) by pressing `Ctrl + Shift + P` (or `Cmd + Shift + P` on macOS) and typing `Preferences: Open Settings (JSON)`
 2. Add the following configuration:
@@ -92,6 +111,7 @@ If you need to manually configure the settings, here's a basic example for VS Co
   "mcp": {
     "servers": {
       "bit-cli": {
+        "type": "stdio",
         "command": "bit",
         "args": ["mcp-server", "start"]
       }

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1266,7 +1266,10 @@ export class CliMcpServerMain {
     const editorLower = editor.toLowerCase();
 
     if (editorLower === 'vscode') {
-      return McpSetupUtils.getVSCodeSettingsPath(isGlobal, workspaceDir);
+      // For VS Code, return appropriate config path based on global vs workspace scope
+      return isGlobal
+        ? McpSetupUtils.getVSCodeSettingsPath(isGlobal, workspaceDir)
+        : McpSetupUtils.getVSCodeMcpConfigPath(workspaceDir);
     } else if (editorLower === 'cursor') {
       return McpSetupUtils.getCursorSettingsPath(isGlobal, workspaceDir);
     } else if (editorLower === 'windsurf') {


### PR DESCRIPTION
Updates the Bit MCP server setup command to accommodate VS Code's new MCP server storage location structure.

Key changes:
- Workspace configuration now uses `.vscode/mcp.json` instead of `.vscode/settings.json`
- Updated tests to verify new configuration file creation and structure
- Updated documentation with both workspace and global configuration examples