### PR TITLE
fix(ci): add skip ci flag to merge commit message

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -472,7 +472,7 @@ export class CiMain {
 
     // Commit the .bitmap and pnpm-lock.yaml files using Git
     await git.add(['.bitmap', 'pnpm-lock.yaml']);
-    await git.commit('chore: update .bitmap and pnpm-lock.yaml');
+    await git.commit('chore: update .bitmap and lockfiles as needed [skip ci]');
 
     // Push the commit to the remote repository
     const defaultBranch = await this.getDefaultBranchName();


### PR DESCRIPTION
Prevents CircleCI from running on automatic merge commits that update .bitmap and lockfiles.

The commit message now includes `[skip ci]` to avoid triggering unnecessary CI runs when the merge operation pushes changes to the default branch.