### PR TITLE
fix: add rebase strategy to git pull operations in CI merge

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -361,7 +361,7 @@ export class CiMain {
     // This prevents issues when multiple PRs are merged in sequence
     const defaultBranch = await this.getDefaultBranchName();
     this.logger.console(chalk.blue(`Pulling latest git changes from ${defaultBranch} branch`));
-    await git.pull('origin', defaultBranch);
+    await git.pull('origin', defaultBranch, { '--rebase': 'true' });
     this.logger.console(chalk.green('Pulled latest git changes'));
 
     this.logger.console('🔄 Checking out to main head');
@@ -415,7 +415,7 @@ export class CiMain {
       await git.commit('chore: update .bitmap and lockfiles as needed [skip ci]');
 
       // Pull latest changes and push the commit to the remote repository
-      await git.pull('origin', defaultBranch);
+      await git.pull('origin', defaultBranch, { '--rebase': 'true' });
       await git.push('origin', defaultBranch);
     } else {
       this.logger.console(chalk.yellow('No components were tagged, skipping export and git operations'));


### PR DESCRIPTION
Fixes the "Need to specify how to reconcile divergent branches" error that occurs when another PR is merged during the long-running CI process.

The issue was that `git.pull()` calls didn't specify a merge strategy, causing failures when branches diverged. This fix adds `--rebase` strategy to both pull operations in the `mergePr` method to maintain clean linear history.