### PR TITLE
feat(mcp): add Claude Code support to bit mcp-server setup and rules commands

### DIFF
--- a/scopes/mcp/cli-mcp-server/README.docs.mdx
+++ b/scopes/mcp/cli-mcp-server/README.docs.mdx
@@ -50,7 +50,7 @@ This will automatically configure your VS Code settings to use the Bit MCP serve
 The **recommended way** to integrate the MCP server with your IDE is using the `setup` command:
 
 ```bash
-bit mcp-server setup [vscode|cursor|windsurf] [options]
+bit mcp-server setup [vscode|cursor|windsurf|roo|cline|claude-code] [options]
 ```
 
 This command automatically configures the MCP server settings in your chosen editor. If no editor is specified, it defaults to VS Code.
@@ -60,6 +60,9 @@ This command automatically configures the MCP server settings in your chosen edi
 - **VS Code**: `bit mcp-server setup vscode` (or just `bit mcp-server setup`)
 - **Cursor**: `bit mcp-server setup cursor`
 - **Windsurf**: `bit mcp-server setup windsurf`
+- **Roo Code**: `bit mcp-server setup roo`
+- **Cline**: `bit mcp-server setup cline`
+- **Claude Code**: `bit mcp-server setup claude-code`
 
 #### Configuration Options
 
@@ -78,6 +81,12 @@ bit mcp-server setup cursor --global
 
 # Setup with consumer project mode
 bit mcp-server setup --consumer-project
+
+# Setup for Claude Code (creates .mcp.json file)
+bit mcp-server setup claude-code
+
+# Global setup for Claude Code
+bit mcp-server setup claude-code --global
 ```
 
 #### Manual Configuration
@@ -119,6 +128,59 @@ If you need to manually configure the settings, here's how to set up VS Code MCP
   }
 }
 ```
+
+#### Claude Code Setup
+
+Claude Code uses `.mcp.json` files for MCP server configuration. The setup command creates these files automatically:
+
+**Workspace Configuration:**
+
+```bash
+bit mcp-server setup claude-code
+```
+
+This creates a `.mcp.json` file in your project root:
+
+```json
+{
+  "mcpServers": {
+    "bit": {
+      "command": "bit",
+      "args": ["mcp-server", "start"]
+    }
+  }
+}
+```
+
+**Global Configuration:**
+
+```bash
+bit mcp-server setup claude-code --global
+```
+
+This creates/updates the global configuration file:
+
+- **macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- **Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
+- **Linux**: `~/.config/claude/claude_desktop_config.json`
+
+**Important**: After setup, restart Claude Code for the MCP server to be available.
+
+**Claude Code Rules:**
+
+To provide Bit-specific guidance to Claude Code, use the rules command:
+
+```bash
+bit mcp-server rules claude-code
+```
+
+This creates `.claude/bit.md` with Bit instructions. To integrate with your existing `CLAUDE.md`, add:
+
+```markdown
+@.claude/bit.md
+```
+
+This approach ensures your existing `CLAUDE.md` file is never overwritten.
 
 ### Programmatic Usage
 
@@ -206,7 +268,7 @@ bit mcp-server start --consumer-project --include-additional "deps,get,preview"
 The MCP server provides a `rules` command to create instruction files for AI assistants:
 
 ```bash
-bit mcp-server rules [vscode|cursor|windsurf|cline] [options]
+bit mcp-server rules [vscode|cursor|windsurf|roo|cline|claude-code] [options]
 ```
 
 This command creates rules/instructions markdown files that provide guidance to AI assistants on how to effectively use the Bit MCP server and follow best practices when working with Bit components.
@@ -216,7 +278,9 @@ This command creates rules/instructions markdown files that provide guidance to 
 - **VS Code**: `bit mcp-server rules vscode` (or just `bit mcp-server rules`)
 - **Cursor**: `bit mcp-server rules cursor`
 - **Windsurf**: `bit mcp-server rules windsurf`
+- **Roo Code**: `bit mcp-server rules roo`
 - **Cline**: `bit mcp-server rules cline`
+- **Claude Code**: `bit mcp-server rules claude-code`
 
 #### Configuration Options
 
@@ -235,6 +299,12 @@ bit mcp-server rules cursor --global
 
 # Consumer project rules for VS Code
 bit mcp-server rules --consumer-project
+
+# Claude Code rules (creates .claude/bit.md)
+bit mcp-server rules claude-code
+
+# Global Claude Code rules
+bit mcp-server rules claude-code --global
 
 # Global rules for Cline (macOS only)
 bit mcp-server rules cline --global

--- a/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
+++ b/scopes/mcp/cli-mcp-server/cli-mcp-server.main.runtime.ts
@@ -1278,13 +1278,15 @@ export class CliMcpServerMain {
       return McpSetupUtils.getRooCodeSettingsPath(isGlobal, workspaceDir);
     } else if (editorLower === 'cline') {
       return McpSetupUtils.getClinePromptsPath(isGlobal, workspaceDir);
+    } else if (editorLower === 'claude-code') {
+      return McpSetupUtils.getClaudeCodeSettingsPath(isGlobal, workspaceDir);
     }
 
     throw new Error(`Editor "${editor}" is not supported yet.`);
   }
 
   async setupEditor(editor: string, options: SetupOptions, workspaceDir?: string): Promise<void> {
-    const supportedEditors = ['vscode', 'cursor', 'windsurf', 'roo', 'cline'];
+    const supportedEditors = ['vscode', 'cursor', 'windsurf', 'roo', 'cline', 'claude-code'];
     const editorLower = editor.toLowerCase();
 
     if (!supportedEditors.includes(editorLower)) {
@@ -1309,11 +1311,13 @@ export class CliMcpServerMain {
       // Cline doesn't need MCP server setup, only rules files
       // This is a no-op but we include it for consistency
       // Users should use the 'rules' command to set up Cline instructions
+    } else if (editorLower === 'claude-code') {
+      await McpSetupUtils.setupClaudeCode(setupOptions);
     }
   }
 
   async writeRulesFile(editor: string, options: RulesOptions, workspaceDir?: string): Promise<void> {
-    const supportedEditors = ['vscode', 'cursor', 'roo', 'cline'];
+    const supportedEditors = ['vscode', 'cursor', 'roo', 'cline', 'claude-code'];
     const editorLower = editor.toLowerCase();
 
     if (!supportedEditors.includes(editorLower)) {
@@ -1334,6 +1338,8 @@ export class CliMcpServerMain {
       await McpSetupUtils.writeRooCodeRules(rulesOptions);
     } else if (editorLower === 'cline') {
       await McpSetupUtils.writeClineRules(rulesOptions);
+    } else if (editorLower === 'claude-code') {
+      await McpSetupUtils.writeClaudeCodeRules(rulesOptions);
     }
   }
 

--- a/scopes/mcp/cli-mcp-server/rules-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/rules-cmd.ts
@@ -10,13 +10,14 @@ export type McpRulesCmdOptions = {
 
 export class McpRulesCmd implements Command {
   name = 'rules [editor]';
-  description = 'Write Bit MCP rules/instructions file for VS Code, Cursor, Roo Code, Cline, or print to screen';
+  description =
+    'Write Bit MCP rules/instructions file for VS Code, Cursor, Roo Code, Cline, Claude Code, or print to screen';
   extendedDescription =
-    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code, Cursor, Roo Code, and Cline. Use --print to display content on screen. Use --consumer-project for non-Bit workspaces that only consume components as packages.';
+    'Creates or updates rules/instructions markdown files to provide AI assistants with guidance on using Bit MCP server. Currently supports VS Code, Cursor, Roo Code, Cline, and Claude Code. For Claude Code, creates .claude/bit.md to avoid overwriting existing CLAUDE.md files. Use --print to display content on screen. Use --consumer-project for non-Bit workspaces that only consume components as packages.';
   arguments = [
     {
       name: 'editor',
-      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor, roo, cline',
+      description: 'Editor to write rules for (default: vscode). Available: vscode, cursor, roo, cline, claude-code',
     },
   ];
   options = [
@@ -55,6 +56,21 @@ export class McpRulesCmd implements Command {
 
       const scope = isGlobal ? 'global' : 'workspace';
       const editorName = this.mcpServerMain.getEditorDisplayName(editor);
+
+      // Special message for Claude Code to explain the file location
+      if (editor.toLowerCase() === 'claude-code') {
+        const filePath = isGlobal ? '~/.claude/bit.md' : '.claude/bit.md';
+        const atSyntax = isGlobal ? '@~/.claude/bit.md' : '@.claude/bit.md';
+
+        return chalk.green(
+          `✓ Successfully wrote ${editorName} Bit rules file (${scope})\n` +
+            `  File created: ${chalk.cyan(filePath)}\n\n` +
+            `  ${chalk.yellow('Integration:')} Add this line to your main CLAUDE.md file:\n` +
+            `  ${chalk.cyan(atSyntax)}\n\n` +
+            `  ${chalk.gray('This will automatically include all Bit-specific instructions.')}`
+        );
+      }
+
       return chalk.green(`✓ Successfully wrote ${editorName} Bit MCP rules file (${scope})`);
     } catch (error) {
       const editorName = this.mcpServerMain.getEditorDisplayName(editor);

--- a/scopes/mcp/cli-mcp-server/setup-cmd.ts
+++ b/scopes/mcp/cli-mcp-server/setup-cmd.ts
@@ -10,13 +10,13 @@ export type McpSetupCmdOptions = {
 
 export class McpSetupCmd implements Command {
   name = 'setup [editor]';
-  description = 'Setup MCP integration with VS Code, Cursor, Windsurf, Roo Code, Cline, or other editors';
+  description = 'Setup MCP integration with VS Code, Cursor, Windsurf, Roo Code, Cline, Claude Code, or other editors';
   extendedDescription =
-    'Creates or updates configuration files to integrate Bit MCP server with supported editors. Currently supports VS Code, Cursor, Windsurf, Roo Code, and Cline.';
+    'Creates or updates configuration files to integrate Bit MCP server with supported editors. Currently supports VS Code, Cursor, Windsurf, Roo Code, Cline, and Claude Code.';
   arguments = [
     {
       name: 'editor',
-      description: 'Editor to setup (default: vscode). Available: vscode, cursor, windsurf, roo, cline',
+      description: 'Editor to setup (default: vscode). Available: vscode, cursor, windsurf, roo, cline, claude-code',
     },
   ];
   options = [
@@ -47,6 +47,15 @@ export class McpSetupCmd implements Command {
 
       // Get the config file path based on the editor type
       const configPath = this.mcpServerMain.getEditorConfigPath(editor, isGlobal);
+
+      // Special message for Claude Code to mention restart requirement
+      if (editor.toLowerCase() === 'claude-code') {
+        return chalk.green(
+          `✓ Successfully configured ${editorName} MCP integration (${scope})\n` +
+            `  Configuration written to: ${chalk.cyan(configPath)}\n` +
+            `  ${chalk.yellow('Note:')} Restart Claude Code to use the Bit MCP tools.`
+        );
+      }
 
       return chalk.green(
         `✓ Successfully configured ${editorName} MCP integration (${scope})\n` +


### PR DESCRIPTION
## Summary
- Add Claude Code editor support to `bit mcp-server setup` and `bit mcp-server rules` commands
- Setup command creates `.mcp.json` files with proper platform-specific global paths
- Rules command creates `.claude/bit.md` safely without overwriting existing `CLAUDE.md` files
- Updated documentation with Claude Code configuration examples and integration instructions