### PR TITLE
fix: handle unstaged changes before git pull with rebase

### DIFF
--- a/scopes/git/ci/ci.main.runtime.ts
+++ b/scopes/git/ci/ci.main.runtime.ts
@@ -361,7 +361,23 @@ export class CiMain {
     // This prevents issues when multiple PRs are merged in sequence
     const defaultBranch = await this.getDefaultBranchName();
     this.logger.console(chalk.blue(`Pulling latest git changes from ${defaultBranch} branch`));
+
+    // Check if there are any changes to stash before rebasing
+    const gitStatus = await git.status();
+    const hasChanges = gitStatus.files.length > 0;
+
+    if (hasChanges) {
+      this.logger.console(chalk.yellow('Stashing uncommitted changes before rebase'));
+      await git.stash(['push', '-u', '-m', 'CI merge temporary stash']);
+    }
+
     await git.pull('origin', defaultBranch, { '--rebase': 'true' });
+
+    if (hasChanges) {
+      this.logger.console(chalk.yellow('Restoring stashed changes after rebase'));
+      await git.stash(['pop']);
+    }
+
     this.logger.console(chalk.green('Pulled latest git changes'));
 
     this.logger.console('🔄 Checking out to main head');
@@ -415,6 +431,7 @@ export class CiMain {
       await git.commit('chore: update .bitmap and lockfiles as needed [skip ci]');
 
       // Pull latest changes and push the commit to the remote repository
+      // At this point we have just committed changes, so no need to stash
       await git.pull('origin', defaultBranch, { '--rebase': 'true' });
       await git.push('origin', defaultBranch);
     } else {


### PR DESCRIPTION
Fixes the "cannot pull with rebase: You have unstaged changes" error that occurs when there are uncommitted changes in the working directory during CI merge operations.

The solution adds proper handling of unstaged changes by stashing them before the rebase operation and restoring them afterward. This ensures clean rebases while preserving any working directory changes that may exist during the CI process.