### PR TITLE
ix(ui-server): eliminate duplicate `/_hmr` proxy to restore WebSocket HMR

### DIFF
--- a/scopes/ui-foundation/ui/ui-server.ts
+++ b/scopes/ui-foundation/ui/ui-server.ts
@@ -55,7 +55,7 @@ export class UIServer {
     private logger: Logger,
     private publicDir: string,
     private plugins: StartPlugin[]
-  ) { }
+  ) {}
 
   getName() {
     return this.uiRoot.name;
@@ -111,7 +111,7 @@ export class UIServer {
         context: [hmrRoute],
         target: `ws://${this.host}:${server.port}`,
         ws: true,
-      }
+      },
     ];
 
     if (this._proxyRoutes.has(previewRoute) || this._proxyRoutes.has(hmrRoute)) {
@@ -131,11 +131,13 @@ export class UIServer {
           const reqUrl = req.url?.replace(/\?.+$/, '') || '';
           const path = stripTrailingChar(reqUrl, '/');
 
-          const entry = entries.find((proxy) =>
-            proxy.ws && proxy.context.some(item => {
-              const itemPath = stripTrailingChar(item, '/');
-              return path === itemPath || path.startsWith(itemPath);
-            })
+          const entry = entries.find(
+            (proxy) =>
+              proxy.ws &&
+              proxy.context.some((item) => {
+                const itemPath = stripTrailingChar(item, '/');
+                return path === itemPath || path.startsWith(itemPath);
+              })
           );
 
           if (!entry) {
@@ -207,9 +209,7 @@ export class UIServer {
       const reqUrl = req.url?.replace(/\?.+$/, '') || '';
       const path = stripTrailingChar(reqUrl, '/');
       const proxyEntries = this.getProxyFromPlugins();
-      const entry = proxyEntries.find((proxy) =>
-        proxy.context.some((item) => item === stripTrailingChar(path, '/'))
-      );
+      const entry = proxyEntries.find((proxy) => proxy.context.some((item) => item === stripTrailingChar(path, '/')));
       if (!entry) {
         return;
       }
@@ -315,11 +315,6 @@ export class UIServer {
         target: `http://${this.host}:${port}`,
         changeOrigin: true,
       },
-      {
-        context: ['/_hmr'],
-        target: `ws://${this.host}:${port}`,
-        ws: true,
-      }
     ];
 
     const gqlProxies: ProxyEntry[] = [


### PR DESCRIPTION
This PR removes the generic `/_hmr` WebSocket proxy entry from UIServer.getProxy().

Previously, 
`/_hmr/<envId>` matched two ProxyEntrys (catch-all & env-specific) → the same socket was proxied twice, sending a second 101 header → “Invalid frame header / ECONNRESET” in the browser and broken HMR

With this fix,
Each HMR request matches exactly one proxy entry. The connection upgrades once; HMR frames flow without errors.