### PR TITLE
refactor(ci): streamline nightly and harmony_deploy workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1423,24 +1423,18 @@ workflows:
                 - master
     jobs:
       - checkout_code
-      - set_ssh_key
-      - set_npm_registries
-      - setup_harmony:
-          requires:
-            - set_npm_registries
-            - checkout_code
       - bundle_version_linux:
           <<: *master_only_filter
           requires:
-            - setup_harmony
+            - checkout_code
       - bundle_version_macos:
           <<: *master_only_filter
           requires:
-            - setup_harmony
+            - checkout_code
       - bundle_version_windows:
           <<: *master_only_filter
           requires:
-            - setup_harmony
+            - checkout_code
       - harmony_publish_to_gcloud:
           <<: *master_only_filter
           requires:
@@ -1529,52 +1523,21 @@ workflows:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
-      - set_ssh_key:
-          <<: *master_only_filter
-          requires:
-            - harmony_deploy_approval_job
-      - set_npm_registries:
-          <<: *master_only_filter
-          requires:
-            - harmony_deploy_approval_job
-      - setup_harmony:
-          <<: *master_only_filter
-          requires:
-            - harmony_deploy_approval_job
-            - set_npm_registries
-            - checkout_code
-      - bit_tag:
-          <<: *master_only_filter
-          requires:
-            - harmony_deploy_approval_job
-            - setup_harmony
-      - sleep_5_minutes:
-          <<: *master_only_filter
-          requires:
-            - harmony_deploy_approval_job
-            - bit_tag
-            - bit_export
       - bundle_version_linux:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
-            - bit_tag
-            - bit_export
-            - sleep_5_minutes
+            - checkout_code
       - bundle_version_macos:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
-            - bit_tag
-            - bit_export
-            - sleep_5_minutes
+            - checkout_code
       - bundle_version_windows:
           <<: *master_only_filter
           requires:
             - harmony_deploy_approval_job
-            - bit_tag
-            - bit_export
-            - sleep_5_minutes
+            - checkout_code
       - harmony_publish_to_gcloud:
           <<: *master_only_filter
           requires:
@@ -1583,11 +1546,6 @@ workflows:
             - bundle_version_macos
             - bundle_version_windows
             - checkout_code # This is needed to generate index.json
-      - bit_export:
-          <<: *master_only_filter
-          requires:
-            - bit_tag
-            - harmony_deploy_approval_job
       # - docker_build:
       #     requires:
       #       - harmony_deploy_approval_job


### PR DESCRIPTION
Removes redundant setup and tagging jobs from both nightly and harmony_deploy workflows. Since component tagging/export is now handled by the merge workflow, these workflows can focus solely on creating Docker containers and BVM bundles from published packages.

Eliminates unnecessary setup_harmony, set_ssh_key, set_npm_registries, bit_tag, bit_export, and sleep_5_minutes jobs, reducing workflow complexity and execution time.