### PR TITLE
fix(ci): detect default Git branch for push operation in bit ci merge

### DIFF
--- a/.bitmap
+++ b/.bitmap
@@ -215,7 +215,7 @@
     "bit": {
         "name": "bit",
         "scope": "teambit.harmony",
-        "version": "1.11.34",
+        "version": "1.11.35",
         "mainFile": "index.ts",
         "rootDir": "scopes/harmony/bit"
     },
@@ -271,7 +271,7 @@
     "ci": {
         "name": "ci",
         "scope": "teambit.git",
-        "version": "0.0.2",
+        "version": "0.0.3",
         "mainFile": "index.ts",
         "rootDir": "scopes/git/ci"
     },


### PR DESCRIPTION
## Summary
Fixes the Git push error in `bit ci merge` by detecting the actual default Git branch instead of assuming it's `main`.