### PR TITLE
ci: add back setup_harmony job to nightly for the e2e-tests to run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1424,6 +1424,9 @@ workflows:
                 - master
     jobs:
       - checkout_code
+      - setup_harmony:
+          requires:
+            - checkout_code
       - bundle_version_linux:
           <<: *master_only_filter
           requires:
@@ -1466,6 +1469,7 @@ workflows:
             - docker_build_node_22
       - e2e_test_bbit:
           requires:
+            - setup_harmony
             - harmony_publish_to_gcloud
 
   windows-nightly:


### PR DESCRIPTION
It has been removed yesterday. It's needed for the e2e-tests task.