### PR TITLE
refactor: split massive lanes.e2e.ts into focused test files

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1021,7 +1021,7 @@ jobs:
     environment:
       BITSRC_ENV: stg
       BIT_FEATURES: cloud-importer-v2
-    parallelism: 25
+    parallelism: 35
     steps:
       - e2e_test_cmd
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,7 +515,7 @@ jobs:
 
 
   setup_harmony:
-    resource_class: large
+    resource_class: xlarge
     <<: *defaults
     environment:
       BIT_FEATURES: cloud-importer-v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1017,6 +1017,7 @@ jobs:
 
   e2e_test:
     <<: *defaults
+    resource_class: large
     environment:
       BITSRC_ENV: stg
       BIT_FEATURES: cloud-importer-v2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -515,7 +515,8 @@ jobs:
 
 
   setup_harmony:
-    resource_class: xlarge
+    # changing to xlarge doesn't make any change
+    resource_class: large
     <<: *defaults
     environment:
       BIT_FEATURES: cloud-importer-v2
@@ -1017,11 +1018,12 @@ jobs:
 
   e2e_test:
     <<: *defaults
-    resource_class: large
+    # changing from medium to large, doesn't affect the performance
+    # resource_class: large
     environment:
       BITSRC_ENV: stg
       BIT_FEATURES: cloud-importer-v2
-    parallelism: 35
+    parallelism: 30
     steps:
       - e2e_test_cmd
 

--- a/e2e/harmony/lanes/lanes-basic.e2e.ts
+++ b/e2e/harmony/lanes/lanes-basic.e2e.ts
@@ -1,0 +1,209 @@
+import chai, { expect } from 'chai';
+import { LANE_REMOTE_DELIMITER } from '@teambit/lane-id';
+import { LANE_KEY } from '@teambit/legacy.bit-map';
+import { fixtures, Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes basic operations', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('creating a new lane without any component', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.reInitWorkspace({ addRemoteScopeAsDefaultScope: false });
+      helper.command.createLane();
+      output = helper.command.listLanes();
+    });
+    it('bit lane should show the active lane', () => {
+      expect(output).to.have.string(`current lane - my-scope/dev`);
+      expect(output).to.have.string('main');
+    });
+  });
+
+  describe('create a snap on main then on a new lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('bit status should show the component only once as staged', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents).to.have.lengthOf(1);
+      expect(status.importPendingComponents).to.have.lengthOf(0);
+      expect(status.invalidComponents).to.have.lengthOf(0);
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+      expect(status.newComponents).to.have.lengthOf(0);
+      expect(status.outdatedComponents).to.have.lengthOf(0);
+    });
+    it('bit log should show both snaps', () => {
+      const log = helper.command.log('bar/foo');
+      const mainSnap = helper.command.getHead('bar/foo');
+      const devSnap = helper.command.getHeadOfLane('dev', 'bar/foo');
+      expect(log).to.have.string(mainSnap);
+      expect(log).to.have.string(devSnap);
+    });
+    it('bit log --parents should show the parents', () => {
+      const log = helper.command.log('bar/foo', '--parents');
+      const mainSnap = helper.command.getHeadShort('bar/foo');
+      expect(log).to.have.string(`Parent(s): ${mainSnap}`);
+    });
+    describe('bit lane with --details flag', () => {
+      let output: string;
+      before(() => {
+        output = helper.command.listLanes('--details');
+      });
+      it('should show all lanes and mark the current one', () => {
+        expect(output).to.have.string(`current lane - ${helper.scopes.remote}/dev`);
+      });
+    });
+    describe('exporting the lane', () => {
+      before(() => {
+        helper.command.exportLane();
+      });
+      it('should export components on that lane', () => {
+        const list = helper.command.listRemoteScopeParsed();
+        expect(list).to.have.lengthOf(1);
+      });
+      it('bit status should show a clean state', () => {
+        helper.command.expectStatusToBeClean();
+      });
+      it('should change .bitmap to have the remote lane', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap[LANE_KEY].id).to.deep.equal({ name: 'dev', scope: helper.scopes.remote });
+      });
+      it('bit lane --remote should show the exported lane', () => {
+        const remoteLanes = helper.command.listRemoteLanesParsed();
+        expect(remoteLanes.lanes).to.have.lengthOf(1);
+        expect(remoteLanes.lanes[0].name).to.equal('dev');
+      });
+      describe('importing the component', () => {
+        before(() => {
+          helper.scopeHelper.reInitWorkspace();
+          helper.scopeHelper.addRemoteScope();
+          helper.command.importComponent('bar/foo');
+        });
+        it('should import the component from main and not from the lane', () => {
+          const fooContent = helper.fs.readFile('bar/foo/foo.js');
+          expect(fooContent).to.have.string('console.log("v1")');
+        });
+      });
+    });
+  });
+
+  describe('tagging on a lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
+      helper.command.tagAllWithoutBuild();
+    });
+    it('bit status should show the component as staged', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents).to.have.lengthOf(1);
+    });
+  });
+
+  describe('main => lane => main => lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.createLane();
+      helper.command.switchLocalLane('main');
+      helper.command.switchLocalLane('dev');
+    });
+    it('bit status should be clean', () => {
+      helper.command.expectStatusToBeClean();
+    });
+  });
+
+  describe('default tracking data', () => {
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.command.createLane();
+    });
+    it('should set the remote-scope to the default-scope and remote-name to the local-lane', () => {
+      const laneData = helper.command.showOneLane('dev');
+      expect(laneData).to.have.string(`${helper.scopes.remote}${LANE_REMOTE_DELIMITER}dev`);
+    });
+  });
+
+  describe('change tracking data', () => {
+    let output: string;
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.command.createLane();
+      output = helper.command.changeLaneScope('my-remote');
+    });
+    it('should output the changes', () => {
+      expect(output).to.have.string(
+        `the remote-scope of dev has been changed from ${helper.scopes.remote} to my-remote`
+      );
+    });
+    it('bit lane show should show the changed values', () => {
+      const laneData = helper.command.showOneLane('dev');
+      expect(laneData).to.have.string(`my-remote${LANE_REMOTE_DELIMITER}dev`);
+    });
+  });
+
+  describe('untag on a lane', () => {
+    let output;
+    before(() => {
+      helper.scopeHelper.reInitWorkspace();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      output = helper.command.resetAll();
+    });
+    it('should untag successfully', () => {
+      expect(output).to.have.string('1 component(s) were reset');
+    });
+    it('should change the component to be new', () => {
+      const status = helper.command.statusJson();
+      expect(status.newComponents).to.have.lengthOf(1);
+    });
+  });
+
+  describe('creating a new lane to a different scope than main', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+    });
+    it('should not throw even when --fork-lane-new-scope was not used', () => {
+      expect(() => helper.command.createLane('dev', '--scope some-scope')).to.not.throw();
+    });
+  });
+
+  describe('creating components on lanes, that do not exist on main', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('should add "onLanesOnly" prop', () => {
+      const bitMap = helper.bitMap.read();
+      expect(bitMap.comp1.onLanesOnly).to.be.true;
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes-diff.e2e.ts
+++ b/e2e/harmony/lanes/lanes-diff.e2e.ts
@@ -1,0 +1,109 @@
+import chai, { expect } from 'chai';
+import { fixtures, Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes diff operations', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('bit lane diff operations', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo(fixtures.fooFixtureV2);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.exportLane();
+    });
+
+    describe('bit lane diff on the scope', () => {
+      let diffOutput: string;
+      before(() => {
+        diffOutput = helper.command.diffLane('dev', true);
+      });
+      it('should show the diff', () => {
+        expect(diffOutput).to.have.string('console.log("v2")');
+      });
+    });
+
+    describe('bit lane diff on the workspace', () => {
+      let diffOutput: string;
+      before(() => {
+        diffOutput = helper.command.diffLane('main');
+      });
+      it('should show the diff', () => {
+        expect(diffOutput).to.have.string('console.log("v2")');
+      });
+      it('should show the file names', () => {
+        expect(diffOutput).to.have.string('bar/foo/foo.js');
+      });
+      it('should show the legends', () => {
+        expect(diffOutput).to.have.string('--- bar/foo/foo.js (main)');
+        expect(diffOutput).to.have.string('+++ bar/foo/foo.js (dev)');
+      });
+    });
+
+    describe('bit lane diff {toLane - default} on the workspace', () => {
+      let diffOutput: string;
+      before(() => {
+        diffOutput = helper.command.diffLane('main');
+      });
+      it('should show the diff', () => {
+        expect(diffOutput).to.have.string('console.log("v2")');
+      });
+      it('should show the file names', () => {
+        expect(diffOutput).to.have.string('bar/foo/foo.js');
+      });
+      it('should show the legends', () => {
+        expect(diffOutput).to.have.string('--- foo.js (main)');
+        expect(diffOutput).to.have.string('+++ foo.js (dev)');
+      });
+    });
+
+    describe('bit lane diff {toLane - non default} on the workspace', () => {
+      let diffOutput: string;
+      before(() => {
+        helper.command.switchLocalLane('main');
+        helper.command.createLane('stage');
+        helper.fixtures.createComponentBarFoo('console.log("v3")');
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+        helper.command.switchLocalLane('dev');
+        diffOutput = helper.command.diffLane('stage');
+      });
+      it('should show the diff', () => {
+        expect(diffOutput).to.have.string('console.log("v3")');
+      });
+      it('should show the legends', () => {
+        expect(diffOutput).to.have.string('--- foo.js (stage)');
+        expect(diffOutput).to.have.string('+++ foo.js (dev)');
+      });
+    });
+
+    describe('bit lane diff {fromLane} {toLane} on the workspace', () => {
+      let diffOutput: string;
+      before(() => {
+        diffOutput = helper.command.diffLane('main dev');
+      });
+      it('should show the diff', () => {
+        expect(diffOutput).to.have.string('console.log("v2")');
+      });
+      it('should show the legends', () => {
+        expect(diffOutput).to.have.string('--- foo.js (main)');
+        expect(diffOutput).to.have.string('+++ foo.js (dev)');
+      });
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes-import-export.e2e.ts
+++ b/e2e/harmony/lanes/lanes-import-export.e2e.ts
@@ -1,0 +1,219 @@
+import chai, { expect } from 'chai';
+import { IMPORT_PENDING_MSG } from '@teambit/legacy.constants';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes import and export operations', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('export on main then on a lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      // simulate cloning the project and coping scope.json to be checked out to the lane
+      const scopeJson = helper.scopeJson.read();
+      helper.fs.deletePath('.bit');
+      helper.command.init();
+      helper.scopeJson.write(scopeJson);
+
+      helper.command.import();
+    });
+    it('bit status should not complain about outdated objects', () => {
+      const status = helper.command.status();
+      expect(status).to.not.have.string(IMPORT_PENDING_MSG);
+    });
+  });
+
+  describe('deleting the local scope after exporting a lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.exportLane();
+      helper.fs.deletePath('.bit');
+      helper.command.init();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('should re-create scope.json with checkout to the lane specified in the .bitmap file', () => {
+      helper.command.expectCurrentLaneToBe('dev');
+    });
+    // previously, it used to throw "component X has no versions and the head is empty"
+    it('bit import should not throw an error', () => {
+      expect(() => helper.command.import()).to.not.throw();
+    });
+  });
+
+  describe('some components are on a lane some are not', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagWithoutBuild('comp3');
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('bit list should not show components from the lanes', () => {
+      const list = helper.command.listRemoteScopeParsed();
+      expect(list).to.have.lengthOf(1);
+    });
+    it('bit import should not throw', () => {
+      expect(() => helper.command.importComponent('*')).to.not.throw();
+    });
+  });
+
+  describe('export on lane with tiny cache', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.runCmd('bit config set cache.max.objects 1');
+    });
+    after(() => {
+      helper.command.runCmd('bit config del cache.max.objects');
+    });
+    // previously, it was throwing "HeadNotFound"/"ComponentNotFound" when there were many objects in the cache
+    it('should not throw', () => {
+      expect(() => helper.command.export()).not.to.throw();
+    });
+  });
+
+  describe('export multiple snaps on lane when the remote has it already', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      // the second snap is mandatory, don't skip it.
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // previously, it was throwing ParentNotFound
+    it('bit export should not throw ParentNotFound', () => {
+      expect(() => helper.command.export()).not.to.throw();
+    });
+  });
+
+  describe('import from one lane to another directly', () => {
+    let headOnLaneB: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.fixtures.populateComponents(1, false, 'from-lane-b');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      headOnLaneB = helper.command.getHeadOfLane('lane-b', 'comp1');
+      helper.command.switchLocalLane('lane-a', '-x');
+      helper.fixtures.populateComponents(1, false, 'from-lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+    });
+    it('should block the import', () => {
+      expect(() => helper.command.importComponent(`comp1@${headOnLaneB}`)).to.throw(
+        `unable to import the following component(s) as they belong to other lane(s)`
+      );
+    });
+  });
+
+  describe('import from a lane to main', () => {
+    let headOnLaneA: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      headOnLaneA = helper.command.getHeadOfLane('lane-a', 'comp1');
+      helper.command.export();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('should block the import', () => {
+      expect(() => helper.command.importComponent(`comp1@${headOnLaneA}`)).to.throw(
+        `unable to import the following component(s) as they belong to other lane(s)`
+      );
+    });
+  });
+
+  describe('import from one lane to another directly when current lane does not have the component', () => {
+    let headOnLaneA: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      headOnLaneA = helper.command.getHeadOfLane('lane-a', 'comp1');
+      helper.command.export();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane('lane-b');
+    });
+    it('should block the import', () => {
+      expect(() => helper.command.importComponent(`comp1@${headOnLaneA}`)).to.throw(
+        `unable to import the following component(s) as they belong to other lane(s)`
+      );
+    });
+  });
+
+  describe('import from one lane to another directly when current lane does have the component', () => {
+    let headOnLaneA: string;
+    let headOnLaneB: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      const laneAWs = helper.scopeHelper.cloneWorkspace();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane('lane-b');
+      helper.command.mergeLane(`${helper.scopes.remote}/lane-a`, '-x');
+      helper.command.export();
+      headOnLaneB = helper.command.getHeadOfLane('lane-b', 'comp1');
+      const laneBWs = helper.scopeHelper.cloneWorkspace();
+      helper.scopeHelper.getClonedWorkspace(laneAWs);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      headOnLaneA = helper.command.getHeadOfLane('lane-a', 'comp1');
+      helper.scopeHelper.getClonedWorkspace(laneBWs);
+    });
+    // previously, it was quietly importing the component from the current lane and ignores the provided version.
+    it('should not bring that snap', () => {
+      const output = helper.command.importComponent(`comp1@${headOnLaneA}`, '--override');
+      expect(output).to.have.string('Missing Components');
+    });
+    it('should not not change .bitmap', () => {
+      const bitMap = helper.bitMap.read();
+      const bitMapVer = bitMap.comp1.version;
+      expect(bitMapVer).to.equal(headOnLaneB);
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes-merge-update.e2e.ts
+++ b/e2e/harmony/lanes/lanes-merge-update.e2e.ts
@@ -1,0 +1,261 @@
+import chai, { expect } from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes merge and update operations', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('tag on main, export, create lane and snap', () => {
+    before(() => {
+      helper.command.export();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(2, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('bit status should show the correct staged versions', () => {
+      // before it was a bug that "versions" part of the staged-component was empty
+      // another bug was that it had all versions included exported.
+      const status = helper.command.status('--verbose');
+      const hash = helper.command.getHeadOfLane('dev', 'comp1');
+      expect(status).to.have.string(`versions: ${hash} ...`);
+    });
+
+    describe('export the lane, then switch back to main', () => {
+      let afterSwitchingLocal: string;
+      let afterSwitchingRemote: string;
+      before(() => {
+        helper.command.export();
+        afterSwitchingLocal = helper.scopeHelper.cloneWorkspace();
+        afterSwitchingRemote = helper.scopeHelper.cloneRemoteScope();
+        helper.command.switchLocalLane('main', '-x');
+      });
+      it('status should not show the components as pending updates', () => {
+        helper.command.expectStatusToBeClean();
+      });
+
+      describe('switch the lane back to dev', () => {
+        before(() => {
+          helper.command.switchLocalLane('dev', '-x');
+        });
+        describe('switch back to main', () => {
+          before(() => {
+            helper.command.switchLocalLane('main', '-x');
+          });
+          it('should not show the components as pending updates', () => {
+            helper.command.expectStatusToBeClean();
+          });
+        });
+      });
+
+      describe('merging the dev lane when the lane is ahead (no diverge)', () => {
+        before(() => {
+          helper.command.mergeLane('dev', '-x');
+        });
+        it('should merge the lane successfully', () => {
+          const status = helper.command.statusJson();
+          expect(status.stagedComponents).to.have.lengthOf(2);
+        });
+        it('should not show the components as modified', () => {
+          const status = helper.command.statusJson();
+          expect(status.modifiedComponents).to.have.lengthOf(0);
+        });
+        describe('tagging the components', () => {
+          before(() => {
+            helper.command.tagAllWithoutBuild();
+          });
+          it('should tag successfully', () => {
+            const status = helper.command.statusJson();
+            expect(status.stagedComponents).to.have.lengthOf(2);
+          });
+        });
+      });
+
+      describe('merging the dev lane when the lane has diverged from main', () => {
+        before(() => {
+          helper.scopeHelper.getClonedWorkspace(afterSwitchingLocal);
+          helper.scopeHelper.getClonedRemoteScope(afterSwitchingRemote);
+          helper.command.switchLocalLane('main', '-x');
+          helper.fixtures.populateComponents(2, undefined, 'v3');
+          helper.command.snapAllComponentsWithoutBuild();
+          helper.command.export();
+          helper.command.mergeLane('dev', '-x');
+        });
+        it('should merge the lane successfully', () => {
+          const status = helper.command.statusJson();
+          expect(status.stagedComponents).to.have.lengthOf(2);
+        });
+        describe('tagging the components', () => {
+          before(() => {
+            helper.command.tagAllWithoutBuild();
+          });
+          it('should tag successfully', () => {
+            const status = helper.command.statusJson();
+            expect(status.stagedComponents).to.have.lengthOf(2);
+          });
+        });
+      });
+    });
+  });
+
+  describe('update components from remote lane', () => {
+    let afterFirstExport: string;
+    let remoteAfterSecondExport: string;
+    let beforeSecondExport: string;
+    let remoteBeforeSecondExport: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane('dev');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      afterFirstExport = helper.scopeHelper.cloneWorkspace();
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      beforeSecondExport = helper.scopeHelper.cloneWorkspace();
+      remoteBeforeSecondExport = helper.scopeHelper.cloneRemoteScope();
+      helper.command.export();
+      remoteAfterSecondExport = helper.scopeHelper.cloneRemoteScope();
+    });
+
+    describe('running "bit import" when the local is behind', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(afterFirstExport);
+        helper.command.import();
+      });
+      it('bit import should not only bring the components but also merge the lane object', () => {
+        const headOnLocalLane = helper.command.getHeadOfLane('dev', 'comp1');
+        const headOnRemoteLane = helper.command.getHeadOfLane('dev', 'comp1', helper.scopes.remotePath);
+        expect(headOnLocalLane).to.equal(headOnRemoteLane);
+      });
+      it('bit status should show the components as pending-updates', () => {
+        const status = helper.command.statusJson();
+        expect(status.outdatedComponents).to.have.lengthOf(1);
+      });
+      it('bit checkout head --all should update them all to the head version', () => {
+        helper.command.checkoutHead('--all');
+        helper.command.expectStatusToBeClean();
+      });
+    });
+
+    describe('running "bit import" when the remote is behind', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(beforeSecondExport);
+        helper.scopeHelper.getClonedRemoteScope(remoteBeforeSecondExport);
+        helper.command.import();
+      });
+      it('bit import should not change the heads with the older snaps', () => {
+        const headOnLocalLane = helper.command.getHeadOfLane('dev', 'comp1');
+        const headOnRemoteLane = helper.command.getHeadOfLane('dev', 'comp1', helper.scopes.remotePath);
+        expect(headOnLocalLane).to.not.equal(headOnRemoteLane);
+      });
+      it('bit status should still show the components as staged', () => {
+        const status = helper.command.statusJson();
+        expect(status.stagedComponents).to.have.lengthOf(1);
+      });
+    });
+
+    describe('running "bit import" when the remote and the local have diverged', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(afterFirstExport);
+        // it's imported, otherwise the auto-import brings the second snap from the remote
+        helper.scopeHelper.getClonedRemoteScope(remoteBeforeSecondExport);
+        helper.fixtures.populateComponents(1, undefined, 'v3');
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.scopeHelper.getClonedRemoteScope(remoteAfterSecondExport);
+        helper.command.import();
+      });
+      it('bit import should not change the heads with the older snaps', () => {
+        const headOnLocalLane = helper.command.getHeadOfLane('dev', 'comp1');
+        const headOnRemoteLane = helper.command.getHeadOfLane('dev', 'comp1', helper.scopes.remotePath);
+        expect(headOnLocalLane).to.not.equal(headOnRemoteLane);
+      });
+      it('bit status should show the components as pending-merge', () => {
+        const status = helper.command.statusJson();
+        expect(status.mergePendingComponents).to.have.lengthOf(1);
+      });
+      it('bit merge with no args should merge them', () => {
+        const output = helper.command.merge(`--manual`);
+        expect(output).to.have.string('successfully merged');
+        expect(output).to.have.string('CONFLICT');
+      });
+    });
+  });
+
+  describe('rename an exported lane', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('dev');
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.renameLane('new-lane');
+    });
+    it('should rename the lane locally', () => {
+      const lanes = helper.command.listLanes();
+      expect(lanes).to.have.string('new-lane');
+      expect(lanes).to.not.have.string('dev');
+    });
+    it('should change the current lane', () => {
+      const lanes = helper.command.listLanesParsed();
+      expect(lanes.currentLane).to.equal('new-lane');
+    });
+    it('should not change the remote lane name before export', () => {
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      expect(remoteLanes.lanes).to.have.lengthOf(1);
+      expect(remoteLanes.lanes[0].name).to.equal('dev');
+    });
+    it('should change the remote lane name after export', () => {
+      helper.command.export();
+      const remoteLanes = helper.command.listRemoteLanesParsed();
+      expect(remoteLanes.lanes).to.have.lengthOf(1);
+      expect(remoteLanes.lanes[0].name).to.equal('new-lane');
+    });
+  });
+
+  describe('lane-a => lane-b', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(2);
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(2, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.createLane('lane-b');
+    });
+    // previously, it was showing the components as staged, because it was comparing them to head, instead of
+    // comparing them to lane-a.
+    it('bit status should be clean', () => {
+      helper.command.expectStatusToBeClean();
+    });
+    describe('lane-a (exported) => lane-b (not-exported) => lane-c', () => {
+      before(() => {
+        helper.command.createLane('lane-c');
+      });
+      it('forkedFrom should be of lane-a and not lane-b because this is the last exported one', () => {
+        const lane = helper.command.catLane('lane-c');
+        expect(lane.forkedFrom.name).to.equal('lane-a');
+      });
+    });
+    describe('switching back to lane-a', () => {
+      before(() => {
+        helper.command.switchLocalLane('lane-a');
+      });
+      it('bitmap should show the lane as exported', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap['@teambit/legacy.bit-map'].exported).to.be.true;
+      });
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes-multiple-scopes.e2e.ts
+++ b/e2e/harmony/lanes/lanes-multiple-scopes.e2e.ts
@@ -1,0 +1,385 @@
+import chai, { expect } from 'chai';
+import { FetchMissingHistory } from '@teambit/scope.remote-actions';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes multiple scopes', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('multiple scopes', () => {
+    let anotherRemote: string;
+    let anotherRemotePath: string;
+    let localScope: string;
+    let remoteScope: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      anotherRemotePath = scopePath;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fs.outputFile('bar1/foo1.js', 'console.log("v1");');
+      helper.fs.outputFile('bar2/foo2.js', 'console.log("v1");');
+      helper.command.addComponent('bar1');
+      helper.workspaceJsonc.addToVariant('bar2', 'defaultScope', anotherRemote);
+      helper.command.addComponent('bar2');
+      helper.command.linkAndRewire();
+      helper.command.compile();
+      helper.command.tagAllComponents();
+      helper.command.export();
+
+      helper.command.createLane();
+      helper.fs.outputFile('bar1/foo1.js', 'console.log("v2");');
+      helper.fs.outputFile('bar2/foo2.js', 'console.log("v2");');
+      helper.command.snapAllComponents();
+
+      localScope = helper.scopeHelper.cloneWorkspace();
+      remoteScope = helper.scopeHelper.cloneRemoteScope();
+    });
+    // previously, it was showing an error about missing versions.
+    describe('exporting the lane to the remote', () => {
+      it('should not throw an error', () => {
+        expect(() => helper.command.export()).to.not.throw();
+      });
+      // previously, it would remove the staged-config only when the component-scope was the same as the lane-scope or when the comp is new
+      it('should remove the content of the staged-config', () => {
+        const stagedConfig = helper.general.getStagedConfig(`${helper.scopes.remote}/dev`);
+        expect(stagedConfig).to.have.lengthOf(0);
+      });
+      // previously, it was changing the scope-name of bar2 to the first remote.
+      it('the components scope should not be changed on the remote', () => {
+        const catRemote = helper.command.catScope(false, helper.scopes.remotePath);
+        const bar2 = catRemote.find((c) => c.name === 'bar2');
+        expect(bar2.scope).to.equal(anotherRemote);
+      });
+    });
+    describe('when artifacts from older versions are missing locally', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(localScope);
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        // delete an artifact
+        const artifacts = helper.command.getArtifacts(`${anotherRemote}/bar2@0.0.1`);
+        const pkgArtifacts = artifacts.find((a) => a.generatedBy === 'teambit.pkg/pkg');
+        const artifactFileHash = pkgArtifacts.files[0].file;
+        const hashPath = helper.general.getHashPathOfObject(artifactFileHash);
+        helper.fs.deleteObject(hashPath);
+      });
+      // previously, throwing an error "unable to find an artifact object file".
+      it('should not throw an error', () => {
+        expect(() => helper.command.export()).to.not.throw();
+      });
+    });
+    describe('importing the lane', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(localScope);
+        helper.scopeHelper.getClonedRemoteScope(remoteScope);
+        helper.command.export();
+        helper.scopeHelper.reInitWorkspace();
+        helper.scopeHelper.addRemoteScope();
+        helper.scopeHelper.addRemoteScope(anotherRemotePath); // needed to fetch the head from the original scope.
+        // previously, it was throwing an error while trying to fetch these two components, each from its own scope.
+        helper.command.switchRemoteLane('dev');
+      });
+      // previous error was trying to get the Ref of the remote-scope according to the component-scope
+      // resulting in zero data from the ref file and assuming all versions are staged
+      it('should not show the component as staged', () => {
+        helper.command.expectStatusToBeClean();
+      });
+    });
+  });
+
+  describe('multiple scopes when the components are new', () => {
+    let anotherRemote: string;
+    let anotherRemotePath: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      anotherRemotePath = scopePath;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.fs.outputFile('bar1/index.js', 'const bar2 = require("../bar2"); console.log(bar2);');
+      helper.fs.outputFile('bar2/index.js', 'console.log("v1");');
+      helper.command.add('bar1');
+      helper.command.add('bar2', `--scope ${anotherRemote}`);
+      helper.command.linkAndRewire();
+
+      helper.command.compile();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    describe('exporting the lane to the remote', () => {
+      before(() => {
+        helper.command.export();
+      });
+      // previously, it was changing the scope-name of bar2 to the first remote.
+      it('should not change the scope of the components in .bitmap', () => {
+        const bitMap = helper.bitMap.read();
+        expect(bitMap.bar2.scope).to.equal(anotherRemote);
+      });
+      // previously, it was changing the scope-name of bar2 to the first remote.
+      it('should not change the scope-name in the lane object', () => {
+        const lane = helper.command.catLane('dev');
+        const bar2 = lane.components.find((c) => c.id.name === 'bar2');
+        expect(bar2.id.scope).to.equal(anotherRemote);
+      });
+      describe('importing the lane', () => {
+        before(() => {
+          helper.scopeHelper.reInitWorkspace();
+          helper.scopeHelper.addRemoteScope();
+          helper.scopeHelper.addRemoteScope(anotherRemotePath); // needed to fetch the head from the original scope.
+          helper.command.switchRemoteLane('dev');
+        });
+        it('should not show the component as staged', () => {
+          helper.command.expectStatusToBeClean();
+        });
+      });
+    });
+  });
+
+  describe('multiple scopes when main is ahead', () => {
+    let anotherRemote: string;
+    let localScope: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fs.outputFile('bar1/foo1.js', 'console.log("v1");');
+      helper.fs.outputFile('bar2/foo2.js', 'console.log("v1");');
+      helper.command.addComponent('bar1');
+      helper.command.addComponent('bar2');
+      helper.command.setScope(anotherRemote, 'bar2');
+      helper.command.compile();
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      localScope = helper.scopeHelper.cloneWorkspace();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.command.import(`${scopeName}/bar2`);
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.getClonedWorkspace(localScope);
+      helper.command.import();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    // previously, it used to error with "error: version "0.0.2" of component jozc1y79-remote2/bar2 was not found."
+    it('should be able to export', () => {
+      expect(() => helper.command.export()).to.not.throw();
+      // import used to throw as well
+      expect(() => helper.command.import()).to.not.throw();
+    });
+  });
+
+  describe('multiple scopes when a component in the origin is different than on the lane', () => {
+    let anotherRemote: string;
+    let beforeExport: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope(anotherRemote, 'comp1');
+      beforeExport = helper.scopeHelper.cloneWorkspace();
+
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+
+      helper.scopeHelper.getClonedWorkspace(beforeExport);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('bit export should throw an error', () => {
+      expect(() => helper.command.export()).to.throw('unable to export a lane with a new component');
+    });
+  });
+
+  describe('multiple scopes when a scope of the component does not exist', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope('non-exist-scope', 'comp1');
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    it('bit export should throw an error saying the scope does not exist', () => {
+      expect(() => helper.command.export()).to.throw('cannot find scope');
+    });
+  });
+
+  describe('multiple scopes when the origin-scope exits but does not have the component. only lane-scope has it', () => {
+    let anotherRemote: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope(anotherRemote, 'comp1');
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+    });
+    // should not throw an error "the component {component-name} has no versions and the head is empty."
+    it('bit import should not throw an error', () => {
+      expect(() => helper.command.import()).to.not.throw();
+    });
+  });
+
+  describe('multiple scopes - using FetchMissingHistory action', () => {
+    let anotherRemote: string;
+    const getFirstTagFromRemote = () =>
+      helper.command.catComponent(`${anotherRemote}/comp1@0.0.1`, helper.scopes.remotePath);
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1);
+      helper.command.setScope(anotherRemote, 'comp1');
+      helper.command.tagAllWithoutBuild();
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+
+      // currently, the objects from remote2 are in remote. so simulate a case where it's missing.
+      const firstTagHash = helper.command.catComponent('comp1').versions['0.0.1'];
+      const objectPath = helper.general.getHashPathOfObject(firstTagHash);
+      helper.fs.deleteRemoteObject(objectPath);
+
+      // an intermediate step. make sure the object is missing.
+      expect(getFirstTagFromRemote).to.throw();
+
+      helper.command.runAction(FetchMissingHistory.name, helper.scopes.remote, { ids: [`${anotherRemote}/comp1`] });
+    });
+    it('the remote should have the history of a component from the other remote', () => {
+      expect(getFirstTagFromRemote).to.not.throw();
+    });
+  });
+
+  describe('multiple scopes - lane-scope does not have main tags', () => {
+    let anotherRemote: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(1, false);
+      helper.command.setScope(scopeName, 'comp1');
+      helper.command.tagAllWithoutBuild();
+      // snap multiple times on main. these snaps will be missing locally during the snap-from-scope
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.command.import(`${anotherRemote}/comp1`);
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('bit status should show only the last snap of the imported component as staged', () => {
+      const status = helper.command.statusJson();
+      status.stagedComponents.forEach((comp) => {
+        expect(comp.versions).to.have.lengthOf(1);
+      });
+    });
+    it('bit export should not throw an error', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+
+  describe('multiple scopes - fork the lane and export to another scope', () => {
+    let anotherRemote: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(2);
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+
+      helper.command.createLane('lane-b', `--scope ${anotherRemote} --fork-lane-new-scope`);
+      helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
+      // previously, it was errored here because the remote didn't have comp2, so it couldn't merge the lane.
+      helper.command.export('--fork-lane-new-scope');
+    });
+    it('should be able to import the forked lane with no errors', () => {
+      expect(() => helper.command.import(`${anotherRemote}/lane-b`)).to.not.throw();
+    });
+  });
+
+  describe('multiple scopes - fork the lane, then original lane progresses and squashed to main', () => {
+    let anotherRemote: string;
+    let laneB: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      const { scopeName, scopePath } = helper.scopeHelper.getNewBareScope();
+      anotherRemote = scopeName;
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.scopeHelper.addRemoteScope(scopePath, helper.scopes.remotePath);
+      helper.scopeHelper.addRemoteScope(helper.scopes.remotePath, scopePath);
+      helper.fixtures.populateComponents(2);
+      helper.command.createLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.command.createLane('lane-b', `--scope ${anotherRemote} --fork-lane-new-scope`);
+      laneB = helper.scopeHelper.cloneWorkspace();
+      helper.command.switchLocalLane('lane-a', '-x');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.command.switchLocalLane('main', '-x');
+      helper.command.mergeLane('lane-a', '-x');
+      helper.command.export();
+      helper.scopeHelper.getClonedWorkspace(laneB);
+      helper.command.import();
+    });
+    it('should not throw NoCommonSnap on bit status', () => {
+      expect(() => helper.command.status()).not.to.throw();
+    });
+    it('should be able to export with no error', () => {
+      expect(() => helper.command.export('--fork-lane-new-scope --all')).to.not.throw();
+    });
+  });
+});

--- a/e2e/harmony/lanes/lanes-test-helper.ts
+++ b/e2e/harmony/lanes/lanes-test-helper.ts
@@ -1,0 +1,12 @@
+import chai from 'chai';
+import { Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+/**
+ * Shared setup for lanes e2e tests
+ */
+export function setupLanesTestHelper(): Helper {
+  const helper = new Helper();
+  return helper;
+}

--- a/e2e/harmony/lanes/lanes-workflow.e2e.ts
+++ b/e2e/harmony/lanes/lanes-workflow.e2e.ts
@@ -1,0 +1,473 @@
+import chai, { expect } from 'chai';
+import { InvalidScopeName } from '@teambit/legacy-bit-id';
+import { AUTO_SNAPPED_MSG } from '@teambit/legacy.constants';
+import { NpmCiRegistry, supportNpmCiRegistryTesting, Helper } from '@teambit/legacy.e2e-helper';
+
+chai.use(require('chai-fs'));
+
+describe('lanes workflow operations', function () {
+  this.timeout(0);
+  let helper: Helper;
+
+  before(() => {
+    helper = new Helper();
+  });
+
+  after(() => {
+    helper.scopeHelper.destroy();
+  });
+
+  describe('exporting a lane to a different scope than the component scope', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      const { scopePath } = helper.scopeHelper.getNewBareScope();
+      helper.scopeHelper.addRemoteScope(scopePath);
+      helper.command.createLane('dev', `--scope ${scopePath}`);
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+    });
+    it('should export to the lane scope and not to the component scope', () => {
+      const list = helper.command.listRemoteScopeParsed();
+      expect(list).to.have.lengthOf(1);
+    });
+  });
+
+  describe('branching out when a component is checked out to an older version', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.tagAllWithoutBuild();
+      helper.command.tagAllWithoutBuild('--unmodified');
+      helper.command.export();
+      helper.command.checkoutVersion('0.0.1', 'comp1');
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.switchLocalLane('main', '-x');
+    });
+    it('should checkout to the head of the origin branch', () => {
+      const comp1 = helper.command.catComponent('comp1');
+      expect(comp1.head).to.equal('0.0.2');
+    });
+    it('bit status should be clean', () => {
+      helper.command.expectStatusToBeClean();
+    });
+    // previously, the behavior was to checkout to the same version it had before
+    it.skip('should checkout to the same version the origin branch had before the switch', () => {
+      const showComp = helper.command.showComponent('comp1');
+      expect(showComp).to.have.string('0.0.1');
+    });
+    // previously, the behavior was to checkout to the same version it had before
+    it.skip('bit status should not show the component as modified only as pending update', () => {
+      const status = helper.command.statusJson();
+      expect(status.outdatedComponents).to.have.lengthOf(1);
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+    });
+  });
+
+  describe('snap on lane, export, clear project, snap and export', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importLane('dev');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('should export with no errors about missing artifact files from the first snap', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+
+  describe('auto-snap when on a lane', () => {
+    let snapOutput;
+    let comp3Head;
+    let comp2Head;
+    let comp1Head;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.fs.outputFile('comp3/index.js', 'console.log("v2")');
+      snapOutput = helper.command.snapAllComponentsWithoutBuild();
+      comp3Head = helper.command.getHeadOfLane('dev', 'comp3');
+      comp2Head = helper.command.getHeadOfLane('dev', 'comp2');
+      comp1Head = helper.command.getHeadOfLane('dev', 'comp1');
+    });
+    it('should auto snap the dependencies and the nested dependencies', () => {
+      expect(snapOutput).to.have.string(AUTO_SNAPPED_MSG);
+      expect(snapOutput).to.have.string('comp2');
+      expect(snapOutput).to.have.string('comp1');
+    });
+    it('should update the dependencies and the flattenedDependencies of the dependent with the new versions', () => {
+      const comp2 = helper.command.catComponent(`comp2@${comp2Head}`, helper.scopes.remotePath);
+      const comp3Dep = comp2.dependencies.find((dep) => dep.id.name === 'comp3');
+      expect(comp3Dep.id.version).to.equal(comp3Head);
+      const comp3FlattenedDep = comp2.flattenedDependencies.find((dep) => dep.name === 'comp3');
+      expect(comp3FlattenedDep.version).to.equal(comp3Head);
+    });
+    it('should update the dependencies and the flattenedDependencies of the dependent of the dependent with the new versions', () => {
+      const comp1 = helper.command.catComponent(`comp1@${comp1Head}`, helper.scopes.remotePath);
+      const comp2Dep = comp1.dependencies.find((dep) => dep.id.name === 'comp2');
+      expect(comp2Dep.id.version).to.equal(comp2Head);
+      const comp2FlattenedDep = comp1.flattenedDependencies.find((dep) => dep.name === 'comp2');
+      expect(comp2FlattenedDep.version).to.equal(comp2Head);
+      const comp3FlattenedDep = comp1.flattenedDependencies.find((dep) => dep.name === 'comp3');
+      expect(comp3FlattenedDep.version).to.equal(comp3Head);
+    });
+    it('bit-status should show them all as staged and not modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.stagedComponents).to.have.lengthOf(3);
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+    });
+  });
+
+  (supportNpmCiRegistryTesting ? describe : describe.skip)('import with dependencies as packages', () => {
+    let npmCiRegistry: NpmCiRegistry;
+    before(async () => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagAllWithoutBuild();
+      helper.command.export();
+      npmCiRegistry = new NpmCiRegistry(helper);
+      await npmCiRegistry.init();
+      helper.command.install();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(3, undefined, 'v2');
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+    });
+    after(() => {
+      npmCiRegistry.destroy();
+    });
+    describe('switching to a new lane', () => {
+      before(() => {
+        helper.command.createLane('lane-b');
+      });
+      it('should not show the component as modified', () => {
+        helper.command.expectStatusToBeClean();
+      });
+    });
+  });
+
+  describe('snapping and un-tagging on a lane', () => {
+    let afterFirstSnap: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      afterFirstSnap = helper.scopeHelper.cloneWorkspace();
+      helper.command.resetAll();
+    });
+    it('bit lane show should not show the component as belong to the lane anymore', () => {
+      const lane = helper.command.showOneLaneParsed('dev');
+      expect(lane.components).to.have.lengthOf(0);
+    });
+    // a previous bug kept the WorkspaceLane object as is with the previous, untagged version
+    it('bit list should not show the currentVersion as the untagged version', () => {
+      const list = helper.command.listParsed();
+      expect(list[0].currentVersion).to.equal('N/A');
+    });
+    describe('switching to main', () => {
+      before(() => {
+        helper.command.switchLocalLane('main');
+      });
+      it('bit status should show the component as new', () => {
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(1);
+      });
+    });
+    describe('add another snap and then untag only the last snap', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(afterFirstSnap);
+        helper.command.snapComponentWithoutBuild('comp1', '--unmodified');
+        helper.command.reset('comp1', true);
+      });
+      it('should not show the component as new', () => {
+        const status = helper.command.statusJson();
+        expect(status.newComponents).to.have.lengthOf(0);
+        expect(status.stagedComponents).to.have.lengthOf(1);
+      });
+    });
+    describe('un-snap by specifying the component name', () => {
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(afterFirstSnap);
+      });
+      // a previous bug was showing "unable to untag comp1, the component is not staged" error.
+      it('should not throw an error', () => {
+        expect(() => helper.command.reset('comp1')).to.not.throw();
+      });
+    });
+  });
+
+  describe('bit checkout to a previous snap', () => {
+    let firstSnap: string;
+    let secondSnap: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      firstSnap = helper.command.getHeadOfLane('dev', 'comp1');
+      helper.fixtures.populateComponents(1, undefined, 'v2');
+      helper.command.snapComponentWithoutBuild('comp1');
+      secondSnap = helper.command.getHeadOfLane('dev', 'comp1');
+      helper.command.checkoutVersion(firstSnap, 'comp1');
+    });
+    it('should not show the component as modified', () => {
+      const status = helper.command.statusJson();
+      expect(status.modifiedComponents).to.have.lengthOf(0);
+    });
+    it('bit list should show the scope-version as latest and workspace-version as the checked out one', () => {
+      const list = helper.command.listParsed();
+      const comp1 = list[0];
+      expect(comp1.currentVersion).to.equal(firstSnap);
+      expect(comp1.localVersion).to.equal(secondSnap);
+    });
+  });
+
+  describe('head on the lane is not in the filesystem', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      helper.fs.deletePath('.bit');
+      helper.command.init();
+      helper.scopeHelper.addRemoteScope();
+    });
+    it('bit status should not throw', () => {
+      expect(() => helper.command.status()).not.to.throw();
+    });
+  });
+
+  describe('export when previous versions have deleted dependencies', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(3);
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.command.removeComponentFromRemote(`${helper.scopes.remote}/comp3`, '--force');
+      helper.command.removeComponent('comp3', '--force');
+      helper.fs.outputFile('comp2/index.js', ''); // remove the dependency from the code
+      helper.command.tagWithoutBuild();
+      helper.command.export();
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+    });
+    it('should not throw ComponentNotFound on export', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+
+  describe('getting new components from the lane', () => {
+    let firstWorkspaceAfterExport: string;
+    let secondWorkspace: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      const firstWorkspace = helper.scopeHelper.cloneWorkspace();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.importLane('dev');
+      secondWorkspace = helper.scopeHelper.cloneWorkspace();
+      helper.scopeHelper.getClonedWorkspace(firstWorkspace);
+      helper.fixtures.populateComponents(2);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      firstWorkspaceAfterExport = helper.scopeHelper.cloneWorkspace();
+      helper.scopeHelper.getClonedWorkspace(secondWorkspace);
+    });
+    it('bit checkout with --workspace-only flag should not add the component and should suggest omitting --workspace-only flag', () => {
+      const output = helper.command.checkoutHead('--skip-dependency-installation --workspace-only');
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(1);
+      expect(output).to.have.string('omit --workspace-only flag to add them');
+    });
+    it('bit checkout without --workspace-only flag should add the new components', () => {
+      helper.command.checkoutHead('--skip-dependency-installation');
+      const list = helper.command.listParsed();
+      expect(list).to.have.lengthOf(2);
+    });
+    describe('when the new component is soft-removed', () => {
+      let beforeCheckout: string;
+      before(() => {
+        helper.scopeHelper.getClonedWorkspace(firstWorkspaceAfterExport);
+        helper.command.softRemoveOnLane('comp2');
+        helper.fs.writeFile('comp1/index.js', ''); // remove the comp2 dependency from the code
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+        helper.scopeHelper.getClonedWorkspace(secondWorkspace);
+        helper.command.import();
+        beforeCheckout = helper.scopeHelper.cloneWorkspace();
+      });
+      it('bit checkout with --workspace-only flag, should not suggest omitting it', () => {
+        const output = helper.command.checkoutHead('--skip-dependency-installation');
+        expect(output).to.not.have.string('omit --workspace-only flag to add them');
+        expect(output).to.not.have.string('comp2');
+      });
+      it('bit checkout head should not add it', () => {
+        helper.scopeHelper.getClonedWorkspace(beforeCheckout);
+        helper.command.checkoutHead('--skip-dependency-installation');
+        const list = helper.command.listParsed();
+        expect(list).to.have.lengthOf(1);
+      });
+    });
+  });
+
+  describe('exporting a component on a lane when the staged snaps exist already on the remote (from another lane)', function () {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane('lane-a');
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild(); // snapA
+      helper.command.export();
+      helper.command.createLane('lane-b');
+      helper.command.export();
+      const laneAFirstSnap = helper.scopeHelper.cloneWorkspace();
+      helper.command.switchLocalLane('lane-a');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified'); // snapX1
+      helper.command.snapAllComponentsWithoutBuild('--unmodified'); // snapX2
+      helper.command.export();
+
+      // locally
+      helper.scopeHelper.getClonedWorkspace(laneAFirstSnap);
+      helper.command.mergeLane('lane-a'); // now lane-b has snapA + snapB + snapX1 (from lane-a) + snapX2 (the from lane-a)
+      helper.command.import();
+      // keep this to fetch from all lanes, because in the future, by default, only the current lane is fetched
+      helper.command.fetchAllLanes();
+    });
+    it('bit export should not throw', () => {
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+
+  describe('change-scope', () => {
+    describe('when the lane is exported', () => {
+      before(() => {
+        helper.scopeHelper.setWorkspaceWithRemoteScope();
+        helper.command.createLane();
+        helper.fixtures.populateComponents(1, false);
+        helper.command.snapAllComponentsWithoutBuild();
+        helper.command.export();
+      });
+      it('should block the rename', () => {
+        expect(() => helper.command.changeLaneScope('new-scope')).to.throw(
+          'changing lane scope-name is allowed for new lanes only'
+        );
+      });
+    });
+    describe('when the scope-name is invalid', () => {
+      before(() => {
+        helper.scopeHelper.setWorkspaceWithRemoteScope();
+        helper.command.createLane();
+        helper.fixtures.populateComponents(1, false);
+      });
+      it('should throw InvalidScopeName error', () => {
+        const err = new InvalidScopeName('invalid.scope.name');
+        const cmd = () => helper.command.changeLaneScope('invalid.scope.name');
+        helper.general.expectToThrow(cmd, err);
+      });
+    });
+  });
+
+  describe('checking out to a different version from main', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.tagAllWithoutBuild(); // 0.0.1
+      helper.command.tagAllWithoutBuild('--unmodified'); // 0.0.2
+      helper.command.export();
+
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.command.createLane();
+      helper.fixtures.createComponentBarFoo();
+      helper.fixtures.addComponentBarFoo();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.importComponent('comp1@0.0.1', '--save-in-lane'); // now the lane has it as 0.0.1
+      helper.command.export();
+
+      helper.command.checkoutVersion('0.0.2', 'comp1', '-x');
+
+      // deleting the local scope
+      helper.command.init('--reset-scope');
+
+      helper.command.import();
+    });
+    it('bit import should bring the version in the bitmap', () => {
+      expect(() => helper.command.catComponent(`${helper.scopes.remote}/comp1@0.0.2`)).to.not.throw();
+    });
+    it('bit status should not throw ComponentsPendingImport', () => {
+      expect(() => helper.command.status()).to.not.throw();
+    });
+  });
+
+  describe('create comp on a lane then same on main', () => {
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.command.createLane();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.scopeHelper.reInitWorkspace();
+      helper.scopeHelper.addRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.fetchLane(`${helper.scopes.remote}/dev`);
+    });
+    // previously, it was throwing "getHeadRegardlessOfLaneAsTagOrHash() failed finding a head for lyq5piak-remote/comp1"
+    it('bit status should not throw', () => {
+      expect(() => helper.command.status()).to.not.throw();
+    });
+  });
+
+  describe('export interrupted, reset, snap then import', () => {
+    let beforeExport: string;
+    before(() => {
+      helper.scopeHelper.setWorkspaceWithRemoteScope();
+      helper.fixtures.populateComponents(1, false);
+      helper.command.createLane();
+      helper.command.snapAllComponentsWithoutBuild();
+      helper.command.export();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+
+      beforeExport = helper.scopeHelper.cloneWorkspace();
+      helper.command.export();
+
+      helper.scopeHelper.getClonedWorkspace(beforeExport);
+      helper.command.resetAll();
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      // previously, this import wasn't writing the .bit/refs files and as a result, it wasn't shown as merge-pending
+      helper.command.import();
+    });
+    it('bit status should show the components as merge-pending', () => {
+      const status = helper.command.statusJson();
+      expect(status.mergePendingComponents).to.have.lengthOf(1);
+    });
+    it('bit export should fail', () => {
+      expect(() => helper.command.export()).to.throw();
+    });
+    it('reset, checkout-head and re-snap should fix it and make it possible to export', () => {
+      helper.command.resetAll();
+      helper.command.checkoutHead('-x');
+      helper.command.snapAllComponentsWithoutBuild('--unmodified');
+      expect(() => helper.command.export()).to.not.throw();
+    });
+  });
+});


### PR DESCRIPTION
Split 1604-line lanes.e2e.ts into 6 focused test files for better maintainability and readability. Each file handles specific lane operations like basic workflows, diffs, imports/exports, merges, and complex scenarios.