### PR TITLE
feat(lanes): add --branch flag to bit lane import command

### DIFF
--- a/scopes/lanes/lanes/lane.cmd.ts
+++ b/scopes/lanes/lanes/lane.cmd.ts
@@ -620,6 +620,7 @@ export class LaneImportCmd implements Command {
       'pattern <component-pattern>',
       'import only components from the lane that fit the specified component-pattern to the workspace. works only when the workspace is empty',
     ],
+    ['', 'branch', 'create and checkout a new git branch named after the lane'],
   ] as CommandOptions;
   loader = true;
 
@@ -627,9 +628,17 @@ export class LaneImportCmd implements Command {
 
   async report(
     [lane]: [string],
-    { skipDependencyInstallation = false, pattern }: { skipDependencyInstallation: boolean; pattern?: string }
+    {
+      skipDependencyInstallation = false,
+      pattern,
+      branch = false,
+    }: {
+      skipDependencyInstallation: boolean;
+      pattern?: string;
+      branch?: boolean;
+    }
   ): Promise<string> {
-    return this.switchCmd.report([lane], { skipDependencyInstallation, pattern });
+    return this.switchCmd.report([lane], { skipDependencyInstallation, pattern, branch });
   }
 }
 

--- a/scopes/lanes/lanes/switch.cmd.ts
+++ b/scopes/lanes/lanes/switch.cmd.ts
@@ -43,6 +43,7 @@ ${COMPONENT_PATTERN_HELP}`,
     ],
     ['', 'verbose', 'display detailed information about components that legitimately were not switched'],
     ['j', 'json', 'return the output as JSON'],
+    ['', 'branch', 'create and checkout a new git branch named after the lane'],
   ] as CommandOptions;
   loader = true;
 
@@ -62,6 +63,7 @@ ${COMPONENT_PATTERN_HELP}`,
       pattern,
       verbose,
       json = false,
+      branch = false,
     }: {
       head?: boolean;
       alias?: string;
@@ -75,6 +77,7 @@ ${COMPONENT_PATTERN_HELP}`,
       pattern?: string;
       verbose?: boolean;
       json?: boolean;
+      branch?: boolean;
     }
   ) {
     const { components, failedComponents, installationError, compilationError } = await this.lanes.switchLanes(lane, {
@@ -86,6 +89,7 @@ ${COMPONENT_PATTERN_HELP}`,
       workspaceOnly,
       pattern,
       skipDependencyInstallation,
+      branch,
     });
     if (getAll) {
       this.lanes.logger.warn('the --get-all flag is deprecated and currently the default behavior');


### PR DESCRIPTION
Adds a new `--branch` flag to `bit lane import` that creates and checks out a new git branch named after the lane.

Features:
- Only creates git branch when flag is specified and git repository exists
- Sanitizes lane name to create valid git branch names
- Gracefully handles git command failures with warnings