### PR TITLE
feat: reduce bit link verbosity with summary output by default

### DIFF
--- a/scopes/workspace/install/link/component-list-links.ts
+++ b/scopes/workspace/install/link/component-list-links.ts
@@ -7,12 +7,23 @@ import { LinkDetail } from '@teambit/dependency-resolver';
 type ComponentListLinksProps = {
   componentListLinks?: NodeModulesLinksResult[];
   verbose: boolean;
+  compSummary?: boolean;
 };
 
-export function ComponentListLinks({ componentListLinks, verbose = false }: ComponentListLinksProps) {
+export function ComponentListLinks({
+  componentListLinks,
+  verbose = false,
+  compSummary = false,
+}: ComponentListLinksProps) {
   if (!componentListLinks || !componentListLinks.length) {
     return chalk.cyan('No components link were generated');
   }
+
+  if (compSummary) {
+    const count = componentListLinks.length;
+    return chalk.cyan(`${count} components were linked`);
+  }
+
   const title = chalk.bold.cyan('Components links');
   const links = componentListLinks.map((componentLinks) => ComponentLinks({ componentLinks, verbose })).join('\n');
 
@@ -25,11 +36,13 @@ export function packageListLinks(packageList?: LinkDetail[]) {
   }
   const title = chalk.bold.cyan('Non-Core Package links');
 
-  const links = packageList.map((link) => {
-    const id = link.packageName;
-    const packagePath = getPackageNameFromTarget(link.to);
-    return LinkRow({ title: id, target: packagePath, padding: 50 });
-  }).join('\n');
+  const links = packageList
+    .map((link) => {
+      const id = link.packageName;
+      const packagePath = getPackageNameFromTarget(link.to);
+      return LinkRow({ title: id, target: packagePath, padding: 50 });
+    })
+    .join('\n');
 
   return `${title}\n${links}`;
 }

--- a/scopes/workspace/install/link/core-aspects-links.ts
+++ b/scopes/workspace/install/link/core-aspects-links.ts
@@ -13,9 +13,16 @@ export function CoreAspectsLinks({ coreAspectsLinks, verbose = false }: CoreAspe
   if (!coreAspectsLinks || !coreAspectsLinks.length) {
     return chalk.cyan('No core aspects were linked');
   }
-  const title = chalk.cyan('Core aspects links');
-  const links = coreAspectsLinks.map((link) => CoreAspectLinkRow({ coreAspectLink: link, verbose })).join('\n');
-  return `${title}\n${links}`;
+
+  if (verbose) {
+    const title = chalk.cyan('Core aspects links');
+    const links = coreAspectsLinks.map((link) => CoreAspectLinkRow({ coreAspectLink: link, verbose })).join('\n');
+    return `${title}\n${links}`;
+  }
+
+  // Show summary by default
+  const count = coreAspectsLinks.length;
+  return chalk.cyan(`${count} core-aspects were linked`);
 }
 
 type CoreAspectLinkProps = {

--- a/scopes/workspace/install/link/link.cmd.ts
+++ b/scopes/workspace/install/link/link.cmd.ts
@@ -17,6 +17,7 @@ type LinkCommandOpts = {
   target: string;
   skipFetchingObjects?: boolean;
   peers?: boolean;
+  compSummary?: boolean;
 };
 export class LinkCommand implements Command {
   name = 'link [component-names...]';
@@ -38,6 +39,7 @@ export class LinkCommand implements Command {
     ],
     ['', 'skip-fetching-objects', 'skip fetch missing objects from remotes before linking'],
     ['', 'peers', 'link peer dependencies of the components too'],
+    ['', 'comp-summary', 'show only a summary of component links instead of listing all components'],
   ] as CommandOptions;
 
   constructor(
@@ -71,7 +73,11 @@ export class LinkCommand implements Command {
       verbose: opts.verbose,
     });
     const nonCorePackagesLinks = packageListLinks(linkResults.slotOriginatedLinks);
-    const compsLinks = ComponentListLinks({ componentListLinks: linkResults.legacyLinkResults, verbose: opts.verbose });
+    const compsLinks = ComponentListLinks({
+      componentListLinks: linkResults.legacyLinkResults,
+      verbose: opts.verbose,
+      compSummary: opts.compSummary,
+    });
     const rewireRow = RewireRow({ legacyCodemodResults: linkResults.legacyLinkCodemodResults });
     const nestedLinks = NestedComponentLinksLinks({
       nestedDepsInNmLinks: linkResults.nestedDepsInNmLinks,


### PR DESCRIPTION
## Summary
- Modified core-aspects output to show summary by default ("x core-aspects were linked")
- Added --verbose flag support for detailed core-aspects output
- Added --comp-summary flag to show component summary instead of full listing