### PR TITLE
fix(ci): serialize merge operations to prevent race conditions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,6 +641,7 @@ jobs:
   bit_merge:
     resource_class: xlarge
     <<: *defaults
+    serial-group: "bit-merge-operations"
     environment:
       BIT_FEATURES: cloud-importer-v2
       NODE_OPTIONS: --max-old-space-size=15000

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -641,7 +641,6 @@ jobs:
   bit_merge:
     resource_class: xlarge
     <<: *defaults
-    serial-group: "bit-merge-operations"
     environment:
       BIT_FEATURES: cloud-importer-v2
       NODE_OPTIONS: --max-old-space-size=15000
@@ -1390,6 +1389,7 @@ workflows:
           filters:
             branches:
               only: master
+          serial-group: "bit-merge-operations"
 
   # windows_e2e:
   #   jobs:


### PR DESCRIPTION
Adds serial-group to the bit_merge job to ensure only one merge operation runs at a time organization-wide. This prevents race conditions where multiple PRs merged quickly could cause parallel tagging of the same components with identical versions.

Jobs are queued in FIFO order with a 5-hour timeout, ensuring safe sequential execution of component versioning operations.